### PR TITLE
perf: bind tool registry schema payload caches

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -1,0 +1,36 @@
+# Tool Registry Schema Payload Local Bindings
+
+## Scope
+
+This Python performance slice is limited to the agentic tool registry schema
+payload hot path in `services/mlx-worker-python/worker/runtime/tool_registry.py`.
+It does not change tool registry behavior, protobuf schemas, dependencies, or
+runtime observability.
+
+## Optimization Hypothesis
+
+`ToolDescriptor.schema_payload()` is exercised repeatedly by the registered tool
+registry probe while constructing OpenAI tool schemas and measuring schema
+payload overhead. Binding the cached schema-property tuple and required argument
+tuple to locals before constructing the returned payload should reduce attribute
+and property lookup overhead while preserving the existing copy-on-return
+semantics for nested schema dictionaries and required argument lists.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped probe
+`tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`. The
+entry includes focused `test_command`, `coverage_command`, and `probe_command`
+commands and reports `schema_payload_elapsed_ms_mean` as the primary metric for
+this slice. The same watch glob also triggers adjacent tool registry registered
+probes in CI.
+
+## Validation Plan
+
+1. Run the registered focused test command locally on Linux.
+2. Run the registered changed-scope coverage command locally and require at
+   least 95% coverage for touched scope.
+3. Run the registered probe command locally before and after the slice and
+   compare `schema_payload_elapsed_ms_mean` over repeated samples.
+4. Push only if local evidence is neutral-to-improved and rely on the GitHub
+   PR-scoped performance workflow as the merge gate.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -108,13 +108,13 @@ class ToolDescriptor:
         return self._cached_required_arguments
 
     def schema_payload(self) -> dict[str, Any]:
+        schema_properties = self._cached_schema_properties
+        required_arguments = self._cached_required_arguments
         return {
             "type": "object",
             "additionalProperties": False,
-            "properties": {
-                name: schema.copy() for name, schema in self._cached_schema_properties
-            },
-            "required": list(self.required_arguments),
+            "properties": {name: schema.copy() for name, schema in schema_properties},
+            "required": list(required_arguments),
         }
 
     def json_schema(self) -> str:


### PR DESCRIPTION
## Summary
- Bind cached schema properties and required arguments to locals inside `ToolDescriptor.schema_payload()`.
- Preserve the existing copy-on-return semantics for property dictionaries and required argument lists.
- Add a focused plan documenting the registered probe and local validation boundary.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 45 passed in 0.84s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py
# 45 passed in 0.33s; TOTAL 2 0 100%

MELIX_TOOL_REGISTRY_METRICS_SAMPLES=7 MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=40000 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
# Ran 3 samples on origin/main worktree and 3 samples on this branch worktree; see metrics below.

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`TOTAL 2 0 100%`) for `services/mlx-worker-python/worker/runtime/tool_registry.py`.
- Registered local probe: `tool-registry-schema-bytes-cache` / `scripts/tool_registry_schema_bytes_probe.py`.
- Local Linux base-vs-head metric over three probe executions, each with `MELIX_TOOL_REGISTRY_METRICS_SAMPLES=7` and `MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=40000`:
  - `schema_payload_elapsed_ms_mean`: base `171.194 ms`, head `165.478 ms`, delta `-5.715 ms` (`-3.34%`).
- CI PR-scoped performance remains the merge gate for the registered probe report.

## Known Gaps
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally for this Python micro-slice.
- No Swift runtime effect is claimed; this slice is Python-only and locally verified on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. (N/A: no observability behavior change; existing PR-scoped evidence probe is reused.)
- [x] Deferred work and known gaps are stated explicitly.
