### PR TITLE
perf: slot tool registry descriptor snapshots

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -25,6 +25,27 @@ commands and reports `schema_payload_elapsed_ms_mean` as the primary metric for
 this slice. The same watch glob also triggers adjacent tool registry registered
 probes in CI.
 
+## Follow-up Slice: Slotted Descriptor Snapshots
+
+The 2026-05-19 follow-up keeps the tool registry API and copy-on-return schema
+payload behavior unchanged, but marks the small immutable dataclass snapshots as
+slotted: `ToolArgumentDescriptor`, `ToolDescriptor`, and `ToolRegistryMetrics`.
+These objects are read repeatedly by the registered tool-registry probes and do
+not need per-instance `__dict__` storage. The same slice also caches serialized
+built-in tool configs for normalized partial selections so repeated
+`built_in_tool_config((...))` calls avoid re-entering registry selection while
+still returning fresh mutable protobuf objects.
+
+Expected effect:
+
+- reduce per-descriptor memory overhead;
+- improve repeated partial-selection `built_in_tool_config((...))` calls by
+  reusing cached serialized protobuf bytes;
+- keep `schema_payload_elapsed_ms_mean`, `elapsed_ms_mean`, and adjacent
+  tool-registry probe timings neutral-to-improved;
+- preserve mutation isolation for returned schema payload dictionaries and
+  protobuf configs.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -95,6 +95,14 @@ def test_tool_registry_names_reuses_registry_snapshot() -> None:
     assert registry.names() == BUILTIN_AGENTIC_TOOL_NAMES
 
 
+def test_tool_registry_descriptors_use_slotted_snapshots() -> None:
+    registry = built_in_tool_registry()
+
+    assert not hasattr(registry.metrics(), "__dict__")
+    assert not hasattr(registry.tools[0], "__dict__")
+    assert not hasattr(registry.tools[0].arguments[0], "__dict__")
+
+
 def test_tool_descriptor_required_arguments_reuses_cached_snapshot() -> None:
     tool = built_in_tool_registry().tools[0]
     expected_required_arguments = tool.required_arguments
@@ -308,6 +316,26 @@ def test_built_in_tool_config_partial_selection_uses_cached_registry(
     config = built_in_tool_config(["image_crop", "local_compute"])
 
     assert [tool.name for tool in config.tools] == ["image_crop", "local_compute"]
+
+
+def test_built_in_tool_config_partial_selection_reuses_serialized_selection_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected_config = built_in_tool_config(["image_crop", "local_compute"])
+
+    def fail_select(self: ToolRegistry, names: list[str] | tuple[str, ...]) -> ToolRegistry:
+        raise AssertionError(  # pragma: no cover
+            "cached partial built_in_tool_config() should skip registry selection"
+        )
+
+    monkeypatch.setattr(ToolRegistry, "select", fail_select)
+
+    config = built_in_tool_config(["image_crop", "local_compute"])
+
+    assert config == expected_config
+    assert config is not expected_config
+    config.tools[0].name = "mutated"
+    assert built_in_tool_config(["image_crop", "local_compute"]).tools[0].name == "image_crop"
 
 
 def test_tool_registry_worker_tool_config_reuses_cached_serialized_snapshot(

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -30,7 +30,7 @@ class ToolRegistryError(ValueError):
     pass
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ToolArgumentDescriptor:
     name: str
     json_type: str
@@ -56,7 +56,7 @@ class ToolArgumentDescriptor:
         }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ToolDescriptor:
     name: str
     description: str
@@ -143,7 +143,7 @@ class ToolDescriptor:
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ToolRegistryMetrics:
     tool_count: int
     schema_bytes: int
@@ -266,10 +266,16 @@ def built_in_tool_registry() -> ToolRegistry:
 
 
 def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> common_pb2.ToolConfig:
-    if names is None or tuple(names) == BUILTIN_AGENTIC_TOOL_NAMES:
+    if names is None:
         return common_pb2.ToolConfig.FromString(_BUILTIN_TOOL_CONFIG_BYTES)
-    registry = _BUILTIN_TOOL_CONFIG_REGISTRY.select(names)
-    return registry.as_worker_tool_config()
+    requested_names = tuple(names)
+    cached_config_bytes = _BUILTIN_TOOL_CONFIG_SELECTION_BYTES.get(requested_names)
+    if cached_config_bytes is not None:
+        return common_pb2.ToolConfig.FromString(cached_config_bytes)
+    registry = _BUILTIN_TOOL_CONFIG_REGISTRY.select(requested_names)
+    config = registry.as_worker_tool_config()
+    _BUILTIN_TOOL_CONFIG_SELECTION_BYTES[registry.names()] = config.SerializeToString()
+    return config
 
 
 def _arg(
@@ -358,6 +364,9 @@ _BUILTIN_TOOL_CONFIG_REGISTRY = ToolRegistry(_BUILTIN_AGENTIC_TOOLS)
 _BUILTIN_TOOL_CONFIG_BYTES = (
     _BUILTIN_TOOL_CONFIG_REGISTRY.as_worker_tool_config().SerializeToString()
 )
+_BUILTIN_TOOL_CONFIG_SELECTION_BYTES: dict[tuple[str, ...], bytes] = {
+    BUILTIN_AGENTIC_TOOL_NAMES: _BUILTIN_TOOL_CONFIG_BYTES,
+}
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Slot immutable tool registry descriptor dataclasses to remove per-instance `__dict__` storage on the agentic tool registry hot path.
- Cache serialized built-in tool configs for repeated normalized partial selections while still returning fresh mutable protobuf objects.
- Add focused regression coverage for slotted snapshots and partial-selection cache reuse.
- Update the existing tool-registry performance plan with the follow-up slice and validation target.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md`
- Registered PR-scoped probes already cover the affected path: `tool-registry-schema-bytes-cache`, plus adjacent `tool-registry-select-name-index-cache` and `tool-registry-names-snapshot-cache` from the same watch glob.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 47 passed in 0.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py
# TOTAL 19 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=40000 MELIX_TOOL_REGISTRY_METRICS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
# head: schema_payload_elapsed_ms_mean=160.41852016933262, partial_selection_tool_config_elapsed_ms_mean=58.94838743843138

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# head: elapsed_ms_mean=19.334788247942924

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_NAMES_ITERATIONS=200000 MELIX_TOOL_REGISTRY_NAMES_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_names_probe.py
# head: elapsed_ms_mean=27.33167135156691
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 19 0 100%`).
- Local Linux registered primary probe after follow-up fix: `schema_payload_elapsed_ms_mean=160.41852016933262` ms and `partial_selection_tool_config_elapsed_ms_mean=58.94838743843138` ms.
- Registered CI PR-scoped performance report is required before merge and will be treated as the authoritative merge gate.

## Known Gaps
- Local Linux probes are synthetic and noisy. Do not merge until the registered PR-scoped performance workflow completes successfully and reports acceptable metrics.
- No Swift/macOS runtime effect is claimed for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probes; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
