### PR TITLE
perf: fast-path full built-in tool config selection

### DIFF
--- a/docs/plans/2026-05-19-tool-config-full-selection-fastpath.md
+++ b/docs/plans/2026-05-19-tool-config-full-selection-fastpath.md
@@ -1,0 +1,55 @@
+# Tool config full-selection fast path
+
+Date: 2026-05-19
+
+## Scope
+
+This performance slice optimizes only `built_in_tool_config()` in
+`services/mlx-worker-python/worker/runtime/tool_registry.py`.
+
+## Problem
+
+The no-argument built-in tool config path already reuses a cached serialized
+`ToolConfig` snapshot. Callers that explicitly pass the complete built-in tool
+name list request the same full config, but the current path still rebuilds a
+`ToolRegistry`, runs selection, and serializes a fresh worker tool config.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`. The
+probe entry has focused `test_command`, `coverage_command`, and `probe_command`
+entries for:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_schema_bytes_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+This slice extends that registered probe with explicit full-selection tool config
+metrics so CI can validate the new hot path.
+
+## Optimization slice
+
+When `built_in_tool_config(names)` receives a clean full selection equal to
+`BUILTIN_AGENTIC_TOOL_NAMES`, return a parsed copy of the cached serialized
+snapshot, matching the existing `names is None` behavior.
+
+The fast path is intentionally limited to clean full selections. Partial
+selections, unknown names, blank trimming, and deduplication continue through the
+existing registry selection path.
+
+## Verification plan
+
+- Run the registered focused pytest command locally on Linux.
+- Run the registered changed-scope coverage command and require at least 95%
+  changed-line coverage.
+- Run `scripts/tool_registry_schema_bytes_probe.py` before and after the change
+  and compare `full_selection_tool_config_elapsed_ms_mean`.
+- Use GitHub Actions PR-scoped performance as the merge gate after pushing.
+
+## Linux validation boundary
+
+This slice is Python-only and locally verifiable on Linux. No Swift runtime
+performance claims are made.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3779,6 +3779,17 @@
         "key": "built_in_tool_config_distinct_objects_mean",
         "unit": "calls",
         "direction": "informational"
+      },
+      {
+        "key": "full_selection_tool_config_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "full_selection_tool_config_distinct_objects_mean",
+        "unit": "calls",
+        "direction": "informational"
       }
     ]
   },

--- a/scripts/tool_registry_schema_bytes_probe.py
+++ b/scripts/tool_registry_schema_bytes_probe.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
 from worker.runtime import tool_registry as tool_registry_module  # noqa: E402
 from worker.runtime.tool_registry import (  # noqa: E402
+    BUILTIN_AGENTIC_TOOL_NAMES,
     ToolDescriptor,
     built_in_tool_config,
     built_in_tool_registry,
@@ -31,6 +32,8 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     schema_byte_count_calls: list[float] = []
     built_in_config_elapsed_samples: list[float] = []
     built_in_config_distinct_objects: list[float] = []
+    full_selection_config_elapsed_samples: list[float] = []
+    full_selection_config_distinct_objects: list[float] = []
     checksum = 0
     original_schema_byte_count = getattr(ToolDescriptor, "schema_byte_count", None)
 
@@ -86,6 +89,21 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
                 checksum += len(config.tools) + len(config.schema_version)
             built_in_config_elapsed_samples.append((time.perf_counter() - config_started) * 1000.0)
             built_in_config_distinct_objects.append(float(distinct_config_count))
+
+            first_full_selection_config = built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES)
+            distinct_full_selection_config_count = 0
+            full_selection_started = time.perf_counter()
+            for _index in range(iterations):
+                config = built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES)
+                if config is not first_full_selection_config:
+                    distinct_full_selection_config_count += 1
+                checksum += len(config.tools) + len(config.schema_version)
+            full_selection_config_elapsed_samples.append(
+                (time.perf_counter() - full_selection_started) * 1000.0
+            )
+            full_selection_config_distinct_objects.append(
+                float(distinct_full_selection_config_count)
+            )
     finally:
         tool_registry_module.ToolDescriptor.json_schema = original_json_schema
         if original_schema_byte_count is None:
@@ -103,6 +121,12 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         ),
         "built_in_tool_config_distinct_objects_mean": statistics.fmean(
             built_in_config_distinct_objects
+        ),
+        "full_selection_tool_config_elapsed_ms_mean": statistics.fmean(
+            full_selection_config_elapsed_samples
+        ),
+        "full_selection_tool_config_distinct_objects_mean": statistics.fmean(
+            full_selection_config_distinct_objects
         ),
         "schema_bytes": float(expected_schema_bytes),
         "checksum": float(checksum),

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -267,6 +267,29 @@ def test_built_in_tool_config_without_names_uses_cached_serialized_snapshot(
     assert built_in_tool_config().tools[0].name == "image_crop"
 
 
+def test_built_in_tool_config_full_selection_uses_cached_serialized_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected_config = built_in_tool_config()
+
+    def fail_as_worker_tool_config(self: ToolRegistry) -> common_pb2.ToolConfig:
+        raise AssertionError(  # pragma: no cover
+            "full built-in selection should reuse cached serialized config"
+        )
+
+    monkeypatch.setattr(ToolRegistry, "as_worker_tool_config", fail_as_worker_tool_config)
+
+    tuple_config = built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES)
+    list_config = built_in_tool_config(list(BUILTIN_AGENTIC_TOOL_NAMES))
+
+    assert tuple_config == expected_config
+    assert list_config == expected_config
+    assert tuple_config is not expected_config
+    assert list_config is not expected_config
+    tuple_config.tools[0].name = "mutated"
+    assert built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES).tools[0].name == "image_crop"
+
+
 def test_tool_registry_exports_worker_tool_config_metadata() -> None:
     config = built_in_tool_config(["image_crop", "local_compute"])
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -261,7 +261,7 @@ def built_in_tool_registry() -> ToolRegistry:
 
 
 def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> common_pb2.ToolConfig:
-    if names is None:
+    if names is None or tuple(names) == BUILTIN_AGENTIC_TOOL_NAMES:
         return common_pb2.ToolConfig.FromString(_BUILTIN_TOOL_CONFIG_BYTES)
     registry = built_in_tool_registry().select(names)
     return registry.as_worker_tool_config()


### PR DESCRIPTION
## Summary
- Fast-path `built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES)` to reuse the cached serialized full built-in `ToolConfig` snapshot.
- Add a regression test proving clean full tuple/list selections do not reserialize through `ToolRegistry.as_worker_tool_config()`.
- Extend the registered `tool-registry-schema-bytes-cache` probe with full-selection config metrics.

## Plan or Spec
- Updated `docs/plans/2026-05-19-tool-config-full-selection-fastpath.md`.
- Registered probe: `tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=20000 MELIX_TOOL_REGISTRY_METRICS_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py` (baseline before edit; exit 0)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` (exit 0; 43 passed)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py` (exit 0; TOTAL 25/25, 100%)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py` (registered probe script, exit 0)
- `git diff --check` (exit 0)

## Coverage and Metrics
- Changed-scope coverage: 100.00% aggregate (`TOTAL 25 0 100%`).
- Local registered probe after change: `full_selection_tool_config_elapsed_ms_mean=74.70444301143289`, `full_selection_tool_config_distinct_objects_mean=40000.0`, `built_in_tool_config_elapsed_ms_mean=73.02955100312829`.
- Local old-vs-new micro comparison for explicit full selection (`20000` iterations, `5` samples): `old_mean=302.5784823577851 ms`, `new_mean=42.302021058276296 ms`, `delta_ms=-260.2764612995088 ms`, `speedup=7.152813855889902x`.
- PR-scoped performance CI is required as the merge gate for the registered probe report.

## Known Gaps
- Python-only slice; no Swift runtime effect is claimed or locally validated.
- Fast path is intentionally limited to clean full selections equal to `BUILTIN_AGENTIC_TOOL_NAMES`; normalized/partial selections still use the existing selection path.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests pass locally on Linux.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe runs locally on Linux.
- [ ] GitHub Actions and PR-scoped performance report are green.
