### PR TITLE
perf: slot dataset snapshot records

### DIFF
--- a/docs/plans/2026-05-20-dataset-registry-snapshot-slots.md
+++ b/docs/plans/2026-05-20-dataset-registry-snapshot-slots.md
@@ -1,0 +1,47 @@
+# Dataset Registry Snapshot Slots
+
+## Scope
+
+This Python-only performance slice is limited to the dataset snapshot value
+record in `services/mlx-worker-python/worker/dataset_registry/catalog.py`.
+
+## Registered PR-scoped probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`dataset-registry-snapshot-inference-single-pass` in
+`infra/perf/pr_scoped_probes.json`. The entry declares focused
+`test_command`, `coverage_command`, and `probe_command` values for:
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_snapshot_probe.py`
+
+No probe registry change is required for this slice.
+
+## Optimization hypothesis
+
+Dataset snapshot construction creates one `DatasetSnapshot` value record per
+discovered snapshot before serializing the registry payload. The record is
+frozen and does not need per-instance `__dict__` storage. Enabling dataclass
+slots should reduce per-snapshot allocation pressure while preserving field
+access, equality, immutability, and `to_dict()` behavior.
+
+## Verification plan
+
+1. Add a focused regression test that proves `DatasetSnapshot` remains frozen,
+   serializes through `to_dict()`, and no longer exposes a mutable instance
+   `__dict__`.
+2. Implement only `DatasetSnapshot` slots.
+3. Run the registered focused pytest command locally on Linux.
+4. Run the registered changed-scope coverage command locally on Linux and require
+   at least 95 percent changed-scope coverage.
+5. Run `scripts/dataset_registry_snapshot_probe.py` before and after the change
+   and compare `peak_bytes_mean` and `elapsed_ms_mean`.
+6. Use GitHub Actions PR-scoped performance as the final registered probe gate
+   before merge.
+
+## Linux validation boundary
+
+This slice is Python-only and locally verifiable on Linux. No Swift runtime
+performance claims are made.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -13,6 +13,7 @@ from worker.model_ops.errors import ModelOperationError
 from worker.dataset_registry.catalog import (
     DatasetCatalog,
     DatasetFile,
+    DatasetSnapshot,
     read_hf_dataset_snapshot_rows,
 )
 
@@ -55,6 +56,45 @@ def test_dataset_file_is_frozen_slots_value_record() -> None:
     }
     with pytest.raises(FrozenInstanceError):
         dataset_file.size_bytes = 43  # type: ignore[misc]
+
+
+def test_dataset_snapshot_is_frozen_slots_value_record(tmp_path: Path) -> None:
+    dataset_file = DatasetFile(
+        relative_path="data/train-00000-of-00001.jsonl",
+        size_bytes=42,
+        file_format="jsonl",
+    )
+    snapshot = DatasetSnapshot(
+        dataset_id="org/repo@main",
+        repo_id="org/repo",
+        revision="main",
+        snapshot_id="abc123",
+        snapshot_path=tmp_path / "snapshot",
+        cache_repo_path=tmp_path / "cache-repo",
+        source_kind="hf_cache_snapshot",
+        files=(dataset_file,),
+        total_bytes=42,
+        splits=("train",),
+        configs=("default",),
+    )
+
+    assert not hasattr(snapshot, "__dict__")
+    assert snapshot.to_dict() == {
+        "dataset_id": "org/repo@main",
+        "repo_id": "org/repo",
+        "revision": "main",
+        "snapshot_id": "abc123",
+        "snapshot_path": str(tmp_path / "snapshot"),
+        "cache_repo_path": str(tmp_path / "cache-repo"),
+        "source_kind": "hf_cache_snapshot",
+        "files": [dataset_file.to_dict()],
+        "total_bytes": 42,
+        "splits": ["train"],
+        "configs": ["default"],
+        "restore_command": "melix dataset hub download --repo-id org/repo --revision main",
+    }
+    with pytest.raises(FrozenInstanceError):
+        snapshot.total_bytes = 43  # type: ignore[misc]
 
 
 def test_dataset_catalog_discovers_default_huggingface_cache_snapshot(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -59,7 +59,7 @@ class DatasetFile:
         }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class DatasetSnapshot:
     dataset_id: str
     repo_id: str


### PR DESCRIPTION
## Summary
- Enables `slots=True` for the frozen `DatasetSnapshot` value record to reduce per-snapshot allocation overhead.
- Adds a focused regression test proving `DatasetSnapshot` remains frozen, serializes through `to_dict()`, and no longer exposes an instance `__dict__`.
- Adds the governing performance-slice plan for this one-record optimization.

## Plan or Spec
- `docs/plans/2026-05-20-dataset-registry-snapshot-slots.md`
- Registered probe: `dataset-registry-snapshot-inference-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py
# origin/main baseline: exit 0; {"elapsed_ms_mean": 651.5453808009624, "file_count_mean": 2401.0, "legacy_inference_helper_calls_mean": 0.0, "peak_bytes_mean": 781041.0, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_snapshot_is_frozen_slots_value_record
# exit 0; 1 passed in 0.20s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics
# exit 0; 48 passed in 0.70s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py
# exit 0; 48 passed; TOTAL 8 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py
# head: exit 0; {"elapsed_ms_mean": 633.4913725964725, "file_count_mean": 2401.0, "legacy_inference_helper_calls_mean": 0.0, "peak_bytes_mean": 780889.0, "sample_count": 5.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%`.
- Local registered probe (`dataset_registry_snapshot_probe.py`, Linux):
  - `elapsed_ms_mean`: 651.5453808009624 ms → 633.4913725964725 ms (`-18.054008204489946 ms`, `-2.771%`).
  - `peak_bytes_mean`: 781041.0 bytes → 780889.0 bytes (`-152.0 bytes`, `-0.019%`).
  - `legacy_inference_helper_calls_mean`: 0.0 → 0.0.
- CI PR-scoped performance remains the required registered-probe merge gate.

## Known Gaps
- This is Python-only and locally verified on Linux; no Swift runtime performance claims are made.
- The local memory improvement is intentionally small because the probe creates one `DatasetSnapshot` per scan; the change removes per-instance `__dict__` storage for this immutable record.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
