### PR TITLE
perf: extend serving diagnostics jsonl buffer directly

### DIFF
--- a/docs/plans/2026-05-17-serving-diagnostics-jsonl-bytearray-extend.md
+++ b/docs/plans/2026-05-17-serving-diagnostics-jsonl-bytearray-extend.md
@@ -1,0 +1,27 @@
+# Serving diagnostics JSONL bytearray extend slice
+
+## Scope
+
+This Python-only performance slice targets the empty-attribute serving diagnostics JSONL fast path in `services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+
+The affected path is covered by the registered PR-scoped performance probe `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for the serving diagnostics implementation, focused unit tests, PR-scoped probe tests, and `scripts/serving_diagnostics_queue_probe.py`.
+
+## Optimization
+
+The previous writer built each fast-path event row as a temporary `bytes` object via the direct helper and then extended the output buffer. This slice keeps the public direct helper for tests and compatibility, but lets `_write_jsonl(...)` append the known JSON fragments directly into the shared `bytearray`.
+
+This removes one per-row `bytes.join(...)` allocation on the common decode/completed empty-attribute event path while preserving the JSON field order, request-id literal cache, numeric literal caches, fallback behavior, and event bundle schema.
+
+## Verification plan
+
+1. Add a focused regression test proving `_write_jsonl(...)` no longer depends on the per-row join helper for the fast path.
+2. Run focused serving diagnostics tests and PR-scoped probe registry tests.
+3. Run changed-scope coverage for the touched implementation and test files.
+4. Run the registered `serving-diagnostics-debug-queue-bounds` probe locally on Linux before and after the change.
+5. Let the PR-scoped performance workflow validate the registered probe in CI before merge.
+
+## Metrics
+
+Primary metric: `serialization_elapsed_ms_mean` from `serving-diagnostics-debug-queue-bounds` (lower is better). Secondary metric: `elapsed_ms_mean` should not regress materially because queue append behavior is unchanged.
+
+Local Linux probe samples with `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20` showed the serialization mean moving from roughly `1.107274 ms` on `origin/main` to roughly `0.994488 ms` after the change across three repeated probe runs. CI remains the registered validation source for merge.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -335,6 +335,36 @@ def test_serving_diagnostics_jsonl_fast_path_reuses_request_id_literal(
     assert calls == ["req-shared-fast-path"]
 
 
+def test_serving_diagnostics_jsonl_writer_extends_fast_path_without_join_helper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_join_helper(*_: object) -> None:  # pragma: no cover
+        raise AssertionError("writer should extend the bytearray without per-row join")
+
+    monkeypatch.setattr(
+        serving_diagnostics_module,
+        "_empty_attribute_event_json_line_bytes",
+        fail_join_helper,
+    )
+    path = tmp_path / "events.jsonl"
+
+    serving_diagnostics_module._write_jsonl(
+        path,
+        (
+            ServingDiagnosticsEvent(
+                request_id="req-extend-fast-path",
+                phase="decode",
+                event_index=4,
+                status="completed",
+                duration_ms=0.001,
+            ),
+        ),
+    )
+
+    assert json.loads(path.read_text(encoding="utf-8"))["request_id"] == "req-extend-fast-path"
+
+
 def test_serving_diagnostics_jsonl_fast_path_preserves_direct_helper_call() -> None:
     event = ServingDiagnosticsEvent(
         request_id="req-direct-fast-path",

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -508,9 +508,11 @@ def _write_jsonl(path: Path, rows: Any) -> None:
     request_id_literals: dict[str, bytes] = {}
     for row in rows:
         if isinstance(row, ServingDiagnosticsEvent):
-            fast_line = _empty_attribute_event_json_line_bytes(row, request_id_literals)
-            if fast_line is not None:
-                append_line(fast_line)
+            if _extend_empty_attribute_event_json_line_bytes(
+                append_line,
+                row,
+                request_id_literals,
+            ):
                 append_line(newline)
                 continue
             row = row.to_dict()
@@ -527,6 +529,51 @@ def _empty_attribute_event_json_line(
     if line is None:
         return None
     return line.decode("utf-8")
+
+
+def _extend_empty_attribute_event_json_line_bytes(
+    append_line: Any,
+    event: ServingDiagnosticsEvent,
+    request_id_literals: dict[str, bytes],
+) -> bool:
+    if event.attributes is not _EMPTY_EVENT_ATTRIBUTES:
+        return False
+    event_index = event.event_index
+    duration_ms = event.duration_ms
+    if type(event_index) is not int or type(duration_ms) is not float:
+        return False
+    if not math.isfinite(duration_ms):
+        return False
+    phase = event.phase
+    request_id = event.request_id
+    status = event.status
+    encoded_request_id = request_id_literals.get(request_id)
+    if encoded_request_id is None:
+        encoded_request_id = _json_string_literal(request_id).encode("utf-8")
+        request_id_literals[request_id] = encoded_request_id
+    duration_literal = _ascii_float_literal(duration_ms)
+    event_index_literal = _ascii_int_literal(event_index)
+    if phase == "decode" and status == "completed":
+        append_line(_EMPTY_EVENT_JSON_DECODE_COMPLETED_PREFIX)
+        append_line(duration_literal)
+        append_line(_EMPTY_EVENT_JSON_DECODE_COMPLETED_MID)
+        append_line(event_index_literal)
+        append_line(_EMPTY_EVENT_JSON_DECODE_COMPLETED_REQUEST_PREFIX)
+        append_line(encoded_request_id)
+        append_line(_EMPTY_EVENT_JSON_DECODE_COMPLETED_SUFFIX)
+        return True
+    append_line(b'{"attributes":{},"duration_ms":')
+    append_line(duration_literal)
+    append_line(b',"event_index":')
+    append_line(event_index_literal)
+    append_line(b',"phase":')
+    append_line(_json_string_literal(phase).encode("utf-8"))
+    append_line(b',"request_id":')
+    append_line(encoded_request_id)
+    append_line(b',"schema_version":"melix.serving_diagnostics.event.v1","status":')
+    append_line(_json_string_literal(status).encode("utf-8"))
+    append_line(b"}")
+    return True
 
 
 def _empty_attribute_event_json_line_bytes(


### PR DESCRIPTION
## Summary
- Optimize the serving diagnostics JSONL fast path by extending the shared bytearray directly instead of building a per-row joined bytes object.
- Keep the direct JSON-line helper available for focused tests and compatibility.
- Add a regression test and a governing plan for this slice.

## Plan or Spec
- `docs/plans/2026-05-17-serving-diagnostics-jsonl-bytearray-extend.md`
- Registered probe coverage: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json` already has focused `test_command`, `coverage_command`, and `probe_command` entries for this path.

## Commands Run
- `uv run --project services/mlx-worker-python python3 /tmp/melix_run_pytest_with_path.py -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` → 42 passed
- `uv run --project services/mlx-worker-python coverage run /tmp/melix_run_pytest_with_path.py -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py` → TOTAL 45 0 100%
- `env MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` repeated on `origin/main` and this branch for local Linux probe comparison
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 45 0 100%`).
- Local Linux registered probe comparison (`MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20`, three repeated runs):
  - `origin/main` serialization mean: `1.107274 ms`
  - branch serialization mean: `0.994488 ms`
  - delta: `-0.112786 ms` (`10.19%` lower)
- Queue append `elapsed_ms_mean` is noisy and not the primary metric for this serialization-only slice.

## Known Gaps
- This is a Python-only slice validated locally on Linux. The registered PR-scoped performance workflow must still run in CI before merge.
- Local commands used a temporary pytest path runner instead of `PYTHONPATH` because this scheduled environment blocks explicit `PYTHONPATH` shell exports; the runner only inserts the repo root and worker source root into `sys.path` for equivalent focused test execution.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused regression/unit tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux and showed an improvement on the primary metric.
- [ ] GitHub Actions and the PR-scoped performance report are green.
