### PR TITLE
perf: cache tool registry worker config bytes

### DIFF
--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -310,6 +310,27 @@ def test_built_in_tool_config_partial_selection_uses_cached_registry(
     assert [tool.name for tool in config.tools] == ["image_crop", "local_compute"]
 
 
+def test_tool_registry_worker_tool_config_reuses_cached_serialized_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = built_in_tool_registry().select(["image_crop", "local_compute"])
+    expected_config = registry.as_worker_tool_config()
+
+    def fail_as_worker_tool_definition(self: ToolDescriptor) -> common_pb2.ToolDefinition:
+        raise AssertionError(  # pragma: no cover
+            "as_worker_tool_config() should reuse cached serialized config"
+        )
+
+    monkeypatch.setattr(ToolDescriptor, "as_worker_tool_definition", fail_as_worker_tool_definition)
+
+    config = registry.as_worker_tool_config()
+
+    assert config == expected_config
+    assert config is not expected_config
+    config.tools[0].name = "mutated"
+    assert registry.as_worker_tool_config().tools[0].name == "image_crop"
+
+
 def test_tool_registry_exports_worker_tool_config_metadata() -> None:
     config = built_in_tool_config(["image_crop", "local_compute"])
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -169,6 +169,7 @@ class ToolRegistry:
         self._tool_names = tuple(tool.name for tool in self._tools)
         self._tool_by_name = {tool.name: tool for tool in self._tools}
         self._selection_cache: dict[tuple[str, ...], ToolRegistry] = {}
+        self._worker_tool_config_bytes: bytes = b""
         self._metrics = ToolRegistryMetrics(
             tool_count=len(self._tools),
             schema_bytes=sum(tool.schema_byte_count() for tool in self._tools),
@@ -231,7 +232,9 @@ class ToolRegistry:
         return [tool.as_openai_tool() for tool in self._tools]
 
     def as_worker_tool_config(self) -> common_pb2.ToolConfig:
-        return common_pb2.ToolConfig(
+        if self._worker_tool_config_bytes:
+            return common_pb2.ToolConfig.FromString(self._worker_tool_config_bytes)
+        config = common_pb2.ToolConfig(
             tools=[tool.as_worker_tool_definition() for tool in self._tools],
             schema_format="openai-function",
             schema_version=self._schema_version,
@@ -239,6 +242,8 @@ class ToolRegistry:
             parser=self._parser,
             parser_contract_version=self._parser_contract_version,
         )
+        self._worker_tool_config_bytes = config.SerializeToString()
+        return config
 
     def _validate(self) -> None:
         if not self._schema_version:


### PR DESCRIPTION
## Summary
- Cache each `ToolRegistry` worker `ToolConfig` as serialized bytes after the first build.
- Keep returning fresh protobuf objects on every call so caller mutation cannot leak through the cache.
- Add a focused regression test for the cached serialized snapshot behavior.

## Plan or Spec
- `docs/unified-agentic-tool-runtime-contract.md` governs the tool registry contract.
- Registered PR-scoped probe: `tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/runtime/tool_registry.py` and includes focused test, coverage, and probe commands.

## Commands Run
```text
# Rejected exploratory attempt (not committed): cached schema property-map copy
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=40000 MELIX_TOOL_REGISTRY_METRICS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
Result: rejected; schema_payload_elapsed_ms_mean regressed from 170.362262 ms to 195.818272 ms.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
Result: 45 passed in 0.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py
Result: 45 passed; TOTAL 16 0 100%

# Registered local probe, base worktree at origin/main
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=120000 MELIX_TOOL_REGISTRY_METRICS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
Result base: partial_selection_tool_config_elapsed_ms_mean=575.401954 ms

# Registered local probe, head worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=120000 MELIX_TOOL_REGISTRY_METRICS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
Result head: partial_selection_tool_config_elapsed_ms_mean=188.834024 ms

git diff --check
Result: exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Registered probe metric: `partial_selection_tool_config_elapsed_ms_mean` improved from `575.401954 ms` to `188.834024 ms` on 120k iterations / 5 samples (`delta=-386.567930 ms`, `speedup=3.0471x`).
- Other measured registry metrics stayed informational for this slice; `built_in_tool_config_elapsed_ms_mean` is not the target path and remained within probe noise for the unchanged full built-in path.

## Known Gaps
- Local validation was Linux/Python-only. GitHub Actions PR-scoped performance must confirm the registered probe in CI before merge.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A: no registry contract behavior changed; this only caches serialized bytes behind the same fresh-object API.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or N/A: existing PR-scoped performance probe only; no runtime observability mode changed.
- [x] Deferred work and known gaps are stated explicitly.
