### PR TITLE
perf: cache hub catalog summary pipeline tag

### DIFF
--- a/docs/plans/2026-05-19-hub-catalog-summary-pipeline-tag-cache.md
+++ b/docs/plans/2026-05-19-hub-catalog-summary-pipeline-tag-cache.md
@@ -1,0 +1,32 @@
+# Hub catalog summary pipeline tag cache
+
+## Scope
+
+This Python-only performance slice is limited to `HubCatalog._summary_record` in
+`services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+
+The affected path is already covered by the registered PR-scoped performance
+probe `hub-catalog-tag-normalization-single-pass` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for local Linux
+verification and hosted PR-scoped CI validation.
+
+## Change
+
+`_summary_record` now normalizes the selected Hub `pipeline_tag` once and reuses
+that value for both local-fit evidence and the returned summary record. This
+preserves behavior while avoiding a repeated payload/card-data lookup and string
+normalization on every summarized Hub record.
+
+## Verification
+
+Run, from the repository root:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py
+MELIX_HUB_CATALOG_TAG_PROBE_RECORDS=5000 MELIX_HUB_CATALOG_TAG_PROBE_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
+```
+
+Hosted PR-scoped performance CI remains the merge gate for base-vs-head probe
+validation.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -195,6 +195,7 @@ class HubCatalog:
         tags = _string_list(payload.get("tags"))
         lowered_tags = _lowered_tag_set(tags)
         library_name = _string(payload.get("library_name") or card_data.get("library_name"))
+        pipeline_tag = _string(payload.get("pipeline_tag") or card_data.get("pipeline_tag"))
         sibling_files = _sibling_files(payload.get("siblings"))
         mlx_compatible = _is_mlx_compatible(
             repo_id=repo_id,
@@ -206,7 +207,7 @@ class HubCatalog:
         local_fit = _local_fit_evidence(
             payload=payload,
             repo_id=repo_id,
-            pipeline_tag=_string(payload.get("pipeline_tag") or card_data.get("pipeline_tag")),
+            pipeline_tag=pipeline_tag,
             tags=tags,
             lowered_tags=lowered_tags,
             mlx_compatible=mlx_compatible,
@@ -217,7 +218,7 @@ class HubCatalog:
             author=_author(payload, repo_id),
             model_name=_model_name(repo_id),
             summary=_string(card_data.get("model_name") or payload.get("description")),
-            pipeline_tag=_string(payload.get("pipeline_tag") or card_data.get("pipeline_tag")),
+            pipeline_tag=pipeline_tag,
             tags=tags,
             downloads=_int(payload.get("downloads")),
             likes=_int(payload.get("likes")),


### PR DESCRIPTION
## Summary
- Cache the normalized Hub summary `pipeline_tag` inside `HubCatalog._summary_record`.
- Reuse the same value for local-fit evidence and the returned summary record to avoid repeated payload/card-data lookups on each summarized record.

## Plan or Spec
- Added `docs/plans/2026-05-19-hub-catalog-summary-pipeline-tag-cache.md` for this Python-only performance slice.
- Affected path is covered by the registered PR-scoped probe `hub-catalog-tag-normalization-single-pass`, which already has focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py`
- `MELIX_HUB_CATALOG_TAG_PROBE_RECORDS=5000 MELIX_HUB_CATALOG_TAG_PROBE_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 54 passed.
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Local registered probe (Linux, 5000 records x 5 samples):
  - Before: `elapsed_ms_mean=248.81431800313294`, `tag_normalization_calls_mean=5000.0`, `peak_bytes_mean=9835382.0`.
  - After: `elapsed_ms_mean=232.87077783606946`, `tag_normalization_calls_mean=5000.0`, `peak_bytes_mean=9835382.0`.
  - Delta: `-15.944 ms` mean elapsed, `6.41%` faster.
- CI PR-scoped performance remains the base-vs-head merge gate.

## Known Gaps
- This is a Python-only Linux-verified slice; no Swift runtime effects are changed or claimed.
- The local probe is synthetic; hosted PR-scoped performance CI is required before merge.

## Evidence Checklist
- [x] Registered PR-scoped performance probe exists for the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met the repository threshold for changed lines.
- [x] Registered probe ran locally on Linux.
- [ ] PR-scoped performance CI completed successfully.
- [ ] All PR checks completed successfully.
