### PR TITLE
perf: use static dispatch for probe policy helpers

### DIFF
--- a/docs/plans/2026-05-18-probe-policy-static-dispatch.md
+++ b/docs/plans/2026-05-18-probe-policy-static-dispatch.md
@@ -1,0 +1,29 @@
+# Probe policy factory static dispatch slice
+
+## Scope
+
+This Python-only performance slice targets the no-op probe policy helper path in
+`services/mlx-worker-python/worker/productization/probe_policy.py`. The affected
+path is covered by the registered PR-scoped probe `probe-policy-noop-overhead` in
+`infra/perf/pr_scoped_probes.json`, which has focused `test_command`,
+`coverage_command`, and `probe_command` entries.
+
+## Change
+
+Keep `ProbePolicy.evidence()` and `ProbePolicy.debug()` behavior unchanged while
+using static dispatch for the cached singleton helpers. These helpers do not use a
+class object, so avoiding classmethod binding removes unnecessary descriptor work
+from the hot no-op policy overhead probe.
+
+## Verification plan
+
+- Run focused probe policy tests and PR-scoped probe registry tests.
+- Run changed-scope coverage through the registered `coverage_command`.
+- Run the registered probe policy no-op overhead probe locally on Linux and
+  compare `evidence_policy_call_ms_mean` and `debug_policy_call_ms_mean` against
+  `origin/main` with the same iteration and sample counts.
+
+## Linux validation boundary
+
+This slice is entirely Python and locally verifiable on Linux. No Swift runtime
+performance claims are made.

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -80,12 +80,12 @@ class ProbePolicy:
             return policy
         return _invalid_probe_policy(raw_value, default_mode)
 
-    @classmethod
-    def evidence(cls) -> ProbePolicy:
+    @staticmethod
+    def evidence() -> ProbePolicy:
         return _EVIDENCE_PROBE_POLICY
 
-    @classmethod
-    def debug(cls) -> ProbePolicy:
+    @staticmethod
+    def debug() -> ProbePolicy:
         return _DEBUG_PROBE_POLICY
 
 


### PR DESCRIPTION
## Summary
- Change `ProbePolicy.evidence()` and `ProbePolicy.debug()` from classmethod dispatch to static dispatch while preserving cached singleton return values.
- Keep the slice scoped to the registered Python no-op probe policy helper hot path.

## Plan or Spec
- `docs/plans/2026-05-18-probe-policy-static-dispatch.md`
- Registered PR-scoped probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json` (focused test, coverage, and probe commands are already present).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py`
- Comparison probe runs with `MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=500000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=20` on `origin/main` and this branch.

## Coverage and Metrics
- Focused tests: 16 passed.
- Changed-scope coverage: 100.00% (4/4 changed executable lines covered).
- Local Linux registered probe (default 1,000,000 iterations / 5 samples) passed with `threshold_passed=1.0`.
- Baseline comparison (`origin/main`, 500,000 iterations / 20 samples): `evidence_policy_call_ms_mean=0.000041971`, `debug_policy_call_ms_mean=0.000043164`.
- Branch comparison (same command): `evidence_policy_call_ms_mean=0.000039864`, `debug_policy_call_ms_mean=0.000040076`.
- Delta: evidence helper `-0.000002107 ms` (~5.02% faster); debug helper `-0.000003088 ms` (~7.15% faster).

## Known Gaps
- Python-only slice validated locally on Linux; no Swift runtime performance claim is made.
- CI PR-scoped performance must run the registered `probe-policy-noop-overhead` probe before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe.
- [x] Registered probe includes focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux with an improving helper metric comparison.
- [ ] GitHub Actions PR-scoped performance completed successfully.
