### PR TITLE
perf: static dispatch probe policy env parse

### DIFF
--- a/docs/plans/2026-05-18-probe-policy-env-static-dispatch.md
+++ b/docs/plans/2026-05-18-probe-policy-env-static-dispatch.md
@@ -1,0 +1,34 @@
+# Probe policy environment parse static dispatch
+
+## Scope
+
+This Python-only performance slice targets the empty-environment probe policy parse path in
+`services/mlx-worker-python/worker/productization/probe_policy.py`.
+
+The affected path is covered by the registered PR-scoped performance probe
+`probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`. The registry entry has
+focused `test_command`, `coverage_command`, and `probe_command` entries, and the probe reports
+`env_parse_empty_call_ms_mean` together with the existing no-op policy overhead metrics.
+
+## Hypothesis
+
+`ProbePolicy.from_env(...)` is called on hot productization setup paths and is also exercised by
+the registered no-op overhead probe. It does not need dynamic subclass construction, so changing the
+factory from a classmethod to a staticmethod avoids classmethod binding and removes one descriptor
+argument on the hot empty-env path while preserving the same cached policy instances.
+
+## Verification plan
+
+Run the focused registered probe policy tests, changed-scope coverage, and the local Linux registered
+probe comparison:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id probe-policy-noop-overhead --base-repo <baseline-worktree> --head-repo "$PWD" --output /tmp/probe_policy_noop_overhead.json
+```
+
+## Linux validation boundary
+
+This slice is entirely Python and locally verifiable on Linux. GitHub Actions PR-scoped performance
+remains the merge gate for the registered CI probe report.

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -39,9 +39,8 @@ class ProbePolicy:
             "" if telemetry_enabled else f"probe_mode_{mode.value}",
         )
 
-    @classmethod
+    @staticmethod
     def from_env(
-        cls,
         env: Mapping[str, str] | None = None,
         *,
         default_mode: ProbeMode = ProbeMode.MINIMAL,
@@ -50,7 +49,7 @@ class ProbePolicy:
         raw_value = values.get(MELIX_PROBE_MODE_ENV, "")
         if not raw_value:
             return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
-        return cls.from_value(raw_value, default_mode=default_mode)
+        return ProbePolicy.from_value(raw_value, default_mode=default_mode)
 
     @classmethod
     def from_value(


### PR DESCRIPTION
## Summary
- Switch `ProbePolicy.from_env(...)` from classmethod dispatch to static dispatch for the empty-env hot path.
- Add a scoped plan documenting the registered probe and Linux verification boundary.

## Plan or Spec
- `docs/plans/2026-05-18-probe-policy-env-static-dispatch.md`
- Registered probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json` (already includes focused test, coverage, and probe commands).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` → 15 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py` → 15 passed, changed-scope coverage 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=400000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id probe-policy-noop-overhead --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/probe_policy_noop_overhead.json` → passed
- `git diff --check` → passed

## Coverage and Metrics
- Changed-scope coverage: 100% (2/2 changed measurable lines).
- Local Linux registered probe (`probe-policy-noop-overhead`, 400k iterations × 5 samples):
  - `env_parse_empty_call_ms_mean`: base `0.000200819`, head `0.000159937`, delta `-0.000040882 ms` (~20.36% faster).
  - `threshold_passed`: base `1.0`, head `1.0`.
- CI PR-scoped performance must run the registered probe before merge.

## Known Gaps
- This is a Python-only slice validated locally on Linux; no Swift runtime effect is claimed.
- Microbenchmarks have normal run-to-run noise; the target metric improved locally and CI remains the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally with base/head comparison.
- [ ] GitHub Actions and PR-scoped performance completed successfully.
