### PR TITLE
perf: cache tool schema payload properties

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-cache.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-cache.md
@@ -1,0 +1,48 @@
+# Tool Registry Schema Payload Cache Performance Slice
+
+## Scope
+
+This Python-only performance slice targets `ToolDescriptor.schema_payload()` in
+`services/mlx-worker-python/worker/runtime/tool_registry.py`. The method is used
+when exporting agentic tool definitions to OpenAI-compatible payloads and is also
+covered by the existing schema-byte-count registered probe workload.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_schema_bytes_probe.py`
+
+## Optimization hypothesis
+
+`schema_payload()` currently rebuilds every argument schema by calling
+`ToolArgumentDescriptor.json_schema()` for each export. Tool descriptors are
+immutable after construction, so the normalized argument schema dictionaries can
+be cached at descriptor construction time. Each call should still return fresh
+mutable dictionaries to preserve caller isolation, but it can avoid repeated
+method dispatch and field lookup while constructing the payload.
+
+## Verification plan
+
+1. Add focused tests proving `schema_payload()` reuses the cached argument schema
+   snapshot and still returns isolated mutable payload dictionaries.
+2. Implement only the descriptor-level cached argument schema tuple.
+3. Run the registered focused pytest command and changed-scope coverage command
+   locally on Linux.
+4. Run the registered `tool-registry-schema-bytes-cache` probe locally on Linux
+   before and after the change and compare `schema_payload_elapsed_ms_mean`.
+5. Use PR-scoped performance CI as the final registered probe gate before merge.
+
+## Success criteria
+
+- Focused tests pass and changed-scope coverage remains at or above 95%.
+- Registered local probe shows a clear improvement in
+  `schema_payload_elapsed_ms_mean` without changing schema bytes or required
+  argument behavior.
+- GitHub Actions and the PR-scoped performance workflow are green before merge.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -104,6 +104,39 @@ def test_tool_descriptor_required_arguments_reuses_cached_snapshot() -> None:
     assert tool.schema_payload()["required"] == ["media_ref", "region"]
 
 
+def test_tool_descriptor_schema_payload_reuses_cached_argument_schemas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool = built_in_tool_registry().tools[0]
+
+    def fail_json_schema(self: ToolArgumentDescriptor) -> dict[str, str]:  # pragma: no cover
+        raise AssertionError("schema_payload() should reuse cached argument schemas")
+
+    monkeypatch.setattr(ToolArgumentDescriptor, "json_schema", fail_json_schema)
+
+    payload = tool.schema_payload()
+
+    assert payload["properties"]["media_ref"] == {
+        "type": "string",
+        "description": "Identifier or URI for the source image.",
+    }
+
+
+def test_tool_descriptor_schema_payload_returns_isolated_mutable_payloads() -> None:
+    tool = built_in_tool_registry().tools[0]
+
+    first_payload = tool.schema_payload()
+    first_payload["properties"]["media_ref"]["description"] = "mutated"
+    first_payload["required"].append("mutated")
+
+    second_payload = tool.schema_payload()
+
+    assert second_payload["properties"]["media_ref"]["description"] == (
+        "Identifier or URI for the source image."
+    )
+    assert second_payload["required"] == ["media_ref", "region"]
+
+
 def test_tool_registry_rejects_duplicate_tool_names() -> None:
     registry = built_in_tool_registry()
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -64,6 +64,9 @@ class ToolDescriptor:
     observation_kind: str
     arguments: tuple[ToolArgumentDescriptor, ...]
     _cached_required_arguments: tuple[str, ...] = field(default=(), init=False, repr=False)
+    _cached_schema_properties: tuple[tuple[str, dict[str, Any]], ...] = field(
+        default=(), init=False, repr=False
+    )
     _cached_schema: str = field(default="", init=False, repr=False)
     _cached_schema_bytes: int = field(default=0, init=False, repr=False)
 
@@ -92,6 +95,10 @@ class ToolDescriptor:
             argument_names.add(argument.name)
         required_arguments = tuple(argument.name for argument in self.arguments if argument.required)
         object.__setattr__(self, "_cached_required_arguments", required_arguments)
+        schema_properties = tuple(
+            (argument.name, argument.json_schema()) for argument in self.arguments
+        )
+        object.__setattr__(self, "_cached_schema_properties", schema_properties)
         cached_schema = _COMPACT_SORTED_JSON_ENCODER.encode(self.schema_payload())
         object.__setattr__(self, "_cached_schema", cached_schema)
         object.__setattr__(self, "_cached_schema_bytes", len(cached_schema.encode("utf-8")))
@@ -105,8 +112,7 @@ class ToolDescriptor:
             "type": "object",
             "additionalProperties": False,
             "properties": {
-                argument.name: argument.json_schema()
-                for argument in self.arguments
+                name: schema.copy() for name, schema in self._cached_schema_properties
             },
             "required": list(self.required_arguments),
         }


### PR DESCRIPTION
## Summary
- Cache each tool descriptor's normalized argument schema properties at construction time.
- Keep `schema_payload()` behavior-compatible by returning fresh mutable payload dictionaries on every call.
- Add regression coverage for cached schema reuse and payload mutation isolation.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-schema-payload-cache.md`
- Registered probe: `tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline local probe on origin/main before editing
env MELIX_TOOL_REGISTRY_METRICS_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
# exit 0; schema_payload_elapsed_ms_mean=193.71481984853745

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 41 passed in 0.14s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py
# exit 0; TOTAL 16 0 100%

env MELIX_TOOL_REGISTRY_METRICS_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
# exit 0; schema_payload_elapsed_ms_mean=174.05842653741794

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-schema-bytes-cache --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-main --head-repo "$PWD" --output /tmp/tool_registry_schema_payload_probe.json
# exit 0; head verification passed, base/head probe completed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Registered base-vs-head probe (`tool-registry-schema-bytes-cache`):
  - `schema_payload_elapsed_ms_mean`: base `203.1270633917302 ms`, head `175.3723369911313 ms`, delta `-27.754726400598884 ms` (`-13.663726505548865%`, `1.1582617126326056x`).
  - `schema_bytes`: base/head `1845.0` unchanged.
  - `json_schema_calls_mean`: base/head `0.0` unchanged.
  - `schema_byte_count_calls_mean`: base/head `0.0` unchanged.
- PR-scoped performance CI is still required as the merge gate for the registered probe report.

## Known Gaps
- Linux local verification covers this Python-only slice. No Swift/macOS runtime effect is claimed.
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; focused registered tests/coverage/probe were run for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing registered PR-scoped probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
