### PR TITLE
Add agentic tool adapter status controls

### DIFF
--- a/docs/plans/2026-05-20-agentic-tool-adapter-status-controls.md
+++ b/docs/plans/2026-05-20-agentic-tool-adapter-status-controls.md
@@ -1,0 +1,64 @@
+# Agentic Tool Adapter Status Controls
+
+## Goal
+
+Complete issue #680 by making timeout, cancellation, and failure-stage behavior
+testable for every deterministic built-in agentic tool adapter.
+
+## Scope
+
+- Add fixture-driven status overrides to the deterministic agentic tool runtime.
+- Support `timeout`, `failed`, and cancellation aliases for all built-in tools.
+- Map cancellation to the existing observation status model as `failed` with an
+  explicit `failure_stage: cancelled` payload marker.
+- Keep the observation status enum unchanged: `completed`, `timeout`, and
+  `failed`.
+
+## Non-Goals
+
+- No network-backed providers.
+- No asynchronous process cancellation.
+- No protocol schema changes.
+- No benchmark or evaluation schema changes.
+
+## Design
+
+Fixture runs may provide `tool_status_overrides` in the tool fixture context.
+The runtime checks overrides before executing a concrete adapter payload. The
+lookup order is:
+
+1. exact tool call id
+2. tool name
+3. `*`
+
+Override values may be a string status or an object with `status`, `message`,
+and `failure_stage` fields. Cancellation aliases (`cancelled`, `canceled`, and
+`cancel`) are normalized to observation status `failed` and preserve
+`cancelled: true` in the payload.
+
+This keeps the production observation contract stable while making failure and
+timeout states deterministic in focused tests for every adapter.
+
+## Verification
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic-tool-status.coverage uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic-tool-status.coverage uv run --project services/mlx-worker-python coverage json -o /tmp/agentic-tool-status-coverage.json
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/agentic-tool-status-coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
+git diff --check
+```
+
+## Success Metrics
+
+- Six built-in tool adapters covered by timeout assertions.
+- Six built-in tool adapters covered by failure-stage assertions.
+- Six built-in tool adapters covered by cancellation assertions.
+- Changed-line coverage for touched Python files is at least 95 percent.
+
+## Known Gaps
+
+- Real asynchronous cancellation of external providers remains out of scope
+  because the deterministic runtime has no external provider processes.
+- Future network-backed adapters must convert provider-level cancellation into
+  the same observation payload fields.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -165,6 +165,14 @@ or visit adapters can be introduced later only behind an explicit local
 configuration surface, secret redaction, and separate evidence fields that make
 external dependency use visible.
 
+Deterministic fixture runs may force adapter status through fixture context when
+testing failure handling. Status overrides must be available to every built-in
+adapter and must still emit normal `melix.agentic_tool_observation.v1` records.
+Cancellation is represented as observation status `failed` with
+`failure_stage: cancelled` and `cancelled: true` in the sanitized payload,
+because the v1 observation status set is intentionally limited to `completed`,
+`timeout`, and `failed`.
+
 ## Surface Contracts
 
 ### SFT Data Replay

--- a/services/mlx-worker-python/tests/test_agentic_tools.py
+++ b/services/mlx-worker-python/tests/test_agentic_tools.py
@@ -5,6 +5,17 @@ import json
 import pytest
 
 from worker.runtime.agentic_tools import AgenticToolRuntimeError, execute_agentic_tool_calls
+from worker.runtime.tool_observation import ToolObservationPolicy
+
+
+_BUILT_IN_TOOL_CALLS = (
+    ("image_crop", {"media_ref": "img-1", "region": "sign"}),
+    ("layout_parse", {"media_ref": "img-1"}),
+    ("text_search", {"query": "melix"}),
+    ("image_search", {"query": "receipt"}),
+    ("visit", {"url": "fixture://page-1"}),
+    ("local_compute", {"code": "2 + 3 * 4"}),
+)
 
 
 def test_agentic_tool_runtime_executes_all_builtin_tools_with_shared_observation_shape() -> None:
@@ -47,6 +58,64 @@ def test_agentic_tool_runtime_records_timeout_and_failed_statuses() -> None:
     assert run.metrics["agentic_tool.timeout_count"] == 1.0
     assert run.metrics["agentic_tool.failed_count"] == 1.0
     assert "only supports deterministic arithmetic" in run.observations[1]["payload"]["error"]
+
+
+@pytest.mark.parametrize(("tool_name", "arguments"), _BUILT_IN_TOOL_CALLS)
+@pytest.mark.parametrize(
+    ("override", "expected_status", "expected_failure_stage", "expected_cancelled"),
+    [
+        ({"status": "timeout", "message": "forced timeout"}, "timeout", "tool_timeout", False),
+        ({"status": "failed", "failure_stage": "fixture_failure"}, "failed", "fixture_failure", False),
+        ({"status": "cancelled"}, "failed", "cancelled", True),
+    ],
+)
+def test_agentic_tool_runtime_applies_status_controls_to_every_adapter(
+    tool_name: str,
+    arguments: dict[str, object],
+    override: dict[str, str],
+    expected_status: str,
+    expected_failure_stage: str,
+    expected_cancelled: bool,
+) -> None:
+    run = execute_agentic_tool_calls(
+        [{"id": f"{tool_name}-1", "name": tool_name, "arguments": arguments}],
+        fixture_context={"tool_status_overrides": {tool_name: override}},
+        observation_policy=ToolObservationPolicy(timeout_ms=250),
+    )
+
+    observation = run.observations[0]
+    assert observation["status"] == expected_status
+    assert observation["payload"]["failure_stage"] == expected_failure_stage
+    assert bool(observation["payload"].get("cancelled", False)) is expected_cancelled
+    assert run.metrics["agentic_tool.timeout_count"] == float(expected_status == "timeout")
+    assert run.metrics["agentic_tool.failed_count"] == float(expected_status == "failed")
+    if expected_status == "timeout":
+        assert observation["timeout_ms"] == 250
+
+
+def test_agentic_tool_runtime_prefers_call_id_status_control_over_tool_status() -> None:
+    run = execute_agentic_tool_calls(
+        [{"id": "visit-special", "name": "visit", "arguments": {"url": "fixture://page-1"}}],
+        fixture_context={
+            "tool_status_overrides": {
+                "visit": {"status": "timeout"},
+                "visit-special": {"status": "failed", "failure_stage": "call_specific_failure"},
+            }
+        },
+    )
+
+    assert run.observations[0]["status"] == "failed"
+    assert run.observations[0]["payload"]["failure_stage"] == "call_specific_failure"
+
+
+def test_agentic_tool_runtime_accepts_wildcard_string_status_control() -> None:
+    run = execute_agentic_tool_calls(
+        [{"id": "visit-1", "name": "visit", "arguments": {"url": "fixture://page-1"}}],
+        fixture_context={"tool_status_overrides": {"*": "timeout"}},
+    )
+
+    assert run.observations[0]["status"] == "timeout"
+    assert run.observations[0]["payload"]["failure_stage"] == "tool_timeout"
 
 
 def test_agentic_tool_runtime_covers_edge_payload_branches() -> None:
@@ -97,3 +166,23 @@ def test_agentic_tool_runtime_rejects_malformed_tool_calls(tool_calls: list[obje
 def test_agentic_tool_runtime_rejects_missing_required_arguments() -> None:
     with pytest.raises(AgenticToolRuntimeError, match="Missing required arguments for image_crop"):
         execute_agentic_tool_calls([{"name": "image_crop", "arguments": {"media_ref": "img-1"}}])
+
+
+def test_agentic_tool_runtime_rejects_invalid_status_controls() -> None:
+    run = execute_agentic_tool_calls(
+        [{"id": "visit-1", "name": "visit", "arguments": {"url": "fixture://page-1"}}],
+        fixture_context={"tool_status_overrides": {"visit": {"status": "paused"}}},
+    )
+
+    assert run.observations[0]["status"] == "failed"
+    assert "Unsupported agentic tool status override" in run.observations[0]["payload"]["error"]
+
+
+def test_agentic_tool_runtime_rejects_non_object_status_controls() -> None:
+    run = execute_agentic_tool_calls(
+        [{"id": "visit-1", "name": "visit", "arguments": {"url": "fixture://page-1"}}],
+        fixture_context={"tool_status_overrides": {"visit": 42}},
+    )
+
+    assert run.observations[0]["status"] == "failed"
+    assert "status override must be a string or JSON object" in run.observations[0]["payload"]["error"]

--- a/services/mlx-worker-python/worker/runtime/agentic_tools.py
+++ b/services/mlx-worker-python/worker/runtime/agentic_tools.py
@@ -233,7 +233,11 @@ def _status_override_payload(
     tool_call_id: str,
 ) -> dict[str, Any] | None:
     overrides = _context_mapping(fixture_context, "tool_status_overrides")
-    raw_override = overrides.get(tool_call_id, overrides.get(tool_name, overrides.get("*")))
+    raw_override = overrides.get(tool_call_id)
+    if raw_override is None:
+        raw_override = overrides.get(tool_name)
+    if raw_override is None:
+        raw_override = overrides.get("*")
     if raw_override is None:
         return None
     if isinstance(raw_override, str):

--- a/services/mlx-worker-python/worker/runtime/agentic_tools.py
+++ b/services/mlx-worker-python/worker/runtime/agentic_tools.py
@@ -117,7 +117,11 @@ class DeterministicAgenticToolRuntime:
             raise AgenticToolRuntimeError(f"Unknown agentic tool requested: {tool_name}")
         _validate_required_arguments(descriptor, arguments)
         try:
-            payload = self._execute_payload(tool_name=tool_name, arguments=arguments)
+            payload = self._execute_payload(
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                arguments=arguments,
+            )
         except (AgenticToolRuntimeError, SyntaxError, TypeError, ValueError) as exc:
             payload = {"error": str(exc), "_status": "failed"}
         status = str(payload.pop("_status", "completed"))
@@ -150,7 +154,20 @@ class DeterministicAgenticToolRuntime:
             "required_argument_count": metrics.required_argument_count,
         }
 
-    def _execute_payload(self, *, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    def _execute_payload(
+        self,
+        *,
+        tool_name: str,
+        tool_call_id: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        status_override = _status_override_payload(
+            fixture_context=self._fixture_context,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+        )
+        if status_override is not None:
+            return status_override
         if tool_name == "text_search":
             return _text_search_payload(arguments=arguments, fixture_context=self._fixture_context)
         if tool_name == "image_search":
@@ -207,6 +224,48 @@ def _validate_required_arguments(descriptor: ToolDescriptor, arguments: dict[str
     if missing:
         joined = ", ".join(missing)
         raise AgenticToolRuntimeError(f"Missing required arguments for {descriptor.name}: {joined}")
+
+
+def _status_override_payload(
+    *,
+    fixture_context: dict[str, Any],
+    tool_name: str,
+    tool_call_id: str,
+) -> dict[str, Any] | None:
+    overrides = _context_mapping(fixture_context, "tool_status_overrides")
+    raw_override = overrides.get(tool_call_id, overrides.get(tool_name, overrides.get("*")))
+    if raw_override is None:
+        return None
+    if isinstance(raw_override, str):
+        override = {"status": raw_override}
+    elif isinstance(raw_override, dict):
+        override = dict(raw_override)
+    else:
+        raise AgenticToolRuntimeError("Agentic tool status override must be a string or JSON object.")
+
+    raw_status = str(override.get("status", "")).strip().lower()
+    message = str(override.get("message", "")).strip()
+    failure_stage = str(override.get("failure_stage", "")).strip()
+    if raw_status == "timeout":
+        return {
+            "text": message or f"{tool_name} timed out before producing a result.",
+            "failure_stage": failure_stage or "tool_timeout",
+            "_status": "timeout",
+        }
+    if raw_status in ("cancel", "cancelled", "canceled"):
+        return {
+            "error": message or f"{tool_name} was cancelled before producing a result.",
+            "failure_stage": failure_stage or "cancelled",
+            "cancelled": True,
+            "_status": "failed",
+        }
+    if raw_status == "failed":
+        return {
+            "error": message or f"{tool_name} failed before producing a result.",
+            "failure_stage": failure_stage or "tool_execution",
+            "_status": "failed",
+        }
+    raise AgenticToolRuntimeError(f"Unsupported agentic tool status override: {raw_status or '<empty>'}")
 
 
 def _text_search_payload(*, arguments: dict[str, Any], fixture_context: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- Add fixture-driven status controls for the deterministic agentic tool runtime so every built-in adapter can exercise `timeout`, `failed`, and cancellation paths.
- Document the cancellation mapping as observation status `failed` with `failure_stage=cancelled` and `cancelled=true` payload evidence.
- Extend focused tests across `image_crop`, `layout_parse`, `text_search`, `image_search`, `visit`, and `local_compute`, including call-id precedence, wildcard controls, invalid controls, and the review-requested sequential override lookup.

Closes #680.
Refs #674, #678.

## Plan or Spec
- `docs/plans/2026-05-20-agentic-tool-adapter-status-controls.md`
- `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 29 passed in 0.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic-tool-status.coverage uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic-tool-status.coverage uv run --project services/mlx-worker-python coverage json -o /tmp/agentic-tool-status-coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/agentic-tool-status-coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
# TOTAL 100.00% 55/55

git diff --check
# passed

git commit -m "Add agentic tool adapter status controls"
# pre-commit enforced full local gate on 256 GiB macOS host:
# make swift-test: rc=0, elapsed=597.7s
# make py-test: 2836 passed, 14 skipped, 2 warnings in 129.82s
# make integration-test: 114 passed, 1 skipped in 628.03s
# Melix PR Scoped Performance Report: Status ok; selected probes 0; regressions 0; verification failures 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 29 passed in 0.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic-tool-status-review.coverage uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic-tool-status-review.coverage uv run --project services/mlx-worker-python coverage json -o /tmp/agentic-tool-status-review-coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/agentic-tool-status-review-coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
# TOTAL 100.00% 59/59

git diff --check origin/main...HEAD
# passed

git commit -m "Address agentic status override review"
# pre-commit enforced full local gate on 256 GiB macOS host:
# make swift-test: rc=0, elapsed=178.7s
# make py-test: 2837 passed, 14 skipped, 2 warnings in 117.70s
# make integration-test: 114 passed, 1 skipped in 309.98s
# Melix PR Scoped Performance Report: Status ok; selected probes 0; regressions 0; verification failures 0
```

## Coverage and Metrics
- Changed-line coverage: 100.00% (59/59) for `services/mlx-worker-python/worker/runtime/agentic_tools.py` and `services/mlx-worker-python/tests/test_agentic_tools.py` after the review fix.
- Adapter status matrix: 6 built-in adapters x 3 status controls = 18 deterministic adapter status assertions for `timeout`, `failed`, and cancellation.
- Performance reports: `.runtime/pre-commit-performance/20260519-164039-0dc17925/report/report.md` and `.runtime/pre-commit-performance/20260519-173511-45faa07b/report/report.md`; both `Status: ok`, `Regressions: 0`, `Verification failures: 0`.
- Observability mode: evidence/test fixture only. Probe overhead: N/A because this adds deterministic fixture controls and documentation without production runtime metrics, PR-scoped probes, or protocol/dependency changes.

## Known Gaps
- Real asynchronous cancellation for external providers is out of scope; this change covers the deterministic local agentic tool runtime fixture path needed for #680.
- No protocol, generated artifact, lockfile, or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
