### PR TITLE
perf: fast-path integer hub size hints

### DIFF
--- a/docs/plans/2026-05-18-hub-catalog-size-hint-integer-parser.md
+++ b/docs/plans/2026-05-18-hub-catalog-size-hint-integer-parser.md
@@ -1,0 +1,28 @@
+# Hub catalog size-hint integer parser fast path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.model_ops.hub_catalog._size_hint_from_text(...)` when the precompiled size-hint regex captures an integer value such as `MODEL SIZE | 512 kb`.
+
+## Registered probe
+
+Affected paths are covered by the existing PR-scoped performance probe `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+
+The probe workload includes integer explicit README hints and records `elapsed_ms_mean` plus `size_hint_calls_mean`.
+
+## Implementation plan
+
+1. Preserve the precompiled regex and accepted `kb`/`mb`/`gb` units.
+2. After a successful regex match, use direct multiplier branches for common exact-case units instead of normalizing every unit string.
+3. Multiply integer captures with `int(value_text)` directly.
+4. Keep decimal captures on the existing `float(value_text)` fallback path.
+5. Add focused regression tests proving integer hints skip float conversion and decimal/mixed-case hints still use the fallback behavior.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage, and the local registered probe on Linux before opening the PR. Use the hosted PR-scoped performance workflow as the merge gate.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -732,6 +732,27 @@ def test_size_hint_parsers_cover_units_and_invalid_values() -> None:
     assert _size_hint_from_text("Model size: 512 kb", allow_bare=False) == 512 * KB
     assert _size_hint_from_text("Model size: 1.5 MB", allow_bare=False) == int(1.5 * MB)
     assert _size_hint_from_text("Model size: 2 GB", allow_bare=False) == 2 * GB
+    assert _size_hint_from_text("Model size: 3 mB", allow_bare=False) == 3 * MB
+
+
+def test_size_hint_from_text_integer_value_skips_float_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    float_parser = Mock(side_effect=AssertionError("integer hint should not call float"))
+    monkeypatch.setattr(hub_catalog_module, "float", float_parser, raising=False)
+
+    assert _size_hint_from_text("Model size: 512 kb", allow_bare=False) == 512 * KB
+    float_parser.assert_not_called()
+
+
+def test_size_hint_from_text_decimal_value_preserves_float_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    float_parser = Mock(return_value=1.5)
+    monkeypatch.setattr(hub_catalog_module, "float", float_parser, raising=False)
+
+    assert _size_hint_from_text("Model size: 1.5 MB", allow_bare=False) == int(1.5 * MB)
+    float_parser.assert_called_once_with("1.5")
 
 
 @pytest.mark.parametrize(

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -654,9 +654,19 @@ def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:
     match = pattern.search(text)
     if not match:
         return 0
-    value = float(match.group(1))
-    multiplier = _SIZE_HINT_MULTIPLIERS[match.group(2).lower()]
-    return int(value * multiplier)
+    value_text = match.group(1)
+    unit_text = match.group(2)
+    if unit_text == "kb" or unit_text == "KB":
+        multiplier = _SIZE_HINT_KB
+    elif unit_text == "mb" or unit_text == "MB":
+        multiplier = _SIZE_HINT_MB
+    elif unit_text == "gb" or unit_text == "GB":
+        multiplier = _SIZE_HINT_GB
+    else:
+        multiplier = _SIZE_HINT_MULTIPLIERS[unit_text.lower()]
+    if value_text.isdecimal():
+        return int(value_text) * multiplier
+    return int(float(value_text) * multiplier)
 
 
 def _may_contain_model_marker(text: str) -> bool:


### PR DESCRIPTION
## Summary
- Fast-path integer Hub catalog size-hint regex matches by multiplying integer captures directly instead of converting through `float()`.
- Reuse direct multiplier branches for common exact-case `kb`/`mb`/`gb` unit captures while preserving mixed-case fallback behavior.
- Add focused tests covering integer, decimal, and mixed-case unit parsing.

## Plan or Spec
- `docs/plans/2026-05-18-hub-catalog-size-hint-integer-parser.md`

## Commands Run
```text
# Baseline probe on origin/main before editing
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# exit 0; elapsed_ms_mean=1435.470019467175; size_hint_calls_mean=40000.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py::test_size_hint_parsers_cover_units_and_invalid_values services/mlx-worker-python/tests/test_hub_catalog.py::test_size_hint_from_text_integer_value_skips_float_conversion services/mlx-worker-python/tests/test_hub_catalog.py::test_size_hint_from_text_decimal_value_preserves_float_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# exit 0; 6 passed in 0.78s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# exit 0; 54 passed in 0.29s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# exit 0; TOTAL 23 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/hub-size-hint-integer-probe-final.json
# exit 0; head verification ok; base elapsed_ms_mean=1448.07776552625; head elapsed_ms_mean=1467.1260583680123; size_hint_calls_mean=40000.0 both

python3 -m compileall -q services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py
# exit 0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 23 0 100%`.
- Registered probe: `hub-catalog-size-hint-regex-precompile` is already registered with focused `test_command`, `coverage_command`, and `probe_command`.
- Local PR-scoped probe final run: base `elapsed_ms_mean=1448.07776552625`, head `elapsed_ms_mean=1467.1260583680123`, delta `+19.048292841762304 ms` (`+1.32%`); `size_hint_calls_mean=40000.0` unchanged. This is within the probe warning threshold but noisy/non-improving locally, so hosted PR-scoped performance CI is required before merge.

## Known Gaps
- Local Linux probe timing was noisy and the final base-vs-head run did not show improvement; do not treat local runtime effect as validated until GitHub's registered PR-scoped performance workflow completes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
