### PR TITLE
perf: fast-path event response fence trailer

### DIFF
--- a/docs/plans/2026-05-18-event-response-json-fence-trailer-strip.md
+++ b/docs/plans/2026-05-18-event-response-json-fence-trailer-strip.md
@@ -1,0 +1,69 @@
+# Event extraction fenced JSON newline trailer fast path
+
+## Scope
+
+This Python-only performance slice targets fenced event-extraction response parsing in
+`services/mlx-worker-python/worker/productization/event_extraction.py`.
+
+The affected path is covered by the registered PR-scoped performance probe
+`event-extraction-response-json-fence-trim` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/event_extraction.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/event_extraction_response_json_probe.py`
+
+## Optimization hypothesis
+
+After `json.JSONDecoder.raw_decode(...)` parses a fenced JSON payload, the parser
+only needs to validate that the remaining trailer is either whitespace or a
+closing Markdown fence plus whitespace. The common emitted shape places the
+closing fence on the next line (newline followed by three backticks). Adding a
+narrow fast path for that newline-plus-fence trailer avoids the generic
+whitespace/fence loop while
+preserving the fallback for partial fences, leading whitespace, and rejected
+trailing text.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage, and registered probe
+locally on Linux before opening the PR:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list \
+  services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space \
+  services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_leading_whitespace_before_fence \
+  services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_unfenced_json_without_pretrim_copy \
+  services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_trailing_text_after_fenced_json \
+  services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_fenced_non_object_payload \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics
+```
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && \
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && \
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/event_extraction.py \
+  services/mlx-worker-python/tests/test_event_extraction.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/event_extraction_response_json_probe.py
+```
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_response_json_probe.py
+```
+
+The PR-scoped performance workflow must select and complete
+`event-extraction-response-json-fence-trim` in CI before merge.
+
+## Success criteria
+
+- Focused behavior tests pass.
+- Changed-scope coverage for touched Python paths is at least 95%.
+- The registered local probe shows lower `elapsed_ms_mean` on the fenced JSON
+  parser hot path without a peak-memory regression.

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2864,6 +2864,9 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
 
 
 def _has_only_optional_closing_fence(response_text: str, start: int, response_length: int) -> bool:
+    if response_text.startswith("\n```", start):
+        trailer_start = start + 4
+        return trailer_start == response_length or response_text[trailer_start:response_length].isspace()
     while start < response_length and response_text[start].isspace():
         start += 1
     if start == response_length:

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -79,6 +79,8 @@ Rules:
 """
 SEMANTIC_JUDGE_PROMPT_HASH = f"sha256:{sha256(SEMANTIC_JUDGE_SYSTEM_PROMPT.encode('utf-8')).hexdigest()}"
 _JSON_DECODER = json.JSONDecoder()
+_CLOSING_FENCE_WITH_LEADING_NEWLINE = "\n```"
+_CLOSING_FENCE_WITH_LEADING_NEWLINE_LENGTH = len(_CLOSING_FENCE_WITH_LEADING_NEWLINE)
 
 EVENT_EXTRACTION_LEGACY_SYSTEM_PROMPT = """Extract established events and future plans from a dialogue.
 
@@ -2864,8 +2866,8 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
 
 
 def _has_only_optional_closing_fence(response_text: str, start: int, response_length: int) -> bool:
-    if response_text.startswith("\n```", start):
-        trailer_start = start + len("\n```")
+    if response_text.startswith(_CLOSING_FENCE_WITH_LEADING_NEWLINE, start):
+        trailer_start = start + _CLOSING_FENCE_WITH_LEADING_NEWLINE_LENGTH
         return trailer_start == response_length or response_text[trailer_start:response_length].isspace()
     while start < response_length and response_text[start].isspace():
         start += 1

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2865,7 +2865,7 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
 
 def _has_only_optional_closing_fence(response_text: str, start: int, response_length: int) -> bool:
     if response_text.startswith("\n```", start):
-        trailer_start = start + 4
+        trailer_start = start + len("\n```")
         return trailer_start == response_length or response_text[trailer_start:response_length].isspace()
     while start < response_length and response_text[start].isspace():
         start += 1


### PR DESCRIPTION
## Summary
- Add a narrow fast path for fenced event-extraction JSON responses whose parsed payload is followed by a newline and closing Markdown fence.
- Preserve the existing generic trailer validation fallback for partial fences, leading whitespace, and rejected trailing text.
- Document the slice and registered probe under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-05-18-event-response-json-fence-trailer-strip.md`
- Registered PR-scoped probe: `event-extraction-response-json-fence-trim` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_leading_whitespace_before_fence services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_unfenced_json_without_pretrim_copy services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_trailing_text_after_fenced_json services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_fenced_non_object_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_response_json_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_response_json_probe.py`
- `python3 - <<'PY' ... old/new direct parser comparison ... PY`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 9 passed.
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Registered local probe after change: `elapsed_ms_mean=1393.6713268049061`, `peak_bytes_mean=2999220.0`, `event_count=1600`, `iterations_per_sample=80`, `sample_count=5`.
- Same-process old/new parser comparison on the newline-plus-fence response shape: old mean `215.31149273505434 ms`, new mean `209.9742421269184 ms`, delta `-5.337250608135939 ms` (`~2.48%` faster), checksum unchanged (`2048000`).
- CI PR-scoped performance workflow is required to validate the registered probe before merge.

## Known Gaps
- Local validation is Linux-only and covers the Python parser path; no Swift/runtime effect is claimed.
- The registered end-to-end probe is dominated by JSON decoding, so the direct parser comparison is included as focused supporting evidence for the trailer-validation slice.

## Evidence Checklist
- [x] Affected path has registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused behavior tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered local probe ran locally.
- [ ] GitHub Actions and registered PR-scoped performance probe completed successfully.
