### PR TITLE
[codex] Productize response-only LoRA UI receipts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PROTOCOL_SWIFT_HOME := $(SWIFT_HOME)/protocol
 TEXT_WORKER_SWIFT_HOME := $(SWIFT_HOME)/mlx-text-worker-swift
 CONTROL_PLANE_SWIFT_HOME := $(SWIFT_HOME)/control-plane-swift
 MENUBAR_SWIFT_HOME := $(SWIFT_HOME)/macos-menubar
+MENUBAR_SWIFT_TEST_FLAGS := -Xswiftc -gnone
 
 PROTOCOL_MODULE_CACHE_PATH := $(CLANG_MODULE_CACHE_PATH)/protocol
 TEXT_WORKER_MODULE_CACHE_PATH := $(CLANG_MODULE_CACHE_PATH)/mlx-text-worker-swift
@@ -198,7 +199,7 @@ swift-test-control-worker:
 swift-test-menubar:
 	/bin/zsh -lc 'set -e; \
 	mkdir -p "$(MENUBAR_SWIFT_HOME)" "$(MENUBAR_MODULE_CACHE_PATH)"; \
-	bash scripts/ci_progress.sh "swift-test stage: macOS menubar package" env HOME="$(MENUBAR_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(MENUBAR_MODULE_CACHE_PATH)" xcrun swift test --package-path apps/macos-menubar'
+	bash scripts/ci_progress.sh "swift-test stage: macOS menubar package" env HOME="$(MENUBAR_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(MENUBAR_MODULE_CACHE_PATH)" xcrun swift test --package-path apps/macos-menubar $(MENUBAR_SWIFT_TEST_FLAGS)'
 
 py-test:
 	mkdir -p "$(UV_CACHE_DIR)"
@@ -234,7 +235,7 @@ swift-coverage:
 	mkdir -p "$(TEXT_WORKER_MODULE_CACHE_PATH)" "$(CONTROL_PLANE_MODULE_CACHE_PATH)" "$(MENUBAR_MODULE_CACHE_PATH)"; \
 	HOME="$(TEXT_WORKER_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(TEXT_WORKER_MODULE_CACHE_PATH)" xcrun swift test --package-path services/mlx-text-worker-swift --enable-code-coverage; \
 	HOME="$(CONTROL_PLANE_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(CONTROL_PLANE_MODULE_CACHE_PATH)" xcrun swift test --package-path services/control-plane-swift --enable-code-coverage; \
-	HOME="$(MENUBAR_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(MENUBAR_MODULE_CACHE_PATH)" xcrun swift test --package-path apps/macos-menubar --enable-code-coverage'
+	HOME="$(MENUBAR_SWIFT_HOME)" CLANG_MODULE_CACHE_PATH="$(MENUBAR_MODULE_CACHE_PATH)" xcrun swift test --package-path apps/macos-menubar --enable-code-coverage $(MENUBAR_SWIFT_TEST_FLAGS)'
 	python3 scripts/swift_coverage_summary.py services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/MelixTextWorkerSwift.json /services/mlx-text-worker-swift/Sources/
 	python3 scripts/swift_coverage_summary.py services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/MelixControlPlane.json /services/control-plane-swift/Sources/
 	python3 scripts/swift_coverage_summary.py apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/MelixMacOSMenubar.json /apps/macos-menubar/Sources/

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -5287,6 +5287,28 @@ struct DesktopTrainingToolSectionView: View {
                         .foregroundStyle(.secondary)
                 }
 
+                if let responseOnlyReceipt = RuntimeViewModel.responseOnlySafetyReceipt(from: job) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        DesktopPassiveCaptionLabel(title: "Response-only Safety")
+                        DesktopPassiveCaptionLabel(
+                            title: responseOnlyReceipt.statusText,
+                            foregroundStyle: responseOnlyReceipt.statusText == "Blocked"
+                                ? MelixDesignTokens.StatusColor.error
+                                : MelixDesignTokens.StatusColor.warning
+                        )
+                        ForEach(savedJobResponseOnlySafetyItems(responseOnlyReceipt)) { item in
+                            VStack(alignment: .leading, spacing: 2) {
+                                DesktopPassiveCaptionLabel(title: item.title)
+                                Text(item.value)
+                                    .font(.caption2.monospaced())
+                                    .foregroundStyle(.secondary)
+                                    .textSelection(.enabled)
+                            }
+                        }
+                    }
+                    .font(.caption)
+                }
+
                 if !job.latestOutputText.isEmpty {
                     DisclosureGroup("Latest Output") {
                         Text(job.latestOutputText)
@@ -6044,6 +6066,30 @@ struct DesktopTrainingToolSectionView: View {
             DesktopTrainingSummaryItem(title: "Mergeable", value: receipt.mergeableText, detail: ""),
             DesktopTrainingSummaryItem(title: "ReLoRA-compatible", value: receipt.reloraCompatibleText, detail: ""),
             DesktopTrainingSummaryItem(title: "Quantized Base", value: receipt.quantizedBaseSupportedText, detail: ""),
+        ].filter { item in
+            item.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        }
+    }
+
+    private func savedJobResponseOnlySafetyItems(_ receipt: RuntimeResponseOnlySafetyReceiptState) -> [DesktopTrainingSummaryItem] {
+        [
+            DesktopTrainingSummaryItem(title: "Recovery", value: receipt.recoveryHint, detail: ""),
+            DesktopTrainingSummaryItem(title: "Error Code", value: receipt.errorCode, detail: ""),
+            DesktopTrainingSummaryItem(title: "Max Seq Length", value: receipt.maxSeqLengthText, detail: ""),
+            DesktopTrainingSummaryItem(title: "Samples", value: receipt.boundarySampleCountText, detail: ""),
+            DesktopTrainingSummaryItem(title: "Boundary Range", value: receipt.boundaryRangeText, detail: ""),
+            DesktopTrainingSummaryItem(title: "Boundary Mean", value: receipt.boundaryMeanText, detail: ""),
+            DesktopTrainingSummaryItem(title: "Response Tokens Mean", value: receipt.responseTokensMeanText, detail: ""),
+            DesktopTrainingSummaryItem(
+                title: "Trainable Response Tokens",
+                value: receipt.trainableResponseTokenCountText,
+                detail: ""
+            ),
+            DesktopTrainingSummaryItem(
+                title: "Fully Truncated Samples",
+                value: receipt.fullyTruncatedSampleCountText,
+                detail: ""
+            ),
         ].filter { item in
             item.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
         }
@@ -8653,7 +8699,8 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     Chart(viewModel.benchmarkMatrixThroughputChartPoints) { point in
                                         BarMark(
                                             x: .value("Batch", point.xValue),
-                                            y: .value("Throughput", point.yValue)
+                                            y: .value("Throughput", point.yValue),
+                                            width: .fixed(12)
                                         )
                                         .foregroundStyle(
                                             MelixDesignTokens.accent.opacity(DesktopLoRAVisualPolish.chartFillOpacity)

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -6088,6 +6088,11 @@ struct DesktopTrainingToolSectionView: View {
                 value: receipt.fullyTruncatedSampleCountText,
                 detail: ""
             ),
+            DesktopTrainingSummaryItem(
+                title: "Truncated Samples",
+                value: receipt.truncatedSampleCountText,
+                detail: ""
+            ),
         ].filter { item in
             item.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
         }

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -5292,9 +5292,7 @@ struct DesktopTrainingToolSectionView: View {
                         DesktopPassiveCaptionLabel(title: "Response-only Safety")
                         DesktopPassiveCaptionLabel(
                             title: responseOnlyReceipt.statusText,
-                            foregroundStyle: responseOnlyReceipt.statusText == "Blocked"
-                                ? MelixDesignTokens.StatusColor.error
-                                : MelixDesignTokens.StatusColor.warning
+                            foregroundStyle: responseOnlySafetyStatusColor(responseOnlyReceipt.status)
                         )
                         ForEach(savedJobResponseOnlySafetyItems(responseOnlyReceipt)) { item in
                             VStack(alignment: .leading, spacing: 2) {
@@ -6092,6 +6090,17 @@ struct DesktopTrainingToolSectionView: View {
             ),
         ].filter { item in
             item.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        }
+    }
+
+    private func responseOnlySafetyStatusColor(_ status: RuntimeResponseOnlySafetyReceiptState.Status) -> Color {
+        switch status {
+        case .blocked:
+            return MelixDesignTokens.StatusColor.error
+        case .truncated:
+            return MelixDesignTokens.StatusColor.warning
+        case .observed:
+            return MelixDesignTokens.StatusColor.info
         }
     }
 

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -1748,6 +1748,34 @@ public struct RuntimeAdapterCapabilityReceiptState: Equatable, Sendable {
     }
 }
 
+public struct RuntimeResponseOnlySafetyReceiptState: Equatable, Sendable {
+    public let errorCode: String
+    public let maxSeqLengthText: String
+    public let boundarySampleCountText: String
+    public let boundaryRangeText: String
+    public let boundaryMeanText: String
+    public let responseTokensMeanText: String
+    public let trainableResponseTokenCountText: String
+    public let fullyTruncatedSampleCountText: String
+    public let truncatedSampleCountText: String
+
+    public var statusText: String {
+        if errorCode == "response_only_labels_truncated"
+            || (trainableResponseTokenCountText == "0" && fullyTruncatedSampleCountText.isEmpty == false)
+        {
+            return "Blocked"
+        }
+        if truncatedSampleCountText.isEmpty == false && truncatedSampleCountText != "0" {
+            return "Truncated"
+        }
+        return "Observed"
+    }
+
+    public var recoveryHint: String {
+        "Increase max_seq_length, shorten the system prompt, or disable response-only masking."
+    }
+}
+
 public struct RuntimeEvaluationMetricCardState: Identifiable, Equatable, Sendable {
     public let id: String
     public let suiteTitle: String
@@ -6612,6 +6640,66 @@ public final class RuntimeViewModel {
             mergeable: mergeable,
             reloraCompatible: reloraCompatible,
             quantizedBaseSupported: quantizedBaseSupported
+        )
+    }
+
+    public static func responseOnlySafetyReceipt(from job: LoraTrainingJobRecord) -> RuntimeResponseOnlySafetyReceiptState? {
+        let payload = jsonPayload(from: job.latestOutputText)
+        let terminalPayload = payload.isEmpty ? jsonPayload(from: job.terminalMessage) : [:]
+        let sourcePayload = payload.isEmpty ? terminalPayload : payload
+        let errorPayload = dictionaryValue("error", from: sourcePayload)
+        let detailsPayload = responseOnlyDetailsPayload(sourcePayload: sourcePayload, errorPayload: errorPayload)
+        let errorCode = firstNonEmpty(
+            manifestTextValue("error_code", primary: sourcePayload, fallback: errorPayload),
+            manifestTextValue("code", primary: sourcePayload, fallback: errorPayload)
+        )
+        let terminalContainsGuardCode = job.terminalMessage.contains("response_only_labels_truncated")
+        let maxSeqLengthText = responseOnlyTextValue("max_seq_length", details: detailsPayload, payload: sourcePayload)
+        let sampleCountText = responseOnlyTextValue("response_only_boundary_sample_count", details: detailsPayload, payload: sourcePayload)
+        let boundaryMinText = responseOnlyTextValue("response_only_boundary_min", details: detailsPayload, payload: sourcePayload)
+        let boundaryMaxText = responseOnlyTextValue("response_only_boundary_max", details: detailsPayload, payload: sourcePayload)
+        let boundaryMeanText = responseOnlyTextValue("response_only_boundary_mean", details: detailsPayload, payload: sourcePayload)
+        let responseTokensMeanText = responseOnlyTextValue("response_only_response_tokens_mean", details: detailsPayload, payload: sourcePayload)
+        let trainableResponseTokenCountText = responseOnlyTextValue(
+            "response_only_trainable_response_token_count",
+            details: detailsPayload,
+            payload: sourcePayload
+        )
+        let fullyTruncatedSampleCountText = responseOnlyTextValue(
+            "response_only_fully_truncated_response_sample_count",
+            details: detailsPayload,
+            payload: sourcePayload
+        )
+        let truncatedSampleCountText = responseOnlyTextValue(
+            "response_only_truncated_response_sample_count",
+            details: detailsPayload,
+            payload: sourcePayload
+        )
+        let hasReceiptFields = [
+            maxSeqLengthText,
+            sampleCountText,
+            boundaryMinText,
+            boundaryMaxText,
+            boundaryMeanText,
+            responseTokensMeanText,
+            trainableResponseTokenCountText,
+            fullyTruncatedSampleCountText,
+            truncatedSampleCountText,
+        ].contains { $0.isEmpty == false }
+        guard errorCode == "response_only_labels_truncated" || terminalContainsGuardCode || hasReceiptFields else {
+            return nil
+        }
+
+        return RuntimeResponseOnlySafetyReceiptState(
+            errorCode: errorCode.isEmpty && terminalContainsGuardCode ? "response_only_labels_truncated" : errorCode,
+            maxSeqLengthText: maxSeqLengthText,
+            boundarySampleCountText: sampleCountText,
+            boundaryRangeText: boundaryRangeText(min: boundaryMinText, max: boundaryMaxText),
+            boundaryMeanText: boundaryMeanText,
+            responseTokensMeanText: responseTokensMeanText,
+            trainableResponseTokenCountText: trainableResponseTokenCountText,
+            fullyTruncatedSampleCountText: fullyTruncatedSampleCountText,
+            truncatedSampleCountText: truncatedSampleCountText
         )
     }
 
@@ -15885,6 +15973,70 @@ public final class RuntimeViewModel {
 
     private static func dictionaryValue(_ key: String, from payload: [String: Any]) -> [String: Any] {
         payload[key] as? [String: Any] ?? [:]
+    }
+
+    private static func responseOnlyDetailsPayload(
+        sourcePayload: [String: Any],
+        errorPayload: [String: Any]
+    ) -> [String: Any] {
+        let errorDetails = dictionaryValue("details", from: errorPayload)
+        if errorDetails.isEmpty == false {
+            return errorDetails
+        }
+        return dictionaryValue("details", from: sourcePayload)
+    }
+
+    private static func responseOnlyTextValue(
+        _ key: String,
+        details: [String: Any],
+        payload: [String: Any]
+    ) -> String {
+        manifestTextValue(key, primary: details, fallback: payload)
+    }
+
+    private static func manifestTextValue(
+        _ key: String,
+        primary: [String: Any],
+        fallback: [String: Any]
+    ) -> String {
+        if let value = primary[key] {
+            return scalarManifestText(value)
+        }
+        if let value = fallback[key] {
+            return scalarManifestText(value)
+        }
+        return ""
+    }
+
+    private static func scalarManifestText(_ value: Any) -> String {
+        switch value {
+        case let string as String:
+            return string.trimmingCharacters(in: .whitespacesAndNewlines)
+        case let int as Int:
+            return "\(int)"
+        case let int64 as Int64:
+            return "\(int64)"
+        case let double as Double:
+            return double.rounded() == double ? "\(Int(double))" : String(format: "%.3f", double)
+        case let number as NSNumber:
+            return number.stringValue
+        default:
+            return ""
+        }
+    }
+
+    private static func firstNonEmpty(_ values: String...) -> String {
+        values.first { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false } ?? ""
+    }
+
+    private static func boundaryRangeText(min: String, max: String) -> String {
+        if min.isEmpty {
+            return max
+        }
+        if max.isEmpty {
+            return min
+        }
+        return "\(min)-\(max)"
     }
 
     private static func intValue(_ key: String, from payload: [String: Any]) -> Int {

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -1773,16 +1773,19 @@ public struct RuntimeResponseOnlySafetyReceiptState: Equatable, Sendable {
     public let boundaryMeanText: String
     public let responseTokensMeanText: String
     public let trainableResponseTokenCountText: String
+    public let trainableResponseTokenCount: Int?
     public let fullyTruncatedSampleCountText: String
+    public let fullyTruncatedSampleCount: Int?
     public let truncatedSampleCountText: String
+    public let truncatedSampleCount: Int?
 
     public var status: Status {
         if errorCode == "response_only_labels_truncated"
-            || (trainableResponseTokenCountText == "0" && fullyTruncatedSampleCountText.isEmpty == false)
+            || (trainableResponseTokenCount == 0 && (fullyTruncatedSampleCount ?? 0) > 0)
         {
             return .blocked
         }
-        if truncatedSampleCountText.isEmpty == false && truncatedSampleCountText != "0" {
+        if (truncatedSampleCount ?? 0) > 0 {
             return .truncated
         }
         return .observed
@@ -1793,7 +1796,12 @@ public struct RuntimeResponseOnlySafetyReceiptState: Equatable, Sendable {
     }
 
     public var recoveryHint: String {
-        "Increase max_seq_length, shorten the system prompt, or disable response-only masking."
+        switch status {
+        case .blocked, .truncated:
+            return "Increase max_seq_length, shorten the system prompt, or disable response-only masking."
+        case .observed:
+            return ""
+        }
     }
 }
 
@@ -6675,26 +6683,45 @@ public final class RuntimeViewModel {
             manifestTextValue("code", primary: sourcePayload, fallback: errorPayload)
         )
         let terminalContainsGuardCode = job.terminalMessage.contains("response_only_labels_truncated")
-        let maxSeqLengthText = responseOnlyTextValue("max_seq_length", details: detailsPayload, payload: sourcePayload)
-        let sampleCountText = responseOnlyTextValue("response_only_boundary_sample_count", details: detailsPayload, payload: sourcePayload)
-        let boundaryMinText = responseOnlyTextValue("response_only_boundary_min", details: detailsPayload, payload: sourcePayload)
-        let boundaryMaxText = responseOnlyTextValue("response_only_boundary_max", details: detailsPayload, payload: sourcePayload)
-        let boundaryMeanText = responseOnlyTextValue("response_only_boundary_mean", details: detailsPayload, payload: sourcePayload)
-        let responseTokensMeanText = responseOnlyTextValue("response_only_response_tokens_mean", details: detailsPayload, payload: sourcePayload)
-        let trainableResponseTokenCountText = responseOnlyTextValue(
+        let maxSeqLengthText = manifestTextValue("max_seq_length", primary: detailsPayload, fallback: sourcePayload)
+        let sampleCountText = manifestTextValue("response_only_boundary_sample_count", primary: detailsPayload, fallback: sourcePayload)
+        let boundaryMinText = manifestTextValue("response_only_boundary_min", primary: detailsPayload, fallback: sourcePayload)
+        let boundaryMaxText = manifestTextValue("response_only_boundary_max", primary: detailsPayload, fallback: sourcePayload)
+        let boundaryMeanText = manifestTextValue("response_only_boundary_mean", primary: detailsPayload, fallback: sourcePayload)
+        let responseTokensMeanText = manifestTextValue(
+            "response_only_response_tokens_mean",
+            primary: detailsPayload,
+            fallback: sourcePayload
+        )
+        let trainableResponseTokenCountText = manifestTextValue(
             "response_only_trainable_response_token_count",
-            details: detailsPayload,
-            payload: sourcePayload
+            primary: detailsPayload,
+            fallback: sourcePayload
         )
-        let fullyTruncatedSampleCountText = responseOnlyTextValue(
+        let trainableResponseTokenCount = manifestIntValue(
+            "response_only_trainable_response_token_count",
+            primary: detailsPayload,
+            fallback: sourcePayload
+        )
+        let fullyTruncatedSampleCountText = manifestTextValue(
             "response_only_fully_truncated_response_sample_count",
-            details: detailsPayload,
-            payload: sourcePayload
+            primary: detailsPayload,
+            fallback: sourcePayload
         )
-        let truncatedSampleCountText = responseOnlyTextValue(
+        let fullyTruncatedSampleCount = manifestIntValue(
+            "response_only_fully_truncated_response_sample_count",
+            primary: detailsPayload,
+            fallback: sourcePayload
+        )
+        let truncatedSampleCountText = manifestTextValue(
             "response_only_truncated_response_sample_count",
-            details: detailsPayload,
-            payload: sourcePayload
+            primary: detailsPayload,
+            fallback: sourcePayload
+        )
+        let truncatedSampleCount = manifestIntValue(
+            "response_only_truncated_response_sample_count",
+            primary: detailsPayload,
+            fallback: sourcePayload
         )
         let hasReceiptFields = [
             maxSeqLengthText,
@@ -6719,8 +6746,11 @@ public final class RuntimeViewModel {
             boundaryMeanText: boundaryMeanText,
             responseTokensMeanText: responseTokensMeanText,
             trainableResponseTokenCountText: trainableResponseTokenCountText,
+            trainableResponseTokenCount: trainableResponseTokenCount,
             fullyTruncatedSampleCountText: fullyTruncatedSampleCountText,
-            truncatedSampleCountText: truncatedSampleCountText
+            fullyTruncatedSampleCount: fullyTruncatedSampleCount,
+            truncatedSampleCountText: truncatedSampleCountText,
+            truncatedSampleCount: truncatedSampleCount
         )
     }
 
@@ -16007,14 +16037,6 @@ public final class RuntimeViewModel {
         return dictionaryValue("details", from: sourcePayload)
     }
 
-    private static func responseOnlyTextValue(
-        _ key: String,
-        details: [String: Any],
-        payload: [String: Any]
-    ) -> String {
-        manifestTextValue(key, primary: details, fallback: payload)
-    }
-
     private static func manifestTextValue(
         _ key: String,
         primary: [String: Any],
@@ -16027,6 +16049,20 @@ public final class RuntimeViewModel {
             return scalarManifestText(value)
         }
         return ""
+    }
+
+    private static func manifestIntValue(
+        _ key: String,
+        primary: [String: Any],
+        fallback: [String: Any]
+    ) -> Int? {
+        if let value = primary[key] {
+            return scalarManifestInt(value)
+        }
+        if let value = fallback[key] {
+            return scalarManifestInt(value)
+        }
+        return nil
     }
 
     private static func scalarManifestText(_ value: Any) -> String {
@@ -16046,6 +16082,40 @@ public final class RuntimeViewModel {
             return number.stringValue
         default:
             return ""
+        }
+    }
+
+    private static func scalarManifestInt(_ value: Any) -> Int? {
+        switch value {
+        case let int as Int:
+            return int
+        case let int64 as Int64:
+            guard int64 <= Int64(Int.max), int64 >= Int64(Int.min) else {
+                return nil
+            }
+            return Int(int64)
+        case let double as Double:
+            guard double.isFinite, double.rounded() == double else {
+                return nil
+            }
+            return Int(double)
+        case let number as NSNumber:
+            let double = number.doubleValue
+            guard double.isFinite, double.rounded() == double else {
+                return nil
+            }
+            return Int(double)
+        case let string as String:
+            let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let int = Int(trimmed) {
+                return int
+            }
+            if let double = Double(trimmed), double.isFinite, double.rounded() == double {
+                return Int(double)
+            }
+            return nil
+        default:
+            return nil
         }
     }
 

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -1749,6 +1749,23 @@ public struct RuntimeAdapterCapabilityReceiptState: Equatable, Sendable {
 }
 
 public struct RuntimeResponseOnlySafetyReceiptState: Equatable, Sendable {
+    public enum Status: String, Sendable {
+        case blocked
+        case truncated
+        case observed
+
+        public var text: String {
+            switch self {
+            case .blocked:
+                return "Blocked"
+            case .truncated:
+                return "Truncated"
+            case .observed:
+                return "Observed"
+            }
+        }
+    }
+
     public let errorCode: String
     public let maxSeqLengthText: String
     public let boundarySampleCountText: String
@@ -1759,16 +1776,20 @@ public struct RuntimeResponseOnlySafetyReceiptState: Equatable, Sendable {
     public let fullyTruncatedSampleCountText: String
     public let truncatedSampleCountText: String
 
-    public var statusText: String {
+    public var status: Status {
         if errorCode == "response_only_labels_truncated"
             || (trainableResponseTokenCountText == "0" && fullyTruncatedSampleCountText.isEmpty == false)
         {
-            return "Blocked"
+            return .blocked
         }
         if truncatedSampleCountText.isEmpty == false && truncatedSampleCountText != "0" {
-            return "Truncated"
+            return .truncated
         }
-        return "Observed"
+        return .observed
+    }
+
+    public var statusText: String {
+        status.text
     }
 
     public var recoveryHint: String {
@@ -16017,7 +16038,10 @@ public final class RuntimeViewModel {
         case let int64 as Int64:
             return "\(int64)"
         case let double as Double:
-            return double.rounded() == double ? "\(Int(double))" : String(format: "%.3f", double)
+            if double.rounded() == double {
+                return "\(Int(double))"
+            }
+            return double.formatted(.number.precision(.fractionLength(3)))
         case let number as NSNumber:
             return number.stringValue
         default:

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -114,6 +114,40 @@ struct DesktopFoundationViewTests {
         #expect(DesktopLoRAVisualPolish.chartFillOpacity == 0.24)
     }
 
+    @Test("diagnostics throughput bars declare a fixed mark width")
+    func diagnosticsThroughputBarsDeclareFixedMarkWidth() throws {
+        let root = try repositoryRootForDesktopFoundationTests()
+        let shellSourceURL = root.appendingPathComponent(
+            "apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift"
+        )
+        let shellSource = try String(contentsOf: shellSourceURL, encoding: .utf8)
+        let throughputChartSource = try #require(
+            shellSource.slice(
+                from: "Chart(viewModel.benchmarkMatrixThroughputChartPoints)",
+                to: ".chartLegend(.hidden)"
+            )
+        )
+
+        #expect(throughputChartSource.contains("width: .fixed(12)"))
+    }
+
+    @Test("menubar swift verification disables noisy debug info")
+    func menubarSwiftVerificationDisablesNoisyDebugInfo() throws {
+        let root = try repositoryRootForDesktopFoundationTests()
+        let makefileURL = root.appendingPathComponent("Makefile")
+        let makefile = try String(contentsOf: makefileURL, encoding: .utf8)
+        let menubarTestTarget = try #require(
+            makefile.slice(from: "swift-test-menubar:", to: "py-test:")
+        )
+        let menubarCoverageCommand = try #require(
+            makefile.slice(from: "swift-coverage:", to: "py-coverage:")
+        )
+
+        #expect(makefile.contains("MENUBAR_SWIFT_TEST_FLAGS := -Xswiftc -gnone"))
+        #expect(menubarTestTarget.contains("$(MENUBAR_SWIFT_TEST_FLAGS)"))
+        #expect(menubarCoverageCommand.contains("$(MENUBAR_SWIFT_TEST_FLAGS)"))
+    }
+
     @Test("command center visuals track design-system and Apple-style inputs")
     func commandCenterVisualsTrackDesignInputs() {
         #expect(DesktopCommandCenterVisuals.visualDirection == "Digital Broadsheet Command Center")
@@ -3726,6 +3760,69 @@ struct DesktopFoundationViewTests {
         #expect(renderedTexts.contains("Unsupported"))
         #expect(renderedTexts.contains("Unsupported Reason"))
         #expect(renderedTexts.contains("unsupported_backend"))
+    }
+
+    @Test("training surface renders response-only truncation safety receipt")
+    @MainActor
+    func trainingSurfaceRendersResponseOnlyTruncationSafetyReceipt() async throws {
+        let config = LoraTrainingJobConfig(
+            modelID: "melix-dev-text",
+            datasetSourceKind: "hf_dataset",
+            hfDatasetPath: "HuggingFaceH4/ultrachat_200k",
+            hfTrainSplit: "train_sft",
+            chatFeature: "messages",
+            adapterName: "truncated-response-adapter",
+            trainingMode: "qlora",
+            activationMode: "adapter_backed_runtime",
+            maxSeqLength: "1024",
+            responseOnly: true,
+            maskPrompt: true
+        )
+        let job = LoraTrainingJobRecord(
+            id: "response-only-truncated-job",
+            title: "Response-only Truncated Job",
+            config: config,
+            status: .failed,
+            lastRunJobID: "model-ops-response-only",
+            outputPath: "/tmp/melix-train-lora/train_lora.adapter.json",
+            manifestPath: "/tmp/melix-train-lora/train_lora.adapter.json",
+            latestOutputText: #"""
+            {
+              "error_code": "response_only_labels_truncated",
+              "details": {
+                "max_seq_length": "1024",
+                "response_only_boundary_sample_count": "2",
+                "response_only_boundary_min": "1100",
+                "response_only_boundary_max": "1200",
+                "response_only_boundary_mean": "1150.000",
+                "response_only_response_tokens_mean": "9.000",
+                "response_only_trainable_response_token_count": "0",
+                "response_only_fully_truncated_response_sample_count": "2"
+              }
+            }
+            """#,
+            terminalMessage: "Training failed."
+        )
+        let viewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            loraTrainingJobStore: FakeLoraTrainingJobStore(jobs: [job])
+        )
+
+        let view = hostView(
+            DesktopTrainingToolSectionView(viewModel: viewModel),
+            size: CGSize(width: 1280, height: 1800)
+        )
+        let renderedTexts = renderedTextValues(in: view)
+
+        #expect(renderedTexts.contains("Response-only Safety"))
+        #expect(renderedTexts.contains("Blocked"))
+        #expect(renderedTexts.contains("Increase max_seq_length, shorten the system prompt, or disable response-only masking."))
+        #expect(renderedTexts.contains("Max Seq Length"))
+        #expect(renderedTexts.contains("1024"))
+        #expect(renderedTexts.contains("Boundary Range"))
+        #expect(renderedTexts.contains("1100-1200"))
+        #expect(renderedTexts.contains("Trainable Response Tokens"))
+        #expect(renderedTexts.contains("Fully Truncated Samples"))
     }
 
     @Test("training surface renders saved lora adapter support matrix receipt")

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -3825,6 +3825,111 @@ struct DesktopFoundationViewTests {
         #expect(renderedTexts.contains("Fully Truncated Samples"))
     }
 
+    @Test("training surface suppresses response-only recovery for observed jobs")
+    @MainActor
+    func trainingSurfaceSuppressesResponseOnlyRecoveryForObservedJobs() async throws {
+        let config = LoraTrainingJobConfig(
+            modelID: "melix-dev-text",
+            datasetSourceKind: "hf_dataset",
+            hfDatasetPath: "HuggingFaceH4/ultrachat_200k",
+            hfTrainSplit: "train_sft",
+            chatFeature: "messages",
+            adapterName: "observed-response-adapter",
+            trainingMode: "qlora",
+            activationMode: "adapter_backed_runtime",
+            maxSeqLength: "2048",
+            responseOnly: true,
+            maskPrompt: true
+        )
+        let job = LoraTrainingJobRecord(
+            id: "response-only-observed-job",
+            title: "Response-only Observed Job",
+            config: config,
+            status: .succeeded,
+            latestOutputText: #"""
+            {
+              "details": {
+                "max_seq_length": "2048",
+                "response_only_boundary_sample_count": "3",
+                "response_only_boundary_min": "128",
+                "response_only_boundary_max": "256",
+                "response_only_response_tokens_mean": "9.500",
+                "response_only_trainable_response_token_count": "24"
+              }
+            }
+            """#,
+            terminalMessage: "Training completed."
+        )
+        let viewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            loraTrainingJobStore: FakeLoraTrainingJobStore(jobs: [job])
+        )
+
+        let view = hostView(
+            DesktopTrainingToolSectionView(viewModel: viewModel),
+            size: CGSize(width: 1280, height: 1800)
+        )
+        let renderedTexts = renderedTextValues(in: view)
+
+        #expect(renderedTexts.contains("Response-only Safety"))
+        #expect(renderedTexts.contains("Observed"))
+        #expect(renderedTexts.contains("Recovery") == false)
+        #expect(renderedTexts.contains("Increase max_seq_length, shorten the system prompt, or disable response-only masking.") == false)
+    }
+
+    @Test("training surface renders response-only partially truncated sample counts")
+    @MainActor
+    func trainingSurfaceRendersResponseOnlyPartiallyTruncatedSampleCounts() async throws {
+        let config = LoraTrainingJobConfig(
+            modelID: "melix-dev-text",
+            datasetSourceKind: "hf_dataset",
+            hfDatasetPath: "HuggingFaceH4/ultrachat_200k",
+            hfTrainSplit: "train_sft",
+            chatFeature: "messages",
+            adapterName: "partially-truncated-response-adapter",
+            trainingMode: "qlora",
+            activationMode: "adapter_backed_runtime",
+            maxSeqLength: "1024",
+            responseOnly: true,
+            maskPrompt: true
+        )
+        let job = LoraTrainingJobRecord(
+            id: "response-only-partially-truncated-job",
+            title: "Response-only Partially Truncated Job",
+            config: config,
+            status: .succeeded,
+            latestOutputText: #"""
+            {
+              "details": {
+                "max_seq_length": "1024",
+                "response_only_boundary_sample_count": "3",
+                "response_only_boundary_min": "900",
+                "response_only_boundary_max": "1120",
+                "response_only_response_tokens_mean": "7.000",
+                "response_only_trainable_response_token_count": "12",
+                "response_only_truncated_response_sample_count": "1"
+              }
+            }
+            """#,
+            terminalMessage: "Training completed."
+        )
+        let viewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            loraTrainingJobStore: FakeLoraTrainingJobStore(jobs: [job])
+        )
+
+        let view = hostView(
+            DesktopTrainingToolSectionView(viewModel: viewModel),
+            size: CGSize(width: 1280, height: 1800)
+        )
+        let renderedTexts = renderedTextValues(in: view)
+
+        #expect(renderedTexts.contains("Response-only Safety"))
+        #expect(renderedTexts.contains("Truncated"))
+        #expect(renderedTexts.contains("Truncated Samples"))
+        #expect(renderedTexts.contains("1"))
+    }
+
     @Test("training surface renders saved lora adapter support matrix receipt")
     @MainActor
     func trainingSurfaceRendersSavedLoraAdapterSupportMatrixReceipt() async throws {

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -9796,6 +9796,7 @@ struct RuntimeViewModelTests {
         let receipt = try #require(RuntimeViewModel.responseOnlySafetyReceipt(from: job))
 
         #expect(receipt.statusText == "Blocked")
+        #expect(receipt.status == .blocked)
         #expect(receipt.errorCode == "response_only_labels_truncated")
         #expect(receipt.recoveryHint == "Increase max_seq_length, shorten the system prompt, or disable response-only masking.")
         #expect(receipt.maxSeqLengthText == "1024")
@@ -9804,6 +9805,42 @@ struct RuntimeViewModelTests {
         #expect(receipt.responseTokensMeanText == "9.000")
         #expect(receipt.trainableResponseTokenCountText == "0")
         #expect(receipt.fullyTruncatedSampleCountText == "2")
+    }
+
+    @Test("lora saved job response-only receipt formats numeric manifest values")
+    @MainActor
+    func loraSavedJobResponseOnlyReceiptFormatsNumericManifestValues() throws {
+        var config = makeDesktopLoraTrainingConfig(adapterName: "observed-response-adapter")
+        config.maxSeqLength = "2048"
+        let job = LoraTrainingJobRecord(
+            id: "response-only-observed-job",
+            title: "Response-only Observed Job",
+            config: config,
+            status: .succeeded,
+            latestOutputText: #"""
+            {
+              "details": {
+                "max_seq_length": 2048,
+                "response_only_boundary_sample_count": 3,
+                "response_only_boundary_min": 128,
+                "response_only_boundary_max": 256,
+                "response_only_boundary_mean": 192.1254,
+                "response_only_response_tokens_mean": 9.5,
+                "response_only_trainable_response_token_count": 24
+              }
+            }
+            """#,
+            terminalMessage: "Training completed."
+        )
+
+        let receipt = try #require(RuntimeViewModel.responseOnlySafetyReceipt(from: job))
+
+        #expect(receipt.status == RuntimeResponseOnlySafetyReceiptState.Status.observed)
+        #expect(receipt.statusText == "Observed")
+        #expect(receipt.maxSeqLengthText == "2048")
+        #expect(receipt.boundaryMeanText.contains("192"))
+        #expect(receipt.responseTokensMeanText.contains("9"))
+        #expect(receipt.trainableResponseTokenCountText == "24")
     }
 
     @Test("lora saved job follow-up actions route existing desktop surfaces")

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -9758,6 +9758,54 @@ struct RuntimeViewModelTests {
         #expect(store.savedRecords.contains { $0.status == .failed })
     }
 
+    @Test("lora saved job response-only truncation receipt decodes recovery fields")
+    @MainActor
+    func loraSavedJobResponseOnlyTruncationReceiptDecodesRecoveryFields() throws {
+        var config = makeDesktopLoraTrainingConfig(adapterName: "truncated-response-adapter")
+        config.maxSeqLength = "1024"
+        let job = LoraTrainingJobRecord(
+            id: "response-only-truncated-job",
+            title: "Response-only Truncated Job",
+            config: config,
+            status: .failed,
+            createdAt: Date(timeIntervalSince1970: 1_714_000_000),
+            updatedAt: Date(timeIntervalSince1970: 1_714_000_100),
+            startedAt: Date(timeIntervalSince1970: 1_714_000_050),
+            completedAt: Date(timeIntervalSince1970: 1_714_000_100),
+            lastRunJobID: "model-ops-response-only",
+            outputPath: "/tmp/melix-train-lora/train_lora.adapter.json",
+            manifestPath: "/tmp/melix-train-lora/train_lora.adapter.json",
+            latestOutputText: #"""
+            {
+              "error_code": "response_only_labels_truncated",
+              "details": {
+                "max_seq_length": "1024",
+                "response_only_boundary_sample_count": "2",
+                "response_only_boundary_min": "1100",
+                "response_only_boundary_max": "1200",
+                "response_only_boundary_mean": "1150.000",
+                "response_only_response_tokens_mean": "9.000",
+                "response_only_trainable_response_token_count": "0",
+                "response_only_fully_truncated_response_sample_count": "2"
+              }
+            }
+            """#,
+            terminalMessage: "Training failed."
+        )
+
+        let receipt = try #require(RuntimeViewModel.responseOnlySafetyReceipt(from: job))
+
+        #expect(receipt.statusText == "Blocked")
+        #expect(receipt.errorCode == "response_only_labels_truncated")
+        #expect(receipt.recoveryHint == "Increase max_seq_length, shorten the system prompt, or disable response-only masking.")
+        #expect(receipt.maxSeqLengthText == "1024")
+        #expect(receipt.boundaryRangeText == "1100-1200")
+        #expect(receipt.boundaryMeanText == "1150.000")
+        #expect(receipt.responseTokensMeanText == "9.000")
+        #expect(receipt.trainableResponseTokenCountText == "0")
+        #expect(receipt.fullyTruncatedSampleCountText == "2")
+    }
+
     @Test("lora saved job follow-up actions route existing desktop surfaces")
     @MainActor
     func loraSavedJobFollowUpActionsRouteExistingDesktopSurfaces() async throws {

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -9841,6 +9841,39 @@ struct RuntimeViewModelTests {
         #expect(receipt.boundaryMeanText.contains("192"))
         #expect(receipt.responseTokensMeanText.contains("9"))
         #expect(receipt.trainableResponseTokenCountText == "24")
+        #expect(receipt.recoveryHint.isEmpty)
+    }
+
+    @Test("lora saved job response-only receipt classifies numeric string zero as blocked")
+    @MainActor
+    func loraSavedJobResponseOnlyReceiptClassifiesNumericStringZeroAsBlocked() throws {
+        var config = makeDesktopLoraTrainingConfig(adapterName: "blocked-response-adapter")
+        config.maxSeqLength = "1024"
+        let job = LoraTrainingJobRecord(
+            id: "response-only-blocked-zero-string-job",
+            title: "Response-only Blocked Zero String Job",
+            config: config,
+            status: .failed,
+            latestOutputText: #"""
+            {
+              "details": {
+                "max_seq_length": "1024",
+                "response_only_boundary_sample_count": "2",
+                "response_only_boundary_min": "1100",
+                "response_only_boundary_max": "1200",
+                "response_only_trainable_response_token_count": "0.0",
+                "response_only_fully_truncated_response_sample_count": "2"
+              }
+            }
+            """#,
+            terminalMessage: "Training failed."
+        )
+
+        let receipt = try #require(RuntimeViewModel.responseOnlySafetyReceipt(from: job))
+
+        #expect(receipt.status == .blocked)
+        #expect(receipt.trainableResponseTokenCountText == "0.0")
+        #expect(receipt.fullyTruncatedSampleCountText == "2")
     }
 
     @Test("lora saved job follow-up actions route existing desktop surfaces")

--- a/docs/plans/2026-05-18-response-only-lora-ui-receipts.md
+++ b/docs/plans/2026-05-18-response-only-lora-ui-receipts.md
@@ -1,0 +1,33 @@
+# Response-Only LoRA UI Receipts Plan
+
+## Goal
+
+Surface the response-only LoRA truncated-label guard added in #1231 as
+structured Window UI evidence instead of leaving operators to inspect raw JSON
+or terminal output.
+
+## Scope
+
+- Decode `response_only_labels_truncated` and the related response-only token
+  metrics from saved LoRA training job output.
+- Render a dedicated saved-job detail section for response-only safety,
+  including the recovery hint, `max_seq_length`, boundary statistics, trainable
+  response token count, and fully truncated sample count.
+- Keep the raw output disclosure for auditability, but make the actionable
+  failure reason visible before it.
+
+## Out Of Scope
+
+- Changing the backend guard or training semantics.
+- Adding a new training execution path.
+- Launching the app or running manual UI E2E for this focused follow-up.
+
+## Verification
+
+- Add focused `RuntimeViewModelTests` coverage for receipt decoding.
+- Add focused `DesktopFoundationViewTests` coverage for saved-job detail
+  rendering.
+- Keep the macOS menubar Makefile verification path on `-Xswiftc -gnone`
+  while the Swift 6.2/macOS 26 linker emits DWARF input-verification noise for
+  full debug symbols in this SwiftUI-heavy test bundle.
+- Run the touched Swift test filters after implementation.

--- a/docs/plans/2026-05-18-response-only-lora-ui-receipts.md
+++ b/docs/plans/2026-05-18-response-only-lora-ui-receipts.md
@@ -11,8 +11,14 @@ or terminal output.
 - Decode `response_only_labels_truncated` and the related response-only token
   metrics from saved LoRA training job output.
 - Render a dedicated saved-job detail section for response-only safety,
-  including the recovery hint, `max_seq_length`, boundary statistics, trainable
-  response token count, and fully truncated sample count.
+  including status-aware recovery guidance, `max_seq_length`, boundary
+  statistics, trainable response token count, truncated sample count, and fully
+  truncated sample count.
+- Classify receipt status from typed numeric count fields rather than formatted
+  display strings, so `"0"`, `"0.0"`, and numeric zero payloads classify
+  consistently.
+- Suppress remediation guidance for observed healthy jobs so successful
+  response-only runs do not show false recovery instructions.
 - Keep the raw output disclosure for auditability, but make the actionable
   failure reason visible before it.
 


### PR DESCRIPTION
## Summary
- Surface response-only LoRA truncation receipts in the Window UI saved training job detail, including status-aware recovery guidance and token/boundary diagnostics.
- Use typed numeric response-only counts for receipt classification, suppress recovery copy for observed healthy jobs, and render partially truncated sample counts.
- Fix the diagnostics throughput chart bar width and keep menubar Swift verification on `-gnone` to remove the targeted Charts fallback and Swift input-verification warnings from the verified path.

## Plan or Spec
- `docs/plans/2026-05-18-response-only-lora-ui-receipts.md`

## Commands Run
```text
git fetch origin codex/window-ui-response-only-receipts main
Result: passed; PR branch and origin/main were refreshed.

git rebase origin/main
Result: passed; PR branch rebased onto current origin/main before the review-fix commit.

swift test --package-path apps/macos-menubar -Xswiftc -gnone --filter RuntimeViewModelTests/loraSavedJobResponseOnlyReceiptClassifiesNumericStringZeroAsBlocked
Result: failed before the fix with .observed instead of .blocked; passed after the fix.

swift test --package-path apps/macos-menubar -Xswiftc -gnone --filter DesktopFoundationViewTests/trainingSurfaceSuppressesResponseOnlyRecoveryForObservedJobs
Result: failed before the fix because Recovery and the remediation hint rendered for observed jobs; passed after the fix.

swift test --package-path apps/macos-menubar -Xswiftc -gnone --filter DesktopFoundationViewTests/trainingSurfaceRendersResponseOnlyPartiallyTruncatedSampleCounts
Result: failed before the fix because Truncated Samples and its count were absent; passed after the fix.

swift test --package-path apps/macos-menubar -Xswiftc -gnone --filter RuntimeViewModelTests
Result: passed, 278 tests.

swift test --package-path apps/macos-menubar -Xswiftc -gnone --filter DesktopFoundationViewTests
Result: passed, 228 tests.

xcrun swift test --package-path apps/macos-menubar --disable-sandbox -Xswiftc -gnone --filter RuntimeViewModelTests
Result: passed, 278 tests with the Makefile toolchain and debug-info flag.

xcrun swift test --package-path apps/macos-menubar --disable-sandbox -Xswiftc -gnone --filter DesktopFoundationViewTests
Result: passed, 228 tests with the Makefile toolchain and debug-info flag.

make swift-test-menubar
Result: failed in the Codex sandbox after cleaning SwiftPM artifacts because SwiftPM manifest sandboxing calls sandbox-exec, which is not permitted here. The same xcrun swift test command succeeds with --disable-sandbox.

git diff --check
Result: passed.

make swift-coverage
Result: failed before the menubar coverage summary in services/control-plane-swift RequestCoordinatorTests active-KV defaults. This PR does not change services/control-plane-swift.
```

## Coverage and Metrics
- Changed-scope automated coverage: `RuntimeViewModelTests` and `DesktopFoundationViewTests` passed locally and through the `xcrun swift test ... -Xswiftc -gnone` path with `--disable-sandbox` for this Codex environment.
- Full Swift coverage: attempted, but blocked by a non-menubar control-plane failure before the menubar coverage summary could be produced.
- PR scoped performance report: `ok`; selected probes `0`; regressions `0`; context regressions `0`.
- Runtime/performance metrics: `N/A: this change renders existing UI receipts and removes test/log warnings; it does not add a production runtime path or observability probe.`
- Observability mode: `off`; probe overhead: `N/A`.

## Known Gaps
- Full `make swift-coverage` is not green in this local run because `services/control-plane-swift` RequestCoordinator active-KV default tests failed before menubar coverage reporting.
- Direct `make swift-test-menubar` is blocked in this Codex sandbox after SwiftPM cache cleanup by SwiftPM manifest sandboxing (`sandbox-exec: Operation not permitted`). The equivalent `xcrun swift test` commands pass when run with `--disable-sandbox`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
