### PR TITLE
perf: streamline PR performance result loading

### DIFF
--- a/docs/plans/2026-05-20-pr-scoped-report-result-path-list.md
+++ b/docs/plans/2026-05-20-pr-scoped-report-result-path-list.md
@@ -1,0 +1,41 @@
+# PR-Scoped Performance Report Result Path List Slice
+
+## Scope
+
+This Python tooling performance slice is limited to result-file discovery in
+`scripts/pr_scoped_performance_report.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`pr-scoped-performance-report-results-scandir` in
+`infra/perf/pr_scoped_probes.json`. The registry entry already defines focused
+`test_command`, `coverage_command`, and `probe_command` entries for the report
+loader, probe script, and PR-scoped performance tests.
+
+## Optimization
+
+`_load_results()` now materializes matching `os.scandir()` paths into a list,
+sorts the list in place, and binds the hot `results.append` and `json.loads`
+lookups once before the per-file loop. This keeps the existing `os.scandir()` and
+binary JSON read behavior while avoiding the `sorted(generator)` path and repeated
+attribute lookups for the hot result-file loader used by PR-scoped performance
+reporting.
+
+## Verification plan
+
+1. Run the registered focused test command locally on Linux.
+2. Run the registered changed-scope coverage command locally and require the
+   repository's 95 percent changed-scope threshold.
+3. Run the registered probe locally on Linux with repeated baseline and head
+   samples, comparing `elapsed_ms_mean` and `elapsed_ms_min` for 2,000 synthetic
+   result JSON files.
+4. Use PR-scoped performance CI as the final registered probe gate before merge.
+
+## Acceptance
+
+- Focused tests and changed-scope coverage pass.
+- The local registered probe is neutral-to-improved for `elapsed_ms_mean` while
+  preserving `result_count=2000.0`.
+- PR-scoped performance CI selects and runs
+  `pr-scoped-performance-report-results-scandir` before merge.

--- a/scripts/pr_scoped_performance_report.py
+++ b/scripts/pr_scoped_performance_report.py
@@ -25,14 +25,17 @@ def _load_results(results_dir: Path) -> list[dict[str, object]]:
     results: list[dict[str, object]] = []
     try:
         with os.scandir(results_dir) as entries:
-            result_paths = sorted(entry.path for entry in entries if entry.name.endswith(".json"))
+            result_paths = [entry.path for entry in entries if entry.name.endswith(".json")]
     except OSError:
         return []
+    result_paths.sort()
+    results_append = results.append
+    json_loads = json.loads
     for path in result_paths:
         with open(path, "rb") as result_file:
-            payload = json.loads(result_file.read())
+            payload = json_loads(result_file.read())
         if isinstance(payload, dict):
-            results.append(payload)
+            results_append(payload)
     return results
 
 


### PR DESCRIPTION
## Summary
- Streamline PR-scoped performance report result loading by materializing scandir result paths into a list before in-place sorting.
- Bind `results.append` and `json.loads` once before the per-file loop to avoid repeated hot-loop attribute lookups.
- Add a focused plan note for this small Python tooling performance slice.

## Plan or Spec
- `docs/plans/2026-05-20-pr-scoped-report-result-path-list.md`
- Registered probe: `pr-scoped-performance-report-results-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin && git reset --hard origin/main` from the clean base worktree before branching.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_scandir_and_binary_json_reads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_performance_report_results_probe_script_emits_metrics`
- Registered test command for `pr-scoped-performance-report-results-scandir` (exit 0): `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_performance_report_results_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_scandir_and_binary_json_reads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_performance_report_results_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke`
- Registered coverage command for `pr-scoped-performance-report-results-scandir` (exit 0): changed-scope coverage `TOTAL 6 0 100%`.
- Registered probe command for `pr-scoped-performance-report-results-scandir` (exit 0): `elapsed_ms_mean=24.830312`, `elapsed_ms_min=22.264582`, `file_count=2000.0`, `result_count=2000.0`.

## Coverage and Metrics
- Changed-scope coverage: 100% (`scripts/pr_scoped_performance_report.py`, 6/6 changed lines covered).
- Local baseline probe samples on `origin/main`: `elapsed_ms_mean` values `24.475208`, `31.071804`, `24.219155`; baseline mean `26.588722 ms`.
- Local head probe samples after the slice: `elapsed_ms_mean` values `30.381276`, `23.126100`, `23.691096`; head mean `25.732824 ms`.
- Local delta: `-0.855898 ms` mean, about `1.0333x` faster. Final registered probe run reported `24.830312 ms`, about `1.0708x` faster than the baseline mean.
- Registered PR-scoped performance CI is required as the merge gate for the probe report.

## Known Gaps
- Local measurements are Linux synthetic probe results; CI remains the authoritative registered probe report before merge.
- This slice does not change report rendering or probe selection behavior.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at 100%.
- [x] Registered probe ran locally and showed a small mean improvement.
- [ ] PR-scoped performance CI completed successfully.
- [ ] PR merged after green CI.
