### PR TITLE
perf: cache parsed video URI metadata

### DIFF
--- a/docs/plans/2026-05-18-video-preprocessing-uri-parse-cache.md
+++ b/docs/plans/2026-05-18-video-preprocessing-uri-parse-cache.md
@@ -1,0 +1,28 @@
+# Video preprocessing URI parse cache slice
+
+This Python-only performance slice targets repeated URI video preprocessing in `services/mlx-worker-python/worker/runtime/video_preprocessing.py`.
+
+## Scope
+
+Cache `_parse_video_reference()` results for repeated URI/path strings with a bounded `lru_cache`. The `ParsedVideoReference` result is immutable (`slots=True`, `frozen=True`), so repeated preprocessing of the same URI can reuse decoded path/name/suffix metadata without changing validation, format inference, filename fallback, byte-length accounting, or identity-hash payloads.
+
+## Registered probe coverage
+
+The affected path is covered by the existing PR-scoped registered probe `video-preprocessing-uri-byte-length-reuse` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/video_preprocessing_uri_probe.py`
+
+## Verification plan
+
+1. Run the focused registered test command for `video-preprocessing-uri-byte-length-reuse`.
+2. Run the registered changed-scope coverage command and require at least 95% measured scope coverage.
+3. Run the registered local Linux probe before and after the implementation.
+4. Push the branch only if the probe direction is favorable or the delta is clearly neutral with explainable measurement noise.
+5. Treat hosted PR-scoped performance CI as the merge gate.
+
+## Metrics
+
+Primary metric: `elapsed_ms_mean` from `video-preprocessing-uri-byte-length-reuse` (lower is better). Secondary guard metrics: `byte_length_getattrs_per_call` and `parse_calls_per_call` must not regress; parse-call instrumentation wraps the parser function and may remain at one wrapper call per preprocessing call even when the internal parser result is served from the cache.

--- a/services/mlx-worker-python/tests/test_video_preprocessing.py
+++ b/services/mlx-worker-python/tests/test_video_preprocessing.py
@@ -210,6 +210,19 @@ def test_parse_video_reference_decodes_remote_and_file_uris_once() -> None:
     assert local.path_suffix == "webm"
 
 
+def test_parse_video_reference_caches_repeated_uri_metadata() -> None:
+    _parse_video_reference.cache_clear()
+
+    first = _parse_video_reference("https://example.com/media/reused%20clip.mov")
+    second = _parse_video_reference("https://example.com/media/reused%20clip.mov")
+    cache_info = _parse_video_reference.cache_info()
+
+    assert second is first
+    assert cache_info.hits == 1
+    assert cache_info.misses == 1
+    assert second.path_name == "reused clip.mov"
+
+
 @pytest.mark.parametrize(
     ("reference", "expected_name", "expected_suffix"),
     [

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -18,6 +18,7 @@ SUPPORTED_VIDEO_MIME_TYPES = {
     "video/webm": "webm",
 }
 MAX_VIDEO_FRAME_BUDGET = 128
+VIDEO_REFERENCE_PARSE_CACHE_SIZE = 512
 
 
 @dataclass(frozen=True, slots=True)
@@ -133,7 +134,7 @@ def _validate_bounds(duration_ms: int, frame_budget: int, start_ms: int, end_ms:
         raise VideoPreprocessError("end_ms must be less than or equal to duration_ms.")
 
 
-@lru_cache(maxsize=512)
+@lru_cache(maxsize=VIDEO_REFERENCE_PARSE_CACHE_SIZE)
 def _parse_video_reference(reference: str) -> ParsedVideoReference:
     parsed = urlparse(reference)
     if parsed.scheme in {"http", "https", "file"}:

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 import hashlib
 from urllib.parse import unquote, urlparse
 
@@ -132,6 +133,7 @@ def _validate_bounds(duration_ms: int, frame_budget: int, start_ms: int, end_ms:
         raise VideoPreprocessError("end_ms must be less than or equal to duration_ms.")
 
 
+@lru_cache(maxsize=512)
 def _parse_video_reference(reference: str) -> ParsedVideoReference:
     parsed = urlparse(reference)
     if parsed.scheme in {"http", "https", "file"}:


### PR DESCRIPTION
## Summary
- Cache parsed video URI/path metadata with a bounded `lru_cache` for repeated URI preprocessing.
- Add a regression test proving repeated references reuse the immutable parsed metadata object.
- Document the slice plan and registered probe coverage.

## Plan or Spec
- Added `docs/plans/2026-05-18-video-preprocessing-uri-parse-cache.md`.
- Existing registered PR-scoped probe: `video-preprocessing-uri-byte-length-reuse`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/video_preprocessing_uri_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/video_preprocessing_uri_probe.py` (baseline and post-change)
- `git diff --check`

## Coverage and Metrics
- Focused tests: `25 passed in 3.64s`.
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Registered local probe (`video-preprocessing-uri-byte-length-reuse`): baseline `elapsed_ms_mean=765.8714577555656`, post-change `elapsed_ms_mean=612.0963292196393`; delta `-153.77512853592634 ms` (`~20.08%` faster). Guard metrics unchanged: `byte_length_getattrs_per_call=1.0`, `parse_calls_per_call=1.0`.

## Known Gaps
- Local validation is Linux/Python only. Hosted PR-scoped performance CI remains the merge gate for the registered probe.
- The probe's parse-call wrapper still records one wrapper call per preprocessing call; the optimization reduces work inside the cached parser path and is reflected by elapsed time.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path and has focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met the repository threshold.
- [x] Registered local probe improved on Linux.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
