### PR TITLE
perf: fast-path full tool registry list selection

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-select-full-list-fast-path.md
+++ b/docs/plans/2026-05-19-tool-registry-select-full-list-fast-path.md
@@ -1,0 +1,31 @@
+# Tool Registry Select Full-List Fast Path
+
+## Goal
+
+Reduce repeated normalization work in `worker.runtime.tool_registry.ToolRegistry.select()` when callers pass an exact ordered list containing the complete built-in tool registry. This path appears in agentic tool configuration setup where JSON-derived lists may already match the registry order.
+
+## Scope
+
+This slice is intentionally limited to the Python tool registry selection path:
+
+- cache a private list-form name snapshot beside the existing immutable tuple snapshot;
+- detect exact full-list selections before trimming and deduplicating requested names;
+- return the current registry instance for that exact list, matching the existing complete-selection semantics;
+- keep whitespace trimming, duplicate removal, unknown-name errors, and partial-selection cache behavior unchanged;
+- extend the registered select probe to include the exact full-list workload.
+
+It does not change tool descriptors, schema serialization, worker protobuf exports, built-in tool definitions, or non-exact selection normalization.
+
+## Performance Probe
+
+Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+
+The probe runs `scripts/tool_registry_select_probe.py`, mixes cached partial tuple selections with exact full-list selections, and reports:
+
+- `elapsed_ms_mean` (`lower_is_better`)
+- `select_calls_mean` (`informational`)
+- `full_list_self_hits_mean` (`higher_is_better`)
+
+## Verification Plan
+
+Run the focused registry tests, changed-scope coverage command, and the registered probe locally on Linux before opening the PR. CI remains the source of truth for the PR-scoped base-vs-head performance report.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3827,6 +3827,12 @@
         "key": "select_calls_mean",
         "unit": "calls",
         "direction": "informational"
+      },
+      {
+        "key": "full_list_self_hits_mean",
+        "unit": "calls",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
       }
     ]
   },

--- a/scripts/tool_registry_select_probe.py
+++ b/scripts/tool_registry_select_probe.py
@@ -24,23 +24,33 @@ _SELECTIONS: tuple[tuple[str, ...], ...] = (
 
 def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     registry = built_in_tool_registry()
+    full_selection = list(registry.names())
     elapsed_samples: list[float] = []
+    full_list_self_samples: list[float] = []
     checksum = 0
 
     for _ in range(sample_count):
+        full_list_self_count = 0
         started = time.perf_counter()
         for index in range(iterations):
-            selected = registry.select(_SELECTIONS[index % len(_SELECTIONS)])
+            if index % 5 == 0:
+                selected = registry.select(full_selection)
+                if selected is registry:
+                    full_list_self_count += 1
+            else:
+                selected = registry.select(_SELECTIONS[index % len(_SELECTIONS)])
             checksum += len(selected.tools)
         elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        full_list_self_samples.append(float(full_list_self_count))
 
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
         "select_calls_mean": float(iterations),
+        "full_list_self_hits_mean": statistics.fmean(full_list_self_samples),
         "checksum": float(checksum),
         "iterations": float(iterations),
         "sample_count": float(sample_count),
-        "selection_case_count": float(len(_SELECTIONS)),
+        "selection_case_count": float(len(_SELECTIONS) + 1),
     }
 
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -225,7 +225,8 @@ def test_tool_registry_select_probe_script_emits_metrics(
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["elapsed_ms_mean"] >= 0.0
     assert metrics["select_calls_mean"] == 20.0
-    assert metrics["selection_case_count"] == 4.0
+    assert metrics["selection_case_count"] == 5.0
+    assert metrics["full_list_self_hits_mean"] == 4.0
 
 
 def test_tool_registry_names_probe_script_emits_metrics(

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -231,6 +231,21 @@ def test_tool_registry_select_returns_self_for_complete_selection() -> None:
     assert registry.names() == BUILTIN_AGENTIC_TOOL_NAMES
 
 
+def test_tool_registry_select_exact_full_list_skips_normalization() -> None:
+    class StripCountingName(str):
+        strip_calls = 0
+
+        def strip(self, chars: str | None = None) -> str:  # pragma: no cover - exact-list fast path skips this
+            type(self).strip_calls += 1
+            return super().strip(chars)
+
+    registry = built_in_tool_registry()
+    exact_names = [StripCountingName(name) for name in BUILTIN_AGENTIC_TOOL_NAMES]
+
+    assert registry.select(exact_names) is registry
+    assert StripCountingName.strip_calls == 0
+
+
 def test_tool_registry_selection_cache_is_bounded() -> None:
     registry = built_in_tool_registry()
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -167,6 +167,7 @@ class ToolRegistry:
         self._parser_contract_version = parser_contract_version.strip()
         self._validate()
         self._tool_names = tuple(tool.name for tool in self._tools)
+        self._tool_names_list = list(self._tool_names)
         self._tool_by_name = {tool.name: tool for tool in self._tools}
         self._selection_cache: dict[tuple[str, ...], ToolRegistry] = {}
         self._worker_tool_config_bytes: bytes = b""
@@ -193,6 +194,8 @@ class ToolRegistry:
             cached_selection = self._selection_cache.get(names)
             if cached_selection is not None:
                 return cached_selection
+        elif names == self._tool_names_list:
+            return self
 
         requested_names_list: list[str] = []
         seen_names: set[str] = set()


### PR DESCRIPTION
## Summary
- Add an exact full-list fast path for `ToolRegistry.select()` so JSON-derived lists that already match the registry order return the current registry before normalization.
- Cache a private list-form tool-name snapshot beside the existing tuple snapshot.
- Extend the registered select probe metrics with full-list self-hit reporting.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-select-full-list-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 48 passed in 0.15s

rm -f coverage.json .coverage && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py && rm -f coverage.json .coverage
# 48 passed; changed-scope coverage TOTAL 21 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# {"checksum": 1120000.0, "elapsed_ms_mean": 21.844827197492123, "full_list_self_hits_mean": 16000.0, "iterations": 80000.0, "sample_count": 5.0, "select_calls_mean": 80000.0, "selection_case_count": 5.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 21 0 100%`).
- Registered probe: `tool-registry-select-name-index-cache`.
- Local registered probe result: `elapsed_ms_mean=21.844827197492123`, `full_list_self_hits_mean=16000.0` over 80,000 select calls.
- Local full-list microbench before/after: `old_mean=209.1034669894725ms`, `new_mean=61.49265016429126ms`, `delta=-147.61081682518125ms`, `speedup=3.400462761497613x` for 200,000 exact full-list selections.
- CI PR-scoped performance is required for the registered base-vs-head report.

## Known Gaps
- Local validation is Linux-only Python verification; CI remains the source of truth for the registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped registered probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
