### PR TITLE
perf: cache tool registry metrics snapshot

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-metrics-snapshot-cache.md
+++ b/docs/plans/2026-05-19-tool-registry-metrics-snapshot-cache.md
@@ -1,0 +1,35 @@
+# Tool registry metrics snapshot cache slice
+
+## Goal
+
+Reduce repeated aggregate work in `worker.runtime.tool_registry.ToolRegistry.metrics()`.
+The descriptor-level schema byte cache removes repeated JSON encoding, but each metrics call still iterates over every tool and required-argument tuple. This slice stores the immutable registry metrics snapshot once during `ToolRegistry` construction and returns it directly for repeated calls.
+
+## Scope
+
+- Python-only runtime change in `services/mlx-worker-python/worker/runtime/tool_registry.py`.
+- Focused unit coverage in `services/mlx-worker-python/tests/test_tool_registry.py`.
+- Existing registered PR-scoped probe coverage through `tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`.
+- No protocol schema, generated artifact, dependency, Swift, or macOS runtime changes.
+
+## Probe
+
+Registered PR-scoped probe: `tool-registry-schema-bytes-cache`.
+
+The probe measures repeated `ToolRegistry.metrics()` calls over the built-in agentic tool registry and reports:
+
+- `elapsed_ms_mean`: wall-clock time for repeated metrics calls.
+- `json_schema_calls_mean`: calls to `ToolDescriptor.json_schema()` during metrics collection; the optimized path remains `0.0`.
+- `schema_byte_count_calls_mean`: calls to `ToolDescriptor.schema_byte_count()` during repeated metrics collection; this slice targets `0.0` after the registry snapshot has been constructed.
+
+## Verification Plan
+
+Run the registered focused command set locally on Linux before opening the PR:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
+```
+
+CI PR-scoped performance remains the merge gate for the registered probe report.

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -203,8 +203,7 @@ def test_tool_registry_schema_bytes_probe_script_emits_metrics(
     assert metrics["schema_bytes"] > 0.0
     assert metrics["elapsed_ms_mean"] >= 0.0
     assert metrics["json_schema_calls_mean"] == 0.0
-    tool_count = len(probe_script["built_in_tool_registry"]().tools)
-    assert metrics["schema_byte_count_calls_mean"] == 20.0 * tool_count
+    assert metrics["schema_byte_count_calls_mean"] == 0.0
 
 
 def test_tool_registry_select_probe_script_emits_metrics(

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -59,6 +59,32 @@ def test_tool_registry_metrics_reuses_cached_schema_byte_counts(monkeypatch: pyt
     assert registry.metrics().schema_bytes == expected_schema_bytes
 
 
+def test_tool_registry_metrics_reuses_registry_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = built_in_tool_registry()
+    expected_metrics = registry.metrics()
+
+    def fail_schema_byte_count(self: ToolDescriptor) -> int:
+        raise AssertionError("metrics() should reuse the registry metrics snapshot")
+
+    monkeypatch.setattr(ToolDescriptor, "schema_byte_count", fail_schema_byte_count)
+
+    with pytest.raises(AssertionError, match=r"metrics\(\) should reuse"):
+        registry.tools[0].schema_byte_count()
+    assert registry.metrics() is expected_metrics
+    assert registry.metrics().schema_bytes == expected_metrics.schema_bytes
+
+
+def test_tool_registry_metrics_snapshot_updates_for_selected_registry() -> None:
+    registry = built_in_tool_registry()
+
+    selected = registry.select(["visit", "image_crop", "visit"])
+
+    assert selected.metrics().tool_count == 2
+    assert selected.metrics().schema_bytes == sum(
+        tool.schema_byte_count() for tool in selected.tools
+    )
+
+
 def test_tool_registry_rejects_duplicate_tool_names() -> None:
     registry = built_in_tool_registry()
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -157,6 +157,11 @@ class ToolRegistry:
         self._parser_contract_version = parser_contract_version.strip()
         self._validate()
         self._tool_by_name = {tool.name: tool for tool in self._tools}
+        self._metrics = ToolRegistryMetrics(
+            tool_count=len(self._tools),
+            schema_bytes=sum(tool.schema_byte_count() for tool in self._tools),
+            required_argument_count=sum(len(tool.required_arguments) for tool in self._tools),
+        )
 
     @property
     def tools(self) -> tuple[ToolDescriptor, ...]:
@@ -166,11 +171,7 @@ class ToolRegistry:
         return tuple(tool.name for tool in self._tools)
 
     def metrics(self) -> ToolRegistryMetrics:
-        return ToolRegistryMetrics(
-            tool_count=len(self._tools),
-            schema_bytes=sum(tool.schema_byte_count() for tool in self._tools),
-            required_argument_count=sum(len(tool.required_arguments) for tool in self._tools),
-        )
+        return self._metrics
 
     def select(self, names: list[str] | tuple[str, ...]) -> ToolRegistry:
         requested_names = tuple(dict.fromkeys(name.strip() for name in names if name.strip()))


### PR DESCRIPTION
## Summary
- Cache the immutable `ToolRegistryMetrics` snapshot during `ToolRegistry` construction.
- Return the cached snapshot from repeated `metrics()` calls instead of recomputing aggregate counts.
- Update focused tests and the registered probe expectation for zero repeated `schema_byte_count()` calls.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-metrics-snapshot-cache.md`
- Registered probe: `tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `30 passed`.
- Changed-scope coverage: `TOTAL 18 0 100%`.
- Local registered probe on Linux:
  - Baseline from `origin/main`: `elapsed_ms_mean=199.54756358638406`, `schema_byte_count_calls_mean=240000.0`.
  - This branch: `elapsed_ms_mean=4.071275983005762`, `schema_byte_count_calls_mean=0.0`.
  - Delta: `-195.4762876033783 ms` mean, about `49.0x` faster for the repeated metrics microprobe.

## Known Gaps
- This is a Python-only slice validated locally on Linux.
- The registered PR-scoped performance workflow is still required as the CI merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe was run locally with before/after metrics.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
