### PR TITLE
perf: inline response boundary aggregate counts

### DIFF
--- a/docs/plans/2026-05-19-response-only-boundary-slots.md
+++ b/docs/plans/2026-05-19-response-only-boundary-slots.md
@@ -10,9 +10,12 @@ by LoRA dataset preparation and trainer manifest aggregation:
 - `scripts/response_only_boundary_slots_probe.py`
 - `infra/perf/pr_scoped_probes.json`
 
-The slice keeps response-only masking semantics unchanged. It only removes
+The original slice kept response-only masking semantics unchanged while removing
 per-instance `__dict__` allocation from the immutable boundary and aggregate
-records by using slotted dataclasses.
+records by using slotted dataclasses. The 2026-05-20 follow-up keeps the same
+registered probe and inlines response-token and truncation arithmetic inside the
+single-pass aggregate loop to avoid repeated property/method dispatch per
+boundary record.
 
 ## Registered probe
 

--- a/services/mlx-worker-python/tests/test_response_only_boundary.py
+++ b/services/mlx-worker-python/tests/test_response_only_boundary.py
@@ -364,11 +364,16 @@ def test_aggregate_response_only_boundaries_handles_empty_and_full() -> None:
 def test_response_only_boundary_records_are_slotted() -> None:
     boundary = ResponseOnlyBoundary(assistant_offset=8, total_tokens=10)
     aggregate = aggregate_response_only_boundaries([boundary])
+    over_offset_aggregate = aggregate_response_only_boundaries(
+        [ResponseOnlyBoundary(assistant_offset=12, total_tokens=10)]
+    )
 
     assert not hasattr(boundary, "__dict__")
     assert not hasattr(aggregate, "__dict__")
     assert boundary.response_tokens == 2
     assert aggregate.trainable_response_token_count == 2
+    assert over_offset_aggregate.response_tokens_max == 0
+    assert over_offset_aggregate.trainable_response_token_count == 0
 
 
 def test_aggregate_response_only_boundaries_marks_truncated_labels() -> None:

--- a/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
+++ b/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
@@ -166,10 +166,21 @@ def aggregate_response_only_boundaries(
     total_trainable_response_tokens = 0
     truncated_response_sample_count = 0
     fully_truncated_response_sample_count = 0
+    has_truncation_limit = max_seq_length is not None and max_seq_length > 0
+    effective_limit = max_seq_length if has_truncation_limit else 0
     for entry in boundaries:
         offset = entry.assistant_offset
-        response_tokens = entry.response_tokens
-        trainable_response_tokens = entry.trainable_response_tokens(max_seq_length)
+        total_tokens = entry.total_tokens
+        response_tokens = total_tokens - offset
+        if response_tokens < 0:
+            response_tokens = 0
+        if has_truncation_limit:
+            effective_total = total_tokens if total_tokens < effective_limit else effective_limit
+        else:
+            effective_total = total_tokens
+        trainable_response_tokens = effective_total - offset
+        if trainable_response_tokens < 0:
+            trainable_response_tokens = 0
         if sample_count == 0:
             boundary_min = offset
             boundary_max = offset


### PR DESCRIPTION
## Summary
- Inline response-token and truncation arithmetic inside `aggregate_response_only_boundaries` to avoid repeated property/method dispatch per boundary record.
- Extend the focused slotted-record regression to pin the over-offset clamp behavior covered by the inline path.
- Update the response-only boundary performance plan with this follow-up slice.

## Plan or Spec
- `docs/plans/2026-05-19-response-only-boundary-slots.md`
- Registered probe: `response-only-boundary-slotted-records`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` — 8 passed, 1 skipped
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/response_only_boundary.py services/mlx-worker-python/tests/test_response_only_boundary.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/response_only_boundary_slots_probe.py` — TOTAL 15 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/response_only_boundary_slots_probe.py`
- `git diff --check`

## Coverage and Metrics
- Changed-line coverage: 100.00% aggregate changed-line coverage (`TOTAL 15 0 100%`).
- Local Linux registered probe baseline from `origin/main` before the change: `aggregation_elapsed_ms_mean=305.9007644187659`, `construction_elapsed_ms_mean=124.53029779717326`, `peak_bytes_mean=3422112.0`, `checksum=7970445.0`.
- Local Linux registered probe after the change: `aggregation_elapsed_ms_mean=261.2320340704173`, `construction_elapsed_ms_mean=125.7202249020338`, `peak_bytes_mean=3422112.0`, `checksum=7970445.0`.
- Aggregation delta: `-44.66873034834862 ms` (~14.60% faster) on the synthetic 50k-boundary registered probe workload.

## Known Gaps
- Local validation is Linux-only. This slice is Python-only, so Swift runtime effects are not applicable.
- GitHub Actions PR-scoped performance must still complete successfully before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally and showed improved aggregation time without checksum drift.
- [ ] PR-scoped performance workflow completed successfully in CI.
