### PR TITLE
perf: streamline dataset split config inference

### DIFF
--- a/docs/plans/2026-05-19-dataset-inferred-split-config-constant-sets.md
+++ b/docs/plans/2026-05-19-dataset-inferred-split-config-constant-sets.md
@@ -1,0 +1,22 @@
+# Dataset inferred split/config constant membership slice
+
+## Scope
+
+This Python-only performance slice is limited to dataset snapshot split/config inference in `services/mlx-worker-python/worker/dataset_registry/catalog.py`.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped performance probe `dataset-registry-snapshot-inference-single-pass` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for the dataset registry snapshot path and can run locally on Linux.
+
+## Plan
+
+1. Keep dataset discovery semantics unchanged for file names, nested config directories, and default/data split directories.
+2. Avoid rebuilding small membership sets for every `_inferred_split_and_config(...)` call by hoisting them to module constants.
+3. Add focused regression coverage for equivalent split/config inference on representative path shapes.
+4. Verify with the registered focused tests, changed-scope coverage, and local registered probe before opening the PR.
+
+## Success metrics
+
+- Focused dataset registry tests pass.
+- Changed-scope coverage for touched Python scope is at least 95%.
+- `dataset_registry_snapshot_probe.py` reports lower mean elapsed time than the synced `origin/main` baseline, or the slice is rejected.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -94,7 +94,10 @@ def test_dataset_catalog_inferred_split_and_config_preserves_legacy_helpers() ->
     assert catalog._inferred_split_and_config("data/train-00000-of-00001.jsonl") == ("train", "default")
     assert catalog._inferred_split_and_config("custom\\test.json") == ("test", "custom")
     assert catalog._inferred_split_and_config("validation/shard-00000.jsonl") == ("validation", "default")
+    assert catalog._inferred_split_and_config("valid/shard-00000.jsonl") == ("validation", "default")
+    assert catalog._inferred_split_and_config("dev/shard-00000.jsonl") == ("validation", "default")
     assert catalog._inferred_split_and_config("data/shard-00000.jsonl") == ("", "default")
+    assert catalog._inferred_split_and_config("default/test-00000.jsonl") == ("test", "default")
     assert catalog._inferred_split_and_config("README.md") == ("", "default")
     assert catalog._inferred_split_and_config("") == ("", "default")
 

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -38,6 +38,10 @@ _SPLIT_ALIASES = {
 }
 _JSON_DECODER = json.JSONDecoder()
 _JSON_ROW_ARRAY_KEYS = frozenset({"rows", "data"})
+_DEFAULT_CONFIG_PARTS = frozenset({"data", "default"})
+_DEFAULT_CONFIG_FIRST_PARTS = frozenset(
+    {"data", "train", "test", "validation", "valid", "dev"}
+)
 _JSON_LIMITED_PREVIEW_CHUNK_CHARS = 64 * 1024
 
 
@@ -904,7 +908,7 @@ def _inferred_config(relative_path: str) -> str:
 
 
 def _inferred_split_and_config(relative_path: str) -> tuple[str, str]:
-    parts = tuple(part for part in relative_path.replace("\\", "/").split("/") if part)
+    parts = [part for part in relative_path.replace("\\", "/").split("/") if part]
     if not parts:
         return "", "default"
     filename = parts[-1]
@@ -912,7 +916,7 @@ def _inferred_split_and_config(relative_path: str) -> tuple[str, str]:
     split = _split_alias_from_candidate(stem)
     if not split:
         for candidate in parts[:-1]:
-            if candidate in {"data", "default"}:
+            if candidate in _DEFAULT_CONFIG_PARTS:
                 continue
             split = _split_alias_from_candidate(candidate)
             if split:
@@ -920,7 +924,7 @@ def _inferred_split_and_config(relative_path: str) -> tuple[str, str]:
     if len(parts) < 2:
         return split, "default"
     first = parts[0]
-    if first in {"data", "train", "test", "validation", "valid", "dev"}:
+    if first in _DEFAULT_CONFIG_FIRST_PARTS:
         return split, "default"
     return split, first
 


### PR DESCRIPTION
## Summary
- Streamlines dataset snapshot split/config inference by using a list comprehension instead of a generator-to-tuple allocation.
- Hoists repeated default/config membership sets into module constants.
- Adds regression coverage for `valid`, `dev`, and `default` path inference cases.

## Plan or Spec
- Plan: `docs/plans/2026-05-19-dataset-inferred-split-config-constant-sets.md`
- Registered probe: `dataset-registry-snapshot-inference-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_inferred_split_and_config_preserves_legacy_helpers`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py` (baseline on `origin/main`, 3 runs; PR head, 3 runs)
- `git diff --check`

## Coverage and Metrics
- Focused tests: `46 passed`.
- Changed-scope coverage: `TOTAL 8 0 100%`.
- Local Linux registered probe baseline (`origin/main`, 3 run means): `675.017`, `678.075`, `662.757` ms; aggregate `old_mean=671.949` ms.
- Local Linux registered probe PR head (3 run means): `636.026`, `647.689`, `647.431` ms; aggregate `new_mean=643.716` ms.
- Delta: `-28.234` ms; speedup: `1.0439x`; improvement: `4.20%`.

## Known Gaps
- This is a Python-only slice locally verified on Linux; no Swift runtime behavior is changed.
- GitHub Actions PR-scoped performance validation is still required before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows an improvement versus synced `origin/main`.
- [ ] GitHub Actions and PR-scoped performance workflow passed.
