### PR TITLE
perf: cache partial built-in tool config registry

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-partial-config-registry-cache.md
+++ b/docs/plans/2026-05-19-tool-registry-partial-config-registry-cache.md
@@ -1,0 +1,29 @@
+# Tool registry partial config registry cache
+
+## Scope
+
+This Python-only performance slice is limited to partial-selection calls through
+`built_in_tool_config()` in
+`services/mlx-worker-python/worker/runtime/tool_registry.py`.
+
+## Probe
+
+The affected path is already covered by the registered PR-scoped probe
+`tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`. This
+slice extends the probe script to report
+`partial_selection_tool_config_elapsed_ms_mean` while keeping the existing
+focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Implementation plan
+
+- Reuse a module-local built-in `ToolRegistry` for partial built-in tool config
+  selection instead of constructing a fresh registry for every call.
+- Preserve the existing defensive `ToolConfig` copy behavior for callers.
+- Add a regression test proving partial `built_in_tool_config()` no longer routes
+  through the public `built_in_tool_registry()` constructor path.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage command, and the
+registered PR-scoped performance probe locally on Linux. Use PR-scoped
+performance CI as the final base-vs-head validation source before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3790,6 +3790,12 @@
         "key": "full_selection_tool_config_distinct_objects_mean",
         "unit": "calls",
         "direction": "informational"
+      },
+      {
+        "key": "partial_selection_tool_config_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
       }
     ]
   },

--- a/scripts/tool_registry_schema_bytes_probe.py
+++ b/scripts/tool_registry_schema_bytes_probe.py
@@ -34,6 +34,7 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     built_in_config_distinct_objects: list[float] = []
     full_selection_config_elapsed_samples: list[float] = []
     full_selection_config_distinct_objects: list[float] = []
+    partial_selection_config_elapsed_samples: list[float] = []
     checksum = 0
     original_schema_byte_count = getattr(ToolDescriptor, "schema_byte_count", None)
 
@@ -104,6 +105,14 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
             full_selection_config_distinct_objects.append(
                 float(distinct_full_selection_config_count)
             )
+
+            partial_selection_started = time.perf_counter()
+            for _index in range(iterations):
+                config = built_in_tool_config(("image_crop", "local_compute"))
+                checksum += len(config.tools) + len(config.schema_version)
+            partial_selection_config_elapsed_samples.append(
+                (time.perf_counter() - partial_selection_started) * 1000.0
+            )
     finally:
         tool_registry_module.ToolDescriptor.json_schema = original_json_schema
         if original_schema_byte_count is None:
@@ -127,6 +136,9 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         ),
         "full_selection_tool_config_distinct_objects_mean": statistics.fmean(
             full_selection_config_distinct_objects
+        ),
+        "partial_selection_tool_config_elapsed_ms_mean": statistics.fmean(
+            partial_selection_config_elapsed_samples
         ),
         "schema_bytes": float(expected_schema_bytes),
         "checksum": float(checksum),

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -208,6 +208,7 @@ def test_tool_registry_schema_bytes_probe_script_emits_metrics(
     assert metrics["schema_byte_count_calls_mean"] == 0.0
     assert metrics["built_in_tool_config_elapsed_ms_mean"] >= 0.0
     assert metrics["built_in_tool_config_distinct_objects_mean"] == 20.0
+    assert metrics["partial_selection_tool_config_elapsed_ms_mean"] >= 0.0
 
 
 def test_tool_registry_select_probe_script_emits_metrics(

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -6,6 +6,7 @@ import pytest
 
 from packages.protocol.python.worker.v1 import common_pb2
 
+from worker.runtime import tool_registry as tool_registry_module
 from worker.runtime.tool_registry import (
     BUILTIN_AGENTIC_TOOL_NAMES,
     ToolArgumentDescriptor,
@@ -288,6 +289,25 @@ def test_built_in_tool_config_full_selection_uses_cached_serialized_snapshot(
     assert list_config is not expected_config
     tuple_config.tools[0].name = "mutated"
     assert built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES).tools[0].name == "image_crop"
+
+
+def test_built_in_tool_config_partial_selection_uses_cached_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_built_in_tool_registry() -> ToolRegistry:
+        raise AssertionError(  # pragma: no cover
+            "partial built_in_tool_config() should reuse the cached built-in registry"
+        )
+
+    monkeypatch.setattr(
+        tool_registry_module,
+        "built_in_tool_registry",
+        fail_built_in_tool_registry,
+    )
+
+    config = built_in_tool_config(["image_crop", "local_compute"])
+
+    assert [tool.name for tool in config.tools] == ["image_crop", "local_compute"]
 
 
 def test_tool_registry_exports_worker_tool_config_metadata() -> None:

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -263,7 +263,7 @@ def built_in_tool_registry() -> ToolRegistry:
 def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> common_pb2.ToolConfig:
     if names is None or tuple(names) == BUILTIN_AGENTIC_TOOL_NAMES:
         return common_pb2.ToolConfig.FromString(_BUILTIN_TOOL_CONFIG_BYTES)
-    registry = built_in_tool_registry().select(names)
+    registry = _BUILTIN_TOOL_CONFIG_REGISTRY.select(names)
     return registry.as_worker_tool_config()
 
 
@@ -349,8 +349,9 @@ _BUILTIN_AGENTIC_TOOLS = (
 )
 
 
+_BUILTIN_TOOL_CONFIG_REGISTRY = ToolRegistry(_BUILTIN_AGENTIC_TOOLS)
 _BUILTIN_TOOL_CONFIG_BYTES = (
-    ToolRegistry(_BUILTIN_AGENTIC_TOOLS).as_worker_tool_config().SerializeToString()
+    _BUILTIN_TOOL_CONFIG_REGISTRY.as_worker_tool_config().SerializeToString()
 )
 
 


### PR DESCRIPTION
## Summary
- Cache a module-local built-in `ToolRegistry` for partial `built_in_tool_config()` selections.
- Preserve defensive `ToolConfig` copy behavior while avoiding per-call registry construction for partial built-in selections.
- Extend the registered tool-registry PR-scoped probe with a partial-selection metric.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-partial-config-registry-cache.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-schema-bytes-cache --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-tool-registry-partial-config-20260519 --head-repo "$PWD" --output /tmp/tool_registry_partial_probe2.json`

## Coverage and Metrics
- Focused pytest: 44 passed.
- Changed-scope coverage: 100% (15/15 measurable changed lines).
- Registered local probe `tool-registry-schema-bytes-cache`: base/head completed successfully.
  - `built_in_tool_config_elapsed_ms_mean`: 72.638 ms -> 70.247 ms (3.29% faster).
  - `schema_payload_elapsed_ms_mean`: 170.368 ms -> 169.014 ms (0.79% faster).
  - `full_selection_tool_config_elapsed_ms_mean`: 76.407 ms -> 77.022 ms (0.80% slower, outside the changed path).
  - New `partial_selection_tool_config_elapsed_ms_mean` is emitted by head at 190.667 ms; base lacks this newly registered metric because the old probe script did not emit it.

## Known Gaps
- This is a Python-only Linux-verifiable slice. Swift/macOS runtime effects are not involved.
- The newly added partial-selection metric is head-only until this probe extension lands; CI PR-scoped performance remains the merge gate for registered probe validation.

## Evidence Checklist
- [x] Branch synced from `origin/main` before implementation.
- [x] Affected path covered by registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe completed successfully.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
