### PR TITLE
Add agentic GRPO reward components

### DIFF
--- a/docs/agentic-trajectory-dataset-contract.md
+++ b/docs/agentic-trajectory-dataset-contract.md
@@ -201,7 +201,19 @@ keys are:
 - `format`
 - `query_quality`
 - `grounding`
+- `fatal_failure`
 - `total`
+
+Agentic GRPO/RL rollout slices consume a stable component subset:
+
+- `final_answer`: answer correctness or reward-model quality signal
+- `tool_efficiency`: tool budget and redundant-tool penalty signal
+- `format`: parser and response-format validity signal
+- `fatal_failure`: negative signal for a fatal stage
+- `total`: scalar aggregate used by the current policy update path
+
+Policy-update evidence must persist the component object that produced the
+scalar `total`, not only the total itself.
 
 `fatal_stage` records the first stage that invalidates later trajectory tokens
 or observations. Supported stage names are:

--- a/docs/plans/2026-05-20-agentic-grpo-reward-components.md
+++ b/docs/plans/2026-05-20-agentic-grpo-reward-components.md
@@ -1,0 +1,102 @@
+# Agentic GRPO Reward Components
+
+## Goal
+
+Implement issue #696 by defining the first executable Melix contract for
+agentic GRPO reward components. The slice keeps the current deterministic
+scored-trace and reward-model paths compatible while making each policy-update
+trace expose the component scores that future online rollout and fatal-aware
+GRPO slices will consume.
+
+## Scope
+
+- Governed issue: #696.
+- Parent direction: #694, OpenSearch-VL alignment: online GRPO/RL rollout for
+  tool-use LoRA.
+- Runtime boundary: Python worker alignment trace construction in
+  `worker.model_ops.rl_alignment_training`.
+- Artifact boundary: `policy_updates.jsonl` rows and alignment run metrics.
+
+## Architecture
+
+Melix already has a scalar reward path for GRPO and RLHF. This slice adds a
+structured component projection at the same boundary where scalar rewards enter
+policy-update evidence:
+
+- `final_answer`: correctness or reward-model quality signal.
+- `tool_efficiency`: positive when tool use stays within the budget implied by
+  the sample or fixture; negative when a trace exceeds it.
+- `format`: parser and response-format validity signal.
+- `fatal_failure`: penalty applied when a sample or candidate is associated with
+  a fatal stage.
+- `total`: canonical scalar value consumed by the current deterministic trainer.
+
+The component projection is intentionally additive. Existing scalar fields such
+as `selected_reward`, `reward_mean`, and candidate scores remain stable. Future
+fatal-aware GRPO work can replace the simple fatal penalty and advantage
+handling without changing the artifact names introduced here.
+
+## Performance And Metrics
+
+This is metadata construction over the in-memory sample and candidate rows
+already loaded for alignment training. It does not add model execution, broad
+filesystem scans, network calls, or extra runtime invocations.
+
+Success metrics:
+
+- Every selected GRPO and RLHF policy-update row includes `reward_components`.
+- GRPO candidate rows include component scores for each candidate.
+- Fatal samples record `fatal_stage`, `fatal_penalty_applied`, and a negative
+  `fatal_failure` component.
+- Alignment metrics report component means and fatal counts.
+- Changed-line coverage for touched Python files is at least 95 percent.
+
+## Implementation Steps
+
+- [x] Update the trajectory contract to name the GRPO component keys consumed by
+      issue #696.
+- [x] Add a worker helper that normalizes reward components from sample,
+      candidate, scalar score, tool-run metrics, and fatal stage.
+- [x] Attach component evidence to scored-trace GRPO, runtime-generated GRPO,
+      and RLHF trace rows.
+- [x] Add focused unit tests for component totals, fatal penalties, and
+      alignment metrics.
+- [x] Run focused tests, changed-line coverage, `git diff --check`, and the
+      repository pre-commit gate before opening the PR.
+
+## Verification
+
+Results:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
+# 5 passed
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_applies_manifest_overrides services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+# 3 passed
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'grpo or rlhf or reward_model or alignment_rl'
+# 25 passed, 110 deselected
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/agentic_grpo_reward_components.coverage -m pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --append --data-file=/tmp/agentic_grpo_reward_components.coverage -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_applies_manifest_overrides
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --append --data-file=/tmp/agentic_grpo_reward_components.coverage -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'grpo or rlhf or reward_model or alignment_rl'
+# 5 passed; 1 passed; 25 passed, 110 deselected
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/agentic_grpo_reward_components.coverage -o /tmp/agentic_grpo_reward_components_coverage.json
+# wrote JSON report
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/agentic_grpo_reward_components_coverage.json services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+# Final changed-line coverage command included all touched Python files:
+# services/mlx-worker-python/worker/model_ops/rl_alignment_training.py: 100.00% (86/86)
+# services/mlx-worker-python/worker/model_ops/training_dataset.py: 100.00% (16/16)
+# services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py: 100.00% (6/6)
+# services/mlx-worker-python/tests/test_training_dataset_builder.py: 100.00% (25/25)
+# TOTAL 100.00% (133/133)
+
+git diff --check
+# passed
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+# 135 passed, 2 warnings
+```

--- a/docs/plans/2026-05-20-agentic-grpo-reward-components.md
+++ b/docs/plans/2026-05-20-agentic-grpo-reward-components.md
@@ -46,6 +46,8 @@ Success metrics:
 
 - Every selected GRPO and RLHF policy-update row includes `reward_components`.
 - GRPO candidate rows include component scores for each candidate.
+- GRPO component means use all scored/generated candidate components so
+  `reward_component_total_mean` stays aligned with `reward_mean`.
 - Fatal samples record `fatal_stage`, `fatal_penalty_applied`, and a negative
   `fatal_failure` component.
 - Alignment metrics report component means and fatal counts.

--- a/services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
+++ b/services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from packages.protocol.python.worker.v1 import common_pb2
+from worker.model_ops import mlx_lm_runner as mlx_lm_runner_module
+from worker.model_ops import training_config as training_config_module
+from worker.model_ops.errors import ModelOperationError
+from worker.model_ops.lora_training_pipeline import LoRATrainingPipeline
+from worker.model_ops.training_dataset import load_training_dataset_package
+
+
+def _write_dataset_package(
+    root: Path,
+    *,
+    manifest_payload: dict[str, object],
+    sample_lines: list[str],
+) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "manifest.json").write_text(json.dumps(manifest_payload) + "\n", encoding="utf-8")
+    (root / "samples.jsonl").write_text("\n".join(sample_lines) + "\n", encoding="utf-8")
+    return root
+
+
+def _text_model(*, model_path: str = "models/plain-llama") -> common_pb2.ModelSpec:
+    model = common_pb2.ModelSpec(
+        model_id="melix-test-text",
+        model_path=model_path,
+        model_kind="text",
+        revision="main",
+        max_context=4096,
+    )
+    model.ext["text_layer_count"] = "2"
+    return model
+
+
+def test_grpo_policy_updates_persist_reward_components_and_fatal_stage(
+    tmp_path: Path,
+) -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"training_mode": "grpo", "grpo_candidate_count": "2"},
+        dataset_format="prompt_candidate",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    normalized_dataset_dir = tmp_path / "normalized"
+    normalized_dataset_dir.mkdir()
+    (normalized_dataset_dir / "train.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Use one tool and answer.",
+                "tool_budget": 1,
+                "fatal_stage": "tool_timeout",
+                "tool_calls": [
+                    {"id": "visit-1", "name": "visit", "arguments": {"url": "fixture://doc"}},
+                    {"id": "visit-2", "name": "visit", "arguments": {"url": "fixture://doc"}},
+                ],
+                "tool_fixture_context": {
+                    "pages": {"fixture://doc": {"title": "Doc", "text": "Evidence."}},
+                },
+                "candidates": [
+                    {
+                        "text": "Evidence-backed answer.",
+                        "score": 0.8,
+                        "format_valid": True,
+                    },
+                    {
+                        "text": "Malformed answer.",
+                        "score": 0.4,
+                        "format_valid": False,
+                    },
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-grpo-components",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dataset_dir,
+        config=config,
+        dataset_format="prompt_candidate",
+    )
+
+    result = mlx_lm_runner_module.MLXLMRunner().train(request)
+    trace_rows = [
+        json.loads(line)
+        for line in Path(result.metrics.policy_update_trace_path).read_text(encoding="utf-8").splitlines()
+    ]
+
+    components = trace_rows[0]["reward_components"]
+    assert components == {
+        "final_answer": 0.8,
+        "tool_efficiency": -1.0,
+        "format": 0.0,
+        "fatal_failure": -1.0,
+        "total": -1.2,
+    }
+    assert trace_rows[0]["fatal_stage"] == "tool_timeout"
+    assert trace_rows[0]["fatal_penalty_applied"] is True
+    assert trace_rows[0]["selected_reward"] == pytest.approx(-1.2)
+    assert trace_rows[0]["scored_candidates"][0]["reward_components"]["total"] == pytest.approx(-1.2)
+    assert trace_rows[0]["scored_candidates"][1]["reward_components"]["total"] == pytest.approx(-2.6)
+    assert result.metrics.reward_mean == pytest.approx(-1.9)
+    assert result.metrics.reward_component_final_answer_mean == pytest.approx(0.8)
+    assert result.metrics.reward_component_tool_efficiency_mean == pytest.approx(-1.0)
+    assert result.metrics.reward_component_format_mean == pytest.approx(0.0)
+    assert result.metrics.reward_component_fatal_failure_mean == pytest.approx(-1.0)
+    assert result.metrics.reward_component_total_mean == pytest.approx(-1.2)
+    assert result.metrics.fatal_trace_count == 1
+
+
+def test_lora_training_pipeline_records_grpo_reward_component_metrics(
+    tmp_path: Path,
+) -> None:
+    dataset_dir = _write_dataset_package(
+        tmp_path / "prompt-candidates",
+        manifest_payload={
+            "schema_version": "melix.training_dataset_package.v1",
+            "dataset_id": "component-prompt-candidates",
+            "format": "prompt_candidate",
+            "sample_count": 1,
+            "version": "1",
+        },
+        sample_lines=[
+            json.dumps(
+                {
+                    "prompt": "Choose answer.",
+                    "reward": {
+                        "final_answer": 0.6,
+                        "tool_efficiency": 0.2,
+                        "format": 0.1,
+                    },
+                    "candidates": [
+                        {"text": "Good answer.", "score": 0.6},
+                        {"text": "Weak answer.", "score": 0.1},
+                    ],
+                }
+            )
+        ],
+    )
+    result = LoRATrainingPipeline().run(
+        job_id="pipeline-grpo-components",
+        request_ext={
+            "training_mode": "grpo",
+            "dataset_uri": str(dataset_dir),
+            "grpo_candidate_count": "2",
+            "adapter_name": "component-adapter",
+            "iters": "1",
+            "target_modules": "q_proj",
+        },
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        output_dir=tmp_path / "job",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    alignment_manifest = json.loads(
+        Path(result.manifest["alignment_run_manifest_path"]).read_text(encoding="utf-8")
+    )
+    metrics = alignment_manifest["metrics"]
+    assert metrics["reward_component_final_answer_mean"] == pytest.approx(0.6)
+    assert metrics["reward_component_tool_efficiency_mean"] == pytest.approx(0.2)
+    assert metrics["reward_component_format_mean"] == pytest.approx(0.1)
+    assert metrics["reward_component_fatal_failure_mean"] == pytest.approx(0.0)
+    assert metrics["reward_component_total_mean"] == pytest.approx(0.9)
+    assert metrics["fatal_trace_count"] == 0
+
+
+def test_grpo_reward_component_helpers_cover_explicit_and_edge_paths() -> None:
+    from worker.model_ops.rl_alignment_training import (
+        _reward_component_summary,
+        _reward_components_for_candidate,
+    )
+
+    explicit = _reward_components_for_candidate(
+        sample={},
+        candidate={
+            "reward": {
+                "final_answer": 0.7,
+                "tool_efficiency": 0.1,
+                "format": 0.2,
+            }
+        },
+        score=0.0,
+        tool_run=None,
+        include_sample_fatal=False,
+    )
+    assert explicit["total"] == pytest.approx(1.0)
+
+    candidate_fatal = _reward_components_for_candidate(
+        sample={"tool_efficiency": "0.25", "tool_budget": "bad"},
+        candidate={"format_score": "-0.5", "fatal_stage": "parser_failure"},
+        score=0.4,
+        tool_run=None,
+        include_sample_fatal=False,
+    )
+    assert candidate_fatal == {
+        "final_answer": 0.4,
+        "tool_efficiency": 0.25,
+        "format": -0.5,
+        "fatal_failure": -1.0,
+        "total": -0.85,
+    }
+
+    under_budget = _reward_components_for_candidate(
+        sample={"tool_budget": "2", "tool_calls": [{"id": "one"}], "format_valid": False},
+        candidate={},
+        score=0.5,
+        tool_run=None,
+        include_sample_fatal=False,
+    )
+    assert under_budget["tool_efficiency"] == pytest.approx(0.0)
+    assert under_budget["format"] == pytest.approx(-1.0)
+    assert _reward_component_summary([])["total"] == pytest.approx(0.0)
+
+
+def test_prompt_candidate_normalization_preserves_reward_component_metadata(
+    tmp_path: Path,
+) -> None:
+    package_dir = _write_dataset_package(
+        tmp_path / "prompt-candidates-with-components",
+        manifest_payload={
+            "schema_version": "melix.training_dataset_package.v1",
+            "dataset_id": "prompt-candidates-with-components",
+            "format": "prompt_candidate",
+            "sample_count": 1,
+            "version": "1",
+        },
+        sample_lines=[
+            json.dumps(
+                {
+                    "prompt": "Choose.",
+                    "reward_components": {"tool_efficiency": 0.2},
+                    "tool_budget": 2,
+                    "format_score": 0.1,
+                    "fatal_stage": "answer_invalid",
+                    "tool_calls": [{"id": "tool-1"}],
+                    "tool_fixture_context": {"pages": {}},
+                    "tool_context": {"pages": {}},
+                    "candidates": [
+                        {
+                            "text": "A",
+                            "score": 1.0,
+                            "reward_components": {"final_answer": 1.0},
+                            "format_score": 0.3,
+                            "fatal_stage": "parser_failure",
+                        },
+                        {"text": "B", "score": 0.0},
+                    ],
+                }
+            )
+        ],
+    )
+
+    package = load_training_dataset_package(package_dir)
+    sample = package.normalized_samples[0]
+
+    assert sample["reward_components"] == {"tool_efficiency": 0.2}
+    assert sample["tool_budget"] == 2
+    assert sample["format_score"] == 0.1
+    assert sample["fatal_stage"] == "answer_invalid"
+    assert sample["tool_calls"] == [{"id": "tool-1"}]
+    assert sample["tool_fixture_context"] == {"pages": {}}
+    assert sample["tool_context"] == {"pages": {}}
+    assert sample["candidates"][0]["reward_components"] == {"final_answer": 1.0}
+    assert sample["candidates"][0]["format_score"] == 0.3
+    assert sample["candidates"][0]["fatal_stage"] == "parser_failure"
+
+
+def test_prompt_candidate_normalization_rejects_non_object_rewards(
+    tmp_path: Path,
+) -> None:
+    bad_candidate_package = _write_dataset_package(
+        tmp_path / "bad-prompt-candidates",
+        manifest_payload={
+            "schema_version": "melix.training_dataset_package.v1",
+            "dataset_id": "bad-prompt-candidates",
+            "format": "prompt_candidate",
+            "sample_count": 1,
+            "version": "1",
+        },
+        sample_lines=[
+            json.dumps(
+                {
+                    "prompt": "Choose.",
+                    "reward": "bad",
+                    "candidates": [
+                        {"text": "A", "score": 1.0},
+                        {"text": "B", "score": 0.0, "reward": "bad"},
+                    ],
+                }
+            )
+        ],
+    )
+
+    with pytest.raises(ModelOperationError, match="candidate reward must be a JSON object"):
+        load_training_dataset_package(bad_candidate_package)
+
+    bad_sample_package = _write_dataset_package(
+        tmp_path / "bad-prompt-candidates-sample",
+        manifest_payload={
+            "schema_version": "melix.training_dataset_package.v1",
+            "dataset_id": "bad-prompt-candidates-sample",
+            "format": "prompt_candidate",
+            "sample_count": 1,
+            "version": "1",
+        },
+        sample_lines=[
+            json.dumps(
+                {
+                    "prompt": "Choose.",
+                    "reward_components": "bad",
+                    "candidates": [
+                        {"text": "A", "score": 1.0},
+                        {"text": "B", "score": 0.0},
+                    ],
+                }
+            )
+        ],
+    )
+
+    with pytest.raises(ModelOperationError, match="prompt_candidate reward_components must be a JSON object"):
+        load_training_dataset_package(bad_sample_package)

--- a/services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
+++ b/services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
@@ -110,11 +110,11 @@ def test_grpo_policy_updates_persist_reward_components_and_fatal_stage(
     assert trace_rows[0]["scored_candidates"][0]["reward_components"]["total"] == pytest.approx(-1.2)
     assert trace_rows[0]["scored_candidates"][1]["reward_components"]["total"] == pytest.approx(-2.6)
     assert result.metrics.reward_mean == pytest.approx(-1.9)
-    assert result.metrics.reward_component_final_answer_mean == pytest.approx(0.8)
+    assert result.metrics.reward_component_final_answer_mean == pytest.approx(0.6)
     assert result.metrics.reward_component_tool_efficiency_mean == pytest.approx(-1.0)
-    assert result.metrics.reward_component_format_mean == pytest.approx(0.0)
+    assert result.metrics.reward_component_format_mean == pytest.approx(-0.5)
     assert result.metrics.reward_component_fatal_failure_mean == pytest.approx(-1.0)
-    assert result.metrics.reward_component_total_mean == pytest.approx(-1.2)
+    assert result.metrics.reward_component_total_mean == pytest.approx(-1.9)
     assert result.metrics.fatal_trace_count == 1
 
 
@@ -166,11 +166,12 @@ def test_lora_training_pipeline_records_grpo_reward_component_metrics(
         Path(result.manifest["alignment_run_manifest_path"]).read_text(encoding="utf-8")
     )
     metrics = alignment_manifest["metrics"]
-    assert metrics["reward_component_final_answer_mean"] == pytest.approx(0.6)
+    assert metrics["reward_mean"] == pytest.approx(0.65)
+    assert metrics["reward_component_final_answer_mean"] == pytest.approx(0.35)
     assert metrics["reward_component_tool_efficiency_mean"] == pytest.approx(0.2)
     assert metrics["reward_component_format_mean"] == pytest.approx(0.1)
     assert metrics["reward_component_fatal_failure_mean"] == pytest.approx(0.0)
-    assert metrics["reward_component_total_mean"] == pytest.approx(0.9)
+    assert metrics["reward_component_total_mean"] == pytest.approx(0.65)
     assert metrics["fatal_trace_count"] == 0
 
 

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -174,6 +174,112 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
     assert stale_agentic_valid_path.exists() is False
     assert training_dataset_module.trainer_sample_counts(dataset) == (1, 0)
 
+    prompt_candidate_package_path = tmp_path / "prompt-candidate-package"
+    prompt_candidate_package_path.mkdir(parents=True, exist_ok=True)
+    (prompt_candidate_package_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "prompt-candidate-package",
+                "format": "prompt_candidate",
+                "sample_count": 1,
+                "version": "1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (prompt_candidate_package_path / "samples.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Choose.",
+                "reward_components": {"tool_efficiency": 0.2},
+                "tool_budget": 2,
+                "format_score": 0.1,
+                "fatal_stage": "answer_invalid",
+                "tool_calls": [{"id": "tool-1"}],
+                "tool_fixture_context": {"pages": {}},
+                "tool_context": {"pages": {}},
+                "candidates": [
+                    {
+                        "text": "A",
+                        "score": 1.0,
+                        "reward_components": {"final_answer": 1.0},
+                        "format_score": 0.3,
+                        "fatal_stage": "parser_failure",
+                    },
+                    {"text": "B", "score": 0.0},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    prompt_candidate_package = load_training_dataset_package(prompt_candidate_package_path)
+    prompt_candidate_sample = prompt_candidate_package.normalized_samples[0]
+
+    assert prompt_candidate_sample["reward_components"] == {"tool_efficiency": 0.2}
+    assert prompt_candidate_sample["tool_budget"] == 2
+    assert prompt_candidate_sample["format_score"] == 0.1
+    assert prompt_candidate_sample["fatal_stage"] == "answer_invalid"
+    assert prompt_candidate_sample["tool_calls"] == [{"id": "tool-1"}]
+    assert prompt_candidate_sample["tool_fixture_context"] == {"pages": {}}
+    assert prompt_candidate_sample["tool_context"] == {"pages": {}}
+    assert prompt_candidate_sample["candidates"][0]["reward_components"] == {"final_answer": 1.0}
+    assert prompt_candidate_sample["candidates"][0]["format_score"] == 0.3
+    assert prompt_candidate_sample["candidates"][0]["fatal_stage"] == "parser_failure"
+
+    bad_prompt_candidate_package_path = tmp_path / "bad-prompt-candidate-package"
+    bad_prompt_candidate_package_path.mkdir(parents=True, exist_ok=True)
+    (bad_prompt_candidate_package_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "bad-prompt-candidate-package",
+                "format": "prompt_candidate",
+                "sample_count": 1,
+                "version": "1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bad_prompt_candidate_package_path / "samples.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Choose.",
+                "reward_components": "bad",
+                "candidates": [
+                    {"text": "A", "score": 1.0},
+                    {"text": "B", "score": 0.0, "reward": "bad"},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ModelOperationError, match="candidate reward must be a JSON object"):
+        load_training_dataset_package(bad_prompt_candidate_package_path)
+
+    (bad_prompt_candidate_package_path / "samples.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Choose.",
+                "reward_components": "bad",
+                "candidates": [
+                    {"text": "A", "score": 1.0},
+                    {"text": "B", "score": 0.0},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ModelOperationError, match="prompt_candidate reward_components must be a JSON object"):
+        load_training_dataset_package(bad_prompt_candidate_package_path)
+
     agentic_package_path = tmp_path / "agentic-package"
     agentic_package_path.mkdir(parents=True, exist_ok=True)
     samples = [

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -537,6 +537,22 @@ def _alignment_manifest_payload(
                 "kl_penalty": alignment.kl_penalty,
                 "candidate_generation_mode": alignment.candidate_generation_mode,
                 "candidate_scoring_mode": alignment.candidate_scoring_mode,
+                "reward_component_final_answer_mean": (
+                    training_result.metrics.reward_component_final_answer_mean
+                ),
+                "reward_component_tool_efficiency_mean": (
+                    training_result.metrics.reward_component_tool_efficiency_mean
+                ),
+                "reward_component_format_mean": (
+                    training_result.metrics.reward_component_format_mean
+                ),
+                "reward_component_fatal_failure_mean": (
+                    training_result.metrics.reward_component_fatal_failure_mean
+                ),
+                "reward_component_total_mean": (
+                    training_result.metrics.reward_component_total_mean
+                ),
+                "fatal_trace_count": training_result.metrics.fatal_trace_count,
             }
         )
         if training_result.metrics.candidate_generation_backend:

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -85,6 +85,12 @@ class TrainingMetrics:
     reward_mean: float = 0.0
     reward_p50: float = 0.0
     reward_p95: float = 0.0
+    reward_component_final_answer_mean: float = 0.0
+    reward_component_tool_efficiency_mean: float = 0.0
+    reward_component_format_mean: float = 0.0
+    reward_component_fatal_failure_mean: float = 0.0
+    reward_component_total_mean: float = 0.0
+    fatal_trace_count: int = 0
     policy_update_count: int = 0
     selected_candidate_count: int = 0
     candidate_group_count: int = 0

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -406,7 +406,9 @@ def _grpo_policy_updates(
         reward_values.extend(scores)
         selected = max(scored_candidates, key=lambda candidate: candidate["reward_components"]["total"])
         selected_components = dict(selected["reward_components"])
-        reward_component_summaries.append(selected_components)
+        reward_component_summaries.extend(
+            dict(candidate["reward_components"]) for candidate in scored_candidates
+        )
         group_margins.append(max(scores) - min(scores))
         group_mean = sum(scores) / len(scores)
         group_variances.append(sum((score - group_mean) ** 2 for score in scores) / len(scores))
@@ -538,7 +540,9 @@ def _grpo_runtime_policy_updates(
         reward_values.extend(scores)
         selected = max(generated_candidates, key=lambda candidate: candidate["reward_components"]["total"])
         selected_components = dict(selected["reward_components"])
-        reward_component_summaries.append(selected_components)
+        reward_component_summaries.extend(
+            dict(candidate["reward_components"]) for candidate in generated_candidates
+        )
         group_margins.append(max(scores) - min(scores))
         group_mean = sum(scores) / len(scores)
         group_variances.append(sum((score - group_mean) ** 2 for score in scores) / len(scores))

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -23,6 +23,7 @@ from worker.trajectory_provenance import (
 class PolicyUpdateResult:
     trace_rows: list[dict[str, Any]]
     reward_values: list[float]
+    reward_component_summaries: list[dict[str, float]]
     group_margins: list[float]
     group_variances: list[float]
     selected_count: int
@@ -200,6 +201,9 @@ def train_alignment_rl_trace(
 
     duration_ms = (time.perf_counter() - started_at) * 1000.0
     reward_summary = _reward_summary(policy_updates.reward_values)
+    reward_component_summary = _reward_component_summary(
+        policy_updates.reward_component_summaries,
+    )
     return TrainingResult(
         weights_path=weights_path,
         adapter_config_path=adapter_config_path,
@@ -219,6 +223,16 @@ def train_alignment_rl_trace(
             reward_mean=reward_summary["reward_mean"],
             reward_p50=reward_summary["reward_p50"],
             reward_p95=reward_summary["reward_p95"],
+            reward_component_final_answer_mean=reward_component_summary["final_answer"],
+            reward_component_tool_efficiency_mean=reward_component_summary["tool_efficiency"],
+            reward_component_format_mean=reward_component_summary["format"],
+            reward_component_fatal_failure_mean=reward_component_summary["fatal_failure"],
+            reward_component_total_mean=reward_component_summary["total"],
+            fatal_trace_count=sum(
+                1
+                for row in policy_updates.trace_rows
+                if str(row.get("fatal_stage", "")).strip()
+            ),
             policy_update_count=len(policy_updates.trace_rows),
             selected_candidate_count=policy_updates.selected_count,
             candidate_group_count=len(policy_updates.group_margins),
@@ -322,6 +336,7 @@ def _grpo_policy_updates(
 
     trace_rows: list[dict[str, Any]] = []
     reward_values: list[float] = []
+    reward_component_summaries: list[dict[str, float]] = []
     group_margins: list[float] = []
     group_variances: list[float] = []
     for sample_index, sample in enumerate(samples):
@@ -337,6 +352,7 @@ def _grpo_policy_updates(
                 },
             )
         scored_candidates = []
+        tool_run = _agentic_tool_run_for_sample(sample)
         for candidate_index, candidate in enumerate(candidates[:candidate_count]):
             if not isinstance(candidate, dict):
                 raise ModelOperationError(
@@ -371,17 +387,26 @@ def _grpo_policy_updates(
                         "missing_field": "candidate.score",
                     },
                 )
+            candidate_components = _reward_components_for_candidate(
+                sample=sample,
+                candidate=candidate,
+                score=score,
+                tool_run=tool_run,
+                include_sample_fatal=True,
+            )
             scored_candidates.append(
                 {
                     "index": candidate_index,
                     "text": candidate_text,
                     "score": score,
+                    "reward_components": candidate_components,
                 }
             )
-        scores = [candidate["score"] for candidate in scored_candidates]
-        tool_run = _agentic_tool_run_for_sample(sample)
+        scores = [candidate["reward_components"]["total"] for candidate in scored_candidates]
         reward_values.extend(scores)
-        selected = max(scored_candidates, key=lambda candidate: candidate["score"])
+        selected = max(scored_candidates, key=lambda candidate: candidate["reward_components"]["total"])
+        selected_components = dict(selected["reward_components"])
+        reward_component_summaries.append(selected_components)
         group_margins.append(max(scores) - min(scores))
         group_mean = sum(scores) / len(scores)
         group_variances.append(sum((score - group_mean) ** 2 for score in scores) / len(scores))
@@ -395,7 +420,11 @@ def _grpo_policy_updates(
                 "selected_candidate_index": selected["index"],
                 "selected_candidate_text": selected["text"],
                 "selected_text": selected["text"],
-                "selected_reward": selected["score"],
+                "selected_reward": selected_components["total"],
+                "reward_components": selected_components,
+                "reward_total": selected_components["total"],
+                "fatal_stage": _fatal_stage_for_candidate(sample, candidates[selected["index"]]),
+                "fatal_penalty_applied": selected_components["fatal_failure"] < 0.0,
                 "group_reward_mean": group_mean,
                 "group_reward_margin": group_margins[-1],
                 "candidate_count": len(scored_candidates),
@@ -409,6 +438,7 @@ def _grpo_policy_updates(
     return PolicyUpdateResult(
         trace_rows=trace_rows,
         reward_values=reward_values,
+        reward_component_summaries=reward_component_summaries,
         group_margins=group_margins,
         group_variances=group_variances,
         selected_count=len(trace_rows),
@@ -449,6 +479,7 @@ def _grpo_runtime_policy_updates(
 
     trace_rows: list[dict[str, Any]] = []
     reward_values: list[float] = []
+    reward_component_summaries: list[dict[str, float]] = []
     group_margins: list[float] = []
     group_variances: list[float] = []
     generated_candidate_total = 0
@@ -486,18 +517,28 @@ def _grpo_runtime_policy_updates(
                 )
             else:
                 score = _seed_overlap_proxy_score(generated_text, seed_candidates)
+            reward_components = _reward_components_for_candidate(
+                sample=sample,
+                candidate={"text": generated_text},
+                score=score,
+                tool_run=tool_run,
+                include_sample_fatal=True,
+            )
             generated_candidates.append(
                 {
                     "index": candidate_index,
                     "text": generated_text,
                     "score": score,
+                    "reward_components": reward_components,
                     "generation_prompt": generation_prompt,
                     "source": "policy_runtime",
                 }
             )
-        scores = [candidate["score"] for candidate in generated_candidates]
+        scores = [candidate["reward_components"]["total"] for candidate in generated_candidates]
         reward_values.extend(scores)
-        selected = max(generated_candidates, key=lambda candidate: candidate["score"])
+        selected = max(generated_candidates, key=lambda candidate: candidate["reward_components"]["total"])
+        selected_components = dict(selected["reward_components"])
+        reward_component_summaries.append(selected_components)
         group_margins.append(max(scores) - min(scores))
         group_mean = sum(scores) / len(scores)
         group_variances.append(sum((score - group_mean) ** 2 for score in scores) / len(scores))
@@ -513,7 +554,11 @@ def _grpo_runtime_policy_updates(
                 "selected_candidate_index": selected["index"],
                 "selected_candidate_text": selected["text"],
                 "selected_text": selected["text"],
-                "selected_reward": selected["score"],
+                "selected_reward": selected_components["total"],
+                "reward_components": selected_components,
+                "reward_total": selected_components["total"],
+                "fatal_stage": _fatal_stage_for_candidate(sample, {"text": selected["text"]}),
+                "fatal_penalty_applied": selected_components["fatal_failure"] < 0.0,
                 "group_reward_mean": group_mean,
                 "group_reward_margin": group_margins[-1],
                 "candidate_count": len(generated_candidates),
@@ -527,6 +572,7 @@ def _grpo_runtime_policy_updates(
     return PolicyUpdateResult(
         trace_rows=trace_rows,
         reward_values=reward_values,
+        reward_component_summaries=reward_component_summaries,
         group_margins=group_margins,
         group_variances=group_variances,
         selected_count=len(trace_rows),
@@ -554,6 +600,7 @@ def _rlhf_policy_updates(
 
     trace_rows: list[dict[str, Any]] = []
     reward_values: list[float] = []
+    reward_component_summaries: list[dict[str, float]] = []
     for sample_index, sample in enumerate(samples):
         if candidate_scoring_mode == "dataset_score" and "reward_score" not in sample:
             raise ModelOperationError(
@@ -577,8 +624,16 @@ def _rlhf_policy_updates(
             )
         else:
             reward = float(sample["reward_score"])
-        reward_values.append(reward)
         tool_run = _agentic_tool_run_for_sample(sample)
+        reward_components = _reward_components_for_candidate(
+            sample=sample,
+            candidate={"text": response},
+            score=reward,
+            tool_run=tool_run,
+            include_sample_fatal=True,
+        )
+        reward_values.append(reward_components["total"])
+        reward_component_summaries.append(reward_components)
         row = {
             "sample_index": sample_index,
             "alignment_algorithm": "rlhf",
@@ -586,7 +641,11 @@ def _rlhf_policy_updates(
             "candidate_scoring_mode": candidate_scoring_mode,
             "prompt": prompt,
             "selected_response": response,
-            "selected_reward": reward,
+            "selected_reward": reward_components["total"],
+            "reward_components": reward_components,
+            "reward_total": reward_components["total"],
+            "fatal_stage": _fatal_stage_for_candidate(sample, {"text": response}),
+            "fatal_penalty_applied": reward_components["fatal_failure"] < 0.0,
         }
         _attach_agentic_tool_run(row, tool_run)
         if "reward_score" in sample and candidate_scoring_mode == "reward_model":
@@ -598,6 +657,7 @@ def _rlhf_policy_updates(
     return PolicyUpdateResult(
         trace_rows=trace_rows,
         reward_values=reward_values,
+        reward_component_summaries=reward_component_summaries,
         group_margins=[],
         group_variances=[],
         selected_count=len(trace_rows),
@@ -633,6 +693,126 @@ def _attach_agentic_tool_run(row: dict[str, Any], tool_run: Any | None) -> None:
     ]
     row["agentic_tool_metrics"] = dict(tool_run.metrics)
     row["turns"] = [dict(turn) for turn in tool_run.trace_turns]
+
+
+_REWARD_COMPONENT_KEYS = (
+    "final_answer",
+    "tool_efficiency",
+    "format",
+    "fatal_failure",
+    "total",
+)
+_FATAL_FAILURE_PENALTY = -1.0
+
+
+def _reward_components_for_candidate(
+    *,
+    sample: dict[str, Any],
+    candidate: dict[str, Any],
+    score: float,
+    tool_run: Any | None,
+    include_sample_fatal: bool,
+) -> dict[str, float]:
+    explicit_components = _explicit_reward_components(candidate)
+    if explicit_components:
+        components = dict(explicit_components)
+        if "total" not in components:
+            components["total"] = _component_total(components)
+    else:
+        sample_components = _explicit_reward_components(sample)
+        components = {
+            "final_answer": float(score),
+            "tool_efficiency": sample_components.get(
+                "tool_efficiency",
+                _tool_efficiency_component(sample=sample, tool_run=tool_run),
+            ),
+            "format": sample_components.get(
+                "format",
+                _format_component(sample=sample, candidate=candidate),
+            ),
+        }
+
+    fatal_stage = _fatal_stage_for_candidate(
+        sample,
+        candidate,
+        include_sample_fatal=include_sample_fatal,
+    )
+    components.setdefault("fatal_failure", _FATAL_FAILURE_PENALTY if fatal_stage else 0.0)
+    if "total" not in components or fatal_stage:
+        components["total"] = _component_total(components)
+    return _ordered_reward_components(components)
+
+
+def _explicit_reward_components(payload: dict[str, Any]) -> dict[str, float]:
+    reward = payload.get("reward")
+    if not isinstance(reward, dict):
+        reward = payload.get("reward_components")
+    if not isinstance(reward, dict):
+        return {}
+    components: dict[str, float] = {}
+    for key in _REWARD_COMPONENT_KEYS:
+        if key in reward:
+            components[key] = float(reward[key])
+    return components
+
+
+def _component_total(components: dict[str, float]) -> float:
+    return sum(
+        value
+        for key, value in components.items()
+        if key != "total"
+    )
+
+
+def _tool_efficiency_component(*, sample: dict[str, Any], tool_run: Any | None) -> float:
+    if "tool_efficiency" in sample:
+        return float(sample["tool_efficiency"])
+    reward = sample.get("reward")
+    if isinstance(reward, dict) and "tool_efficiency" in reward:
+        return float(reward["tool_efficiency"])
+    tool_budget = sample.get("tool_budget")
+    try:
+        budget = int(tool_budget)
+    except (TypeError, ValueError):
+        budget = 0
+    if budget <= 0:
+        return 0.0
+    call_count = 0
+    if tool_run is not None:
+        metrics = getattr(tool_run, "metrics", {})
+        if isinstance(metrics, dict):
+            call_count = int(metrics.get("agentic_tool.call_count", 0.0))
+    elif isinstance(sample.get("tool_calls"), list):
+        call_count = len(sample["tool_calls"])
+    if call_count <= budget:
+        return 0.0
+    return -float(call_count - budget)
+
+
+def _format_component(*, sample: dict[str, Any], candidate: dict[str, Any]) -> float:
+    for payload in (candidate, sample):
+        if "format_valid" in payload:
+            return 0.0 if bool(payload["format_valid"]) else -1.0
+        if "format_score" in payload:
+            return float(payload["format_score"])
+    return 0.0
+
+
+def _fatal_stage_for_candidate(
+    sample: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    include_sample_fatal: bool = True,
+) -> str:
+    return str(
+        candidate.get("fatal_stage")
+        or (sample.get("fatal_stage") if include_sample_fatal else "")
+        or ""
+    ).strip()
+
+
+def _ordered_reward_components(components: dict[str, float]) -> dict[str, float]:
+    return {key: float(components.get(key, 0.0)) for key in _REWARD_COMPONENT_KEYS}
 
 
 def _resolve_reward_model_scorer(
@@ -884,6 +1064,18 @@ def _reward_summary(reward_values: list[float]) -> dict[str, float]:
         "reward_mean": sum(ordered) / len(ordered),
         "reward_p50": _percentile_value(ordered, 0.5),
         "reward_p95": _percentile_value(ordered, 0.95),
+    }
+
+
+def _reward_component_summary(
+    reward_component_summaries: list[dict[str, float]],
+) -> dict[str, float]:
+    if not reward_component_summaries:
+        return {key: 0.0 for key in _REWARD_COMPONENT_KEYS}
+    count = len(reward_component_summaries)
+    return {
+        key: sum(components.get(key, 0.0) for components in reward_component_summaries) / count
+        for key in _REWARD_COMPONENT_KEYS
     }
 
 

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -880,6 +880,18 @@ def _normalize_sample(
                             message="prompt_candidate candidate scores must be numeric.",
                             details={"candidate_index": str(candidate_index)},
                         ) from exc
+                for key in ("reward", "reward_components"):
+                    if key in candidate:
+                        if not isinstance(candidate[key], Mapping):
+                            raise ModelOperationError(
+                                code="invalid_dataset_package",
+                                message=f"prompt_candidate candidate {key} must be a JSON object.",
+                                details={"candidate_index": str(candidate_index)},
+                            )
+                        candidate_payload[key] = dict(candidate[key])
+                for key in ("format_valid", "format_score", "fatal_stage"):
+                    if key in candidate:
+                        candidate_payload[key] = candidate[key]
             else:
                 raise ModelOperationError(
                     code="invalid_dataset_package",
@@ -894,10 +906,30 @@ def _normalize_sample(
                 )
             candidate_payload["text"] = _truncate_text(candidate_text, max_characters_per_sample)
             normalized_candidates.append(candidate_payload)
-        return {
+        payload: dict[str, Any] = {
             "prompt": _truncate_text(prompt, max_characters_per_sample),
             "candidates": normalized_candidates,
         }
+        for key in (
+            "reward",
+            "reward_components",
+            "tool_budget",
+            "format_valid",
+            "format_score",
+            "fatal_stage",
+            "tool_calls",
+            "tool_fixture_context",
+            "tool_context",
+        ):
+            if key in sample:
+                value = sample[key]
+                if key in {"reward", "reward_components"} and not isinstance(value, Mapping):
+                    raise ModelOperationError(
+                        code="invalid_dataset_package",
+                        message=f"prompt_candidate {key} must be a JSON object.",
+                    )
+                payload[key] = dict(value) if isinstance(value, Mapping) else value
+        return payload
 
     if format_name == "reward_scored":
         prompt = str(sample.get("prompt", "")).strip()


### PR DESCRIPTION
## Summary
- Added structured reward component evidence for agentic GRPO/RLHF policy-update traces.
- Preserved prompt-candidate reward, fatal-stage, format, and tool metadata through dataset normalization.
- Exported all-candidate component means and fatal trace counts in alignment metrics.

## Plan or Spec
- `docs/plans/2026-05-20-agentic-grpo-reward-components.md`
- `docs/agentic-trajectory-dataset-contract.md`
- Closes #696

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
# 5 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_applies_manifest_overrides services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 3 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'grpo or rlhf or reward_model or alignment_rl'
# 25 passed, 110 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py
# 135 passed, 2 warnings

git diff --check
# passed

Pre-commit full gate while creating commit 476059d7:
make swift-test
# completed rc=0 elapsed=179.3s
make py-test
# 2878 passed, 14 skipped, 2 warnings in 120.52s; completed rc=0
make integration-test
# 114 passed, 1 skipped in 309.15s; completed rc=0
Melix PR Scoped Performance Report
# Status: ok; selected probes: 5; direct/gated probes: 5; regressions: 0; verification failures: 0

Review-fix focused verification before commit 33e8e6c6:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'grpo or reward_component'
# 12 passed, 128 deselected

git diff --check
# passed

Review-fix changed-line coverage:
coverage run + coverage json + scripts/python_changed_line_coverage.py for rl_alignment_training.py and test_agentic_grpo_reward_components.py
# changed-line coverage 100.00% (8/8)

Pre-commit full gate while creating commit 33e8e6c6:
make swift-test
# completed rc=0 elapsed=180.0s
make py-test
# 2878 passed, 14 skipped, 2 warnings in 120.12s; completed rc=0
make integration-test
# 114 passed, 1 skipped in 314.44s; completed rc=0
Melix PR Scoped Performance Report
# Status: ok; selected probes: 0; direct/gated probes: 0; regressions: 0; verification failures: 0
```

## Coverage and Metrics
- Initial changed-line coverage: 100.00% (133/133) for the touched Python scope.
- Review-fix changed-line coverage: 100.00% (8/8) for the touched Python/test lines.
- Initial performance report: `Status: ok`, 5 direct/gated probes selected, 0 regressions, 0 verification failures.
- Review-fix performance report: `Status: ok`, 0 probes selected, 0 regressions, 0 verification failures.
- Reward metrics added: `reward_component_final_answer_mean`, `reward_component_tool_efficiency_mean`, `reward_component_format_mean`, `reward_component_fatal_failure_mean`, `reward_component_total_mean`, and `fatal_trace_count`.
- Observability mode: evidence. Probe overhead: N/A for serving path because this only constructs alignment training artifacts and metadata from rows already loaded for training.

## Known Gaps
- This defines deterministic component evidence only. Later OpenSearch-VL alignment issues still own online multi-turn GRPO rollout, one-sided advantage clamping, and fatal token masking.
- No protobuf, generated artifact, dependency, or lockfile changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
