### PR TITLE
Add OpenSearch-VL artifact provenance

### DIFF
--- a/docs/agentic-trajectory-dataset-contract.md
+++ b/docs/agentic-trajectory-dataset-contract.md
@@ -271,7 +271,9 @@ must expose trajectory provenance. The stable field names are:
 - `trajectory_snapshot_manifest_path`
 - `trajectory_trace_digest`
 - `trajectory_toolset_version`
+- `trajectory_registry_schema_version`
 - `trajectory_reward_policy_id`
+- `trajectory_leakage_policy_id`
 - `trajectory_quality_metrics`
 
 Artifact-specific schemas may nest these fields under a `trajectory` object when

--- a/docs/plans/2026-05-19-opensearch-vl-artifact-provenance.md
+++ b/docs/plans/2026-05-19-opensearch-vl-artifact-provenance.md
@@ -1,0 +1,84 @@
+# OpenSearch-VL Artifact Provenance
+
+## Goal
+
+Complete the artifact-provenance slice for OpenSearch-VL alignment issues
+#671, #672, and #673.
+
+## Scope
+
+- `services/mlx-worker-python/worker/trajectory_provenance.py`
+- `services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py`
+- `services/mlx-worker-python/worker/model_ops/rl_alignment_training.py`
+- `services/mlx-worker-python/worker/model_ops/training_config.py`
+- `services/mlx-worker-python/worker/productization/benchmark_export.py`
+- `services/mlx-worker-python/worker/productization/benchmark_schemas.py`
+- `services/mlx-worker-python/worker/productization/evaluation_schemas.py`
+- `services/mlx-worker-python/worker/productization/evaluation_store.py`
+- `services/mlx-worker-python/worker/productization/run_evidence.py`
+- Focused Python tests for the changed artifact writers and export schemas.
+
+## Field Contract
+
+Agentic trajectory provenance is a flat optional field set. Writers must omit
+the fields for non-`agentic_tool_trace` datasets and preserve backward
+compatibility for existing benchmark and evaluation exports.
+
+- `trajectory_dataset_id`
+- `trajectory_dataset_version`
+- `trajectory_schema_version`
+- `trajectory_snapshot_manifest_path`
+- `trajectory_split`
+- `trajectory_trace_digest`
+- `trajectory_toolset_version`
+- `trajectory_registry_schema_version`
+- `trajectory_reward_policy_id`
+- `trajectory_leakage_policy_id`
+- `trajectory_package_path`
+- `trajectory_quality_metrics`
+
+The normalized training dataset snapshot manifest remains the source of truth.
+Adapter, RL, benchmark, evaluation, and run-evidence writers should derive the
+same field set from that manifest or from an already-normalized provenance map.
+
+## Plan
+
+1. Add a reusable provenance extractor for normalized training dataset snapshot
+   manifests.
+2. Add trajectory provenance to LoRA adapter manifests and RL alignment trace
+   artifacts when the training dataset is `agentic_tool_trace`.
+3. Add optional trajectory provenance to benchmark and evaluation schema
+   records, JSON exports, CSV exports, and run-evidence domain results.
+4. Keep non-agentic artifact semantics backward-compatible and make export
+   changes append-only when optional provenance columns are introduced.
+5. Add focused tests that prove provenance survives adapter packaging, RL trace
+   writing, benchmark/evaluation stores, CSV exports, and run-evidence payloads.
+
+## Metrics
+
+- `trajectory_provenance_field_count`
+- `trajectory_reward_policy_present`
+- adapter manifest byte size
+- RL policy update trace row count
+- evaluation sample provenance coverage count
+- benchmark row provenance coverage count
+- run-evidence trajectory artifact reference count
+
+## Verification
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_benchmark_schemas.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_evaluation_schemas.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_run_evidence.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_benchmark_schemas.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_evaluation_schemas.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_run_evidence.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/opensearch-vl-artifact-provenance.coverage uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_benchmark_schemas.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_evaluation_schemas.py services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_run_evidence.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/opensearch-vl-artifact-provenance.coverage uv run --project services/mlx-worker-python coverage json -o /tmp/opensearch-vl-artifact-provenance-coverage.json
+uv run --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/opensearch-vl-artifact-provenance-coverage.json --diff-from origin/main services/mlx-worker-python/worker/trajectory_provenance.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/productization/benchmark_export.py services/mlx-worker-python/worker/productization/benchmark_schemas.py services/mlx-worker-python/worker/productization/evaluation_schemas.py services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/run_evidence.py
+git diff --check
+```
+
+## Known Gaps
+
+- This plan does not add a new UI surface for browsing trajectory provenance.
+- The trace digest identifies the normalized dataset content; it is not a
+  reward-quality score.
+- Existing benchmark and evaluation callers must pass provenance explicitly
+  until a higher-level runner wires dataset-package discovery into every run.

--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -20,6 +20,7 @@ from worker.productization.benchmark_export import (
     _iter_sorted_matching_files,
     _load_json_object,
     _resolve_artifact_root,
+    _csv_value,
     _rows_to_csv,
     build_comparison_table,
     build_benchmark_batch_csv,
@@ -1491,11 +1492,11 @@ def test_build_benchmark_matrix_summary_and_requests_csv_use_canonical_rows(tmp_
     assert summary_lines[1].startswith(
         "bench-matrix-1,text-generation,HuggingFaceH4/ultrachat_200k,melix-dev-text,smoke,1024,128,2,cold,enabled,plain_text,1,3,24,0,24.45,1.2,88.4,3.1,1400.0,58.2,3.8,221.5,1.0,2147483648,5.1,9.2,"
     )
-    assert summary_lines[1].endswith("111")
+    assert list(csv.DictReader(io.StringIO(summary_csv)))[0]["created_at_unix_ms"] == "111"
     assert request_lines[1].startswith(
         "bench-matrix-1,cell-1,text-generation,smoke,1024,128,2,cold,enabled,plain_text,1,0,0,24.45,88.4,1400.0,58.2,5.1,2147483648,completed,,"
     )
-    assert request_lines[1].endswith("111")
+    assert list(csv.DictReader(io.StringIO(requests_csv)))[0]["created_at_unix_ms"] == "111"
 
 
 def test_export_csv_preserves_probe_columns() -> None:
@@ -1819,6 +1820,72 @@ def test_evaluation_samples_csv_builder_maps_sample_id_and_preserves_modalities(
     assert rows[0]["input_modalities"] == "text"
 
 
+def test_export_csv_builders_preserve_trajectory_provenance_columns() -> None:
+    provenance = {
+        "trajectory_dataset_id": "opensearch-vl.dev",
+        "trajectory_dataset_version": "2026-05-19",
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "trajectory_snapshot_manifest_path": "/tmp/run/normalized_dataset/manifest.json",
+        "trajectory_package_path": "/tmp/package",
+        "trajectory_split": "train",
+        "trajectory_trace_digest": "abc123",
+        "trajectory_toolset_version": "melix.agentic_tools.builtin.v1",
+        "trajectory_reward_policy_id": "reward-policy.v1",
+        "trajectory_quality_metrics": {"agentic_trace_count": 1},
+    }
+    bundle = {
+        "evaluation_samples": [
+            {
+                "job_id": "eval-1",
+                "suite_id": "agentic",
+                "sample_id": "sample-1",
+                "target": "MELIX",
+                "extracted_result": "MELIX",
+                "input_text": "Inspect image.",
+                "raw_response": "MELIX",
+                "typed_score": 1.0,
+                **provenance,
+            }
+        ],
+        "benchmark_context_rows": [
+            {
+                "job_id": "bench-1",
+                "model_id": "melix-dev-text",
+                "task_kind": "text-generation",
+                "source_repo": "local",
+                "suite": "agentic",
+                "context_length": 16,
+                "generation_length": 8,
+                "batch_size": 1,
+                "repeat_index": 0,
+                **provenance,
+            }
+        ],
+        "benchmark_matrix_request_rows": [
+            {
+                "job_id": "matrix-1",
+                "cell_id": "cell-1",
+                "task_kind": "text-generation",
+                "suite_id": "agentic",
+                "context_length": 16,
+                "generation_length": 8,
+                "batch_size": 1,
+                "created_at_unix_ms": 101,
+                **provenance,
+            }
+        ],
+    }
+
+    eval_rows = list(csv.DictReader(io.StringIO(build_evaluation_samples_csv(bundle))))
+    context_rows = list(csv.DictReader(io.StringIO(build_benchmark_context_csv(bundle))))
+    request_rows = list(csv.DictReader(io.StringIO(build_benchmark_matrix_requests_csv(bundle))))
+
+    assert eval_rows[0]["trajectory_trace_digest"] == "abc123"
+    assert json.loads(eval_rows[0]["trajectory_quality_metrics"])["agentic_trace_count"] == 1
+    assert context_rows[0]["trajectory_dataset_id"] == "opensearch-vl.dev"
+    assert request_rows[0]["trajectory_reward_policy_id"] == "reward-policy.v1"
+
+
 def test_rows_to_csv_accepts_generators_without_materializing_lists() -> None:
     rows = (
         {"job_id": f"eval-{index}", "typed_score": index / 10}
@@ -1832,6 +1899,25 @@ def test_rows_to_csv_accepts_generators_without_materializing_lists() -> None:
         {"job_id": "eval-1", "typed_score": "0.1"},
         {"job_id": "eval-2", "typed_score": "0.2"},
     ]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("literal", "literal"),
+        (0, "0"),
+        (False, "False"),
+        ([], ""),
+        ((), ""),
+        ({}, ""),
+        ({"reward_coverage_count": 1}, "{\"reward_coverage_count\": 1}"),
+    ],
+)
+def test_csv_value_fast_paths_cover_scalars_and_nested_values(
+    value: object,
+    expected: str,
+) -> None:
+    assert _csv_value(value) == expected
 
 
 def test_rows_to_csv_uses_writerows_stream_without_dictwriter(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -1935,6 +1935,19 @@ def test_rows_to_csv_uses_writerows_stream_without_dictwriter(monkeypatch: pytes
     assert csv_text == 'job_id,suite\r\nbench-1,"a,b"\r\n'
 
 
+def test_rows_to_csv_falls_back_for_custom_values() -> None:
+    class CustomValue:
+        def __str__(self) -> str:
+            return "custom-value"
+
+    csv_text = _rows_to_csv(
+        iter(({"job_id": "bench-1", "custom": CustomValue()},)),
+        ["job_id", "custom"],
+    )
+
+    assert csv_text == "job_id,custom\r\nbench-1,custom-value\r\n"
+
+
 def test_evaluation_compare_csv_builders_emit_compare_rows() -> None:
     bundle: dict[str, object] = {
         "evaluation_compare_summary_rows": [

--- a/services/mlx-worker-python/tests/test_benchmark_schemas.py
+++ b/services/mlx-worker-python/tests/test_benchmark_schemas.py
@@ -364,6 +364,56 @@ def test_benchmark_rows_preserve_agentic_tool_evidence() -> None:
     assert request_row["agentic_tool_metrics"]["agentic_tool.call_count"] == 1.0
 
 
+def test_benchmark_job_and_rows_preserve_trajectory_provenance() -> None:
+    provenance = {
+        "trajectory_dataset_id": "opensearch-vl.dev",
+        "trajectory_dataset_version": "2026-05-19",
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "trajectory_snapshot_manifest_path": "/tmp/run/normalized_dataset/manifest.json",
+        "trajectory_split": "train",
+        "trajectory_trace_digest": "abc123",
+        "trajectory_toolset_version": "melix.agentic_tools.builtin.v1",
+        "trajectory_reward_policy_id": "reward-policy.v1",
+        "trajectory_quality_metrics": {"agentic_trace_count": 1},
+    }
+    job = build_serving_benchmark_job(
+        job_id="bench-123",
+        model_id="melix-dev-text",
+        source_repo="local",
+        suites=("agentic",),
+        parameters={},
+        status="completed",
+        output_dir="/tmp/bench",
+        trajectory_provenance=provenance,
+    ).to_dict()
+    context_row = build_serving_benchmark_context_row(
+        job_id="bench-123",
+        model_id="melix-dev-text",
+        task_kind="text-generation",
+        source_repo="local",
+        suite="agentic",
+        context_length=64,
+        generation_length=16,
+        batch_size=1,
+        repeat_index=0,
+        prefill_tokens_per_second=24.5,
+        decode_tokens_per_second=51.25,
+        ttft_ms=11.2,
+        request_latency_ms=42.8,
+        peak_memory_bytes=4096.0,
+        speedup_vs_batch_1=1.0,
+        cache_profile="cold",
+        reasoning_mode="",
+        structured_output_mode="",
+        trajectory_provenance=provenance,
+    ).to_dict()
+
+    assert job["trajectory_dataset_id"] == "opensearch-vl.dev"
+    assert context_row["trajectory_trace_digest"] == "abc123"
+    assert context_row["trajectory_split"] == "train"
+    assert context_row["trajectory_quality_metrics"]["agentic_trace_count"] == 1
+
+
 def test_build_serving_benchmark_results_groups_metrics_by_suite() -> None:
     results = build_serving_benchmark_results(
         job_id="bench-123",

--- a/services/mlx-worker-python/tests/test_benchmark_store.py
+++ b/services/mlx-worker-python/tests/test_benchmark_store.py
@@ -5,6 +5,10 @@ from pathlib import Path
 
 import pytest
 
+from worker.productization.benchmark_export import (
+    build_benchmark_context_csv,
+    collect_benchmark_artifacts,
+)
 from worker.productization.benchmark_schemas import (
     build_benchmark_matrix_job,
     build_benchmark_matrix_request_row,
@@ -131,6 +135,87 @@ def test_persist_serving_benchmark_writes_expected_artifact_names_and_payloads(
         "telemetry_jsonl",
     }
     assert run_record["probes"][0]["phase"] == "run_record_write"
+
+
+def test_persist_serving_benchmark_exports_trajectory_provenance_fields(
+    tmp_path: Path,
+) -> None:
+    store = BenchmarkStore(telemetry_collector=fixture_telemetry_collector())
+    jobs_root = tmp_path / "bench"
+    snapshot_manifest = tmp_path / "snapshots" / "normalized_dataset" / "manifest.json"
+    snapshot_manifest.parent.mkdir(parents=True)
+    snapshot_manifest.write_text("{}\n", encoding="utf-8")
+    provenance = {
+        "trajectory_dataset_id": "opensearch-vl.dev",
+        "trajectory_dataset_version": "2026-05-19",
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "trajectory_snapshot_manifest_path": str(snapshot_manifest),
+        "trajectory_package_path": str(tmp_path / "packages" / "opensearch-vl.dev"),
+        "trajectory_split": "train",
+        "trajectory_trace_digest": "abc123",
+        "trajectory_toolset_version": "melix.agentic_tools.builtin.v1",
+        "trajectory_reward_policy_id": "reward-policy.v1",
+        "trajectory_quality_metrics": {"agentic_trace_count": 1},
+    }
+    job = build_serving_benchmark_job(
+        job_id="bench-trajectory",
+        model_id="melix-dev-text",
+        source_repo="local",
+        suites=("agentic",),
+        parameters={},
+        status="completed",
+        output_dir=str(jobs_root),
+        trajectory_provenance=provenance,
+    )
+    results = build_serving_benchmark_results(
+        job_id="bench-trajectory",
+        metrics={"bench.agentic.ttft_ms": 24.45},
+        units={"bench.agentic.ttft_ms": "ms"},
+        report_path=str(jobs_root / "bench-report.md"),
+        report_markdown="# Melix Bench\n",
+    )
+    context_row = {
+        "job_id": "bench-trajectory",
+        "model_id": "melix-dev-text",
+        "task_kind": "text-generation",
+        "source_repo": "local",
+        "suite": "agentic",
+        "context_length": 16,
+        "generation_length": 8,
+        "batch_size": 1,
+        "repeat_index": 0,
+        "prefill_tokens_per_second": 1.0,
+        "decode_tokens_per_second": 1.0,
+        "ttft_ms": 1.0,
+        "request_latency_ms": 2.0,
+        "peak_memory_bytes": 4096,
+        "speedup_vs_batch_1": 1.0,
+        "cache_profile": "cold",
+        "reasoning_mode": "",
+        "structured_output_mode": "",
+        **provenance,
+    }
+
+    persisted = store.persist_serving_benchmark(
+        jobs_root=jobs_root,
+        job=job,
+        results=results,
+        context_rows=(context_row,),
+    )
+
+    context_jsonl = json.loads(persisted["context_rows_jsonl"].read_text(encoding="utf-8"))
+    evidence = json.loads(persisted["evidence"].read_text(encoding="utf-8"))
+    export_bundle = collect_benchmark_artifacts(jobs_root)
+    context_csv = build_benchmark_context_csv(export_bundle)
+
+    assert context_jsonl["trajectory_dataset_id"] == "opensearch-vl.dev"
+    assert "trajectory_trace_digest" in context_csv.splitlines()[0]
+    assert ",abc123," in context_csv
+    assert evidence["domain_results"]["trajectory_provenance"]["trajectory_reward_policy_id"] == "reward-policy.v1"
+    assert {
+        artifact["kind"]
+        for artifact in evidence["artifacts"]
+    } >= {"trajectory_snapshot_manifest", "trajectory_package"}
 
 
 def test_persist_serving_benchmark_defaults_to_no_op_telemetry(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_evaluation_schemas.py
+++ b/services/mlx-worker-python/tests/test_evaluation_schemas.py
@@ -199,6 +199,58 @@ def test_build_evaluation_sample_record_preserves_agentic_tool_evidence() -> Non
     assert payload["agentic_tool_metrics"]["agentic_tool.call_count"] == 1.0
 
 
+def test_build_evaluation_job_and_sample_records_preserve_trajectory_provenance() -> None:
+    provenance = {
+        "trajectory_dataset_id": "opensearch-vl.dev",
+        "trajectory_dataset_version": "2026-05-19",
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "trajectory_snapshot_manifest_path": "/tmp/run/normalized_dataset/manifest.json",
+        "trajectory_split": "train",
+        "trajectory_trace_digest": "abc123",
+        "trajectory_toolset_version": "melix.agentic_tools.builtin.v1",
+        "trajectory_reward_policy_id": "reward-policy.v1",
+        "trajectory_quality_metrics": {"reward_coverage_count": 1},
+    }
+    job = build_evaluation_job_record(
+        job_id="eval-1",
+        model_id="melix-dev-text",
+        task_kind="text-generation",
+        source_repo="local",
+        suite_id="agentic",
+        dataset_id="agentic-dev",
+        sample_size=1,
+        scoring_mode="exact",
+        parameters={},
+        status="completed",
+        trajectory_provenance=provenance,
+    )
+    sample = build_evaluation_sample_record(
+        job_id="eval-1",
+        suite_id="agentic",
+        dataset_id="agentic-dev",
+        sample_id="sample-1",
+        system="",
+        input_text="Inspect image.",
+        target="MELIX",
+        raw_response="MELIX",
+        extracted_result="MELIX",
+        typed_score=1.0,
+        time_s=0.1,
+        extraction_status="extracted",
+        validation_status="validated",
+        failure_reason="",
+        trajectory_provenance=provenance,
+    )
+
+    job_payload = job.to_dict()
+    sample_payload = sample.to_dict()
+
+    assert job_payload["trajectory_dataset_id"] == "opensearch-vl.dev"
+    assert sample_payload["trajectory_trace_digest"] == "abc123"
+    assert sample_payload["trajectory_reward_policy_id"] == "reward-policy.v1"
+    assert sample_payload["trajectory_quality_metrics"]["reward_coverage_count"] == 1
+
+
 def test_build_evaluation_sample_record_preserves_probe_fields() -> None:
     sample = build_evaluation_sample_record(
         job_id="eval-1",

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -1903,7 +1903,7 @@ def test_train_lora_rejects_sft_mode_with_preference_pair_dataset(tmp_path: Path
     assert events[-1].failed.error.code == "invalid_dataset_package"
     assert events[-1].failed.error.details["training_mode"] == "lora"
     assert events[-1].failed.error.details["required_format"] == (
-        "chat_messages,prompt_completion,text_completion"
+        "chat_messages,prompt_completion,text_completion,agentic_tool_trace"
     )
     assert events[-1].failed.error.details["actual_format"] == "preference_pair"
 
@@ -1940,7 +1940,7 @@ def test_train_lora_rejects_sft_mode_with_prompt_candidate_dataset(tmp_path: Pat
     assert events[-1].failed.error.code == "invalid_dataset_package"
     assert events[-1].failed.error.details["training_mode"] == "lora"
     assert events[-1].failed.error.details["required_format"] == (
-        "chat_messages,prompt_completion,text_completion"
+        "chat_messages,prompt_completion,text_completion,agentic_tool_trace"
     )
     assert events[-1].failed.error.details["actual_format"] == "prompt_candidate"
 

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -39,7 +39,11 @@ from worker.model_ops.multimodal_lora_contracts import (
 )
 from worker.model_ops.mlx_lm_runner import MLXLMRunner
 from worker.model_ops.mlx_lm_runner import TrainingMetrics, TrainingRequest, TrainingResult
-from worker.model_ops.training_dataset import HFDatasetReference, load_training_dataset_package, materialize_hf_training_dataset_package
+from worker.model_ops.training_dataset import (
+    HFDatasetReference,
+    load_training_dataset_package,
+    materialize_hf_training_dataset_package,
+)
 from worker.runtime.mlx_text_runtime import MLXTextRuntime, RuntimeTokenEvent, RuntimeUnavailableError
 
 

--- a/services/mlx-worker-python/tests/test_run_evidence.py
+++ b/services/mlx-worker-python/tests/test_run_evidence.py
@@ -21,6 +21,7 @@ from worker.productization.run_evidence import (
     summarize_run_evidence_probes,
     summarize_probe_timeline,
     validate_run_evidence_payload,
+    _artifacts_with_trajectory_provenance,
 )
 
 
@@ -394,6 +395,34 @@ def test_probe_summary_ignores_malformed_run_evidence_payloads() -> None:
 
     assert summary["probe_count"] == 1
     assert summary["runs"][0]["run_id"] == "run-with-probes"
+
+
+def test_trajectory_provenance_artifacts_deduplicate_existing_entries(
+    tmp_path: Path,
+) -> None:
+    artifact_root = tmp_path / "run"
+    snapshot_manifest = artifact_root / "normalized_dataset" / "manifest.json"
+    package_path = tmp_path / "packages" / "opensearch-vl.dev"
+    existing = (
+        RunEvidenceArtifact(
+            kind="trajectory_snapshot_manifest",
+            path="normalized_dataset/manifest.json",
+            role="trajectory_snapshot_manifest",
+        ),
+    )
+
+    artifacts = _artifacts_with_trajectory_provenance(
+        existing,
+        {
+            "trajectory_snapshot_manifest_path": str(snapshot_manifest),
+            "trajectory_package_path": str(package_path),
+        },
+        artifact_root,
+    )
+
+    assert [artifact.kind for artifact in artifacts].count("trajectory_snapshot_manifest") == 1
+    assert artifacts[-1].kind == "trajectory_package"
+    assert artifacts[-1].path == str(package_path)
 
 
 def _evidence(*, status: str) -> RunEvidenceEnvelope:

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -42,7 +42,14 @@ from worker.registry import WorkerRegistry
 from worker.runtime.deterministic_backend import DeterministicTextBackend
 from worker.runtime.mlx_text_runtime import MLXTextRuntime
 from worker.trajectory_provenance import (
+    adapter_manifest_trajectory_provenance,
+    alignment_metrics_trajectory_provenance,
+    append_trajectory_provenance,
+    load_trajectory_provenance_from_normalized_snapshot,
     load_trajectory_provenance_from_snapshot_manifest,
+    load_trajectory_provenance_from_snapshot_dir,
+    normalize_trajectory_provenance,
+    trajectory_provenance_from_snapshot_manifest,
 )
 from telemetry_fixtures import fixture_telemetry_collector
 
@@ -190,6 +197,31 @@ def test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_nam
         "trajectory_package_path": str(tmp_path / "agentic-package"),
         "trajectory_quality_metrics": {"reward_coverage_count": 1},
     }
+
+
+def test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs(
+    tmp_path: Path,
+) -> None:
+    payload = {"existing": "value"}
+    append_trajectory_provenance(payload, None)
+
+    non_mapping_manifest = tmp_path / "non-mapping-manifest.json"
+    non_mapping_manifest.write_text("[]\n", encoding="utf-8")
+
+    assert normalize_trajectory_provenance(None) == {}
+    assert payload == {"existing": "value"}
+    assert trajectory_provenance_from_snapshot_manifest({"format": "text"}) == {}
+    assert load_trajectory_provenance_from_snapshot_manifest(non_mapping_manifest) == {}
+    assert (
+        load_trajectory_provenance_from_normalized_snapshot(
+            format_name="text",
+            manifest_path=non_mapping_manifest,
+        )
+        == {}
+    )
+    assert load_trajectory_provenance_from_snapshot_dir(tmp_path / "missing-snapshot") == {}
+    assert adapter_manifest_trajectory_provenance(None) == {}
+    assert alignment_metrics_trajectory_provenance(None) == {}
 
 
 def test_train_lora_records_agentic_trajectory_provenance_in_adapter_manifest(

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -1,0 +1,498 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from packages.protocol.python.worker.v1 import common_pb2, maintenance_pb2
+from worker.engine.maintenance_core import MaintenanceCore
+from worker.grpc_server import WorkerMaintenanceService
+from worker.model_ops.adapter_activation_pipeline import AdapterActivationPipeline
+from worker.model_ops.lora_training_pipeline import (
+    LoRATrainingPipeline,
+    _alignment_manifest_payload,
+)
+from worker.model_ops.mlx_lm_runner import (
+    MLXLMRunner,
+    TrainingMetrics,
+    TrainingRequest,
+    TrainingResult,
+)
+from worker.model_ops import training_config as training_config_module
+from worker.model_ops import mlx_lm_runner as mlx_lm_runner_module
+from worker.model_ops.training_dataset import (
+    ResolvedTrainingDatasetPackage,
+    TrainingDatasetPackage,
+)
+from worker.model_registry.catalog import WorkerModelCatalog
+from worker.productization.benchmark_export import (
+    build_evaluation_samples_csv,
+    collect_evaluation_artifacts,
+)
+from worker.productization.evaluation_schemas import (
+    build_evaluation_job_record,
+    build_evaluation_result_record,
+    build_evaluation_sample_record,
+)
+from worker.productization.evaluation_store import EvaluationStore
+from worker.registry import WorkerRegistry
+from worker.runtime.deterministic_backend import DeterministicTextBackend
+from worker.runtime.mlx_text_runtime import MLXTextRuntime
+from worker.trajectory_provenance import (
+    load_trajectory_provenance_from_snapshot_manifest,
+)
+from telemetry_fixtures import fixture_telemetry_collector
+
+
+def _write_agentic_dataset_package(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    sample = {
+        "trace_id": "trace-001",
+        "question": "Use tools before answering.",
+        "turns": [
+            {"role": "user", "content": "Read the page."},
+            {
+                "role": "assistant",
+                "tool_call": {
+                    "id": "visit-1",
+                    "name": "visit",
+                    "arguments": {"url": "fixture://doc"},
+                },
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "visit-1",
+                "observation": {"text": "The answer is MELIX."},
+            },
+            {"role": "assistant", "content": "MELIX"},
+        ],
+        "final_answer": "MELIX",
+        "reward": {"total": 1.0},
+        "fatal_stage": "",
+    }
+    manifest = {
+        "schema_version": "melix.training_dataset_package.v1",
+        "dataset_id": "agentic-package",
+        "format": "agentic_tool_trace",
+        "sample_count": 1,
+        "version": "2026-05-19",
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "toolset_version": "melix.agentic_tools.builtin.v1",
+        "registry_schema_version": "melix.agentic_tool_registry.v1",
+        "reward_policy_id": "reward-policy.v1",
+        "source_dataset_id": "opensearch-vl.dev",
+        "source_split": "train",
+    }
+    (root / "manifest.json").write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+    (root / "samples.jsonl").write_text(json.dumps(sample) + "\n", encoding="utf-8")
+    return root
+
+
+def _text_model(*, model_path: str = "models/plain-llama") -> common_pb2.ModelSpec:
+    model = common_pb2.ModelSpec(
+        model_id="melix-dev-text",
+        model_path=model_path,
+        model_kind="text",
+        revision="main",
+        max_context=4096,
+    )
+    model.ext["text_layer_count"] = "2"
+    return model
+
+
+class SuccessfulRunner(MLXLMRunner):
+    def __init__(self) -> None:
+        super().__init__()
+        self.last_train_request: TrainingRequest | None = None
+
+    def train_native(self, request: TrainingRequest) -> TrainingResult:
+        self.last_train_request = request
+        request.adapter_output_dir.mkdir(parents=True, exist_ok=True)
+        weights_path = request.adapter_output_dir / "adapters.safetensors"
+        adapter_config_path = request.adapter_output_dir / "adapter_config.json"
+        weights_path.write_bytes(b"melix-test-adapter")
+        adapter_config_path.write_text(
+            json.dumps({"fine_tune_type": "lora"}) + "\n",
+            encoding="utf-8",
+        )
+        return TrainingResult(
+            weights_path=weights_path,
+            adapter_config_path=adapter_config_path,
+            metrics=TrainingMetrics(
+                job_duration_ms=1234.0,
+                tokens_seen=2048,
+                examples_seen=1,
+                loss_final=0.42,
+                loss_best=0.33,
+                learning_rate_final=1e-4,
+            ),
+            execution_backend="native",
+        )
+
+
+def _build_service(tmp_path: Path, runner: MLXLMRunner) -> WorkerMaintenanceService:
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=DeterministicTextBackend()),
+        model_catalog=WorkerModelCatalog(),
+    )
+    service = WorkerMaintenanceService(registry, jobs_root=tmp_path / "model-ops")
+    service._core = MaintenanceCore(
+        registry,
+        jobs_root=tmp_path / "model-ops",
+        lora_training_pipeline=LoRATrainingPipeline(runner=runner),
+        adapter_activation_pipeline=AdapterActivationPipeline(runner=runner),
+    )
+    return service
+
+
+def test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names(
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "normalized_dataset" / "manifest.json"
+    manifest_path.parent.mkdir()
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_snapshot.v1",
+                "dataset_id": "agentic-snapshot",
+                "format": "agentic_tool_trace",
+                "version": "2026-05-19",
+                "source_package_path": str(tmp_path / "agentic-package"),
+                "source_dataset_id": "opensearch-vl.dev",
+                "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+                "trajectory_split": "train",
+                "trajectory_trace_digest": "abc123",
+                "trajectory_toolset_version": "melix.agentic_tools.builtin.v1",
+                "trajectory_registry_schema_version": "melix.agentic_tool_registry.v1",
+                "trajectory_reward_policy_id": "reward-policy.v1",
+                "trajectory_quality_metrics": {"reward_coverage_count": 1},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    provenance = load_trajectory_provenance_from_snapshot_manifest(manifest_path)
+
+    assert provenance == {
+        "trajectory_dataset_id": "opensearch-vl.dev",
+        "trajectory_dataset_version": "2026-05-19",
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "trajectory_snapshot_manifest_path": str(manifest_path),
+        "trajectory_split": "train",
+        "trajectory_trace_digest": "abc123",
+        "trajectory_toolset_version": "melix.agentic_tools.builtin.v1",
+        "trajectory_registry_schema_version": "melix.agentic_tool_registry.v1",
+        "trajectory_reward_policy_id": "reward-policy.v1",
+        "trajectory_package_path": str(tmp_path / "agentic-package"),
+        "trajectory_quality_metrics": {"reward_coverage_count": 1},
+    }
+
+
+def test_train_lora_records_agentic_trajectory_provenance_in_adapter_manifest(
+    tmp_path: Path,
+) -> None:
+    dataset_dir = _write_agentic_dataset_package(tmp_path / "dataset-agentic")
+    runner = SuccessfulRunner()
+    service = _build_service(tmp_path, runner)
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train-agentic"),
+                generate_manifest=True,
+                ext={
+                    "operation": "train_lora",
+                    "training_mode": "lora",
+                    "adapter_name": "melix-agentic-adapter",
+                    "dataset_uri": str(dataset_dir),
+                },
+            ),
+            context=None,
+        )
+    )
+
+    payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+
+    assert events[-1].HasField("completed")
+    assert payload["dataset_format"] == "agentic_tool_trace"
+    assert payload["trajectory_dataset_id"] == "opensearch-vl.dev"
+    assert payload["trajectory_dataset_version"] == "2026-05-19"
+    assert payload["trajectory_schema_version"] == "melix.agentic_tool_trace.v1"
+    assert payload["trajectory_split"] == "train"
+    assert payload["trajectory_reward_policy_id"] == "reward-policy.v1"
+    assert payload["trajectory_toolset_version"] == "melix.agentic_tools.builtin.v1"
+    assert payload["trajectory_snapshot_manifest_path"] == payload["normalized_dataset_manifest_path"]
+    assert payload["trajectory_provenance_field_count"] >= 8
+    assert payload["trajectory_reward_policy_present"] is True
+    assert runner.last_train_request is not None
+    assert runner.last_train_request.dataset_format == "agentic_tool_trace"
+
+
+def test_alignment_rl_trace_runner_attaches_trajectory_provenance(tmp_path: Path) -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"training_mode": "grpo", "grpo_candidate_count": "2"},
+        dataset_format="prompt_candidate",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    normalized_dataset_dir = tmp_path / "normalized"
+    normalized_dataset_dir.mkdir()
+    (normalized_dataset_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_snapshot.v1",
+                "dataset_id": "agentic-snapshot",
+                "format": "agentic_tool_trace",
+                "version": "2026-05-19",
+                "source_package_path": str(tmp_path / "agentic-package"),
+                "source_dataset_id": "opensearch-vl.dev",
+                "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+                "trajectory_split": "train",
+                "trajectory_trace_digest": "abc123",
+                "trajectory_reward_policy_id": "reward-policy.v1",
+                "trajectory_toolset_version": "melix.agentic_tools.builtin.v1",
+                "trajectory_quality_metrics": {"reward_coverage_count": 1},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (normalized_dataset_dir / "train.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Use tools before choosing.",
+                "candidates": [
+                    {"text": "Tool-backed answer.", "score": 0.9},
+                    {"text": "Guess.", "score": 0.1},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-grpo-provenance",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dataset_dir,
+        config=config,
+        dataset_format="prompt_candidate",
+    )
+
+    result = mlx_lm_runner_module.MLXLMRunner().train(request)
+    adapter_config = json.loads(result.adapter_config_path.read_text(encoding="utf-8"))
+    trace_rows = [
+        json.loads(line)
+        for line in Path(result.metrics.policy_update_trace_path).read_text(encoding="utf-8").splitlines()
+    ]
+
+    assert adapter_config["trajectory_dataset_id"] == "opensearch-vl.dev"
+    assert adapter_config["trajectory_reward_policy_id"] == "reward-policy.v1"
+    assert adapter_config["trajectory_provenance_field_count"] >= 8
+    assert trace_rows[0]["trajectory_trace_digest"] == "abc123"
+    assert trace_rows[0]["trajectory_snapshot_manifest_path"] == str(
+        normalized_dataset_dir / "manifest.json"
+    )
+
+
+def test_alignment_manifest_payload_records_trajectory_provenance_metrics(
+    tmp_path: Path,
+) -> None:
+    weights_path = tmp_path / "adapters.safetensors"
+    config_path = tmp_path / "adapter_config.json"
+    weights_path.write_bytes(b"weights")
+    config_path.write_text("{}\n", encoding="utf-8")
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"training_mode": "grpo", "grpo_candidate_count": "2"},
+        dataset_format="prompt_candidate",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    dataset = ResolvedTrainingDatasetPackage(
+        package=TrainingDatasetPackage(
+            package_path=tmp_path / "dataset",
+            manifest_path=tmp_path / "dataset" / "manifest.json",
+            samples_path=tmp_path / "dataset" / "samples.jsonl",
+            schema_version="melix.training_dataset_package.v1",
+            dataset_id="agentic-package",
+            format="agentic_tool_trace",
+            sample_count=1,
+            version="2026-05-19",
+            normalized_samples=[
+                {
+                    "prompt": "Use tools.",
+                    "candidates": [
+                        {"text": "Tool-backed answer.", "score": 0.9},
+                        {"text": "Guess.", "score": 0.1},
+                    ],
+                }
+            ],
+            normalized_validation_samples=[],
+            validation_sample_count=0,
+            response_only_supported=False,
+        ),
+        source_kind="local",
+        dataset_uri="file:///tmp/agentic",
+        materialized_package_path=tmp_path / "dataset",
+        cache_key="",
+        cache_hit=False,
+        hf_reference=None,
+    )
+    training_result = TrainingResult(
+        weights_path=weights_path,
+        adapter_config_path=config_path,
+        metrics=TrainingMetrics(
+            job_duration_ms=12.0,
+            tokens_seen=8,
+            examples_seen=1,
+            loss_final=0.2,
+            loss_best=0.2,
+            learning_rate_final=1e-4,
+            policy_update_count=1,
+            selected_candidate_count=1,
+            policy_update_trace_path=str(tmp_path / "policy_updates.jsonl"),
+        ),
+        execution_backend="scored_trace",
+    )
+    provenance = {
+        "trajectory_dataset_id": "opensearch-vl.dev",
+        "trajectory_trace_digest": "abc123",
+        "trajectory_reward_policy_id": "reward-policy.v1",
+        "trajectory_quality_metrics": {"reward_coverage_count": 1},
+    }
+
+    payload = _alignment_manifest_payload(
+        job_id="train-grpo-provenance",
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        config=config,
+        dataset=dataset,
+        training_result=training_result,
+        adapter_manifest_path=tmp_path / "train_lora.adapter.json",
+        candidate_trace_path=str(tmp_path / "train_lora.candidates.jsonl"),
+        trajectory_provenance=provenance,
+        created_at_unix_ms=123,
+    )
+
+    assert payload["trajectory_trace_digest"] == "abc123"
+    assert payload["metrics"]["trajectory_provenance_field_count"] == len(provenance)
+    assert payload["metrics"]["trajectory_reward_policy_present"] == 1
+    assert payload["metrics"]["trajectory_reward_component_coverage"] == 1
+
+
+def test_persist_result_exports_trajectory_provenance_fields(tmp_path: Path) -> None:
+    store = EvaluationStore(telemetry_collector=fixture_telemetry_collector())
+    jobs_root = tmp_path / "evaluation"
+    run_root = jobs_root / "runs" / "eval-trajectory"
+    snapshot_manifest = tmp_path / "snapshots" / "normalized_dataset" / "manifest.json"
+    snapshot_manifest.parent.mkdir(parents=True)
+    snapshot_manifest.write_text("{}\n", encoding="utf-8")
+    provenance = {
+        "trajectory_dataset_id": "opensearch-vl.dev",
+        "trajectory_dataset_version": "2026-05-19",
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "trajectory_snapshot_manifest_path": str(snapshot_manifest),
+        "trajectory_package_path": str(tmp_path / "packages" / "opensearch-vl.dev"),
+        "trajectory_split": "train",
+        "trajectory_trace_digest": "abc123",
+        "trajectory_toolset_version": "melix.agentic_tools.builtin.v1",
+        "trajectory_reward_policy_id": "reward-policy.v1",
+        "trajectory_quality_metrics": {"reward_coverage_count": 1},
+    }
+    job = build_evaluation_job_record(
+        job_id="eval-trajectory",
+        model_id="melix-dev-text",
+        task_kind="text-generation",
+        source_repo="local",
+        suite_id="agentic",
+        dataset_id="agentic-dev",
+        sample_size=1,
+        scoring_mode="exact",
+        parameters={},
+        status="completed",
+        output_dir=str(run_root),
+        trajectory_provenance=provenance,
+    )
+    result = build_evaluation_result_record(
+        job_id="eval-trajectory",
+        suite_id="agentic",
+        dataset_id="agentic-dev",
+        sample_size=1,
+        primary_score_name="exact",
+        primary_score_value=1.0,
+        extraction_success_count=1,
+        validation_success_count=1,
+        scored_sample_count=1,
+        failure_count=0,
+        metrics={"eval.agentic.score": 1.0},
+        report_path=str(run_root / "evaluation-result.json"),
+    )
+    sample = build_evaluation_sample_record(
+        job_id="eval-trajectory",
+        suite_id="agentic",
+        dataset_id="agentic-dev",
+        sample_id="sample-1",
+        system="",
+        input_text="Inspect image.",
+        target="MELIX",
+        raw_response="MELIX",
+        extracted_result="MELIX",
+        typed_score=1.0,
+        time_s=0.01,
+        extraction_status="extracted",
+        validation_status="validated",
+        failure_reason="",
+        agentic_tool_calls=({"id": "call-1", "name": "visit", "arguments": {}},),
+        agentic_tool_observations=({"status": "completed"},),
+        agentic_tool_metrics={"agentic_tool.call_count": 1.0},
+        trajectory_provenance=provenance,
+    )
+
+    persisted = store.persist_result(
+        jobs_root=jobs_root,
+        job=job,
+        result=result,
+        samples=(sample,),
+    )
+
+    sample_jsonl = json.loads(persisted["samples_jsonl"].read_text(encoding="utf-8"))
+    evidence = json.loads(persisted["evidence"].read_text(encoding="utf-8"))
+    export_bundle = collect_evaluation_artifacts(jobs_root)
+    export_rows = list(csv.DictReader(io.StringIO(build_evaluation_samples_csv(export_bundle))))
+
+    assert sample_jsonl["trajectory_dataset_id"] == "opensearch-vl.dev"
+    assert sample_jsonl["agentic_tool_calls"][0]["name"] == "visit"
+    assert evidence["domain_results"]["trajectory_provenance"]["trajectory_split"] == "train"
+    assert {artifact["kind"] for artifact in evidence["artifacts"]} >= {
+        "trajectory_snapshot_manifest",
+        "trajectory_package",
+    }
+    assert export_rows[0]["trajectory_reward_policy_id"] == "reward-policy.v1"
+    assert json.loads(export_rows[0]["trajectory_quality_metrics"])["reward_coverage_count"] == 1
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ({}, ""),
+        ([], ""),
+        ((), ""),
+        (None, ""),
+        ({"reward_coverage_count": 1}, "{\"reward_coverage_count\": 1}"),
+    ],
+)
+def test_benchmark_export_csv_value_handles_empty_and_nested_provenance(
+    value: object,
+    expected: str,
+) -> None:
+    from worker.productization.benchmark_export import _csv_value
+
+    assert _csv_value(value) == expected

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -28,6 +28,13 @@ from worker.model_ops.training_dataset import (
     write_normalized_dataset_snapshot,
 )
 from worker.productization.lora_experiment_store import LoraExperimentStore
+from worker.trajectory_provenance import (
+    adapter_manifest_trajectory_provenance,
+    alignment_metrics_trajectory_provenance,
+    append_trajectory_provenance,
+    load_trajectory_provenance_from_normalized_snapshot,
+    normalize_trajectory_provenance,
+)
 
 
 _NUMERIC_TOKEN_RE = re.compile(r"\d+")
@@ -99,6 +106,10 @@ class LoRATrainingPipeline:
             dataset.package,
             output_dir=output_dir,
             manifest_overrides=normalized_manifest_overrides,
+        )
+        trajectory_provenance = load_trajectory_provenance_from_normalized_snapshot(
+            format_name=normalized_snapshot.format,
+            manifest_path=normalized_snapshot.manifest_path,
         )
 
         emit("apply_lora", 0.65)
@@ -261,6 +272,7 @@ class LoRATrainingPipeline:
             "created_at_unix_ms": persisted_at_unix_ms,
             "updated_at_unix_ms": persisted_at_unix_ms,
         }
+        manifest.update(adapter_manifest_trajectory_provenance(trajectory_provenance))
         manifest.update(adapter_audit_fields)
         if resume_context["resume_manifest_path"] is not None:
             manifest["resume_source_manifest_path"] = str(resume_context["resume_manifest_path"])
@@ -333,6 +345,7 @@ class LoRATrainingPipeline:
                 training_result=training_result,
                 adapter_manifest_path=manifest_path,
                 candidate_trace_path=candidate_trace_path,
+                trajectory_provenance=trajectory_provenance,
                 created_at_unix_ms=persisted_at_unix_ms,
             )
             alignment_manifest_path.write_text(
@@ -451,6 +464,7 @@ def _alignment_manifest_payload(
     training_result: TrainingResult,
     adapter_manifest_path: Path,
     candidate_trace_path: str,
+    trajectory_provenance: dict[str, Any] | None = None,
     created_at_unix_ms: int,
 ) -> dict[str, Any]:
     alignment = config.alignment
@@ -477,6 +491,8 @@ def _alignment_manifest_payload(
     reward_summary = _reward_summary(dataset.package.normalized_samples)
     if reward_summary:
         metrics.update(reward_summary)
+    provenance = normalize_trajectory_provenance(trajectory_provenance)
+    metrics.update(alignment_metrics_trajectory_provenance(provenance))
     if alignment.dataset_contract in {"prompt_candidate", "reward_scored"}:
         metrics.update(
             {
@@ -507,7 +523,7 @@ def _alignment_manifest_payload(
                 training_result.metrics.candidate_group_reward_variance_mean
             )
 
-    return {
+    payload = {
         "schema_version": "melix.alignment_run.v1",
         "operation": "train_alignment",
         "job_id": job_id,
@@ -539,6 +555,8 @@ def _alignment_manifest_payload(
         "created_at_unix_ms": created_at_unix_ms,
         "updated_at_unix_ms": created_at_unix_ms,
     }
+    append_trajectory_provenance(payload, provenance)
+    return payload
 
 
 def _reward_summary(samples: list[dict[str, Any]]) -> dict[str, float | int]:

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -13,6 +13,10 @@ from packages.protocol.python.worker.v1 import common_pb2
 
 from worker.model_ops.errors import ModelOperationError
 from worker.runtime.agentic_tools import execute_agentic_tool_calls
+from worker.trajectory_provenance import (
+    append_trajectory_provenance,
+    load_trajectory_provenance_from_snapshot_dir,
+)
 
 
 @dataclass(frozen=True)
@@ -106,6 +110,9 @@ def train_alignment_rl_trace(
 
     started_at = time.perf_counter()
     samples = _load_training_rows(request.normalized_dataset_dir / "train.jsonl")
+    trajectory_provenance = load_trajectory_provenance_from_snapshot_dir(
+        request.normalized_dataset_dir,
+    )
     reward_scorer = _resolve_reward_model_scorer(alignment, reward_runtime)
     if alignment.alignment_algorithm == "grpo":
         if alignment.candidate_generation_mode == "runtime_generate":
@@ -144,6 +151,9 @@ def train_alignment_rl_trace(
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
     latest_checkpoint_path = checkpoint_dir / "adapters.safetensors"
 
+    if trajectory_provenance:
+        for row in policy_updates.trace_rows:
+            append_trajectory_provenance(row, trajectory_provenance)
     _write_jsonl(policy_update_trace_path, policy_updates.trace_rows)
     adapter_config = _load_resume_adapter_config(request.resume_source_path) or {
         "fine_tune_type": "lora",
@@ -174,6 +184,9 @@ def train_alignment_rl_trace(
             ),
         }
     )
+    if trajectory_provenance:
+        append_trajectory_provenance(adapter_config, trajectory_provenance)
+        adapter_config["trajectory_provenance_field_count"] = len(trajectory_provenance)
     adapter_config_path.write_text(json.dumps(adapter_config, indent=2) + "\n", encoding="utf-8")
     weights_bytes = _alignment_adapter_weights_bytes(
         source_weights_path=request.resume_source_path,

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -153,7 +153,7 @@ def train_alignment_rl_trace(
 
     if trajectory_provenance:
         for row in policy_updates.trace_rows:
-            append_trajectory_provenance(row, trajectory_provenance)
+            row.update(trajectory_provenance)
     _write_jsonl(policy_update_trace_path, policy_updates.trace_rows)
     adapter_config = _load_resume_adapter_config(request.resume_source_path) or {
         "fine_tune_type": "lora",

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -655,13 +655,21 @@ def normalize_training_config(
 
 def _resolve_training_mode_contract(training_mode: str, dataset_format: str) -> dict[str, str]:
     if training_mode in _SFT_TRAINING_MODES:
-        if dataset_format not in {"chat_messages", "prompt_completion", "text_completion"}:
+        if dataset_format not in {
+            "chat_messages",
+            "prompt_completion",
+            "text_completion",
+            "agentic_tool_trace",
+        }:
             raise ModelOperationError(
                 code="invalid_dataset_package",
                 message="SFT training modes require supervised training datasets.",
                 details={
                     "training_mode": training_mode,
-                    "required_format": "chat_messages,prompt_completion,text_completion",
+                    "required_format": (
+                        "chat_messages,prompt_completion,text_completion,"
+                        "agentic_tool_trace"
+                    ),
                     "actual_format": dataset_format,
                 },
             )

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -4,7 +4,7 @@ import csv
 import json
 import io
 import time
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
 import os
 from pathlib import Path
@@ -12,6 +12,27 @@ from pathlib import Path
 from worker.trajectory_provenance import TRAJECTORY_PROVENANCE_CSV_FIELDS
 
 _EXPORT_SCHEMA_VERSION = "melix.benchmark_export.v1"
+
+_BENCHMARK_SUMMARY_COLUMNS = (
+    "job_id",
+    "model_id",
+    "task_kind",
+    "source_repo",
+    "suites",
+    "context_lengths",
+    "generation_length",
+    "batch_sizes",
+    "repeats",
+    "cache_profile",
+    "reasoning_mode",
+    "structured_output_mode",
+    "request_p50_ms",
+    "request_p95_ms",
+    "status",
+    "output_dir",
+    "created_at_unix_ms",
+    "updated_at_unix_ms",
+)
 
 
 @dataclass(frozen=True)
@@ -479,26 +500,7 @@ def build_evaluation_compare_samples_csv(bundle: dict[str, object]) -> str:
 def build_benchmark_summary_csv(bundle: dict[str, object]) -> str:
     return _rows_to_csv(
         (row for row in bundle.get("benchmark_summary_rows", []) if isinstance(row, dict)),
-        [
-            "job_id",
-            "model_id",
-            "task_kind",
-            "source_repo",
-            "suites",
-            "context_lengths",
-            "generation_length",
-            "batch_sizes",
-            "repeats",
-            "cache_profile",
-            "reasoning_mode",
-            "structured_output_mode",
-            "request_p50_ms",
-            "request_p95_ms",
-            "status",
-            "output_dir",
-            "created_at_unix_ms",
-            "updated_at_unix_ms",
-        ],
+        _BENCHMARK_SUMMARY_COLUMNS,
     )
 
 
@@ -821,16 +823,37 @@ def _iter_jsonl_dict_rows(path: Path) -> Iterator[dict[str, object]]:
                 yield row
 
 
-def _rows_to_csv(rows: Iterable[dict[str, object]], fieldnames: list[str]) -> str:
+def _rows_to_csv(rows: Iterable[dict[str, object]], fieldnames: Sequence[str]) -> str:
     buffer = io.StringIO()
     writer = csv.writer(buffer)
-    writer.writerow(fieldnames)
-    normalize_csv_value = _csv_value
+    fields = tuple(fieldnames)
+    writer.writerow(fields)
 
     def csv_rows() -> Iterable[list[str]]:
         for row in rows:
             row_get = row.get
-            yield [normalize_csv_value(row_get(field, "")) for field in fieldnames]
+            csv_row: list[str] = []
+            append_value = csv_row.append
+            for field in fields:
+                value = row_get(field, "")
+                if value is None:
+                    append_value("")
+                    continue
+                value_type = type(value)
+                if value_type is str:
+                    append_value(value)
+                    continue
+                if value_type is int or value_type is float or value_type is bool:
+                    append_value(str(value))
+                    continue
+                if value_type is list or value_type is tuple:
+                    append_value(",".join(map(str, value)) if value else "")
+                    continue
+                if value_type is dict:
+                    append_value(json.dumps(value, sort_keys=True) if value else "")
+                    continue
+                append_value(_csv_value(value))
+            yield csv_row
 
     writer.writerows(csv_rows())
     return buffer.getvalue()

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 import os
 from pathlib import Path
 
+from worker.trajectory_provenance import TRAJECTORY_PROVENANCE_CSV_FIELDS
+
 _EXPORT_SCHEMA_VERSION = "melix.benchmark_export.v1"
 
 
@@ -878,6 +880,7 @@ def _canonical_benchmark_row_columns() -> list[str]:
         "dflash_block_size",
         "dflash_rollback_count",
         "dflash_target_hidden_layers",
+        *TRAJECTORY_PROVENANCE_CSV_FIELDS,
     ]
 
 
@@ -917,6 +920,7 @@ def _canonical_evaluation_sample_columns() -> list[str]:
         "raw_response_chars",
         "extracted_result_chars",
         "failure_stage",
+        *TRAJECTORY_PROVENANCE_CSV_FIELDS,
     ]
 
 
@@ -966,6 +970,10 @@ def _normalized_evaluation_sample_row(row: dict[str, object]) -> dict[str, objec
             len(str(row.get("extracted_result", row.get("predicted", "")))),
         ),
         "failure_stage": row.get("failure_stage", ""),
+        **{
+            field_name: row.get(field_name, "")
+            for field_name in TRAJECTORY_PROVENANCE_CSV_FIELDS
+        },
     }
 
 
@@ -1006,6 +1014,7 @@ def _canonical_benchmark_matrix_summary_columns() -> list[str]:
         "request_latency_p50_ms",
         "request_latency_p95_ms",
         "created_at_unix_ms",
+        *TRAJECTORY_PROVENANCE_CSV_FIELDS,
     ]
 
 
@@ -1057,16 +1066,29 @@ def _canonical_benchmark_matrix_request_columns() -> list[str]:
         "dflash_rollback_count",
         "dflash_target_hidden_layers",
         "created_at_unix_ms",
+        *TRAJECTORY_PROVENANCE_CSV_FIELDS,
     ]
 
 
 def _csv_value(value: object) -> str:
-    if isinstance(value, list):
-        return ",".join(str(item) for item in value)
-    if isinstance(value, tuple):
-        return ",".join(str(item) for item in value)
     if value is None:
         return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    if isinstance(value, list):
+        if not value:
+            return ""
+        return ",".join(str(item) for item in value)
+    if isinstance(value, tuple):
+        if not value:
+            return ""
+        return ",".join(str(item) for item in value)
+    if isinstance(value, dict):
+        if not value:
+            return ""
+        return json.dumps(value, sort_keys=True)
     return str(value)
 
 

--- a/services/mlx-worker-python/worker/productization/benchmark_schemas.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_schemas.py
@@ -11,6 +11,7 @@ from worker.productization.evaluation_schemas import (
     build_evaluation_result_record,
     build_evaluation_sample_record,
 )
+from worker.trajectory_provenance import append_trajectory_provenance
 
 
 _SERVING_BENCHMARK_JOB_SCHEMA_VERSION = "melix.serving_benchmark_job.v1"
@@ -55,6 +56,7 @@ class ServingBenchmarkJob:
     created_at_unix_ms: int
     updated_at_unix_ms: int
     suite_metadata: dict[str, dict[str, object]] = field(default_factory=dict)
+    trajectory_provenance: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -84,6 +86,7 @@ class ServingBenchmarkJob:
                 suite_id: dict(metadata)
                 for suite_id, metadata in self.suite_metadata.items()
             }
+        append_trajectory_provenance(payload, self.trajectory_provenance)
         return payload
 
 
@@ -136,6 +139,7 @@ class ServingBenchmarkContextRow:
     agentic_tool_calls: tuple[dict[str, object], ...] = ()
     agentic_tool_observations: tuple[dict[str, object], ...] = ()
     agentic_tool_metrics: dict[str, float] | None = None
+    trajectory_provenance: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -190,6 +194,7 @@ class ServingBenchmarkContextRow:
             observations=self.agentic_tool_observations,
             metrics=self.agentic_tool_metrics,
         )
+        append_trajectory_provenance(payload, self.trajectory_provenance)
         return payload
 
 
@@ -242,6 +247,7 @@ class ServingBenchmarkBatchRow:
     agentic_tool_calls: tuple[dict[str, object], ...] = ()
     agentic_tool_observations: tuple[dict[str, object], ...] = ()
     agentic_tool_metrics: dict[str, float] | None = None
+    trajectory_provenance: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -296,6 +302,7 @@ class ServingBenchmarkBatchRow:
             observations=self.agentic_tool_observations,
             metrics=self.agentic_tool_metrics,
         )
+        append_trajectory_provenance(payload, self.trajectory_provenance)
         return payload
 
 
@@ -333,9 +340,10 @@ class BenchmarkMatrixJob:
     created_at_unix_ms: int
     updated_at_unix_ms: int
     parameters: dict[str, str] = field(default_factory=dict)
+    trajectory_provenance: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "schema_version": self.schema_version,
             "job_id": self.job_id,
             "model_id": self.model_id,
@@ -349,6 +357,8 @@ class BenchmarkMatrixJob:
             "created_at_unix_ms": self.created_at_unix_ms,
             "updated_at_unix_ms": self.updated_at_unix_ms,
         }
+        append_trajectory_provenance(payload, self.trajectory_provenance)
+        return payload
 
 
 @dataclass(frozen=True)
@@ -481,6 +491,7 @@ class BenchmarkMatrixRequestRow:
     agentic_tool_calls: tuple[dict[str, object], ...] = ()
     agentic_tool_observations: tuple[dict[str, object], ...] = ()
     agentic_tool_metrics: dict[str, float] | None = None
+    trajectory_provenance: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -538,6 +549,7 @@ class BenchmarkMatrixRequestRow:
             observations=self.agentic_tool_observations,
             metrics=self.agentic_tool_metrics,
         )
+        append_trajectory_provenance(payload, self.trajectory_provenance)
         return payload
 
 
@@ -563,6 +575,7 @@ def build_serving_benchmark_job(
     created_at_unix_ms: int = 0,
     updated_at_unix_ms: int = 0,
     suite_metadata: dict[str, dict[str, object]] | None = None,
+    trajectory_provenance: dict[str, object] | None = None,
 ) -> ServingBenchmarkJob:
     return ServingBenchmarkJob(
         schema_version=_SERVING_BENCHMARK_JOB_SCHEMA_VERSION,
@@ -586,6 +599,7 @@ def build_serving_benchmark_job(
         created_at_unix_ms=created_at_unix_ms,
         updated_at_unix_ms=updated_at_unix_ms,
         suite_metadata=dict(suite_metadata or {}),
+        trajectory_provenance=dict(trajectory_provenance or {}),
     )
 
 
@@ -619,6 +633,7 @@ def build_benchmark_matrix_job(
     created_at_unix_ms: int = 0,
     updated_at_unix_ms: int = 0,
     parameters: dict[str, str] | None = None,
+    trajectory_provenance: dict[str, object] | None = None,
 ) -> BenchmarkMatrixJob:
     return BenchmarkMatrixJob(
         schema_version=_BENCHMARK_MATRIX_JOB_SCHEMA_VERSION,
@@ -633,6 +648,7 @@ def build_benchmark_matrix_job(
         created_at_unix_ms=created_at_unix_ms,
         updated_at_unix_ms=updated_at_unix_ms,
         parameters=dict(parameters or {}),
+        trajectory_provenance=dict(trajectory_provenance or {}),
     )
 
 
@@ -765,6 +781,7 @@ def build_benchmark_matrix_request_row(
     agentic_tool_calls: tuple[dict[str, object], ...] = (),
     agentic_tool_observations: tuple[dict[str, object], ...] = (),
     agentic_tool_metrics: dict[str, float] | None = None,
+    trajectory_provenance: dict[str, object] | None = None,
 ) -> BenchmarkMatrixRequestRow:
     return BenchmarkMatrixRequestRow(
         job_id=job_id,
@@ -817,6 +834,7 @@ def build_benchmark_matrix_request_row(
         agentic_tool_calls=tuple(dict(call) for call in agentic_tool_calls),
         agentic_tool_observations=tuple(dict(observation) for observation in agentic_tool_observations),
         agentic_tool_metrics=dict(agentic_tool_metrics or {}),
+        trajectory_provenance=dict(trajectory_provenance or {}),
     )
 
 
@@ -868,6 +886,7 @@ def build_serving_benchmark_context_row(
     agentic_tool_calls: tuple[dict[str, object], ...] = (),
     agentic_tool_observations: tuple[dict[str, object], ...] = (),
     agentic_tool_metrics: dict[str, float] | None = None,
+    trajectory_provenance: dict[str, object] | None = None,
 ) -> ServingBenchmarkContextRow:
     return ServingBenchmarkContextRow(
         schema_version="melix.serving_benchmark_context_row.v1",
@@ -917,6 +936,7 @@ def build_serving_benchmark_context_row(
         agentic_tool_calls=tuple(dict(call) for call in agentic_tool_calls),
         agentic_tool_observations=tuple(dict(observation) for observation in agentic_tool_observations),
         agentic_tool_metrics=dict(agentic_tool_metrics or {}),
+        trajectory_provenance=dict(trajectory_provenance or {}),
     )
 
 
@@ -968,6 +988,7 @@ def build_serving_benchmark_batch_row(
     agentic_tool_calls: tuple[dict[str, object], ...] = (),
     agentic_tool_observations: tuple[dict[str, object], ...] = (),
     agentic_tool_metrics: dict[str, float] | None = None,
+    trajectory_provenance: dict[str, object] | None = None,
 ) -> ServingBenchmarkBatchRow:
     return ServingBenchmarkBatchRow(
         schema_version="melix.serving_benchmark_batch_row.v1",
@@ -1017,6 +1038,7 @@ def build_serving_benchmark_batch_row(
         agentic_tool_calls=tuple(dict(call) for call in agentic_tool_calls),
         agentic_tool_observations=tuple(dict(observation) for observation in agentic_tool_observations),
         agentic_tool_metrics=dict(agentic_tool_metrics or {}),
+        trajectory_provenance=dict(trajectory_provenance or {}),
     )
 
 
@@ -1062,6 +1084,7 @@ def build_evaluation_job(
     output_dir: str = "",
     created_at_unix_ms: int = 0,
     updated_at_unix_ms: int = 0,
+    trajectory_provenance: dict[str, object] | None = None,
 ) -> EvaluationJob:
     return build_evaluation_job_record(
         job_id=job_id,
@@ -1077,6 +1100,7 @@ def build_evaluation_job(
         output_dir=output_dir,
         created_at_unix_ms=created_at_unix_ms,
         updated_at_unix_ms=updated_at_unix_ms,
+        trajectory_provenance=trajectory_provenance,
     )
 
 
@@ -1114,19 +1138,24 @@ def build_evaluation_sample(
     correct: bool,
     time_s: float,
     parse_status: str,
+    trajectory_provenance: dict[str, object] | None = None,
 ) -> EvaluationSample:
     return build_evaluation_sample_record(
         job_id=job_id,
         suite_id=suite_id,
         dataset_id=dataset_id,
         sample_id=sample_id,
-        question=question,
-        expected=expected,
-        predicted=predicted,
+        system="",
+        input_text=question,
+        target=expected,
         raw_response=raw_response,
-        correct=correct,
+        extracted_result=predicted,
+        typed_score=1.0 if correct else 0.0,
         time_s=time_s,
-        parse_status=parse_status,
+        extraction_status=parse_status,
+        validation_status="validated",
+        failure_reason="" if correct else "incorrect",
+        trajectory_provenance=trajectory_provenance,
     )
 
 

--- a/services/mlx-worker-python/worker/productization/evaluation_schemas.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_schemas.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from worker.trajectory_provenance import append_trajectory_provenance
+
 
 _EVALUATION_DATASET_PACKAGE_SCHEMA_VERSION = "melix.evaluation_dataset_package.v2"
 _EVALUATION_JOB_SCHEMA_VERSION = "melix.evaluation_job.v2"
@@ -87,9 +89,10 @@ class EvaluationJob:
     output_dir: str
     created_at_unix_ms: int
     updated_at_unix_ms: int
+    trajectory_provenance: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "schema_version": self.schema_version,
             "job_id": self.job_id,
             "model_id": self.model_id,
@@ -108,6 +111,8 @@ class EvaluationJob:
             "created_at_unix_ms": self.created_at_unix_ms,
             "updated_at_unix_ms": self.updated_at_unix_ms,
         }
+        append_trajectory_provenance(payload, self.trajectory_provenance)
+        return payload
 
 
 @dataclass(frozen=True)
@@ -189,6 +194,7 @@ class EvaluationSample:
     agentic_tool_calls: tuple[dict[str, object], ...] = ()
     agentic_tool_observations: tuple[dict[str, object], ...] = ()
     agentic_tool_metrics: dict[str, float] | None = None
+    trajectory_provenance: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -238,6 +244,7 @@ class EvaluationSample:
             ]
         if self.agentic_tool_metrics:
             payload["agentic_tool_metrics"] = dict(self.agentic_tool_metrics)
+        append_trajectory_provenance(payload, self.trajectory_provenance)
         if self.category_label:
             payload["category_label"] = self.category_label
         if self.subject_label:
@@ -296,9 +303,10 @@ class EvaluationCompareJob:
     # that pre-date the adapter-native compare surface; ``to_dict``/``from_dict``
     # handle that as a clean default.
     target_lineage: tuple[EvaluationCompareTargetLineage, ...] = ()
+    trajectory_provenance: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "schema_version": self.schema_version,
             "job_id": self.job_id,
             "base_model_id": self.base_model_id,
@@ -316,6 +324,8 @@ class EvaluationCompareJob:
             "updated_at_unix_ms": self.updated_at_unix_ms,
             "target_lineage": [entry.to_dict() for entry in self.target_lineage],
         }
+        append_trajectory_provenance(payload, self.trajectory_provenance)
+        return payload
 
 
 @dataclass(frozen=True)
@@ -421,6 +431,7 @@ class EvaluationCompareSample:
     target_code_failure_detail: str = ""
     category_label: str = ""
     subject_label: str = ""
+    trajectory_provenance: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -467,6 +478,7 @@ class EvaluationCompareSample:
             "base_code_failure_detail": self.base_code_failure_detail,
             "target_code_failure_detail": self.target_code_failure_detail,
         }
+        append_trajectory_provenance(payload, self.trajectory_provenance)
         if self.category_label:
             payload["category_label"] = self.category_label
         if self.subject_label:
@@ -532,6 +544,7 @@ def build_evaluation_job_record(
     output_dir: str = "",
     created_at_unix_ms: int = 0,
     updated_at_unix_ms: int = 0,
+    trajectory_provenance: dict[str, object] | None = None,
 ) -> EvaluationJob:
     return EvaluationJob(
         schema_version=_EVALUATION_JOB_SCHEMA_VERSION,
@@ -551,6 +564,7 @@ def build_evaluation_job_record(
         output_dir=output_dir,
         created_at_unix_ms=created_at_unix_ms,
         updated_at_unix_ms=updated_at_unix_ms,
+        trajectory_provenance=dict(trajectory_provenance or {}),
     )
 
 
@@ -636,6 +650,7 @@ def build_evaluation_sample_record(
     agentic_tool_calls: tuple[dict[str, object], ...] = (),
     agentic_tool_observations: tuple[dict[str, object], ...] = (),
     agentic_tool_metrics: dict[str, float] | None = None,
+    trajectory_provenance: dict[str, object] | None = None,
 ) -> EvaluationSample:
     return EvaluationSample(
         schema_version=_EVALUATION_SAMPLE_SCHEMA_VERSION,
@@ -685,6 +700,7 @@ def build_evaluation_sample_record(
         agentic_tool_calls=tuple(dict(call) for call in agentic_tool_calls),
         agentic_tool_observations=tuple(dict(observation) for observation in agentic_tool_observations),
         agentic_tool_metrics=dict(agentic_tool_metrics or {}),
+        trajectory_provenance=dict(trajectory_provenance or {}),
     )
 
 
@@ -705,6 +721,7 @@ def build_evaluation_compare_job_record(
     created_at_unix_ms: int = 0,
     updated_at_unix_ms: int = 0,
     target_lineage: tuple[EvaluationCompareTargetLineage, ...] = (),
+    trajectory_provenance: dict[str, object] | None = None,
 ) -> EvaluationCompareJob:
     return EvaluationCompareJob(
         schema_version=_EVALUATION_COMPARE_JOB_SCHEMA_VERSION,
@@ -723,6 +740,7 @@ def build_evaluation_compare_job_record(
         created_at_unix_ms=created_at_unix_ms,
         updated_at_unix_ms=updated_at_unix_ms,
         target_lineage=tuple(target_lineage),
+        trajectory_provenance=dict(trajectory_provenance or {}),
     )
 
 
@@ -832,6 +850,7 @@ def build_evaluation_compare_sample_record(
     target_code_failure_detail: str = "",
     category_label: str = "",
     subject_label: str = "",
+    trajectory_provenance: dict[str, object] | None = None,
 ) -> EvaluationCompareSample:
     return EvaluationCompareSample(
         schema_version=_EVALUATION_COMPARE_SAMPLE_SCHEMA_VERSION,
@@ -878,4 +897,5 @@ def build_evaluation_compare_sample_record(
         target_code_failure_detail=target_code_failure_detail,
         category_label=category_label,
         subject_label=subject_label,
+        trajectory_provenance=dict(trajectory_provenance or {}),
     )

--- a/services/mlx-worker-python/worker/productization/run_evidence.py
+++ b/services/mlx-worker-python/worker/productization/run_evidence.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from worker.trajectory_provenance import normalize_trajectory_provenance
+
 from worker.productization.git_env import scrub_git_local_env
 
 
@@ -527,6 +529,68 @@ def _model_memory_summary(
     return default_model_memory_summary()
 
 
+def _trajectory_provenance_from_records(
+    *records: dict[str, object],
+) -> dict[str, object]:
+    for record in records:
+        provenance = normalize_trajectory_provenance(record)
+        if provenance:
+            return provenance
+    return {}
+
+
+def _trajectory_provenance_from_objects(
+    *objects: object,
+) -> dict[str, object]:
+    for item in objects:
+        if isinstance(item, dict):
+            provenance = normalize_trajectory_provenance(item)
+        else:
+            provenance = normalize_trajectory_provenance(
+                getattr(item, "trajectory_provenance", None)
+            )
+        if provenance:
+            return provenance
+    return {}
+
+
+def _artifacts_with_trajectory_provenance(
+    artifacts: tuple[RunEvidenceArtifact, ...],
+    provenance: dict[str, object],
+    artifact_root: Path,
+) -> tuple[RunEvidenceArtifact, ...]:
+    snapshot_path = str(provenance.get("trajectory_snapshot_manifest_path", "")).strip()
+    package_path = str(provenance.get("trajectory_package_path", "")).strip()
+    extra_artifacts: list[RunEvidenceArtifact] = []
+    if snapshot_path:
+        extra_artifacts.append(
+            RunEvidenceArtifact(
+                kind="trajectory_snapshot_manifest",
+                path=_artifact_path(Path(snapshot_path), artifact_root),
+                role="trajectory_snapshot_manifest",
+            )
+        )
+    if package_path:
+        extra_artifacts.append(
+            RunEvidenceArtifact(
+                kind="trajectory_package",
+                path=_artifact_path(Path(package_path), artifact_root),
+                role="trajectory_package",
+            )
+        )
+    if not extra_artifacts:
+        return artifacts
+    seen = {(artifact.kind, artifact.path) for artifact in artifacts}
+    merged = [*artifacts]
+    for artifact in extra_artifacts:
+        key = (artifact.kind, artifact.path)
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(artifact)
+    return tuple(merged)
+
+
 def build_serving_benchmark_run_evidence(
     *,
     job: Any,
@@ -553,6 +617,8 @@ def build_serving_benchmark_run_evidence(
         RunEvidenceArtifact(kind=kind, path=_artifact_path(path, artifact_root), role=kind)
         for kind, path in sorted(artifact_paths.items())
     )
+    context_rows_tuple = tuple(context_rows)
+    batch_rows_tuple = tuple(batch_rows)
     run_started_at_monotonic_ms = _run_started_at_monotonic_ms(
         artifact_write_started_at_monotonic_ms=artifact_write_started_at_monotonic_ms,
         duration_ms=max(int(job.updated_at_unix_ms) - int(job.created_at_unix_ms), 0),
@@ -587,7 +653,7 @@ def build_serving_benchmark_run_evidence(
             trace_id=trace_id,
             parent_span_id=root_span_id,
             started_at_monotonic_ms=run_started_at_monotonic_ms + 1,
-            rows=(*tuple(context_rows), *tuple(batch_rows)),
+            rows=(*context_rows_tuple, *batch_rows_tuple),
         ),
         *tuple(telemetry_probes),
         artifact_write_probe(
@@ -599,6 +665,25 @@ def build_serving_benchmark_run_evidence(
             artifact_count=len(artifacts),
         ),
     )
+    trajectory_provenance = _trajectory_provenance_from_objects(job)
+    if not trajectory_provenance:
+        trajectory_provenance = _trajectory_provenance_from_records(
+            *context_rows_tuple,
+            *batch_rows_tuple,
+        )
+    artifacts_with_trajectory = _artifacts_with_trajectory_provenance(
+        artifacts,
+        trajectory_provenance,
+        artifact_root,
+    )
+    domain_results: dict[str, object] = {
+        "serving_benchmark": {
+            "job": job.to_dict(),
+            "results": [result.to_dict() for result in results],
+        },
+    }
+    if trajectory_provenance:
+        domain_results["trajectory_provenance"] = trajectory_provenance
     return RunEvidenceEnvelope(
         run_id=job.job_id,
         melix_commit=commit,
@@ -639,15 +724,10 @@ def build_serving_benchmark_run_evidence(
         probe_timeline=probe_timeline,
         telemetry_summary=telemetry_summary or default_telemetry_summary(),
         model_memory_summary=_model_memory_summary(model_memory_summary),
-        artifacts=artifacts,
+        artifacts=artifacts_with_trajectory,
         failure_summary=_failure_summary(job.status),
         fallback_summary=_fallback_summary(job.parameters),
-        domain_results={
-            "serving_benchmark": {
-                "job": job.to_dict(),
-                "results": [result.to_dict() for result in results],
-            },
-        },
+        domain_results=domain_results,
     )
 
 
@@ -676,6 +756,7 @@ def build_evaluation_run_evidence(
         RunEvidenceArtifact(kind=kind, path=_artifact_path(path, artifact_root), role=kind)
         for kind, path in sorted(artifact_paths.items())
     )
+    samples_tuple = tuple(samples)
     run_started_at_monotonic_ms = _run_started_at_monotonic_ms(
         artifact_write_started_at_monotonic_ms=artifact_write_started_at_monotonic_ms,
         duration_ms=max(int(job.updated_at_unix_ms) - int(job.created_at_unix_ms), 0),
@@ -710,7 +791,7 @@ def build_evaluation_run_evidence(
             trace_id=trace_id,
             parent_span_id=root_span_id,
             started_at_monotonic_ms=run_started_at_monotonic_ms + 1,
-            samples=samples,
+            samples=samples_tuple,
         ),
         *tuple(telemetry_probes),
         artifact_write_probe(
@@ -722,6 +803,21 @@ def build_evaluation_run_evidence(
             artifact_count=len(artifacts),
         ),
     )
+    trajectory_provenance = _trajectory_provenance_from_objects(job, *samples_tuple)
+    artifacts_with_trajectory = _artifacts_with_trajectory_provenance(
+        artifacts,
+        trajectory_provenance,
+        artifact_root,
+    )
+    domain_results: dict[str, object] = {
+        "evaluation": {
+            "job": job.to_dict(),
+            "result": result.to_dict(),
+            "sample_count": sample_count,
+        },
+    }
+    if trajectory_provenance:
+        domain_results["trajectory_provenance"] = trajectory_provenance
     return RunEvidenceEnvelope(
         run_id=job.job_id,
         melix_commit=commit,
@@ -757,16 +853,10 @@ def build_evaluation_run_evidence(
         probe_timeline=probe_timeline,
         telemetry_summary=telemetry_summary or default_telemetry_summary(),
         model_memory_summary=_model_memory_summary(model_memory_summary),
-        artifacts=artifacts,
+        artifacts=artifacts_with_trajectory,
         failure_summary=_failure_summary(job.status, failure_count=result.failure_count),
         fallback_summary=_fallback_summary(job.parameters),
-        domain_results={
-            "evaluation": {
-                "job": job.to_dict(),
-                "result": result.to_dict(),
-                "sample_count": sample_count,
-            },
-        },
+        domain_results=domain_results,
     )
 
 

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+
+TRAJECTORY_PROVENANCE_FIELDS = (
+    "trajectory_dataset_id",
+    "trajectory_dataset_version",
+    "trajectory_schema_version",
+    "trajectory_snapshot_manifest_path",
+    "trajectory_split",
+    "trajectory_trace_digest",
+    "trajectory_toolset_version",
+    "trajectory_registry_schema_version",
+    "trajectory_reward_policy_id",
+    "trajectory_leakage_policy_id",
+    "trajectory_package_path",
+    "trajectory_quality_metrics",
+)
+
+TRAJECTORY_PROVENANCE_CSV_FIELDS = (
+    "trajectory_dataset_id",
+    "trajectory_dataset_version",
+    "trajectory_schema_version",
+    "trajectory_snapshot_manifest_path",
+    "trajectory_split",
+    "trajectory_trace_digest",
+    "trajectory_toolset_version",
+    "trajectory_registry_schema_version",
+    "trajectory_reward_policy_id",
+    "trajectory_leakage_policy_id",
+    "trajectory_package_path",
+    "trajectory_quality_metrics",
+)
+
+
+def normalize_trajectory_provenance(
+    provenance: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if not provenance:
+        return {}
+    normalized: dict[str, Any] = {}
+    for field in TRAJECTORY_PROVENANCE_FIELDS:
+        value = provenance.get(field)
+        if value in ("", None):
+            continue
+        if isinstance(value, (dict, list)):
+            normalized[field] = copy.deepcopy(value)
+        else:
+            normalized[field] = value
+    return normalized
+
+
+def append_trajectory_provenance(
+    payload: dict[str, Any],
+    provenance: Mapping[str, Any] | None,
+) -> None:
+    if not provenance:
+        return
+    normalized = normalize_trajectory_provenance(provenance)
+    if normalized:
+        payload.update(normalized)
+
+
+def trajectory_provenance_from_snapshot_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    snapshot_manifest_path: Path | str | None = None,
+) -> dict[str, Any]:
+    if (
+        str(manifest.get("format", "")).strip() != "agentic_tool_trace"
+        and not str(manifest.get("trajectory_trace_digest", "")).strip()
+    ):
+        return {}
+
+    provenance: dict[str, Any] = {
+        "trajectory_dataset_id": str(
+            manifest.get("source_dataset_id") or manifest.get("dataset_id") or ""
+        ).strip(),
+        "trajectory_dataset_version": str(manifest.get("version") or "").strip(),
+        "trajectory_schema_version": str(
+            manifest.get("trajectory_schema_version") or "melix.agentic_tool_trace.v1"
+        ).strip(),
+        "trajectory_split": str(manifest.get("trajectory_split") or "train").strip(),
+        "trajectory_trace_digest": str(manifest.get("trajectory_trace_digest") or "").strip(),
+    }
+    if snapshot_manifest_path is not None:
+        provenance["trajectory_snapshot_manifest_path"] = str(snapshot_manifest_path)
+    for source_field, output_field in (
+        ("trajectory_toolset_version", "trajectory_toolset_version"),
+        ("trajectory_registry_schema_version", "trajectory_registry_schema_version"),
+        ("trajectory_reward_policy_id", "trajectory_reward_policy_id"),
+        ("trajectory_leakage_policy_id", "trajectory_leakage_policy_id"),
+        ("source_package_path", "trajectory_package_path"),
+        ("trajectory_quality_metrics", "trajectory_quality_metrics"),
+    ):
+        value = manifest.get(source_field)
+        if value in ("", None):
+            continue
+        provenance[output_field] = copy.deepcopy(value) if isinstance(value, (dict, list)) else value
+    return normalize_trajectory_provenance(provenance)
+
+
+def load_trajectory_provenance_from_snapshot_manifest(
+    manifest_path: Path,
+) -> dict[str, Any]:
+    payload = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return {}
+    return trajectory_provenance_from_snapshot_manifest(
+        payload,
+        snapshot_manifest_path=manifest_path,
+    )
+
+
+def load_trajectory_provenance_from_normalized_snapshot(
+    *,
+    format_name: str,
+    manifest_path: Path,
+) -> dict[str, Any]:
+    if format_name != "agentic_tool_trace":
+        return {}
+    return load_trajectory_provenance_from_snapshot_manifest(manifest_path)
+
+
+def load_trajectory_provenance_from_snapshot_dir(
+    snapshot_dir: Path,
+) -> dict[str, Any]:
+    manifest_path = Path(snapshot_dir) / "manifest.json"
+    if not manifest_path.is_file():
+        return {}
+    return load_trajectory_provenance_from_snapshot_manifest(manifest_path)
+
+
+def adapter_manifest_trajectory_provenance(
+    provenance: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    normalized = normalize_trajectory_provenance(provenance)
+    if not normalized:
+        return {}
+    payload = dict(normalized)
+    payload["trajectory_provenance_field_count"] = len(normalized)
+    payload["trajectory_reward_policy_present"] = bool(
+        normalized.get("trajectory_reward_policy_id")
+    )
+    return payload
+
+
+def alignment_metrics_trajectory_provenance(
+    provenance: Mapping[str, Any] | None,
+) -> dict[str, int]:
+    normalized = normalize_trajectory_provenance(provenance)
+    if not normalized:
+        return {}
+    metrics = {
+        "trajectory_provenance_field_count": len(normalized),
+        "trajectory_reward_policy_present": int(
+            bool(normalized.get("trajectory_reward_policy_id"))
+        ),
+    }
+    quality_metrics = normalized.get("trajectory_quality_metrics")
+    if isinstance(quality_metrics, Mapping):
+        metrics["trajectory_reward_component_coverage"] = int(
+            quality_metrics.get("reward_coverage_count", 0) or 0
+        )
+    return metrics

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -22,20 +22,7 @@ TRAJECTORY_PROVENANCE_FIELDS = (
     "trajectory_quality_metrics",
 )
 
-TRAJECTORY_PROVENANCE_CSV_FIELDS = (
-    "trajectory_dataset_id",
-    "trajectory_dataset_version",
-    "trajectory_schema_version",
-    "trajectory_snapshot_manifest_path",
-    "trajectory_split",
-    "trajectory_trace_digest",
-    "trajectory_toolset_version",
-    "trajectory_registry_schema_version",
-    "trajectory_reward_policy_id",
-    "trajectory_leakage_policy_id",
-    "trajectory_package_path",
-    "trajectory_quality_metrics",
-)
+TRAJECTORY_PROVENANCE_CSV_FIELDS = TRAJECTORY_PROVENANCE_FIELDS
 
 
 def normalize_trajectory_provenance(


### PR DESCRIPTION
## Summary
- Add trajectory provenance normalization for agentic trajectory snapshots and carry it into LoRA adapter manifests, RL alignment traces, run evidence artifacts, benchmark exports, evaluation exports, and schema objects.
- Document the OpenSearch-VL artifact provenance slice and extend the dataset contract with exportable provenance requirements.
- Add focused coverage for provenance normalization, adapter/evidence propagation, schema serialization, and CSV export columns.

Closes #672
Closes #673
Refs #671
Refs #664

## Plan or Spec
- `docs/plans/2026-05-19-opensearch-vl-artifact-provenance.md`
- `docs/agentic-trajectory-dataset-contract.md`

## Commands Run
```text
make bootstrap
# pass: uv sync completed with frozen project environment.

make proto
# pass: proto generation completed; no generated artifact changes.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py services/mlx-worker-python/tests/test_run_evidence.py services/mlx-worker-python/tests/test_benchmark_export.py
# pass: 90 passed in 0.32s after merging current origin/main.

git diff --check origin/main...HEAD
# pass: no whitespace errors.

MAKEFLAGS=-e MENUBAR_SWIFT_TEST_FLAGS='--no-parallel -Xswiftc -gnone' git commit -m "Add OpenSearch-VL artifact provenance"
# pass: pre-commit gate completed and created commit 554d4350.
# make swift-test: pass, elapsed 3056.6s.
# make py-test: pass, 2809 passed, 14 skipped, 2 warnings in 118.16s.
# make integration-test: pass, 114 passed, 1 skipped in 312.35s.
# PR-scoped performance: pass, Status ok, 5 direct/gated probes, 0 regressions, 0 verification failures.
```

## Coverage and Metrics
- Changed-scope coverage from the pre-commit PR-scoped probes: 100% for `benchmark_export.py` and related test changes; 100% for benchmark store test changes; 100% for `training_config.py`; 100% for LoRA pipeline changed lines selected by the reward probe.
- Broader changed-line coverage run before commit: `416 passed, 2 warnings`; `TOTAL 173/177 97.74%` across the executable provenance, LoRA/RL, schema, export, and evidence paths.
- Performance report: `.runtime/pre-commit-performance/20260519-154435-2383087d/report/report.md`, Status `ok`, 5 selected direct/gated probes, 0 regressions, 0 context regressions, 0 verification failures.
- Benchmark export run-scan probe improved: `elapsed_ms_mean` 54.128 -> 50.409 ms (-6.87%), `csv_elapsed_ms_mean` 0.976 -> 0.927 ms (-5.02%).
- Benchmark store matrix streaming stayed neutral: `peak_bytes_mean` 179050.000 -> 178410.700 (-0.36%).
- Observability mode: evidence. The change adds provenance fields to persisted training/evaluation/benchmark evidence artifacts and no production runtime metrics. Probe overhead is covered by the PR-scoped performance report above.

## Known Gaps
- No UI surface is added in this slice.
- This does not claim model quality improvement; it only makes the trajectory inputs auditable in artifacts.
- Exporters preserve provenance when upstream runners provide snapshot/package metadata; missing upstream metadata remains represented as absent provenance fields.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.

## Follow-up Verification
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py services/mlx-worker-python/tests/test_benchmark_export.py
# pass: 77 passed in 0.33s after merging origin/main 612bc3f4.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/opensearch-vl-followup-postmerge.coverage uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py services/mlx-worker-python/tests/test_benchmark_export.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/opensearch-vl-followup-postmerge.coverage uv run --project services/mlx-worker-python coverage json -o /tmp/opensearch-vl-followup-postmerge-coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/opensearch-vl-followup-postmerge-coverage.json --diff-from origin/main services/mlx-worker-python/worker/trajectory_provenance.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/productization/benchmark_export.py services/mlx-worker-python/tests/test_trajectory_provenance.py services/mlx-worker-python/tests/test_benchmark_export.py
# pass: TOTAL 100.00%, 285/285 changed lines covered.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c 'import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_export_run_scan as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))'
# pass: csv_elapsed_ms_mean=0.909175 ms, elapsed_ms_mean=61.972975 ms, sample_count=5.

git diff --check origin/main...HEAD
# pass: no whitespace errors.
```

Follow-up commit `849b9cb1` addresses both Gemini review threads and adds a benchmark-summary CSV hot-path optimization. The branch was merged with current `origin/main` (`612bc3f4`) before this verification.