### PR TITLE
perf: cache tool registry select index

### DIFF
--- a/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
+++ b/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
@@ -1,0 +1,46 @@
+# Tool Registry Select Name Index Cache
+
+Date: 2026-05-18
+
+## Scope
+
+This performance slice optimizes `ToolRegistry.select()` in
+`services/mlx-worker-python/worker/runtime/tool_registry.py` only.
+
+## Problem
+
+The agentic tool registry contract requires selection requests to preserve the
+requested order, deduplicate repeated names, and reject unknown tool names before
+execution. The current select path rebuilds a `name -> descriptor` dictionary and
+an additional set for every selection call even though the registry descriptor
+set is immutable for the lifetime of a `ToolRegistry` instance.
+
+## Plan
+
+- Add a registry-local cached tool-name index after duplicate-name validation.
+- Keep duplicate-name validation in `_validate()` so malformed registries still
+  fail with the existing error.
+- Update tests to prove `select()` uses the cached index while preserving order,
+  deduplication, and unknown-name errors.
+- Register a focused PR-scoped performance probe for repeated registry selection.
+
+## Performance Probe
+
+Registered PR-scoped probe: `tool-registry-select-name-index-cache` in
+`infra/perf/pr_scoped_probes.json`.
+
+Focused commands:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
+```
+
+## Acceptance Criteria
+
+- Focused behavior tests pass locally on Linux.
+- Changed-scope coverage is at least 95%.
+- The registered probe shows a directionally lower repeated-selection elapsed
+  time on head compared with the base implementation.
+- CI PR-scoped performance completes successfully before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3764,5 +3764,35 @@
         "direction": "informational"
       }
     ]
+  },
+  {
+    "id": "tool-registry-select-name-index-cache",
+    "name": "Tool registry select cached name index",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/tool_registry.py",
+      "services/mlx-worker-python/tests/test_tool_registry.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/tool_registry_select_probe.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/tool_registry_select_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "select_calls_mean",
+        "unit": "calls",
+        "direction": "informational"
+      }
+    ]
   }
 ]

--- a/scripts/tool_registry_select_probe.py
+++ b/scripts/tool_registry_select_probe.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime.tool_registry import built_in_tool_registry  # noqa: E402
+
+_SELECTIONS: tuple[tuple[str, ...], ...] = (
+    ("visit", "image_crop", "visit"),
+    ("text_search", "image_search", "local_compute"),
+    ("layout_parse", "visit"),
+    ("image_crop",),
+)
+
+
+def _measure(iterations: int, sample_count: int) -> dict[str, float]:
+    registry = built_in_tool_registry()
+    elapsed_samples: list[float] = []
+    checksum = 0
+
+    for _ in range(sample_count):
+        started = time.perf_counter()
+        for index in range(iterations):
+            selected = registry.select(_SELECTIONS[index % len(_SELECTIONS)])
+            checksum += len(selected.tools)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "select_calls_mean": float(iterations),
+        "checksum": float(checksum),
+        "iterations": float(iterations),
+        "sample_count": float(sample_count),
+        "selection_case_count": float(len(_SELECTIONS)),
+    }
+
+
+def main() -> int:
+    iterations = int(os.environ.get("MELIX_TOOL_REGISTRY_SELECT_ITERATIONS", "80000"))
+    sample_count = int(os.environ.get("MELIX_TOOL_REGISTRY_SELECT_SAMPLES", "5"))
+    print(json.dumps(_measure(iterations, sample_count), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -181,8 +181,11 @@ def test_scope_report_selects_tool_registry_schema_bytes_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/tool_registry.py"],
     )
 
-    assert scope["selected_count"] == 1
-    assert _selected_probe_ids(scope) == ["tool-registry-schema-bytes-cache"]
+    assert scope["selected_count"] == 2
+    assert _selected_probe_ids(scope) == [
+        "tool-registry-schema-bytes-cache",
+        "tool-registry-select-name-index-cache",
+    ]
 
 
 def test_tool_registry_schema_bytes_probe_script_emits_metrics(
@@ -202,6 +205,23 @@ def test_tool_registry_schema_bytes_probe_script_emits_metrics(
     assert metrics["json_schema_calls_mean"] == 0.0
     tool_count = len(probe_script["built_in_tool_registry"]().tools)
     assert metrics["schema_byte_count_calls_mean"] == 20.0 * tool_count
+
+
+def test_tool_registry_select_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_TOOL_REGISTRY_SELECT_ITERATIONS", "20")
+    monkeypatch.setenv("MELIX_TOOL_REGISTRY_SELECT_SAMPLES", "1")
+
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/tool_registry_select_probe.py"))
+
+    assert probe_script["main"]() == 0
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] >= 0.0
+    assert metrics["select_calls_mean"] == 20.0
+    assert metrics["selection_case_count"] == 4.0
 
 
 def test_scope_report_selects_integration_swift_binary_resolution_probe() -> None:
@@ -2371,6 +2391,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "statistical-evidence-category-breakdown-single-pass",
         "text-family-config-copy-elision",
         "tool-registry-schema-bytes-cache",
+        "tool-registry-select-name-index-cache",
     }
     registry_probe = None
     maintenance_probe = None

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -82,7 +82,7 @@ def test_tool_registry_selects_tools_in_requested_order() -> None:
 
 
 def test_tool_registry_select_reuses_cached_name_index() -> None:
-    registry = built_in_tool_registry()
+    registry = ToolRegistry(built_in_tool_registry().tools)
     object.__setattr__(registry, "_tools", ())
 
     selected = registry.select(["visit", "image_crop", "visit"])

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -81,6 +81,15 @@ def test_tool_registry_selects_tools_in_requested_order() -> None:
     assert selected.names() == ("visit", "image_crop")
 
 
+def test_tool_registry_select_reuses_cached_name_index() -> None:
+    registry = built_in_tool_registry()
+    object.__setattr__(registry, "_tools", ())
+
+    selected = registry.select(["visit", "image_crop", "visit"])
+
+    assert selected.names() == ("visit", "image_crop")
+
+
 def test_tool_registry_exports_worker_tool_config_metadata() -> None:
     config = built_in_tool_config(["image_crop", "local_compute"])
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -155,7 +155,9 @@ class ToolRegistry:
         self._toolset_version = toolset_version.strip()
         self._parser = parser.strip()
         self._parser_contract_version = parser_contract_version.strip()
+        self._tool_by_name: dict[str, ToolDescriptor] = {}
         self._validate()
+        self._tool_by_name = {tool.name: tool for tool in self._tools}
 
     @property
     def tools(self) -> tuple[ToolDescriptor, ...]:
@@ -173,13 +175,11 @@ class ToolRegistry:
 
     def select(self, names: list[str] | tuple[str, ...]) -> ToolRegistry:
         requested_names = tuple(dict.fromkeys(name.strip() for name in names if name.strip()))
-        tool_by_name = {tool.name: tool for tool in self._tools}
-        known_names = set(tool_by_name)
-        missing_names = [name for name in requested_names if name not in known_names]
+        missing_names = [name for name in requested_names if name not in self._tool_by_name]
         if missing_names:
             joined = ", ".join(missing_names)
             raise ToolRegistryError(f"Unknown tool registry entry requested: {joined}")
-        selected = [tool_by_name[name] for name in requested_names]
+        selected = [self._tool_by_name[name] for name in requested_names]
         return ToolRegistry(
             selected,
             schema_version=self._schema_version,

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -155,7 +155,6 @@ class ToolRegistry:
         self._toolset_version = toolset_version.strip()
         self._parser = parser.strip()
         self._parser_contract_version = parser_contract_version.strip()
-        self._tool_by_name: dict[str, ToolDescriptor] = {}
         self._validate()
         self._tool_by_name = {tool.name: tool for tool in self._tools}
 


### PR DESCRIPTION
## Summary
- Cache the immutable `ToolRegistry` name index once after duplicate-name validation.
- Reuse the cached index in `ToolRegistry.select()` instead of rebuilding a name map and set for every selection request.
- Add a focused PR-scoped probe for repeated tool-registry selection.

## Plan or Spec
- Governing spec: `docs/unified-agentic-tool-runtime-contract.md` (tool selection must preserve request order, deduplicate repeated names, and fail on unknown names).
- Plan: `docs/plans/2026-05-18-tool-registry-select-name-index-cache.md`.

## Commands Run
```text
# Baseline before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
... repeated registry.select micro-probe ...
PY
exit 0; old_mean=205.47069660387933 ms over 5 samples

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.json && git diff --check
exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
exit 0; 28 passed in 0.65s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
exit 0; TOTAL 20 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
exit 0; {"elapsed_ms_mean": 184.57278441637754, "iterations": 80000.0, "sample_count": 5.0, "select_calls_mean": 80000.0}
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 20 0 100%`).
- Local Linux probe: old_mean=205.47069660387933 ms, new_mean=184.57278441637754 ms, delta=-20.89791218750179 ms, speedup=1.1132x (~10.17% lower elapsed time).
- Registered probe: `tool-registry-select-name-index-cache` (`command_json`) with `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json`.
- CI PR-scoped performance report is required for base-vs-head validation before merge.

## Known Gaps
- Full repository gates were not run locally; this Python slice was verified with focused tests, changed-scope coverage, and the registered probe on Linux.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
