### PR TITLE
perf: reduce integration remove-tree stack allocation

### DIFF
--- a/docs/plans/2026-05-18-integration-remove-tree-local-bindings.md
+++ b/docs/plans/2026-05-18-integration-remove-tree-local-bindings.md
@@ -1,0 +1,35 @@
+# Integration remove-tree local bindings performance slice
+
+## Scope
+
+This Python-only slice is limited to `tests/integration/helpers.py` and the
+registered integration cleanup probe path. It keeps `LiveMelixStack._remove_tree`
+semantics unchanged while reducing per-directory stack tuple allocation inside the
+`os.scandir()` cleanup loop.
+
+## Registered performance probe
+
+The affected path is covered by the registered PR-scoped probe
+`integration-swift-binary-resolution-scandir` in
+`infra/perf/pr_scoped_probes.json`. The entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries and reports the
+remove-tree timing/peak-memory metrics emitted by
+`scripts/integration_remove_tree_probe.py`.
+
+## Implementation plan
+
+1. Reuse the existing focused remove-tree behavior tests to preserve cleanup
+   parity for nested files, symlinks, missing roots, and disappearing entries.
+2. Keep the non-recursive post-order traversal but replace `(path, visited)`
+   stack tuples with a single sentinel marker plus path entries. This removes one
+   tuple allocation per stack push while preserving bounded stack behavior.
+3. Run the registered focused tests, changed-scope coverage, and PR-scoped probe
+   locally on Linux against an `origin/main` baseline worktree and this branch.
+4. Use PR-scoped performance CI as the final registered probe gate before merge.
+
+## Verification notes
+
+Local Linux verification can validate Python behavior and probe direction. This
+slice does not change Swift runtime behavior; Swift binary-resolution metrics in
+the shared registered probe remain CI-reported context, while the remove-tree
+metrics are directly affected by this Python helper change.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -357,24 +357,36 @@ class LiveMelixStack:
 
     def _remove_tree(self, root: Path) -> None:
         root_path = os.fspath(root)
-        stack: list[tuple[str, bool]] = [(root_path, False)]
+        post_order_marker = object()
+        stack: list[str | object] = [root_path]
+        scandir = os.scandir
+        unlink = os.unlink
+        rmdir = os.rmdir
+        stack_pop = stack.pop
+        stack_append = stack.append
+
         while stack:
-            path, visited = stack.pop()
-            if visited:
+            item = stack_pop()
+            if item is post_order_marker:
+                path = stack_pop()
                 try:
-                    os.rmdir(path)
+                    rmdir(path)  # type: ignore[arg-type]
                 except FileNotFoundError:
                     pass
                 continue
+
+            path = item
             try:
-                with os.scandir(path) as entries:
-                    stack.append((path, True))
+                with scandir(path) as entries:  # type: ignore[arg-type]
+                    stack_append(path)
+                    stack_append(post_order_marker)
                     for entry in entries:
                         try:
+                            entry_path = entry.path
                             if entry.is_dir(follow_symlinks=False):
-                                stack.append((entry.path, False))
+                                stack_append(entry_path)
                             else:
-                                os.unlink(entry.path)
+                                unlink(entry_path)
                         except FileNotFoundError:
                             pass
             except (FileNotFoundError, NotADirectoryError):

--- a/tests/integration/test_helper_remove_tree.py
+++ b/tests/integration/test_helper_remove_tree.py
@@ -98,6 +98,29 @@ def test_remove_tree_ignores_disappearing_directory_before_scan(
     assert not root.exists()
 
 
+def test_remove_tree_ignores_disappearing_directory_before_final_rmdir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "runtime-state"
+    nested = root / "state"
+    nested.mkdir(parents=True)
+    (nested / "session.json").write_text("{}", encoding="utf-8")
+    original_rmdir = helpers.os.rmdir
+
+    def tracked_rmdir(path: str) -> None:
+        if Path(path).name == "state":
+            original_rmdir(path)
+            raise FileNotFoundError(path)
+        original_rmdir(path)
+
+    monkeypatch.setattr(helpers.os, "rmdir", tracked_rmdir)
+
+    _stack()._remove_tree(root)
+
+    assert not root.exists()
+
+
 def test_remove_tree_ignores_disappearing_file_entries(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Reworks `LiveMelixStack._remove_tree` to keep the non-recursive post-order cleanup while replacing `(path, visited)` stack tuples with a sentinel marker.
- Adds a regression test for directories that disappear immediately before final `rmdir`.
- Documents the Python-only performance slice and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-05-18-integration-remove-tree-local-bindings.md`
- Registered probe: `integration-swift-binary-resolution-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_remove_tree_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REMOVE_TREE_SAMPLES=9 MELIX_REMOVE_TREE_DIRECTORIES=1200 MELIX_REMOVE_TREE_FILES_PER_DIRECTORY=2 uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id integration-swift-binary-resolution-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/remove_tree_marker_noisinstance_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 11 passed.
- Registered probe verification rerun by `pr_scoped_performance_run.py`: 18 passed.
- Changed-scope coverage: 32/32 changed measurable lines covered, 100%.
- Local Linux registered probe (9 remove-tree samples, 1200 directories, 2 files/directory):
  - base `remove_tree_elapsed_ms_mean=74.58728820913367`
  - head `remove_tree_elapsed_ms_mean=69.93873611403008`
  - delta `-4.648552095103597 ms`
  - base `remove_tree_delta_ms_mean=-182.1193164990594`
  - head `remove_tree_delta_ms_mean=-190.4445997853246`
  - delta `-8.325283286265204 ms`
  - base `remove_tree_peak_bytes_mean=16918.88888888889`
  - head `remove_tree_peak_bytes_mean=15100.222222222223`
  - delta `-1818.6666666666679 bytes`

## Known Gaps
- This is a Python helper slice verified locally on Linux. It does not claim Swift runtime effect validation locally; the shared registered CI probe remains the merge gate.
- The registered probe also reports Swift binary-resolution context metrics that are not the target of this slice.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branch creation.
- [x] Affected path is covered by a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally on Linux with improved remove-tree timing and peak bytes.
- [ ] GitHub Actions and PR-scoped performance workflow complete successfully.
