### PR TITLE
perf: cache repeated tool registry selections

### DIFF
--- a/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
+++ b/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
@@ -37,6 +37,16 @@ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-
 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
 ```
 
+## Slice update: selected-registry cache
+
+The next incremental slice keeps the same `tool-registry-select-name-index-cache`
+registered probe and narrows the optimization to repeated `ToolRegistry.select()`
+calls with the same normalized requested-name tuple. The registry now caches the
+constructed selected `ToolRegistry` per tuple after unknown-name validation,
+so hot selection loops avoid rebuilding the selected registry, its name index,
+and its aggregate metrics snapshot. Selection order, whitespace normalization,
+deduplication, and unknown-name errors remain unchanged.
+
 ## Acceptance Criteria
 
 - Focused behavior tests pass locally on Linux.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -116,6 +116,15 @@ def test_tool_registry_select_reuses_cached_name_index() -> None:
     assert selected.names() == ("visit", "image_crop")
 
 
+def test_tool_registry_select_reuses_cached_selected_registry() -> None:
+    registry = built_in_tool_registry()
+
+    selected = registry.select([" visit ", "image_crop", "visit"])
+
+    assert registry.select(["visit", "image_crop"]) is selected
+    assert selected.names() == ("visit", "image_crop")
+
+
 def test_tool_registry_exports_worker_tool_config_metadata() -> None:
     config = built_in_tool_config(["image_crop", "local_compute"])
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -157,6 +157,7 @@ class ToolRegistry:
         self._parser_contract_version = parser_contract_version.strip()
         self._validate()
         self._tool_by_name = {tool.name: tool for tool in self._tools}
+        self._selection_cache: dict[tuple[str, ...], ToolRegistry] = {}
         self._metrics = ToolRegistryMetrics(
             tool_count=len(self._tools),
             schema_bytes=sum(tool.schema_byte_count() for tool in self._tools),
@@ -175,18 +176,23 @@ class ToolRegistry:
 
     def select(self, names: list[str] | tuple[str, ...]) -> ToolRegistry:
         requested_names = tuple(dict.fromkeys(name.strip() for name in names if name.strip()))
+        cached_selection = self._selection_cache.get(requested_names)
+        if cached_selection is not None:
+            return cached_selection
         missing_names = [name for name in requested_names if name not in self._tool_by_name]
         if missing_names:
             joined = ", ".join(missing_names)
             raise ToolRegistryError(f"Unknown tool registry entry requested: {joined}")
         selected = [self._tool_by_name[name] for name in requested_names]
-        return ToolRegistry(
+        selection = ToolRegistry(
             selected,
             schema_version=self._schema_version,
             toolset_version=self._toolset_version,
             parser=self._parser,
             parser_contract_version=self._parser_contract_version,
         )
+        self._selection_cache[requested_names] = selection
+        return selection
 
     def as_openai_tools(self) -> list[dict[str, Any]]:
         return [tool.as_openai_tool() for tool in self._tools]


### PR DESCRIPTION
## Summary
- Cache normalized `ToolRegistry.select()` results on each immutable registry instance.
- Avoid rebuilding the same selected registry, name index, and metrics snapshot in repeated selection loops.
- Add a regression test proving duplicate/whitespace-normalized selections reuse the cached selected registry.

## Plan or Spec
- `docs/plans/2026-05-18-tool-registry-select-name-index-cache.md`
- Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json` (already has focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# baseline probe on origin/main worktree before changes: exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
{"elapsed_ms_mean": 385.2370923385024, ...}

# focused tests: exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
31 passed in 0.65s

# changed-scope coverage: exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
TOTAL 12 0 100%

# head registered probe locally: exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
{"elapsed_ms_mean": 66.48988821543753, ...}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (12/12 measurable changed lines).
- Local registered probe (`tool_registry_select_probe.py`, 80,000 iterations, 5 samples):
  - base `elapsed_ms_mean=385.2370923385024`
  - head `elapsed_ms_mean=66.48988821543753`
  - delta `-318.747204 ms`
  - speedup `5.793920x` / `82.74%` lower mean elapsed time
- CI PR-scoped performance is still required as the merge gate for the registered probe report.

## Known Gaps
- Swift/macOS runtime effects are not relevant to this Python-only slice.
- CI registered probe validation is pending after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability-mode change.
- [x] Deferred work and known gaps are stated explicitly.
