### PR TITLE
perf: intersect PR scope exact matcher paths

### DIFF
--- a/docs/plans/2026-05-18-pr-scoped-scope-matcher-single-pass.md
+++ b/docs/plans/2026-05-18-pr-scoped-scope-matcher-single-pass.md
@@ -1,0 +1,29 @@
+# PR-scoped scope matcher single-pass slice
+
+## Scope
+
+This Python-only performance slice targets the PR-scoped performance scope matcher in `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`.
+
+## Registered probe
+
+The affected path is covered by the existing registered PR-scoped performance probe `pr-scoped-performance-scope-matcher` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries, so this slice does not add a new probe.
+
+## Change
+
+Keep matching semantics unchanged while reducing per-scope matcher overhead:
+
+- retain the exact-path fast path for exact-only registries;
+- reuse the incoming changed-path set when available instead of rebuilding set membership state;
+- intersect exact watch paths with the changed-path set so exact matching scales with exact hits rather than every changed path;
+- bind hot-path lookups locally inside `_match_probe_indexes_uncached`.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage command, and registered probe locally on Linux before opening the PR. GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.
+
+## Success criteria
+
+- Focused behavior tests pass.
+- Changed-scope coverage for the touched files is at least 95 percent.
+- Local registered probe shows lower or non-regressing `build_scope_report_ms_mean` while preserving `selected_probe_count_mean` and `force_all_selected_mean`.
+- PR-scoped performance CI selects and completes `pr-scoped-performance-scope-matcher` successfully before merge.

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -2482,7 +2482,16 @@ def _match_probe_indexes(
     cache_key = (id(probes), len(probes), changed_path_tuple)
     cached = _MATCH_PROBE_INDEXES_CACHE.get(cache_key)
     if cached is None:
-        cached = _match_probe_indexes_uncached(probes=probes, changed_paths=changed_path_tuple)
+        changed_path_set = (
+            changed_paths
+            if isinstance(changed_paths, (set, frozenset))
+            else frozenset(changed_path_tuple)
+        )
+        cached = _match_probe_indexes_uncached(
+            probes=probes,
+            changed_paths=changed_path_tuple,
+            changed_path_set=changed_path_set,
+        )
         _MATCH_PROBE_INDEXES_CACHE[cache_key] = cached
     return cached
 
@@ -2491,13 +2500,14 @@ def _match_probe_indexes_uncached(
     *,
     probes: tuple[ProbeDefinition, ...],
     changed_paths: tuple[str, ...],
+    changed_path_set: set[str] | frozenset[str],
 ) -> frozenset[int]:
     exact_path_to_probe_indexes, wildcard_glob_matchers = _probe_match_indexes(probes)
     matched_probe_indexes: set[int] = set()
-    for path in changed_paths:
-        probe_indexes = exact_path_to_probe_indexes.get(path)
-        if probe_indexes is not None:
-            matched_probe_indexes.update(probe_indexes)
+    matched_probe_indexes_update = matched_probe_indexes.update
+    exact_path_to_probe_indexes_get = exact_path_to_probe_indexes.get
+    for path in exact_path_to_probe_indexes.keys() & changed_path_set:
+        matched_probe_indexes_update(exact_path_to_probe_indexes_get(path, ()))
     if not wildcard_glob_matchers:
         return frozenset(matched_probe_indexes)
     for path in changed_paths:
@@ -2505,7 +2515,7 @@ def _match_probe_indexes_uncached(
             if prefix and not path.startswith(prefix):
                 continue
             if pattern.match(path) is not None:
-                matched_probe_indexes.update(probe_indexes)
+                matched_probe_indexes_update(probe_indexes)
     return frozenset(matched_probe_indexes)
 
 


### PR DESCRIPTION
## Summary
- Optimize PR-scoped performance scope matching by intersecting exact watch paths with the changed-path set instead of scanning every changed path for exact matches.
- Reuse incoming set/frozenset state when available and keep wildcard matching semantics unchanged.
- Add the governing plan for this Python-only slice.

## Plan or Spec
- `docs/plans/2026-05-18-pr-scoped-scope-matcher-single-pass.md`
- Registered probe: `pr-scoped-performance-scope-matcher` in `infra/perf/pr_scoped_probes.json` already covers `services/mlx-worker-python/worker/productization/pr_scoped_performance.py` and includes focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# Baseline smoke on origin/main-equivalent local worktree before edits
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_exact_only_intersects_changed_paths services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_reuses_cached_frozenset_without_copying services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo
# exit 0; 3 passed in 14.82s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_scope_probe.py
# exit 0; {"build_scope_report_ms_mean": 1.806239, "build_scope_report_ms_min": 0.713329, "changed_file_count": 3205.0, "force_all_selected_mean": 0.0, "sample_count": 6.0, "selected_probe_count_mean": 7.0}

# Registered focused test command for pr-scoped-performance-scope-matcher
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_exact_force_all_skips_wildcard_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_pr_scope_script_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_changed_paths_force_all_wildcards_handles_empty_matchers services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_empty_direct_paths_skips_probe_matching services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_exact_only_intersects_changed_paths services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_reuses_cached_frozenset_without_copying services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_matching_preserves_prefix_short_circuit services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo
# exit 0; 14 passed in 13.38s and 13.64s during repeated runs

# Registered coverage command for pr-scoped-performance-scope-matcher
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_exact_force_all_skips_wildcard_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_pr_scope_script_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_changed_paths_force_all_wildcards_handles_empty_matchers services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_empty_direct_paths_skips_probe_matching services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_exact_only_intersects_changed_paths services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_reuses_cached_frozenset_without_copying services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_matching_preserves_prefix_short_circuit services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; 14 passed in 43.71s; TOTAL 7 0 100%

# Local base-vs-head registered probe comparison helper (uses the same registered probe function)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 .runtime/compare_scope_probe.py
# exit 0; {"base_mean": 1.844574, "head_mean": 1.774892, "delta_ms": -0.069681, "speedup": 1.03926}

# Registered probe command locally on head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_scope_probe.py
# exit 0; {"build_scope_report_ms_mean": 1.823576, "build_scope_report_ms_min": 0.725331, "changed_file_count": 3205.0, "force_all_selected_mean": 0.0, "sample_count": 6.0, "selected_probe_count_mean": 7.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%` for `services/mlx-worker-python/worker/productization/pr_scoped_performance.py` and `services/mlx-worker-python/tests/test_pr_scoped_performance.py`.
- Local base-vs-head probe comparison: `base_mean=1.844574ms`, `head_mean=1.774892ms`, `delta=-0.069681ms`, `speedup=1.03926x` for `build_scope_report_ms_mean`.
- Semantics guard metrics remained unchanged: `selected_probe_count_mean=7.0`, `force_all_selected_mean=0.0`.
- CI PR-scoped performance report is required before merge and should select `pr-scoped-performance-scope-matcher`.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this was scoped to the registered Python performance slice on Linux.
- No Swift runtime behavior is changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
