### PR TITLE
perf: cache tool registry schema byte counts

### DIFF
--- a/docs/plans/2026-05-18-tool-registry-schema-byte-cache.md
+++ b/docs/plans/2026-05-18-tool-registry-schema-byte-cache.md
@@ -1,0 +1,35 @@
+# Tool registry schema byte-count cache slice
+
+## Goal
+
+Reduce repeated UTF-8 encoding work in `worker.runtime.tool_registry.ToolRegistry.metrics()`.
+The registry already caches each tool JSON schema string at descriptor construction time; this slice also caches the schema byte count once and reuses that integer when metrics are requested repeatedly.
+
+## Scope
+
+- Python-only runtime change in `services/mlx-worker-python/worker/runtime/tool_registry.py`.
+- Focused unit coverage in `services/mlx-worker-python/tests/test_tool_registry.py`.
+- PR-scoped probe registration and probe script for the affected path.
+- No protocol schema, generated artifact, dependency, Swift, or macOS runtime changes.
+
+## Probe
+
+Registered PR-scoped probe: `tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`.
+
+The probe measures repeated `ToolRegistry.metrics()` calls over the built-in agentic tool registry and reports:
+
+- `elapsed_ms_mean`: wall-clock time for repeated metrics calls.
+- `json_schema_calls_mean`: calls to `ToolDescriptor.json_schema()` during metrics collection; the optimized path should be `0.0`.
+- `schema_byte_count_calls_mean`: informational count proving metrics still account for each tool on each iteration.
+
+## Verification Plan
+
+Run the registered focused command set locally on Linux before opening the PR:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
+```
+
+CI PR-scoped performance remains the merge gate for the registered probe report.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3728,5 +3728,41 @@
         "warn_pct": 0.0
       }
     ]
+  },
+  {
+    "id": "tool-registry-schema-bytes-cache",
+    "name": "Tool registry schema byte-count cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/tool_registry.py",
+      "services/mlx-worker-python/tests/test_tool_registry.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/tool_registry_schema_bytes_probe.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/tool_registry_schema_bytes_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "json_schema_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "schema_byte_count_calls_mean",
+        "unit": "calls",
+        "direction": "informational"
+      }
+    ]
   }
 ]

--- a/scripts/tool_registry_schema_bytes_probe.py
+++ b/scripts/tool_registry_schema_bytes_probe.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime import tool_registry as tool_registry_module  # noqa: E402
+from worker.runtime.tool_registry import ToolDescriptor, built_in_tool_registry  # noqa: E402
+
+
+def _measure(iterations: int, sample_count: int) -> dict[str, float]:
+    registry = built_in_tool_registry()
+    expected_schema_bytes = sum(len(tool.json_schema().encode("utf-8")) for tool in registry.tools)
+    original_json_schema = ToolDescriptor.json_schema
+    elapsed_samples: list[float] = []
+    json_schema_calls: list[float] = []
+    schema_byte_count_calls: list[float] = []
+    checksum = 0
+    original_schema_byte_count = getattr(ToolDescriptor, "schema_byte_count", None)
+
+    try:
+        for _ in range(sample_count):
+            json_calls = 0
+            byte_count_calls = 0
+
+            def counted_json_schema(self: ToolDescriptor) -> str:
+                nonlocal json_calls
+                json_calls += 1
+                return original_json_schema(self)
+
+            def counted_schema_byte_count(self: ToolDescriptor) -> int:
+                nonlocal byte_count_calls
+                byte_count_calls += 1
+                if original_schema_byte_count is None:
+                    return len(original_json_schema(self).encode("utf-8"))
+                return original_schema_byte_count(self)
+
+            tool_registry_module.ToolDescriptor.json_schema = counted_json_schema
+            tool_registry_module.ToolDescriptor.schema_byte_count = counted_schema_byte_count
+            started = time.perf_counter()
+            for _index in range(iterations):
+                metrics = registry.metrics()
+                if metrics.schema_bytes != expected_schema_bytes:
+                    raise RuntimeError(
+                        f"unexpected schema_bytes: {metrics.schema_bytes} != {expected_schema_bytes}"
+                    )
+                checksum += metrics.schema_bytes + metrics.required_argument_count
+            elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+            json_schema_calls.append(float(json_calls))
+            schema_byte_count_calls.append(float(byte_count_calls))
+    finally:
+        tool_registry_module.ToolDescriptor.json_schema = original_json_schema
+        if original_schema_byte_count is None:
+            delattr(tool_registry_module.ToolDescriptor, "schema_byte_count")
+        else:
+            tool_registry_module.ToolDescriptor.schema_byte_count = original_schema_byte_count
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "json_schema_calls_mean": statistics.fmean(json_schema_calls),
+        "schema_byte_count_calls_mean": statistics.fmean(schema_byte_count_calls),
+        "schema_bytes": float(expected_schema_bytes),
+        "checksum": float(checksum),
+        "iterations": float(iterations),
+        "sample_count": float(sample_count),
+    }
+
+
+def main() -> int:
+    iterations = int(os.environ.get("MELIX_TOOL_REGISTRY_METRICS_ITERATIONS", "40000"))
+    sample_count = int(os.environ.get("MELIX_TOOL_REGISTRY_METRICS_SAMPLES", "5"))
+    print(json.dumps(_measure(iterations, sample_count), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -175,6 +175,34 @@ def test_scope_report_selects_engine_generate_usage_probe() -> None:
     assert _selected_probe_ids(scope) == ["engine-generate-usage-token-elision"]
 
 
+def test_scope_report_selects_tool_registry_schema_bytes_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/tool_registry.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert _selected_probe_ids(scope) == ["tool-registry-schema-bytes-cache"]
+
+
+def test_tool_registry_schema_bytes_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_TOOL_REGISTRY_METRICS_ITERATIONS", "20")
+    monkeypatch.setenv("MELIX_TOOL_REGISTRY_METRICS_SAMPLES", "1")
+
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/tool_registry_schema_bytes_probe.py"))
+
+    assert probe_script["main"]() == 0
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["schema_bytes"] > 0.0
+    assert metrics["elapsed_ms_mean"] >= 0.0
+    assert metrics["json_schema_calls_mean"] == 0.0
+    assert metrics["schema_byte_count_calls_mean"] == 120.0
+
+
 def test_scope_report_selects_integration_swift_binary_resolution_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -2341,6 +2369,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "statistical-evidence-bootstrap-single-sort",
         "statistical-evidence-category-breakdown-single-pass",
         "text-family-config-copy-elision",
+        "tool-registry-schema-bytes-cache",
     }
     registry_probe = None
     maintenance_probe = None

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -200,7 +200,8 @@ def test_tool_registry_schema_bytes_probe_script_emits_metrics(
     assert metrics["schema_bytes"] > 0.0
     assert metrics["elapsed_ms_mean"] >= 0.0
     assert metrics["json_schema_calls_mean"] == 0.0
-    assert metrics["schema_byte_count_calls_mean"] == 120.0
+    tool_count = len(probe_script["built_in_tool_registry"]().tools)
+    assert metrics["schema_byte_count_calls_mean"] == 20.0 * tool_count
 
 
 def test_scope_report_selects_integration_swift_binary_resolution_probe() -> None:

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -45,6 +45,20 @@ def test_built_in_tool_schemas_are_object_contracts_with_required_arguments() ->
         assert "x-melix-observation-kind" not in parsed
 
 
+def test_tool_registry_metrics_reuses_cached_schema_byte_counts(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = built_in_tool_registry()
+    expected_schema_bytes = sum(len(tool.json_schema().encode("utf-8")) for tool in registry.tools)
+
+    def fail_json_schema(self: ToolDescriptor) -> str:
+        raise AssertionError("metrics() should not re-encode cached JSON schemas")
+
+    monkeypatch.setattr(ToolDescriptor, "json_schema", fail_json_schema)
+
+    with pytest.raises(AssertionError, match=r"metrics\(\) should not re-encode"):
+        registry.tools[0].json_schema()
+    assert registry.metrics().schema_bytes == expected_schema_bytes
+
+
 def test_tool_registry_rejects_duplicate_tool_names() -> None:
     registry = built_in_tool_registry()
 
@@ -117,6 +131,7 @@ def test_tool_descriptor_normalizes_exported_fields_and_caches_schema() -> None:
     assert tool.tool_kind == "vision.image_crop"
     assert tool.observation_kind == "image_region"
     assert tool.json_schema() is tool.json_schema()
+    assert tool.schema_byte_count() == len(tool.json_schema().encode("utf-8"))
     assert tool.as_openai_tool()["function"]["parameters"] == {
         "type": "object",
         "additionalProperties": False,

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -63,6 +63,7 @@ class ToolDescriptor:
     observation_kind: str
     arguments: tuple[ToolArgumentDescriptor, ...]
     _cached_schema: str = field(default="", init=False, repr=False)
+    _cached_schema_bytes: int = field(default=0, init=False, repr=False)
 
     def __post_init__(self) -> None:
         normalized_name = self.name.strip()
@@ -87,7 +88,9 @@ class ToolDescriptor:
                     f"Duplicate argument {argument.name} in tool registry entry {normalized_name}."
                 )
             argument_names.add(argument.name)
-        object.__setattr__(self, "_cached_schema", _COMPACT_SORTED_JSON_ENCODER.encode(self.schema_payload()))
+        cached_schema = _COMPACT_SORTED_JSON_ENCODER.encode(self.schema_payload())
+        object.__setattr__(self, "_cached_schema", cached_schema)
+        object.__setattr__(self, "_cached_schema_bytes", len(cached_schema.encode("utf-8")))
 
     @property
     def required_arguments(self) -> tuple[str, ...]:
@@ -106,6 +109,9 @@ class ToolDescriptor:
 
     def json_schema(self) -> str:
         return self._cached_schema
+
+    def schema_byte_count(self) -> int:
+        return self._cached_schema_bytes
 
     def as_openai_tool(self) -> dict[str, Any]:
         return {
@@ -161,7 +167,7 @@ class ToolRegistry:
     def metrics(self) -> ToolRegistryMetrics:
         return ToolRegistryMetrics(
             tool_count=len(self._tools),
-            schema_bytes=sum(len(tool.json_schema().encode("utf-8")) for tool in self._tools),
+            schema_bytes=sum(tool.schema_byte_count() for tool in self._tools),
             required_argument_count=sum(len(tool.required_arguments) for tool in self._tools),
         )
 


### PR DESCRIPTION
## Summary
- Cache each tool descriptor's UTF-8 schema byte count when the compact JSON schema string is built.
- Update `ToolRegistry.metrics()` to reuse the cached byte count instead of re-encoding schemas on every metrics call.
- Register a PR-scoped performance probe for the affected tool registry path.

## Plan or Spec
- `docs/plans/2026-05-18-tool-registry-schema-byte-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 27 passed in 0.15s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py
# 27 passed; changed-scope coverage TOTAL 30 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
# {"checksum": 370400000.0, "elapsed_ms_mean": 198.34293867461383, "iterations": 40000.0, "json_schema_calls_mean": 0.0, "sample_count": 5.0, "schema_byte_count_calls_mean": 240000.0, "schema_bytes": 1845.0}

Baseline equivalent probe against origin/main:
# {"checksum": 370400000.0, "elapsed_ms_mean": 225.56011038832366, "iterations": 40000.0, "json_schema_calls_mean": 240000.0, "sample_count": 5.0, "schema_byte_count_calls_mean": 0.0, "schema_bytes": 1845.0}
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (30/30 measurable changed lines).
- Local Linux probe delta: old_mean=225.560 ms, new_mean=198.343 ms, delta=-27.217 ms, speedup=1.137x (-12.07%).
- JSON schema calls during metrics: 240000.0 -> 0.0 across the probe workload.
- Registered PR-scoped probe: `tool-registry-schema-bytes-cache`; CI registered probe report is required before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift or macOS runtime behavior is changed.
- CI PR-scoped performance report is still required to validate the registered probe in GitHub Actions.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
