### PR TITLE
perf: cache tool required argument names

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-required-arguments-cache.md
+++ b/docs/plans/2026-05-19-tool-registry-required-arguments-cache.md
@@ -1,0 +1,25 @@
+# Tool registry required-arguments cache
+
+## Scope
+
+This Python-only performance slice narrows the repeated `ToolDescriptor.required_arguments` hot path in `services/mlx-worker-python/worker/runtime/tool_registry.py`.
+
+The behavior remains unchanged: descriptors still validate duplicate argument names during construction, `schema_payload()` still returns a fresh mutable payload dictionary, and registry metrics continue to report the same required-argument totals.
+
+## Optimization
+
+Cache the required argument-name tuple once during `ToolDescriptor.__post_init__` and have the `required_arguments` property return that immutable snapshot. This removes repeated tuple construction when callers request `required_arguments` or rebuild schema payload dictionaries for already-validated descriptors.
+
+## PR-scoped performance CI
+
+The affected Python path is already covered by the registered PR-scoped probes in `infra/perf/pr_scoped_probes.json`:
+
+- `tool-registry-schema-bytes-cache`
+- `tool-registry-select-name-index-cache`
+- `tool-registry-names-snapshot-cache`
+
+This slice extends the `tool-registry-schema-bytes-cache` probe with `schema_payload_elapsed_ms_mean` so CI and local Linux runs compare the schema-payload path directly. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for the changed code, tests, and probe script.
+
+## Linux validation boundary
+
+This slice is entirely Python and locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered command-json probe. No Swift runtime performance claim is made.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3753,6 +3753,12 @@
         "warn_pct": 5.0
       },
       {
+        "key": "schema_payload_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
         "key": "json_schema_calls_mean",
         "unit": "calls",
         "direction": "lower_is_better",

--- a/scripts/tool_registry_schema_bytes_probe.py
+++ b/scripts/tool_registry_schema_bytes_probe.py
@@ -19,8 +19,10 @@ from worker.runtime.tool_registry import ToolDescriptor, built_in_tool_registry 
 def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     registry = built_in_tool_registry()
     expected_schema_bytes = sum(len(tool.json_schema().encode("utf-8")) for tool in registry.tools)
+    expected_required_arguments = [list(tool.required_arguments) for tool in registry.tools]
     original_json_schema = ToolDescriptor.json_schema
     elapsed_samples: list[float] = []
+    schema_payload_elapsed_samples: list[float] = []
     json_schema_calls: list[float] = []
     schema_byte_count_calls: list[float] = []
     checksum = 0
@@ -56,6 +58,17 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
             elapsed_samples.append((time.perf_counter() - started) * 1000.0)
             json_schema_calls.append(float(json_calls))
             schema_byte_count_calls.append(float(byte_count_calls))
+
+            payload_started = time.perf_counter()
+            for _index in range(iterations):
+                for tool_index, tool in enumerate(registry.tools):
+                    payload = tool.schema_payload()
+                    if payload["required"] != expected_required_arguments[tool_index]:  # pragma: no cover
+                        raise RuntimeError(
+                            f"unexpected required arguments: {payload['required']!r}"
+                        )
+                    checksum += len(payload["required"])
+            schema_payload_elapsed_samples.append((time.perf_counter() - payload_started) * 1000.0)
     finally:
         tool_registry_module.ToolDescriptor.json_schema = original_json_schema
         if original_schema_byte_count is None:
@@ -65,6 +78,7 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
 
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "schema_payload_elapsed_ms_mean": statistics.fmean(schema_payload_elapsed_samples),
         "json_schema_calls_mean": statistics.fmean(json_schema_calls),
         "schema_byte_count_calls_mean": statistics.fmean(schema_byte_count_calls),
         "schema_bytes": float(expected_schema_bytes),

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -203,6 +203,7 @@ def test_tool_registry_schema_bytes_probe_script_emits_metrics(
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["schema_bytes"] > 0.0
     assert metrics["elapsed_ms_mean"] >= 0.0
+    assert metrics["schema_payload_elapsed_ms_mean"] >= 0.0
     assert metrics["json_schema_calls_mean"] == 0.0
     assert metrics["schema_byte_count_calls_mean"] == 0.0
 

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -94,6 +94,16 @@ def test_tool_registry_names_reuses_registry_snapshot() -> None:
     assert registry.names() == BUILTIN_AGENTIC_TOOL_NAMES
 
 
+def test_tool_descriptor_required_arguments_reuses_cached_snapshot() -> None:
+    tool = built_in_tool_registry().tools[0]
+    expected_required_arguments = tool.required_arguments
+    object.__setattr__(tool, "arguments", ())
+
+    assert tool.required_arguments is expected_required_arguments
+    assert tool.required_arguments == ("media_ref", "region")
+    assert tool.schema_payload()["required"] == ["media_ref", "region"]
+
+
 def test_tool_registry_rejects_duplicate_tool_names() -> None:
     registry = built_in_tool_registry()
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -63,6 +63,7 @@ class ToolDescriptor:
     tool_kind: str
     observation_kind: str
     arguments: tuple[ToolArgumentDescriptor, ...]
+    _cached_required_arguments: tuple[str, ...] = field(default=(), init=False, repr=False)
     _cached_schema: str = field(default="", init=False, repr=False)
     _cached_schema_bytes: int = field(default=0, init=False, repr=False)
 
@@ -89,13 +90,15 @@ class ToolDescriptor:
                     f"Duplicate argument {argument.name} in tool registry entry {normalized_name}."
                 )
             argument_names.add(argument.name)
+        required_arguments = tuple(argument.name for argument in self.arguments if argument.required)
+        object.__setattr__(self, "_cached_required_arguments", required_arguments)
         cached_schema = _COMPACT_SORTED_JSON_ENCODER.encode(self.schema_payload())
         object.__setattr__(self, "_cached_schema", cached_schema)
         object.__setattr__(self, "_cached_schema_bytes", len(cached_schema.encode("utf-8")))
 
     @property
     def required_arguments(self) -> tuple[str, ...]:
-        return tuple(argument.name for argument in self.arguments if argument.required)
+        return self._cached_required_arguments
 
     def schema_payload(self) -> dict[str, Any]:
         return {


### PR DESCRIPTION
## Summary
- Cache each `ToolDescriptor` required-argument tuple during descriptor initialization.
- Keep `schema_payload()` behavior unchanged while removing repeated required-argument tuple construction.
- Extend the registered tool-registry schema probe with `schema_payload_elapsed_ms_mean` and add regression coverage for the cached snapshot.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-required-arguments-cache.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_tool_descriptor_required_arguments_reuses_cached_snapshot services/mlx-worker-python/tests/test_tool_registry.py::test_built_in_agentic_tool_registry_exports_stable_contracts services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_metrics_snapshot_updates_for_selected_registry services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py`
- Baseline comparison helper: `MELIX_REPO_UNDER_TEST=<repo> uv run --project services/mlx-worker-python python3 /tmp/tool_registry_required_args_compare.py`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: 4 passed.
- Changed-scope coverage: 100% aggregate changed-line coverage.
- Registered local probe (`tool_registry_schema_bytes_probe.py`): `schema_payload_elapsed_ms_mean=194.028 ms`, `elapsed_ms_mean=4.112 ms`, `json_schema_calls_mean=0.0`, `schema_byte_count_calls_mean=0.0`.
- Baseline comparison helper: old `schema_payload_elapsed_ms_mean=332.250 ms`, new `236.718 ms`, delta `-95.531 ms` (`-28.75%`, `1.404x`).
- CI PR-scoped performance is required for the registered probe validation before merge.

## Known Gaps
- Linux-only local validation; no Swift runtime effect is claimed.
- The focused comparison uses a synthetic schema-payload loop matching the registered probe metric.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path and has focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe runs locally and reports metrics.
- [ ] GitHub Actions PR-scoped performance report is green.
