### PR TITLE
perf: streamline tool registry selection normalization

### DIFF
--- a/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
+++ b/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
@@ -47,6 +47,19 @@ so hot selection loops avoid rebuilding the selected registry, its name index,
 and its aggregate metrics snapshot. Selection order, whitespace normalization,
 deduplication, and unknown-name errors remain unchanged.
 
+## Slice update: single-pass selection normalization
+
+This incremental slice still uses the `tool-registry-select-name-index-cache`
+registered probe and narrows the hot path before cache lookup. `ToolRegistry.select()`
+now normalizes, drops blanks, and deduplicates requested names in one explicit
+pass instead of building a generator and a temporary insertion-ordered dictionary.
+When the normalized requested-name tuple already matches the immutable registry
+name tuple, the method returns the current registry instead of constructing and
+caching an equivalent selected registry. The registry also keeps a bounded
+selected-registry cache so repeated ad hoc selections retain the hot cache
+benefit without unbounded growth. Selection order, whitespace normalization,
+deduplication, and unknown-name errors remain unchanged.
+
 ## Acceptance Criteria
 
 - Focused behavior tests pass locally on Linux.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -125,6 +125,27 @@ def test_tool_registry_select_reuses_cached_selected_registry() -> None:
     assert selected.names() == ("visit", "image_crop")
 
 
+def test_tool_registry_select_returns_self_for_complete_selection() -> None:
+    registry = built_in_tool_registry()
+
+    selected = registry.select([" " + name + " " for name in BUILTIN_AGENTIC_TOOL_NAMES])
+
+    assert selected is registry
+    assert registry.names() == BUILTIN_AGENTIC_TOOL_NAMES
+
+
+def test_tool_registry_selection_cache_is_bounded() -> None:
+    registry = built_in_tool_registry()
+
+    for index in range(40):
+        registry._selection_cache[("visit", f"probe_{index}")] = registry
+
+    selected = registry.select(["image_crop"])
+
+    assert selected.names() == ("image_crop",)
+    assert registry._selection_cache == {("image_crop",): selected}
+
+
 def test_tool_registry_exports_worker_tool_config_metadata() -> None:
     config = built_in_tool_config(["image_crop", "local_compute"])
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -10,6 +10,7 @@ from packages.protocol.python.worker.v1 import common_pb2
 
 _COMPACT_SORTED_JSON_ENCODER = json.JSONEncoder(separators=(",", ":"), sort_keys=True)
 _TOOL_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_SELECTION_CACHE_MAX_SIZE = 32
 
 TOOL_REGISTRY_SCHEMA_VERSION = "melix.agentic_tool_registry.v1"
 BUILTIN_TOOLSET_VERSION = "melix.agentic_tools.builtin.v1"
@@ -156,6 +157,7 @@ class ToolRegistry:
         self._parser = parser.strip()
         self._parser_contract_version = parser_contract_version.strip()
         self._validate()
+        self._tool_names = tuple(tool.name for tool in self._tools)
         self._tool_by_name = {tool.name: tool for tool in self._tools}
         self._selection_cache: dict[tuple[str, ...], ToolRegistry] = {}
         self._metrics = ToolRegistryMetrics(
@@ -169,13 +171,23 @@ class ToolRegistry:
         return self._tools
 
     def names(self) -> tuple[str, ...]:
-        return tuple(tool.name for tool in self._tools)
+        return self._tool_names
 
     def metrics(self) -> ToolRegistryMetrics:
         return self._metrics
 
     def select(self, names: list[str] | tuple[str, ...]) -> ToolRegistry:
-        requested_names = tuple(dict.fromkeys(name.strip() for name in names if name.strip()))
+        requested_names_list: list[str] = []
+        seen_names: set[str] = set()
+        for name in names:
+            normalized_name = name.strip()
+            if not normalized_name or normalized_name in seen_names:
+                continue
+            seen_names.add(normalized_name)
+            requested_names_list.append(normalized_name)
+        requested_names = tuple(requested_names_list)
+        if requested_names == self._tool_names:
+            return self
         cached_selection = self._selection_cache.get(requested_names)
         if cached_selection is not None:
             return cached_selection
@@ -191,6 +203,8 @@ class ToolRegistry:
             parser=self._parser,
             parser_contract_version=self._parser_contract_version,
         )
+        if len(self._selection_cache) >= _SELECTION_CACHE_MAX_SIZE:
+            self._selection_cache.clear()
         self._selection_cache[requested_names] = selection
         return selection
 


### PR DESCRIPTION
## Summary
- Streamline `ToolRegistry.select()` normalization into one explicit pass before cache lookup.
- Reuse the immutable registry name tuple for `names()` and return the current registry when a complete selection is requested.
- Bound the selected-registry cache to prevent unbounded growth while preserving the repeated-selection hot cache.

## Plan or Spec
- `docs/plans/2026-05-18-tool-registry-select-name-index-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 33 passed in 0.68s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# 33 passed; changed-scope coverage TOTAL 28/28, 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-select-name-index-cache --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-perf-base-tool-registry-self-select-20260519 --head-repo "$PWD" --output /tmp/tool_registry_select_normalization_probe.json
# ok; base elapsed_ms_mean=66.83303355239332, head elapsed_ms_mean=44.94424196891487

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 28 0 100%`).
- Registered local probe: `tool-registry-select-name-index-cache`.
  - `elapsed_ms_mean`: base `66.83303355239332 ms`, head `44.94424196891487 ms`, delta `-21.88879158347845 ms` (`32.751456009128894%` faster).
  - Workload parity: `select_calls_mean=80000`, `selection_case_count=4` for both base and head.
- Observability mode: evidence; probe overhead is limited to the synthetic PR-scoped performance command and is not in production runtime.
- CI PR-scoped performance is required as the merge gate.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime effect is claimed.
- Full repository `make py-test` / integration suites were not run locally for this focused Python slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
