### PR TITLE
perf: slot dataset file records

### DIFF
--- a/docs/plans/2026-05-20-dataset-registry-file-slots.md
+++ b/docs/plans/2026-05-20-dataset-registry-file-slots.md
@@ -1,0 +1,47 @@
+# Dataset Registry File Slots
+
+## Scope
+
+This Python-only performance slice is limited to the dataset snapshot file record
+path in `services/mlx-worker-python/worker/dataset_registry/catalog.py`.
+
+## Registered PR-scoped probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `dataset-registry-snapshot-inference-single-pass` in
+`infra/perf/pr_scoped_probes.json`. The entry declares focused `test_command`,
+`coverage_command`, and `probe_command` values for:
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_snapshot_probe.py`
+
+No probe registry change is required for this slice.
+
+## Optimization hypothesis
+
+Dataset snapshot construction creates one `DatasetFile` record per supported
+file before serializing the registry payload. `DatasetFile` instances are frozen
+value records and do not need per-instance `__dict__` storage. Enabling dataclass
+slots for this hot record should reduce peak allocation pressure during large
+snapshot scans while preserving field access, equality, and `to_dict()` behavior.
+
+## Verification plan
+
+1. Add a focused regression test that proves `DatasetFile` remains a frozen value
+   record, serializes through `to_dict()`, and no longer exposes a mutable
+   instance `__dict__`.
+2. Implement only `DatasetFile` slots.
+3. Run the registered focused pytest command locally on Linux.
+4. Run the registered changed-scope coverage command locally on Linux and require
+   at least 95 percent changed-scope coverage.
+5. Run `scripts/dataset_registry_snapshot_probe.py` before and after the change
+   and compare `peak_bytes_mean` and `elapsed_ms_mean`.
+6. Use GitHub Actions PR-scoped performance as the final registered probe gate
+   before merge.
+
+## Linux validation boundary
+
+This slice is Python-only and locally verifiable on Linux. No Swift runtime
+performance claims are made.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sys
 import types
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,7 @@ import worker.dataset_registry.catalog as catalog
 from worker.model_ops.errors import ModelOperationError
 from worker.dataset_registry.catalog import (
     DatasetCatalog,
+    DatasetFile,
     read_hf_dataset_snapshot_rows,
 )
 
@@ -36,6 +38,23 @@ def _write_hf_dataset_snapshot(
             handle.write("\n")
     (snapshot_dir / "README.md").write_text("# Dataset\n", encoding="utf-8")
     return snapshot_dir
+
+
+def test_dataset_file_is_frozen_slots_value_record() -> None:
+    dataset_file = DatasetFile(
+        relative_path="data/train-00000-of-00001.jsonl",
+        size_bytes=42,
+        file_format="jsonl",
+    )
+
+    assert not hasattr(dataset_file, "__dict__")
+    assert dataset_file.to_dict() == {
+        "relative_path": "data/train-00000-of-00001.jsonl",
+        "size_bytes": 42,
+        "file_format": "jsonl",
+    }
+    with pytest.raises(FrozenInstanceError):
+        dataset_file.size_bytes = 43  # type: ignore[misc]
 
 
 def test_dataset_catalog_discovers_default_huggingface_cache_snapshot(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -45,7 +45,7 @@ _DEFAULT_CONFIG_FIRST_PARTS = frozenset(
 _JSON_LIMITED_PREVIEW_CHUNK_CHARS = 16 * 1024
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class DatasetFile:
     relative_path: str
     size_bytes: int


### PR DESCRIPTION
## Summary
- Enable dataclass slots for the hot `DatasetFile` snapshot record to avoid per-file instance `__dict__` allocation during dataset catalog scans.
- Add a focused regression test covering frozen value semantics, `to_dict()`, and the no-`__dict__` allocation contract.

## Plan or Spec
- `docs/plans/2026-05-20-dataset-registry-file-slots.md`
- Registered probe: `dataset-registry-snapshot-inference-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
MELIX_DATASET_REGISTRY_PROBE_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py
# baseline on origin/main: exit 0; {"elapsed_ms_mean": 665.7549407798797, "file_count_mean": 2401.0, "legacy_inference_helper_calls_mean": 0.0, "peak_bytes_mean": 858465.0, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_file_is_frozen_slots_value_record services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_builds_snapshot_inference_in_one_pass
# exit 0; 2 passed in 0.19s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics
# exit 0; 47 passed in 0.69s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py
# exit 0; 47 passed in 0.33s; TOTAL 8 0 100%

MELIX_DATASET_REGISTRY_PROBE_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py
# head: exit 0; {"elapsed_ms_mean": 660.5420078616589, "file_count_mean": 2401.0, "legacy_inference_helper_calls_mean": 0.0, "peak_bytes_mean": 781053.2, "sample_count": 5.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 8 0 100%`).
- Local registered probe (`dataset_registry_snapshot_probe.py`, 5 samples):
  - `elapsed_ms_mean`: 665.755 ms -> 660.542 ms (`-5.213 ms`, `-0.78%`, lower is better).
  - `peak_bytes_mean`: 858,465.0 bytes -> 781,053.2 bytes (`-77,411.8 bytes`, `-9.02%`, lower is better).
  - `legacy_inference_helper_calls_mean`: 0.0 -> 0.0.
- CI PR-scoped performance is required as the final registered base-vs-head validation gate.

## Known Gaps
- Linux-local validation only; this slice is Python-only and makes no Swift runtime performance claims.
- Full repository gates were not run locally; the PR-scoped registered probe and GitHub Actions are the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability behavior change; existing PR-scoped probe was used.
- [x] Deferred work and known gaps are stated explicitly.
