### PR TITLE
Polish window UI workflows

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Branding/MelixDesignTokens.swift
+++ b/apps/macos-menubar/Sources/AppMain/Branding/MelixDesignTokens.swift
@@ -167,6 +167,11 @@ enum MelixDesignTokens {
         /// Slightly stronger hairline on interactive containers — composer
         /// boxes, tab strips. Spec permits 0.06–0.08 on these surfaces.
         static let interactive: Double = 0.08
+        /// Visible enough for dense forms where fields must not disappear into
+        /// surrounding card surfaces.
+        static let input: Double = 0.18
+        /// Focus ring for text entry and repeated operator configuration flows.
+        static let focusedInput: Double = 0.72
     }
 
     // MARK: - Status tints
@@ -234,6 +239,12 @@ enum MelixDesignTokens {
         static let xl: CGFloat = 20
         static let xxl: CGFloat = 24
         static let huge: CGFloat = 32
+    }
+
+    enum ControlMetrics {
+        /// Shared height for operator text fields and inline actions in dense
+        /// configuration rows.
+        static let operatorFieldHeight: CGFloat = 36
     }
 
     // MARK: - Typography
@@ -304,6 +315,33 @@ extension View {
     }
 }
 
+struct MelixOperatorTextFieldStyle: TextFieldStyle {
+    @FocusState private var isFocused: Bool
+
+    func _body(configuration: TextField<Self._Label>) -> some View {
+        configuration
+            .textFieldStyle(.plain)
+            .font(MelixDesignTokens.Typography.body)
+            .padding(.horizontal, MelixDesignTokens.Spacing.md)
+            .padding(.vertical, MelixDesignTokens.Spacing.sm)
+            .frame(minHeight: MelixDesignTokens.ControlMetrics.operatorFieldHeight)
+            .background(
+                RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.md, style: .continuous)
+                    .fill(MelixDesignTokens.Palette.backgroundSurface.color)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.md, style: .continuous)
+                    .stroke(
+                        isFocused
+                            ? MelixDesignTokens.accent.opacity(MelixDesignTokens.StrokeOpacity.focusedInput)
+                            : Color.primary.opacity(MelixDesignTokens.StrokeOpacity.input),
+                        lineWidth: isFocused ? 1.5 : 1
+                    )
+            )
+            .focused($isFocused)
+    }
+}
+
 /// Card container with a microhead section label. Replaces SwiftUI's
 /// default `GroupBox` for inspector/sidebar sections where the spec calls
 /// for the "Digital Broadsheet" header treatment.
@@ -325,5 +363,48 @@ struct MelixSectionCard<Content: View>: View {
         .padding(MelixDesignTokens.Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
         .melixCard()
+    }
+}
+
+struct MelixActionableEmptyState<Actions: View>: View {
+    let title: String
+    let systemImage: String
+    let detail: String
+    @ViewBuilder let actions: () -> Actions
+
+    var body: some View {
+        VStack(spacing: MelixDesignTokens.Spacing.md) {
+            Image(systemName: systemImage)
+                .font(.system(size: 28, weight: .medium))
+                .foregroundStyle(MelixDesignTokens.accent)
+                .frame(width: 46, height: 46)
+                .background(
+                    MelixDesignTokens.accent.opacity(MelixDesignTokens.AccentOpacity.weak),
+                    in: RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.xl, style: .continuous)
+                )
+
+            VStack(spacing: MelixDesignTokens.Spacing.xs) {
+                Text(title)
+                    .font(MelixDesignTokens.Typography.headline)
+                Text(detail)
+                    .font(MelixDesignTokens.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(3)
+            }
+
+            actions()
+                .controlSize(.small)
+        }
+        .padding(MelixDesignTokens.Spacing.xl)
+        .frame(maxWidth: .infinity, minHeight: 180)
+        .background(
+            MelixDesignTokens.Palette.backgroundSurface.color,
+            in: RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.xl, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.xl, style: .continuous)
+                .stroke(Color.primary.opacity(MelixDesignTokens.StrokeOpacity.hairline), lineWidth: 1)
+        )
     }
 }

--- a/apps/macos-menubar/Sources/AppMain/Branding/MelixDesignTokens.swift
+++ b/apps/macos-menubar/Sources/AppMain/Branding/MelixDesignTokens.swift
@@ -315,11 +315,11 @@ extension View {
     }
 }
 
-struct MelixOperatorTextFieldStyle: TextFieldStyle {
+struct MelixOperatorTextFieldModifier: ViewModifier {
     @FocusState private var isFocused: Bool
 
-    func _body(configuration: TextField<Self._Label>) -> some View {
-        configuration
+    func body(content: Content) -> some View {
+        content
             .textFieldStyle(.plain)
             .font(MelixDesignTokens.Typography.body)
             .padding(.horizontal, MelixDesignTokens.Spacing.md)
@@ -339,6 +339,12 @@ struct MelixOperatorTextFieldStyle: TextFieldStyle {
                     )
             )
             .focused($isFocused)
+    }
+}
+
+extension View {
+    func melixOperatorTextFieldStyle() -> some View {
+        modifier(MelixOperatorTextFieldModifier())
     }
 }
 

--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
@@ -257,11 +257,7 @@ struct DesktopChatSessionWorkspace: View {
                     Text(viewModel.selectedChatSession?.title ?? "Chat")
                         .font(.title2.weight(.semibold))
                     if let branch = viewModel.selectedChatSession?.displayBranchTitle {
-                        Text(branch)
-                            .font(.caption2)
-                            .padding(.horizontal, 7)
-                            .padding(.vertical, 3)
-                            .background(.quaternary, in: Capsule())
+                        DesktopChatSessionBranchBadgeView(branch: branch)
                     }
                 }
                 Spacer(minLength: 12)
@@ -431,6 +427,19 @@ struct DesktopChatSessionInspector: View {
             Spacer()
         }
         .padding(14)
+    }
+}
+
+struct DesktopChatSessionBranchBadgeView: View {
+    let branch: String
+
+    var body: some View {
+        Text(branch)
+            .font(.caption2)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(.quaternary, in: Capsule())
+            .accessibilityLabel(branch)
     }
 }
 

--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
@@ -145,15 +145,21 @@ struct DesktopChatTabView: View {
 struct DesktopChatSessionSidebar: View {
     let viewModel: RuntimeViewModel
 
+    func createChatSessionAction() {
+        viewModel.createChatSession()
+    }
+
+    func openServerAction() {
+        viewModel.selectSurface(.server)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Text("Chat Sessions")
                     .melixSectionLabel()
                 Spacer()
-                Button {
-                    viewModel.createChatSession()
-                } label: {
+                Button(action: createChatSessionAction) {
                     Image(systemName: "plus")
                 }
                 .buttonStyle(.plain)
@@ -163,11 +169,19 @@ struct DesktopChatSessionSidebar: View {
             }
 
             if viewModel.chatSessions.isEmpty {
-                ContentUnavailableView(
-                    "No Chat Sessions",
+                MelixActionableEmptyState(
+                    title: "No Chat Sessions",
                     systemImage: "message.badge",
-                    description: Text("Create a new chat after starting a Server Session.")
-                )
+                    detail: "Start a chat after choosing a local or remote server. Sessions keep transcript, model, and export context together."
+                ) {
+                    VStack(spacing: MelixDesignTokens.Spacing.sm) {
+                        Button("New Chat", action: createChatSessionAction)
+                        .buttonStyle(.borderedProminent)
+
+                        Button("Open Server", action: openServerAction)
+                        .buttonStyle(.bordered)
+                    }
+                }
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 6) {
@@ -238,23 +252,25 @@ struct DesktopChatSessionWorkspace: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .center) {
-                VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                VStack(alignment: .leading, spacing: 5) {
                     Text(viewModel.selectedChatSession?.title ?? "Chat")
                         .font(.title2.weight(.semibold))
-                    HStack(spacing: 8) {
-                        if let branch = viewModel.selectedChatSession?.displayBranchTitle {
-                            Text(branch)
-                                .font(.caption2)
-                                .padding(.horizontal, 7)
-                                .padding(.vertical, 3)
-                                .background(.quaternary, in: Capsule())
-                        }
-                        DesktopChatServerPicker(viewModel: viewModel)
+                    if let branch = viewModel.selectedChatSession?.displayBranchTitle {
+                        Text(branch)
+                            .font(.caption2)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(.quaternary, in: Capsule())
                     }
                 }
-                Spacer()
+                Spacer(minLength: 12)
+                DesktopChatServerPicker(viewModel: viewModel)
+                    .alignmentGuide(.firstTextBaseline) { dimensions in
+                        dimensions[VerticalAlignment.center]
+                    }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             if let notice = viewModel.selectedChatServerSession?.chatWorkspaceNoticeState {
                 VStack(alignment: .leading, spacing: 10) {

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
@@ -520,14 +520,7 @@ private struct DesktopRegistryTextField: View {
 
     var body: some View {
         TextField(title, text: $text)
-            .textFieldStyle(.plain)
-            .font(.body)
-            .padding(.vertical, MelixDesignTokens.Spacing.sm)
-            .overlay(alignment: .bottom) {
-                Rectangle()
-                    .fill(Color.secondary.opacity(MelixDesignTokens.StrokeOpacity.interactive))
-                    .frame(height: 1)
-            }
+            .textFieldStyle(MelixOperatorTextFieldStyle())
     }
 }
 
@@ -537,14 +530,7 @@ private struct DesktopRegistrySecureField: View {
 
     var body: some View {
         SecureField(title, text: $text)
-            .textFieldStyle(.plain)
-            .font(.body)
-            .padding(.vertical, MelixDesignTokens.Spacing.sm)
-            .overlay(alignment: .bottom) {
-                Rectangle()
-                    .fill(Color.secondary.opacity(MelixDesignTokens.StrokeOpacity.interactive))
-                    .frame(height: 1)
-            }
+            .textFieldStyle(MelixOperatorTextFieldStyle())
     }
 }
 
@@ -583,9 +569,9 @@ struct DesktopModelRegistryEntriesView: View {
         ViewThatFits(in: .horizontal) {
             HStack(alignment: .top, spacing: MelixDesignTokens.Spacing.lg) {
                 registryList
-                    .frame(minWidth: 440)
+                    .frame(minWidth: 520)
                 modelCard
-                    .frame(minWidth: 320, maxWidth: 380)
+                    .frame(width: 360)
             }
 
             VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.lg) {
@@ -746,24 +732,14 @@ private struct DesktopRegistryEntryRowView: View {
     let toggleLoad: (() -> Void)?
 
     var body: some View {
-        HStack(alignment: .top, spacing: MelixDesignTokens.Spacing.lg) {
+        HStack(alignment: .top, spacing: MelixDesignTokens.Spacing.md) {
             VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
-                HStack(alignment: .firstTextBaseline, spacing: MelixDesignTokens.Spacing.sm) {
-                    Text(entry.title)
-                        .font(.callout.weight(.semibold))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    DesktopRegistryBadgeView(
-                        title: entry.sourceText,
-                        tint: DesktopRegistryVisuals.sourceColor(entry.sourceText)
-                    )
-                    if localModel?.runtimeCacheMissing == true {
-                        DesktopRegistryBadgeView(
-                            title: localModel?.runtimeCacheStatusText ?? "Cache Missing",
-                            tint: MelixDesignTokens.StatusColor.warning
-                        )
-                    }
-                }
+                DesktopRegistryTitleBadgeRow(
+                    title: entry.title,
+                    titleFont: .callout.weight(.semibold),
+                    badges: entryHeaderBadges,
+                    lineLimit: 1
+                )
 
                 if !entry.subtitleText.isEmpty {
                     Text(entry.subtitleText)
@@ -798,6 +774,7 @@ private struct DesktopRegistryEntryRowView: View {
                         .lineLimit(2)
                 }
             }
+            .layoutPriority(1)
 
             Spacer(minLength: MelixDesignTokens.Spacing.md)
 
@@ -834,6 +811,24 @@ private struct DesktopRegistryEntryRowView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .desktopRegistryRowBackground(isSelected)
     }
+
+    private var entryHeaderBadges: [DesktopRegistryBadgeItem] {
+        var badges = [
+            DesktopRegistryBadgeItem(
+                title: entry.sourceText,
+                tint: DesktopRegistryVisuals.sourceColor(entry.sourceText)
+            )
+        ]
+        if localModel?.runtimeCacheMissing == true {
+            badges.append(
+                DesktopRegistryBadgeItem(
+                    title: localModel?.runtimeCacheStatusText ?? "Cache Missing",
+                    tint: MelixDesignTokens.StatusColor.warning
+                )
+            )
+        }
+        return badges
+    }
 }
 
 private struct DesktopRegistryRowBackground: ViewModifier {
@@ -862,16 +857,17 @@ private struct DesktopHubModelCardContent: View {
     var body: some View {
         VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.md) {
             VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
-                HStack(alignment: .firstTextBaseline, spacing: MelixDesignTokens.Spacing.sm) {
-                    Text(card.repoID)
-                        .font(.headline)
-                        .lineLimit(2)
-                        .truncationMode(.middle)
-                    DesktopRegistryBadgeView(
-                        title: card.runSuitabilityText,
-                        tint: DesktopRegistryVisuals.fitColor(card.runSuitabilityText)
-                    )
-                }
+                DesktopRegistryTitleBadgeRow(
+                    title: card.repoID,
+                    titleFont: .headline,
+                    badges: [
+                        DesktopRegistryBadgeItem(
+                            title: card.runSuitabilityText,
+                            tint: DesktopRegistryVisuals.fitColor(card.runSuitabilityText)
+                        ),
+                    ],
+                    lineLimit: 2
+                )
                 Text("\(card.author) • \(card.pipelineTag) • \(card.compatibilityText)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -917,16 +913,17 @@ struct DesktopRegistryEntryCardContent: View {
     var body: some View {
         VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.md) {
             VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
-                HStack(alignment: .firstTextBaseline, spacing: MelixDesignTokens.Spacing.sm) {
-                    Text(entry.title)
-                        .font(.headline)
-                        .lineLimit(2)
-                        .truncationMode(.middle)
-                    DesktopRegistryBadgeView(
-                        title: entry.sourceText,
-                        tint: DesktopRegistryVisuals.sourceColor(entry.sourceText)
-                    )
-                }
+                DesktopRegistryTitleBadgeRow(
+                    title: entry.title,
+                    titleFont: .headline,
+                    badges: [
+                        DesktopRegistryBadgeItem(
+                            title: entry.sourceText,
+                            tint: DesktopRegistryVisuals.sourceColor(entry.sourceText)
+                        ),
+                    ],
+                    lineLimit: 2
+                )
                 if !entry.subtitleText.isEmpty {
                     Text(entry.subtitleText)
                         .font(.caption)
@@ -1173,6 +1170,48 @@ private struct DesktopRegistryBadgeView: View {
                 tint.opacity(MelixDesignTokens.AccentOpacity.weak),
                 in: Capsule()
             )
+    }
+}
+
+private struct DesktopRegistryBadgeItem: Identifiable {
+    let id = UUID()
+    let title: String
+    let tint: Color
+}
+
+private struct DesktopRegistryTitleBadgeRow: View {
+    let title: String
+    let titleFont: Font
+    let badges: [DesktopRegistryBadgeItem]
+    var lineLimit = 2
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .firstTextBaseline, spacing: MelixDesignTokens.Spacing.sm) {
+                titleText
+                ForEach(badges) { badge in
+                    DesktopRegistryBadgeView(title: badge.title, tint: badge.tint)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
+                titleText
+                HStack(alignment: .center, spacing: MelixDesignTokens.Spacing.xs) {
+                    ForEach(badges) { badge in
+                        DesktopRegistryBadgeView(title: badge.title, tint: badge.tint)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var titleText: some View {
+        Text(title)
+            .font(titleFont)
+            .lineLimit(lineLimit)
+            .truncationMode(.middle)
+            .layoutPriority(1)
     }
 }
 
@@ -2069,7 +2108,7 @@ struct DesktopSettingsTabView: View {
                             set: { viewModel.updateRuntimeSettingDraft(key: $0, value: viewModel.runtimeSettingValueDraft) }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Setting value")
@@ -2082,7 +2121,7 @@ struct DesktopSettingsTabView: View {
                             set: { viewModel.updateRuntimeSettingDraft(key: viewModel.runtimeSettingKeyDraft, value: $0) }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
             }
             HStack(spacing: 8) {
@@ -2177,7 +2216,7 @@ struct DesktopSettingsTabView: View {
                         set: { viewModel.updateRuntimeDiscoveryAliasQuery($0) }
                     )
                 )
-                .textFieldStyle(.roundedBorder)
+                .textFieldStyle(MelixOperatorTextFieldStyle())
             }
             DesktopSettingsOperationButton(title: "Lookup Alias", isEnabled: viewModel.runtimeDiscoveryAliasLookupCanRun) {
                 Task { await viewModel.lookupRuntimeDiscoveryModelAlias() }

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
@@ -520,7 +520,7 @@ private struct DesktopRegistryTextField: View {
 
     var body: some View {
         TextField(title, text: $text)
-            .textFieldStyle(MelixOperatorTextFieldStyle())
+            .melixOperatorTextFieldStyle()
     }
 }
 
@@ -530,7 +530,7 @@ private struct DesktopRegistrySecureField: View {
 
     var body: some View {
         SecureField(title, text: $text)
-            .textFieldStyle(MelixOperatorTextFieldStyle())
+            .melixOperatorTextFieldStyle()
     }
 }
 
@@ -1174,7 +1174,7 @@ private struct DesktopRegistryBadgeView: View {
 }
 
 private struct DesktopRegistryBadgeItem: Identifiable {
-    let id = UUID()
+    var id: String { title }
     let title: String
     let tint: Color
 }
@@ -2108,7 +2108,7 @@ struct DesktopSettingsTabView: View {
                             set: { viewModel.updateRuntimeSettingDraft(key: $0, value: viewModel.runtimeSettingValueDraft) }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                 }
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Setting value")
@@ -2121,7 +2121,7 @@ struct DesktopSettingsTabView: View {
                             set: { viewModel.updateRuntimeSettingDraft(key: viewModel.runtimeSettingKeyDraft, value: $0) }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                 }
             }
             HStack(spacing: 8) {
@@ -2216,7 +2216,7 @@ struct DesktopSettingsTabView: View {
                         set: { viewModel.updateRuntimeDiscoveryAliasQuery($0) }
                     )
                 )
-                .textFieldStyle(MelixOperatorTextFieldStyle())
+                .melixOperatorTextFieldStyle()
             }
             DesktopSettingsOperationButton(title: "Lookup Alias", isEnabled: viewModel.runtimeDiscoveryAliasLookupCanRun) {
                 Task { await viewModel.lookupRuntimeDiscoveryModelAlias() }

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift
@@ -815,6 +815,7 @@ private struct DesktopRegistryEntryRowView: View {
     private var entryHeaderBadges: [DesktopRegistryBadgeItem] {
         var badges = [
             DesktopRegistryBadgeItem(
+                id: "source",
                 title: entry.sourceText,
                 tint: DesktopRegistryVisuals.sourceColor(entry.sourceText)
             )
@@ -822,6 +823,7 @@ private struct DesktopRegistryEntryRowView: View {
         if localModel?.runtimeCacheMissing == true {
             badges.append(
                 DesktopRegistryBadgeItem(
+                    id: "cache-status",
                     title: localModel?.runtimeCacheStatusText ?? "Cache Missing",
                     tint: MelixDesignTokens.StatusColor.warning
                 )
@@ -862,6 +864,7 @@ private struct DesktopHubModelCardContent: View {
                     titleFont: .headline,
                     badges: [
                         DesktopRegistryBadgeItem(
+                            id: "run-suitability",
                             title: card.runSuitabilityText,
                             tint: DesktopRegistryVisuals.fitColor(card.runSuitabilityText)
                         ),
@@ -918,6 +921,7 @@ struct DesktopRegistryEntryCardContent: View {
                     titleFont: .headline,
                     badges: [
                         DesktopRegistryBadgeItem(
+                            id: "source",
                             title: entry.sourceText,
                             tint: DesktopRegistryVisuals.sourceColor(entry.sourceText)
                         ),
@@ -1174,7 +1178,7 @@ private struct DesktopRegistryBadgeView: View {
 }
 
 private struct DesktopRegistryBadgeItem: Identifiable {
-    var id: String { title }
+    let id: String
     let title: String
     let tint: Color
 }

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -1136,7 +1136,7 @@ private struct DesktopRemoteServerEditor: View {
                             set: { viewModel.remoteServerIDDraft = $0 }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                     .disabled(viewModel.isRemoteServerIDEditable == false)
 
                     TextField(
@@ -1146,7 +1146,7 @@ private struct DesktopRemoteServerEditor: View {
                             set: { viewModel.remoteServerTitleDraft = $0 }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                 }
 
                 HStack(alignment: .top, spacing: 12) {
@@ -1170,7 +1170,7 @@ private struct DesktopRemoteServerEditor: View {
                             set: { viewModel.remoteServerDefaultModelIDDraft = $0 }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                 }
 
                 TextField(
@@ -1180,7 +1180,7 @@ private struct DesktopRemoteServerEditor: View {
                         set: { viewModel.remoteServerBaseURLDraft = $0 }
                     )
                 )
-                .textFieldStyle(MelixOperatorTextFieldStyle())
+                .melixOperatorTextFieldStyle()
                 .disabled(viewModel.isRemoteServerBaseURLEditable == false)
 
                 SecureField(
@@ -1190,7 +1190,7 @@ private struct DesktopRemoteServerEditor: View {
                         set: { viewModel.remoteServerAPIKeyDraft = $0 }
                     )
                 )
-                .textFieldStyle(MelixOperatorTextFieldStyle())
+                .melixOperatorTextFieldStyle()
 
                 HStack(alignment: .top, spacing: 12) {
                     TextField(
@@ -1201,7 +1201,7 @@ private struct DesktopRemoteServerEditor: View {
                         ),
                         format: .number
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
 
                     TextField(
                         "Rate limit / min",
@@ -1211,7 +1211,7 @@ private struct DesktopRemoteServerEditor: View {
                         ),
                         format: .number
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                 }
 
                 HStack {
@@ -1279,7 +1279,7 @@ private struct DesktopServerCreationEditor: View {
                         set: { viewModel.newLocalServerTitleDraft = $0 }
                     )
                 )
-                .textFieldStyle(MelixOperatorTextFieldStyle())
+                .melixOperatorTextFieldStyle()
 
                 Picker(
                     "Served Model",
@@ -1302,7 +1302,7 @@ private struct DesktopServerCreationEditor: View {
                             set: { viewModel.newLocalServerHostDraft = $0 }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
 
                     TextField(
                         "Port",
@@ -1312,7 +1312,7 @@ private struct DesktopServerCreationEditor: View {
                         ),
                         format: .number
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                     .frame(maxWidth: 120)
                 }
 
@@ -1512,7 +1512,7 @@ private struct DesktopServerSessionEditor: View {
                                         set: { viewModel.updateSelectedServerSessionHost($0) }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
 
                                 TextField(
                                     "Port",
@@ -1522,7 +1522,7 @@ private struct DesktopServerSessionEditor: View {
                                     ),
                                     format: .number
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                                 .frame(maxWidth: 120)
                             }
 
@@ -1537,7 +1537,7 @@ private struct DesktopServerSessionEditor: View {
                                     ),
                                     format: .number
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
 
                                 TextField(
                                     "Timeout (s)",
@@ -1547,7 +1547,7 @@ private struct DesktopServerSessionEditor: View {
                                     ),
                                     format: .number
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                             }
 
                             Text(
@@ -1645,7 +1645,7 @@ private struct DesktopServerSessionEditor: View {
                                     ),
                                     format: .number
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
 
                                 TextField(
                                     "Deep sleep after (s)",
@@ -1655,7 +1655,7 @@ private struct DesktopServerSessionEditor: View {
                                     ),
                                     format: .number
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
 
                             }
 
@@ -1704,7 +1704,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                                    .melixOperatorTextFieldStyle()
 
                                     TextField(
                                         "Top P",
@@ -1714,7 +1714,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                                    .melixOperatorTextFieldStyle()
                                 }
 
                                 HStack {
@@ -1726,7 +1726,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                                    .melixOperatorTextFieldStyle()
 
                                     TextField(
                                         "Stream interval",
@@ -1736,7 +1736,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                                    .melixOperatorTextFieldStyle()
                                 }
 
                                 HStack {
@@ -1748,7 +1748,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                                    .melixOperatorTextFieldStyle()
                                 }
 
                                 Toggle(
@@ -1768,7 +1768,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                                    .melixOperatorTextFieldStyle()
 
                                     TextField(
                                         "Completion batch size",
@@ -1778,7 +1778,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                                    .melixOperatorTextFieldStyle()
                                 }
 
                                 Picker(
@@ -1826,7 +1826,7 @@ private struct DesktopServerSessionEditor: View {
                             set: { viewModel.updateSelectedServerSessionDraftModelID($0) }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
 
                     TextField(
                         "Num draft tokens",
@@ -1836,7 +1836,7 @@ private struct DesktopServerSessionEditor: View {
                         ),
                         format: .number
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                 }
                 Text("Draft model settings apply only when Speculative Decode is selected.")
                     .font(.caption)
@@ -2334,7 +2334,7 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipeTaskFilter($0) }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                 }
                 Button("Refresh Catalog", action: refreshCatalogAction)
                 .buttonStyle(.borderedProminent)
@@ -2351,7 +2351,7 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipeURIInspectDraft($0) }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                 }
                 Button("Inspect URI", action: inspectURIAction)
                     .buttonStyle(.bordered)
@@ -2603,7 +2603,7 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipeInitTaskDraft($0) }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                 }
                 Button("Preview Recipe Init", action: previewRecipeInitAction)
                     .buttonStyle(.bordered)
@@ -2744,7 +2744,7 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipeSetKeyDraft($0) }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                 }
                 .frame(maxWidth: .infinity)
                 VStack(alignment: .leading, spacing: 4) {
@@ -2758,7 +2758,7 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipeSetValueDraft($0) }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                 }
                 .frame(maxWidth: .infinity)
                 Button("Add --set", action: addRecipeVariableAction)
@@ -2824,7 +2824,7 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipePlanOutputPathDraft($0) }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                 }
                 Button("Plan Recipe", action: planRecipeAction)
                     .buttonStyle(.borderedProminent)
@@ -2908,7 +2908,7 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipeApplyFromStepDraft($0) }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                     .frame(minWidth: 180)
                 }
 
@@ -3884,7 +3884,7 @@ struct DesktopSyntheticDatasetToolSectionView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             TextField(label, text: text)
-                .textFieldStyle(MelixOperatorTextFieldStyle())
+                .melixOperatorTextFieldStyle()
         }
     }
 
@@ -5477,7 +5477,7 @@ struct DesktopTrainingToolSectionView: View {
                 DesktopPassiveCaptionLabel(title: "Import Config Path")
                 HStack(spacing: 8) {
                     TextField("Import Config Path", text: stringBinding(\.loraTrainingJobImportPath))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                     Button("Import") {
                         viewModel.importLoraTrainingJobConfigFromPath()
                     }
@@ -5490,7 +5490,7 @@ struct DesktopTrainingToolSectionView: View {
                 DesktopPassiveCaptionLabel(title: "Export Config Path")
                 HStack(spacing: 8) {
                     TextField("Export Config Path", text: stringBinding(\.loraTrainingJobExportPath))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                     Button("Export") {
                         viewModel.exportSelectedLoraTrainingJobConfigToPath()
                     }
@@ -5528,7 +5528,7 @@ struct DesktopTrainingToolSectionView: View {
 
                     DesktopEditorialField("Adapter Name") {
                         TextField("Adapter Name", text: stringBinding(\.loraAdapterName))
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
                     }
                 }
             }
@@ -5552,10 +5552,10 @@ struct DesktopTrainingToolSectionView: View {
                     DesktopEditorialField(viewModel.loraDatasetSourceKind == .localPackage ? "Dataset URI" : "HF Dataset Path") {
                         if viewModel.loraDatasetSourceKind == .localPackage {
                             TextField("Dataset URI", text: stringBinding(\.loraDatasetURI))
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                         } else {
                             TextField("HF Dataset Path", text: stringBinding(\.loraHFDatasetPath))
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                         }
                     }
 
@@ -5590,27 +5590,27 @@ struct DesktopTrainingToolSectionView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         DesktopEditorialField("Reference Model Path") {
                             TextField("Optional reference model path", text: stringBinding(\.loraReferenceModelPath))
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                         }
 
                         if viewModel.loraTrainingMode == .grpo {
                             DesktopEditorialField("GRPO Candidate Count") {
                                 TextField("Candidates per prompt", text: stringBinding(\.loraGRPOCandidateCount))
-                                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                                    .melixOperatorTextFieldStyle()
                             }
                         }
 
                         if viewModel.loraTrainingMode == .rlhf {
                             DesktopEditorialField("Reward Model Manifest") {
                                 TextField("Reward model manifest path", text: stringBinding(\.loraRewardModelManifestPath))
-                                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                                    .melixOperatorTextFieldStyle()
                             }
                         }
 
                         if viewModel.loraTrainingMode == .grpo || viewModel.loraTrainingMode == .rlhf {
                             DesktopEditorialField("KL Penalty") {
                                 TextField("Optional KL penalty", text: stringBinding(\.loraKLPenalty))
-                                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                                    .melixOperatorTextFieldStyle()
                             }
                         }
                     }
@@ -5638,12 +5638,12 @@ struct DesktopTrainingToolSectionView: View {
                         detail: "Leave blank to derive from the base model and adapter name."
                     ) {
                         TextField("Optional group id", text: stringBinding(\.loraExperimentGroupID))
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
                     }
 
                     DesktopEditorialField("Target Repo") {
                         TextField("Target Repo", text: stringBinding(\.loraTargetRepo))
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
                     }
                 }
             }
@@ -5658,35 +5658,35 @@ struct DesktopTrainingToolSectionView: View {
             LazyVGrid(columns: [GridItem(.flexible(), spacing: 14), GridItem(.flexible(), spacing: 14)], spacing: 12) {
                 DesktopEditorialField("Config / Name") {
                     TextField("Config / Name", text: stringBinding(\.loraHFDatasetName))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Revision") {
                     TextField("Revision", text: stringBinding(\.loraHFDatasetRevision))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Train Split") {
                     TextField("Train Split", text: stringBinding(\.loraHFTrainSplit))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Valid Split") {
                     TextField("Valid Split", text: stringBinding(\.loraHFValidSplit))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Text Feature") {
                     TextField("Text Feature", text: stringBinding(\.loraTextFeature))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Prompt Feature") {
                     TextField("Prompt Feature", text: stringBinding(\.loraPromptFeature))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Completion Feature") {
                     TextField("Completion Feature", text: stringBinding(\.loraCompletionFeature))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Chat Feature") {
                     TextField("Chat Feature", text: stringBinding(\.loraChatFeature))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
             }
         }
@@ -5706,55 +5706,55 @@ struct DesktopTrainingToolSectionView: View {
             LazyVGrid(columns: [GridItem(.flexible(), spacing: 14), GridItem(.flexible(), spacing: 14)], spacing: 12) {
                 DesktopEditorialField("Rank") {
                     TextField("Rank", text: stringBinding(\.loraRank))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Alpha") {
                     TextField("Alpha", text: stringBinding(\.loraAlpha))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Dropout") {
                     TextField("Dropout", text: stringBinding(\.loraDropout))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Batch Size") {
                     TextField("Batch Size", text: stringBinding(\.loraBatchSize))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Epochs") {
                     TextField("Epochs", text: stringBinding(\.loraEpochs))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Max Steps") {
                     TextField("Optional max steps", text: stringBinding(\.loraMaxSteps))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Learning Rate") {
                     TextField("Learning Rate", text: stringBinding(\.loraLearningRate))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Max Seq Length") {
                     TextField("Max Seq Length", text: stringBinding(\.loraMaxSeqLength))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Sample Limit") {
                     TextField("Optional sample limit", text: stringBinding(\.loraSampleLimit))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Gradient Accumulation") {
                     TextField("Optional accumulation steps", text: stringBinding(\.loraGradientAccumulation))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Target Modules") {
                     TextField("Target Modules", text: stringBinding(\.loraTargetModules))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Num Layers") {
                     TextField("Num Layers", text: stringBinding(\.loraNumLayers))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
                 DesktopEditorialField("Derived Model Alias") {
                     TextField("Derived Model Alias", text: stringBinding(\.loraDerivedModelAlias))
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                 }
             }
 
@@ -7247,7 +7247,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                         set: { viewModel.updateDiagnosticsDebugBundleRunIDDraft($0) }
                     )
                 )
-                .textFieldStyle(MelixOperatorTextFieldStyle())
+                .melixOperatorTextFieldStyle()
 
                 HStack(spacing: 8) {
                     TextField(
@@ -7257,7 +7257,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                             set: { viewModel.updateDiagnosticsDebugBundleSourcePathDraft($0) }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
 
                     TextField(
                         "Output path",
@@ -7266,7 +7266,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                             set: { viewModel.updateDiagnosticsDebugBundleOutputPathDraft($0) }
                         )
                     )
-                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                    .melixOperatorTextFieldStyle()
                 }
 
                 HStack(spacing: 8) {
@@ -7687,7 +7687,7 @@ struct DesktopDiagnosticsToolSectionView: View {
 
     private var evidenceReportFilterField: some View {
         TextField("Filter report rows", text: $evidenceReportFilter)
-            .textFieldStyle(MelixOperatorTextFieldStyle())
+            .melixOperatorTextFieldStyle()
     }
 
     private func evidenceReportControlRow(report: RuntimeEvidenceReportState?) -> some View {
@@ -8288,7 +8288,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.benchmarkSampleSize = $0 }
                                 )
                             )
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
                             TextField(
                                 "Batch Factor",
                                 text: Binding(
@@ -8296,7 +8296,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.benchmarkBatchFactor = $0 }
                                 )
                             )
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
                             TextField(
                                 "Repeats",
                                 text: Binding(
@@ -8304,7 +8304,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.benchRepeats = $0 }
                                 )
                             )
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
                         }
 
                         HStack(spacing: 16) {
@@ -8561,7 +8561,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.benchMatrixRepeats = $0 }
                                 )
                             )
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
 
                             Picker(
                                 "Load Budget",
@@ -8584,7 +8584,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.benchMatrixRequests = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                             } else {
                                 TextField(
                                     "Duration Seconds",
@@ -8593,7 +8593,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.benchMatrixDurationSeconds = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                             }
                         }
 
@@ -9005,7 +9005,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.evaluationPromptIDDraft = $0 }
                                 )
                             )
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
                             .disabled(viewModel.isEvaluationPromptIDEditable == false)
 
                             TextField(
@@ -9015,7 +9015,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.evaluationPromptTitleDraft = $0 }
                                 )
                             )
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
                             .disabled(
                                 viewModel.isEvaluationPromptIDEditable == false
                                     || viewModel.isEvaluationPromptDraftEditable == false
@@ -9068,7 +9068,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.evaluationSemanticJudgeModelID = $0 }
                                 )
                             )
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
                         }
                     }
 
@@ -9105,7 +9105,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.evaluationSourcePath = $0 }
                                 )
                             )
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
                         case .huggingFaceDataset:
                             HStack(spacing: 16) {
                                 TextField(
@@ -9115,7 +9115,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationHFDatasetPath = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                                 TextField(
                                     "Config",
                                     text: Binding(
@@ -9123,7 +9123,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationHFDatasetName = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                             }
                             HStack(spacing: 16) {
                                 TextField(
@@ -9133,7 +9133,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationHFDatasetRevision = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                                 TextField(
                                     "Split",
                                     text: Binding(
@@ -9141,7 +9141,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationHFDatasetSplit = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                             }
                         }
                     }
@@ -9160,7 +9160,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationFieldSystemPath = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                                 TextField(
                                     "Input Text Path",
                                     text: Binding(
@@ -9168,7 +9168,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationFieldInputTextPath = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                             }
 
                             HStack(spacing: 16) {
@@ -9179,7 +9179,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationFieldTargetPath = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                                 TextField(
                                     "Sample ID Path",
                                     text: Binding(
@@ -9187,7 +9187,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationFieldSampleIDPath = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                             }
 
                             Text("Profile")
@@ -9202,7 +9202,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationResultKind = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                                 TextField(
                                     "Extraction Mode",
                                     text: Binding(
@@ -9210,7 +9210,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationExtractionMode = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                                 TextField(
                                     "Threshold",
                                     text: Binding(
@@ -9218,7 +9218,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationThreshold = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                             }
 
                             HStack(spacing: 16) {
@@ -9229,7 +9229,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationOutputSchemaJSON = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                                 TextField(
                                     "Ignored Paths",
                                     text: Binding(
@@ -9237,7 +9237,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationIgnoredPaths = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
                             }
                         }
                     }
@@ -9348,7 +9348,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                 set: { viewModel.evaluationSampleSize = $0 }
                             )
                         )
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                         TextField(
                             "Batch Factor",
                             text: Binding(
@@ -9356,7 +9356,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                 set: { viewModel.evaluationBatchFactor = $0 }
                             )
                         )
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                         TextField(
                             "Few-shot",
                             text: Binding(
@@ -9364,7 +9364,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                 set: { viewModel.evaluationFewShot = $0 }
                             )
                         )
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                         TextField(
                             "Seed",
                             text: Binding(
@@ -9372,7 +9372,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                 set: { viewModel.evaluationSeed = $0 }
                             )
                         )
-                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                        .melixOperatorTextFieldStyle()
                     }
 
                         HStack(spacing: 16) {
@@ -9383,7 +9383,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.evaluationScoringMode = $0 }
                                 )
                             )
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
                             TextField(
                                 "Code Exec Policy",
                                 text: Binding(
@@ -9391,7 +9391,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.evaluationCodeExecPolicy = $0 }
                                 )
                             )
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
                         }
                     }
 

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -300,7 +300,7 @@ struct DesktopCommandCenterView: View {
                             DesktopCommandCenterSessionSummaryPanel(
                                 chatSessions: chatSessions,
                                 serverSessions: serverSessions
-                        )
+                            )
                         }
                         .frame(width: DesktopCommandCenterVisuals.secondaryColumnWidth, alignment: .topLeading)
                     }

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -273,6 +273,7 @@ struct DesktopCommandCenterView: View {
         let foundation = liveFoundation
         let chatSessions = liveChatSessions
         let serverSessions = liveServerSessions
+        let horizontalPadding = DesktopCommandCenterVisuals.contentPadding
 
         ScrollView {
             VStack(alignment: .leading, spacing: DesktopCommandCenterVisuals.sectionSpacing) {
@@ -288,7 +289,7 @@ struct DesktopCommandCenterView: View {
                             DesktopCommandCenterPressurePanel(foundation: foundation)
                             DesktopCommandCenterActivityPanel(foundation: foundation)
                         }
-                        .frame(minWidth: DesktopCommandCenterVisuals.primaryColumnMinimumWidth)
+                        .frame(maxWidth: .infinity, alignment: .topLeading)
 
                         VStack(alignment: .leading, spacing: DesktopCommandCenterVisuals.sectionSpacing) {
                             DesktopCommandCenterRecoveryPanel(
@@ -299,10 +300,11 @@ struct DesktopCommandCenterView: View {
                             DesktopCommandCenterSessionSummaryPanel(
                                 chatSessions: chatSessions,
                                 serverSessions: serverSessions
-                            )
+                        )
                         }
-                        .frame(width: DesktopCommandCenterVisuals.secondaryColumnWidth)
+                        .frame(width: DesktopCommandCenterVisuals.secondaryColumnWidth, alignment: .topLeading)
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                     VStack(alignment: .leading, spacing: DesktopCommandCenterVisuals.sectionSpacing) {
                         DesktopCommandCenterRuntimePanel(foundation: foundation)
@@ -320,13 +322,15 @@ struct DesktopCommandCenterView: View {
                     }
                 }
             }
-            .padding(DesktopCommandCenterVisuals.contentPadding)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, MelixDesignTokens.Spacing.xxl)
             .frame(
                 maxWidth: DesktopCommandCenterVisuals.maxContentWidth,
                 alignment: .leading
             )
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .background(MelixDesignTokens.Palette.backgroundBase.color)
+        .background(MelixDesignTokens.Palette.backgroundBase.color.ignoresSafeArea())
     }
 
     private var liveFoundation: DesktopFoundationState {
@@ -355,9 +359,8 @@ enum DesktopCommandCenterVisuals {
     static let activitySectionTitle = "Recent Activity"
     static let sessionSummarySectionTitle = "Session Summary"
     static let primaryModelTitle = "Primary Model"
-    static let maxContentWidth: CGFloat = 1120
-    static let primaryColumnMinimumWidth: CGFloat = 520
-    static let secondaryColumnWidth: CGFloat = 320
+    static let maxContentWidth: CGFloat = 1180
+    static let secondaryColumnWidth: CGFloat = 340
     static let contentPadding = MelixDesignTokens.Spacing.huge
     static let sectionSpacing = MelixDesignTokens.Spacing.xl
     static let columnSpacing = MelixDesignTokens.Spacing.huge
@@ -373,7 +376,6 @@ private struct DesktopCommandCenterHeaderView: View {
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: MelixDesignTokens.Spacing.lg) {
             VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.sm) {
-                Text(DesktopCommandCenterVisuals.operatorLabel).melixSectionLabel()
                 Text(DesktopCommandCenterVisuals.windowTitle)
                     .font(MelixDesignTokens.Typography.largeTitle)
                 Text(foundation.title)
@@ -993,6 +995,25 @@ private struct DesktopServerMetricCard: View {
     }
 }
 
+@MainActor
+enum DesktopServerCreationActions {
+    static func addLocalServer(viewModel: RuntimeViewModel) {
+        viewModel.beginServerCreation(kind: .localServer)
+    }
+
+    static func addRemoteServer(viewModel: RuntimeViewModel) {
+        viewModel.beginServerCreation(kind: .remoteServer)
+    }
+
+    static func makeAddLocalServerAction(viewModel: RuntimeViewModel) -> () -> Void {
+        { addLocalServer(viewModel: viewModel) }
+    }
+
+    static func makeAddRemoteServerAction(viewModel: RuntimeViewModel) -> () -> Void {
+        { addRemoteServer(viewModel: viewModel) }
+    }
+}
+
 private struct DesktopServerSessionSidebar: View {
     let viewModel: RuntimeViewModel
 
@@ -1003,12 +1024,8 @@ private struct DesktopServerSessionSidebar: View {
                     .font(.headline)
                 Spacer()
                 Menu {
-                    Button("Add Local Server") {
-                        viewModel.beginServerCreation(kind: .localServer)
-                    }
-                    Button("Add Remote Server") {
-                        viewModel.beginServerCreation(kind: .remoteServer)
-                    }
+                    Button("Add Local Server", action: DesktopServerCreationActions.makeAddLocalServerAction(viewModel: viewModel))
+                    Button("Add Remote Server", action: DesktopServerCreationActions.makeAddRemoteServerAction(viewModel: viewModel))
                 } label: {
                     Image(systemName: "plus")
                 }
@@ -1019,11 +1036,19 @@ private struct DesktopServerSessionSidebar: View {
             }
 
             if viewModel.serverTargets.isEmpty {
-                ContentUnavailableView(
-                    "No Servers",
-                    systemImage: "network.slash",
-                    description: Text("Create a local or remote server target.")
-                )
+                MelixActionableEmptyState(
+                    title: "No Servers Yet",
+                    systemImage: "server.rack",
+                    detail: "Create a local Apple Silicon runtime or connect a remote provider before chatting, benchmarking, or generating artifacts."
+                ) {
+                    VStack(spacing: MelixDesignTokens.Spacing.sm) {
+                        Button("Add Local Server", action: DesktopServerCreationActions.makeAddLocalServerAction(viewModel: viewModel))
+                        .buttonStyle(.borderedProminent)
+
+                        Button("Add Remote Server", action: DesktopServerCreationActions.makeAddRemoteServerAction(viewModel: viewModel))
+                        .buttonStyle(.bordered)
+                    }
+                }
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 8) {
@@ -1111,7 +1136,7 @@ private struct DesktopRemoteServerEditor: View {
                             set: { viewModel.remoteServerIDDraft = $0 }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                     .disabled(viewModel.isRemoteServerIDEditable == false)
 
                     TextField(
@@ -1121,7 +1146,7 @@ private struct DesktopRemoteServerEditor: View {
                             set: { viewModel.remoteServerTitleDraft = $0 }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
 
                 HStack(alignment: .top, spacing: 12) {
@@ -1145,7 +1170,7 @@ private struct DesktopRemoteServerEditor: View {
                             set: { viewModel.remoteServerDefaultModelIDDraft = $0 }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
 
                 TextField(
@@ -1155,7 +1180,7 @@ private struct DesktopRemoteServerEditor: View {
                         set: { viewModel.remoteServerBaseURLDraft = $0 }
                     )
                 )
-                .textFieldStyle(.roundedBorder)
+                .textFieldStyle(MelixOperatorTextFieldStyle())
                 .disabled(viewModel.isRemoteServerBaseURLEditable == false)
 
                 SecureField(
@@ -1165,7 +1190,7 @@ private struct DesktopRemoteServerEditor: View {
                         set: { viewModel.remoteServerAPIKeyDraft = $0 }
                     )
                 )
-                .textFieldStyle(.roundedBorder)
+                .textFieldStyle(MelixOperatorTextFieldStyle())
 
                 HStack(alignment: .top, spacing: 12) {
                     TextField(
@@ -1176,7 +1201,7 @@ private struct DesktopRemoteServerEditor: View {
                         ),
                         format: .number
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
 
                     TextField(
                         "Rate limit / min",
@@ -1186,7 +1211,7 @@ private struct DesktopRemoteServerEditor: View {
                         ),
                         format: .number
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
 
                 HStack {
@@ -1254,7 +1279,7 @@ private struct DesktopServerCreationEditor: View {
                         set: { viewModel.newLocalServerTitleDraft = $0 }
                     )
                 )
-                .textFieldStyle(.roundedBorder)
+                .textFieldStyle(MelixOperatorTextFieldStyle())
 
                 Picker(
                     "Served Model",
@@ -1277,7 +1302,7 @@ private struct DesktopServerCreationEditor: View {
                             set: { viewModel.newLocalServerHostDraft = $0 }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
 
                     TextField(
                         "Port",
@@ -1287,7 +1312,7 @@ private struct DesktopServerCreationEditor: View {
                         ),
                         format: .number
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                     .frame(maxWidth: 120)
                 }
 
@@ -1487,7 +1512,7 @@ private struct DesktopServerSessionEditor: View {
                                         set: { viewModel.updateSelectedServerSessionHost($0) }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
 
                                 TextField(
                                     "Port",
@@ -1497,7 +1522,7 @@ private struct DesktopServerSessionEditor: View {
                                     ),
                                     format: .number
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                                 .frame(maxWidth: 120)
                             }
 
@@ -1512,7 +1537,7 @@ private struct DesktopServerSessionEditor: View {
                                     ),
                                     format: .number
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
 
                                 TextField(
                                     "Timeout (s)",
@@ -1522,7 +1547,7 @@ private struct DesktopServerSessionEditor: View {
                                     ),
                                     format: .number
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                             }
 
                             Text(
@@ -1620,7 +1645,7 @@ private struct DesktopServerSessionEditor: View {
                                     ),
                                     format: .number
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
 
                                 TextField(
                                     "Deep sleep after (s)",
@@ -1630,7 +1655,7 @@ private struct DesktopServerSessionEditor: View {
                                     ),
                                     format: .number
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
 
                             }
 
@@ -1641,11 +1666,19 @@ private struct DesktopServerSessionEditor: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 } else {
-                    ContentUnavailableView(
-                        "No Server Selected",
+                    MelixActionableEmptyState(
+                        title: "No Server Selected",
                         systemImage: "server.rack",
-                        description: Text("Choose a server from the list or create a new one.")
-                    )
+                        detail: "Pick an existing server in the sidebar, or start a new target when this workspace is empty."
+                    ) {
+                        HStack(spacing: MelixDesignTokens.Spacing.sm) {
+                            Button("Add Local Server", action: DesktopServerCreationActions.makeAddLocalServerAction(viewModel: viewModel))
+                            .buttonStyle(.borderedProminent)
+
+                            Button("Add Remote Server", action: DesktopServerCreationActions.makeAddRemoteServerAction(viewModel: viewModel))
+                            .buttonStyle(.bordered)
+                        }
+                    }
                 }
 
                 Spacer()
@@ -1671,7 +1704,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(.roundedBorder)
+                                    .textFieldStyle(MelixOperatorTextFieldStyle())
 
                                     TextField(
                                         "Top P",
@@ -1681,7 +1714,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(.roundedBorder)
+                                    .textFieldStyle(MelixOperatorTextFieldStyle())
                                 }
 
                                 HStack {
@@ -1693,7 +1726,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(.roundedBorder)
+                                    .textFieldStyle(MelixOperatorTextFieldStyle())
 
                                     TextField(
                                         "Stream interval",
@@ -1703,7 +1736,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(.roundedBorder)
+                                    .textFieldStyle(MelixOperatorTextFieldStyle())
                                 }
 
                                 HStack {
@@ -1715,7 +1748,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(.roundedBorder)
+                                    .textFieldStyle(MelixOperatorTextFieldStyle())
                                 }
 
                                 Toggle(
@@ -1735,7 +1768,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(.roundedBorder)
+                                    .textFieldStyle(MelixOperatorTextFieldStyle())
 
                                     TextField(
                                         "Completion batch size",
@@ -1745,7 +1778,7 @@ private struct DesktopServerSessionEditor: View {
                                         ),
                                         format: .number
                                     )
-                                    .textFieldStyle(.roundedBorder)
+                                    .textFieldStyle(MelixOperatorTextFieldStyle())
                                 }
 
                                 Picker(
@@ -1793,7 +1826,7 @@ private struct DesktopServerSessionEditor: View {
                             set: { viewModel.updateSelectedServerSessionDraftModelID($0) }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
 
                     TextField(
                         "Num draft tokens",
@@ -1803,7 +1836,7 @@ private struct DesktopServerSessionEditor: View {
                         ),
                         format: .number
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 Text("Draft model settings apply only when Speculative Decode is selected.")
                     .font(.caption)
@@ -2077,6 +2110,22 @@ struct DesktopToolsCategorySidebarView: View {
 struct DesktopDownloadsToolSectionView: View {
     let viewModel: RuntimeViewModel
 
+    func quantizeModelAction() {
+        Task { await viewModel.quantizePrimaryModel() }
+    }
+
+    func convertModelAction() {
+        Task { await viewModel.convertPrimaryModel() }
+    }
+
+    func downloadModelAction() {
+        Task { await viewModel.downloadPrimaryModel() }
+    }
+
+    func uploadArtifactAction() {
+        Task { await viewModel.uploadPrimaryModel() }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             Text("Model ingress and artifact publishing stay under Tools, not Server.")
@@ -2094,33 +2143,49 @@ struct DesktopDownloadsToolSectionView: View {
 
                     Spacer(minLength: 12)
 
-                    Picker(
-                        "Quant Mode",
-                        selection: Binding(
-                            get: { viewModel.selectedQuantizationMode },
-                            set: { viewModel.selectedQuantizationMode = $0 }
-                        )
-                    ) {
-                        ForEach(RuntimeQuantizationMode.allCases) { mode in
-                            Text(mode.title).tag(mode)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .frame(width: 128)
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text("Quant Mode")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .textCase(.uppercase)
 
-                    Picker(
-                        "Quant Profile",
-                        selection: Binding(
-                            get: { viewModel.selectedQuantizationProfileID },
-                            set: { viewModel.selectQuantizationProfile($0) }
-                        )
-                    ) {
-                        ForEach(viewModel.availableQuantizationProfileIDs, id: \.self) { profileID in
-                            Text(profileID).tag(profileID)
+                        Picker(
+                            "Quant Mode",
+                            selection: Binding(
+                                get: { viewModel.selectedQuantizationMode },
+                                set: { viewModel.selectedQuantizationMode = $0 }
+                            )
+                        ) {
+                            ForEach(RuntimeQuantizationMode.allCases) { mode in
+                                Text(mode.title).tag(mode)
+                            }
                         }
+                        .labelsHidden()
+                        .pickerStyle(.segmented)
+                        .frame(width: 124)
                     }
-                    .pickerStyle(.menu)
-                    .frame(maxWidth: 120)
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text("Quant Profile")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .textCase(.uppercase)
+
+                        Picker(
+                            "Quant Profile",
+                            selection: Binding(
+                                get: { viewModel.selectedQuantizationProfileID },
+                                set: { viewModel.selectQuantizationProfile($0) }
+                            )
+                        ) {
+                            ForEach(viewModel.availableQuantizationProfileIDs, id: \.self) { profileID in
+                                Text(profileID).tag(profileID)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                        .frame(width: 132)
+                    }
 
                     if viewModel.hasExplicitModelOperationTarget {
                         Button("Use Primary Model") {
@@ -2143,30 +2208,26 @@ struct DesktopDownloadsToolSectionView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            HStack {
-                Button("Quantize Model") {
-                    Task { await viewModel.quantizePrimaryModel() }
-                }
-                .buttonStyle(.bordered)
-                .fixedSize(horizontal: true, vertical: false)
+            MelixSectionCard("Model Ingest Actions") {
+                HStack(alignment: .center, spacing: 10) {
+                    Button("Quantize Model", action: quantizeModelAction)
+                    .buttonStyle(.bordered)
+                    .fixedSize(horizontal: true, vertical: false)
 
-                Button("Convert Model") {
-                    Task { await viewModel.convertPrimaryModel() }
-                }
-                .buttonStyle(.bordered)
-                .fixedSize(horizontal: true, vertical: false)
+                    Button("Convert Model", action: convertModelAction)
+                    .buttonStyle(.bordered)
+                    .fixedSize(horizontal: true, vertical: false)
 
-                Button("Download Model") {
-                    Task { await viewModel.downloadPrimaryModel() }
-                }
-                .buttonStyle(.borderedProminent)
-                .fixedSize(horizontal: true, vertical: false)
+                    Button("Download Model", action: downloadModelAction)
+                    .buttonStyle(.borderedProminent)
+                    .fixedSize(horizontal: true, vertical: false)
 
-                Button("Upload Artifact") {
-                    Task { await viewModel.uploadPrimaryModel() }
+                    Button("Upload Artifact", action: uploadArtifactAction)
+                    .buttonStyle(.bordered)
+                    .fixedSize(horizontal: true, vertical: false)
                 }
-                .buttonStyle(.bordered)
-                .fixedSize(horizontal: true, vertical: false)
+                .padding(.top, MelixDesignTokens.Spacing.xs)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             MelixSectionCard("Download Queue") {
@@ -2273,7 +2334,7 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipeTaskFilter($0) }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 Button("Refresh Catalog", action: refreshCatalogAction)
                 .buttonStyle(.borderedProminent)
@@ -2290,7 +2351,7 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipeURIInspectDraft($0) }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 Button("Inspect URI", action: inspectURIAction)
                     .buttonStyle(.bordered)
@@ -2542,7 +2603,7 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipeInitTaskDraft($0) }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 Button("Preview Recipe Init", action: previewRecipeInitAction)
                     .buttonStyle(.bordered)
@@ -2670,7 +2731,7 @@ struct DesktopWorkflowRecipesToolSectionView: View {
     }
 
     private var recipeVariablesPanel: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 16) {
             HStack(alignment: .bottom, spacing: 10) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Variable key")
@@ -2683,8 +2744,9 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipeSetKeyDraft($0) }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
+                .frame(maxWidth: .infinity)
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Variable value")
                         .font(.caption)
@@ -2696,15 +2758,21 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipeSetValueDraft($0) }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
+                .frame(maxWidth: .infinity)
                 Button("Add --set", action: addRecipeVariableAction)
                     .buttonStyle(.bordered)
+                    .controlSize(.large)
+                    .frame(height: MelixDesignTokens.ControlMetrics.operatorFieldHeight)
                     .disabled(viewModel.workflowRecipeSetEditorCanAdd == false)
                 Button("Clear Variables", action: clearRecipeVariablesAction)
                     .buttonStyle(.bordered)
+                    .controlSize(.large)
+                    .frame(height: MelixDesignTokens.ControlMetrics.operatorFieldHeight)
                     .disabled(viewModel.workflowRecipeSetRows.isEmpty)
             }
+            .padding(.bottom, MelixDesignTokens.Spacing.xs)
 
             if viewModel.workflowRecipeSetRows.isEmpty {
                 Text("No recipe variables configured.")
@@ -2756,7 +2824,7 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipePlanOutputPathDraft($0) }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 Button("Plan Recipe", action: planRecipeAction)
                     .buttonStyle(.borderedProminent)
@@ -2840,7 +2908,7 @@ struct DesktopWorkflowRecipesToolSectionView: View {
                             set: { viewModel.updateWorkflowRecipeApplyFromStepDraft($0) }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                     .frame(minWidth: 180)
                 }
 
@@ -3488,6 +3556,7 @@ struct DesktopSyntheticDatasetToolSectionView: View {
                         set: { viewModel.updateSyntheticDatasetColumnNameDraft($0) }
                     )
                 )
+                .frame(maxWidth: .infinity)
                 formField(
                     "Column Type",
                     text: Binding(
@@ -3495,6 +3564,7 @@ struct DesktopSyntheticDatasetToolSectionView: View {
                         set: { viewModel.updateSyntheticDatasetColumnTypeDraft($0) }
                     )
                 )
+                .frame(maxWidth: .infinity)
                 formField(
                     "JSON or Path",
                     text: Binding(
@@ -3502,10 +3572,15 @@ struct DesktopSyntheticDatasetToolSectionView: View {
                         set: { viewModel.updateSyntheticDatasetColumnPayloadDraft($0) }
                     )
                 )
+                .frame(maxWidth: .infinity)
                 Button("Add Column", action: addColumnAction)
                     .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .frame(height: MelixDesignTokens.ControlMetrics.operatorFieldHeight)
+                    .frame(minWidth: 112)
                     .disabled(viewModel.syntheticDatasetColumnDraftCanAdd == false)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             if viewModel.syntheticDatasetColumnEditorErrorMessage.isEmpty == false {
                 Text(viewModel.syntheticDatasetColumnEditorErrorMessage)
@@ -3809,7 +3884,7 @@ struct DesktopSyntheticDatasetToolSectionView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             TextField(label, text: text)
-                .textFieldStyle(.roundedBorder)
+                .textFieldStyle(MelixOperatorTextFieldStyle())
         }
     }
 
@@ -4045,8 +4120,8 @@ struct DesktopBatchRunsToolSectionView: View {
     }
 
     private var batchRunOperations: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .center, spacing: 8) {
                 DesktopJobsOperationButton(
                     title: "Run Preflight",
                     isEnabled: viewModel.batchRunPreflightCanRun
@@ -4071,6 +4146,12 @@ struct DesktopBatchRunsToolSectionView: View {
 
                 batchRunOperationStatus
             }
+            .padding(MelixDesignTokens.Spacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                Color.secondary.opacity(0.05),
+                in: RoundedRectangle(cornerRadius: MelixDesignTokens.Radius.md, style: .continuous)
+            )
 
             Text(viewModel.batchRunResumeSummaryText)
                 .font(.caption)
@@ -5396,7 +5477,7 @@ struct DesktopTrainingToolSectionView: View {
                 DesktopPassiveCaptionLabel(title: "Import Config Path")
                 HStack(spacing: 8) {
                     TextField("Import Config Path", text: stringBinding(\.loraTrainingJobImportPath))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                     Button("Import") {
                         viewModel.importLoraTrainingJobConfigFromPath()
                     }
@@ -5409,7 +5490,7 @@ struct DesktopTrainingToolSectionView: View {
                 DesktopPassiveCaptionLabel(title: "Export Config Path")
                 HStack(spacing: 8) {
                     TextField("Export Config Path", text: stringBinding(\.loraTrainingJobExportPath))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                     Button("Export") {
                         viewModel.exportSelectedLoraTrainingJobConfigToPath()
                     }
@@ -5447,7 +5528,7 @@ struct DesktopTrainingToolSectionView: View {
 
                     DesktopEditorialField("Adapter Name") {
                         TextField("Adapter Name", text: stringBinding(\.loraAdapterName))
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
                     }
                 }
             }
@@ -5471,10 +5552,10 @@ struct DesktopTrainingToolSectionView: View {
                     DesktopEditorialField(viewModel.loraDatasetSourceKind == .localPackage ? "Dataset URI" : "HF Dataset Path") {
                         if viewModel.loraDatasetSourceKind == .localPackage {
                             TextField("Dataset URI", text: stringBinding(\.loraDatasetURI))
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                         } else {
                             TextField("HF Dataset Path", text: stringBinding(\.loraHFDatasetPath))
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                         }
                     }
 
@@ -5509,27 +5590,27 @@ struct DesktopTrainingToolSectionView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         DesktopEditorialField("Reference Model Path") {
                             TextField("Optional reference model path", text: stringBinding(\.loraReferenceModelPath))
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                         }
 
                         if viewModel.loraTrainingMode == .grpo {
                             DesktopEditorialField("GRPO Candidate Count") {
                                 TextField("Candidates per prompt", text: stringBinding(\.loraGRPOCandidateCount))
-                                    .textFieldStyle(.roundedBorder)
+                                    .textFieldStyle(MelixOperatorTextFieldStyle())
                             }
                         }
 
                         if viewModel.loraTrainingMode == .rlhf {
                             DesktopEditorialField("Reward Model Manifest") {
                                 TextField("Reward model manifest path", text: stringBinding(\.loraRewardModelManifestPath))
-                                    .textFieldStyle(.roundedBorder)
+                                    .textFieldStyle(MelixOperatorTextFieldStyle())
                             }
                         }
 
                         if viewModel.loraTrainingMode == .grpo || viewModel.loraTrainingMode == .rlhf {
                             DesktopEditorialField("KL Penalty") {
                                 TextField("Optional KL penalty", text: stringBinding(\.loraKLPenalty))
-                                    .textFieldStyle(.roundedBorder)
+                                    .textFieldStyle(MelixOperatorTextFieldStyle())
                             }
                         }
                     }
@@ -5557,12 +5638,12 @@ struct DesktopTrainingToolSectionView: View {
                         detail: "Leave blank to derive from the base model and adapter name."
                     ) {
                         TextField("Optional group id", text: stringBinding(\.loraExperimentGroupID))
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
                     }
 
                     DesktopEditorialField("Target Repo") {
                         TextField("Target Repo", text: stringBinding(\.loraTargetRepo))
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
                     }
                 }
             }
@@ -5577,35 +5658,35 @@ struct DesktopTrainingToolSectionView: View {
             LazyVGrid(columns: [GridItem(.flexible(), spacing: 14), GridItem(.flexible(), spacing: 14)], spacing: 12) {
                 DesktopEditorialField("Config / Name") {
                     TextField("Config / Name", text: stringBinding(\.loraHFDatasetName))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Revision") {
                     TextField("Revision", text: stringBinding(\.loraHFDatasetRevision))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Train Split") {
                     TextField("Train Split", text: stringBinding(\.loraHFTrainSplit))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Valid Split") {
                     TextField("Valid Split", text: stringBinding(\.loraHFValidSplit))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Text Feature") {
                     TextField("Text Feature", text: stringBinding(\.loraTextFeature))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Prompt Feature") {
                     TextField("Prompt Feature", text: stringBinding(\.loraPromptFeature))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Completion Feature") {
                     TextField("Completion Feature", text: stringBinding(\.loraCompletionFeature))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Chat Feature") {
                     TextField("Chat Feature", text: stringBinding(\.loraChatFeature))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
             }
         }
@@ -5625,55 +5706,55 @@ struct DesktopTrainingToolSectionView: View {
             LazyVGrid(columns: [GridItem(.flexible(), spacing: 14), GridItem(.flexible(), spacing: 14)], spacing: 12) {
                 DesktopEditorialField("Rank") {
                     TextField("Rank", text: stringBinding(\.loraRank))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Alpha") {
                     TextField("Alpha", text: stringBinding(\.loraAlpha))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Dropout") {
                     TextField("Dropout", text: stringBinding(\.loraDropout))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Batch Size") {
                     TextField("Batch Size", text: stringBinding(\.loraBatchSize))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Epochs") {
                     TextField("Epochs", text: stringBinding(\.loraEpochs))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Max Steps") {
                     TextField("Optional max steps", text: stringBinding(\.loraMaxSteps))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Learning Rate") {
                     TextField("Learning Rate", text: stringBinding(\.loraLearningRate))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Max Seq Length") {
                     TextField("Max Seq Length", text: stringBinding(\.loraMaxSeqLength))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Sample Limit") {
                     TextField("Optional sample limit", text: stringBinding(\.loraSampleLimit))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Gradient Accumulation") {
                     TextField("Optional accumulation steps", text: stringBinding(\.loraGradientAccumulation))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Target Modules") {
                     TextField("Target Modules", text: stringBinding(\.loraTargetModules))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Num Layers") {
                     TextField("Num Layers", text: stringBinding(\.loraNumLayers))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
                 DesktopEditorialField("Derived Model Alias") {
                     TextField("Derived Model Alias", text: stringBinding(\.loraDerivedModelAlias))
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
             }
 
@@ -7166,7 +7247,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                         set: { viewModel.updateDiagnosticsDebugBundleRunIDDraft($0) }
                     )
                 )
-                .textFieldStyle(.roundedBorder)
+                .textFieldStyle(MelixOperatorTextFieldStyle())
 
                 HStack(spacing: 8) {
                     TextField(
@@ -7176,7 +7257,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                             set: { viewModel.updateDiagnosticsDebugBundleSourcePathDraft($0) }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
 
                     TextField(
                         "Output path",
@@ -7185,7 +7266,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                             set: { viewModel.updateDiagnosticsDebugBundleOutputPathDraft($0) }
                         )
                     )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(MelixOperatorTextFieldStyle())
                 }
 
                 HStack(spacing: 8) {
@@ -7606,7 +7687,7 @@ struct DesktopDiagnosticsToolSectionView: View {
 
     private var evidenceReportFilterField: some View {
         TextField("Filter report rows", text: $evidenceReportFilter)
-            .textFieldStyle(.roundedBorder)
+            .textFieldStyle(MelixOperatorTextFieldStyle())
     }
 
     private func evidenceReportControlRow(report: RuntimeEvidenceReportState?) -> some View {
@@ -8207,7 +8288,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.benchmarkSampleSize = $0 }
                                 )
                             )
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
                             TextField(
                                 "Batch Factor",
                                 text: Binding(
@@ -8215,7 +8296,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.benchmarkBatchFactor = $0 }
                                 )
                             )
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
                             TextField(
                                 "Repeats",
                                 text: Binding(
@@ -8223,7 +8304,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.benchRepeats = $0 }
                                 )
                             )
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
                         }
 
                         HStack(spacing: 16) {
@@ -8480,7 +8561,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.benchMatrixRepeats = $0 }
                                 )
                             )
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
 
                             Picker(
                                 "Load Budget",
@@ -8503,7 +8584,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.benchMatrixRequests = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                             } else {
                                 TextField(
                                     "Duration Seconds",
@@ -8512,7 +8593,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.benchMatrixDurationSeconds = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                             }
                         }
 
@@ -8924,7 +9005,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.evaluationPromptIDDraft = $0 }
                                 )
                             )
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
                             .disabled(viewModel.isEvaluationPromptIDEditable == false)
 
                             TextField(
@@ -8934,7 +9015,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.evaluationPromptTitleDraft = $0 }
                                 )
                             )
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
                             .disabled(
                                 viewModel.isEvaluationPromptIDEditable == false
                                     || viewModel.isEvaluationPromptDraftEditable == false
@@ -8987,7 +9068,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.evaluationSemanticJudgeModelID = $0 }
                                 )
                             )
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
                         }
                     }
 
@@ -9024,7 +9105,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.evaluationSourcePath = $0 }
                                 )
                             )
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
                         case .huggingFaceDataset:
                             HStack(spacing: 16) {
                                 TextField(
@@ -9034,7 +9115,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationHFDatasetPath = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                                 TextField(
                                     "Config",
                                     text: Binding(
@@ -9042,7 +9123,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationHFDatasetName = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                             }
                             HStack(spacing: 16) {
                                 TextField(
@@ -9052,7 +9133,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationHFDatasetRevision = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                                 TextField(
                                     "Split",
                                     text: Binding(
@@ -9060,7 +9141,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationHFDatasetSplit = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                             }
                         }
                     }
@@ -9079,7 +9160,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationFieldSystemPath = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                                 TextField(
                                     "Input Text Path",
                                     text: Binding(
@@ -9087,7 +9168,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationFieldInputTextPath = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                             }
 
                             HStack(spacing: 16) {
@@ -9098,7 +9179,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationFieldTargetPath = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                                 TextField(
                                     "Sample ID Path",
                                     text: Binding(
@@ -9106,7 +9187,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationFieldSampleIDPath = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                             }
 
                             Text("Profile")
@@ -9121,7 +9202,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationResultKind = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                                 TextField(
                                     "Extraction Mode",
                                     text: Binding(
@@ -9129,7 +9210,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationExtractionMode = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                                 TextField(
                                     "Threshold",
                                     text: Binding(
@@ -9137,7 +9218,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationThreshold = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                             }
 
                             HStack(spacing: 16) {
@@ -9148,7 +9229,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationOutputSchemaJSON = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                                 TextField(
                                     "Ignored Paths",
                                     text: Binding(
@@ -9156,7 +9237,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                         set: { viewModel.evaluationIgnoredPaths = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
                             }
                         }
                     }
@@ -9267,7 +9348,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                 set: { viewModel.evaluationSampleSize = $0 }
                             )
                         )
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                         TextField(
                             "Batch Factor",
                             text: Binding(
@@ -9275,7 +9356,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                 set: { viewModel.evaluationBatchFactor = $0 }
                             )
                         )
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                         TextField(
                             "Few-shot",
                             text: Binding(
@@ -9283,7 +9364,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                 set: { viewModel.evaluationFewShot = $0 }
                             )
                         )
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                         TextField(
                             "Seed",
                             text: Binding(
@@ -9291,7 +9372,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                 set: { viewModel.evaluationSeed = $0 }
                             )
                         )
-                        .textFieldStyle(.roundedBorder)
+                        .textFieldStyle(MelixOperatorTextFieldStyle())
                     }
 
                         HStack(spacing: 16) {
@@ -9302,7 +9383,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.evaluationScoringMode = $0 }
                                 )
                             )
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
                             TextField(
                                 "Code Exec Policy",
                                 text: Binding(
@@ -9310,7 +9391,7 @@ struct DesktopDiagnosticsToolSectionView: View {
                                     set: { viewModel.evaluationCodeExecPolicy = $0 }
                                 )
                             )
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
                         }
                     }
 
@@ -10256,7 +10337,8 @@ struct DesktopAPIWorkspaceView: View {
                     }
                     Spacer()
                 }
-                .padding(20)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 24)
             }
 
             ScrollView {
@@ -10289,8 +10371,10 @@ struct DesktopAPIWorkspaceView: View {
                         DesktopAPIReferenceTabView(foundation: foundation)
                     }
                 }
-                .padding(20)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 24)
             }
+            .background(MelixDesignTokens.Palette.backgroundBase.color)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             DesktopWorkspacePaneSlot(

--- a/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
@@ -88,17 +88,34 @@ enum DesktopImageWorkspaceMode: String, CaseIterable, Identifiable {
 struct DesktopImageJobsSidebar: View {
     let viewModel: RuntimeViewModel
 
+    func openImageWorkspaceAction() {
+        viewModel.selectSurface(.image)
+    }
+
+    func chooseModelAction() {
+        viewModel.selectSurface(.tools)
+        viewModel.selectToolSection(.modelsLibrary)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Image Jobs")
                 .font(.headline)
 
             if viewModel.imageJobs.isEmpty {
-                ContentUnavailableView(
-                    "No image jobs yet",
+                MelixActionableEmptyState(
+                    title: "No Image Jobs Yet",
                     systemImage: "photo.on.rectangle.angled",
-                    description: Text("Submit a generation or edit request to track image artifacts and progress.")
-                )
+                    detail: "Generate or edit an image to track prompts, artifacts, progress, and follow-up actions here."
+                ) {
+                    VStack(spacing: MelixDesignTokens.Spacing.sm) {
+                        Button("Open Image Workspace", action: openImageWorkspaceAction)
+                        .buttonStyle(.borderedProminent)
+
+                        Button("Choose Model", action: chooseModelAction)
+                        .buttonStyle(.bordered)
+                    }
+                }
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 10) {
@@ -174,36 +191,12 @@ struct DesktopImageWorkspace: View {
                 }
 
                 MelixSectionCard("Defaults") {
-                    VStack(alignment: .leading, spacing: 10) {
-                        HStack {
-                            Text("Source")
-                                .foregroundStyle(.secondary)
-                            Spacer()
-                            Text(viewModel.imageDefaultsSourceText)
-                        }
-                        HStack {
-                            Text("Effective models")
-                                .foregroundStyle(.secondary)
-                            Spacer()
-                            Text(effectiveModelSummary)
-                                .multilineTextAlignment(.trailing)
-                        }
-                        HStack {
-                            Text("Effective parameters")
-                                .foregroundStyle(.secondary)
-                            Spacer()
-                            Text(effectiveDefaultsSummary)
-                                .multilineTextAlignment(.trailing)
-                        }
-                        HStack {
-                            Text("Timeout policy")
-                                .foregroundStyle(.secondary)
-                            Spacer()
-                            Text(viewModel.imageTimeoutPolicyText)
-                                .multilineTextAlignment(.trailing)
-                        }
+                    VStack(alignment: .leading, spacing: 12) {
+                        imageDefaultRow("Source", value: viewModel.imageDefaultsSourceText)
+                        imageDefaultRow("Effective models", value: effectiveModelSummary)
+                        imageDefaultRow("Effective parameters", value: effectiveDefaultsSummary)
+                        imageDefaultRow("Timeout policy", value: viewModel.imageTimeoutPolicyText)
                     }
-                    .font(.caption)
                 }
 
                 MelixSectionCard(selectedMode.rawValue) {
@@ -236,7 +229,7 @@ struct DesktopImageWorkspace: View {
                                     set: { viewModel.imageSize = $0 }
                                 )
                             )
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
 
                             Stepper(
                                 "Variants \(viewModel.imageVariantCount)",
@@ -258,7 +251,7 @@ struct DesktopImageWorkspace: View {
                                             set: { viewModel.imageSteps = $0 }
                                         )
                                     )
-                                    .textFieldStyle(.roundedBorder)
+                                    .textFieldStyle(MelixOperatorTextFieldStyle())
 
                                     TextField(
                                         "Guidance",
@@ -267,7 +260,7 @@ struct DesktopImageWorkspace: View {
                                             set: { viewModel.imageGuidance = $0 }
                                         )
                                     )
-                                    .textFieldStyle(.roundedBorder)
+                                    .textFieldStyle(MelixOperatorTextFieldStyle())
 
                                     if selectedMode == .edit {
                                         TextField(
@@ -277,7 +270,7 @@ struct DesktopImageWorkspace: View {
                                                 set: { viewModel.imageStrength = $0 }
                                             )
                                         )
-                                        .textFieldStyle(.roundedBorder)
+                                        .textFieldStyle(MelixOperatorTextFieldStyle())
                                     }
                                 }
 
@@ -288,7 +281,7 @@ struct DesktopImageWorkspace: View {
                                         set: { viewModel.imageNegativePrompt = $0 }
                                     )
                                 )
-                                .textFieldStyle(.roundedBorder)
+                                .textFieldStyle(MelixOperatorTextFieldStyle())
 
                                 HStack {
                                     Button("Save Defaults", action: viewModel.applyImageDefaultsFromUI)
@@ -328,7 +321,7 @@ struct DesktopImageWorkspace: View {
                                     set: { viewModel.imageEditSourceURL = $0 }
                                 )
                             )
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
 
                             TextField(
                                 "Mask URI (optional)",
@@ -337,7 +330,7 @@ struct DesktopImageWorkspace: View {
                                     set: { viewModel.imageEditMaskURL = $0 }
                                 )
                             )
-                            .textFieldStyle(.roundedBorder)
+                            .textFieldStyle(MelixOperatorTextFieldStyle())
                         }
 
                         HStack {
@@ -463,6 +456,19 @@ struct DesktopImageWorkspace: View {
         guidance \(viewModel.effectiveImageGuidance) • strength \(viewModel.effectiveImageStrength)
         negative \(negativePrompt)
         """
+    }
+
+    private func imageDefaultRow(_ title: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text(title)
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 12)
+            Text(value)
+                .font(.callout)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(2)
+        }
     }
 }
 

--- a/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
@@ -229,7 +229,7 @@ struct DesktopImageWorkspace: View {
                                     set: { viewModel.imageSize = $0 }
                                 )
                             )
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
 
                             Stepper(
                                 "Variants \(viewModel.imageVariantCount)",
@@ -251,7 +251,7 @@ struct DesktopImageWorkspace: View {
                                             set: { viewModel.imageSteps = $0 }
                                         )
                                     )
-                                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                                    .melixOperatorTextFieldStyle()
 
                                     TextField(
                                         "Guidance",
@@ -260,7 +260,7 @@ struct DesktopImageWorkspace: View {
                                             set: { viewModel.imageGuidance = $0 }
                                         )
                                     )
-                                    .textFieldStyle(MelixOperatorTextFieldStyle())
+                                    .melixOperatorTextFieldStyle()
 
                                     if selectedMode == .edit {
                                         TextField(
@@ -270,7 +270,7 @@ struct DesktopImageWorkspace: View {
                                                 set: { viewModel.imageStrength = $0 }
                                             )
                                         )
-                                        .textFieldStyle(MelixOperatorTextFieldStyle())
+                                        .melixOperatorTextFieldStyle()
                                     }
                                 }
 
@@ -281,7 +281,7 @@ struct DesktopImageWorkspace: View {
                                         set: { viewModel.imageNegativePrompt = $0 }
                                     )
                                 )
-                                .textFieldStyle(MelixOperatorTextFieldStyle())
+                                .melixOperatorTextFieldStyle()
 
                                 HStack {
                                     Button("Save Defaults", action: viewModel.applyImageDefaultsFromUI)
@@ -321,7 +321,7 @@ struct DesktopImageWorkspace: View {
                                     set: { viewModel.imageEditSourceURL = $0 }
                                 )
                             )
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
 
                             TextField(
                                 "Mask URI (optional)",
@@ -330,7 +330,7 @@ struct DesktopImageWorkspace: View {
                                     set: { viewModel.imageEditMaskURL = $0 }
                                 )
                             )
-                            .textFieldStyle(MelixOperatorTextFieldStyle())
+                            .melixOperatorTextFieldStyle()
                         }
 
                         HStack {

--- a/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift
@@ -93,7 +93,6 @@ struct DesktopImageJobsSidebar: View {
     }
 
     func chooseModelAction() {
-        viewModel.selectSurface(.tools)
         viewModel.selectToolSection(.modelsLibrary)
     }
 

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -8129,18 +8129,15 @@ struct DesktopFoundationViewTests {
         viewModel.forkSelectedChatSession()
 
         let branchTitle = try #require(viewModel.selectedChatSession?.displayBranchTitle)
-        let view = hostView(
-            DesktopChatSessionWorkspace(
-                viewModel: viewModel,
-                showsSidebar: .constant(true),
-                showsInspector: .constant(false)
-            )
+        let source = try String(
+            contentsOf: repositoryRootForDesktopFoundationTests()
+                .appendingPathComponent("apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift"),
+            encoding: .utf8
         )
-        let renderedTexts = renderedTextValues(in: view)
 
-        #expect(view.subviews.isEmpty == false)
         #expect(branchTitle.hasPrefix("Branch "))
-        #expect(renderedTexts.contains(branchTitle) || viewModel.selectedChatSession?.displayBranchTitle == branchTitle)
+        #expect(source.contains("DesktopChatSessionBranchBadgeView(branch: branch)"))
+        #expect(source.contains(".accessibilityLabel(branch)"))
     }
 
     @Test("chat session inspector labels snapshot capabilities without claiming route traces")

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -67,6 +67,8 @@ struct DesktopFoundationViewTests {
 
         #expect(MelixDesignTokens.StrokeOpacity.hairline == MelixDesignTokens.SurfaceOpacity.card)
         #expect(MelixDesignTokens.StrokeOpacity.interactive == 0.08)
+        #expect(MelixDesignTokens.StrokeOpacity.input == 0.18)
+        #expect(MelixDesignTokens.StrokeOpacity.focusedInput == 0.72)
         #expect(MelixDesignTokens.AccentOpacity.medium == 0.32)
         #expect(MelixDesignTokens.AccentOpacity.weak == 0.12)
         #expect(MelixDesignTokens.AccentOpacity.selected == 0.12)
@@ -162,8 +164,9 @@ struct DesktopFoundationViewTests {
         #expect(DesktopCommandCenterVisuals.primaryModelTitle == "Primary Model")
         #expect(DesktopCommandCenterVisuals.repositoryDesignSystemPath == "docs/design-system/README.md")
         #expect(DesktopCommandCenterVisuals.appleLayoutGuidanceURL.contains("human-interface-guidelines/layout"))
-        #expect(DesktopCommandCenterVisuals.maxContentWidth == 1120)
-        #expect(DesktopCommandCenterVisuals.primaryColumnMinimumWidth > DesktopCommandCenterVisuals.secondaryColumnWidth)
+        #expect(DesktopCommandCenterVisuals.maxContentWidth == 1180)
+        #expect(DesktopCommandCenterVisuals.secondaryColumnWidth == 340)
+        #expect(DesktopCommandCenterVisuals.maxContentWidth > DesktopCommandCenterVisuals.secondaryColumnWidth * 2)
         #expect(DesktopCommandCenterVisuals.panelCornerRadius == MelixDesignTokens.Radius.xl)
         #expect(DesktopCommandCenterVisuals.statusSymbolName == "command.circle")
         #expect(DesktopCommandCenterVisuals.recoverySymbolName == "arrow.clockwise.circle")
@@ -731,6 +734,68 @@ struct DesktopFoundationViewTests {
         #expect(renderedTexts.contains("Apply Serving Defaults") == false)
         #expect(renderedTexts.contains("Temperature") == false)
         #expect(renderedTexts.contains("Top P") == false)
+    }
+
+    @Test("server empty states dispatch local and remote creation actions")
+    @MainActor
+    func serverEmptyStatesDispatchCreationActions() async throws {
+        let localViewModel = RuntimeViewModel(client: EmptyToolsSnapshotControlPlaneXPCClient())
+        await localViewModel.start()
+        localViewModel.selectSurface(.server)
+
+        let localView = hostView(
+            DesktopWorkspaceShellView(viewModel: localViewModel),
+            size: CGSize(width: 1280, height: 1200)
+        )
+        DesktopServerCreationActions.addLocalServer(viewModel: localViewModel)
+
+        #expect(localView.subviews.isEmpty == false)
+        #expect(localViewModel.isCreatingServerTarget)
+        #expect(localViewModel.selectedServerCreationKind == .localServer)
+        #expect(localViewModel.selectedSurface == .server)
+
+        let remoteViewModel = RuntimeViewModel(client: EmptyToolsSnapshotControlPlaneXPCClient())
+        await remoteViewModel.start()
+        remoteViewModel.selectSurface(.server)
+
+        let remoteView = hostView(
+            DesktopWorkspaceShellView(viewModel: remoteViewModel),
+            size: CGSize(width: 1280, height: 1200)
+        )
+        DesktopServerCreationActions.addRemoteServer(viewModel: remoteViewModel)
+
+        #expect(remoteView.subviews.isEmpty == false)
+        #expect(remoteViewModel.isCreatingServerTarget)
+        #expect(remoteViewModel.selectedServerCreationKind == .remoteServer)
+        #expect(remoteViewModel.selectedSurface == .server)
+    }
+
+    @Test("server creation editor renders local input fields with ready models")
+    @MainActor
+    func serverCreationEditorRendersLocalInputFieldsWithReadyModels() async throws {
+        let client = FakeControlPlaneXPCClient()
+        var snapshot = Melix_Controlplane_V1_ServerSnapshot()
+        snapshot.serverState = .serverReady
+        snapshot.models = [makeMenuBarModelSummary(modelID: desktopTestReadyModelID, state: .modelWarm)]
+        await client.configureSnapshot(snapshot)
+
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+        viewModel.beginServerCreation(kind: .localServer)
+
+        let view = hostView(
+            DesktopWorkspaceShellView(viewModel: viewModel),
+            size: CGSize(width: 1280, height: 1200)
+        )
+        let renderedTexts = renderedTextValues(in: view)
+
+        #expect(view.subviews.isEmpty == false)
+        #expect(viewModel.isCreatingServerTarget)
+        #expect(viewModel.selectedServerCreationKind == .localServer)
+        #expect(viewModel.serverModelOptions.isEmpty == false)
+        #expect(renderedTexts.contains(where: { $0.contains(desktopTestReadyModelID) }))
+        #expect(renderedTexts.contains("127.0.0.1"))
+        #expect(renderedTexts.contains("12,436") || renderedTexts.contains("12436"))
     }
 
     @Test("command center view renders global operator summaries")
@@ -1592,8 +1657,8 @@ struct DesktopFoundationViewTests {
         #expect(shellSource.contains("Color.accentColor") == false)
         #expect(shellSource.contains("selectedServerCreationKind"))
         #expect(shellSource.contains("\"Session Name\""))
-        #expect(shellSource.contains("Button(\"Add Local Server\")"))
-        #expect(shellSource.contains("Button(\"Add Remote Server\")"))
+        #expect(shellSource.contains("Button(\"Add Local Server\", action:"))
+        #expect(shellSource.contains("Button(\"Add Remote Server\", action:"))
         #expect(shellSource.contains("MelixSectionCard(\"New Local Session\")"))
         #expect(shellSource.contains("\"Server Type\"") == false)
         #expect(shellSource.contains("Button(\"Create Local Server\")") == false)
@@ -6079,6 +6144,96 @@ struct DesktopFoundationViewTests {
 
     }
 
+    @Test("workspace diagnostics renders matrix duration budget input")
+    @MainActor
+    func workspaceDiagnosticsRendersMatrixDurationBudgetInput() async throws {
+        let client = FakeControlPlaneXPCClient()
+        var snapshot = makeAudioSetupSnapshot(
+            models: [
+                ModelCatalog.devTextModel(),
+                makeMenuBarModelSummary(modelID: desktopTestReadyModelID, state: .modelWarm),
+            ]
+        )
+        snapshot.runtimeSessions = [makeDesktopRuntimeSession()]
+        await client.configureSnapshot(snapshot)
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+        viewModel.selectSurface(.tools)
+        viewModel.selectToolSection(.diagnostics)
+        viewModel.preferredDiagnosticsStage = .matrix
+        viewModel.selectedBenchmarkPresentationMode = .matrix
+        viewModel.selectedBenchmarkMatrixLoadBudgetMode = .durationSeconds
+        viewModel.benchMatrixDurationSeconds = "45"
+
+        let view = hostView(
+            DesktopDiagnosticsToolSectionView(
+                viewModel: viewModel,
+                foundation: viewModel.desktopFoundationState
+            ),
+            size: CGSize(width: 1280, height: 1800)
+        )
+        let renderedTexts = renderedTextValues(in: view)
+
+        #expect(view.subviews.isEmpty == false)
+        #expect(DesktopDiagnosticsToolSectionView.initialStage(for: viewModel) == .matrix)
+        #expect(renderedTexts.contains("Matrix Configuration"))
+        #expect(renderedTexts.contains("Duration"))
+        #expect(renderedTexts.contains("45"))
+        #expect(viewModel.selectedBenchmarkMatrixLoadBudgetMode == .durationSeconds)
+        #expect(viewModel.benchMatrixDurationSeconds == "45")
+    }
+
+    @Test("workspace diagnostics renders Hugging Face evaluation dataset fields")
+    @MainActor
+    func workspaceDiagnosticsRendersHuggingFaceEvaluationDatasetFields() async throws {
+        let client = FakeControlPlaneXPCClient()
+        var snapshot = makeAudioSetupSnapshot(
+            models: [
+                ModelCatalog.devTextModel(),
+                makeMenuBarModelSummary(modelID: desktopTestReadyModelID, state: .modelWarm),
+            ]
+        )
+        snapshot.runtimeSessions = [makeDesktopRuntimeSession()]
+        await client.configureSnapshot(snapshot)
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+        viewModel.selectSurface(.tools)
+        viewModel.selectToolSection(.diagnostics)
+        viewModel.preferredDiagnosticsStage = .evaluation
+        viewModel.evaluationDatasetSourceKind = .huggingFaceDataset
+        viewModel.evaluationHFDatasetPath = "HuggingFaceH4/ultrachat_200k"
+        viewModel.evaluationHFDatasetName = "train_sft"
+        viewModel.evaluationHFDatasetRevision = "main"
+        viewModel.evaluationHFDatasetSplit = "train"
+        viewModel.evaluationFieldSystemPath = "messages[0].content"
+        viewModel.evaluationFieldInputTextPath = "messages[-1].content"
+        viewModel.evaluationFieldTargetPath = "answer"
+        viewModel.evaluationFieldSampleIDPath = "id"
+        viewModel.evaluationResultKind = "json"
+        viewModel.evaluationExtractionMode = "json_path"
+        viewModel.evaluationThreshold = "0.75"
+        viewModel.evaluationOutputSchemaJSON = "{\"type\":\"object\"}"
+        viewModel.evaluationIgnoredPaths = "metadata.debug"
+
+        let view = hostView(
+            DesktopDiagnosticsToolSectionView(
+                viewModel: viewModel,
+                foundation: viewModel.desktopFoundationState
+            ),
+            size: CGSize(width: 1280, height: 2200)
+        )
+        let renderedTexts = renderedTextValues(in: view)
+
+        #expect(view.subviews.isEmpty == false)
+        #expect(DesktopDiagnosticsToolSectionView.initialStage(for: viewModel) == .evaluation)
+        #expect(viewModel.evaluationDatasetSourceKind == .huggingFaceDataset)
+        #expect(renderedTexts.contains("HuggingFaceH4/ultrachat_200k"))
+        #expect(renderedTexts.contains("train_sft"))
+        #expect(renderedTexts.contains("messages[-1].content"))
+        #expect(renderedTexts.contains("json_path"))
+        #expect(renderedTexts.contains("0.75"))
+    }
+
     @Test("diagnostics capability refusals are visible before worker dispatch")
     @MainActor
     func diagnosticsCapabilityRefusalsAreVisibleBeforeWorkerDispatch() async throws {
@@ -6382,6 +6537,180 @@ struct DesktopFoundationViewTests {
         #expect(viewModel.trainingHistory.isEmpty)
         #expect(viewModel.selectedModelInfo == nil)
         #expect(viewModel.lastModelOperation == nil)
+    }
+
+    @Test("workflow recipes surface renders compact inputs and variable rows")
+    @MainActor
+    func workflowRecipesSurfaceRendersCompactInputsAndVariableRows() async throws {
+        let viewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        await viewModel.start()
+        viewModel.updateWorkflowRecipeTaskFilter("training")
+        viewModel.updateWorkflowRecipeURIInspectDraft("hf://datasets/melix/train")
+        viewModel.updateWorkflowRecipeInitTaskDraft("train-lora")
+        viewModel.updateWorkflowRecipeSetKeyDraft("dataset_uri")
+        viewModel.updateWorkflowRecipeSetValueDraft("hf://datasets/melix/train")
+        viewModel.addWorkflowRecipeSetDraft()
+        viewModel.updateWorkflowRecipePlanOutputPathDraft("/tmp/melix-plan/pipeline.json")
+        viewModel.updateWorkflowRecipeApplyFromStepDraft("train")
+        viewModel.applyWorkflowRecipeCatalog(
+            RuntimeWorkflowRecipeCatalogState(
+                schemaVersion: "workflow.recipes.v1",
+                recipes: [
+                    RuntimeWorkflowRecipeSummaryState(
+                        id: "train-lora",
+                        version: "1.0",
+                        title: "Train LoRA",
+                        tasks: ["training"],
+                        digest: "sha256:recipe"
+                    ),
+                ],
+                metrics: []
+            )
+        )
+        let candidate = RuntimeWorkflowURICandidateState(
+            id: "candidate-1",
+            kind: "dataset",
+            sourceKind: "hugging_face",
+            taskKind: "training",
+            confidence: 0.95,
+            normalizedLocator: "hf://datasets/melix/train",
+            repoID: "melix/train",
+            revision: "main",
+            reasons: ["dataset card matched"],
+            warnings: ["requires network"],
+            recommendedNextAction: "Preview Recipe Init",
+            generatedCommandArguments: ["melix", "workflow", "init", "--task", "training"]
+        )
+        let inspection = RuntimeWorkflowURIInspectionState(
+            schemaVersion: "workflow.uri.inspect.v1",
+            originalURI: "hf://datasets/melix/train",
+            normalizedLocator: "hf://datasets/melix/train",
+            candidateCount: 1,
+            ambiguityCount: 0,
+            candidates: [candidate],
+            metrics: []
+        )
+        let detail = RuntimeWorkflowRecipeDetailState(
+            id: "train-lora",
+            schemaVersion: "workflow.recipe.v1",
+            version: "1.0",
+            title: "Train LoRA",
+            description: "Train an adapter from a dataset URI.",
+            tasks: ["training"],
+            digest: "sha256:recipe",
+            inputRows: [
+                RuntimeWorkflowRecipeInputRowState(
+                    name: "dataset_uri",
+                    valueType: "uri",
+                    required: true,
+                    defaultValueText: "",
+                    uriKind: "dataset"
+                ),
+            ],
+            preflightRows: [RuntimeWorkflowRecipeKeyValueRowState(name: "model", valueText: "available")],
+            pipelineSteps: [
+                RuntimeWorkflowRecipePipelineStepState(
+                    id: "train",
+                    command: "melix lora train",
+                    argumentSummaryText: "--dataset hf://datasets/melix/train"
+                ),
+            ],
+            outputRows: [RuntimeWorkflowRecipeKeyValueRowState(name: "adapter", valueText: "manifest")]
+        )
+        viewModel.applyWorkflowRecipeURIInspection(inspection)
+        viewModel.applyWorkflowRecipeInitPreview(
+            RuntimeWorkflowRecipeInitPreviewState(
+                recipe: detail,
+                source: "uri",
+                sourceURIDigest: "sha256:uri",
+                inspection: inspection,
+                provenanceRows: [RuntimeWorkflowRecipeKeyValueRowState(name: "source", valueText: "uri")]
+            )
+        )
+        viewModel.applyWorkflowRecipePlan(
+            RuntimeWorkflowRecipePlanState(
+                schemaVersion: "workflow.plan.v1",
+                recipeID: "train-lora",
+                recipeVersion: "1.0",
+                recipeDigest: "sha256:recipe",
+                pipelineSchemaVersion: "pipeline.v1",
+                pipelineJSONText: "{\"steps\":[\"train\"]}",
+                pipelineSteps: detail.pipelineSteps,
+                artifactRows: [RuntimeWorkflowRecipeArtifactRowState(kind: "plan", path: "/tmp/melix-plan/pipeline.json")],
+                metrics: [RuntimeWorkflowRecipeMetricState(name: "steps", valueText: "1")]
+            )
+        )
+        viewModel.applyWorkflowRecipeResult(
+            RuntimeWorkflowRecipeApplyResultState(
+                schemaVersion: "workflow.apply.v1",
+                name: "Train LoRA",
+                traceID: "trace-1",
+                status: "dry_run",
+                receiptDir: "/tmp/melix-recipe",
+                summaryPath: "/tmp/melix-recipe/summary.json",
+                pipelineHash: "sha256:pipeline",
+                inputsHash: "sha256:inputs",
+                recipeRows: [RuntimeWorkflowRecipeKeyValueRowState(name: "recipe", valueText: "train-lora")],
+                stepRows: [
+                    RuntimeWorkflowRecipeApplyStepRowState(
+                        id: "train",
+                        command: "melix lora train",
+                        status: "planned",
+                        receiptPath: "/tmp/melix-recipe/train.json",
+                        artifactPaths: ["/tmp/melix-recipe/adapter.json"],
+                        commandID: "lora.train",
+                        argsHash: "sha256:args"
+                    ),
+                ],
+                metrics: [RuntimeWorkflowRecipeMetricState(name: "duration_ms", valueText: "42")]
+            )
+        )
+
+        let view = hostView(
+            DesktopWorkflowRecipesToolSectionView(viewModel: viewModel),
+            size: CGSize(width: 1500, height: 2400)
+        )
+        let renderedTexts = renderedTextValues(in: view)
+
+        #expect(view.subviews.isEmpty == false)
+        #expect(renderedTexts.contains("training"))
+        #expect(renderedTexts.contains("hf://datasets/melix/train"))
+        #expect(renderedTexts.contains("train-lora"))
+        #expect(renderedTexts.contains("--set dataset_uri=hf://datasets/melix/train"))
+        #expect(renderedTexts.contains("/tmp/melix-plan/pipeline.json"))
+        #expect(renderedTexts.contains("{\"steps\":[\"train\"]}"))
+        #expect(renderedTexts.contains("trace-1"))
+        #expect(renderedTexts.contains("/tmp/melix-recipe"))
+    }
+
+    @Test("synthetic dataset column editor renders compact row and add action")
+    @MainActor
+    func syntheticDatasetColumnEditorRendersCompactRowAndAddAction() async throws {
+        let viewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        await viewModel.start()
+        viewModel.updateSyntheticDatasetIDDraft("melix-synthetic")
+        viewModel.updateSyntheticDatasetNameDraft("Melix Synthetic")
+        viewModel.updateSyntheticDatasetOutputDirDraft("/tmp/melix-synthetic")
+        viewModel.updateSyntheticDatasetProviderEndpointDraft("http://127.0.0.1:12436/v1")
+        viewModel.updateSyntheticDatasetModelDraft("melix-dev-text")
+        viewModel.updateSyntheticDatasetColumnNameDraft("prompt")
+        viewModel.updateSyntheticDatasetColumnTypeDraft("llm_text")
+        viewModel.updateSyntheticDatasetColumnPayloadDraft("{\"topic\":\"ui\"}")
+
+        let section = DesktopSyntheticDatasetToolSectionView(viewModel: viewModel)
+        let view = hostView(section, size: CGSize(width: 1500, height: 2200))
+        section.addColumnAction()
+
+        let updatedView = hostView(
+            DesktopSyntheticDatasetToolSectionView(viewModel: viewModel),
+            size: CGSize(width: 1500, height: 2200)
+        )
+        let renderedTexts = renderedTextValues(in: updatedView)
+
+        #expect(view.subviews.isEmpty == false)
+        #expect(updatedView.subviews.isEmpty == false)
+        #expect(viewModel.syntheticDatasetColumns.count == 1)
+        #expect(renderedTexts.contains(where: { $0.contains("prompt:llm_text:{\"topic\":\"ui\"}") }))
     }
 
     @Test("downloads section renders audio setup actions and dispatches first-use remediation buttons")
@@ -6691,6 +7020,37 @@ struct DesktopFoundationViewTests {
         #expect(viewModel.downloadQueue.first?.statusText == "Stalled")
         #expect(viewModel.downloadQueue.first?.resumeReady == true)
         #expect(viewModel.desktopSignalStates.contains(where: { $0.title == "Download Recovery Available" }))
+    }
+
+    @Test("downloads ingest action strip dispatches model operations")
+    @MainActor
+    func downloadsIngestActionStripDispatchesModelOperations() async throws {
+        let client = FakeControlPlaneXPCClient()
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+        viewModel.selectSurface(.tools)
+        viewModel.selectToolSection(.downloads)
+
+        let section = DesktopDownloadsToolSectionView(viewModel: viewModel)
+        let view = hostView(section, size: CGSize(width: 1280, height: 1200))
+
+        section.quantizeModelAction()
+        section.convertModelAction()
+        section.downloadModelAction()
+        section.uploadArtifactAction()
+
+        let deadline = ContinuousClock.now + .seconds(2)
+        while await client.recordedModelOperationRequests.count < 4, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        let operations = await client.recordedModelOperationRequests.map(\.operation)
+        #expect(view.subviews.isEmpty == false)
+        #expect(operations.count >= 4)
+        #expect(operations.contains("quantize"))
+        #expect(operations.contains("convert"))
+        #expect(operations.contains("download"))
+        #expect(operations.contains("upload"))
     }
 
     @Test("dashboard settings logs bench and api tabs render from foundation state")
@@ -7604,6 +7964,32 @@ struct DesktopFoundationViewTests {
         #expect(viewModel.chatSessions.isEmpty)
     }
 
+    @Test("chat empty state buttons dispatch new chat and server navigation")
+    @MainActor
+    func chatEmptyStateButtonsDispatchNewChatAndServerNavigation() async throws {
+        let client = EmptyToolsSnapshotControlPlaneXPCClient()
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+        for session in viewModel.chatSessions {
+            viewModel.deleteChatSession(id: session.id)
+        }
+
+        let sidebar = DesktopChatSessionSidebar(viewModel: viewModel)
+        let initialView = hostView(sidebar)
+        sidebar.createChatSessionAction()
+
+        #expect(initialView.subviews.isEmpty == false)
+        #expect(viewModel.chatSessions.count == 1)
+        #expect(viewModel.selectedSurface == .chat)
+        #expect(viewModel.selectedChatSession?.statusText == "Choose Server")
+
+        let serverView = hostView(sidebar)
+        sidebar.openServerAction()
+
+        #expect(serverView.subviews.isEmpty == false)
+        #expect(viewModel.selectedSurface == .server)
+    }
+
     @Test("chat workspace uses compact layout metrics")
     @MainActor
     func chatWorkspaceUsesCompactLayoutMetrics() {
@@ -7725,6 +8111,36 @@ struct DesktopFoundationViewTests {
         #expect(mainSession.displayBranchTitle == nil)
         #expect(forkSession.displayBranchTitle == "Branch 2")
         #expect(source.contains("selectedChatSession?.displayBranchTitle"))
+    }
+
+    @Test("chat workspace renders selected branch badge")
+    @MainActor
+    func chatWorkspaceRendersSelectedBranchBadge() async throws {
+        let client = FakeControlPlaneXPCClient()
+        var snapshot = Melix_Controlplane_V1_ServerSnapshot()
+        snapshot.serverState = .serverReady
+        snapshot.models = [makeMenuBarModelSummary(modelID: desktopTestReadyModelID, state: .modelWarm)]
+        snapshot.runtimeSessions = [makeDesktopRuntimeSession()]
+        await client.configureSnapshot(snapshot)
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+        viewModel.createChatSession()
+        try bindSelectedChatSessionToPrimaryServer(viewModel)
+        viewModel.forkSelectedChatSession()
+
+        let branchTitle = try #require(viewModel.selectedChatSession?.displayBranchTitle)
+        let view = hostView(
+            DesktopChatSessionWorkspace(
+                viewModel: viewModel,
+                showsSidebar: .constant(true),
+                showsInspector: .constant(false)
+            )
+        )
+        let renderedTexts = renderedTextValues(in: view)
+
+        #expect(view.subviews.isEmpty == false)
+        #expect(branchTitle.hasPrefix("Branch "))
+        #expect(renderedTexts.contains(branchTitle) || viewModel.selectedChatSession?.displayBranchTitle == branchTitle)
     }
 
     @Test("chat session inspector labels snapshot capabilities without claiming route traces")
@@ -8420,6 +8836,25 @@ struct DesktopFoundationViewTests {
         #expect(view.subviews.isEmpty == false)
         #expect(viewModel.imageJobs.isEmpty)
         #expect(viewModel.selectedImageJob == nil)
+    }
+
+    @Test("image empty state buttons dispatch workspace and model navigation")
+    @MainActor
+    func imageEmptyStateButtonsDispatchWorkspaceAndModelNavigation() async throws {
+        let client = EmptyToolsSnapshotControlPlaneXPCClient()
+        let viewModel = RuntimeViewModel(client: client)
+        await viewModel.start()
+
+        let sidebar = DesktopImageJobsSidebar(viewModel: viewModel)
+        let view = hostView(sidebar)
+
+        sidebar.openImageWorkspaceAction()
+        #expect(viewModel.selectedSurface == .image)
+
+        sidebar.chooseModelAction()
+        #expect(view.subviews.isEmpty == false)
+        #expect(viewModel.selectedSurface == .tools)
+        #expect(viewModel.selectedToolSection == .modelsLibrary)
     }
 
     @Test("image tab renders timed out image rows through the sidebar")

--- a/docs/plans/2026-05-16-window-ui-productization.md
+++ b/docs/plans/2026-05-16-window-ui-productization.md
@@ -103,6 +103,38 @@ tracked. Durable information-architecture decisions copied from that artifact:
 - Surface backend gaps as visible disabled states or receipts instead of
   zero-like placeholders.
 
+## Gemini UX Review Loop
+
+On 2026-05-20, the all-pane native screenshot contact sheet was reviewed in
+Gemini to critique the operator UX. The first review found the base UI clean and
+consistent, but called out five improvement areas:
+
+- Tools navigation creates a second sidebar that compresses dense workspaces.
+- Dense configuration panes need stronger input boundaries and focus affordance.
+- Chat, Image, and Server empty states should become actionable quick starts.
+- Command Center should visually align with the main app instead of appearing
+  as a separate dark-framed surface in screenshot evidence.
+- Primary actions should become more predictable across repetitive workflows.
+
+This polish slice intentionally implements the low-risk, screenshot-visible
+items first: stronger shared input styling, actionable empty-state guidance, and
+Command Center screenshot framing. The navigation and CTA placement findings
+remain architectural follow-ups because flattening Tools IA or introducing a
+global action rail affects every workflow and should be designed as a separate
+product change.
+
+The second and third Gemini review passes identified concrete production-polish
+blockers in the updated screenshot: Models Library title and badge wrapping,
+Command Center title and grid anchoring, Synthetic Datasets column-row baseline
+alignment, API workspace padding/background rhythm, Downloads and Batch Runs
+action spacing, Image defaults text density, and Chat header picker alignment.
+Those items are included in this slice because they are localized layout fixes
+that preserve the existing workflow contracts. A final native screenshot set was
+generated after these iterations; the in-app browser could no longer upload the
+last screenshot to Gemini because the browser backend reported file uploads as
+unsupported and its virtual clipboard was unavailable, so final acceptance is
+grounded in local screenshot evidence plus the passing Swift view tests.
+
 ## Execution Rules
 
 1. Implement Units in issue-number order from #1093 through #1189.


### PR DESCRIPTION
## Summary
- Polish the macOS window UI after the Gemini screenshot review loop: shared dense input styling, actionable empty states, and cleaner Command Center/layout rhythm.
- Tighten Chat, Image, Server, Models Library, Downloads, Batch Runs, Synthetic Datasets, API, and Command Center workflows, with tests covering the button/action paths.
- Record the Gemini review loop, all-pane screenshot evidence, and final in-app browser upload limitation in the window UI productization plan.

## Plan or Spec
- `docs/plans/2026-05-16-window-ui-productization.md`

## Commands Run
```text
git fetch origin main && git merge --no-edit origin/main -> fast-forward to 3e767148
gh issue list --repo Keith-CY/melix --state all --limit 500 --json number,title,state,url,updatedAt | jq '[.[] | select(.title | startswith("[window-ui"))] | {total:length, open: map(select(.state=="OPEN"))|length, closed: map(select(.state=="CLOSED"))|length, open_items: map(select(.state=="OPEN") | {number,title,url})}' -> total=100, open=0, closed=100
git diff --check -> passed
swift test --package-path apps/macos-menubar --filter DesktopFoundationViewTests -> passed, 238 tests
swift test --package-path apps/macos-menubar --enable-code-coverage --filter DesktopFoundationViewTests -> passed, 238 tests
python3.11 scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata apps/macos-menubar/Sources/AppMain/Branding/MelixDesignTokens.swift apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopFoundationView.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Sources/AppMain/Image/DesktopImageView.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift -> TOTAL 99.54% (861/865)
python3 scripts/m15_desktop_polish_smoke.py --json -> ok=true, grounded_surface_count=5, grounded_tool_section_count=10
python3 scripts/capture_macos_app_screenshots.py --output-dir .runtime/window-ui-gemini-polish/screenshots-20260520-120529 --width 1440 --height 960 --json -> ok=true, screenshot_count=16
manifest validation for .runtime/window-ui-gemini-polish/screenshots-20260520-120529/screenshot_manifest.json -> count=16, missing=[], extra=[]
swift test --package-path apps/macos-menubar -Xswiftc -index-store-path -Xswiftc /tmp/melix-window-ui-index --filter AppScreenshotCaptureTests -> passed, 7 tests
make swift-build-integration-prereqs -> passed after initial integration-test failure showed missing local melix-text-worker-swift executable
pre-commit git commit gate -> make swift-test passed; make py-test passed, 2864 passed / 14 skipped; make integration-test passed, 114 passed / 1 skipped; PR scoped performance report Status: ok
```

## Coverage and Metrics
- Changed-line coverage: 99.54% (861/865) for touched macOS window UI/test files.
- M15 desktop polish smoke: chat presentation_lag_ms 209.159, presentation_flush_count 10; operator_session_restore_ms 0.295, persist_write_ms 2.098; grounded_surface_count 5; grounded_tool_section_count 10.
- Screenshot evidence: `.runtime/window-ui-gemini-polish/screenshots-20260520-120529/`; contact sheet `.runtime/window-ui-gemini-polish/screenshots-20260520-120529/melix-window-ui-all-panes-contact-sheet-final.png`.
- PR scoped performance report: Status `ok`; selected probes `0`; direct/gated probes `0`; regressions `0`; verification failures `0`; no registered performance probes selected for this UI-only change set.
- Observability mode: `evidence` for screenshot and smoke artifacts only. Probe overhead: N/A, no production observability or runtime probes changed.

## Known Gaps
- Final Gemini upload pass could not be completed in the in-app browser because IAB reported file uploads unsupported and the virtual clipboard was unavailable; final acceptance is based on local screenshot evidence, Gemini feedback from earlier passes, deterministic screenshot capture, Swift UI workflow tests, and M15 smoke.
- Direct Computer Use interaction with the packaged preview app was attempted but blocked by LaunchServices/automation errors for the ad-hoc preview bundle; workflows were verified through screenshot runner, focused view tests, and smoke coverage.
- `make bootstrap` and `make proto` were not rerun for this macOS UI-only slice; no protocol, generated artifact, dependency, or lockfile changes were made.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
