### PR TITLE
perf: cache raw tool select tuple aliases

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-raw-tuple-cache-alias.md
+++ b/docs/plans/2026-05-19-tool-registry-raw-tuple-cache-alias.md
@@ -1,0 +1,51 @@
+# Tool registry raw tuple cache alias
+
+## Summary
+
+This Python-only performance slice keeps `ToolRegistry.select()` behavior
+unchanged while caching a validated raw tuple request as an alias to the
+normalized selection result. The registered select probe repeatedly sends a
+small set of tuple selections, including a duplicate-name tuple, so the current
+implementation still re-normalizes that duplicate tuple on every call even after
+its normalized selected registry is cached.
+
+## Registered PR-scoped probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `tool-registry-select-name-index-cache` in
+`infra/perf/pr_scoped_probes.json`. The probe entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_select_probe.py`
+
+No new probe registry entry is required for this slice.
+
+## Optimization slice
+
+After `select()` strips, filters, deduplicates, validates, and builds or reuses
+the normalized selection, store the original tuple request as an additional
+cache key when it differs from the normalized tuple. Future identical tuple
+requests can use the existing tuple cache fast path before repeating the
+normalization loop. List inputs remain uncached by raw identity and still follow
+the existing normalization path.
+
+The cache remains bounded by the existing selection-cache limit and cache-clear
+behavior. Missing-name errors, blank-name filtering, deduplication order, and
+complete-selection self returns are unchanged.
+
+## Verification plan
+
+- Run the focused tool-registry tests locally on Linux.
+- Run the registered changed-scope coverage command and require at least 95%
+  changed-line coverage.
+- Run `scripts/tool_registry_select_probe.py` before and after the change and
+  compare `elapsed_ms_mean` while preserving `select_calls_mean` and checksum.
+- Use GitHub Actions PR-scoped performance as the merge gate after pushing.
+
+## Linux validation boundary
+
+This slice is entirely Python and locally verifiable on Linux. No Swift runtime
+performance claims are made.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -163,6 +163,22 @@ def test_tool_registry_select_tuple_cache_hit_skips_name_lookup(monkeypatch: pyt
         registry.select(["image_crop", "visit"])
 
 
+def test_tool_registry_select_caches_raw_tuple_alias_after_normalization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = built_in_tool_registry()
+    selected = registry.select((" visit ", "image_crop", "visit", ""))
+
+    monkeypatch.setattr(registry, "_tool_by_name", {})
+
+    assert selected.names() == ("visit", "image_crop")
+    assert registry._selection_cache[(" visit ", "image_crop", "visit", "")] is selected
+    del registry._selection_cache[("visit", "image_crop")]
+    assert registry.select((" visit ", "image_crop", "visit", "")) is selected
+    with pytest.raises(ToolRegistryError, match="Unknown tool registry entry requested"):
+        registry.select(["layout_parse"])
+
+
 def test_tool_registry_select_returns_self_for_complete_selection() -> None:
     registry = built_in_tool_registry()
 
@@ -183,6 +199,21 @@ def test_tool_registry_selection_cache_is_bounded() -> None:
 
     assert selected.names() == ("image_crop",)
     assert registry._selection_cache == {("image_crop",): selected}
+
+
+def test_tool_registry_raw_tuple_alias_keeps_selection_cache_bounded() -> None:
+    registry = built_in_tool_registry()
+
+    for index in range(31):
+        registry._selection_cache[("visit", f"probe_{index}")] = registry
+
+    selected = registry.select((" visit ", "image_crop", "visit"))
+
+    assert selected.names() == ("visit", "image_crop")
+    assert registry._selection_cache == {
+        ("visit", "image_crop"): selected,
+        (" visit ", "image_crop", "visit"): selected,
+    }
 
 
 def test_tool_registry_exports_worker_tool_config_metadata() -> None:

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -213,9 +213,12 @@ class ToolRegistry:
             parser=self._parser,
             parser_contract_version=self._parser_contract_version,
         )
-        if len(self._selection_cache) >= _SELECTION_CACHE_MAX_SIZE:
+        cache_raw_tuple = isinstance(names, tuple) and names != requested_names
+        if len(self._selection_cache) >= _SELECTION_CACHE_MAX_SIZE - int(cache_raw_tuple):
             self._selection_cache.clear()
         self._selection_cache[requested_names] = selection
+        if cache_raw_tuple:
+            self._selection_cache[names] = selection
         return selection
 
     def as_openai_tools(self) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Cache validated raw tuple `ToolRegistry.select()` requests as aliases to their normalized selected registry.
- Preserve selection order, blank filtering, duplicate removal, missing-name errors, and the existing bounded cache behavior.
- Add focused regression coverage for raw tuple alias reuse and bounded cache clearing.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-raw-tuple-cache-alias.md`
- Registered PR-scoped probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe on origin/main before edits
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# exit 0; {"elapsed_ms_mean": 27.70077777095139, "select_calls_mean": 80000.0, "checksum": 800000.0, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 39 passed in 0.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# exit 0; TOTAL 21 0 100%; coverage.json removed after the report

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# exit 0; {"elapsed_ms_mean": 20.49709614366293, "select_calls_mean": 80000.0, "checksum": 800000.0, ...}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 21 0 100%`).
- Local Linux registered probe: old_mean=27.70077777095139 ms, new_mean=20.49709614366293 ms, delta_ms=-7.203682, speedup=1.3514x, improvement=26.01%.
- Registered CI probe validation is required before merge: `tool-registry-select-name-index-cache` via PR-scoped performance workflow.

## Known Gaps
- None for the Python slice. No Swift runtime performance claims are made.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
