### PR TITLE
perf: fast-path saturated serving diagnostics append

### DIFF
--- a/docs/plans/2026-05-18-serving-diagnostics-saturated-append.md
+++ b/docs/plans/2026-05-18-serving-diagnostics-saturated-append.md
@@ -1,0 +1,38 @@
+# Serving diagnostics saturated append fast path
+
+## Scope
+
+This Python-only performance slice targets `BoundedServingDiagnosticsEventQueue.append(...)`
+in `services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+The affected path is covered by the registered PR-scoped performance probe
+`serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`,
+including focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Hypothesis
+
+The debug diagnostics queue spends most probe iterations after the deque reaches
+capacity. Checking the saturated branch before appending lets the hot full-queue
+path skip retained-count arithmetic and the saturation assignment while
+preserving the same deque append/drop semantics and `False` return value for
+dropped events.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage, and local Linux probe:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
+```
+
+The PR-scoped performance workflow remains the merge gate for the registered CI
+probe result.
+
+## Acceptance
+
+- Queue behavior remains unchanged for retained events, dropped events, snapshots,
+  and serialized diagnostics bundles.
+- Changed-scope coverage for touched Python scope is at least 95%.
+- The registered local probe shows a clear or neutral improvement in
+  `elapsed_ms_mean`; CI must complete the same registered probe before merge.

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -86,10 +86,11 @@ class BoundedServingDiagnosticsEventQueue:
         lock = self._lock
         lock.acquire()
         try:
-            self._append_event(event)
             if self._is_saturated:
+                self._append_event(event)
                 self._dropped_count += 1
                 return False
+            self._append_event(event)
             retained_count = self._retained_count + 1
             self._retained_count = retained_count
             self._is_saturated = retained_count >= self._max_events


### PR DESCRIPTION
## Summary
- Fast-path `BoundedServingDiagnosticsEventQueue.append(...)` when the debug queue is already saturated.
- Keep deque append/drop semantics unchanged while skipping retained-count work on the hot full-queue path.
- Document the slice and registered probe coverage in `docs/plans/2026-05-18-serving-diagnostics-saturated-append.md`.

## Plan or Spec
- `docs/plans/2026-05-18-serving-diagnostics-saturated-append.md`
- Registered PR-scoped probe: `serving-diagnostics-debug-queue-bounds`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` (3 local post-change runs)
- Baseline comparison probes from `origin/main` and this branch, 5 old runs / 8 new runs total.
- `git diff --check`

## Coverage and Metrics
- Focused tests: `43 passed`.
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Local probe comparison: `old_mean=5.616219 ms`, `new_mean=5.522091 ms`, `delta_ms=-0.094129`, `speedup=1.017046`, `improvement_pct=1.676` for `elapsed_ms_mean`.
- Registered PR-scoped performance CI must complete `serving-diagnostics-debug-queue-bounds` before merge.

## Known Gaps
- This is a Python-only slice validated locally on Linux; no Swift runtime behavior is changed.
- The measured local improvement is small and should be treated as directional until the registered CI probe reports.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe was run and compared against `origin/main`.
- [ ] GitHub Actions PR-scoped performance probe completed successfully.
