### PR TITLE
perf: fast-path empty probe policy values

### DIFF
--- a/docs/plans/2026-05-18-probe-policy-empty-string-fast-path.md
+++ b/docs/plans/2026-05-18-probe-policy-empty-string-fast-path.md
@@ -1,0 +1,41 @@
+# Probe Policy Empty String Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to `ProbePolicy.from_value` in
+`services/mlx-worker-python/worker/productization/probe_policy.py`. The targeted
+hot path is the explicit empty-string parse used by no-op probe policy checks
+and by synthetic overhead measurement.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`. The registry
+entry already includes focused `test_command`, `coverage_command`, and
+`probe_command` values covering:
+
+- `services/mlx-worker-python/worker/productization/probe_policy.py`
+- `services/mlx-worker-python/worker/productization/probe_policy_overhead.py`
+- `services/mlx-worker-python/tests/test_probe_policy.py`
+- `scripts/probe_policy_noop_overhead_probe.py`
+
+The probe reports `mode_parse_empty_call_ms_mean`, along with the existing no-op
+recorder and policy overhead metrics.
+
+## Implementation Plan
+
+1. Keep behavior identical for supported modes, whitespace-normalized strings,
+   invalid values, non-strings, and explicit default modes.
+2. Add a direct exact-empty-string return before dictionary lookup and
+   normalization in `ProbePolicy.from_value`.
+3. Verify with the focused registered tests, changed-scope coverage, and the
+   registered probe locally on Linux.
+4. Use the PR-scoped performance workflow as the merge gate after opening the PR.
+
+## Acceptance Criteria
+
+- Focused tests pass.
+- Changed-scope coverage for touched Python/test/probe paths is at least 95%.
+- Local registered probe shows lower `mode_parse_empty_call_ms_mean` compared
+  with `origin/main` without regressing probe threshold pass status.
+- GitHub Actions and the PR-scoped performance workflow are green before merge.

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -60,6 +60,8 @@ class ProbePolicy:
         default_mode: ProbeMode = ProbeMode.MINIMAL,
     ) -> ProbePolicy:
         if type(value) is str:
+            if not value:
+                return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
             policy = _PROBE_POLICY_BY_VALUE_GET(value)
             if policy is not None:
                 return policy


### PR DESCRIPTION
## Summary
- Add a direct exact-empty-string fast path in `ProbePolicy.from_value` before dictionary lookup and normalization.
- Document the slice plan for the registered `probe-policy-noop-overhead` PR-scoped probe.

## Plan or Spec
- `docs/plans/2026-05-18-probe-policy-empty-string-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 16 passed in 0.69s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py
# 16 passed in 0.23s; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py
# HEAD: mode_parse_empty_call_ms_mean=0.000163263, threshold_passed=1.0

# Baseline comparison from /root/.hermes/profiles/coder/workspace/melix at origin/main:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py
# origin/main: mode_parse_empty_call_ms_mean=0.000214942, threshold_passed=1.0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`aggregate_measurable_changed_lines=2`, `aggregate_covered_changed_lines=2`).
- Registered local Linux probe: `probe-policy-noop-overhead`.
- Probe metric delta: `mode_parse_empty_call_ms_mean` improved from `0.000214942 ms` to `0.000163263 ms` (`delta=-0.000051679 ms`, `speedup=1.3165x`, `24.04%` lower).
- Observability mode: minimal/no-op probe policy parsing path; probe overhead remains threshold-passing (`threshold_passed=1.0`).
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- None for the Python slice. Swift/macOS runtime effects are not touched.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
