### PR TITLE
perf: fast-path lowercase code eval fence tags

### DIFF
--- a/docs/plans/2026-05-16-code-eval-code-block-tag-case-fast-path.md
+++ b/docs/plans/2026-05-16-code-eval-code-block-tag-case-fast-path.md
@@ -4,7 +4,7 @@
 
 This Python-only performance slice narrows the code-evaluation response parser hot path in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
 
-The change keeps the existing behavior that treats any ASCII case spelling of the `python` code-fence language tag as a Python block, while avoiding a per-call six-character lowercase allocation when locating the candidate code content start.
+The change keeps the existing behavior that treats any ASCII case spelling of the `python` code-fence language tag as a Python block, while avoiding a per-call six-character lowercase allocation when locating the candidate code content start. The current slice adds a direct lowercase `python` tag branch before the mixed-case tuple fallback, matching the probe's common lowercase fence workload without changing non-Python tag behavior.
 
 ## Registered probe
 

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -23,6 +23,10 @@ def test_extract_candidate_code_handles_empty_plaintext_and_code_blocks() -> Non
         "print('case')",
         "parsed_code_block",
     )
+    assert code_eval_runner.extract_candidate_code("```PYTHON\nprint('upper')\n```") == (
+        "print('upper')",
+        "parsed_code_block",
+    )
     assert code_eval_runner.extract_candidate_code("```pYtHoN\nprint('case2')\n```") == (
         "print('case2')",
         "parsed_code_block",

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -16,9 +16,9 @@ import textwrap
 _DEFAULT_STDIO_LIMIT_BYTES = 32_768
 _JSON_LOADS = json.loads
 _JSON_DECODE_ERROR = json.JSONDecodeError
-_PYTHON_CODE_BLOCK_TAG_LENGTH = len("python")
+_PYTHON_CODE_BLOCK_TAG = "python"
+_PYTHON_CODE_BLOCK_TAG_LENGTH = len(_PYTHON_CODE_BLOCK_TAG)
 _PYTHON_CODE_BLOCK_TAG_VARIANTS = (
-    "python",
     "Python",
     "PYTHON",
     "PyThOn",
@@ -82,7 +82,9 @@ def extract_candidate_code(raw_response: str) -> tuple[str, str]:
 
 
 def _code_block_content_start(text: str, start: int) -> int:
-    if text.startswith(_PYTHON_CODE_BLOCK_TAG_VARIANTS, start):
+    if text.startswith(_PYTHON_CODE_BLOCK_TAG, start):
+        start += _PYTHON_CODE_BLOCK_TAG_LENGTH
+    elif text.startswith(_PYTHON_CODE_BLOCK_TAG_VARIANTS, start):
         start += _PYTHON_CODE_BLOCK_TAG_LENGTH
     while start < len(text) and text[start].isspace():
         start += 1


### PR DESCRIPTION
## Summary
- Fast-path lowercase `python` code fence tags in the code-evaluation response parser before falling back to the mixed-case tag tuple.
- Preserve ASCII case-insensitive Python tag behavior with an added uppercase regression assertion.

## Plan or Spec
- `docs/plans/2026-05-16-code-eval-code-block-tag-case-fast-path.md`
- Registered PR-scoped probe: `code-eval-code-block-last-match-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# 4 passed in 0.74s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py
# 4 passed; TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py
# before: {"elapsed_ms_mean": 0.02697093545326165, "peak_bytes_mean": 245.0, ...}
# after: repeated samples around 0.0282-0.0292 ms, peak_bytes_mean=245.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-code-block-last-match-streaming --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/code_eval_python_tag_direct_perf.json
# success; base elapsed_ms_mean=0.027680270639913424, head elapsed_ms_mean=0.02746131005031722, peak_bytes_mean 245.0 -> 245.0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Registered local base-vs-head probe: `elapsed_ms_mean` 0.027680270639913424 ms -> 0.02746131005031722 ms (delta -0.0002189605895962033 ms, ~0.79% lower); `peak_bytes_mean` 245.0 -> 245.0 bytes.
- CI PR-scoped performance workflow is required as the merge gate for the registered probe.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and integration gates were not run locally; this is a focused Python parser slice and Linux local validation used the registered probe commands.
- Swift/macOS runtime performance is not claimed for this Python-only change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode changes.
- [x] Deferred work and known gaps are stated explicitly.
