### PR TITLE
perf: cache tool registry names snapshot

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-names-snapshot-cache.md
+++ b/docs/plans/2026-05-19-tool-registry-names-snapshot-cache.md
@@ -1,0 +1,28 @@
+# Tool Registry Names Snapshot Cache
+
+## Goal
+
+Reduce repeated tuple allocation in `worker.runtime.tool_registry.ToolRegistry.names()` for agentic tool configuration paths that query registry names repeatedly during request setup or probe selection.
+
+## Scope
+
+This slice is intentionally limited to the Python tool registry name snapshot path:
+
+- cache the ordered tool-name tuple once during `ToolRegistry` construction;
+- return that immutable snapshot from `names()`;
+- add a registered PR-scoped performance probe for repeated `names()` calls.
+
+It does not change tool descriptors, schema serialization, selection semantics, worker protobuf exports, or built-in tool definitions.
+
+## Performance Probe
+
+Registered probe: `tool-registry-names-snapshot-cache` in `infra/perf/pr_scoped_probes.json`.
+
+The probe runs `scripts/tool_registry_names_probe.py`, repeatedly calls `ToolRegistry.names()`, asserts the stable built-in ordering, and reports:
+
+- `elapsed_ms_mean` (`lower_is_better`)
+- `same_names_object_calls_mean` (`higher_is_better`)
+
+## Verification Plan
+
+Run the focused registry tests, changed-scope coverage command, and the registered probe locally on Linux before opening the PR. CI remains the source of truth for the PR-scoped base-vs-head performance report.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3794,5 +3794,35 @@
         "direction": "informational"
       }
     ]
+  },
+  {
+    "id": "tool-registry-names-snapshot-cache",
+    "name": "Tool registry names snapshot cache",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/tool_registry.py",
+      "services/mlx-worker-python/tests/test_tool_registry.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/tool_registry_names_probe.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_built_in_agentic_tool_registry_exports_stable_contracts services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_names_reuses_registry_snapshot services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_selects_tools_in_requested_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_names_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_built_in_agentic_tool_registry_exports_stable_contracts services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_names_reuses_registry_snapshot services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_selects_tools_in_requested_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_names_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_names_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/tool_registry_names_probe.py ]; then python3 scripts/tool_registry_names_probe.py; else python3 - <<\"PYPROBE\"\nfrom __future__ import annotations\nimport json, os, statistics, sys, time\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.runtime.tool_registry import BUILTIN_AGENTIC_TOOL_NAMES, built_in_tool_registry\ndef measure(iterations: int, sample_count: int) -> dict[str, float]:\n    registry = built_in_tool_registry()\n    expected_names = BUILTIN_AGENTIC_TOOL_NAMES\n    elapsed_samples = []\n    same_object_samples = []\n    checksum = 0\n    for _ in range(sample_count):\n        first_names = registry.names()\n        same_object_count = 0\n        started = time.perf_counter()\n        for _index in range(iterations):\n            names = registry.names()\n            if names != expected_names:\n                raise RuntimeError(f\"unexpected tool names: {names!r}\")\n            if names is first_names:\n                same_object_count += 1\n            checksum += len(names)\n        elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n        same_object_samples.append(float(same_object_count))\n    return {\"elapsed_ms_mean\": statistics.fmean(elapsed_samples), \"names_calls_mean\": float(iterations), \"same_names_object_calls_mean\": statistics.fmean(same_object_samples), \"checksum\": float(checksum), \"iterations\": float(iterations), \"sample_count\": float(sample_count)}\niterations = int(os.environ.get(\"MELIX_TOOL_REGISTRY_NAMES_ITERATIONS\", \"200000\"))\nsample_count = int(os.environ.get(\"MELIX_TOOL_REGISTRY_NAMES_SAMPLES\", \"5\"))\nprint(json.dumps(measure(iterations, sample_count), sort_keys=True))\nPYPROBE\nfi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "same_names_object_calls_mean",
+        "unit": "calls",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      }
+    ]
   }
 ]

--- a/scripts/tool_registry_names_probe.py
+++ b/scripts/tool_registry_names_probe.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime.tool_registry import BUILTIN_AGENTIC_TOOL_NAMES, built_in_tool_registry  # noqa: E402
+
+
+def _measure(iterations: int, sample_count: int) -> dict[str, float]:
+    registry = built_in_tool_registry()
+    expected_names = BUILTIN_AGENTIC_TOOL_NAMES
+    elapsed_samples: list[float] = []
+    same_object_samples: list[float] = []
+    checksum = 0
+
+    for _ in range(sample_count):
+        first_names = registry.names()
+        same_object_count = 0
+        started = time.perf_counter()
+        for _index in range(iterations):
+            names = registry.names()
+            if names != expected_names:
+                raise RuntimeError(f"unexpected tool names: {names!r}")
+            if names is first_names:
+                same_object_count += 1
+            checksum += len(names)
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        same_object_samples.append(float(same_object_count))
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "names_calls_mean": float(iterations),
+        "same_names_object_calls_mean": statistics.fmean(same_object_samples),
+        "checksum": float(checksum),
+        "iterations": float(iterations),
+        "sample_count": float(sample_count),
+    }
+
+
+def main() -> int:
+    iterations = int(os.environ.get("MELIX_TOOL_REGISTRY_NAMES_ITERATIONS", "200000"))
+    sample_count = int(os.environ.get("MELIX_TOOL_REGISTRY_NAMES_SAMPLES", "5"))
+    print(json.dumps(_measure(iterations, sample_count), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -181,10 +181,11 @@ def test_scope_report_selects_tool_registry_schema_bytes_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/tool_registry.py"],
     )
 
-    assert scope["selected_count"] == 2
+    assert scope["selected_count"] == 3
     assert _selected_probe_ids(scope) == [
         "tool-registry-schema-bytes-cache",
         "tool-registry-select-name-index-cache",
+        "tool-registry-names-snapshot-cache",
     ]
 
 
@@ -221,6 +222,23 @@ def test_tool_registry_select_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0.0
     assert metrics["select_calls_mean"] == 20.0
     assert metrics["selection_case_count"] == 4.0
+
+
+def test_tool_registry_names_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_TOOL_REGISTRY_NAMES_ITERATIONS", "20")
+    monkeypatch.setenv("MELIX_TOOL_REGISTRY_NAMES_SAMPLES", "1")
+
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/tool_registry_names_probe.py"))
+
+    assert probe_script["main"]() == 0
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] >= 0.0
+    assert metrics["names_calls_mean"] == 20.0
+    assert metrics["same_names_object_calls_mean"] == 20.0
 
 
 def test_scope_report_selects_integration_swift_binary_resolution_probe() -> None:
@@ -2391,6 +2409,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "text-family-config-copy-elision",
         "tool-registry-schema-bytes-cache",
         "tool-registry-select-name-index-cache",
+        "tool-registry-names-snapshot-cache",
     }
     registry_probe = None
     maintenance_probe = None

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -85,6 +85,15 @@ def test_tool_registry_metrics_snapshot_updates_for_selected_registry() -> None:
     )
 
 
+def test_tool_registry_names_reuses_registry_snapshot() -> None:
+    registry = built_in_tool_registry()
+    expected_names = registry.names()
+    object.__setattr__(registry, "_tools", ())
+
+    assert registry.names() is expected_names
+    assert registry.names() == BUILTIN_AGENTIC_TOOL_NAMES
+
+
 def test_tool_registry_rejects_duplicate_tool_names() -> None:
     registry = built_in_tool_registry()
 


### PR DESCRIPTION
## Summary
- Cache `ToolRegistry.names()` as an immutable registry construction snapshot instead of rebuilding a tuple on every call.
- Register `tool-registry-names-snapshot-cache` with focused test, coverage, and probe commands.
- Add the governing performance slice plan for the names snapshot cache.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-names-snapshot-cache.md`

## Commands Run
```text
# Baseline before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
...
PY
exit 0; elapsed_ms_mean=127.01459201052785, iterations=200000, samples=5

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_probes.json
exit 0

git diff --check
exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_built_in_agentic_tool_registry_exports_stable_contracts services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_names_reuses_registry_snapshot services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_selects_tools_in_requested_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_names_probe_script_emits_metrics
exit 0; 6 passed in 0.67s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_built_in_agentic_tool_registry_exports_stable_contracts services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_names_reuses_registry_snapshot services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_selects_tools_in_requested_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_names_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_names_probe.py
exit 0; 6 passed in 0.23s; TOTAL 19 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_names_probe.py
exit 0; elapsed_ms_mean=26.267582830041647, same_names_object_calls_mean=200000.0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 19 0 100%`.
- Local Linux probe (`tool_registry_names_probe.py`): old_mean=127.01459201052785 ms, new_mean=26.267582830041647 ms, delta_ms=-100.7470091804862 ms, speedup=4.836x for 200000 `names()` calls over 5 samples.
- Registered PR-scoped performance CI is required as the base-vs-head validation source for this PR.

## Known Gaps
- Full repository `make` gates were not run locally; this slice used focused Python tests, changed-scope coverage, and the registered local probe on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; probe overhead is isolated to CI/local probe execution.
- [x] Deferred work and known gaps are stated explicitly.
