### PR TITLE
perf: fast-path full tool config list

### DIFF
--- a/docs/plans/2026-05-20-tool-config-full-list-template-cache.md
+++ b/docs/plans/2026-05-20-tool-config-full-list-template-cache.md
@@ -12,7 +12,11 @@ This Python-only performance slice is limited to the built-in tool config select
 - return an isolated copy of the full built-in `ToolConfig` template when `names` equals that list snapshot;
 - avoid tuple conversion for exact full-list callers;
 - preserve the existing tuple cache, partial-selection cache, isolated-copy behavior, unknown-name validation, and selection ordering semantics;
-- extend the registered tool-registry select probe with a full-list `built_in_tool_config()` workload metric.
+- extend the registered tool-registry select probe with separate full-list
+  `built_in_tool_config()` workload metrics without folding that workload into
+  the existing selection elapsed metric.
+- remove per-instance `ToolRegistry` dictionaries so cached registry and
+  selection objects have lower steady-state attribute and allocation overhead.
 
 It does not change tool descriptor definitions, protobuf schemas, generated outputs, parser contracts, or non-exact partial-selection behavior.
 
@@ -20,12 +24,13 @@ It does not change tool descriptor definitions, protobuf schemas, generated outp
 
 Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
 
-The probe runs `scripts/tool_registry_select_probe.py`, mixing cached partial tuple selections, exact full-list `ToolRegistry.select()` calls, and exact full-list `built_in_tool_config()` calls. It reports:
+The probe runs `scripts/tool_registry_select_probe.py`, mixing cached partial tuple selections and exact full-list `ToolRegistry.select()` calls in the original `elapsed_ms_mean` workload. It measures exact full-list `built_in_tool_config()` calls in a separate timed loop so the selection metric remains comparable with historical base runs. It reports:
 
 - `elapsed_ms_mean` (`lower_is_better`)
 - `select_calls_mean` (`informational`)
 - `full_list_self_hits_mean` (`higher_is_better`)
 - `full_config_template_hits_mean` (`higher_is_better`)
+- `full_config_template_elapsed_ms_mean` (`lower_is_better`)
 
 ## Verification Plan
 

--- a/docs/plans/2026-05-20-tool-config-full-list-template-cache.md
+++ b/docs/plans/2026-05-20-tool-config-full-list-template-cache.md
@@ -1,0 +1,32 @@
+# Tool Config Full-List Template Cache
+
+## Goal
+
+Reduce repeated allocation in `worker.runtime.tool_registry.built_in_tool_config()` when callers pass an exact ordered list containing every built-in agentic tool name. The previous path converted that list to a tuple before discovering that the full built-in config template was already cached.
+
+## Scope
+
+This Python-only performance slice is limited to the built-in tool config selection fast path:
+
+- cache a private list-form snapshot of `BUILTIN_AGENTIC_TOOL_NAMES` next to the existing tuple snapshot;
+- return an isolated copy of the full built-in `ToolConfig` template when `names` equals that list snapshot;
+- avoid tuple conversion for exact full-list callers;
+- preserve the existing tuple cache, partial-selection cache, isolated-copy behavior, unknown-name validation, and selection ordering semantics;
+- extend the registered tool-registry select probe with a full-list `built_in_tool_config()` workload metric.
+
+It does not change tool descriptor definitions, protobuf schemas, generated outputs, parser contracts, or non-exact partial-selection behavior.
+
+## Performance Probe
+
+Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+
+The probe runs `scripts/tool_registry_select_probe.py`, mixing cached partial tuple selections, exact full-list `ToolRegistry.select()` calls, and exact full-list `built_in_tool_config()` calls. It reports:
+
+- `elapsed_ms_mean` (`lower_is_better`)
+- `select_calls_mean` (`informational`)
+- `full_list_self_hits_mean` (`higher_is_better`)
+- `full_config_template_hits_mean` (`higher_is_better`)
+
+## Verification Plan
+
+Run the focused registry tests, changed-scope coverage command, and the registered probe locally on Linux before opening the PR. CI remains the source of truth for the PR-scoped base-vs-head performance report.

--- a/docs/plans/2026-05-20-tool-config-full-list-template-cache.md
+++ b/docs/plans/2026-05-20-tool-config-full-list-template-cache.md
@@ -15,8 +15,6 @@ This Python-only performance slice is limited to the built-in tool config select
 - extend the registered tool-registry select probe with separate full-list
   `built_in_tool_config()` workload metrics without folding that workload into
   the existing selection elapsed metric.
-- remove per-instance `ToolRegistry` dictionaries so cached registry and
-  selection objects have lower steady-state attribute and allocation overhead.
 
 It does not change tool descriptor definitions, protobuf schemas, generated outputs, parser contracts, or non-exact partial-selection behavior.
 

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3876,6 +3876,12 @@
         "unit": "calls",
         "direction": "higher_is_better",
         "warn_pct": 0.0
+      },
+      {
+        "key": "full_config_template_hits_mean",
+        "unit": "calls",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
       }
     ]
   },

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3882,6 +3882,12 @@
         "unit": "calls",
         "direction": "higher_is_better",
         "warn_pct": 0.0
+      },
+      {
+        "key": "full_config_template_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
       }
     ]
   },

--- a/scripts/tool_registry_select_probe.py
+++ b/scripts/tool_registry_select_probe.py
@@ -12,7 +12,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
-from worker.runtime.tool_registry import built_in_tool_registry  # noqa: E402
+from worker.runtime.tool_registry import (  # noqa: E402
+    built_in_tool_config,
+    built_in_tool_registry,
+)
 
 _SELECTIONS: tuple[tuple[str, ...], ...] = (
     ("visit", "image_crop", "visit"),
@@ -27,30 +30,39 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     full_selection = list(registry.names())
     elapsed_samples: list[float] = []
     full_list_self_samples: list[float] = []
+    full_config_template_samples: list[float] = []
     checksum = 0
 
     for _ in range(sample_count):
         full_list_self_count = 0
+        full_config_template_count = 0
         started = time.perf_counter()
         for index in range(iterations):
             if index % 5 == 0:
                 selected = registry.select(full_selection)
                 if selected is registry:
                     full_list_self_count += 1
+            elif index % 5 == 1:
+                config = built_in_tool_config(full_selection)
+                selected = registry
+                full_config_template_count += 1
+                checksum += len(config.tools)
             else:
                 selected = registry.select(_SELECTIONS[index % len(_SELECTIONS)])
             checksum += len(selected.tools)
         elapsed_samples.append((time.perf_counter() - started) * 1000.0)
         full_list_self_samples.append(float(full_list_self_count))
+        full_config_template_samples.append(float(full_config_template_count))
 
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
         "select_calls_mean": float(iterations),
         "full_list_self_hits_mean": statistics.fmean(full_list_self_samples),
+        "full_config_template_hits_mean": statistics.fmean(full_config_template_samples),
         "checksum": float(checksum),
         "iterations": float(iterations),
         "sample_count": float(sample_count),
-        "selection_case_count": float(len(_SELECTIONS) + 1),
+        "selection_case_count": float(len(_SELECTIONS) + 2),
     }
 
 

--- a/scripts/tool_registry_select_probe.py
+++ b/scripts/tool_registry_select_probe.py
@@ -30,39 +30,48 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     full_selection = list(registry.names())
     elapsed_samples: list[float] = []
     full_list_self_samples: list[float] = []
+    full_config_template_elapsed_samples: list[float] = []
     full_config_template_samples: list[float] = []
     checksum = 0
 
     for _ in range(sample_count):
         full_list_self_count = 0
-        full_config_template_count = 0
         started = time.perf_counter()
         for index in range(iterations):
             if index % 5 == 0:
                 selected = registry.select(full_selection)
                 if selected is registry:
                     full_list_self_count += 1
-            elif index % 5 == 1:
-                config = built_in_tool_config(full_selection)
-                selected = registry
-                full_config_template_count += 1
-                checksum += len(config.tools)
             else:
                 selected = registry.select(_SELECTIONS[index % len(_SELECTIONS)])
             checksum += len(selected.tools)
         elapsed_samples.append((time.perf_counter() - started) * 1000.0)
         full_list_self_samples.append(float(full_list_self_count))
+
+        full_config_iterations = iterations // 5
+        full_config_template_count = 0
+        full_config_started = time.perf_counter()
+        for _index in range(full_config_iterations):
+            config = built_in_tool_config(full_selection)
+            full_config_template_count += 1
+            checksum += len(config.tools)
+        full_config_template_elapsed_samples.append(
+            (time.perf_counter() - full_config_started) * 1000.0
+        )
         full_config_template_samples.append(float(full_config_template_count))
 
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
         "select_calls_mean": float(iterations),
         "full_list_self_hits_mean": statistics.fmean(full_list_self_samples),
+        "full_config_template_elapsed_ms_mean": statistics.fmean(
+            full_config_template_elapsed_samples
+        ),
         "full_config_template_hits_mean": statistics.fmean(full_config_template_samples),
         "checksum": float(checksum),
         "iterations": float(iterations),
         "sample_count": float(sample_count),
-        "selection_case_count": float(len(_SELECTIONS) + 2),
+        "selection_case_count": float(len(_SELECTIONS) + 1),
     }
 
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -225,8 +225,9 @@ def test_tool_registry_select_probe_script_emits_metrics(
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["elapsed_ms_mean"] >= 0.0
     assert metrics["select_calls_mean"] == 20.0
-    assert metrics["selection_case_count"] == 5.0
+    assert metrics["selection_case_count"] == 6.0
     assert metrics["full_list_self_hits_mean"] == 4.0
+    assert metrics["full_config_template_hits_mean"] == 4.0
 
 
 def test_tool_registry_names_probe_script_emits_metrics(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -225,8 +225,9 @@ def test_tool_registry_select_probe_script_emits_metrics(
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["elapsed_ms_mean"] >= 0.0
     assert metrics["select_calls_mean"] == 20.0
-    assert metrics["selection_case_count"] == 6.0
+    assert metrics["selection_case_count"] == 5.0
     assert metrics["full_list_self_hits_mean"] == 4.0
+    assert metrics["full_config_template_elapsed_ms_mean"] >= 0.0
     assert metrics["full_config_template_hits_mean"] == 4.0
 
 

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -127,6 +127,7 @@ def test_tool_registry_names_reuses_registry_snapshot() -> None:
 def test_tool_registry_descriptors_use_slotted_snapshots() -> None:
     registry = built_in_tool_registry()
 
+    assert not hasattr(registry, "__dict__")
     assert not hasattr(registry.metrics(), "__dict__")
     assert not hasattr(registry.tools[0], "__dict__")
     assert not hasattr(registry.tools[0].arguments[0], "__dict__")

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -127,7 +127,6 @@ def test_tool_registry_names_reuses_registry_snapshot() -> None:
 def test_tool_registry_descriptors_use_slotted_snapshots() -> None:
     registry = built_in_tool_registry()
 
-    assert not hasattr(registry, "__dict__")
     assert not hasattr(registry.metrics(), "__dict__")
     assert not hasattr(registry.tools[0], "__dict__")
     assert not hasattr(registry.tools[0].arguments[0], "__dict__")

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -323,6 +323,13 @@ def test_built_in_tool_config_without_names_uses_cached_serialized_snapshot(
 def test_built_in_tool_config_full_selection_uses_cached_serialized_snapshot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    class IterCountingList(list[str]):
+        iter_calls = 0
+
+        def __iter__(self):  # pragma: no cover - exact-list fast path must not iterate
+            type(self).iter_calls += 1
+            return super().__iter__()
+
     expected_config = built_in_tool_config()
 
     def fail_as_worker_tool_config(self: ToolRegistry) -> common_pb2.ToolConfig:
@@ -333,11 +340,13 @@ def test_built_in_tool_config_full_selection_uses_cached_serialized_snapshot(
     monkeypatch.setattr(ToolRegistry, "as_worker_tool_config", fail_as_worker_tool_config)
 
     tuple_config = built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES)
-    list_config = built_in_tool_config(list(BUILTIN_AGENTIC_TOOL_NAMES))
+    full_list = IterCountingList(BUILTIN_AGENTIC_TOOL_NAMES)
+    list_config = built_in_tool_config(full_list)
 
     assert tuple_config == expected_config
     assert list_config == expected_config
     assert tuple_config is not expected_config
+    assert IterCountingList.iter_calls == 0
     assert list_config is not expected_config
     tuple_config.tools[0].name = "mutated"
     assert built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES).tools[0].name == "image_crop"

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -162,20 +162,6 @@ class ToolRegistryMetrics:
 
 
 class ToolRegistry:
-    __slots__ = (
-        "_metrics",
-        "_parser",
-        "_parser_contract_version",
-        "_schema_version",
-        "_selection_cache",
-        "_tool_by_name",
-        "_tool_names",
-        "_tool_names_list",
-        "_tools",
-        "_toolset_version",
-        "_worker_tool_config_bytes",
-    )
-
     def __init__(
         self,
         tools: list[ToolDescriptor] | tuple[ToolDescriptor, ...],

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -296,9 +296,15 @@ def built_in_tool_registry() -> ToolRegistry:
 def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> common_pb2.ToolConfig:
     if names is None:
         return _copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
-    if names == _BUILTIN_TOOL_CONFIG_NAMES_LIST:
-        return _copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
-    requested_names = tuple(names)
+    if isinstance(names, tuple):
+        cached_config = _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES.get(names)
+        if cached_config is not None:
+            return _copy_tool_config(cached_config)
+        requested_names = names
+    else:
+        if names == _BUILTIN_TOOL_CONFIG_NAMES_LIST:
+            return _copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
+        requested_names = tuple(names)
     cached_config = _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES.get(requested_names)
     if cached_config is not None:
         return _copy_tool_config(cached_config)

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -282,6 +282,8 @@ def built_in_tool_registry() -> ToolRegistry:
 def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> common_pb2.ToolConfig:
     if names is None:
         return _copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
+    if names == _BUILTIN_TOOL_CONFIG_NAMES_LIST:
+        return _copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
     requested_names = tuple(names)
     cached_config = _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES.get(requested_names)
     if cached_config is not None:
@@ -375,6 +377,7 @@ _BUILTIN_AGENTIC_TOOLS = (
 
 
 _BUILTIN_TOOL_CONFIG_REGISTRY = ToolRegistry(_BUILTIN_AGENTIC_TOOLS)
+_BUILTIN_TOOL_CONFIG_NAMES_LIST = list(BUILTIN_AGENTIC_TOOL_NAMES)
 _BUILTIN_TOOL_CONFIG_BYTES = (
     _BUILTIN_TOOL_CONFIG_REGISTRY.as_worker_tool_config().SerializeToString()
 )

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -162,6 +162,20 @@ class ToolRegistryMetrics:
 
 
 class ToolRegistry:
+    __slots__ = (
+        "_metrics",
+        "_parser",
+        "_parser_contract_version",
+        "_schema_version",
+        "_selection_cache",
+        "_tool_by_name",
+        "_tool_names",
+        "_tool_names_list",
+        "_tools",
+        "_toolset_version",
+        "_worker_tool_config_bytes",
+    )
+
     def __init__(
         self,
         tools: list[ToolDescriptor] | tuple[ToolDescriptor, ...],


### PR DESCRIPTION
## Summary
- Add a full-list fast path in `built_in_tool_config()` so exact ordered list callers reuse the cached built-in `ToolConfig` template without tuple conversion.
- Keep the registered tool-registry select probe comparable by measuring the added full-list `built_in_tool_config()` workload separately from the existing selection elapsed metric.
- Drop the experimental `ToolRegistry.__slots__` follow-up after the PR-scoped names probe reported a direct regression; the slice now remains limited to the full-list template cache.
- Add focused regression coverage and a governing plan for this performance slice.

## Plan or Spec
- `docs/plans/2026-05-20-tool-config-full-list-template-cache.md`
- Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`
- Existing related direct probe observed for regression recovery: `tool-registry-names-snapshot-cache`

## Commands Run
- `python3 -m json.tool infra/perf/pr_scoped_probes.json >/dev/null` -> pass
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics` -> 49 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py scripts/tool_registry_select_probe.py` -> 52 passed, changed-scope coverage 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` -> pass
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py` -> pass
- `git diff --check` -> pass
- Follow-up after CI reported `tool-registry-names-snapshot-cache` direct regression:
  - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_names_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics` -> 50 passed
  - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_names_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py scripts/tool_registry_select_probe.py` -> 53 passed, changed-scope coverage 100%
  - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` -> pass
  - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py` -> pass
  - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python3 scripts/tool_registry_names_probe.py` -> pass
  - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python3 scripts/tool_registry_names_probe.py` on synced `origin/main` -> pass

## Coverage and Metrics
- Changed-scope coverage: 100% in focused coverage runs.
- Latest follow-up `tool_registry_select_probe.py`: `elapsed_ms_mean=22.339982958510518`, `full_config_template_elapsed_ms_mean=22.438097186386585`, `full_config_template_hits_mean=16000.0`, `full_list_self_hits_mean=16000.0`, `select_calls_mean=80000.0`.
- Latest follow-up `tool_registry_schema_bytes_probe.py`: `elapsed_ms_mean=4.2977177537977695`, `built_in_tool_config_elapsed_ms_mean=57.43724014610052`, `full_selection_tool_config_elapsed_ms_mean=62.11718372069299`, `partial_selection_tool_config_elapsed_ms_mean=49.52316056005657`, `json_schema_calls_mean=0.0`, `schema_byte_count_calls_mean=0.0`.
- Latest follow-up `tool_registry_names_probe.py` on branch: `elapsed_ms_mean=27.3814526386559`, `registry_factory_elapsed_ms_mean=27.84360982477665`, `same_names_object_calls_mean=200000.0`.
- Same names probe on synced `origin/main`: `elapsed_ms_mean=28.482481418177485`, `registry_factory_elapsed_ms_mean=24.960704753175378`, `same_names_object_calls_mean=200000.0`.
- Previous CI PR-scoped performance report correctly blocked the branch with a direct `tool-registry-names-snapshot-cache` regression (`base=24.052ms`, `head=25.830ms`, `+7.39%`). Commit `bd706221` removes the experimental registry slots that caused that regression. A fresh PR-scoped CI report is required before merge.
- Observability mode: evidence-only PR-scoped synthetic probes; no production serving-path instrumentation added. Probe overhead is limited to CI/local probe execution.

## Known Gaps
- Linux local probes validate the Python slice only. Final base-vs-head gating depends on the registered PR-scoped CI performance report.
- The added `full_config_template_*` metrics are new head-only metrics for this PR; base rows report them as missing until the registry update is on `main`.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path and has focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probes run locally on Linux.
- [x] CI regression was investigated by run/job logs and fixed before merge.
- [ ] PR-scoped CI performance report is green on the latest commit.
- [ ] Required CI checks are green on the latest commit.
