### PR TITLE
perf: cache built-in tool config bytes

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-built-in-config-bytes.md
+++ b/docs/plans/2026-05-19-tool-registry-built-in-config-bytes.md
@@ -1,0 +1,60 @@
+# Tool Registry Built-in Config Bytes Cache Plan
+
+## Goal
+
+Reduce repeated built-in tool configuration construction cost for the default
+agentic tool path. The hot call is `built_in_tool_config()` with no explicit
+name filter, which currently rebuilds a `ToolRegistry` and serializes each tool
+schema for every call.
+
+## Linux-Only Constraint
+
+This is a Python-only runtime slice under `services/mlx-worker-python` and is
+fully verifiable on Linux with focused pytest, changed-scope coverage, and the
+registered PR-scoped performance probe.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_schema_bytes_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Proposed Change
+
+1. Cache the serialized default `ToolConfig` bytes after the built-in tool
+   descriptors are declared.
+2. For `built_in_tool_config(names=None)`, parse a fresh `ToolConfig` from the
+   cached bytes so callers still receive an isolated mutable protobuf object.
+3. Preserve the existing selected-name path by continuing to build a selected
+   registry when `names` is provided.
+4. Extend the existing registered `tool-registry-schema-bytes-cache` probe with
+   a focused metric for repeated default `built_in_tool_config()` calls.
+
+## Performance Probe
+
+Probe ID: `tool-registry-schema-bytes-cache`
+
+Added metric:
+
+- `built_in_tool_config_elapsed_ms_mean` (lower is better)
+
+The probe also records `built_in_tool_config_distinct_objects_mean` to verify
+that each call still returns an isolated protobuf object rather than a shared
+mutable singleton.
+
+## Success Metrics
+
+- Focused behavior tests pass.
+- Changed-scope coverage is at least 95%.
+- Local Linux registered probe shows a lower mean for repeated default
+  `built_in_tool_config()` calls versus `origin/main`.
+
+## Verification Commands
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
+- Changed-scope `coverage run` plus `scripts/changed_scope_coverage.py`.
+- Registered probe command from `infra/perf/pr_scoped_probes.json` for
+  `tool-registry-schema-bytes-cache`.
+- `git diff --check`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3768,6 +3768,17 @@
         "key": "schema_byte_count_calls_mean",
         "unit": "calls",
         "direction": "informational"
+      },
+      {
+        "key": "built_in_tool_config_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "built_in_tool_config_distinct_objects_mean",
+        "unit": "calls",
+        "direction": "informational"
       }
     ]
   },

--- a/scripts/tool_registry_schema_bytes_probe.py
+++ b/scripts/tool_registry_schema_bytes_probe.py
@@ -13,7 +13,11 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
 from worker.runtime import tool_registry as tool_registry_module  # noqa: E402
-from worker.runtime.tool_registry import ToolDescriptor, built_in_tool_registry  # noqa: E402
+from worker.runtime.tool_registry import (  # noqa: E402
+    ToolDescriptor,
+    built_in_tool_config,
+    built_in_tool_registry,
+)
 
 
 def _measure(iterations: int, sample_count: int) -> dict[str, float]:
@@ -25,6 +29,8 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     schema_payload_elapsed_samples: list[float] = []
     json_schema_calls: list[float] = []
     schema_byte_count_calls: list[float] = []
+    built_in_config_elapsed_samples: list[float] = []
+    built_in_config_distinct_objects: list[float] = []
     checksum = 0
     original_schema_byte_count = getattr(ToolDescriptor, "schema_byte_count", None)
 
@@ -69,6 +75,17 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
                         )
                     checksum += len(payload["required"])
             schema_payload_elapsed_samples.append((time.perf_counter() - payload_started) * 1000.0)
+
+            first_config = built_in_tool_config()
+            distinct_config_count = 0
+            config_started = time.perf_counter()
+            for _index in range(iterations):
+                config = built_in_tool_config()
+                if config is not first_config:
+                    distinct_config_count += 1
+                checksum += len(config.tools) + len(config.schema_version)
+            built_in_config_elapsed_samples.append((time.perf_counter() - config_started) * 1000.0)
+            built_in_config_distinct_objects.append(float(distinct_config_count))
     finally:
         tool_registry_module.ToolDescriptor.json_schema = original_json_schema
         if original_schema_byte_count is None:
@@ -81,6 +98,12 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         "schema_payload_elapsed_ms_mean": statistics.fmean(schema_payload_elapsed_samples),
         "json_schema_calls_mean": statistics.fmean(json_schema_calls),
         "schema_byte_count_calls_mean": statistics.fmean(schema_byte_count_calls),
+        "built_in_tool_config_elapsed_ms_mean": statistics.fmean(
+            built_in_config_elapsed_samples
+        ),
+        "built_in_tool_config_distinct_objects_mean": statistics.fmean(
+            built_in_config_distinct_objects
+        ),
         "schema_bytes": float(expected_schema_bytes),
         "checksum": float(checksum),
         "iterations": float(iterations),

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -206,6 +206,8 @@ def test_tool_registry_schema_bytes_probe_script_emits_metrics(
     assert metrics["schema_payload_elapsed_ms_mean"] >= 0.0
     assert metrics["json_schema_calls_mean"] == 0.0
     assert metrics["schema_byte_count_calls_mean"] == 0.0
+    assert metrics["built_in_tool_config_elapsed_ms_mean"] >= 0.0
+    assert metrics["built_in_tool_config_distinct_objects_mean"] == 20.0
 
 
 def test_tool_registry_select_probe_script_emits_metrics(

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -249,6 +249,24 @@ def test_tool_registry_raw_tuple_alias_keeps_selection_cache_bounded() -> None:
     }
 
 
+def test_built_in_tool_config_without_names_uses_cached_serialized_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected_config = built_in_tool_config()
+
+    def fail_as_worker_tool_config(self: ToolRegistry) -> common_pb2.ToolConfig:
+        raise AssertionError("built_in_tool_config() should reuse cached serialized config")
+
+    monkeypatch.setattr(ToolRegistry, "as_worker_tool_config", fail_as_worker_tool_config)
+
+    config = built_in_tool_config()
+
+    assert config == expected_config
+    assert config is not expected_config
+    config.tools[0].name = "mutated"
+    assert built_in_tool_config().tools[0].name == "image_crop"
+
+
 def test_tool_registry_exports_worker_tool_config_metadata() -> None:
     config = built_in_tool_config(["image_crop", "local_compute"])
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -261,9 +261,9 @@ def built_in_tool_registry() -> ToolRegistry:
 
 
 def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> common_pb2.ToolConfig:
-    registry = built_in_tool_registry()
-    if names is not None:
-        registry = registry.select(names)
+    if names is None:
+        return common_pb2.ToolConfig.FromString(_BUILTIN_TOOL_CONFIG_BYTES)
+    registry = built_in_tool_registry().select(names)
     return registry.as_worker_tool_config()
 
 
@@ -346,6 +346,11 @@ _BUILTIN_AGENTIC_TOOLS = (
             _arg("timeout_ms", "integer", "Maximum execution time in milliseconds.", required=False),
         ),
     ),
+)
+
+
+_BUILTIN_TOOL_CONFIG_BYTES = (
+    ToolRegistry(_BUILTIN_AGENTIC_TOOLS).as_worker_tool_config().SerializeToString()
 )
 
 


### PR DESCRIPTION
## Summary
- Cache the default built-in tool config as serialized protobuf bytes and parse a fresh `ToolConfig` for `built_in_tool_config()` calls without a name filter.
- Preserve selected-name behavior by keeping the existing registry selection path for explicit `names`.
- Extend the registered `tool-registry-schema-bytes-cache` probe with built-in config timing and object-isolation metrics.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-built-in-config-bytes.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 42 passed in 0.80s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py
# 42 passed in 0.34s; TOTAL 29 1 97%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
# {"built_in_tool_config_distinct_objects_mean": 40000.0, "built_in_tool_config_elapsed_ms_mean": 76.53986234217882, ...}

PYTHONPATH= uv run --project services/mlx-worker-python python3 /tmp/melix_tool_config_benchmark.py /root/.hermes/profiles/coder/workspace/melix 40000 5
# built_in_tool_config_elapsed_ms_mean=598.2080423273146
PYTHONPATH= uv run --project services/mlx-worker-python python3 /tmp/melix_tool_config_benchmark.py /root/.hermes/profiles/coder/workspace/worktrees/melix-tool-registry-built-in-config-bytes-20260519 40000 5
# built_in_tool_config_elapsed_ms_mean=82.81967877410352

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 29 1 97%`.
- Registered local probe metric: `built_in_tool_config_elapsed_ms_mean=76.53986234217882` for 40,000 iterations over 5 samples.
- Local base-vs-head focused benchmark: old mean `598.2080423273146 ms`, new mean `82.81967877410352 ms`, delta `-515.3883635532111 ms`, speedup `7.22x` for repeated default `built_in_tool_config()` calls.
- Object isolation remained intact: `built_in_tool_config_distinct_objects_mean=40000.0`.
- CI is required to validate the registered PR-scoped performance workflow on GitHub runners.

## Known Gaps
- The exact registered probe command contains a `bash -c` wrapper in the registry; the local tool environment blocked that wrapper for approval, so I ran the same probe script directly with the same Python path/project context. CI will execute the registered command.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; production behavior unchanged.
- [x] Deferred work and known gaps are stated explicitly.
