### PR TITLE
perf: fast-path tool registry tuple cache hits

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-select-tuple-cache-hit.md
+++ b/docs/plans/2026-05-19-tool-registry-select-tuple-cache-hit.md
@@ -1,0 +1,51 @@
+# Tool registry tuple cache-hit fast path
+
+## Summary
+
+This performance slice keeps `ToolRegistry.select()` behavior unchanged while
+short-circuiting repeated clean tuple selections that already exist in the
+selection cache.
+
+## Registered PR-scoped probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_select_probe.py`
+
+No new probe registry entry is required for this slice.
+
+## Optimization slice
+
+`ToolRegistry.select()` already normalizes requested names, deduplicates them,
+validates missing names, and caches selected registries by the normalized tuple.
+The registered probe repeatedly calls `select()` with clean tuple selections.
+After the first selection builds the cached registry, later identical tuple
+calls can safely probe `_selection_cache` before rebuilding the normalized tuple
+or touching the name index.
+
+The fast path is intentionally limited to tuple inputs:
+
+- complete tuple selections equal to `self._tool_names` return `self` directly;
+- cached clean tuple selections return the cached registry directly;
+- list inputs, blank trimming, deduplication, missing-name errors, and cache
+  population continue through the existing normalization path.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and
+registered probe locally on Linux. The PR-scoped performance workflow must also
+select and complete `tool-registry-select-name-index-cache` before merge.
+
+## Success criteria
+
+- Focused Python tests pass.
+- Changed-scope coverage for the touched files remains at or above 95%.
+- Registered probe shows a clear reduction in `elapsed_ms_mean` for repeated
+  tuple cache hits.
+- GitHub Actions and the PR-scoped performance workflow are green.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -133,12 +133,24 @@ def test_tool_registry_select_reuses_cached_selected_registry() -> None:
     assert selected.names() == ("visit", "image_crop")
 
 
+def test_tool_registry_select_tuple_cache_hit_skips_name_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = built_in_tool_registry()
+    selected = registry.select(("visit", "image_crop"))
+
+    monkeypatch.setattr(registry, "_tool_by_name", {})
+
+    assert registry.select(("visit", "image_crop")) is selected
+    with pytest.raises(ToolRegistryError, match="Unknown tool registry entry requested"):
+        registry.select(["image_crop", "visit"])
+
+
 def test_tool_registry_select_returns_self_for_complete_selection() -> None:
     registry = built_in_tool_registry()
 
     selected = registry.select([" " + name + " " for name in BUILTIN_AGENTIC_TOOL_NAMES])
 
     assert selected is registry
+    assert registry.select(BUILTIN_AGENTIC_TOOL_NAMES) is registry
     assert registry.names() == BUILTIN_AGENTIC_TOOL_NAMES
 
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -177,6 +177,13 @@ class ToolRegistry:
         return self._metrics
 
     def select(self, names: list[str] | tuple[str, ...]) -> ToolRegistry:
+        if isinstance(names, tuple):
+            if names == self._tool_names:
+                return self
+            cached_selection = self._selection_cache.get(names)
+            if cached_selection is not None:
+                return cached_selection
+
         requested_names_list: list[str] = []
         seen_names: set[str] = set()
         for name in names:


### PR DESCRIPTION
## Summary
- Fast-path `ToolRegistry.select()` for repeated clean tuple selections that are already in `_selection_cache`.
- Preserve the existing normalization path for list inputs, blank trimming, deduplication, missing-name validation, and cache population.
- Add regression coverage for tuple cache hits and document the registered probe-backed slice plan.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-select-tuple-cache-hit.md`
- Registered PR-scoped performance probe: `tool-registry-select-name-index-cache`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=120000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` (baseline on `origin/main`): exit 0, `elapsed_ms_mean=68.9725839998573`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`: exit 0, `35 passed in 0.14s`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`: exit 0, changed-line coverage `TOTAL 14 0 100%`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=120000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` (new): exit 0, `elapsed_ms_mean=46.64321015588939`
- `git diff --check`: exit 0

## Coverage and Metrics
- Local focused tests: `35 passed`.
- Changed-scope coverage: `100%` for 14 measurable changed lines.
- Local registered probe comparison (`scripts/tool_registry_select_probe.py`, 120k iterations, 5 samples): old mean `68.9726 ms`, new mean `46.6432 ms`, delta `-22.3294 ms`, speedup `1.48x` (~32.37% lower elapsed mean).
- CI PR-scoped performance must validate `tool-registry-select-name-index-cache` before merge.

## Known Gaps
- This is a Python-only slice locally verified on Linux.
- Local measurements are synthetic probe results; the registered CI probe report is still required before merging.

## Evidence Checklist
- [x] Affected path has registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Behavior-preserving regression test added.
- [x] Focused local tests passed.
- [x] Changed-scope coverage passed at or above 95%.
- [x] Registered probe run locally with before/after metrics.
- [ ] GitHub Actions complete successfully.
- [ ] PR-scoped performance workflow reports `tool-registry-select-name-index-cache` successfully.
