### PR TITLE
Add agentic SFT response-only boundaries

### DIFF
--- a/docs/agentic-trajectory-dataset-contract.md
+++ b/docs/agentic-trajectory-dataset-contract.md
@@ -262,7 +262,9 @@ For LoRA SFT, the snapshot also writes a trainer-facing projection. The source
 snapshot manifest keeps `format: agentic_tool_trace` and records
 `trainer_format: chat_messages`. `samples.jsonl`, `train.jsonl`, and
 `valid.jsonl` contain the supervised `messages` rows consumed by the local
-trainer. Sibling `agentic-traces.train.jsonl` and
+trainer. A single source trace may produce multiple trainer rows: one for each
+assistant tool-call span that should receive loss and one for the final-answer
+span. Sibling `agentic-traces.train.jsonl` and
 `agentic-traces.valid.jsonl` files preserve the original normalized trace rows
 for provenance, audit, replay, and later RL/evaluation reuse.
 
@@ -274,10 +276,25 @@ The v1 SFT projection formats:
 - tool observations as `tool` role messages bound to the source tool-call id
 - the final answer as the supervised assistant answer
 
-Response-only and mask-prompt boundaries for tool-call tokens are governed by a
-later child issue. The first LoRA SFT slice therefore keeps response-only
-support disabled for `agentic_tool_trace` even though the trainer-facing rows
-use the `chat_messages` shape.
+Response-only and mask-prompt support for `agentic_tool_trace` depends on this
+row split. MLX-LM's current chat dataset exposes one contiguous prompt boundary
+per row, so Melix ends each projected row with the assistant span that should
+receive loss. Earlier user, system, assistant reasoning, and tool-observation
+messages remain context and are masked by `mask_prompt=true`. Each projected row
+records a `response_only_boundary` object with:
+
+- `policy_id: melix.agentic_tool_trace.response_only_boundaries.v1`
+- `mask_prompt: true`
+- `trainable_role: assistant`
+- `trainable_kind: tool_call` or `final_answer`
+- `trainable_message_index`
+- `trace_id` when available
+
+The normalized snapshot manifest records `source_trace_sample_count`,
+`trainer_sample_count`, `agentic_sft_boundary_policy`, and projection metrics
+for trainer rows plus response-only/mask-prompt boundary counts. Adapter
+receipts keep `dataset_sample_count` as the source trace count and add
+`trainer_dataset_sample_count` for the expanded trainer rows.
 
 ## Provenance Fields
 

--- a/docs/plans/2026-05-20-agentic-lora-sft-formatting.md
+++ b/docs/plans/2026-05-20-agentic-lora-sft-formatting.md
@@ -30,15 +30,18 @@ handoff:
 - Preserve original normalized trace rows in sibling snapshot evidence files.
 - Keep `dataset_format=agentic_tool_trace` in adapter receipts while passing
   the trainer the projected `chat_messages` row shape.
-- Keep response-only masking disabled for `agentic_tool_trace`; issue #687 owns
-  response-only and mask-prompt boundaries for tool-call tokens.
+- Split each trace into trainer rows that end at one trainable assistant span,
+  so MLX-LM's single contiguous `mask_prompt` boundary trains tool-call tokens
+  and final-answer tokens without training user/system/tool-observation context.
+- Record response-only boundary metadata for each projected row.
 
 Out of scope:
 
 - Schema or protobuf changes.
 - Network-backed tool execution.
 - Claiming quality or benchmark improvement.
-- Enabling response-only masking for agentic traces.
+- A custom MLX-LM loss that trains multiple disjoint assistant spans in a
+  single row.
 
 ## Implementation Plan
 
@@ -51,7 +54,9 @@ Out of scope:
 4. Pass the trainer-facing format from the normalized snapshot into
    `TrainingRequest` while preserving source trajectory provenance in adapter
    receipts.
-5. Add focused tests for the formatter, snapshot artifacts, and LoRA pipeline
+5. Enable response-only masking for `agentic_tool_trace` by default after
+   projecting each trainable assistant span into a separate chat row.
+6. Add focused tests for the formatter, snapshot artifacts, and LoRA pipeline
    handoff.
 
 ## Performance And Metrics
@@ -66,6 +71,9 @@ Measurement points:
 - Formatted tool-observation count.
 - Formatted media-reference count.
 - Formatted final-answer count.
+- Trainer row count.
+- Response-only boundary count.
+- Mask-prompt boundary count.
 - Focused pytest runtime for dataset builder and LoRA pipeline tests.
 - Changed-scope coverage for touched Python files, target >= 95%.
 
@@ -78,6 +86,9 @@ training data preparation path.
 - `agentic_tool_trace` snapshots expose `trainer_format: chat_messages`.
 - `train.jsonl` and `valid.jsonl` contain supervised `messages` rows with
   deterministic tool-call, observation, media-reference, and final-answer text.
+- Each projected row ends with the one assistant span that should receive loss
+  for that row, and records `response_only_boundary` metadata.
+- Agentic SFT defaults to `response_only=true` and `mask_prompt=true`.
 - Original normalized traces are preserved in sibling JSONL evidence files.
 - LoRA training still reports `dataset_format: agentic_tool_trace` and records
   `trainer_dataset_format: chat_messages`.

--- a/docs/runbooks/phase-8-lora-adapter-workflow.md
+++ b/docs/runbooks/phase-8-lora-adapter-workflow.md
@@ -203,6 +203,13 @@ Expected training behavior:
 - `agentic_tool_trace` packages are accepted by SFT modes and projected into a
   trainer-facing `chat_messages` snapshot while preserving the original
   normalized trace rows in sibling `agentic-traces.*.jsonl` evidence files
+- agentic SFT projection splits a source trace into one trainer row per
+  trainable assistant tool-call span plus one final-answer row; each row records
+  `response_only_boundary` metadata and defaults to `response_only=true` with
+  `mask_prompt=true` so user, system, and tool-observation context does not
+  receive loss
+- adapter receipts keep the source trace count in `dataset_sample_count` and
+  record expanded trainer rows in `trainer_dataset_sample_count`
 - Hugging Face dataset materialization is cached under `<jobs_root>/datasets/<cache-key>`
 - Melix supports `lora`, `qlora`, `dora`, `dpo`, `orpo`, and `cpt` through the same `train_lora` surface
 - `dora` records `adapter_algorithm=dora` and `dora_enabled=true` in the adapter manifest

--- a/services/mlx-worker-python/tests/test_agentic_sft_formatter.py
+++ b/services/mlx-worker-python/tests/test_agentic_sft_formatter.py
@@ -64,28 +64,97 @@ def test_agentic_tool_trace_sft_formatter_covers_defensive_branches() -> None:
                     '"name":"visit"}'
                 ),
             },
+        ],
+        "response_only_boundary": {
+            "policy_id": "melix.agentic_tool_trace.response_only_boundaries.v1",
+            "mask_prompt": True,
+            "trainable_role": "assistant",
+            "trainable_kind": "tool_call",
+            "trainable_message_index": 1,
+            "trace_id": "trace-defensive",
+        },
+    }
+    assert rows[1] == {
+        "messages": [
+            {
+                "role": "system",
+                "content": "Media references:\n- fixture://loose\n- {}\n\nUse tools.",
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    'I will inspect.\nTool call: {"arguments":{},"id":"call-1",'
+                    '"name":"visit"}'
+                ),
+            },
             {"role": "tool", "content": "Tool observation: plain observation"},
             {"role": "assistant", "content": "Final answer: Done"},
         ],
-    }
-    assert rows[1] == {
-        "messages": [{"role": "assistant", "content": "Final answer: Only answer"}]
+        "response_only_boundary": {
+            "policy_id": "melix.agentic_tool_trace.response_only_boundaries.v1",
+            "mask_prompt": True,
+            "trainable_role": "assistant",
+            "trainable_kind": "final_answer",
+            "trainable_message_index": 3,
+            "trace_id": "trace-defensive",
+        },
     }
     assert rows[2] == {
-        "messages": [{"role": "assistant", "content": "Final answer: Matched answer"}]
+        "messages": [{"role": "assistant", "content": "Final answer: Only answer"}],
+        "response_only_boundary": {
+            "policy_id": "melix.agentic_tool_trace.response_only_boundaries.v1",
+            "mask_prompt": True,
+            "trainable_role": "assistant",
+            "trainable_kind": "final_answer",
+            "trainable_message_index": 0,
+            "trace_id": "trace-answer-only",
+        },
     }
     assert rows[3] == {
+        "messages": [{"role": "assistant", "content": "Final answer: Matched answer"}],
+        "response_only_boundary": {
+            "policy_id": "melix.agentic_tool_trace.response_only_boundaries.v1",
+            "mask_prompt": True,
+            "trainable_role": "assistant",
+            "trainable_kind": "final_answer",
+            "trainable_message_index": 0,
+            "trace_id": "trace-final-equals-assistant",
+        },
+    }
+    assert rows[4] == {
         "messages": [
             {"role": "assistant", "content": "Final answer: Already formatted"}
-        ]
+        ],
+        "response_only_boundary": {
+            "policy_id": "melix.agentic_tool_trace.response_only_boundaries.v1",
+            "mask_prompt": True,
+            "trainable_role": "assistant",
+            "trainable_kind": "final_answer",
+            "trainable_message_index": 0,
+            "trace_id": "trace-final-already-formatted",
+        },
     }
     assert metrics == {
         "sample_count": 4,
+        "trainer_row_count": 5,
         "tool_call_count": 1,
         "tool_observation_count": 1,
         "media_ref_count": 2,
         "final_answer_count": 4,
+        "response_only_boundary_count": 5,
+        "mask_prompt_boundary_count": 5,
     }
+    assert agentic_sft_formatter.count_trace_trainer_rows(
+        [
+            {
+                "turns": [
+                    {"role": "assistant", "tool_call": {"id": "a"}},
+                    {"role": "assistant", "content": "done"},
+                ],
+                "final_answer": "done",
+            }
+        ]
+    ) == 2
     assert agentic_sft_formatter.merge_projection_metrics(
         {"sample_count": "bad", "tool_call_count": "2"},
         {"sample_count": 1},

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -172,6 +172,7 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
     assert "trajectory_schema_version" not in payload
     assert stale_agentic_train_path.exists() is False
     assert stale_agentic_valid_path.exists() is False
+    assert training_dataset_module.trainer_sample_counts(dataset) == (1, 0)
 
     agentic_package_path = tmp_path / "agentic-package"
     agentic_package_path.mkdir(parents=True, exist_ok=True)
@@ -229,7 +230,7 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
         normalized_samples=samples,
         normalized_validation_samples=validation_samples,
         validation_sample_count=1,
-        response_only_supported=False,
+        response_only_supported=True,
         manifest_fields={
             "schema_version": "melix.training_dataset_package.v1",
             "dataset_id": "agentic-package",
@@ -248,6 +249,7 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
             "media_root": "images/",
         },
     )
+    assert training_dataset_module.trainer_sample_counts(agentic_dataset) == (2, 1)
 
     agentic_snapshot = write_normalized_dataset_snapshot(
         agentic_dataset,
@@ -260,6 +262,17 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
     assert agentic_payload["format"] == "agentic_tool_trace"
     assert agentic_payload["trainer_format"] == "chat_messages"
     assert agentic_payload["agentic_sft_formatter"] == "melix.agentic_tool_trace.sft_formatter.v1"
+    assert (
+        agentic_payload["agentic_sft_boundary_policy"]
+        == "melix.agentic_tool_trace.response_only_boundaries.v1"
+    )
+    assert agentic_payload["sample_count"] == 2
+    assert agentic_payload["validation_sample_count"] == 1
+    assert agentic_payload["source_trace_sample_count"] == 1
+    assert agentic_payload["source_trace_validation_sample_count"] == 1
+    assert agentic_payload["trainer_sample_count"] == 2
+    assert agentic_payload["trainer_validation_sample_count"] == 1
+    assert agentic_payload["response_only_supported"] is True
     assert agentic_payload["agentic_trace_train_path"].endswith(
         "normalized_dataset/agentic-traces.train.jsonl"
     )
@@ -268,10 +281,13 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
     )
     assert agentic_payload["agentic_sft_projection_metrics"] == {
         "sample_count": 2,
+        "trainer_row_count": 3,
         "tool_call_count": 1,
         "tool_observation_count": 1,
         "media_ref_count": 2,
         "final_answer_count": 2,
+        "response_only_boundary_count": 3,
+        "mask_prompt_boundary_count": 3,
     }
     assert agentic_payload["source_package_path"] == str(agentic_package_path)
     assert agentic_payload["source_dataset_id"] == "source-agentic-package"
@@ -324,9 +340,47 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
     }
     assert agentic_snapshot.format == "agentic_tool_trace"
     assert agentic_snapshot.trainer_format == "chat_messages"
-    train_row = json.loads(agentic_snapshot.train_path.read_text(encoding="utf-8"))
-    assert train_row["tools"] == [{"name": "image_crop"}]
-    assert train_row["messages"] == [
+    assert agentic_snapshot.sample_count == 2
+    assert agentic_snapshot.validation_sample_count == 1
+    train_rows = [
+        json.loads(line)
+        for line in agentic_snapshot.train_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(train_rows) == 2
+    assert train_rows[0]["tools"] == [{"name": "image_crop"}]
+    assert train_rows[0]["response_only_boundary"] == {
+        "policy_id": "melix.agentic_tool_trace.response_only_boundaries.v1",
+        "mask_prompt": True,
+        "trainable_role": "assistant",
+        "trainable_kind": "tool_call",
+        "trainable_message_index": 2,
+        "trace_id": "trace-train",
+    }
+    assert train_rows[0]["messages"] == [
+        {
+            "role": "system",
+            "content": "Media references:\n- id=image-1; uri=images/sign-one.jpg",
+        },
+        {"role": "user", "content": "Inspect image one."},
+        {
+            "role": "assistant",
+            "content": (
+                'Tool call: {"arguments":{"media_ref":"image-1"},"id":"call-1",'
+                '"name":"image_crop"}'
+            ),
+        },
+    ]
+    assert train_rows[1]["tools"] == [{"name": "image_crop"}]
+    assert train_rows[1]["response_only_boundary"] == {
+        "policy_id": "melix.agentic_tool_trace.response_only_boundaries.v1",
+        "mask_prompt": True,
+        "trainable_role": "assistant",
+        "trainable_kind": "final_answer",
+        "trainable_message_index": 4,
+        "trace_id": "trace-train",
+    }
+    assert train_rows[1]["messages"] == [
         {
             "role": "system",
             "content": "Media references:\n- id=image-1; uri=images/sign-one.jpg",
@@ -357,6 +411,14 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
     ) == samples[0]
     assert agentic_snapshot.valid_path is not None
     valid_row = json.loads(agentic_snapshot.valid_path.read_text(encoding="utf-8"))
+    assert valid_row["response_only_boundary"] == {
+        "policy_id": "melix.agentic_tool_trace.response_only_boundaries.v1",
+        "mask_prompt": True,
+        "trainable_role": "assistant",
+        "trainable_kind": "final_answer",
+        "trainable_message_index": 2,
+        "trace_id": "trace-valid",
+    }
     assert valid_row["messages"][-1] == {
         "role": "assistant",
         "content": "The label says GOLD-SECRET.\n\nFinal answer: GOLD-SECRET",
@@ -763,7 +825,6 @@ def test_load_training_dataset_package_supports_agentic_tool_trace_contract(
     package = load_training_dataset_package(str(package_path))
 
     assert package.format == "agentic_tool_trace"
-    assert package.response_only_supported is False
     assert package.normalized_samples == [sample]
 
 

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -270,13 +270,26 @@ def test_train_lora_records_agentic_trajectory_provenance_in_adapter_manifest(
     assert payload["trajectory_provenance_field_count"] >= 8
     assert payload["trajectory_reward_policy_present"] is True
     assert payload["trainer_dataset_format"] == "chat_messages"
+    assert payload["trainer_dataset_sample_count"] == 2
+    assert payload["trainer_dataset_validation_sample_count"] == 0
+    assert payload["response_only"] is True
+    assert payload["mask_prompt"] is True
     assert runner.last_train_request is not None
     assert runner.last_train_request.dataset_format == "chat_messages"
     assert runner.last_train_request.config.dataset_contract == "sft"
+    assert runner.last_train_request.config.response_only is True
+    assert runner.last_train_request.config.mask_prompt is True
+    assert runner.last_train_request.config.batch_size == 2
 
     normalized_dataset_path = Path(payload["normalized_dataset_manifest_path"])
     normalized_payload = json.loads(normalized_dataset_path.read_text(encoding="utf-8"))
-    train_row = json.loads((normalized_dataset_path.parent / "train.jsonl").read_text(encoding="utf-8"))
+    train_rows = [
+        json.loads(line)
+        for line in (normalized_dataset_path.parent / "train.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.strip()
+    ]
     trace_row = json.loads(
         (normalized_dataset_path.parent / "agentic-traces.train.jsonl").read_text(
             encoding="utf-8"
@@ -285,26 +298,43 @@ def test_train_lora_records_agentic_trajectory_provenance_in_adapter_manifest(
 
     assert normalized_payload["format"] == "agentic_tool_trace"
     assert normalized_payload["trainer_format"] == "chat_messages"
+    assert normalized_payload["sample_count"] == 2
+    assert normalized_payload["source_trace_sample_count"] == 1
+    assert normalized_payload["trainer_sample_count"] == 2
+    assert normalized_payload["response_only_supported"] is True
+    assert (
+        normalized_payload["agentic_sft_boundary_policy"]
+        == "melix.agentic_tool_trace.response_only_boundaries.v1"
+    )
     assert normalized_payload["agentic_sft_projection_metrics"] == {
         "sample_count": 1,
+        "trainer_row_count": 2,
         "tool_call_count": 1,
         "tool_observation_count": 1,
         "media_ref_count": 1,
         "final_answer_count": 1,
+        "response_only_boundary_count": 2,
+        "mask_prompt_boundary_count": 2,
     }
-    assert train_row["tools"] == [{"name": "visit"}]
-    assert train_row["messages"][0]["content"] == (
+    assert len(train_rows) == 2
+    assert train_rows[0]["tools"] == [{"name": "visit"}]
+    assert train_rows[0]["response_only_boundary"]["trainable_kind"] == "tool_call"
+    assert train_rows[0]["response_only_boundary"]["trainable_message_index"] == 2
+    assert train_rows[0]["messages"][0]["content"] == (
         "Media references:\n- id=page-image; uri=images/page.png; mime_type=image/png"
     )
-    assert train_row["messages"][1]["content"] == "Read the page."
-    assert train_row["messages"][2]["content"] == (
+    assert train_rows[0]["messages"][1]["content"] == "Read the page."
+    assert train_rows[0]["messages"][2]["content"] == (
         'Tool call: {"arguments":{"url":"fixture://doc"},"id":"visit-1",'
         '"name":"visit"}'
     )
-    assert train_row["messages"][3]["content"] == (
+    assert train_rows[1]["tools"] == [{"name": "visit"}]
+    assert train_rows[1]["response_only_boundary"]["trainable_kind"] == "final_answer"
+    assert train_rows[1]["response_only_boundary"]["trainable_message_index"] == 4
+    assert train_rows[1]["messages"][3]["content"] == (
         'Tool observation for visit-1: {"text":"The answer is MELIX."}'
     )
-    assert train_row["messages"][-1]["content"] == "Final answer: MELIX"
+    assert train_rows[1]["messages"][-1]["content"] == "Final answer: MELIX"
     assert trace_row["trace_id"] == "trace-001"
     assert trace_row["turns"][1]["tool_call"]["name"] == "visit"
 

--- a/services/mlx-worker-python/worker/model_ops/agentic_sft_formatter.py
+++ b/services/mlx-worker-python/worker/model_ops/agentic_sft_formatter.py
@@ -165,10 +165,7 @@ def _build_supervised_row(
     counters["response_only_boundary_count"] += 1
     counters["mask_prompt_boundary_count"] += 1
     row: dict[str, Any] = {
-        "messages": [
-            copy.deepcopy(message)
-            for message in [*prefix_messages, assistant_message]
-        ],
+        "messages": [message.copy() for message in [*prefix_messages, assistant_message]],
         "response_only_boundary": {
             "policy_id": AGENTIC_SFT_BOUNDARY_POLICY_ID,
             "mask_prompt": True,
@@ -181,7 +178,7 @@ def _build_supervised_row(
     if trace_id_value:
         row["response_only_boundary"]["trace_id"] = trace_id_value
     if tools is not None:
-        row["tools"] = copy.deepcopy(tools)
+        row["tools"] = tools
     return row
 
 

--- a/services/mlx-worker-python/worker/model_ops/agentic_sft_formatter.py
+++ b/services/mlx-worker-python/worker/model_ops/agentic_sft_formatter.py
@@ -5,15 +5,19 @@ import json
 from typing import Any, Iterable, Mapping
 
 AGENTIC_SFT_FORMATTER_ID = "melix.agentic_tool_trace.sft_formatter.v1"
+AGENTIC_SFT_BOUNDARY_POLICY_ID = "melix.agentic_tool_trace.response_only_boundaries.v1"
 
 
 def new_projection_metrics() -> dict[str, int]:
     return {
         "sample_count": 0,
+        "trainer_row_count": 0,
         "tool_call_count": 0,
         "tool_observation_count": 0,
         "media_ref_count": 0,
         "final_answer_count": 0,
+        "response_only_boundary_count": 0,
+        "mask_prompt_boundary_count": 0,
     }
 
 
@@ -30,24 +34,41 @@ def merge_projection_metrics(
     return merged
 
 
+def count_trace_trainer_rows(samples: Iterable[dict[str, Any]]) -> int:
+    row_count = 0
+    for sample in samples:
+        for raw_turn in sample.get("turns", []):
+            if (
+                isinstance(raw_turn, Mapping)
+                and str(raw_turn.get("role", "")).strip() == "assistant"
+                and isinstance(raw_turn.get("tool_call"), Mapping)
+            ):
+                row_count += 1
+        if str(sample.get("final_answer", "")).strip():
+            row_count += 1
+    return row_count
+
+
 def format_trace_rows(
     samples: Iterable[dict[str, Any]],
 ) -> tuple[list[dict[str, Any]], dict[str, int]]:
     rows: list[dict[str, Any]] = []
     metrics = new_projection_metrics()
     for sample in samples:
-        rows.append(format_trace_row(sample, metrics))
+        rows.extend(format_trace_row(sample, metrics))
     return rows, metrics
 
 
 def format_trace_row(
     sample: dict[str, Any],
     metrics: dict[str, int] | None = None,
-) -> dict[str, Any]:
+) -> list[dict[str, Any]]:
     counters = metrics if metrics is not None else new_projection_metrics()
     counters["sample_count"] += 1
 
-    messages: list[dict[str, str]] = []
+    context_messages: list[dict[str, str]] = []
+    rows: list[dict[str, Any]] = []
+    tools = copy.deepcopy(sample["tools"]) if isinstance(sample.get("tools"), list) else None
     media_refs = sample.get("media_refs")
     media_context = ""
     emitted_media_context = False
@@ -67,45 +88,100 @@ def format_trace_row(
                 if role == "system" and media_context and not emitted_media_context:
                     content = f"{media_context}\n\n{content}"
                     emitted_media_context = True
-                messages.append({"role": role, "content": content})
+                context_messages.append({"role": role, "content": content})
             continue
         if role == "assistant":
             content = _format_assistant_turn(raw_turn)
             if content:
                 if isinstance(raw_turn.get("tool_call"), dict):
                     counters["tool_call_count"] += 1
-                messages.append({"role": "assistant", "content": content})
+                    if media_context and not emitted_media_context:
+                        context_messages.insert(
+                            0, {"role": "system", "content": media_context}
+                        )
+                        emitted_media_context = True
+                    rows.append(
+                        _build_supervised_row(
+                            context_messages,
+                            {"role": "assistant", "content": content},
+                            tools=tools,
+                            trace_id=sample.get("trace_id"),
+                            trainable_kind="tool_call",
+                            counters=counters,
+                        )
+                    )
+                context_messages.append({"role": "assistant", "content": content})
             continue
         if role == "tool":
             content = _format_tool_turn(raw_turn)
             if content:
                 counters["tool_observation_count"] += 1
-                messages.append({"role": "tool", "content": content})
+                context_messages.append({"role": "tool", "content": content})
 
     if media_context and not emitted_media_context:
-        messages.insert(0, {"role": "system", "content": media_context})
+        context_messages.insert(0, {"role": "system", "content": media_context})
 
     final_answer = str(sample.get("final_answer", "")).strip()
     if final_answer:
         counters["final_answer_count"] += 1
         final_content = f"Final answer: {final_answer}"
-        if messages and messages[-1]["role"] == "assistant":
-            existing_content = messages[-1]["content"].strip()
+        if context_messages and context_messages[-1]["role"] == "assistant":
+            existing_content = context_messages[-1]["content"].strip()
             if existing_content == final_answer:
-                messages[-1] = {"role": "assistant", "content": final_content}
+                context_messages[-1] = {"role": "assistant", "content": final_content}
             elif final_content not in existing_content:
-                messages[-1] = {
+                context_messages[-1] = {
                     "role": "assistant",
                     "content": f"{existing_content}\n\n{final_content}",
                 }
         else:
-            messages.append({"role": "assistant", "content": final_content})
+            context_messages.append({"role": "assistant", "content": final_content})
 
+        if context_messages and context_messages[-1]["role"] == "assistant":
+            rows.append(
+                _build_supervised_row(
+                    context_messages[:-1],
+                    context_messages[-1],
+                    tools=tools,
+                    trace_id=sample.get("trace_id"),
+                    trainable_kind="final_answer",
+                    counters=counters,
+                )
+            )
+
+    return rows
+
+
+def _build_supervised_row(
+    prefix_messages: list[dict[str, str]],
+    assistant_message: dict[str, str],
+    *,
+    tools: list[Any] | None,
+    trace_id: Any,
+    trainable_kind: str,
+    counters: dict[str, int],
+) -> dict[str, Any]:
+    counters["trainer_row_count"] += 1
+    counters["response_only_boundary_count"] += 1
+    counters["mask_prompt_boundary_count"] += 1
     row: dict[str, Any] = {
-        "messages": messages,
+        "messages": [
+            copy.deepcopy(message)
+            for message in [*prefix_messages, assistant_message]
+        ],
+        "response_only_boundary": {
+            "policy_id": AGENTIC_SFT_BOUNDARY_POLICY_ID,
+            "mask_prompt": True,
+            "trainable_role": "assistant",
+            "trainable_kind": trainable_kind,
+            "trainable_message_index": len(prefix_messages),
+        },
     }
-    if isinstance(sample.get("tools"), list):
-        row["tools"] = copy.deepcopy(sample["tools"])
+    trace_id_value = str(trace_id or "").strip()
+    if trace_id_value:
+        row["response_only_boundary"]["trace_id"] = trace_id_value
+    if tools is not None:
+        row["tools"] = copy.deepcopy(tools)
     return row
 
 

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -25,6 +25,7 @@ from worker.model_ops.training_dataset import (
     HFDatasetFetcher,
     ResolvedTrainingDatasetPackage,
     resolve_training_dataset_package,
+    trainer_sample_counts,
     write_normalized_dataset_snapshot,
 )
 from worker.productization.lora_experiment_store import LoraExperimentStore
@@ -80,6 +81,9 @@ class LoRATrainingPipeline:
             sample_limit=_int_ext(request_ext, "sample_limit"),
             max_characters_per_sample=_int_ext(request_ext, "max_characters_per_sample"),
         )
+        trainer_sample_count, trainer_validation_sample_count = trainer_sample_counts(
+            dataset.package
+        )
 
         emit("normalize_config", 0.35)
         config = normalize_training_config(
@@ -87,8 +91,8 @@ class LoRATrainingPipeline:
             ext=request_ext,
             dataset_format=dataset.package.format,
             response_only_supported=dataset.package.response_only_supported,
-            sample_count=dataset.package.sample_count,
-            validation_sample_count=dataset.package.validation_sample_count,
+            sample_count=trainer_sample_count,
+            validation_sample_count=trainer_validation_sample_count,
         )
         _validate_alignment_inputs(
             config=config,
@@ -204,6 +208,8 @@ class LoRATrainingPipeline:
             "trainer_dataset_format": trainer_dataset_format,
             "dataset_version": dataset.package.version,
             "dataset_sample_count": dataset.package.sample_count,
+            "trainer_dataset_sample_count": normalized_snapshot.sample_count,
+            "trainer_dataset_validation_sample_count": normalized_snapshot.validation_sample_count,
             "dataset_source_manifest_path": str(dataset.package.manifest_path),
             "dataset_materialized_package_path": str(dataset.materialized_package_path),
             "dataset_cache_key": dataset.cache_key,

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -502,7 +502,7 @@ def normalize_training_config(
 
     response_only = _bool_value(
         ext.get("response_only", ""),
-        default=dataset_format == "chat_messages",
+        default=dataset_format in {"chat_messages", "agentic_tool_trace"},
     )
     if response_only and not response_only_supported:
         raise ModelOperationError(

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -248,7 +248,11 @@ def _build_training_dataset_package(
         normalized_samples=normalized_samples,
         normalized_validation_samples=normalized_validation_samples,
         validation_sample_count=len(normalized_validation_samples),
-        response_only_supported=format_name in {"chat_messages", "prompt_completion"},
+        response_only_supported=format_name in {
+            "chat_messages",
+            "prompt_completion",
+            "agentic_tool_trace",
+        },
         manifest_fields=dict(manifest) if format_name == "agentic_tool_trace" else None,
     )
 
@@ -544,6 +548,8 @@ def write_normalized_dataset_snapshot(
     trainer_format = dataset.format
     train_samples = dataset.normalized_samples
     validation_samples = dataset.normalized_validation_samples
+    trainer_sample_count = dataset.sample_count
+    trainer_validation_sample_count = dataset.validation_sample_count
     agentic_projection: dict[str, Any] = {}
     if dataset.format == "agentic_tool_trace":
         trainer_format = "chat_messages"
@@ -553,13 +559,20 @@ def write_normalized_dataset_snapshot(
         validation_samples, validation_projection_metrics = agentic_sft_formatter.format_trace_rows(
             dataset.normalized_validation_samples
         )
+        trainer_sample_count = len(train_samples)
+        trainer_validation_sample_count = len(validation_samples)
         agentic_projection = {
             "trainer_format": trainer_format,
             "agentic_sft_formatter": agentic_sft_formatter.AGENTIC_SFT_FORMATTER_ID,
+            "agentic_sft_boundary_policy": agentic_sft_formatter.AGENTIC_SFT_BOUNDARY_POLICY_ID,
             "agentic_trace_train_path": str(agentic_train_path),
             "agentic_trace_valid_path": (
                 str(agentic_valid_path) if dataset.normalized_validation_samples else ""
             ),
+            "source_trace_sample_count": dataset.sample_count,
+            "source_trace_validation_sample_count": dataset.validation_sample_count,
+            "trainer_sample_count": trainer_sample_count,
+            "trainer_validation_sample_count": trainer_validation_sample_count,
             "agentic_sft_projection_metrics": agentic_sft_formatter.merge_projection_metrics(
                 train_projection_metrics,
                 validation_projection_metrics,
@@ -571,8 +584,8 @@ def write_normalized_dataset_snapshot(
         "dataset_id": dataset.dataset_id,
         "format": dataset.format,
         "trainer_format": trainer_format,
-        "sample_count": dataset.sample_count,
-        "validation_sample_count": dataset.validation_sample_count,
+        "sample_count": trainer_sample_count,
+        "validation_sample_count": trainer_validation_sample_count,
         "version": dataset.version,
         "source_manifest_path": str(dataset.manifest_path),
         "source_samples_path": str(dataset.samples_path),
@@ -607,10 +620,21 @@ def write_normalized_dataset_snapshot(
         samples_path=samples_path,
         train_path=train_path,
         valid_path=valid_path,
-        sample_count=dataset.sample_count,
-        validation_sample_count=dataset.validation_sample_count,
+        sample_count=trainer_sample_count,
+        validation_sample_count=trainer_validation_sample_count,
         format=dataset.format,
         trainer_format=trainer_format,
+    )
+
+
+def trainer_sample_counts(dataset: TrainingDatasetPackage) -> tuple[int, int]:
+    if dataset.format != "agentic_tool_trace":
+        return dataset.sample_count, dataset.validation_sample_count
+    return (
+        agentic_sft_formatter.count_trace_trainer_rows(dataset.normalized_samples),
+        agentic_sft_formatter.count_trace_trainer_rows(
+            dataset.normalized_validation_samples
+        ),
     )
 
 
@@ -1518,7 +1542,8 @@ def _resolve_dataset_build_source(
         "source_samples_path": str(source_path),
         "samples": normalized_samples,
         "validation_samples": [],
-        "response_only_supported": format_name in {"chat_messages", "prompt_completion"},
+        "response_only_supported": format_name
+        in {"chat_messages", "prompt_completion", "agentic_tool_trace"},
         "conversion_template": resolved_template,
         "hf_metadata": {},
     }
@@ -1838,6 +1863,7 @@ def _build_quality_and_token_stats(
     total_tokens: list[int] = []
     sample_count = 0
     is_prompt_completion = format_name == "prompt_completion"
+    is_agentic_tool_trace = format_name == "agentic_tool_trace"
     prompt_tokens_append = prompt_tokens.append
     completion_tokens_append = completion_tokens.append
     total_tokens_append = total_tokens.append
@@ -1849,12 +1875,12 @@ def _build_quality_and_token_stats(
     sample_token_counts = _sample_token_counts
     whitespace_token_count = _whitespace_token_count
     quality_report_sample_limit = _QUALITY_REPORT_SAMPLE_LIMIT
-    agentic_metrics = _new_agentic_trace_quality_metrics()
+    agentic_metrics = _new_agentic_trace_quality_metrics() if is_agentic_tool_trace else None
     for index, sample in enumerate(samples):
         sample_count += 1
         if is_prompt_completion:
             sample_identity = prompt_completion_duplicate_key(sample)
-        elif format_name == "agentic_tool_trace":
+        elif is_agentic_tool_trace:
             sample_identity = _agentic_trace_duplicate_key(sample)
         else:
             sample_identity = canonical_sample_digest(sample)
@@ -1873,7 +1899,7 @@ def _build_quality_and_token_stats(
             dirty_count += 1
             if len(dirty_samples) < quality_report_sample_limit:
                 dirty_samples_append({"index": index, "reasons": reasons})
-        if format_name == "agentic_tool_trace":
+        if is_agentic_tool_trace and agentic_metrics is not None:
             _update_agentic_trace_quality_metrics(
                 agentic_metrics,
                 sample,
@@ -1899,7 +1925,7 @@ def _build_quality_and_token_stats(
         "dirty_count": dirty_count,
         "dirty_samples": dirty_samples,
     }
-    if format_name == "agentic_tool_trace":
+    if is_agentic_tool_trace and agentic_metrics is not None:
         trace_count = agentic_metrics["agentic_trace_count"]
         if trace_count > 0:
             agentic_metrics["trace_turn_count_avg"] = round(


### PR DESCRIPTION
## Summary
- Split `agentic_tool_trace` LoRA SFT projection into one trainer chat row per assistant tool-call span plus one final-answer row so MLX-LM `mask_prompt` trains only the intended assistant span.
- Persist response-only boundary metadata, trainer/source sample counts, and boundary projection metrics in normalized dataset and adapter manifests.
- Update the agentic trajectory contract, LoRA plan, and Phase 8 runbook with the split-row boundary policy and evidence expectations.
- Address review feedback by avoiding redundant deep copies while preserving row isolation for flat message dictionaries.
- Merge the latest `origin/main` before final PR verification.

Closes #687.

## Plan or Spec
- `docs/plans/2026-05-20-agentic-lora-sft-formatting.md`
- `docs/agentic-trajectory-dataset-contract.md`
- `docs/runbooks/phase-8-lora-adapter-workflow.md`
- Issue #687

## Commands Run
```text
PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_training_dataset_builder.py::test_agentic_tool_trace_fixture_loads_and_reports_quality_metrics services/mlx-worker-python/tests/test_training_dataset_builder.py::test_build_quality_and_token_stats_uses_prompt_completion_fast_path services/mlx-worker-python/tests/test_training_dataset_builder.py::test_build_quality_and_token_stats_uses_prompt_completion_duplicate_key_fast_path services/mlx-worker-python/tests/test_write_normalized_dataset_snapshot_applies_manifest_overrides services/mlx-worker-python/tests/test_agentic_sft_formatter.py -q
# 5 passed in 0.05s
# Note: the first command above was rerun locally with the correct test path during implementation evidence capture.

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_agentic_sft_formatter.py services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_applies_manifest_overrides services/mlx-worker-python/tests/test_trajectory_provenance.py::test_train_lora_records_agentic_trajectory_provenance_in_adapter_manifest -q
# review-fix rerun: 3 passed in 0.23s
# after origin/main merge: 3 passed in 0.23s

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --include='*/worker/model_ops/agentic_sft_formatter.py,*/worker/model_ops/training_dataset.py,*/worker/model_ops/lora_training_pipeline.py,*/worker/model_ops/training_config.py' -m pytest services/mlx-worker-python/tests/test_agentic_sft_formatter.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_trajectory_provenance.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py -q && PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report --include='*/worker/model_ops/agentic_sft_formatter.py,*/worker/model_ops/training_dataset.py,*/worker/model_ops/lora_training_pipeline.py,*/worker/model_ops/training_config.py'
# first run: 293 passed, 2 warnings in 5.25s; changed-scope coverage total 99%
# review-fix rerun: 293 passed, 2 warnings in 5.03s; changed-scope coverage total 99%
# after origin/main merge: 293 passed, 2 warnings in 5.09s; changed-scope coverage total 99%

make swift-test
# first pre-commit: completed rc=0 elapsed=199.0s
# review-fix pre-commit: completed rc=0 elapsed=191.6s
# after origin/main merge: completed rc=0

make py-test
# first pre-commit: 2850 passed, 14 skipped, 2 warnings in 124.76s; completed rc=0 elapsed=125.2s
# review-fix pre-commit: 2850 passed, 14 skipped, 2 warnings in 121.97s; completed rc=0 elapsed=122.4s
# after origin/main merge: 2851 passed, 14 skipped, 2 warnings in 126.55s

make integration-test
# first pre-commit: 114 passed, 1 skipped in 311.88s; completed rc=0 elapsed=312.6s
# review-fix pre-commit: 114 passed, 1 skipped in 308.36s; completed rc=0 elapsed=309.2s
# after origin/main merge: 114 passed, 1 skipped in 603.37s

git diff --check
# passed

git diff --cached --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `agentic_sft_formatter.py` 100%, `lora_training_pipeline.py` 100%, `training_config.py` 97%, `training_dataset.py` 99%, total 99%.
- Pre-commit changed-line coverage: selected direct/gated probes all passed at 100% for measurable changed lines.
- First PR-scoped performance report: `.runtime/pre-commit-performance/20260519-213905-bc78f3ea/report/report.md`.
- First performance report status: `ok`; changed files 10; selected probes 5; direct/gated probes 5; regressions 0; context regressions 0; verification failures 0.
- First probe results: training-config target-module cache ok; training-dataset quality/token summary ok; training-dataset validation split partial selection ok; training-dataset validation sample-limit loading ok; LoRA reward summary candidate min/max reuse ok.
- Review-fix performance report: `.runtime/pre-commit-performance/20260519-220001-4005688c/report/report.md`.
- Review-fix performance report status: `ok`; changed files 1; selected probes 0; direct/gated probes 0; regressions 0; context regressions 0; verification failures 0. No registered performance probes were selected for the one-file copy optimization.
- GitHub PR-scoped performance report after review fix: `ok`; changed files 10; selected probes 5; direct/gated probes 5; regressions 0; context regressions 0; verification failures 0.
- Observability mode: minimal offline artifact metadata. The new boundary metrics are written during dataset snapshot/training artifact preparation, not in the serving request path.
- Probe overhead: N/A for production serving path; formatter and manifest metrics run only on offline LoRA dataset preparation.

## Known Gaps
- No custom MLX-LM multi-span loss is introduced. The implementation intentionally uses split trainer rows because the locked MLX-LM dataset path exposes a single contiguous `mask_prompt` offset.
- No protobuf or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] The affected path has defined performance probes and target metrics.
- [x] Observability mode is identified for the changed path: `minimal` offline artifact metadata.
- [x] Probe overhead is recorded for observability changes, or `N/A` is stated explicitly with the reason.
- [x] Deferred debug, sampled, or evidence-mode work is called out instead of hidden in logs or screenshots.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Command outcomes are recorded.
- [x] Deferred work and known gaps are stated explicitly.
