### PR TITLE
Add agentic LoRA eval compare evidence

### DIFF
--- a/docs/agentic-trajectory-dataset-contract.md
+++ b/docs/agentic-trajectory-dataset-contract.md
@@ -69,6 +69,10 @@ Current implementation anchors that future slices must reuse:
 - `scripts/agentic_lora_sft_smoke.py`
   - deterministic smoke path that runs the LoRA SFT pipeline against the
     checked-in agentic trace fixture without requiring a real MLX training run
+- `scripts/agentic_lora_eval_compare_smoke.py`
+  - deterministic evidence path that trains the smoke fixture, activates the
+    adapter-backed runtime target, and persists base-vs-activated-adapter eval
+    compare artifacts with paired sample evidence
 - `services/mlx-worker-python/worker/runtime/tool_registry.py`
   - defines the built-in tool registry receipt
 - `services/mlx-worker-python/worker/runtime/tool_observation.py`

--- a/docs/plans/2026-05-20-agentic-lora-eval-compare-evidence.md
+++ b/docs/plans/2026-05-20-agentic-lora-eval-compare-evidence.md
@@ -1,0 +1,97 @@
+# Agentic LoRA Eval Compare Evidence
+
+## Goal
+
+Implement issue #693 by adding a deterministic local evidence path that trains
+the repository-owned agentic LoRA SFT smoke fixture, activates the resulting
+adapter as an adapter-backed runtime target, and runs EvaluationCore compare
+against that activated adapter with persisted paired sample evidence.
+
+## Governing Specs
+
+- `docs/agentic-trajectory-dataset-contract.md`
+- `docs/plans/2026-05-20-agentic-lora-sft-smoke-training.md`
+- `docs/plans/2026-04-21-lora-adapter-native-compare.md`
+- `docs/runbooks/phase-8-lora-adapter-workflow.md`
+
+## Scope
+
+This slice is limited to deterministic local evidence for the
+OpenSearch-VL-aligned agentic fixture:
+
+- Reuse the checked-in `agentic-lora-sft-smoke.dev.v1` fixture and deterministic
+  LoRA training runner.
+- Activate the generated adapter with `activation_mode=adapter_backed_runtime`.
+- Register the activated derived model id as the compare target in a local
+  deterministic registry.
+- Run the existing EvaluationCore base-vs-target compare path and persist
+  compare job, summary, CSV, markdown report, and paired sample JSONL artifacts.
+- Emit a top-level JSON evidence payload that records activation provenance,
+  compare artifact paths, score deltas, and release-gate counts.
+
+Out of scope:
+
+- Real MLX-LM training or inference.
+- Claims about production model quality.
+- New protobuf, Swift, or menu bar API surface.
+- Replacing the existing adapter-manifest compare target flow.
+
+## Performance And Metrics
+
+The path is an offline developer/CI smoke path. It does not add serving-path
+overhead.
+
+Measurement points:
+
+- Smoke wall-clock duration.
+- Adapter activation duration and activation mode.
+- Paired compare sample count.
+- Base accuracy, target accuracy, and delta accuracy.
+- Win, loss, tie, and regression counts.
+- Persisted compare artifact paths.
+- Focused pytest runtime for the script.
+- Changed-scope coverage for the new Python smoke path, target >= 95%.
+
+## Implementation Plan
+
+- [x] Add `scripts/agentic_lora_eval_compare_smoke.py`.
+- [x] Add focused pytest coverage for the evidence payload, persisted artifacts,
+  CLI output, and failure exit behavior.
+- [x] Update the trajectory dataset contract anchors to name the eval compare
+  smoke evidence path.
+- [x] Run focused tests, changed-scope coverage, the smoke command, and
+  `git diff --check`.
+
+## Success Criteria
+
+- The smoke exits zero and emits machine-readable evidence.
+- The adapter activation manifest records
+  `activation_mode: adapter_backed_runtime`.
+- The compare job targets the activated derived model id.
+- The paired sample artifact records base and target raw responses, extracted
+  results, typed scores, and outcome.
+- The target score is higher than the base score on the validation trace and
+  the release gate reports no regressions.
+
+## Verification
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_lora_eval_compare_smoke.py`
+  - Result: 4 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_lora_eval_compare_smoke.py services/mlx-worker-python/tests/test_agentic_lora_sft_smoke.py services/mlx-worker-python/tests/test_evaluation_core.py -k 'agentic_lora or compare'`
+  - Result: 27 passed, 78 deselected.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/agentic_lora_eval_compare.coverage -m pytest -q services/mlx-worker-python/tests/test_agentic_lora_eval_compare_smoke.py`
+  - Result: 4 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/agentic_lora_eval_compare.coverage -o /tmp/agentic_lora_eval_compare_coverage.json`
+  - Result: wrote `/tmp/agentic_lora_eval_compare_coverage.json`.
+- `git add -N docs/plans/2026-05-20-agentic-lora-eval-compare-evidence.md scripts/agentic_lora_eval_compare_smoke.py services/mlx-worker-python/tests/test_agentic_lora_eval_compare_smoke.py`
+  - Result: staged intent-to-add so changed-line coverage can measure new
+    Python files before the commit.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/agentic_lora_eval_compare_coverage.json scripts/agentic_lora_eval_compare_smoke.py services/mlx-worker-python/tests/test_agentic_lora_eval_compare_smoke.py`
+  - Result: changed-line coverage 98.29% (230/234).
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/agentic_lora_eval_compare_smoke.py --json --output-dir .runtime/agentic-lora-eval-compare-smoke`
+  - Result: passed with `base_accuracy=0.0`, `target_accuracy=1.0`,
+    `delta_accuracy=1.0`, `win_count=1`, `regression_count=0`, activated
+    adapter target `agentic-lora-sft-smoke-model-lora-e682d3a2`, and persisted
+    compare artifacts under `.runtime/agentic-lora-eval-compare-smoke`.
+- `git diff --check`
+  - Result: passed.

--- a/scripts/agentic_lora_eval_compare_smoke.py
+++ b/scripts/agentic_lora_eval_compare_smoke.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "services" / "mlx-worker-python"))
+
+from agentic_lora_sft_smoke import DEFAULT_FIXTURE_ID, run_smoke as run_sft_smoke
+from packages.protocol.python.worker.v1 import common_pb2
+from worker.engine.evaluation_core import EvaluationCore
+from worker.model_ops.adapter_activation_pipeline import AdapterActivationPipeline
+from worker.model_ops.deterministic_lora_runner import DeterministicLoRARunner
+from worker.productization.evaluation_schemas import build_dataset_package_manifest
+from worker.runtime.mlx_text_runtime import RuntimeTokenEvent
+
+
+DEFAULT_SUITE_ID = "agentic_tool_trace_eval"
+DEFAULT_DATASET_ID = "agentic-lora-sft-smoke.eval.v1"
+
+
+class _ScriptedCompareRuntime:
+    runtime_name = "deterministic-agentic-lora-eval-compare"
+
+    def __init__(self, response: str) -> None:
+        self._response = response
+        self.prompts: list[str] = []
+
+    def render_prompt(self, messages, loaded_model=None, execution_ext=None) -> str:
+        _ = loaded_model
+        _ = execution_ext
+        prompt = "\n".join(
+            part.text
+            for message in messages
+            for part in message.parts
+            if part.text
+        )
+        self.prompts.append(prompt)
+        return prompt
+
+    def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event, execution_ext=None):
+        _ = loaded_model
+        _ = prompt
+        _ = sampling
+        _ = execution_ext
+        if cancel_event.is_set():
+            return
+        yield RuntimeTokenEvent(
+            text=self._response,
+            completion_tokens=max(1, len(self._response.split())),
+        )
+
+
+class _LocalCompareRegistry:
+    def __init__(self) -> None:
+        self._loaded_models_by_handle: dict[str, object] = {}
+        self._handles_by_model_id: dict[str, str] = {}
+
+    def register_model(self, model_spec: common_pb2.ModelSpec, runtime: _ScriptedCompareRuntime):
+        handle = f"{model_spec.model_id}::agentic-eval-compare"
+        loaded_model = SimpleNamespace(
+            handle=handle,
+            runtime_kind="text",
+            runtime_model={"model_id": model_spec.model_id},
+            spec=model_spec,
+            runtime=runtime,
+            estimated_resident_bytes=0,
+        )
+        self._loaded_models_by_handle[handle] = loaded_model
+        self._handles_by_model_id[model_spec.model_id] = handle
+        return loaded_model
+
+    def get_loaded_model(self, handle: str):
+        return self._loaded_models_by_handle.get(handle)
+
+    def list_loaded_models(self) -> list[str]:
+        return sorted(self._loaded_models_by_handle)
+
+    def runtime_for_loaded_model(self, loaded_model):
+        return loaded_model.runtime
+
+    def start_request(self, request_id: str, runtime_kind: str = "text"):
+        _ = request_id
+        _ = runtime_kind
+        return SimpleNamespace(cancel_event=SimpleNamespace(is_set=lambda: False))
+
+    def finish_request(self, request_id: str) -> None:
+        _ = request_id
+
+
+def run_eval_compare_smoke(
+    repo_root: Path,
+    *,
+    output_dir: Path | None = None,
+    fixture_id: str = DEFAULT_FIXTURE_ID,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    if output_dir is None:
+        output_dir = Path(tempfile.mkdtemp(prefix="melix-agentic-lora-eval-compare-"))
+    else:
+        output_dir = output_dir.expanduser().resolve()
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    started = time.perf_counter()
+    training_payload = run_sft_smoke(
+        repo_root,
+        output_dir=output_dir / "training",
+        fixture_id=fixture_id,
+    )
+    adapter_manifest_path = Path(training_payload["adapter_manifest_path"])
+    adapter_manifest = json.loads(adapter_manifest_path.read_text(encoding="utf-8"))
+    source_model = _source_model_from_adapter_manifest(adapter_manifest)
+
+    activation_result = AdapterActivationPipeline(runner=DeterministicLoRARunner()).run(
+        job_id="agentic-lora-eval-compare-activation",
+        request_ext={
+            "operation": "activate_adapter",
+            "artifact_path": str(adapter_manifest_path),
+            "activation_mode": "adapter_backed_runtime",
+            "derived_model_alias": "agentic-lora-sft-smoke-activated",
+        },
+        source_model=source_model,
+        output_dir=output_dir / "activation",
+    )
+    activation_manifest = activation_result.manifest
+
+    normalized_dir = Path(training_payload["normalized_dataset_manifest_path"]).parent
+    validation_trace_path = normalized_dir / "agentic-traces.valid.jsonl"
+    validation_traces = _read_jsonl(validation_trace_path)
+    if not validation_traces:
+        raise ValueError(f"No validation traces were written: {validation_trace_path}")
+
+    final_answer = str(validation_traces[0].get("final_answer", "")).strip()
+    baseline_answer = "VX-000" if final_answer != "VX-000" else "VX-001"
+    dataset_root = _write_eval_dataset_package(
+        output_dir=output_dir,
+        source_trace=validation_traces[0],
+        source_trace_path=validation_trace_path,
+    )
+
+    activated_model_spec = _activated_model_spec_from_manifest(activation_manifest)
+    registry = _LocalCompareRegistry()
+    base_loaded_model = registry.register_model(
+        source_model,
+        _ScriptedCompareRuntime(response=f"Answer: {baseline_answer}"),
+    )
+    registry.register_model(
+        activated_model_spec,
+        _ScriptedCompareRuntime(response=f"Answer: {final_answer}"),
+    )
+
+    evaluation_root = output_dir / "evaluation"
+    run = EvaluationCore(jobs_root=evaluation_root, registry=registry).run_local_suite(
+        model_id=source_model.model_id,
+        model_handle=base_loaded_model.handle,
+        suite_id=DEFAULT_SUITE_ID,
+        dataset_root=dataset_root,
+        sample_size=1,
+        few_shot=0,
+        seed=0,
+        scoring_mode="normalized_exact_match",
+        code_exec_policy="disabled",
+        parameters={
+            "compare_mode": "base_vs_targets",
+            "compare_target_model_ids": activated_model_spec.model_id,
+            "adapter_manifest_path": str(adapter_manifest_path),
+            "activation_manifest_path": str(activation_result.manifest_path),
+            "source_training_fixture_id": fixture_id,
+            "source_training_objective": "agentic_sft",
+            "deterministic_evidence": "true",
+        },
+    )
+    summary = run.results[0]
+    paired_sample = run.samples[0]
+    persisted_paths = {key: str(path) for key, path in run.persisted_paths.items()}
+
+    artifacts = {
+        "adapter_manifest": str(adapter_manifest_path),
+        "activation_manifest": str(activation_result.manifest_path),
+        "evaluation_dataset_manifest": str(dataset_root / "manifest.json"),
+        "evaluation_dataset_samples": str(dataset_root / "samples.jsonl"),
+        **{f"compare_{key}": value for key, value in persisted_paths.items()},
+        "evidence_json": str(output_dir / "agentic-lora-eval-compare-evidence.json"),
+    }
+    checks = {
+        "training_smoke_passed": bool(training_payload.get("passed")),
+        "adapter_manifest_exists": adapter_manifest_path.is_file(),
+        "activation_manifest_exists": activation_result.manifest_path.is_file(),
+        "adapter_backed_activation": activation_manifest.get("activation_mode")
+        == "adapter_backed_runtime",
+        "compare_target_is_activated_adapter": summary.target_model_id
+        == activation_manifest.get("derived_model_id")
+        == activated_model_spec.model_id,
+        "compare_artifacts_exist": all(
+            Path(value).is_file()
+            for key, value in artifacts.items()
+            if key.startswith("compare_")
+        ),
+        "paired_sample_count": len(run.samples) == 1,
+        "paired_sample_has_base_and_target": bool(
+            paired_sample.base_raw_response and paired_sample.target_raw_response
+        ),
+        "base_sample_misses": paired_sample.base_typed_score == 0.0,
+        "target_sample_matches": paired_sample.target_typed_score == 1.0,
+        "target_improves_base": summary.delta_accuracy > 0.0 and summary.win_count >= 1,
+        "no_regressions": summary.regression_count == 0,
+    }
+    duration_ms = (time.perf_counter() - started) * 1000.0
+    payload = {
+        "passed": all(checks.values()),
+        "fixture_id": fixture_id,
+        "output_dir": str(output_dir),
+        "suite_id": DEFAULT_SUITE_ID,
+        "dataset_id": DEFAULT_DATASET_ID,
+        "duration_ms": duration_ms,
+        "checks": checks,
+        "artifacts": artifacts,
+        "activation": {
+            "derived_model_id": activation_manifest.get("derived_model_id"),
+            "activation_mode": activation_manifest.get("activation_mode"),
+            "activation_backend": activation_manifest.get("activation_backend"),
+            "activation_duration_ms": activation_manifest.get("activation_duration_ms"),
+            "adapter_set_hash": activation_manifest.get("adapter_set_hash"),
+        },
+        "compare": {
+            "job_id": run.job.job_id,
+            "base_model_id": summary.base_model_id,
+            "target_model_id": summary.target_model_id,
+            "base_accuracy": summary.base_accuracy,
+            "target_accuracy": summary.target_accuracy,
+            "delta_accuracy": summary.delta_accuracy,
+            "win_count": summary.win_count,
+            "loss_count": summary.loss_count,
+            "tie_count": summary.tie_count,
+            "regression_count": summary.regression_count,
+            "verdict": summary.verdict,
+        },
+        "paired_sample": {
+            "sample_id": paired_sample.sample_id,
+            "target_model_id": paired_sample.target_model_id,
+            "target": paired_sample.target,
+            "base_raw_response": paired_sample.base_raw_response,
+            "target_raw_response": paired_sample.target_raw_response,
+            "base_extracted_result": paired_sample.base_extracted_result,
+            "target_extracted_result": paired_sample.target_extracted_result,
+            "base_typed_score": paired_sample.base_typed_score,
+            "target_typed_score": paired_sample.target_typed_score,
+            "outcome": paired_sample.outcome,
+            "regression_kind": paired_sample.regression_kind,
+        },
+        "metrics": {
+            "agentic_lora_eval_compare.base_accuracy": float(summary.base_accuracy),
+            "agentic_lora_eval_compare.target_accuracy": float(summary.target_accuracy),
+            "agentic_lora_eval_compare.delta_accuracy": float(summary.delta_accuracy),
+            "agentic_lora_eval_compare.win_count": float(summary.win_count),
+            "agentic_lora_eval_compare.loss_count": float(summary.loss_count),
+            "agentic_lora_eval_compare.tie_count": float(summary.tie_count),
+            "agentic_lora_eval_compare.regression_count": float(summary.regression_count),
+            "agentic_lora_eval_compare.paired_sample_count": float(len(run.samples)),
+            "agentic_lora_eval_compare.activated_adapter_target_count": 1.0,
+            "agentic_lora_eval_compare.duration_ms": duration_ms,
+        },
+    }
+    Path(artifacts["evidence_json"]).write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return payload
+
+
+def _source_model_from_adapter_manifest(adapter_manifest: dict[str, Any]) -> common_pb2.ModelSpec:
+    source_ext = adapter_manifest.get("source_model_ext")
+    if not isinstance(source_ext, dict):
+        source_ext = {
+            "text_family_id": "llama",
+            "text_layer_count": "1",
+        }
+    return common_pb2.ModelSpec(
+        model_id=str(adapter_manifest.get("source_model") or "agentic-lora-sft-smoke-model"),
+        model_path=str(adapter_manifest.get("source_model_path") or ""),
+        revision=str(adapter_manifest.get("source_model_revision") or "fixture-v1"),
+        model_kind=str(adapter_manifest.get("source_model_kind") or "text"),
+        max_context=2048,
+        ext={str(key): str(value) for key, value in source_ext.items()},
+    )
+
+
+def _activated_model_spec_from_manifest(activation_manifest: dict[str, Any]) -> common_pb2.ModelSpec:
+    return common_pb2.ModelSpec(
+        model_id=str(activation_manifest["derived_model_id"]),
+        model_path=str(activation_manifest.get("derived_model_path") or ""),
+        revision=str(activation_manifest.get("source_model_revision") or "fixture-v1"),
+        model_kind="text",
+        max_context=2048,
+        ext={
+            "melix.source_kind": "adapter_backed_runtime",
+            "melix.source_repo": str(activation_manifest.get("base_model_repo_id") or ""),
+            "melix.adapter_manifest_path": str(activation_manifest.get("adapter_manifest_path") or ""),
+            "melix.activation_manifest_path": str(activation_manifest.get("manifest_path") or ""),
+        },
+    )
+
+
+def _write_eval_dataset_package(
+    *,
+    output_dir: Path,
+    source_trace: dict[str, Any],
+    source_trace_path: Path,
+) -> Path:
+    dataset_root = output_dir / "evaluation-dataset"
+    dataset_root.mkdir(parents=True, exist_ok=True)
+    manifest = build_dataset_package_manifest(
+        dataset_id=DEFAULT_DATASET_ID,
+        suite_id=DEFAULT_SUITE_ID,
+        version="dev.v1",
+        sample_count=1,
+        split="validation",
+        task_kind="text-generation",
+        input_modalities=("text",),
+        profile_type="final_result",
+        result_kind="text",
+        extraction_mode="heuristic_final",
+        scoring_mode="normalized_exact_match",
+        threshold=1.0,
+        source_kind="agentic_tool_trace",
+        source_path=str(source_trace_path),
+    ).to_dict()
+    manifest.update(
+        {
+            "trajectory_schema_version": source_trace.get(
+                "trajectory_schema_version",
+                "melix.agentic_tool_trace.v1",
+            ),
+            "source_trace_id": str(source_trace.get("trace_id") or ""),
+        }
+    )
+    (dataset_root / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    sample = {
+        "id": str(source_trace.get("trace_id") or "agentic-lora-eval-compare-1"),
+        "system": "Use the agentic tool trace evidence and return only the final short answer.",
+        "input": {"text": _prompt_from_trace(source_trace)},
+        "target": str(source_trace.get("final_answer") or source_trace.get("expected_answer") or ""),
+        "category": "agentic_tool_trace",
+        "subject": "activated_adapter_compare",
+        "source_trace_id": str(source_trace.get("trace_id") or ""),
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+    }
+    _write_jsonl(dataset_root / "samples.jsonl", (sample,))
+    return dataset_root
+
+
+def _prompt_from_trace(source_trace: dict[str, Any]) -> str:
+    observations: list[str] = []
+    for turn in source_trace.get("turns", []):
+        if not isinstance(turn, dict) or turn.get("role") != "tool":
+            continue
+        observation = turn.get("observation")
+        if isinstance(observation, dict):
+            text = str(observation.get("text") or "").strip()
+        else:
+            text = str(observation or "").strip()
+        if text:
+            observations.append(f"- {text}")
+    evidence = "\n".join(observations) if observations else "- No tool observation recorded."
+    return (
+        f"{source_trace.get('question', '')}\n\n"
+        f"Agentic tool observations:\n{evidence}\n\n"
+        "Answer with only the final short answer."
+    )
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not path.is_file():
+        return rows
+    with path.open(encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def _write_jsonl(path: Path, rows) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run deterministic agentic LoRA eval compare smoke evidence."
+    )
+    parser.add_argument("--json", action="store_true", help="Emit a machine-readable payload.")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=ROOT,
+        help="Repository root. Defaults to the script parent repository.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory for persisted smoke artifacts. Defaults to a temporary directory.",
+    )
+    parser.add_argument(
+        "--fixture-id",
+        default=DEFAULT_FIXTURE_ID,
+        help="Training fixture id under services/mlx-worker-python/fixtures/training.",
+    )
+    args = parser.parse_args()
+
+    payload = run_eval_compare_smoke(
+        args.repo_root,
+        output_dir=args.output_dir,
+        fixture_id=args.fixture_id,
+    )
+    if args.json:
+        json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    else:
+        print(
+            "Agentic LoRA eval compare smoke passed."
+            if payload["passed"]
+            else "Agentic LoRA eval compare smoke failed."
+        )
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if payload["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_agentic_lora_eval_compare_smoke.py
+++ b/services/mlx-worker-python/tests/test_agentic_lora_eval_compare_smoke.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "scripts" / "agentic_lora_eval_compare_smoke.py"
+MODULE_SPEC = importlib.util.spec_from_file_location(
+    "agentic_lora_eval_compare_smoke",
+    MODULE_PATH,
+)
+assert MODULE_SPEC is not None
+assert MODULE_SPEC.loader is not None
+agentic_lora_eval_compare_smoke = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(agentic_lora_eval_compare_smoke)
+
+
+def test_agentic_lora_eval_compare_smoke_persists_paired_evidence(
+    tmp_path: Path,
+) -> None:
+    payload = agentic_lora_eval_compare_smoke.run_eval_compare_smoke(
+        REPO_ROOT,
+        output_dir=tmp_path / "eval-compare-output",
+    )
+
+    assert payload["passed"] is True
+    assert all(payload["checks"].values())
+    assert payload["activation"]["activation_mode"] == "adapter_backed_runtime"
+    assert payload["activation"]["activation_backend"] == "internal"
+    assert payload["compare"]["base_accuracy"] == 0.0
+    assert payload["compare"]["target_accuracy"] == 1.0
+    assert payload["compare"]["delta_accuracy"] == 1.0
+    assert payload["compare"]["win_count"] == 1
+    assert payload["compare"]["loss_count"] == 0
+    assert payload["compare"]["regression_count"] == 0
+    assert payload["paired_sample"] == {
+        "sample_id": "agentic-smoke-valid-1",
+        "target_model_id": payload["activation"]["derived_model_id"],
+        "target": "VX-204",
+        "base_raw_response": "Answer: VX-000",
+        "target_raw_response": "Answer: VX-204",
+        "base_extracted_result": "VX-000",
+        "target_extracted_result": "VX-204",
+        "base_typed_score": 0.0,
+        "target_typed_score": 1.0,
+        "outcome": "win",
+        "regression_kind": "",
+    }
+    assert payload["metrics"]["agentic_lora_eval_compare.paired_sample_count"] == 1.0
+    assert payload["metrics"]["agentic_lora_eval_compare.activated_adapter_target_count"] == 1.0
+
+    artifacts = payload["artifacts"]
+    for path in artifacts.values():
+        assert Path(path).is_file()
+
+    activation_manifest = json.loads(
+        Path(artifacts["activation_manifest"]).read_text(encoding="utf-8")
+    )
+    assert activation_manifest["derived_model_id"] == payload["activation"]["derived_model_id"]
+    assert activation_manifest["activation_mode"] == "adapter_backed_runtime"
+
+    compare_job = json.loads(
+        Path(artifacts["compare_job"]).read_text(encoding="utf-8")
+    )
+    assert compare_job["base_model_id"] == "agentic-lora-sft-smoke-model"
+    assert compare_job["target_model_ids"] == [payload["activation"]["derived_model_id"]]
+    assert compare_job["target_lineage"] == [
+        {
+            "target_model_id": payload["activation"]["derived_model_id"],
+            "materialization_kind": "registered",
+            "adapter_manifest_path": "",
+            "adapter_weights_path": "",
+            "adapter_set_hash": "",
+            "derived_from_model_id": "",
+        }
+    ]
+    assert compare_job["parameters"]["activation_manifest_path"] == artifacts["activation_manifest"]
+    assert compare_job["parameters"]["source_training_objective"] == "agentic_sft"
+
+    compare_samples = _jsonl_rows(Path(artifacts["compare_samples_jsonl"]))
+    assert compare_samples == [
+        {
+            "schema_version": "melix.evaluation_compare_sample.v2",
+            "job_id": payload["compare"]["job_id"],
+            "suite_id": "agentic_tool_trace_eval",
+            "dataset_id": "agentic-lora-sft-smoke.eval.v1",
+            "sample_id": "agentic-smoke-valid-1",
+            "target_model_id": payload["activation"]["derived_model_id"],
+            "input_text": compare_samples[0]["input_text"],
+            "target": "VX-204",
+            "base_extracted_result": "VX-000",
+            "target_extracted_result": "VX-204",
+            "base_raw_response": "Answer: VX-000",
+            "target_raw_response": "Answer: VX-204",
+            "base_typed_score": 0.0,
+            "target_typed_score": 1.0,
+            "outcome": "win",
+            "regression_kind": "",
+            "base_time_s": compare_samples[0]["base_time_s"],
+            "target_time_s": compare_samples[0]["target_time_s"],
+            "base_extraction_status": "extracted",
+            "target_extraction_status": "extracted",
+            "base_validation_status": "validated",
+            "target_validation_status": "validated",
+            "base_failure_reason": "",
+            "target_failure_reason": "",
+            "base_parse_status": "extracted",
+            "target_parse_status": "extracted",
+            "code_language": "",
+            "code_entry_point": "",
+            "base_code_compile_status": "",
+            "target_code_compile_status": "",
+            "base_code_runtime_status": "",
+            "target_code_runtime_status": "",
+            "base_code_timeout_status": "",
+            "target_code_timeout_status": "",
+            "base_code_test_status": "",
+            "target_code_test_status": "",
+            "base_code_tests_passed": 0,
+            "target_code_tests_passed": 0,
+            "base_code_tests_total": 0,
+            "target_code_tests_total": 0,
+            "base_code_failure_detail": "",
+            "target_code_failure_detail": "",
+            "category_label": "agentic_tool_trace",
+            "subject_label": "activated_adapter_compare",
+        }
+    ]
+    assert "Agentic tool observations:" in compare_samples[0]["input_text"]
+    assert "VX-204" in compare_samples[0]["input_text"]
+
+    evidence = json.loads(Path(artifacts["evidence_json"]).read_text(encoding="utf-8"))
+    assert evidence == payload
+
+
+def test_agentic_lora_eval_compare_smoke_main_supports_json_and_text_output(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        agentic_lora_eval_compare_smoke,
+        "run_eval_compare_smoke",
+        lambda repo_root, output_dir=None, fixture_id="agentic-lora-sft-smoke.dev.v1": {
+            "passed": True,
+            "repo_root": str(repo_root),
+            "output_dir": str(output_dir or tmp_path),
+            "fixture_id": fixture_id,
+            "metrics": {"agentic_lora_eval_compare.delta_accuracy": 1.0},
+        },
+    )
+    monkeypatch.setattr(
+        agentic_lora_eval_compare_smoke.sys,
+        "argv",
+        [
+            "agentic_lora_eval_compare_smoke.py",
+            "--repo-root",
+            str(REPO_ROOT),
+            "--output-dir",
+            str(tmp_path / "json-output"),
+            "--json",
+        ],
+    )
+
+    assert agentic_lora_eval_compare_smoke.main() == 0
+    json_output = capsys.readouterr().out
+    assert '"passed": true' in json_output
+    assert '"agentic_lora_eval_compare.delta_accuracy": 1.0' in json_output
+
+    monkeypatch.setattr(
+        agentic_lora_eval_compare_smoke.sys,
+        "argv",
+        [
+            "agentic_lora_eval_compare_smoke.py",
+            "--repo-root",
+            str(REPO_ROOT),
+            "--output-dir",
+            str(tmp_path / "text-output"),
+        ],
+    )
+
+    assert agentic_lora_eval_compare_smoke.main() == 0
+    text_output = capsys.readouterr().out
+    assert "Agentic LoRA eval compare smoke passed." in text_output
+    assert "agentic-lora-sft-smoke.dev.v1" in text_output
+
+
+def test_agentic_lora_eval_compare_smoke_main_returns_nonzero_when_check_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        agentic_lora_eval_compare_smoke,
+        "run_eval_compare_smoke",
+        lambda repo_root, output_dir=None, fixture_id="agentic-lora-sft-smoke.dev.v1": {
+            "passed": False,
+            "fixture_id": fixture_id,
+            "checks": {"target_improves_base": False},
+        },
+    )
+    monkeypatch.setattr(
+        agentic_lora_eval_compare_smoke.sys,
+        "argv",
+        ["agentic_lora_eval_compare_smoke.py", "--repo-root", str(REPO_ROOT), "--json"],
+    )
+
+    assert agentic_lora_eval_compare_smoke.main() == 1
+    output = capsys.readouterr().out
+    assert '"passed": false' in output
+    assert '"target_improves_base": false' in output
+
+
+def test_agentic_lora_eval_compare_smoke_covers_default_output_and_missing_inputs(
+    tmp_path: Path,
+) -> None:
+    payload = agentic_lora_eval_compare_smoke.run_eval_compare_smoke(REPO_ROOT)
+
+    assert payload["passed"] is True
+    assert Path(payload["output_dir"]).name.startswith("melix-agentic-lora-eval-compare-")
+    assert Path(payload["artifacts"]["evidence_json"]).is_file()
+    assert agentic_lora_eval_compare_smoke._read_jsonl(tmp_path / "missing.jsonl") == []
+
+    with pytest.raises(FileNotFoundError):
+        agentic_lora_eval_compare_smoke.run_eval_compare_smoke(
+            REPO_ROOT,
+            fixture_id="missing-fixture",
+        )
+
+
+def _jsonl_rows(path: Path) -> list[dict[str, object]]:
+    with path.open(encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]


### PR DESCRIPTION
## Summary
- Added a deterministic agentic LoRA eval-compare smoke that trains from the OpenSearch-VL fixture, activates the adapter-backed target, and runs base-vs-target `EvaluationCore` comparison.
- Publishes paired compare evidence artifacts and records the governing #693 plan plus the dataset contract anchor for repeatable use.

## Plan or Spec
- `docs/plans/2026-05-20-agentic-lora-eval-compare-evidence.md`
- `docs/agentic-trajectory-dataset-contract.md`
- Closes #693

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_lora_eval_compare_smoke.py
# 4 passed in 0.19s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/agentic_lora_eval_compare_smoke.py --json --output-dir .runtime/agentic-lora-eval-compare-smoke
# passed=true; base_accuracy=0.0; target_accuracy=1.0; delta_accuracy=1.0; win_count=1; regression_count=0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_lora_eval_compare_smoke.py services/mlx-worker-python/tests/test_agentic_lora_sft_smoke.py services/mlx-worker-python/tests/test_evaluation_core.py -k 'agentic_lora or compare'
# 27 passed, 78 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/agentic_lora_eval_compare.coverage -m pytest -q services/mlx-worker-python/tests/test_agentic_lora_eval_compare_smoke.py
# 4 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/agentic_lora_eval_compare.coverage -o /tmp/agentic_lora_eval_compare_coverage.json
# wrote /tmp/agentic_lora_eval_compare_coverage.json

git add -N docs/plans/2026-05-20-agentic-lora-eval-compare-evidence.md scripts/agentic_lora_eval_compare_smoke.py services/mlx-worker-python/tests/test_agentic_lora_eval_compare_smoke.py
# intent-to-add recorded for changed-line coverage

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/agentic_lora_eval_compare_coverage.json scripts/agentic_lora_eval_compare_smoke.py services/mlx-worker-python/tests/test_agentic_lora_eval_compare_smoke.py
# TOTAL 98.29% (230/234)

git diff --check
# passed

git diff --check origin/main...HEAD
# passed after merging origin/main

make swift-test
# pre-commit gate passed, rc=0, elapsed=651.5s

make py-test
# pre-commit gate passed: 2872 passed, 14 skipped, 2 warnings in 145.14s

make integration-test
# pre-commit gate passed: 114 passed, 1 skipped in 664.56s

Melix PR Scoped Performance Report
# Status: ok; Changed files: 4; Selected probes: 0; Direct/gated probes: 0; Regressions: 0; Context regressions: 0; Verification failures: 0
# Report: .runtime/pre-commit-performance/20260520-044954-e55c4a57/report/report.md
```

## Coverage and Metrics
- Changed-line coverage: 98.29% (230/234), above the 95% gate.
- Eval compare smoke metrics: base_accuracy=0.0, target_accuracy=1.0, delta_accuracy=1.0, win_count=1, loss_count=0, tie_count=0, regression_count=0, paired_sample_count=1.
- Activation evidence: activation_mode=adapter_backed_runtime, activation_backend=internal, activated target `agentic-lora-sft-smoke-model-lora-e682d3a2`.
- Observability mode: evidence. Probe overhead: N/A, this adds a deterministic local smoke/evidence script and no request-path runtime probes.
- PR-scoped performance: Status ok; no selected probes and no regressions for this change set.

## Known Gaps
- Deterministic smoke only; it does not claim real MLX-LM quality gains or production OpenSearch-VL model improvement.
- No protocol or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
