### PR TITLE
Add agentic LoRA SFT formatting

### DIFF
--- a/docs/agentic-trajectory-dataset-contract.md
+++ b/docs/agentic-trajectory-dataset-contract.md
@@ -258,6 +258,27 @@ The snapshot JSONL rows must preserve the sample envelope and normalized turns.
 Consumers must read the snapshot, not the mutable source package, once a job has
 started.
 
+For LoRA SFT, the snapshot also writes a trainer-facing projection. The source
+snapshot manifest keeps `format: agentic_tool_trace` and records
+`trainer_format: chat_messages`. `samples.jsonl`, `train.jsonl`, and
+`valid.jsonl` contain the supervised `messages` rows consumed by the local
+trainer. Sibling `agentic-traces.train.jsonl` and
+`agentic-traces.valid.jsonl` files preserve the original normalized trace rows
+for provenance, audit, replay, and later RL/evaluation reuse.
+
+The v1 SFT projection formats:
+
+- top-level media references as an optional system message
+- assistant `tool_call` objects as deterministic JSON text in an assistant
+  message
+- tool observations as `tool` role messages bound to the source tool-call id
+- the final answer as the supervised assistant answer
+
+Response-only and mask-prompt boundaries for tool-call tokens are governed by a
+later child issue. The first LoRA SFT slice therefore keeps response-only
+support disabled for `agentic_tool_trace` even though the trainer-facing rows
+use the `chat_messages` shape.
+
 ## Provenance Fields
 
 LoRA, RL, benchmark, and evaluation artifacts that consume a trajectory package

--- a/docs/plans/2026-05-20-agentic-lora-sft-formatting.md
+++ b/docs/plans/2026-05-20-agentic-lora-sft-formatting.md
@@ -1,0 +1,84 @@
+# Agentic LoRA SFT Formatting
+
+## Goal
+
+Implement issue #686 by projecting `agentic_tool_trace` packages into
+trainer-ready supervised rows while preserving the original trajectory evidence
+needed by the OpenSearch-VL alignment family.
+
+## Governing Specs
+
+- `docs/agentic-trajectory-dataset-contract.md`
+- `docs/unified-agentic-tool-runtime-contract.md`
+- `docs/runbooks/phase-8-lora-adapter-workflow.md`
+
+The upstream OpenSearch-VL SFT recipe stores agentic cold-start data as
+ShareGPT-style conversations with `conversations`, `images`, `system`, and
+`tools` columns. Melix keeps its repository-owned `agentic_tool_trace` contract
+as the source shape and emits a local PEFT-friendly supervised projection
+instead of importing the upstream Ray/full-parameter training stack.
+
+## Scope
+
+This slice changes only Python worker dataset normalization and LoRA training
+handoff:
+
+- Add an `agentic_tool_trace` to `chat_messages` SFT projection for normalized
+  dataset snapshots.
+- Format assistant tool calls, tool observations, media references, and final
+  answers as deterministic supervised tokens.
+- Preserve original normalized trace rows in sibling snapshot evidence files.
+- Keep `dataset_format=agentic_tool_trace` in adapter receipts while passing
+  the trainer the projected `chat_messages` row shape.
+- Keep response-only masking disabled for `agentic_tool_trace`; issue #687 owns
+  response-only and mask-prompt boundaries for tool-call tokens.
+
+Out of scope:
+
+- Schema or protobuf changes.
+- Network-backed tool execution.
+- Claiming quality or benchmark improvement.
+- Enabling response-only masking for agentic traces.
+
+## Implementation Plan
+
+1. Add an agentic SFT formatter in
+   `services/mlx-worker-python/worker/model_ops/training_dataset.py`.
+2. Teach `write_normalized_dataset_snapshot(...)` to write projected
+   `train.jsonl` / `valid.jsonl` rows plus original
+   `agentic-traces.train.jsonl` / `agentic-traces.valid.jsonl` evidence.
+3. Record formatter metadata and counts in the normalized snapshot manifest.
+4. Pass the trainer-facing format from the normalized snapshot into
+   `TrainingRequest` while preserving source trajectory provenance in adapter
+   receipts.
+5. Add focused tests for the formatter, snapshot artifacts, and LoRA pipeline
+   handoff.
+
+## Performance And Metrics
+
+The formatter is a linear pass over already-normalized samples during snapshot
+write. It does not add runtime serving overhead.
+
+Measurement points:
+
+- Formatter sample count.
+- Formatted tool-call count.
+- Formatted tool-observation count.
+- Formatted media-reference count.
+- Formatted final-answer count.
+- Focused pytest runtime for dataset builder and LoRA pipeline tests.
+- Changed-scope coverage for touched Python files, target >= 95%.
+
+Existing PR-scoped dataset probes that watch `training_dataset.py` remain
+applicable. No new production metric is required because this is an offline
+training data preparation path.
+
+## Success Criteria
+
+- `agentic_tool_trace` snapshots expose `trainer_format: chat_messages`.
+- `train.jsonl` and `valid.jsonl` contain supervised `messages` rows with
+  deterministic tool-call, observation, media-reference, and final-answer text.
+- Original normalized traces are preserved in sibling JSONL evidence files.
+- LoRA training still reports `dataset_format: agentic_tool_trace` and records
+  `trainer_dataset_format: chat_messages`.
+- Focused tests and changed-scope coverage pass.

--- a/docs/runbooks/phase-8-lora-adapter-workflow.md
+++ b/docs/runbooks/phase-8-lora-adapter-workflow.md
@@ -98,6 +98,7 @@ Supported package formats:
 - `prompt_completion`
 - `text_completion`
 - `preference_pair`
+- `agentic_tool_trace`
 
 Example `manifest.json`:
 
@@ -199,6 +200,9 @@ swift run melix lora train \
 Expected training behavior:
 
 - dataset validation runs before backend execution
+- `agentic_tool_trace` packages are accepted by SFT modes and projected into a
+  trainer-facing `chat_messages` snapshot while preserving the original
+  normalized trace rows in sibling `agentic-traces.*.jsonl` evidence files
 - Hugging Face dataset materialization is cached under `<jobs_root>/datasets/<cache-key>`
 - Melix supports `lora`, `qlora`, `dora`, `dpo`, `orpo`, and `cpt` through the same `train_lora` surface
 - `dora` records `adapter_algorithm=dora` and `dora_enabled=true` in the adapter manifest

--- a/services/mlx-worker-python/tests/test_agentic_sft_formatter.py
+++ b/services/mlx-worker-python/tests/test_agentic_sft_formatter.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from worker.model_ops import agentic_sft_formatter
+
+
+def test_agentic_tool_trace_sft_formatter_covers_defensive_branches() -> None:
+    rows, metrics = agentic_sft_formatter.format_trace_rows(
+        [
+            {
+                "trace_id": "trace-defensive",
+                "question": "What happened?",
+                "media_refs": ["fixture://loose", {}],
+                "turns": [
+                    "ignored",
+                    {"role": "system", "content": "Use tools."},
+                    {
+                        "role": "assistant",
+                        "content": "I will inspect.",
+                        "tool_call": {
+                            "id": "call-1",
+                            "name": "visit",
+                            "arguments": "ignored",
+                        },
+                    },
+                    {"role": "tool", "observation": "plain observation"},
+                    {"role": "tool", "observation": ""},
+                ],
+                "final_answer": "Done",
+            },
+            {
+                "trace_id": "trace-answer-only",
+                "question": "Answer only.",
+                "turns": [],
+                "final_answer": "Only answer",
+            },
+            {
+                "trace_id": "trace-final-equals-assistant",
+                "turns": [{"role": "assistant", "content": "Matched answer"}],
+                "final_answer": "Matched answer",
+            },
+            {
+                "trace_id": "trace-final-already-formatted",
+                "turns": [
+                    {
+                        "role": "assistant",
+                        "content": "Final answer: Already formatted",
+                    }
+                ],
+                "final_answer": "Already formatted",
+            },
+        ]
+    )
+
+    assert rows[0] == {
+        "messages": [
+            {
+                "role": "system",
+                "content": "Media references:\n- fixture://loose\n- {}\n\nUse tools.",
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    'I will inspect.\nTool call: {"arguments":{},"id":"call-1",'
+                    '"name":"visit"}'
+                ),
+            },
+            {"role": "tool", "content": "Tool observation: plain observation"},
+            {"role": "assistant", "content": "Final answer: Done"},
+        ],
+    }
+    assert rows[1] == {
+        "messages": [{"role": "assistant", "content": "Final answer: Only answer"}]
+    }
+    assert rows[2] == {
+        "messages": [{"role": "assistant", "content": "Final answer: Matched answer"}]
+    }
+    assert rows[3] == {
+        "messages": [
+            {"role": "assistant", "content": "Final answer: Already formatted"}
+        ]
+    }
+    assert metrics == {
+        "sample_count": 4,
+        "tool_call_count": 1,
+        "tool_observation_count": 1,
+        "media_ref_count": 2,
+        "final_answer_count": 4,
+    }
+    assert agentic_sft_formatter.merge_projection_metrics(
+        {"sample_count": "bad", "tool_call_count": "2"},
+        {"sample_count": 1},
+    )["sample_count"] == 1

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -127,6 +127,15 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
 ) -> None:
     package_path = tmp_path / "dataset-package"
     package_path.mkdir(parents=True, exist_ok=True)
+    stale_agentic_train_path = (
+        tmp_path / "exports" / "normalized_dataset" / "agentic-traces.train.jsonl"
+    )
+    stale_agentic_valid_path = (
+        tmp_path / "exports" / "normalized_dataset" / "agentic-traces.valid.jsonl"
+    )
+    stale_agentic_train_path.parent.mkdir(parents=True, exist_ok=True)
+    stale_agentic_train_path.write_text("stale\n", encoding="utf-8")
+    stale_agentic_valid_path.write_text("stale\n", encoding="utf-8")
     dataset = TrainingDatasetPackage(
         package_path=package_path,
         manifest_path=package_path / "manifest.json",
@@ -161,6 +170,8 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
     assert "trajectory_quality_metrics" not in payload
     assert "trajectory_trace_digest" not in payload
     assert "trajectory_schema_version" not in payload
+    assert stale_agentic_train_path.exists() is False
+    assert stale_agentic_valid_path.exists() is False
 
     agentic_package_path = tmp_path / "agentic-package"
     agentic_package_path.mkdir(parents=True, exist_ok=True)
@@ -247,6 +258,21 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
     mutated_samples = [dict(samples[0], final_answer="Changed")]
 
     assert agentic_payload["format"] == "agentic_tool_trace"
+    assert agentic_payload["trainer_format"] == "chat_messages"
+    assert agentic_payload["agentic_sft_formatter"] == "melix.agentic_tool_trace.sft_formatter.v1"
+    assert agentic_payload["agentic_trace_train_path"].endswith(
+        "normalized_dataset/agentic-traces.train.jsonl"
+    )
+    assert agentic_payload["agentic_trace_valid_path"].endswith(
+        "normalized_dataset/agentic-traces.valid.jsonl"
+    )
+    assert agentic_payload["agentic_sft_projection_metrics"] == {
+        "sample_count": 2,
+        "tool_call_count": 1,
+        "tool_observation_count": 1,
+        "media_ref_count": 2,
+        "final_answer_count": 2,
+    }
     assert agentic_payload["source_package_path"] == str(agentic_package_path)
     assert agentic_payload["source_dataset_id"] == "source-agentic-package"
     assert agentic_payload["source_manifest_fields"] == {
@@ -296,13 +322,50 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
             {"index": 1, "trace_id": "trace-valid", "terms": ["GOLD-SECRET"]}
         ],
     }
-    assert agentic_snapshot.train_path.read_text(encoding="utf-8") == (
-        json.dumps(samples[0]) + "\n"
-    )
+    assert agentic_snapshot.format == "agentic_tool_trace"
+    assert agentic_snapshot.trainer_format == "chat_messages"
+    train_row = json.loads(agentic_snapshot.train_path.read_text(encoding="utf-8"))
+    assert train_row["tools"] == [{"name": "image_crop"}]
+    assert train_row["messages"] == [
+        {
+            "role": "system",
+            "content": "Media references:\n- id=image-1; uri=images/sign-one.jpg",
+        },
+        {"role": "user", "content": "Inspect image one."},
+        {
+            "role": "assistant",
+            "content": (
+                'Tool call: {"arguments":{"media_ref":"image-1"},"id":"call-1",'
+                '"name":"image_crop"}'
+            ),
+        },
+        {
+            "role": "tool",
+            "content": (
+                'Tool observation for call-1: {"text":"The sign reads MELIX LABS."}'
+            ),
+        },
+        {
+            "role": "assistant",
+            "content": "The sign says MELIX LABS.\n\nFinal answer: MELIX LABS",
+        },
+    ]
+    assert json.loads(
+        (agentic_snapshot.dataset_dir / "agentic-traces.train.jsonl").read_text(
+            encoding="utf-8"
+        )
+    ) == samples[0]
     assert agentic_snapshot.valid_path is not None
-    assert agentic_snapshot.valid_path.read_text(encoding="utf-8") == (
-        json.dumps(validation_samples[0]) + "\n"
-    )
+    valid_row = json.loads(agentic_snapshot.valid_path.read_text(encoding="utf-8"))
+    assert valid_row["messages"][-1] == {
+        "role": "assistant",
+        "content": "The label says GOLD-SECRET.\n\nFinal answer: GOLD-SECRET",
+    }
+    assert json.loads(
+        (agentic_snapshot.dataset_dir / "agentic-traces.valid.jsonl").read_text(
+            encoding="utf-8"
+        )
+    ) == validation_samples[0]
 
 
 def test_write_normalized_dataset_snapshot_clears_stale_valid_jsonl_when_no_validation_samples(

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -59,6 +59,14 @@ def _write_agentic_dataset_package(root: Path) -> Path:
     sample = {
         "trace_id": "trace-001",
         "question": "Use tools before answering.",
+        "media_refs": [
+            {
+                "id": "page-image",
+                "uri": "images/page.png",
+                "mime_type": "image/png",
+            }
+        ],
+        "tools": [{"name": "visit"}],
         "turns": [
             {"role": "user", "content": "Read the page."},
             {
@@ -261,8 +269,44 @@ def test_train_lora_records_agentic_trajectory_provenance_in_adapter_manifest(
     assert payload["trajectory_snapshot_manifest_path"] == payload["normalized_dataset_manifest_path"]
     assert payload["trajectory_provenance_field_count"] >= 8
     assert payload["trajectory_reward_policy_present"] is True
+    assert payload["trainer_dataset_format"] == "chat_messages"
     assert runner.last_train_request is not None
-    assert runner.last_train_request.dataset_format == "agentic_tool_trace"
+    assert runner.last_train_request.dataset_format == "chat_messages"
+    assert runner.last_train_request.config.dataset_contract == "sft"
+
+    normalized_dataset_path = Path(payload["normalized_dataset_manifest_path"])
+    normalized_payload = json.loads(normalized_dataset_path.read_text(encoding="utf-8"))
+    train_row = json.loads((normalized_dataset_path.parent / "train.jsonl").read_text(encoding="utf-8"))
+    trace_row = json.loads(
+        (normalized_dataset_path.parent / "agentic-traces.train.jsonl").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert normalized_payload["format"] == "agentic_tool_trace"
+    assert normalized_payload["trainer_format"] == "chat_messages"
+    assert normalized_payload["agentic_sft_projection_metrics"] == {
+        "sample_count": 1,
+        "tool_call_count": 1,
+        "tool_observation_count": 1,
+        "media_ref_count": 1,
+        "final_answer_count": 1,
+    }
+    assert train_row["tools"] == [{"name": "visit"}]
+    assert train_row["messages"][0]["content"] == (
+        "Media references:\n- id=page-image; uri=images/page.png; mime_type=image/png"
+    )
+    assert train_row["messages"][1]["content"] == "Read the page."
+    assert train_row["messages"][2]["content"] == (
+        'Tool call: {"arguments":{"url":"fixture://doc"},"id":"visit-1",'
+        '"name":"visit"}'
+    )
+    assert train_row["messages"][3]["content"] == (
+        'Tool observation for visit-1: {"text":"The answer is MELIX."}'
+    )
+    assert train_row["messages"][-1]["content"] == "Final answer: MELIX"
+    assert trace_row["trace_id"] == "trace-001"
+    assert trace_row["turns"][1]["tool_call"]["name"] == "visit"
 
 
 def test_alignment_rl_trace_runner_attaches_trajectory_provenance(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/model_ops/agentic_sft_formatter.py
+++ b/services/mlx-worker-python/worker/model_ops/agentic_sft_formatter.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any, Iterable, Mapping
+
+AGENTIC_SFT_FORMATTER_ID = "melix.agentic_tool_trace.sft_formatter.v1"
+
+
+def new_projection_metrics() -> dict[str, int]:
+    return {
+        "sample_count": 0,
+        "tool_call_count": 0,
+        "tool_observation_count": 0,
+        "media_ref_count": 0,
+        "final_answer_count": 0,
+    }
+
+
+def merge_projection_metrics(
+    *metrics_items: Mapping[str, Any],
+) -> dict[str, int]:
+    merged = new_projection_metrics()
+    for metrics in metrics_items:
+        for key in merged:
+            try:
+                merged[key] += int(metrics.get(key, 0) or 0)
+            except (TypeError, ValueError):
+                continue
+    return merged
+
+
+def format_trace_rows(
+    samples: Iterable[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    rows: list[dict[str, Any]] = []
+    metrics = new_projection_metrics()
+    for sample in samples:
+        rows.append(format_trace_row(sample, metrics))
+    return rows, metrics
+
+
+def format_trace_row(
+    sample: dict[str, Any],
+    metrics: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    counters = metrics if metrics is not None else new_projection_metrics()
+    counters["sample_count"] += 1
+
+    messages: list[dict[str, str]] = []
+    media_refs = sample.get("media_refs")
+    media_context = ""
+    emitted_media_context = False
+    if isinstance(media_refs, list) and media_refs:
+        counters["media_ref_count"] += len(media_refs)
+        media_context = "Media references:\n" + "\n".join(
+            _format_media_ref(media_ref) for media_ref in media_refs
+        )
+
+    for raw_turn in sample.get("turns", []):
+        if not isinstance(raw_turn, dict):
+            continue
+        role = str(raw_turn.get("role", "")).strip()
+        if role in {"system", "user"}:
+            content = str(raw_turn.get("content", "")).strip()
+            if content:
+                if role == "system" and media_context and not emitted_media_context:
+                    content = f"{media_context}\n\n{content}"
+                    emitted_media_context = True
+                messages.append({"role": role, "content": content})
+            continue
+        if role == "assistant":
+            content = _format_assistant_turn(raw_turn)
+            if content:
+                if isinstance(raw_turn.get("tool_call"), dict):
+                    counters["tool_call_count"] += 1
+                messages.append({"role": "assistant", "content": content})
+            continue
+        if role == "tool":
+            content = _format_tool_turn(raw_turn)
+            if content:
+                counters["tool_observation_count"] += 1
+                messages.append({"role": "tool", "content": content})
+
+    if media_context and not emitted_media_context:
+        messages.insert(0, {"role": "system", "content": media_context})
+
+    final_answer = str(sample.get("final_answer", "")).strip()
+    if final_answer:
+        counters["final_answer_count"] += 1
+        final_content = f"Final answer: {final_answer}"
+        if messages and messages[-1]["role"] == "assistant":
+            existing_content = messages[-1]["content"].strip()
+            if existing_content == final_answer:
+                messages[-1] = {"role": "assistant", "content": final_content}
+            elif final_content not in existing_content:
+                messages[-1] = {
+                    "role": "assistant",
+                    "content": f"{existing_content}\n\n{final_content}",
+                }
+        else:
+            messages.append({"role": "assistant", "content": final_content})
+
+    row: dict[str, Any] = {
+        "messages": messages,
+    }
+    if isinstance(sample.get("tools"), list):
+        row["tools"] = copy.deepcopy(sample["tools"])
+    return row
+
+
+def _format_media_ref(media_ref: Any) -> str:
+    if not isinstance(media_ref, Mapping):
+        return f"- {media_ref}"
+    ref_id = str(media_ref.get("id", "")).strip()
+    uri = str(media_ref.get("uri", "")).strip()
+    mime_type = str(media_ref.get("mime_type", "")).strip()
+    parts = []
+    if ref_id:
+        parts.append(f"id={ref_id}")
+    if uri:
+        parts.append(f"uri={uri}")
+    if mime_type:
+        parts.append(f"mime_type={mime_type}")
+    if not parts:
+        return "- {}"
+    return "- " + "; ".join(parts)
+
+
+def _format_assistant_turn(turn: Mapping[str, Any]) -> str:
+    content = str(turn.get("content", "")).strip()
+    tool_call = turn.get("tool_call")
+    if not isinstance(tool_call, Mapping):
+        return content
+    call_id = str(tool_call.get("id", "")).strip()
+    name = str(tool_call.get("name", "")).strip()
+    arguments = tool_call.get("arguments")
+    payload = {
+        "id": call_id,
+        "name": name,
+        "arguments": arguments if isinstance(arguments, Mapping) else {},
+    }
+    rendered = "Tool call: " + json.dumps(
+        payload,
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    if content:
+        return f"{content}\n{rendered}"
+    return rendered
+
+
+def _format_tool_turn(turn: Mapping[str, Any]) -> str:
+    tool_call_id = str(turn.get("tool_call_id", "")).strip()
+    observation = turn.get("observation")
+    if isinstance(observation, Mapping):
+        rendered_observation = json.dumps(
+            observation,
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    else:
+        rendered_observation = str(observation or "").strip()
+    if not rendered_observation:
+        return ""
+    if tool_call_id:
+        return f"Tool observation for {tool_call_id}: {rendered_observation}"
+    return f"Tool observation: {rendered_observation}"

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -111,6 +111,7 @@ class LoRATrainingPipeline:
             format_name=normalized_snapshot.format,
             manifest_path=normalized_snapshot.manifest_path,
         )
+        trainer_dataset_format = normalized_snapshot.trainer_format
 
         emit("apply_lora", 0.65)
         adapter_output_dir = output_dir / "adapter"
@@ -128,7 +129,7 @@ class LoRATrainingPipeline:
                 adapter_output_dir=adapter_output_dir,
                 normalized_dataset_dir=normalized_snapshot.dataset_dir,
                 config=config,
-                dataset_format=dataset.package.format,
+                dataset_format=trainer_dataset_format,
                 resume_source_path=resume_context["resume_source_path"],
                 source_model_kind=source_model.model_kind,
                 source_model_ext=dict(source_model.ext),
@@ -200,6 +201,7 @@ class LoRATrainingPipeline:
             "dataset_source_kind": dataset.source_kind,
             "dataset_id": dataset.package.dataset_id,
             "dataset_format": dataset.package.format,
+            "trainer_dataset_format": trainer_dataset_format,
             "dataset_version": dataset.package.version,
             "dataset_sample_count": dataset.package.sample_count,
             "dataset_source_manifest_path": str(dataset.package.manifest_path),

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -15,6 +15,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from worker.model_ops import agentic_sft_formatter
 from worker.model_ops.errors import ModelOperationError
 
 _SUPPORTED_FORMATS = {
@@ -62,6 +63,7 @@ class NormalizedDatasetSnapshot:
     sample_count: int
     validation_sample_count: int
     format: str
+    trainer_format: str
 
 
 @dataclass(frozen=True)
@@ -536,11 +538,39 @@ def write_normalized_dataset_snapshot(
     samples_path = dataset_dir / "samples.jsonl"
     train_path = dataset_dir / "train.jsonl"
     valid_path = dataset_dir / "valid.jsonl"
+    agentic_train_path = dataset_dir / "agentic-traces.train.jsonl"
+    agentic_valid_path = dataset_dir / "agentic-traces.valid.jsonl"
+
+    trainer_format = dataset.format
+    train_samples = dataset.normalized_samples
+    validation_samples = dataset.normalized_validation_samples
+    agentic_projection: dict[str, Any] = {}
+    if dataset.format == "agentic_tool_trace":
+        trainer_format = "chat_messages"
+        train_samples, train_projection_metrics = agentic_sft_formatter.format_trace_rows(
+            dataset.normalized_samples
+        )
+        validation_samples, validation_projection_metrics = agentic_sft_formatter.format_trace_rows(
+            dataset.normalized_validation_samples
+        )
+        agentic_projection = {
+            "trainer_format": trainer_format,
+            "agentic_sft_formatter": agentic_sft_formatter.AGENTIC_SFT_FORMATTER_ID,
+            "agentic_trace_train_path": str(agentic_train_path),
+            "agentic_trace_valid_path": (
+                str(agentic_valid_path) if dataset.normalized_validation_samples else ""
+            ),
+            "agentic_sft_projection_metrics": agentic_sft_formatter.merge_projection_metrics(
+                train_projection_metrics,
+                validation_projection_metrics,
+            ),
+        }
 
     manifest_payload = {
         "schema_version": "melix.training_dataset_snapshot.v1",
         "dataset_id": dataset.dataset_id,
         "format": dataset.format,
+        "trainer_format": trainer_format,
         "sample_count": dataset.sample_count,
         "validation_sample_count": dataset.validation_sample_count,
         "version": dataset.version,
@@ -550,17 +580,26 @@ def write_normalized_dataset_snapshot(
     }
     if dataset.format == "agentic_tool_trace":
         manifest_payload.update(_agentic_trace_snapshot_manifest_fields(dataset))
+        manifest_payload.update(agentic_projection)
     if manifest_overrides:
         manifest_payload.update(manifest_overrides)
     manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
 
-    _write_duplicate_jsonl_rows((samples_path, train_path), dataset.normalized_samples)
-    if dataset.normalized_validation_samples:
-        _write_jsonl_rows(valid_path, dataset.normalized_validation_samples)
+    _write_duplicate_jsonl_rows((samples_path, train_path), train_samples)
+    if dataset.format == "agentic_tool_trace":
+        _write_jsonl_rows(agentic_train_path, dataset.normalized_samples)
+    elif agentic_train_path.exists():
+        agentic_train_path.unlink()
+    if validation_samples:
+        _write_jsonl_rows(valid_path, validation_samples)
+        if dataset.format == "agentic_tool_trace":
+            _write_jsonl_rows(agentic_valid_path, dataset.normalized_validation_samples)
     else:
         if valid_path.exists():
             valid_path.unlink()
         valid_path = None
+        if agentic_valid_path.exists():
+            agentic_valid_path.unlink()
 
     return NormalizedDatasetSnapshot(
         dataset_dir=dataset_dir,
@@ -571,6 +610,7 @@ def write_normalized_dataset_snapshot(
         sample_count=dataset.sample_count,
         validation_sample_count=dataset.validation_sample_count,
         format=dataset.format,
+        trainer_format=trainer_format,
     )
 
 


### PR DESCRIPTION
## Summary
- Add an agentic SFT formatter that projects `agentic_tool_trace` rows into trainer-facing `chat_messages` while preserving tool calls, tool observations, media references, final answers, and tool schemas.
- Preserve original normalized agentic traces beside the projected training rows and record projection metadata in normalized dataset and adapter manifests.
- Document the formatting plan, dataset contract, and LoRA runbook behavior for OpenSearch-VL agentic LoRA SFT.

Closes #686.

## Plan or Spec
- `docs/plans/2026-05-20-agentic-lora-sft-formatting.md`
- `docs/agentic-trajectory-dataset-contract.md`
- `docs/runbooks/phase-8-lora-adapter-workflow.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_sft_formatter.py services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_applies_manifest_overrides services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_clears_stale_valid_jsonl_when_no_validation_samples services/mlx-worker-python/tests/test_trajectory_provenance.py::test_train_lora_records_agentic_trajectory_provenance_in_adapter_manifest
# 4 passed in 0.66s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_sft_formatter.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_trajectory_provenance.py
# 87 passed in 0.37s before rebase; 87 passed in 0.48s after rebase

make swift-test
# Passed in the first full pre-commit gate before the final documentation newline cleanup.
# A second full hook attempt hit an unrelated Swift admission-gate ordering flake after a long helper stall; targeted EventSubscriptionHubTests re-run passed: 16 tests in 2 suites passed after 0.008s.

make py-test
# 2838 passed, 14 skipped, 2 warnings in 144.63s

make integration-test
# 114 passed, 1 skipped in 330.49s

git diff --check HEAD~1..HEAD
# passed

python3 scripts/pre_commit_gate.py scoped performance path via git commit hook / dry run
# Latest report: .runtime/pre-commit-performance/20260519-195208-726bb779/report/report.md
# Status: regression due to validation sample-limit elapsed-only +0.031ms; targeted tests pass, coverage pass, memory neutral, sample count unchanged.
```

## Coverage and Metrics
- Changed-scope coverage over the PR diff: `TOTAL 184 0 100%` from a base/head snapshot run against `origin/main` with the focused formatter, dataset builder, and trajectory provenance suites.
- Focused post-rebase coverage command over the same suites passed; direct PR-diff coverage lines were all covered.
- Performance probes selected: `training-dataset-token-percentiles-single-sort`, `training-dataset-validation-split-nsmallest`, `training-dataset-validation-sample-limit`, and `lora-reward-summary-candidate-minmax`.
- Performance status: the latest dry run reports one elapsed-only regression in the text-completion validation sample-limit probe (`0.291ms` -> `0.322ms`, +0.031ms). The probe path exercises `load_training_dataset_package` on `text_completion`, not the new agentic snapshot projection path. It preserved `validation_sample_count_mean=1.0` and showed neutral memory. The LoRA reward summary probe was ok with `sorted_calls_mean=2.0` unchanged.
- Observability mode: `evidence` for offline dataset snapshot metadata. Serving-path observability overhead: `N/A`; this change does not add serving runtime probes or request-path metrics.

## Known Gaps
- Response-only and mask-prompt trainer boundary handling for projected agentic traces remains deferred to the next OpenSearch-VL unit.
- No training-quality benchmark claim is made here; this PR covers deterministic supervised formatting and provenance preservation only.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
