### PR TITLE
Add agentic trajectory snapshot metrics

### DIFF
--- a/docs/plans/2026-05-19-opensearch-vl-trajectory-snapshots.md
+++ b/docs/plans/2026-05-19-opensearch-vl-trajectory-snapshots.md
@@ -1,0 +1,59 @@
+# OpenSearch-VL Trajectory Snapshot Metrics
+
+## Goal
+
+Complete the executable dataset-materialization slice for issues #669 and #670
+under the OpenSearch-VL alignment parent #664.
+
+## Scope
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset.py`
+- `services/mlx-worker-python/tests/test_training_dataset_builder.py`
+- `services/mlx-worker-python/tests/test_lora_model_ops.py` only if LoRA
+  preparation assertions need to prove job-local snapshot consumption.
+
+## Plan
+
+1. Extend `agentic_tool_trace` quality metrics with trace turn count min, max,
+   and average, media reference count, reward coverage count, and fatal-stage
+   field coverage count.
+2. Add a deterministic normalized-snapshot trace digest for
+   `agentic_tool_trace` datasets.
+3. Persist snapshot manifest provenance required by the contract: source
+   package path, selected split, quality metrics, trace digest, toolset version,
+   reward policy id, and leakage policy id when available.
+4. Add focused tests for the new metrics, snapshot manifest fields, JSONL row
+   preservation, and non-agentic backward-compatible snapshot behavior.
+
+## Metrics
+
+- `agentic_trace_count`
+- `trace_turn_count_min`
+- `trace_turn_count_max`
+- `trace_turn_count_avg`
+- `tool_call_count`
+- `tool_observation_count`
+- `media_ref_count`
+- `reward_coverage_count`
+- `fatal_stage_coverage_count`
+- `fatal_trace_count`
+- `leakage_count`
+- `trajectory_trace_digest`
+
+## Verification
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_training_dataset_builder.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/opensearch-vl-trajectory-snapshots.coverage uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/opensearch-vl-trajectory-snapshots.coverage uv run --project services/mlx-worker-python coverage json -o /tmp/opensearch-vl-trajectory-snapshots-coverage.json
+uv run --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/opensearch-vl-trajectory-snapshots-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/tests/test_training_dataset_builder.py
+git diff --check
+```
+
+## Known Gaps
+
+- This slice does not add LoRA adapter, RL, benchmark, or evaluation artifact
+  provenance fields; those remain assigned to #672 and #673.
+- The trace digest proves snapshot content identity, not model quality.
+- Explicit leakage terms remain deterministic string checks and do not replace
+  semantic leakage review.

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -140,6 +140,7 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
         normalized_validation_samples=[],
         validation_sample_count=0,
         response_only_supported=False,
+        manifest_fields={"trajectory_schema_version": "ignored-for-non-agentic"},
     )
 
     snapshot = write_normalized_dataset_snapshot(
@@ -157,6 +158,151 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
     assert payload["validation_strategy"] == "hf_split"
     assert payload["validation_sample_count"] == 3
     assert payload["hf_valid_split"] == "validation"
+    assert "trajectory_quality_metrics" not in payload
+    assert "trajectory_trace_digest" not in payload
+    assert "trajectory_schema_version" not in payload
+
+    agentic_package_path = tmp_path / "agentic-package"
+    agentic_package_path.mkdir(parents=True, exist_ok=True)
+    samples = [
+        {
+            "trace_id": "trace-train",
+            "question": "Which label is visible?",
+            "media_refs": [{"id": "image-1", "uri": "images/sign-one.jpg"}],
+            "tools": [{"name": "image_crop"}],
+            "turns": [
+                {"role": "user", "content": "Inspect image one.", "media_refs": ["image-1"]},
+                {
+                    "role": "assistant",
+                    "tool_call": {
+                        "id": "call-1",
+                        "name": "image_crop",
+                        "arguments": {"media_ref": "image-1"},
+                    },
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-1",
+                    "observation": {"text": "The sign reads MELIX LABS."},
+                },
+                {"role": "assistant", "content": "The sign says MELIX LABS."},
+            ],
+            "final_answer": "MELIX LABS",
+            "reward": {"final_answer": 1.0},
+            "fatal_stage": "",
+        }
+    ]
+    validation_samples = [
+        {
+            "trace_id": "trace-valid",
+            "question": "Which label is hidden?",
+            "media_refs": [{"id": "image-2", "uri": "images/sign-two.jpg"}],
+            "turns": [
+                {"role": "user", "content": "Inspect image two."},
+                {"role": "assistant", "content": "The label says GOLD-SECRET."},
+            ],
+            "final_answer": "GOLD-SECRET",
+            "fatal_stage": "observation_leak",
+            "leakage_terms": ["GOLD-SECRET"],
+        }
+    ]
+    agentic_dataset = TrainingDatasetPackage(
+        package_path=agentic_package_path,
+        manifest_path=agentic_package_path / "manifest.json",
+        samples_path=agentic_package_path / "samples.jsonl",
+        schema_version="melix.training_dataset_package.v1",
+        dataset_id="agentic-package",
+        format="agentic_tool_trace",
+        sample_count=1,
+        version="2026-05-19",
+        normalized_samples=samples,
+        normalized_validation_samples=validation_samples,
+        validation_sample_count=1,
+        response_only_supported=False,
+        manifest_fields={
+            "schema_version": "melix.training_dataset_package.v1",
+            "dataset_id": "agentic-package",
+            "format": "agentic_tool_trace",
+            "sample_count": 1,
+            "version": "2026-05-19",
+            "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+            "toolset_version": "melix.agentic_tools.builtin.v1",
+            "registry_schema_version": "melix.agentic_tool_registry.v1",
+            "reward_policy_id": "reward-policy.v1",
+            "leakage_policy_id": "leakage-policy.v1",
+            "source_dataset_id": "source-agentic-package",
+            "source_split": "train",
+            "source_revision": "rev-123",
+            "license": "MIT",
+            "media_root": "images/",
+        },
+    )
+
+    agentic_snapshot = write_normalized_dataset_snapshot(
+        agentic_dataset,
+        output_dir=tmp_path / "agentic-exports",
+        manifest_overrides={"validation_strategy": "source_validation"},
+    )
+    agentic_payload = json.loads(agentic_snapshot.manifest_path.read_text(encoding="utf-8"))
+    mutated_samples = [dict(samples[0], final_answer="Changed")]
+
+    assert agentic_payload["format"] == "agentic_tool_trace"
+    assert agentic_payload["source_package_path"] == str(agentic_package_path)
+    assert agentic_payload["source_dataset_id"] == "source-agentic-package"
+    assert agentic_payload["source_manifest_fields"] == {
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "toolset_version": "melix.agentic_tools.builtin.v1",
+        "registry_schema_version": "melix.agentic_tool_registry.v1",
+        "reward_policy_id": "reward-policy.v1",
+        "leakage_policy_id": "leakage-policy.v1",
+        "source_dataset_id": "source-agentic-package",
+        "source_split": "train",
+        "source_revision": "rev-123",
+        "license": "MIT",
+        "media_root": "images/",
+    }
+    assert agentic_payload["trajectory_schema_version"] == "melix.agentic_tool_trace.v1"
+    assert agentic_payload["trajectory_split"] == "train"
+    assert agentic_payload["trajectory_toolset_version"] == "melix.agentic_tools.builtin.v1"
+    assert (
+        agentic_payload["trajectory_registry_schema_version"]
+        == "melix.agentic_tool_registry.v1"
+    )
+    assert agentic_payload["trajectory_reward_policy_id"] == "reward-policy.v1"
+    assert agentic_payload["trajectory_leakage_policy_id"] == "leakage-policy.v1"
+    assert agentic_payload["trajectory_trace_digest"] == training_dataset_module._agentic_trace_digest(
+        samples + validation_samples
+    )
+    assert agentic_payload["trajectory_trace_digest"] != training_dataset_module._agentic_trace_digest(
+        mutated_samples + validation_samples
+    )
+    assert agentic_payload["trajectory_quality_metrics"] == {
+        "duplicate_count": 0,
+        "duplicate_sample_indices": [],
+        "dirty_count": 1,
+        "dirty_samples": [{"index": 1, "reasons": ["leakage_terms"]}],
+        "agentic_trace_count": 2,
+        "trace_turn_count_min": 2,
+        "trace_turn_count_max": 4,
+        "trace_turn_count_avg": 3.0,
+        "tool_call_count": 1,
+        "tool_observation_count": 1,
+        "media_ref_count": 2,
+        "reward_coverage_count": 1,
+        "fatal_stage_coverage_count": 2,
+        "fatal_trace_count": 1,
+        "leakage_count": 1,
+        "leakage_samples": [
+            {"index": 1, "trace_id": "trace-valid", "terms": ["GOLD-SECRET"]}
+        ],
+    }
+    assert agentic_snapshot.train_path.read_text(encoding="utf-8") == (
+        json.dumps(samples[0]) + "\n"
+    )
+    assert agentic_snapshot.valid_path is not None
+    assert agentic_snapshot.valid_path.read_text(encoding="utf-8") == (
+        json.dumps(validation_samples[0]) + "\n"
+    )
 
 
 def test_write_normalized_dataset_snapshot_clears_stale_valid_jsonl_when_no_validation_samples(

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -49,6 +49,7 @@ class TrainingDatasetPackage:
     normalized_validation_samples: list[dict[str, Any]]
     validation_sample_count: int
     response_only_supported: bool
+    manifest_fields: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -246,6 +247,7 @@ def _build_training_dataset_package(
         normalized_validation_samples=normalized_validation_samples,
         validation_sample_count=len(normalized_validation_samples),
         response_only_supported=format_name in {"chat_messages", "prompt_completion"},
+        manifest_fields=dict(manifest) if format_name == "agentic_tool_trace" else None,
     )
 
 
@@ -546,6 +548,8 @@ def write_normalized_dataset_snapshot(
         "source_samples_path": str(dataset.samples_path),
         "response_only_supported": dataset.response_only_supported,
     }
+    if dataset.format == "agentic_tool_trace":
+        manifest_payload.update(_agentic_trace_snapshot_manifest_fields(dataset))
     if manifest_overrides:
         manifest_payload.update(manifest_overrides)
     manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
@@ -1856,6 +1860,7 @@ def _build_quality_and_token_stats(
         "dirty_samples": dirty_samples,
     }
     if format_name == "agentic_tool_trace":
+        agentic_metrics.pop("_trace_turn_count_sum", None)
         quality.update(agentic_metrics)
 
     return (
@@ -1882,11 +1887,18 @@ def _build_quality_and_token_stats(
 def _new_agentic_trace_quality_metrics() -> dict[str, Any]:
     return {
         "agentic_trace_count": 0,
+        "trace_turn_count_min": 0,
+        "trace_turn_count_max": 0,
+        "trace_turn_count_avg": 0.0,
         "tool_call_count": 0,
         "tool_observation_count": 0,
+        "media_ref_count": 0,
+        "reward_coverage_count": 0,
+        "fatal_stage_coverage_count": 0,
         "fatal_trace_count": 0,
         "leakage_count": 0,
         "leakage_samples": [],
+        "_trace_turn_count_sum": 0,
     }
 
 
@@ -1898,9 +1910,24 @@ def _update_agentic_trace_quality_metrics(
     sample_limit: int,
 ) -> None:
     metrics["agentic_trace_count"] += 1
+    turns = sample.get("turns", [])
+    turn_count = len(turns) if isinstance(turns, list) else 0
+    metrics["_trace_turn_count_sum"] += turn_count
+    if metrics["agentic_trace_count"] == 1:
+        metrics["trace_turn_count_min"] = turn_count
+        metrics["trace_turn_count_max"] = turn_count
+    else:
+        metrics["trace_turn_count_min"] = min(metrics["trace_turn_count_min"], turn_count)
+        metrics["trace_turn_count_max"] = max(metrics["trace_turn_count_max"], turn_count)
     if str(sample.get("fatal_stage", "")).strip():
         metrics["fatal_trace_count"] += 1
-    turns = sample.get("turns", [])
+    if "fatal_stage" in sample:
+        metrics["fatal_stage_coverage_count"] += 1
+    media_refs = sample.get("media_refs", [])
+    if isinstance(media_refs, list):
+        metrics["media_ref_count"] += len(media_refs)
+    if isinstance(sample.get("reward"), Mapping):
+        metrics["reward_coverage_count"] += 1
     if isinstance(turns, list):
         for turn in turns:
             if not isinstance(turn, dict):
@@ -1921,6 +1948,12 @@ def _update_agentic_trace_quality_metrics(
                     "terms": leaked_terms,
                 }
             )
+    trace_count = metrics["agentic_trace_count"]
+    if trace_count > 0:
+        metrics["trace_turn_count_avg"] = round(
+            metrics["_trace_turn_count_sum"] / trace_count,
+            3,
+        )
 
 
 def _build_token_stats(samples: Iterable[dict[str, Any]], format_name: str) -> dict[str, Any]:
@@ -2253,6 +2286,62 @@ def _agentic_trace_duplicate_key(sample: dict[str, Any]) -> bytes:
     return hashlib.sha256(
         json.dumps(_agentic_trace_text_segments(sample), ensure_ascii=False).encode("utf-8")
     ).digest()
+
+
+def _agentic_trace_snapshot_manifest_fields(
+    dataset: TrainingDatasetPackage,
+) -> dict[str, Any]:
+    manifest = dataset.manifest_fields or {}
+    quality, _ = _build_quality_and_token_stats(
+        chain(dataset.normalized_samples, dataset.normalized_validation_samples),
+        "agentic_tool_trace",
+    )
+    quality.pop("_trace_turn_count_sum", None)
+    trace_digest = _agentic_trace_digest(
+        chain(dataset.normalized_samples, dataset.normalized_validation_samples)
+    )
+    preserved_manifest_fields = {
+        key: copy.deepcopy(value)
+        for key, value in manifest.items()
+        if key
+        not in {
+            "schema_version",
+            "dataset_id",
+            "format",
+            "sample_count",
+            "validation_sample_count",
+            "version",
+        }
+    }
+    fields: dict[str, Any] = {
+        "source_package_path": str(dataset.package_path),
+        "source_dataset_id": str(manifest.get("source_dataset_id", dataset.dataset_id)),
+        "source_manifest_fields": preserved_manifest_fields,
+        "trajectory_schema_version": str(
+            manifest.get("trajectory_schema_version", "melix.agentic_tool_trace.v1")
+        ),
+        "trajectory_split": str(manifest.get("source_split", "train")),
+        "trajectory_quality_metrics": quality,
+        "trajectory_trace_digest": trace_digest,
+    }
+    for source_field, output_field in (
+        ("toolset_version", "trajectory_toolset_version"),
+        ("registry_schema_version", "trajectory_registry_schema_version"),
+        ("reward_policy_id", "trajectory_reward_policy_id"),
+        ("leakage_policy_id", "trajectory_leakage_policy_id"),
+    ):
+        value = str(manifest.get(source_field, "")).strip()
+        if value:
+            fields[output_field] = value
+    return fields
+
+
+def _agentic_trace_digest(samples: Iterable[dict[str, Any]]) -> str:
+    digest = hashlib.sha256()
+    for sample in samples:
+        digest.update(_canonical_sample_key(sample).encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest()
 
 
 def _canonical_sample_key(sample: dict[str, Any]) -> str:

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1860,6 +1860,12 @@ def _build_quality_and_token_stats(
         "dirty_samples": dirty_samples,
     }
     if format_name == "agentic_tool_trace":
+        trace_count = agentic_metrics["agentic_trace_count"]
+        if trace_count > 0:
+            agentic_metrics["trace_turn_count_avg"] = round(
+                agentic_metrics["_trace_turn_count_sum"] / trace_count,
+                3,
+            )
         agentic_metrics.pop("_trace_turn_count_sum", None)
         quality.update(agentic_metrics)
 
@@ -1948,12 +1954,6 @@ def _update_agentic_trace_quality_metrics(
                     "terms": leaked_terms,
                 }
             )
-    trace_count = metrics["agentic_trace_count"]
-    if trace_count > 0:
-        metrics["trace_turn_count_avg"] = round(
-            metrics["_trace_turn_count_sum"] / trace_count,
-            3,
-        )
 
 
 def _build_token_stats(samples: Iterable[dict[str, Any]], format_name: str) -> dict[str, Any]:
@@ -2296,7 +2296,6 @@ def _agentic_trace_snapshot_manifest_fields(
         chain(dataset.normalized_samples, dataset.normalized_validation_samples),
         "agentic_tool_trace",
     )
-    quality.pop("_trace_turn_count_sum", None)
     trace_digest = _agentic_trace_digest(
         chain(dataset.normalized_samples, dataset.normalized_validation_samples)
     )


### PR DESCRIPTION
## Summary
- Adds `agentic_tool_trace` normalized snapshot provenance for source package, source dataset, split, schema, toolset, reward, leakage, and registry metadata.
- Adds trajectory quality metrics and a deterministic trace digest so LoRA SFT, RL alignment, benchmark, and evaluation consumers can verify package identity and coverage from the same snapshot contract.
- Preserves non-agentic snapshot manifests and keeps validation sample-limit loading on the existing fast path.

Closes #669
Closes #670

## Plan or Spec
- `docs/agentic-trajectory-dataset-contract.md`
- `docs/plans/2026-05-19-opensearch-vl-trajectory-snapshots.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_applies_manifest_overrides services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_limits_validation_samples services/mlx-worker-python/tests/test_training_dataset_builder.py::test_load_training_dataset_package_stops_reading_validation_after_sample_limit
# 3 passed in 0.03s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/opensearch-vl-trajectory-snapshots-after-merge.coverage uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py
# 75 passed in 0.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o /tmp/opensearch-vl-trajectory-snapshots-after-merge-coverage.json
# Wrote JSON report

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/opensearch-vl-trajectory-snapshots-after-merge-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/tests/test_training_dataset_builder.py
# TOTAL 100.00% 67/67

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/pre_commit_gate.py via run_performance_report(root, changed_files, base_ref='origin/main')
# Status ok; 3 selected direct/gated probes; 0 regressions; 0 verification failures

make swift-test
# First full pre-commit attempt passed the macOS menubar package, then failed later on PR-scoped performance before the fast-path fix.
# Later full pre-commit attempts were blocked in this SSH/background session by macOS Pasteboard availability: make swift-test-menubar failed only in existing NSPasteboard copy assertions, and a minimal Swift NSPasteboard probe plus pbcopy also returned no writable pasteboard.
```

## Coverage and Metrics
- Changed-line coverage: `100.00%` (`67/67`) for `training_dataset.py` and `test_training_dataset_builder.py`.
- PR-scoped performance report: `.runtime/pre-commit-performance/20260519-122148-3ddd5136/report/report.md`.
- Direct/gated probes: `3`; status `ok`; regressions `0`; verification failures `0`.
- Quality/token summary: elapsed `-28.70%` improvement, peak bytes `+0.01%` neutral.
- Validation split partial selection: elapsed `+3.98%` neutral, peak bytes `-0.02%` neutral, validation count unchanged.
- Validation sample-limit loading: elapsed `+1.28%` neutral, peak bytes `+0.00%` neutral, validation sample count unchanged.
- Observability mode: evidence for snapshot manifest/quality metrics; probe overhead is covered by the PR-scoped performance report.
- Protocol changes: N/A, no protobuf schema changes.
- Dependency changes: N/A, no dependency or lockfile changes.

## Known Gaps
- This implements the M2 snapshot and validation-metric slice for #669 and #670 only.
- #672 and #673 remain for LoRA/RL adapter provenance and benchmark/evaluation provenance.
- No model-quality or evaluation-score improvement is claimed here.
- Full local pre-commit was not completed after the final fix because the current SSH/background macOS session has no writable `com.apple.pboard` service for existing menubar clipboard tests; CI should run those tests in a normal GUI-capable runner/session.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or are N/A.
- [x] Dependency changes include updated lockfiles, or are N/A.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and deferred evidence work are recorded.
- [x] Deferred work and known gaps are stated explicitly.
