### PR TITLE
perf: lower dataset json preview chunk size

### DIFF
--- a/docs/plans/2026-05-20-dataset-json-preview-chunk-size.md
+++ b/docs/plans/2026-05-20-dataset-json-preview-chunk-size.md
@@ -1,0 +1,46 @@
+# Dataset JSON Preview Chunk Size
+
+## Scope
+
+This Python-only performance slice is limited to the limited JSON preview reader
+in `services/mlx-worker-python/worker/dataset_registry/catalog.py`. It keeps the
+existing `read_hf_dataset_snapshot_rows(..., limit=N)` behavior unchanged for
+Hugging Face snapshot previews and does not change dataset discovery, split
+selection, supported formats, protobufs, or runtime APIs.
+
+## Optimization Hypothesis
+
+The limited JSON preview reader currently reads 64 KiB chunks before trying the
+incremental parser. The registered probe uses a large canonical `{"rows": [...]}`
+JSON file and requests a single preview row. For that common preview shape, the
+first row is near the beginning of the file, so a smaller default chunk should
+reduce transient string allocation and traced peak memory without increasing the
+number of reads needed by normal small-row previews.
+
+This slice lowers `_JSON_LIMITED_PREVIEW_CHUNK_CHARS` to 16 KiB. The existing
+loop still appends chunks until the requested rows are decoded, so large leading
+metadata or large first rows remain supported by falling through to additional
+bounded reads and, when needed, the existing full-payload fallback.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`dataset-registry-preview-limit-short-circuit` in
+`infra/perf/pr_scoped_probes.json`. The registry entry already has focused
+`test_command`, `coverage_command`, and `probe_command` entries for
+`catalog.py`, the dataset registry tests, the probe registry tests, and
+`scripts/dataset_registry_preview_limit_probe.py`.
+
+Primary metric: `peak_bytes_mean` (lower is better). Secondary metric:
+`elapsed_ms_mean` should remain neutral-to-improved.
+
+## Validation Plan
+
+1. Run the registered focused dataset preview tests locally on Linux.
+2. Run the registered changed-scope coverage command locally and require at
+   least 95% coverage for touched scope.
+3. Run the registered probe locally against `origin/main` and head via
+   `scripts/pr_scoped_performance_run.py` and compare `peak_bytes_mean` plus
+   `elapsed_ms_mean`.
+4. Use the GitHub PR-scoped performance workflow as the CI merge gate after the
+   PR is opened.

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -42,7 +42,7 @@ _DEFAULT_CONFIG_PARTS = frozenset({"data", "default"})
 _DEFAULT_CONFIG_FIRST_PARTS = frozenset(
     {"data", "train", "test", "validation", "valid", "dev"}
 )
-_JSON_LIMITED_PREVIEW_CHUNK_CHARS = 64 * 1024
+_JSON_LIMITED_PREVIEW_CHUNK_CHARS = 16 * 1024
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- Lower the limited JSON dataset preview read chunk from 64 KiB to 16 KiB.
- Keep preview row parsing behavior unchanged while reducing transient allocation for small-limit canonical `{"rows": [...]}` previews.

## Plan or Spec
- `docs/plans/2026-05-20-dataset-json-preview-chunk-size.md`
- Registered probe: `dataset-registry-preview-limit-short-circuit` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py` (baseline before change)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py` (head, repeated samples)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-registry-preview-limit-short-circuit --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/dataset_preview_chunk_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused registered coverage command passed via `pr_scoped_performance_run.py`: `20 passed in 1.67s`, changed-scope coverage `TOTAL 1 0 100%`.
- Registered local probe comparison:
  - base `peak_bytes_mean=137514.286`, head `peak_bytes_mean=39210.286` (`-98304 bytes`, about `-71.49%`).
  - base `elapsed_ms_mean=0.375756`, head `elapsed_ms_mean=0.336603` (`-0.039153 ms`, about `-10.42%`).
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- This is a Linux-verified Python slice; no Swift runtime behavior is touched.
- The chunk-size tradeoff is optimized for small preview limits. Very large leading metadata or first rows still use the existing repeated bounded-read loop and fallback path.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused local tests/coverage passed on Linux.
- [x] Registered local probe shows improved peak memory and elapsed mean.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
