### PR TITLE
perf: short-circuit empty probe policy env

### DIFF
--- a/docs/plans/2026-05-19-probe-policy-empty-env-short-circuit.md
+++ b/docs/plans/2026-05-19-probe-policy-empty-env-short-circuit.md
@@ -1,0 +1,43 @@
+# Probe Policy Empty Env Short Circuit
+
+Date: 2026-05-19
+
+## Scope
+
+This Python-only performance slice is limited to
+`services/mlx-worker-python/worker/productization/probe_policy.py` and the
+focused tests in `services/mlx-worker-python/tests/test_probe_policy.py`.
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped probe
+`probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`. The probe
+already declares focused `test_command`, `coverage_command`, and
+`probe_command` entries and reports `env_parse_empty_call_ms_mean` as a
+lower-is-better metric.
+
+## Change
+
+`ProbePolicy.from_env({})` is a hot no-op observability path in tests and
+runtime callers that pass explicit scoped environment mappings. Before this
+slice, the method always performed a mapping `.get()` lookup even when the
+provided mapping was empty. This slice short-circuits explicit empty mappings to
+the cached default policy singleton before probing the mapping.
+
+Behavior remains unchanged: missing `MELIX_PROBE_MODE` still selects the default
+mode, explicit empty values still select the default mode, invalid values still
+fall back with `fallback_applied=True`, and `env=None` still reads `os.environ`.
+
+## Verification Plan
+
+- Run the registered focused probe-policy test command locally on Linux.
+- Run the registered changed-scope coverage command locally on Linux.
+- Run `scripts/probe_policy_noop_overhead_probe.py` locally and compare the
+  `env_parse_empty_call_ms_mean` metric against the pre-change baseline.
+- Use GitHub Actions PR-scoped performance as the merge gate after opening the
+  PR.
+
+## Linux Validation Boundary
+
+This slice changes only Python code and is locally verifiable on Linux. No Swift
+runtime performance claims are made.

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -7,6 +7,11 @@ from worker.productization.probe_policy_overhead import (
 from worker.productization.probe_policy import ProbeMode, ProbePolicy, probe_policy_from_env
 
 
+class _EmptyEnvMapping(dict[str, str]):
+    def get(self, key: str, default: str = "") -> str:  # pragma: no cover - should not run
+        raise AssertionError("empty environment mappings should not be probed")
+
+
 def test_probe_policy_parses_supported_modes() -> None:
     assert ProbePolicy.from_value("off").mode == ProbeMode.OFF
     assert ProbePolicy.from_value("minimal").mode == ProbeMode.MINIMAL
@@ -93,6 +98,16 @@ def test_probe_policy_empty_values_reuse_default_policy_cache() -> None:
     assert debug_policy.mode is ProbeMode.DEBUG
     assert debug_policy.source_value == ""
     assert debug_policy.telemetry_enabled is True
+
+
+def test_probe_policy_empty_env_short_circuits_mapping_lookup() -> None:
+    minimal_policy = ProbePolicy.from_value("")
+
+    assert ProbePolicy.from_env(_EmptyEnvMapping()) is minimal_policy
+    assert (
+        ProbePolicy.from_env(_EmptyEnvMapping(), default_mode=ProbeMode.DEBUG)
+        is ProbePolicy.from_value("", default_mode=ProbeMode.DEBUG)
+    )
 
 
 def test_probe_policy_factory_helpers_reuse_cached_instances() -> None:

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -45,6 +45,8 @@ class ProbePolicy:
         *,
         default_mode: ProbeMode = ProbeMode.MINIMAL,
     ) -> ProbePolicy:
+        if env is not None and not env:
+            return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
         values = os.environ if env is None else env
         raw_value = values.get(MELIX_PROBE_MODE_ENV, "")
         if not raw_value:


### PR DESCRIPTION
## Summary
- Short-circuit explicit empty environment mappings in `ProbePolicy.from_env()` to reuse the cached default policy without a mapping lookup.
- Add a regression test proving empty scoped env mappings are not probed.
- Document the Python-only performance slice and registered probe coverage.

## Plan or Spec
- `docs/plans/2026-05-19-probe-policy-empty-env-short-circuit.md`
- Registered probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=400000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py
# pre-change baseline: env_parse_empty_call_ms_mean=0.000148478, threshold_passed=1.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 17 passed in 0.67s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py
# 17 passed in 0.23s; TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=400000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py
# post-change: env_parse_empty_call_ms_mean=0.000130663, threshold_passed=1.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Local Linux registered probe metric: `env_parse_empty_call_ms_mean` improved from `0.000148478` ms to `0.000130663` ms (`delta=-0.000017815` ms, about `12.0%` lower) using 400,000 iterations and 5 samples.
- CI PR-scoped performance is required for registered probe validation before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this is a focused Python performance slice.
- No Swift runtime performance claims; Linux-local validation only covers the Python path.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
