### PR TITLE
perf: bind tool config parser

### DIFF
--- a/docs/plans/2026-05-19-tool-config-fromstring-binding.md
+++ b/docs/plans/2026-05-19-tool-config-fromstring-binding.md
@@ -1,0 +1,54 @@
+# Tool config FromString binding
+
+Date: 2026-05-19
+
+## Scope
+
+This performance slice optimizes only `built_in_tool_config()` and
+`ToolRegistry.as_worker_tool_config()` in
+`services/mlx-worker-python/worker/runtime/tool_registry.py`.
+
+## Problem
+
+The cached tool-config paths already avoid rebuilding descriptor schemas and
+registry selections, but each hot call still resolves
+`common_pb2.ToolConfig.FromString` through the protobuf module and message class
+before parsing the cached serialized `ToolConfig` bytes. These cached-byte paths
+are exercised frequently when agentic tool metadata is attached to generation
+requests.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`. The
+entry includes focused `test_command`, `coverage_command`, and `probe_command`
+entries for:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_schema_bytes_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+No registry change is required for this slice.
+
+## Optimization slice
+
+Bind `common_pb2.ToolConfig.FromString` once at module import and use that local
+binding for cached serialized tool-config parses. This keeps message mutability
+semantics unchanged because every call still returns a freshly parsed protobuf
+message.
+
+## Verification plan
+
+- Run the registered focused pytest command locally on Linux.
+- Run the registered changed-scope coverage command and require at least 95%
+  changed-line coverage.
+- Run `scripts/tool_registry_schema_bytes_probe.py` before and after the change
+  and compare cached tool-config metrics.
+- Use GitHub Actions PR-scoped performance as the merge gate after pushing.
+
+## Linux validation boundary
+
+This slice is Python-only and locally verifiable on Linux. No Swift runtime
+performance claims are made.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -8,6 +8,7 @@ from typing import Any
 from packages.protocol.python.worker.v1 import common_pb2
 
 
+_TOOL_CONFIG_FROM_BYTES = common_pb2.ToolConfig.FromString
 _COMPACT_SORTED_JSON_ENCODER = json.JSONEncoder(separators=(",", ":"), sort_keys=True)
 _TOOL_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 _SELECTION_CACHE_MAX_SIZE = 32
@@ -233,7 +234,7 @@ class ToolRegistry:
 
     def as_worker_tool_config(self) -> common_pb2.ToolConfig:
         if self._worker_tool_config_bytes:
-            return common_pb2.ToolConfig.FromString(self._worker_tool_config_bytes)
+            return _TOOL_CONFIG_FROM_BYTES(self._worker_tool_config_bytes)
         config = common_pb2.ToolConfig(
             tools=[tool.as_worker_tool_definition() for tool in self._tools],
             schema_format="openai-function",
@@ -267,11 +268,11 @@ def built_in_tool_registry() -> ToolRegistry:
 
 def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> common_pb2.ToolConfig:
     if names is None:
-        return common_pb2.ToolConfig.FromString(_BUILTIN_TOOL_CONFIG_BYTES)
+        return _TOOL_CONFIG_FROM_BYTES(_BUILTIN_TOOL_CONFIG_BYTES)
     requested_names = tuple(names)
     cached_config_bytes = _BUILTIN_TOOL_CONFIG_SELECTION_BYTES.get(requested_names)
     if cached_config_bytes is not None:
-        return common_pb2.ToolConfig.FromString(cached_config_bytes)
+        return _TOOL_CONFIG_FROM_BYTES(cached_config_bytes)
     registry = _BUILTIN_TOOL_CONFIG_REGISTRY.select(requested_names)
     config = registry.as_worker_tool_config()
     _BUILTIN_TOOL_CONFIG_SELECTION_BYTES[registry.names()] = config.SerializeToString()


### PR DESCRIPTION
## Summary
- Bind `common_pb2.ToolConfig.FromString` once in `tool_registry.py` and reuse that local parser on cached serialized `ToolConfig` paths.
- Preserve existing protobuf mutability semantics: every call still returns a freshly parsed `ToolConfig` message.

## Plan or Spec
- `docs/plans/2026-05-19-tool-config-fromstring-binding.md`
- Registered PR-scoped probe: `tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=80000 MELIX_TOOL_REGISTRY_METRICS_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
# before: exit 0; built_in_tool_config_elapsed_ms_mean=146.76793248924827; full_selection_tool_config_elapsed_ms_mean=154.14764303048807; partial_selection_tool_config_elapsed_ms_mean=111.13963987944382
# after:  exit 0; built_in_tool_config_elapsed_ms_mean=136.39866447608387; full_selection_tool_config_elapsed_ms_mean=145.37537337413855; partial_selection_tool_config_elapsed_ms_mean=104.62674242444336

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 47 passed in 0.72s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py
# exit 0; TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
# exit 0; built_in_tool_config_elapsed_ms_mean=69.93381064385176; full_selection_tool_config_elapsed_ms_mean=74.3619707878679; partial_selection_tool_config_elapsed_ms_mean=56.24430361203849
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Local Linux registered-probe comparison at 80k iterations / 7 samples:
  - `built_in_tool_config_elapsed_ms_mean`: 146.7679 ms -> 136.3987 ms (delta -10.3693 ms, ~7.06% faster)
  - `full_selection_tool_config_elapsed_ms_mean`: 154.1476 ms -> 145.3754 ms (delta -8.7723 ms, ~5.69% faster)
  - `partial_selection_tool_config_elapsed_ms_mean`: 111.1396 ms -> 104.6267 ms (delta -6.5129 ms, ~5.86% faster)
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this Python-only slice; CI is the broad gate.
- No Swift runtime performance is claimed or locally validated.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no new probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
