### PR TITLE
perf: streamline statistical category aggregation

### DIFF
--- a/docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md
+++ b/docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md
@@ -23,6 +23,8 @@ The first accepted slice removed the per-row `row_get = row.get` bound-method al
 
 This follow-up slice keeps the same category semantics but moves the common non-empty category-label path from `row.get("category_label", "")` to direct key access with a `KeyError` skip for missing labels. The registered probe workload always carries category labels, so the hot path avoids the default-argument dictionary lookup while existing tests continue to cover missing and blank labels.
 
+The 2026-05-19 slice keeps that direct-key category label path and narrows another hot aggregation step: it replaces `defaultdict(lambda: [0, 0, 0])` with an explicit `dict.get(...)` miss path, avoids calling `str(...)` for already-string category labels, and increments correctness counters only when the row field is truthy. Missing, blank, non-string, sorted-key, and rounding semantics remain unchanged.
+
 ## Acceptance Metric
 
 Accept only if the registered category breakdown probe keeps the same checksum/sample counts and improves `elapsed_ms_mean` versus the origin/main baseline in repeated local samples.

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import math
 import random
-from collections import defaultdict
 from functools import lru_cache
 from statistics import NormalDist
 
@@ -83,19 +82,28 @@ def build_category_breakdown(
     *,
     rows: tuple[dict[str, object], ...],
 ) -> dict[str, dict[str, object]]:
-    category_totals: defaultdict[str, list[int]] = defaultdict(lambda: [0, 0, 0])
+    category_totals: dict[str, list[int]] = {}
     for row in rows:
         try:
             raw_category_label = row["category_label"]
         except KeyError:
             continue
-        category_label = str(raw_category_label).strip()
+        category_label = (
+            raw_category_label.strip()
+            if isinstance(raw_category_label, str)
+            else str(raw_category_label).strip()
+        )
         if not category_label:
             continue
-        totals = category_totals[category_label]
+        totals = category_totals.get(category_label)
+        if totals is None:
+            totals = [0, 0, 0]
+            category_totals[category_label] = totals
         totals[0] += 1
-        totals[1] += 1 if row.get("base_correct", False) else 0
-        totals[2] += 1 if row.get("target_correct", False) else 0
+        if row.get("base_correct", False):
+            totals[1] += 1
+        if row.get("target_correct", False):
+            totals[2] += 1
 
     breakdown: dict[str, dict[str, object]] = {}
     for category_label, totals in sorted(category_totals.items()):


### PR DESCRIPTION
## Summary
- Streamlines `build_category_breakdown` by replacing `defaultdict(lambda: ...)` with an explicit `dict.get` miss path.
- Avoids `str(...)` conversion for already-string category labels while preserving missing/blank/non-string label behavior.
- Records the slice in the existing statistical category breakdown plan.

## Plan or Spec
- `docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md`
- Registered probe: `statistical-evidence-category-breakdown-single-pass` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_statistical_evidence.py::test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_category_breakdown_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id statistical-evidence-category-breakdown-single-pass --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/stat-category-get-local-probe.json`
- Repeated local probe samples with `MELIX_STAT_CATEGORY_PROBE_SAMPLES=8` against base/head three times.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 6 passed.
- Changed-scope coverage: 100.00% (10/10 measurable changed lines).
- Registered local probe comparison: base `elapsed_ms_mean=12.525419238954782`, head `elapsed_ms_mean=11.092810379341245`, delta `-1.4326088596135378 ms`, speedup `11.437612045415941%` / `1.1291475118227536x`.
- Probe payload consistency: `checksum=250365.72`, `row_count=50000.0`, `category_count=64.0`, `sample_count=5.0` for both base and head.
- Repeated 8-sample probes: base `13.0901 / 12.6830 / 12.7546 ms`; head `11.6180 / 11.2130 / 11.1724 ms`.

## Known Gaps
- Local validation is Linux/Python only. No Swift runtime path is changed.
- GitHub Actions must still run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is >=95%.
- [x] Registered local probe shows same payload semantics and lower elapsed time.
- [ ] GitHub Actions / registered PR-scoped performance workflow completed successfully.
