### PR TITLE
Support slug IDs for server start shortcuts

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1092,9 +1092,12 @@ public struct ServerControlOptions: Equatable, Sendable {
         modelIdleTimeoutSeconds: Int = 0,
         json: Bool = false
     ) {
-        self.serverSessionID = serverSessionID.isEmpty
-            ? ServerSessionRuntimeStore.defaultServerSessionID
-            : serverSessionID
+        if serverSessionID.isEmpty || serverSessionID == ServerSessionRuntimeStore.defaultServerSessionID {
+            self.serverSessionID = MelixServerStartShortcutName.sessionIDCandidate(for: serverTitle)
+                ?? ServerSessionRuntimeStore.defaultServerSessionID
+        } else {
+            self.serverSessionID = serverSessionID
+        }
         self.serverTitle = serverTitle
         let resolvedDefaultModelID = MelixServerModelRosterNormalizer.resolvedDefaultModelID(
             defaultModelID,
@@ -1115,6 +1118,23 @@ public struct ServerControlOptions: Equatable, Sendable {
         self.json = json
     }
 
+}
+
+private enum MelixServerStartShortcutName {
+    private static let allowedSessionIDScalars = CharacterSet(
+        charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789._-"
+    )
+
+    static func sessionIDCandidate(for title: String) -> String? {
+        let candidate = title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !candidate.isEmpty else {
+            return nil
+        }
+        guard candidate.rangeOfCharacter(from: allowedSessionIDScalars.inverted) == nil else {
+            return nil
+        }
+        return candidate
+    }
 }
 
 public struct ServerIdlePolicyOptions: Equatable, Sendable {
@@ -8928,6 +8948,7 @@ public actor MelixCLIRunner {
     private func upsertServerSessionForStartIfNeeded(_ options: ServerControlOptions) throws -> String {
         let title = options.serverTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         let host = options.host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let titleSessionID = MelixServerStartShortcutName.sessionIDCandidate(for: title)
         let hasShortcutConfiguration = title.isEmpty == false
             || options.defaultModelID.isEmpty == false
             || options.servedModelIDs.isEmpty == false
@@ -8948,7 +8969,11 @@ public actor MelixCLIRunner {
 
         var resolvedID = ""
         let state = try mutateOperatorState { current in
-            if let index = current.serverSessions.firstIndex(where: { $0.id == title || $0.title == title }) {
+            if let index = current.serverSessions.firstIndex(where: { session in
+                session.id == title
+                    || session.title == title
+                    || titleSessionID.map { session.id == $0 } == true
+            }) {
                 var session = current.serverSessions[index]
                 session.title = title
                 applyServerControlOptions(options, to: &session)
@@ -8969,8 +8994,12 @@ public actor MelixCLIRunner {
                 current.selectedServerSessionID = session.id
                 resolvedID = session.id
             } else {
+                let createdID = nextServerStartShortcutSessionID(
+                    options: options,
+                    existingSessions: current.serverSessions
+                )
                 let created = MelixOperatorServerSessionState(
-                    id: nextGeneratedServerSessionID(in: current.serverSessions),
+                    id: createdID,
                     title: title,
                     defaultModelID: options.defaultModelID,
                     servedModelIDs: options.servedModelIDs,
@@ -9002,6 +9031,19 @@ public actor MelixCLIRunner {
             index += 1
         }
         return "server-session-\(index)"
+    }
+
+    private func nextServerStartShortcutSessionID(
+        options: ServerControlOptions,
+        existingSessions: [MelixOperatorServerSessionState]
+    ) -> String {
+        let id = options.serverSessionID
+        guard id != ServerSessionRuntimeStore.defaultServerSessionID,
+              !existingSessions.contains(where: { $0.id == id })
+        else {
+            return nextGeneratedServerSessionID(in: existingSessions)
+        }
+        return id
     }
 
     private func markServerSessionUnavailable(

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -1959,6 +1959,13 @@ struct MelixCLIParserTests {
             "--model-idle-timeout-seconds", "300",
             "--json",
         ])
+        let namedStartCommand = try MelixCLIParser.parse([
+            "server",
+            "start",
+            "gemma-31b",
+            "--model", "mlx-community/gemma-4-31b-it-4bit",
+            "--port", "12434",
+        ])
         let resumeCommand = try MelixCLIParser.parse([
             "server",
             "resume",
@@ -1981,6 +1988,10 @@ struct MelixCLIParserTests {
         }
         guard case .serverStart(let titledStartOptions) = titledStartCommand else {
             Issue.record("Expected titled serverStart command")
+            return
+        }
+        guard case .serverStart(let namedStartOptions) = namedStartCommand else {
+            Issue.record("Expected named serverStart command")
             return
         }
         guard case .serverResume(let resumeOptions) = resumeCommand else {
@@ -2011,6 +2022,11 @@ struct MelixCLIParserTests {
         #expect(titledStartOptions.timeoutSeconds == 240)
         #expect(titledStartOptions.modelIdleTimeoutSeconds == 300)
         #expect(titledStartOptions.json)
+        #expect(namedStartOptions.serverSessionID == "gemma-31b")
+        #expect(namedStartOptions.serverTitle == "gemma-31b")
+        #expect(namedStartOptions.defaultModelID == "mlx-community/gemma-4-31b-it-4bit")
+        #expect(namedStartOptions.servedModelIDs == ["mlx-community/gemma-4-31b-it-4bit"])
+        #expect(namedStartOptions.port == 12434)
         #expect(resumeOptions.serverSessionID == "server-session-3")
         #expect(!resumeOptions.json)
         #expect(wakeOptions.serverSessionID == "server-session-4")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -5960,6 +5960,160 @@ struct MelixCLIRunnerTests {
         #expect(startedAction == .start("server-session-1"))
     }
 
+    @Test("server start shortcut uses slug title as the server session id")
+    func serverStartShortcutUsesSlugTitleAsServerSessionID() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+
+        let modelID = "mlx-community/gemma-4-31b-it-4bit"
+        let client = StubControlPlaneXPCClient()
+        await client.setServerSnapshot(makeServerSnapshot(models: [
+            makeModelSummary(id: modelID, kind: "text"),
+        ]))
+        let store = MelixOperatorSessionStore(
+            melixHome: MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
+        )
+
+        _ = try await MelixCLIRunner(client: client, operatorSessionStore: store).run(
+            .serverStart(
+                .init(
+                    serverTitle: "gemma-31b",
+                    servedModelIDs: [modelID],
+                    host: "127.0.0.1",
+                    port: 12434
+                )
+            )
+        )
+
+        let state = try #require(try store.load())
+        let session = try #require(state.serverSessions.first(where: { $0.id == "gemma-31b" }))
+        let gatewayConfigCall = try #require(await client.lastGatewayConfigApplyRequest)
+        let startedAction = try #require(await client.lastServerAction)
+
+        #expect(state.selectedServerSessionID == "gemma-31b")
+        #expect(session.title == "gemma-31b")
+        #expect(session.defaultModelID == modelID)
+        #expect(session.servedModelIDs == [modelID])
+        #expect(session.port == 12434)
+        #expect(gatewayConfigCall.serverSessionID == "gemma-31b")
+        #expect(gatewayConfigCall.defaultModelID == modelID)
+        #expect(gatewayConfigCall.servedModelIDs == [modelID])
+        #expect(startedAction == .start("gemma-31b"))
+    }
+
+    @Test("server start shortcut normalizes mixed-case slug titles")
+    func serverStartShortcutNormalizesMixedCaseSlugTitles() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+
+        let modelID = "mlx-community/gemma-4-31b-it-4bit"
+        let client = StubControlPlaneXPCClient()
+        await client.setServerSnapshot(makeServerSnapshot(models: [
+            makeModelSummary(id: modelID, kind: "text"),
+        ]))
+        let store = MelixOperatorSessionStore(
+            melixHome: MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
+        )
+
+        let runner = MelixCLIRunner(client: client, operatorSessionStore: store)
+
+        _ = try await runner.run(
+            .serverStart(
+                .init(
+                    serverTitle: "gemma-31b",
+                    servedModelIDs: [modelID],
+                    port: 8080
+                )
+            )
+        )
+        _ = try await runner.run(
+            .serverStart(
+                .init(
+                    serverTitle: "Gemma-31B",
+                    servedModelIDs: [modelID],
+                    port: 12434
+                )
+            )
+        )
+
+        let state = try #require(try store.load())
+        let session = try #require(state.serverSessions.first(where: { $0.id == "gemma-31b" }))
+        let startedAction = try #require(await client.lastServerAction)
+
+        #expect(state.serverSessions.count == 1)
+        #expect(state.selectedServerSessionID == "gemma-31b")
+        #expect(session.title == "Gemma-31B")
+        #expect(session.port == 12434)
+        #expect(startedAction == .start("gemma-31b"))
+    }
+
+    @Test("server start shortcut falls back when an explicit session id collides")
+    func serverStartShortcutFallsBackWhenExplicitSessionIDCollides() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+
+        let modelID = "mlx-community/gemma-4-31b-it-4bit"
+        let client = StubControlPlaneXPCClient()
+        await client.setServerSnapshot(makeServerSnapshot(models: [
+            makeModelSummary(id: modelID, kind: "text"),
+        ]))
+        let store = MelixOperatorSessionStore(
+            melixHome: MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
+        )
+        try store.save(
+            MelixOperatorSessionState(
+                selectedSurfaceID: "server",
+                selectedToolSectionID: "modelsLibrary",
+                selectedServerSessionID: "gemma-31b",
+                serverSessions: [
+                    .init(
+                        id: "gemma-31b",
+                        title: "Existing Gemma",
+                        defaultModelID: modelID,
+                        servedModelIDs: [modelID]
+                    ),
+                    .init(
+                        id: "server-session-1",
+                        title: "Existing One",
+                        defaultModelID: modelID,
+                        servedModelIDs: [modelID]
+                    ),
+                ]
+            )
+        )
+
+        _ = try await MelixCLIRunner(client: client, operatorSessionStore: store).run(
+            .serverStart(
+                .init(
+                    serverSessionID: "gemma-31b",
+                    serverTitle: "Gemma Archive",
+                    servedModelIDs: [modelID],
+                    port: 12434
+                )
+            )
+        )
+
+        let state = try #require(try store.load())
+        let created = try #require(state.serverSessions.first(where: { $0.title == "Gemma Archive" }))
+        let startedAction = try #require(await client.lastServerAction)
+
+        #expect(created.id == "server-session-2")
+        #expect(state.selectedServerSessionID == "server-session-2")
+        #expect(startedAction == .start("server-session-2"))
+    }
+
     @Test("server start shortcut reuses an existing titled session")
     func serverStartShortcutReusesExistingTitledSession() async throws {
         let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())


### PR DESCRIPTION
## Summary
- Treat slug-safe `melix server start NAME --model ...` shortcuts as stable server session IDs.
- Normalize mixed-case slug titles such as `Gemma-31B` to lowercase session IDs while preserving the display title.
- Preserve generated `server-session-N` IDs for human-readable titles with spaces or unsupported characters.
- Add parser and runner coverage for `melix server start gemma-31b --model ... --port ...`, mixed-case slug reuse, and explicit session-id collision fallback.

## Plan or Spec
- N/A: small CLI behavior polish based on the existing server start shortcut and multi-server session support.

## Commands Run
```text
PASS git diff --check origin/main...HEAD
PASS git diff --check
PASS xcrun swift test --filter MelixCLIParserTests/parsesServerLifecycleCommands
PASS xcrun swift test --filter MelixCLIRunnerTests/serverStartShortcutUsesSlugTitleAsServerSessionID
PASS xcrun swift test --filter MelixCLIRunnerTests/serverStartShortcutNormalizesMixedCaseSlugTitles
PASS xcrun swift test --filter MelixCLIRunnerTests/serverStartShortcutFallsBackWhenExplicitSessionIDCollides
PASS xcrun swift test --filter MelixCLIParserTests/commandCodecRoundTripsTypedCommandArguments
FAIL make swift-test via pre-commit: unrelated macOS menubar pasteboard assertion in DesktopFoundationViewTests/settingsTabRendersDiscoveryCopyAndOpenAffordances()
FAIL xcrun swift test --package-path apps/macos-menubar --filter DesktopFoundationViewTests/settingsTabRendersDiscoveryCopyAndOpenAffordances(): same pasteboard assertion reproduced standalone
```

## Coverage and Metrics
- Parser coverage confirms `melix server start gemma-31b --model ... --port ...` resolves `serverSessionID == "gemma-31b"`.
- Runner coverage confirms the created session, selected session, gateway config, and start action use `gemma-31b`.
- Runner coverage confirms mixed-case slug titles reuse the normalized lowercase session id instead of creating duplicate sessions.
- Runner coverage confirms an explicit colliding session id falls back to the next generated `server-session-N` id.
- Docs N/A: this is a small extension of the existing shortcut behavior and there is no dedicated user-facing CLI doc for this surface in this change scope.
- Metrics report N/A: CLI routing/session-id behavior only; no performance-sensitive path changed.
- Observability/probe overhead N/A: no runtime probe or observability-mode behavior changed.

## Known Gaps
- No live model server was launched; validation is parser/runner-level with existing control-plane stubs.
- Full pre-commit `make swift-test` was not green because an existing macOS menubar pasteboard test fails independently of this CLI change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.