### PR TITLE
perf: cache serving diagnostics JSON bytes

### DIFF
--- a/docs/plans/2026-05-18-serving-diagnostics-json-bytes-cache.md
+++ b/docs/plans/2026-05-18-serving-diagnostics-json-bytes-cache.md
@@ -1,0 +1,24 @@
+# Serving diagnostics JSON literal byte cache slice
+
+## Scope
+
+This Python-only performance slice targets the serving diagnostics JSONL fast path in `services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+
+The affected path is covered by the registered PR-scoped probe `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`, including focused `test_command`, `coverage_command`, and `probe_command` entries for the serving diagnostics implementation, tests, and `scripts/serving_diagnostics_queue_probe.py`.
+
+## Optimization
+
+Keep the existing string JSON literal cache for call sites that need `str`, and add a paired cached byte-literal helper for JSONL serialization. The writer and direct event helper now reuse cached UTF-8 bytes for request IDs, phases, and statuses instead of taking a cached string literal and encoding it again on every miss or generic fast-path row.
+
+This preserves the existing compact, sorted JSON field order and all fallback behavior while avoiding repeated `str.encode("utf-8")` work in the debug queue serialization path.
+
+## Linux validation boundary
+
+This slice is entirely Python and locally verifiable on Linux. No Swift runtime performance claims are made.
+
+## Verification plan
+
+1. Run the registered focused `test_command` for `serving-diagnostics-debug-queue-bounds`.
+2. Run the registered changed-scope `coverage_command` and require at least 95% coverage for touched scope.
+3. Run the registered `probe_command` locally on Linux against `origin/main` and this branch and compare `serialization_elapsed_ms_mean`.
+4. Require the PR-scoped performance workflow to run the registered probe in CI before merge.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -304,15 +304,15 @@ def test_serving_diagnostics_jsonl_fast_path_reuses_request_id_literal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[str] = []
-    original_encoder = serving_diagnostics_module._json_string_literal
+    original_encoder = serving_diagnostics_module._json_string_literal_bytes
 
-    def counting_encoder(value: str) -> str:
+    def counting_encoder(value: str) -> bytes:
         calls.append(value)
         return original_encoder(value)
 
     monkeypatch.setattr(
         serving_diagnostics_module,
-        "_json_string_literal",
+        "_json_string_literal_bytes",
         counting_encoder,
     )
     rows = tuple(
@@ -378,6 +378,26 @@ def test_serving_diagnostics_jsonl_fast_path_preserves_direct_helper_call() -> N
 
     assert line is not None
     assert json.loads(line)["request_id"] == "req-direct-fast-path"
+
+
+def test_serving_diagnostics_jsonl_fast_path_populates_direct_request_id_byte_cache() -> None:
+    event = ServingDiagnosticsEvent(
+        request_id="req-direct-cache-fill",
+        phase="decode",
+        event_index=9,
+        status="completed",
+        duration_ms=0.001,
+    )
+    request_id_literals: dict[str, bytes] = {}
+
+    line = serving_diagnostics_module._empty_attribute_event_json_line_bytes(
+        event,
+        request_id_literals,
+    )
+
+    assert line is not None
+    assert json.loads(line)["request_id"] == "req-direct-cache-fill"
+    assert request_id_literals == {"req-direct-cache-fill": b'"req-direct-cache-fill"'}
 
 
 def test_serving_diagnostics_jsonl_fast_path_builds_direct_bytes() -> None:

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -38,6 +38,11 @@ def _json_string_literal(value: str) -> str:
 
 
 @lru_cache(maxsize=1024)
+def _json_string_literal_bytes(value: str) -> bytes:
+    return _JSON_STRING_ENCODER(value).encode("utf-8")
+
+
+@lru_cache(maxsize=1024)
 def _ascii_float_literal(value: float) -> bytes:
     return str(value).encode("ascii")
 
@@ -549,7 +554,7 @@ def _extend_empty_attribute_event_json_line_bytes(
     status = event.status
     encoded_request_id = request_id_literals.get(request_id)
     if encoded_request_id is None:
-        encoded_request_id = _json_string_literal(request_id).encode("utf-8")
+        encoded_request_id = _json_string_literal_bytes(request_id)
         request_id_literals[request_id] = encoded_request_id
     duration_literal = _ascii_float_literal(duration_ms)
     event_index_literal = _ascii_int_literal(event_index)
@@ -567,11 +572,11 @@ def _extend_empty_attribute_event_json_line_bytes(
     append_line(b',"event_index":')
     append_line(event_index_literal)
     append_line(b',"phase":')
-    append_line(_json_string_literal(phase).encode("utf-8"))
+    append_line(_json_string_literal_bytes(phase))
     append_line(b',"request_id":')
     append_line(encoded_request_id)
     append_line(b',"schema_version":"melix.serving_diagnostics.event.v1","status":')
-    append_line(_json_string_literal(status).encode("utf-8"))
+    append_line(_json_string_literal_bytes(status))
     append_line(b"}")
     return True
 
@@ -592,11 +597,11 @@ def _empty_attribute_event_json_line_bytes(
     request_id = event.request_id
     status = event.status
     if request_id_literals is None:
-        encoded_request_id = _json_string_literal(request_id).encode("utf-8")
+        encoded_request_id = _json_string_literal_bytes(request_id)
     else:
         encoded_request_id = request_id_literals.get(request_id)
         if encoded_request_id is None:
-            encoded_request_id = _json_string_literal(request_id).encode("utf-8")
+            encoded_request_id = _json_string_literal_bytes(request_id)
             request_id_literals[request_id] = encoded_request_id
     if phase == "decode" and status == "completed":
         return b"".join(
@@ -610,8 +615,6 @@ def _empty_attribute_event_json_line_bytes(
                 _EMPTY_EVENT_JSON_DECODE_COMPLETED_SUFFIX,
             )
         )
-    encoded_phase = _json_string_literal(phase).encode("utf-8")
-    encoded_status = _json_string_literal(status).encode("utf-8")
     return b"".join(
         (
             b'{"attributes":{},"duration_ms":',
@@ -619,11 +622,11 @@ def _empty_attribute_event_json_line_bytes(
             b',"event_index":',
             _ascii_int_literal(event_index),
             b',"phase":',
-            encoded_phase,
+            _json_string_literal_bytes(phase),
             b',"request_id":',
             encoded_request_id,
             b',"schema_version":"melix.serving_diagnostics.event.v1","status":',
-            encoded_status,
+            _json_string_literal_bytes(status),
             b"}",
         )
     )


### PR DESCRIPTION
## Summary
- Add a cached UTF-8 JSON string-literal helper for serving diagnostics JSONL serialization.
- Reuse cached bytes for request IDs, phases, and statuses instead of encoding cached string literals again.
- Add regression coverage for the direct helper's request-id byte cache fill path.

## Plan or Spec
- `docs/plans/2026-05-18-serving-diagnostics-json-bytes-cache.md`
- Registered PR-scoped probe: `serving-diagnostics-debug-queue-bounds`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 42 passed in 0.79s (before adding the extra direct-cache test)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
# 43 passed in 0.40s; TOTAL 17 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
# base serialization_elapsed_ms_mean=0.983973; head serialization_elapsed_ms_mean=0.955111 in a direct local comparison

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id serving-diagnostics-debug-queue-bounds --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/serving-diagnostics-json-bytes-cache-probe.json
# completed; first run was noisy (base serialization=0.964441, head serialization=1.001151)

for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id serving-diagnostics-debug-queue-bounds --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output "/tmp/serving-diagnostics-json-bytes-cache-probe-$i.json"; done
# repeated registered probe medians: serialization_elapsed_ms_mean base=1.140816 ms, head=0.988716 ms; delta=-0.152100 ms (-13.33%). elapsed_ms_mean median delta=-0.029586 ms (-0.52%). serialized_bytes unchanged at 10944.

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 17 0 100%`.
- Registered probe: `serving-diagnostics-debug-queue-bounds`.
- Local registered-probe median over three repeated runs:
  - `serialization_elapsed_ms_mean`: base `1.140816 ms`, head `0.988716 ms`, delta `-0.152100 ms` (`-13.33%`).
  - `elapsed_ms_mean`: base `5.729396 ms`, head `5.699810 ms`, delta `-0.029586 ms` (`-0.52%`).
  - `serialized_bytes`: unchanged at `10944`.
- Functional invariants: `serialization_checksum=260064`, `dropped_count=4032`, `retained_count=64` remained stable in the local probe.

## Known Gaps
- Local probe timing is noisy at this small workload size; the repeated local median shows improvement, and CI PR-scoped performance is required as the merge gate.
- No Swift runtime validation is claimed; this is a Python-only Linux-verifiable slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: debug queue serialization; probe overhead: N/A because this does not add observability hooks.
- [x] Deferred work and known gaps are stated explicitly.
