### PR TITLE
perf: slot response-only boundary records

### DIFF
--- a/docs/plans/2026-05-19-response-only-boundary-slots.md
+++ b/docs/plans/2026-05-19-response-only-boundary-slots.md
@@ -1,0 +1,48 @@
+# Response-only boundary slotted records
+
+## Scope
+
+This Python-only performance slice targets the response-only boundary records used
+by LoRA dataset preparation and trainer manifest aggregation:
+
+- `services/mlx-worker-python/worker/model_ops/response_only_boundary.py`
+- `services/mlx-worker-python/tests/test_response_only_boundary.py`
+- `scripts/response_only_boundary_slots_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+The slice keeps response-only masking semantics unchanged. It only removes
+per-instance `__dict__` allocation from the immutable boundary and aggregate
+records by using slotted dataclasses.
+
+## Registered probe
+
+Registered probe: `response-only-boundary-slotted-records`.
+
+The probe constructs a synthetic 50k-boundary workload and aggregates it with the
+same public helper used by LoRA manifest metric collection. It reports:
+
+- `construction_elapsed_ms_mean`
+- `aggregation_elapsed_ms_mean`
+- `peak_bytes_mean`
+- `instance_dict_count_mean`
+
+The focused test and coverage commands in `infra/perf/pr_scoped_probes.json`
+exercise the non-tokenizer aggregate path, the slotted-record regression test,
+probe selection, probe JSON execution, and registry validation.
+
+## Verification plan
+
+1. Run the focused registered pytest command locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run the registered probe locally on `origin/main` and the head branch to
+   compare construction, aggregation, peak memory, and instance dict metrics.
+4. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Acceptance criteria
+
+- `ResponseOnlyBoundary` and `ResponseOnlyBoundaryAggregate` do not expose an
+  instance `__dict__`.
+- Existing response-only aggregate behavior remains unchanged.
+- Local probe shows lower or equal object-allocation structural cost
+  (`instance_dict_count_mean == 0.0` on head) and no functional checksum drift.
+- PR-scoped performance CI completes the registered probe successfully.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3731,6 +3731,49 @@
     ]
   },
   {
+    "id": "response-only-boundary-slotted-records",
+    "name": "Response-only boundary slotted records",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/response_only_boundary.py",
+      "services/mlx-worker-python/tests/test_response_only_boundary.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/response_only_boundary_slots_probe.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/response_only_boundary.py services/mlx-worker-python/tests/test_response_only_boundary.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/response_only_boundary_slots_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/response_only_boundary_slots_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "construction_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "aggregation_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "instance_dict_count_mean",
+        "unit": "instances",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "tool-registry-schema-bytes-cache",
     "name": "Tool registry schema byte-count cache",
     "runner": "ubuntu-latest",

--- a/scripts/response_only_boundary_slots_probe.py
+++ b/scripts/response_only_boundary_slots_probe.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(os.environ.get("MELIX_PROBE_REPO_ROOT", Path.cwd())).resolve()
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.model_ops.response_only_boundary import (  # noqa: E402
+    ResponseOnlyBoundary,
+    aggregate_response_only_boundaries,
+)
+
+
+def _build_boundaries(count: int) -> tuple[ResponseOnlyBoundary, ...]:
+    return tuple(
+        ResponseOnlyBoundary(
+            assistant_offset=16 + (index % 257),
+            total_tokens=16 + (index % 257) + 8 + (index % 97),
+        )
+        for index in range(count)
+    )
+
+
+def _measure(boundary_count: int, sample_count: int) -> dict[str, float]:
+    construction_elapsed_samples: list[float] = []
+    aggregation_elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    instance_dict_samples: list[float] = []
+    checksum = 0
+
+    for _ in range(sample_count):
+        tracemalloc.start()
+        construction_started = time.perf_counter()
+        boundaries = _build_boundaries(boundary_count)
+        construction_elapsed_samples.append((time.perf_counter() - construction_started) * 1000.0)
+        _, construction_peak = tracemalloc.get_traced_memory()
+
+        instance_dict_samples.append(
+            float(sum(1 for boundary in boundaries if hasattr(boundary, "__dict__")))
+        )
+
+        aggregation_started = time.perf_counter()
+        aggregate = aggregate_response_only_boundaries(boundaries, max_seq_length=192)
+        aggregation_elapsed_samples.append((time.perf_counter() - aggregation_started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        peak_samples.append(float(max(peak, construction_peak)))
+        checksum += (
+            aggregate.sample_count
+            + aggregate.boundary_min
+            + aggregate.boundary_max
+            + aggregate.trainable_response_token_count
+        )
+
+    return {
+        "construction_elapsed_ms_mean": statistics.fmean(construction_elapsed_samples),
+        "aggregation_elapsed_ms_mean": statistics.fmean(aggregation_elapsed_samples),
+        "peak_bytes_mean": statistics.fmean(peak_samples),
+        "instance_dict_count_mean": statistics.fmean(instance_dict_samples),
+        "boundary_count": float(boundary_count),
+        "sample_count": float(sample_count),
+        "checksum": float(checksum),
+    }
+
+
+def main() -> int:
+    boundary_count = int(os.environ.get("MELIX_RESPONSE_BOUNDARY_SLOT_PROBE_COUNT", "50000"))
+    sample_count = int(os.environ.get("MELIX_RESPONSE_BOUNDARY_SLOT_PROBE_SAMPLES", "5"))
+    print(json.dumps(_measure(boundary_count, sample_count), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -484,6 +484,33 @@ def test_scope_report_selects_training_dataset_chunker_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "training-dataset-chunker-top-level-base-copy"
 
 
+def test_scope_report_selects_response_only_boundary_slots_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=[
+            "services/mlx-worker-python/worker/model_ops/response_only_boundary.py"
+        ],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "response-only-boundary-slotted-records"
+
+
+def test_response_only_boundary_slots_probe_script_emits_metrics() -> None:
+    probe = next(
+        probe
+        for probe in load_probe_registry(REGISTRY_PATH)
+        if probe.probe_id == "response-only-boundary-slotted-records"
+    )
+
+    metrics = _probe_command_json(probe=probe, repo_root=REPO_ROOT)
+
+    assert metrics["construction_elapsed_ms_mean"] > 0
+    assert metrics["aggregation_elapsed_ms_mean"] > 0
+    assert metrics["instance_dict_count_mean"] == 0.0
+    assert metrics["boundary_count"] == 50000.0
+
+
 def test_scope_report_selects_quantization_qat_source_scan_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -2412,6 +2439,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "statistical-evidence-bootstrap-single-sort",
         "statistical-evidence-category-breakdown-single-pass",
         "text-family-config-copy-elision",
+        "response-only-boundary-slotted-records",
         "tool-registry-schema-bytes-cache",
         "tool-registry-select-name-index-cache",
         "tool-registry-names-snapshot-cache",

--- a/services/mlx-worker-python/tests/test_response_only_boundary.py
+++ b/services/mlx-worker-python/tests/test_response_only_boundary.py
@@ -361,6 +361,16 @@ def test_aggregate_response_only_boundaries_handles_empty_and_full() -> None:
     }
 
 
+def test_response_only_boundary_records_are_slotted() -> None:
+    boundary = ResponseOnlyBoundary(assistant_offset=8, total_tokens=10)
+    aggregate = aggregate_response_only_boundaries([boundary])
+
+    assert not hasattr(boundary, "__dict__")
+    assert not hasattr(aggregate, "__dict__")
+    assert boundary.response_tokens == 2
+    assert aggregate.trainable_response_token_count == 2
+
+
 def test_aggregate_response_only_boundaries_marks_truncated_labels() -> None:
     boundaries = [
         ResponseOnlyBoundary(assistant_offset=8, total_tokens=10),

--- a/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
+++ b/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
@@ -40,7 +40,7 @@ class _ChatTemplateTokenizer(Protocol):
         ...
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ResponseOnlyBoundary:
     """Per-sample response-only boundary record persisted in the manifest."""
 
@@ -61,7 +61,7 @@ class ResponseOnlyBoundary:
         return max(0, effective_total - self.assistant_offset)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ResponseOnlyBoundaryAggregate:
     """Aggregate stats computed across a normalized-dataset pass."""
 


### PR DESCRIPTION
## Summary
- Add the registered `response-only-boundary-slotted-records` PR-scoped performance probe for response-only boundary aggregation.
- Convert `ResponseOnlyBoundary` and `ResponseOnlyBoundaryAggregate` to slotted frozen dataclasses to remove per-instance `__dict__` allocation while preserving manifest semantics.
- Add focused regression coverage for slotted records, probe selection, and probe JSON metrics.

## Plan or Spec
- `docs/plans/2026-05-19-response-only-boundary-slots.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 8 passed, 1 skipped

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/response_only_boundary.py services/mlx-worker-python/tests/test_response_only_boundary.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/response_only_boundary_slots_probe.py
# 8 passed, 1 skipped; changed-scope coverage TOTAL 20 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id response-only-boundary-slotted-records --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base --head-repo "$PWD" --output .runtime/pr-perf/response-only-boundary-slots.json
# ok; base/head probe completed successfully

git diff --check
# ok
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 20 0 100%`).
- Local registered probe (`response-only-boundary-slotted-records`, 50k boundaries × 5 samples):
  - `construction_elapsed_ms_mean`: base `156.184`, head `137.390`, delta `-18.795 ms` (`-12.034%`).
  - `peak_bytes_mean`: base `8,144,092.8`, head `3,422,112.0`, delta `-4,721,980.8 bytes` (`-57.980%`).
  - `instance_dict_count_mean`: base `50,000.0`, head `0.0`, delta `-50,000` (`-100%`).
  - `aggregation_elapsed_ms_mean`: base `324.581`, head `334.736`, delta `+10.156 ms` (`+3.129%`), within the registered 5% warning threshold; checksum unchanged (`7,970,445`).
- CI PR-scoped performance is still required as the merge gate for the registered probe report.

## Known Gaps
- One tokenizer-backed response-only fixture test skipped locally because the cached tokenizer is not present in this Linux worktree; the focused non-tokenizer aggregate/probe path passed locally.
- No Swift runtime validation is applicable; this is a Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
