### PR TITLE
perf: cache tool registry required list snapshot

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -46,6 +46,23 @@ Expected effect:
 - preserve mutation isolation for returned schema payload dictionaries and
   protobuf configs.
 
+## Follow-up Slice: Cached Required-Argument List Copy
+
+The 2026-05-20 follow-up keeps the same `ToolDescriptor.schema_payload()` API
+and copy-on-return behavior, but stores the required argument snapshot in both
+tuple and list form during descriptor initialization. `required_arguments`
+continues to expose the immutable tuple, while `schema_payload()` can copy the
+prebuilt list directly instead of rebuilding a list from the tuple on every
+call.
+
+Expected effect:
+
+- reduce repeated schema payload construction overhead measured by
+  `schema_payload_elapsed_ms_mean`;
+- keep returned schema payloads independently mutable;
+- leave registry selection, protobuf config serialization, and tool definitions
+  unchanged.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -71,6 +71,9 @@ class ToolDescriptor:
     observation_kind: str
     arguments: tuple[ToolArgumentDescriptor, ...]
     _cached_required_arguments: tuple[str, ...] = field(default=(), init=False, repr=False)
+    _cached_required_arguments_list: list[str] = field(
+        default_factory=list, init=False, repr=False
+    )
     _cached_schema_properties: tuple[tuple[str, dict[str, Any]], ...] = field(
         default=(), init=False, repr=False
     )
@@ -102,6 +105,7 @@ class ToolDescriptor:
             argument_names.add(argument.name)
         required_arguments = tuple(argument.name for argument in self.arguments if argument.required)
         object.__setattr__(self, "_cached_required_arguments", required_arguments)
+        object.__setattr__(self, "_cached_required_arguments_list", list(required_arguments))
         schema_properties = tuple(
             (argument.name, argument.json_schema()) for argument in self.arguments
         )
@@ -116,12 +120,12 @@ class ToolDescriptor:
 
     def schema_payload(self) -> dict[str, Any]:
         schema_properties = self._cached_schema_properties
-        required_arguments = self._cached_required_arguments
+        required_arguments = self._cached_required_arguments_list
         return {
             "type": "object",
             "additionalProperties": False,
             "properties": {name: schema.copy() for name, schema in schema_properties},
-            "required": list(required_arguments),
+            "required": required_arguments.copy(),
         }
 
     def json_schema(self) -> str:


### PR DESCRIPTION
## Summary
- Cache a prebuilt required-argument list snapshot on `ToolDescriptor`.
- Keep `required_arguments` tuple semantics and `schema_payload()` copy-on-return behavior unchanged.
- Update the tool-registry schema payload plan with this follow-up slice.

## Plan or Spec
- Updated `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md` with the cached required-argument list copy slice.
- Affected path is covered by the registered PR-scoped probe `tool-registry-schema-bytes-cache` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=20000 MELIX_TOOL_REGISTRY_METRICS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-schema-bytes-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/tool-registry-required-list-probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 50 passed locally.
- Registered probe head verification: 51 passed, changed-scope coverage 100% (3/3 changed measurable lines).
- Local registered probe comparison (`tool-registry-schema-bytes-cache`, 20k iterations x 5 samples):
  - `schema_payload_elapsed_ms_mean`: base 82.166 ms -> head 74.048 ms (delta -8.119 ms, ~9.9% faster).
  - `elapsed_ms_mean`: base 2.148 ms -> head 2.146 ms (neutral).
  - `json_schema_calls_mean`: base 0.0 -> head 0.0.
  - `schema_byte_count_calls_mean`: base 0.0 -> head 0.0.

## Known Gaps
- This is a Python-only slice validated locally on Linux. Swift runtime effects are not applicable.
- CI PR-scoped performance remains the required merge gate for registered base-vs-head validation.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows neutral-to-improved metrics.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
