### PR TITLE
perf: combine startup log excerpts in one pass

### DIFF
--- a/docs/plans/2026-05-18-startup-log-excerpt-single-pass-combine.md
+++ b/docs/plans/2026-05-18-startup-log-excerpt-single-pass-combine.md
@@ -1,0 +1,22 @@
+# Startup log excerpt single-pass combine
+
+## Context
+
+This Python-only performance slice is limited to startup failure log excerpt assembly in `services/mlx-worker-python/worker/productization/startup_signals.py`.
+
+The affected path is covered by the registered PR-scoped performance probe `startup-signals-lazy-worker-log-excerpts` in `infra/perf/pr_scoped_probes.json`. That probe has focused `test_command`, `coverage_command`, and `probe_command` entries and measures classification elapsed time plus log-read counts for the startup signal paths.
+
+## Slice
+
+Avoid allocating a temporary excerpt list and avoid the final `" | ".join(...)` call for the common one-log startup failure cases. `_log_excerpt()` now combines excerpts as it scans paths, preserving order and the same delimiter for multi-log diagnostics.
+
+## Behavior constraints
+
+- Preserve missing-log handling: no `Path.exists()` preflight; rely on read errors.
+- Preserve empty-log skipping.
+- Preserve multi-log order and delimiter: `control | worker`.
+- Preserve startup failure classification and report fields.
+
+## Verification plan
+
+Run the focused startup-signals test set, changed-scope coverage, and the registered `startup-signals-lazy-worker-log-excerpts` probe locally on Linux before opening the PR. GitHub Actions PR-scoped performance remains the merge gate.

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -483,6 +483,24 @@ def test_log_excerpt_skips_missing_paths_without_exists_probe(
     assert startup_signals_module._log_excerpt(missing_log, existing_log) == "ready"
 
 
+def test_log_excerpt_preserves_multiple_log_order_without_list_join(tmp_path: Path) -> None:
+    control_log = tmp_path / "control-plane.stderr.log"
+    worker_log = tmp_path / "python-worker.stderr.log"
+    control_log.write_text("booting\ncontrol ready\n", encoding="utf-8")
+    worker_log.write_text("booting\nworker ready\n", encoding="utf-8")
+
+    assert startup_signals_module._log_excerpt(control_log, worker_log) == "control ready | worker ready"
+
+
+def test_log_excerpt_skips_empty_logs_during_single_pass_combine(tmp_path: Path) -> None:
+    empty_log = tmp_path / "empty.stderr.log"
+    worker_log = tmp_path / "python-worker.stderr.log"
+    empty_log.write_text("\n\t\n", encoding="utf-8")
+    worker_log.write_text("booting\nworker ready\n", encoding="utf-8")
+
+    assert startup_signals_module._log_excerpt(empty_log, worker_log) == "worker ready"
+
+
 def test_read_last_nonempty_line_ignores_trailing_blank_lines(tmp_path: Path) -> None:
     log_path = tmp_path / "control-plane.stderr.log"
     log_path.write_text("booting\nready\n\n", encoding="utf-8")

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -301,7 +301,7 @@ def _contains_any(value: str, patterns: tuple[str, ...]) -> bool:
 
 
 def _log_excerpt(*paths: object) -> str:
-    excerpts: list[str] = []
+    combined_excerpt = ""
     for path in paths:
         if not path:
             continue
@@ -310,9 +310,13 @@ def _log_excerpt(*paths: object) -> str:
             excerpt = _read_last_nonempty_line(resolved)
         except OSError:
             continue
-        if excerpt:
-            excerpts.append(excerpt)
-    return " | ".join(excerpts)
+        if not excerpt:
+            continue
+        if not combined_excerpt:
+            combined_excerpt = excerpt
+        else:
+            combined_excerpt = f"{combined_excerpt} | {excerpt}"
+    return combined_excerpt
 
 
 def _read_last_nonempty_line(path: Path, *, chunk_size: int = 8192) -> str:


### PR DESCRIPTION
## Summary
- Combine startup log excerpts incrementally instead of allocating a temporary list and joining it afterward.
- Preserve missing-log fallback, empty-log skipping, and multi-log `control | worker` ordering.
- Add focused regression tests for multi-log ordering and empty-log skipping.

## Plan or Spec
- `docs/plans/2026-05-18-startup-log-excerpt-single-pass-combine.md`
- Registered PR-scoped probe: `startup-signals-lazy-worker-log-excerpts` in `infra/perf/pr_scoped_probes.json` (existing focused test, coverage, and probe commands).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# exit 0; 38 passed in 1.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
# exit 0; changed-scope coverage TOTAL 19 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py
# exit 0; JSON metrics recorded below

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 19 0 100%`.
- Local registered probe baseline from this worktree before the change:
  - `control_crash_elapsed_ms_mean=10.896125`
  - `worker_crash_elapsed_ms_mean=10.052963`
  - `conflict_elapsed_ms_mean=0.832743`
  - `tail_scan_elapsed_ms_mean=161.519116`
- Local registered probe after the change:
  - `control_crash_elapsed_ms_mean=9.599672` (delta `-1.296453 ms`, about `11.90%` lower)
  - `worker_crash_elapsed_ms_mean=9.650695` (delta `-0.402268 ms`, about `4.00%` lower)
  - `conflict_elapsed_ms_mean=0.797631` (delta `-0.035112 ms`, about `4.22%` lower)
  - `tail_scan_elapsed_ms_mean=158.871549` (delta `-2.647567 ms`, about `1.64%` lower; unchanged path/no regression signal)
  - log read means stayed unchanged (`control=1.0`, `worker=1.0`, `conflict=0.0`).
- CI PR-scoped performance report is still required before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this Linux slice used the registered focused Python test/coverage/probe commands.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
