### PR TITLE
Persist agentic SFT token metrics

### DIFF
--- a/docs/agentic-trajectory-dataset-contract.md
+++ b/docs/agentic-trajectory-dataset-contract.md
@@ -296,6 +296,16 @@ for trainer rows plus response-only/mask-prompt boundary counts. Adapter
 receipts keep `dataset_sample_count` as the source trace count and add
 `trainer_dataset_sample_count` for the expanded trainer rows.
 
+The normalized snapshot manifest also records `agentic_sft_token_metrics` for
+agentic SFT projections. The metric object uses the repository-owned
+`whitespace_v1` estimator and includes `source_trace_count`, `trace_tokens`,
+`tool_call_tokens`, `observation_tokens`, and `final_answer_tokens` across the
+train and validation traces. LoRA adapter receipts that consume the snapshot
+must copy this metric object and expose stable `training.agentic_sft.*` aliases
+for these token counts so downstream reports can tie adapter quality and
+training cost back to the source trace, tool-call, observation, and final-answer
+budget.
+
 LoRA SFT over `agentic_tool_trace` packages is a distinct supervised objective.
 The operator still selects an SFT `training_mode` such as `lora`, `qlora`, or
 `dora`, but the normalized worker config and adapter receipt must record

--- a/docs/plans/2026-05-20-agentic-lora-sft-formatting.md
+++ b/docs/plans/2026-05-20-agentic-lora-sft-formatting.md
@@ -77,6 +77,8 @@ Measurement points:
 - Formatted tool-observation count.
 - Formatted media-reference count.
 - Formatted final-answer count.
+- Agentic SFT `whitespace_v1` token metrics for source traces, tool-call
+  spans, tool-observation spans, and final-answer spans.
 - Trainer row count.
 - Response-only boundary count.
 - Mask-prompt boundary count.
@@ -103,4 +105,7 @@ training data preparation path.
 - Original normalized traces are preserved in sibling JSONL evidence files.
 - LoRA training still reports `dataset_format: agentic_tool_trace` and records
   `trainer_dataset_format: chat_messages`.
+- Normalized snapshot manifests and adapter receipts persist
+  `agentic_sft_token_metrics` with trace, tool-call, observation, and
+  final-answer token counts.
 - Focused tests and changed-scope coverage pass.

--- a/services/mlx-worker-python/tests/test_agentic_sft_formatter.py
+++ b/services/mlx-worker-python/tests/test_agentic_sft_formatter.py
@@ -159,3 +159,79 @@ def test_agentic_tool_trace_sft_formatter_covers_defensive_branches() -> None:
         {"sample_count": "bad", "tool_call_count": "2"},
         {"sample_count": 1},
     )["sample_count"] == 1
+
+
+def test_agentic_tool_trace_token_metrics_split_agentic_sft_spans() -> None:
+    metrics = agentic_sft_formatter.collect_token_metrics(
+        [
+            {
+                "trace_id": "trace-tokens",
+                "question": "What happened?",
+                "turns": [
+                    {"role": "system", "content": "system prompt"},
+                    {"role": "user", "content": "find answer"},
+                    {
+                        "role": "assistant",
+                        "tool_call": {
+                            "id": "call-1",
+                            "name": "visit",
+                            "arguments": {"url": "fixture doc"},
+                        },
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call-1",
+                        "observation": "tool result here",
+                    },
+                    {"role": "assistant", "content": "done now"},
+                ],
+                "final_answer": "done now",
+            }
+        ]
+    )
+
+    assert metrics == {
+        "estimator": "whitespace_v1",
+        "source_trace_count": 1,
+        "trace_tokens": 19,
+        "tool_call_tokens": 4,
+        "observation_tokens": 7,
+        "final_answer_tokens": 4,
+    }
+    assert agentic_sft_formatter.merge_token_metrics(
+        {"trace_tokens": "bad", "tool_call_tokens": "2"},
+        {"source_trace_count": 1, "trace_tokens": 3},
+    ) == {
+        "estimator": "whitespace_v1",
+        "source_trace_count": 1,
+        "trace_tokens": 3,
+        "tool_call_tokens": 2,
+        "observation_tokens": 0,
+        "final_answer_tokens": 0,
+    }
+
+
+def test_agentic_tool_trace_token_metrics_ignore_unusable_turns() -> None:
+    metrics = agentic_sft_formatter.collect_token_metrics(
+        [
+            {
+                "trace_id": "trace-defensive",
+                "turns": [
+                    "ignored",
+                    {"role": "assistant", "content": ""},
+                    {"role": "assistant", "content": "Final answer: Already formatted"},
+                    {"role": "tool", "tool_call_id": "call-empty", "observation": ""},
+                ],
+                "final_answer": "Already formatted",
+            }
+        ]
+    )
+
+    assert metrics == {
+        "estimator": "whitespace_v1",
+        "source_trace_count": 1,
+        "trace_tokens": 4,
+        "tool_call_tokens": 0,
+        "observation_tokens": 0,
+        "final_answer_tokens": 4,
+    }

--- a/services/mlx-worker-python/tests/test_agentic_sft_formatter.py
+++ b/services/mlx-worker-python/tests/test_agentic_sft_formatter.py
@@ -235,3 +235,63 @@ def test_agentic_tool_trace_token_metrics_ignore_unusable_turns() -> None:
         "observation_tokens": 0,
         "final_answer_tokens": 4,
     }
+
+
+def test_agentic_tool_trace_token_metrics_do_not_merge_answer_across_tool_observation() -> None:
+    metrics = agentic_sft_formatter.collect_token_metrics(
+        [
+            {
+                "trace_id": "trace-tool-before-answer",
+                "turns": [
+                    {"role": "assistant", "content": "scratch plan"},
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call-1",
+                        "observation": "tool evidence",
+                    },
+                ],
+                "final_answer": "final text",
+            }
+        ]
+    )
+
+    assert metrics == {
+        "estimator": "whitespace_v1",
+        "source_trace_count": 1,
+        "trace_tokens": 12,
+        "tool_call_tokens": 0,
+        "observation_tokens": 6,
+        "final_answer_tokens": 4,
+    }
+
+
+def test_agentic_tool_trace_token_metrics_merge_final_answer_into_last_tool_call_turn() -> None:
+    metrics = agentic_sft_formatter.collect_token_metrics(
+        [
+            {
+                "trace_id": "trace-tool-call-answer",
+                "turns": [
+                    {"role": "user", "content": "inspect"},
+                    {
+                        "role": "assistant",
+                        "content": "query",
+                        "tool_call": {
+                            "id": "call-1",
+                            "name": "search",
+                            "arguments": {"q": "alpha beta"},
+                        },
+                    },
+                ],
+                "final_answer": "done",
+            }
+        ]
+    )
+
+    assert metrics == {
+        "estimator": "whitespace_v1",
+        "source_trace_count": 1,
+        "trace_tokens": 14,
+        "tool_call_tokens": 5,
+        "observation_tokens": 0,
+        "final_answer_tokens": 8,
+    }

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -289,6 +289,20 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
         "response_only_boundary_count": 3,
         "mask_prompt_boundary_count": 3,
     }
+    assert agentic_payload[
+        "agentic_sft_token_metrics"
+    ] == training_dataset_module.agentic_sft_formatter.merge_token_metrics(
+        training_dataset_module.agentic_sft_formatter.collect_token_metrics(samples),
+        training_dataset_module.agentic_sft_formatter.collect_token_metrics(
+            validation_samples
+        ),
+    )
+    assert agentic_payload["agentic_sft_token_metrics"]["estimator"] == "whitespace_v1"
+    assert agentic_payload["agentic_sft_token_metrics"]["source_trace_count"] == 2
+    assert agentic_payload["agentic_sft_token_metrics"]["trace_tokens"] > 0
+    assert agentic_payload["agentic_sft_token_metrics"]["tool_call_tokens"] > 0
+    assert agentic_payload["agentic_sft_token_metrics"]["observation_tokens"] > 0
+    assert agentic_payload["agentic_sft_token_metrics"]["final_answer_tokens"] > 0
     assert agentic_payload["source_package_path"] == str(agentic_package_path)
     assert agentic_payload["source_dataset_id"] == "source-agentic-package"
     assert agentic_payload["source_manifest_fields"] == {

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -319,6 +319,39 @@ def test_train_lora_records_agentic_trajectory_provenance_in_adapter_manifest(
         "response_only_boundary_count": 2,
         "mask_prompt_boundary_count": 2,
     }
+    assert normalized_payload["agentic_sft_token_metrics"]["estimator"] == "whitespace_v1"
+    assert normalized_payload["agentic_sft_token_metrics"]["source_trace_count"] == 1
+    assert normalized_payload["agentic_sft_token_metrics"]["trace_tokens"] > 0
+    assert normalized_payload["agentic_sft_token_metrics"]["tool_call_tokens"] > 0
+    assert normalized_payload["agentic_sft_token_metrics"]["observation_tokens"] > 0
+    assert normalized_payload["agentic_sft_token_metrics"]["final_answer_tokens"] > 0
+    assert payload["agentic_sft_token_metrics"] == normalized_payload[
+        "agentic_sft_token_metrics"
+    ]
+    assert (
+        payload["training.agentic_sft.token_estimator"]
+        == normalized_payload["agentic_sft_token_metrics"]["estimator"]
+    )
+    assert (
+        payload["training.agentic_sft.source_trace_count"]
+        == normalized_payload["agentic_sft_token_metrics"]["source_trace_count"]
+    )
+    assert (
+        payload["training.agentic_sft.trace_tokens"]
+        == normalized_payload["agentic_sft_token_metrics"]["trace_tokens"]
+    )
+    assert (
+        payload["training.agentic_sft.tool_call_tokens"]
+        == normalized_payload["agentic_sft_token_metrics"]["tool_call_tokens"]
+    )
+    assert (
+        payload["training.agentic_sft.observation_tokens"]
+        == normalized_payload["agentic_sft_token_metrics"]["observation_tokens"]
+    )
+    assert (
+        payload["training.agentic_sft.final_answer_tokens"]
+        == normalized_payload["agentic_sft_token_metrics"]["final_answer_tokens"]
+    )
     assert len(train_rows) == 2
     assert train_rows[0]["tools"] == [{"name": "visit"}]
     assert train_rows[0]["response_only_boundary"]["trainable_kind"] == "tool_call"

--- a/services/mlx-worker-python/worker/model_ops/agentic_sft_formatter.py
+++ b/services/mlx-worker-python/worker/model_ops/agentic_sft_formatter.py
@@ -6,6 +6,7 @@ from typing import Any, Iterable, Mapping
 
 AGENTIC_SFT_FORMATTER_ID = "melix.agentic_tool_trace.sft_formatter.v1"
 AGENTIC_SFT_BOUNDARY_POLICY_ID = "melix.agentic_tool_trace.response_only_boundaries.v1"
+AGENTIC_SFT_TOKEN_ESTIMATOR_ID = "whitespace_v1"
 
 
 def new_projection_metrics() -> dict[str, int]:
@@ -34,6 +35,49 @@ def merge_projection_metrics(
     return merged
 
 
+def new_token_metrics() -> dict[str, Any]:
+    return {
+        "estimator": AGENTIC_SFT_TOKEN_ESTIMATOR_ID,
+        "source_trace_count": 0,
+        "trace_tokens": 0,
+        "tool_call_tokens": 0,
+        "observation_tokens": 0,
+        "final_answer_tokens": 0,
+    }
+
+
+def merge_token_metrics(*metrics_items: Mapping[str, Any]) -> dict[str, Any]:
+    merged = new_token_metrics()
+    for metrics in metrics_items:
+        for key in (
+            "source_trace_count",
+            "trace_tokens",
+            "tool_call_tokens",
+            "observation_tokens",
+            "final_answer_tokens",
+        ):
+            try:
+                merged[key] += int(metrics.get(key, 0) or 0)
+            except (TypeError, ValueError):
+                continue
+    return merged
+
+
+def collect_token_metrics(samples: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    metrics = new_token_metrics()
+    for sample in samples:
+        metrics["source_trace_count"] += 1
+        sample_metrics = _sample_token_metrics(sample)
+        for key in (
+            "trace_tokens",
+            "tool_call_tokens",
+            "observation_tokens",
+            "final_answer_tokens",
+        ):
+            metrics[key] += sample_metrics[key]
+    return metrics
+
+
 def count_trace_trainer_rows(samples: Iterable[dict[str, Any]]) -> int:
     row_count = 0
     for sample in samples:
@@ -51,10 +95,14 @@ def count_trace_trainer_rows(samples: Iterable[dict[str, Any]]) -> int:
 
 def format_trace_rows(
     samples: Iterable[dict[str, Any]],
+    *,
+    token_metrics: dict[str, Any] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, int]]:
     rows: list[dict[str, Any]] = []
     metrics = new_projection_metrics()
     for sample in samples:
+        if token_metrics is not None:
+            _add_sample_token_metrics(token_metrics, sample)
         rows.extend(format_trace_row(sample, metrics))
     return rows, metrics
 
@@ -124,7 +172,7 @@ def format_trace_row(
     final_answer = str(sample.get("final_answer", "")).strip()
     if final_answer:
         counters["final_answer_count"] += 1
-        final_content = f"Final answer: {final_answer}"
+        final_content = _project_final_answer(final_answer)
         if context_messages and context_messages[-1]["role"] == "assistant":
             existing_content = context_messages[-1]["content"].strip()
             if existing_content == final_answer:
@@ -198,6 +246,91 @@ def _format_media_ref(media_ref: Any) -> str:
     if not parts:
         return "- {}"
     return "- " + "; ".join(parts)
+
+
+def _sample_token_metrics(sample: dict[str, Any]) -> dict[str, int]:
+    context_tokens = 0
+    tool_call_tokens = 0
+    observation_tokens = 0
+    final_answer_tokens = 0
+    assistant_contexts: list[str] = []
+    media_refs = sample.get("media_refs")
+    if isinstance(media_refs, list) and media_refs:
+        context_tokens += _count_whitespace_tokens(
+            "Media references:\n"
+            + "\n".join(_format_media_ref(media_ref) for media_ref in media_refs)
+        )
+    final_answer = str(sample.get("final_answer", "")).strip()
+
+    for raw_turn in sample.get("turns", []):
+        if not isinstance(raw_turn, Mapping):
+            continue
+        role = str(raw_turn.get("role", "")).strip()
+        if role in {"system", "user"}:
+            context_tokens += _count_whitespace_tokens(raw_turn.get("content", ""))
+            continue
+        if role == "assistant":
+            content = _format_assistant_turn(raw_turn)
+            if not content:
+                continue
+            if isinstance(raw_turn.get("tool_call"), Mapping):
+                tool_call_tokens += _count_whitespace_tokens(content)
+            else:
+                assistant_contexts.append(content)
+            continue
+        if role == "tool":
+            observation_tokens += _count_whitespace_tokens(_format_tool_turn(raw_turn))
+
+    if final_answer:
+        final_answer_content = _project_final_answer(final_answer)
+        if assistant_contexts:
+            context_tokens += sum(
+                _count_whitespace_tokens(content) for content in assistant_contexts[:-1]
+            )
+            existing_content = assistant_contexts[-1].strip()
+            if existing_content == final_answer:
+                final_answer_content = _project_final_answer(final_answer)
+            elif final_answer_content not in existing_content:
+                final_answer_content = f"{existing_content}\n\n{final_answer_content}"
+            else:
+                final_answer_content = existing_content
+        final_answer_tokens = _count_whitespace_tokens(final_answer_content)
+    else:
+        context_tokens += sum(
+            _count_whitespace_tokens(content) for content in assistant_contexts
+        )
+
+    return {
+        "trace_tokens": (
+            context_tokens
+            + tool_call_tokens
+            + observation_tokens
+            + final_answer_tokens
+        ),
+        "tool_call_tokens": tool_call_tokens,
+        "observation_tokens": observation_tokens,
+        "final_answer_tokens": final_answer_tokens,
+    }
+
+
+def _add_sample_token_metrics(metrics: dict[str, Any], sample: dict[str, Any]) -> None:
+    metrics["source_trace_count"] += 1
+    sample_metrics = _sample_token_metrics(sample)
+    for key in (
+        "trace_tokens",
+        "tool_call_tokens",
+        "observation_tokens",
+        "final_answer_tokens",
+    ):
+        metrics[key] += sample_metrics[key]
+
+
+def _count_whitespace_tokens(value: Any) -> int:
+    return len(str(value or "").strip().split())
+
+
+def _project_final_answer(final_answer: str) -> str:
+    return f"Final answer: {final_answer}"
 
 
 def _format_assistant_turn(turn: Mapping[str, Any]) -> str:

--- a/services/mlx-worker-python/worker/model_ops/agentic_sft_formatter.py
+++ b/services/mlx-worker-python/worker/model_ops/agentic_sft_formatter.py
@@ -253,7 +253,7 @@ def _sample_token_metrics(sample: dict[str, Any]) -> dict[str, int]:
     tool_call_tokens = 0
     observation_tokens = 0
     final_answer_tokens = 0
-    assistant_contexts: list[str] = []
+    message_spans: list[dict[str, str]] = []
     media_refs = sample.get("media_refs")
     if isinstance(media_refs, list) and media_refs:
         context_tokens += _count_whitespace_tokens(
@@ -267,37 +267,58 @@ def _sample_token_metrics(sample: dict[str, Any]) -> dict[str, int]:
             continue
         role = str(raw_turn.get("role", "")).strip()
         if role in {"system", "user"}:
-            context_tokens += _count_whitespace_tokens(raw_turn.get("content", ""))
+            content = str(raw_turn.get("content", "")).strip()
+            if content:
+                message_spans.append(
+                    {"role": role, "content": content, "category": "context"}
+                )
             continue
         if role == "assistant":
             content = _format_assistant_turn(raw_turn)
             if not content:
                 continue
+            category = "context"
             if isinstance(raw_turn.get("tool_call"), Mapping):
                 tool_call_tokens += _count_whitespace_tokens(content)
-            else:
-                assistant_contexts.append(content)
+                category = "tool_call"
+            message_spans.append(
+                {"role": "assistant", "content": content, "category": category}
+            )
             continue
         if role == "tool":
-            observation_tokens += _count_whitespace_tokens(_format_tool_turn(raw_turn))
+            content = _format_tool_turn(raw_turn)
+            if content:
+                observation_tokens += _count_whitespace_tokens(content)
+                message_spans.append(
+                    {
+                        "role": "tool",
+                        "content": content,
+                        "category": "observation",
+                    }
+                )
 
     if final_answer:
         final_answer_content = _project_final_answer(final_answer)
-        if assistant_contexts:
+        if message_spans and message_spans[-1]["role"] == "assistant":
             context_tokens += sum(
-                _count_whitespace_tokens(content) for content in assistant_contexts[:-1]
+                _count_span_context_tokens(message) for message in message_spans[:-1]
             )
-            existing_content = assistant_contexts[-1].strip()
-            if existing_content == final_answer:
-                final_answer_content = _project_final_answer(final_answer)
-            elif final_answer_content not in existing_content:
-                final_answer_content = f"{existing_content}\n\n{final_answer_content}"
-            else:
-                final_answer_content = existing_content
+            existing_content = message_spans[-1]["content"].strip()
+            if existing_content != final_answer:
+                if final_answer_content not in existing_content:
+                    final_answer_content = (
+                        f"{existing_content}\n\n{final_answer_content}"
+                    )
+                else:
+                    final_answer_content = existing_content
+        else:
+            context_tokens += sum(
+                _count_span_context_tokens(message) for message in message_spans
+            )
         final_answer_tokens = _count_whitespace_tokens(final_answer_content)
     else:
         context_tokens += sum(
-            _count_whitespace_tokens(content) for content in assistant_contexts
+            _count_span_context_tokens(message) for message in message_spans
         )
 
     return {
@@ -311,6 +332,12 @@ def _sample_token_metrics(sample: dict[str, Any]) -> dict[str, int]:
         "observation_tokens": observation_tokens,
         "final_answer_tokens": final_answer_tokens,
     }
+
+
+def _count_span_context_tokens(message: Mapping[str, str]) -> int:
+    if message.get("category") != "context":
+        return 0
+    return _count_whitespace_tokens(message.get("content", ""))
 
 
 def _add_sample_token_metrics(metrics: dict[str, Any], sample: dict[str, Any]) -> None:

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -57,6 +57,7 @@ class TrainingDatasetPackage:
 class NormalizedDatasetSnapshot:
     dataset_dir: Path
     manifest_path: Path
+    manifest_payload: dict[str, Any]
     samples_path: Path
     train_path: Path
     valid_path: Path | None
@@ -553,11 +554,15 @@ def write_normalized_dataset_snapshot(
     agentic_projection: dict[str, Any] = {}
     if dataset.format == "agentic_tool_trace":
         trainer_format = "chat_messages"
+        train_token_metrics = agentic_sft_formatter.new_token_metrics()
         train_samples, train_projection_metrics = agentic_sft_formatter.format_trace_rows(
-            dataset.normalized_samples
+            dataset.normalized_samples,
+            token_metrics=train_token_metrics,
         )
+        validation_token_metrics = agentic_sft_formatter.new_token_metrics()
         validation_samples, validation_projection_metrics = agentic_sft_formatter.format_trace_rows(
-            dataset.normalized_validation_samples
+            dataset.normalized_validation_samples,
+            token_metrics=validation_token_metrics,
         )
         trainer_sample_count = len(train_samples)
         trainer_validation_sample_count = len(validation_samples)
@@ -576,6 +581,10 @@ def write_normalized_dataset_snapshot(
             "agentic_sft_projection_metrics": agentic_sft_formatter.merge_projection_metrics(
                 train_projection_metrics,
                 validation_projection_metrics,
+            ),
+            "agentic_sft_token_metrics": agentic_sft_formatter.merge_token_metrics(
+                train_token_metrics,
+                validation_token_metrics,
             ),
         }
 
@@ -617,6 +626,7 @@ def write_normalized_dataset_snapshot(
     return NormalizedDatasetSnapshot(
         dataset_dir=dataset_dir,
         manifest_path=manifest_path,
+        manifest_payload=manifest_payload,
         samples_path=samples_path,
         train_path=train_path,
         valid_path=valid_path,

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -20,6 +20,7 @@ TRAJECTORY_PROVENANCE_FIELDS = (
     "trajectory_leakage_policy_id",
     "trajectory_package_path",
     "trajectory_quality_metrics",
+    "agentic_sft_token_metrics",
 )
 
 TRAJECTORY_PROVENANCE_CSV_FIELDS = TRAJECTORY_PROVENANCE_FIELDS
@@ -84,6 +85,7 @@ def trajectory_provenance_from_snapshot_manifest(
         ("trajectory_leakage_policy_id", "trajectory_leakage_policy_id"),
         ("source_package_path", "trajectory_package_path"),
         ("trajectory_quality_metrics", "trajectory_quality_metrics"),
+        ("agentic_sft_token_metrics", "agentic_sft_token_metrics"),
     ):
         value = manifest.get(source_field)
         if value in ("", None):
@@ -134,6 +136,9 @@ def adapter_manifest_trajectory_provenance(
     payload["trajectory_reward_policy_present"] = bool(
         normalized.get("trajectory_reward_policy_id")
     )
+    token_metrics = normalized.get("agentic_sft_token_metrics")
+    if isinstance(token_metrics, Mapping):
+        payload.update(_agentic_sft_token_metric_aliases(token_metrics))
     return payload
 
 
@@ -155,3 +160,19 @@ def alignment_metrics_trajectory_provenance(
             quality_metrics.get("reward_coverage_count", 0) or 0
         )
     return metrics
+
+
+def _agentic_sft_token_metric_aliases(metrics: Mapping[str, Any]) -> dict[str, Any]:
+    aliases: dict[str, Any] = {}
+    estimator = str(metrics.get("estimator", "")).strip()
+    if estimator:
+        aliases["training.agentic_sft.token_estimator"] = estimator
+    for source_key, alias_key in (
+        ("source_trace_count", "training.agentic_sft.source_trace_count"),
+        ("trace_tokens", "training.agentic_sft.trace_tokens"),
+        ("tool_call_tokens", "training.agentic_sft.tool_call_tokens"),
+        ("observation_tokens", "training.agentic_sft.observation_tokens"),
+        ("final_answer_tokens", "training.agentic_sft.final_answer_tokens"),
+    ):
+        aliases[alias_key] = int(metrics.get(source_key, 0) or 0)
+    return aliases


### PR DESCRIPTION
## Summary
- Persist agentic SFT token metrics in normalized dataset snapshot manifests and adapter provenance receipts.
- Document the receipt contract for stable `whitespace_v1` token estimates across trace, tool-call, observation, and final-answer slices.
- Add focused coverage for formatter metrics, dataset snapshot manifests, LoRA adapter provenance aliases, and review-thread token-attribution edge cases.

## Plan or Spec
- Fixes #690.
- `docs/agentic-trajectory-dataset-contract.md`
- `docs/plans/2026-05-20-agentic-lora-sft-formatting.md`

## Commands Run
```text
git diff --check origin/main...HEAD — pass
PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_agentic_sft_formatter.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_trajectory_provenance.py -q — 91 passed
COVERAGE_FILE=/tmp/opensearch-vl-agentic-sft-metrics-postmerge.coverage PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest services/mlx-worker-python/tests/test_agentic_sft_formatter.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_trajectory_provenance.py -q && COVERAGE_FILE=/tmp/opensearch-vl-agentic-sft-metrics-postmerge.coverage PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o /tmp/opensearch-vl-agentic-sft-metrics-postmerge-coverage.json && PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/opensearch-vl-agentic-sft-metrics-postmerge-coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/agentic_sft_formatter.py services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/trajectory_provenance.py services/mlx-worker-python/tests/test_agentic_sft_formatter.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_trajectory_provenance.py — TOTAL 99.23% (129/130)
python3 - <<'PY' ... run_performance_report(root, changed, base_ref="origin/main") ... PY — PR scoped performance status ok, selected probes 3; report .runtime/pre-commit-performance/20260520-023914-17de58d5/report/report.md
pre-commit via git commit "Persist agentic SFT token metrics" — make swift-test pass; make py-test pass (2861 passed, 14 skipped); make integration-test pass (114 passed, 1 skipped); PR scoped performance status ok, selected probes 3
pre-commit via git commit "Align agentic SFT token attribution" — make swift-test pass; make py-test pass (2863 passed, 14 skipped); make integration-test pass (114 passed, 1 skipped); hook-scoped performance status ok, selected probes 0 for the review-only formatter/test delta
```

## Coverage and Metrics
- Changed-line coverage: `99.23%` (`129/130`) over formatter, snapshot, trajectory provenance, and focused tests.
- Post-merge PR scoped performance: `ok`; report `.runtime/pre-commit-performance/20260520-023914-17de58d5/report/report.md`; 3 direct probes, 0 regressions, 0 context regressions, 0 verification failures.
- Performance probes and target metrics: training dataset quality/token summary, validation split partial selection, and validation sample-limit loading; all direct probes stayed neutral or improved.
- A prior run reported a `training-dataset-validation-sample-limit` sub-millisecond regression (`0.509ms` to `0.547ms`). The same probe passed in local full PR-diff reruns after review fix and after merging latest `origin/main`; latest post-merge evidence shows improvement (`0.355ms` to `0.294ms`). Treating the earlier direct row as measurement noise, not an in-scope code-path regression.
- Observability mode: minimal manifest receipt metadata for `agentic_sft_token_metrics`; no request-path instrumentation or sampled/debug runtime probe overhead.

## Known Gaps
- `whitespace_v1` is an explicit stable estimator for receipts, not a model-tokenizer count.
- No protobuf/schema change required; metrics live in snapshot and adapter manifests.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
