### PR TITLE
Add alignment rollout manifest fields

### DIFF
--- a/docs/agentic-trajectory-dataset-contract.md
+++ b/docs/agentic-trajectory-dataset-contract.md
@@ -215,6 +215,29 @@ Agentic GRPO/RL rollout slices consume a stable component subset:
 Policy-update evidence must persist the component object that produced the
 scalar `total`, not only the total itself.
 
+### Rollout Manifest Fields
+
+Alignment artifacts that perform GRPO or RLHF rollout construction must persist
+a stable rollout manifest projection in the adapter manifest, alignment run
+manifest, and policy-update trace rows. The v1 fields are:
+
+- `rollout_manifest_schema_version`: `melix.alignment_rollout_manifest.v1`
+- `rollout_candidate_count`: configured candidate count for GRPO, or `1` for
+  RLHF response scoring.
+- `rollout_reward_policy_id`: reward policy used for candidate or response
+  scoring. Agentic dataset provenance supplies this when available; otherwise
+  Melix emits a deterministic built-in policy id for GRPO component scoring,
+  reward-model scoring, or dataset-score fallback.
+- `rollout_reference_model_path`: explicit reference model path when supplied,
+  otherwise the resolved source model path used for the alignment run.
+- `rollout_trajectory_digest`: the source trajectory digest from provenance
+  when present, otherwise a deterministic digest of the policy-update rows.
+
+The rollout manifest projection is additive. Existing fields such as
+`grpo_candidate_count`, `reference_model_path`, `reward_model_manifest_path`,
+`candidate_generation_mode`, and `candidate_scoring_mode` remain stable for
+legacy consumers.
+
 `fatal_stage` records the first stage that invalidates later trajectory tokens
 or observations. Supported stage names are:
 

--- a/docs/plans/2026-05-20-agentic-grpo-rollout-manifest-fields.md
+++ b/docs/plans/2026-05-20-agentic-grpo-rollout-manifest-fields.md
@@ -1,0 +1,104 @@
+# Agentic GRPO Rollout Manifest Fields
+
+## Goal
+
+Implement issue #697 by adding a stable rollout manifest projection for
+candidate count, reward policy, reference model, and trajectory digest. This
+continues Milestone 1 for the OpenSearch-VL online GRPO/RL rollout direction
+after the reward-component contract landed in issue #696.
+
+## Scope
+
+- Governed issue: #697.
+- Parent direction: #694, OpenSearch-VL alignment: online GRPO/RL rollout for
+  tool-use LoRA.
+- Runtime boundary: Python worker alignment artifact construction.
+- Artifact boundary: adapter manifest, alignment run manifest, adapter config,
+  and `policy_updates.jsonl`.
+
+## Architecture
+
+Melix already persists scalar alignment settings such as
+`grpo_candidate_count`, `reference_model_path`, `reward_model_manifest_path`,
+`candidate_generation_mode`, and `candidate_scoring_mode`. This slice adds a
+single rollout manifest projection so later online rollout, fatal-aware GRPO,
+benchmark, and evaluation slices can consume the same provenance keys without
+reconstructing them from mode-specific fields.
+
+The v1 projection is:
+
+- `rollout_manifest_schema_version`: names the stable projection schema.
+- `rollout_candidate_count`: configured GRPO candidate count, or `1` for RLHF.
+- `rollout_reward_policy_id`: trajectory provenance policy id when available;
+  otherwise a deterministic built-in policy id based on scoring mode.
+- `rollout_reference_model_path`: explicit reference path when supplied,
+  otherwise the resolved source model path for the run.
+- `rollout_trajectory_digest`: trajectory provenance digest when available,
+  otherwise a deterministic digest of the policy-update rows.
+
+The worker computes this projection once at the alignment runner boundary and
+passes it through `TrainingMetrics` so the pipeline manifest reuses the same
+values. This keeps adapter config, policy updates, adapter manifest, and
+alignment run manifest consistent.
+
+## Performance And Metrics
+
+The only new computation is a SHA-256 digest over policy-update rows when no
+source trajectory digest exists. The rows are already in memory and already
+written to `policy_updates.jsonl`, so this adds no model execution, network
+calls, broad filesystem scans, or extra runtime invocations.
+
+Success metrics:
+
+- Adapter manifest and alignment run manifest include all rollout manifest
+  fields.
+- Adapter config and policy-update trace rows include the same rollout manifest
+  fields.
+- Source trajectory provenance overrides the default reward policy id and
+  digest when present.
+- Reward-model scoring records the reward-model rollout policy id.
+- Changed-line coverage for touched Python files is at least 95 percent.
+
+## Implementation Steps
+
+- [x] Update the trajectory contract with rollout manifest field semantics.
+- [x] Add a Python helper for the shared rollout manifest projection.
+- [x] Attach rollout fields to adapter config and policy-update rows in the
+      alignment runner.
+- [x] Propagate runner-computed rollout fields through training metrics into
+      adapter and alignment manifests.
+- [x] Add focused tests for default GRPO, reward-model GRPO, RLHF, and
+      trajectory-provenance-backed rollout artifacts.
+
+## Verification
+
+Results:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_mlx_lm_runner_scores_generated_grpo_candidates_with_reward_model services/mlx-worker-python/tests/test_trajectory_provenance.py::test_alignment_rl_trace_runner_attaches_trajectory_provenance services/mlx-worker-python/tests/test_trajectory_provenance.py::test_alignment_manifest_payload_records_trajectory_provenance_metrics
+# 9 passed
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_records_runtime_generated_grpo_evidence
+# 3 passed
+
+git diff --check
+# passed
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_rollout_manifest.coverage uv run --frozen --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_rollout_manifest.coverage uv run --frozen --project services/mlx-worker-python coverage run --append -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py -k 'alignment_mode_contracts or runtime_generated_grpo_evidence or reward_model_scored_rlhf'
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_rollout_manifest.coverage uv run --frozen --project services/mlx-worker-python coverage run --append -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'grpo or rlhf or reward_model or rollout'
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_rollout_manifest.coverage uv run --frozen --project services/mlx-worker-python coverage run --append -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py -k 'alignment_rl_trace_runner or alignment_manifest_payload'
+# 6 passed; 4 passed, 67 deselected; 12 passed, 123 deselected; 2 passed, 9 deselected
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_rollout_manifest.coverage uv run --frozen --project services/mlx-worker-python coverage json -o /tmp/agentic_rollout_manifest_coverage.json
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/agentic_rollout_manifest_coverage.json services/mlx-worker-python/worker/model_ops/alignment_rollout_manifest.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_trajectory_provenance.py
+# TOTAL 98.37% (121/123)
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_CHANGED_SCOPE_BASE_ROOT="$PWD" MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON='["services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py"]' uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file
+# 9 passed
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_CHANGED_SCOPE_BASE_ROOT="$PWD" MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON='["services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py"]' uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_extracts_terminal_structured_result_without_splitlines services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_rejects_missing_structured_result services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_accepts_carriage_return_line_end services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_skips_embedded_prefix_and_finds_prior_line services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_lm_runner_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_main_covers_checked_in_file
+# 8 passed
+```
+
+The repository pre-commit gate remains pending for the final commit.

--- a/services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
+++ b/services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
@@ -8,6 +8,9 @@ import pytest
 from packages.protocol.python.worker.v1 import common_pb2
 from worker.model_ops import mlx_lm_runner as mlx_lm_runner_module
 from worker.model_ops import training_config as training_config_module
+from worker.model_ops.alignment_rollout_manifest import (
+    build_alignment_rollout_manifest_fields_from_training_metrics,
+)
 from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.lora_training_pipeline import LoRATrainingPipeline
 from worker.model_ops.training_dataset import load_training_dataset_package
@@ -35,6 +38,19 @@ def _text_model(*, model_path: str = "models/plain-llama") -> common_pb2.ModelSp
     )
     model.ext["text_layer_count"] = "2"
     return model
+
+
+def _minimal_training_metrics(**overrides: object) -> mlx_lm_runner_module.TrainingMetrics:
+    values = {
+        "job_duration_ms": 12.0,
+        "tokens_seen": 8,
+        "examples_seen": 1,
+        "loss_final": 0.2,
+        "loss_best": 0.2,
+        "learning_rate_final": 1e-4,
+    }
+    values.update(overrides)
+    return mlx_lm_runner_module.TrainingMetrics(**values)
 
 
 def test_grpo_policy_updates_persist_reward_components_and_fatal_stage(
@@ -116,6 +132,20 @@ def test_grpo_policy_updates_persist_reward_components_and_fatal_stage(
     assert result.metrics.reward_component_fatal_failure_mean == pytest.approx(-1.0)
     assert result.metrics.reward_component_total_mean == pytest.approx(-1.9)
     assert result.metrics.fatal_trace_count == 1
+    assert result.metrics.rollout_manifest_schema_version == "melix.alignment_rollout_manifest.v1"
+    assert result.metrics.rollout_candidate_count == 2
+    assert result.metrics.rollout_reward_policy_id == "melix.agentic_grpo_reward_components.v1"
+    assert result.metrics.rollout_reference_model_path == str(tmp_path / "base-model")
+    assert len(result.metrics.rollout_trajectory_digest) == 64
+    adapter_config = json.loads(result.adapter_config_path.read_text(encoding="utf-8"))
+    assert adapter_config["rollout_candidate_count"] == 2
+    assert adapter_config["rollout_reward_policy_id"] == result.metrics.rollout_reward_policy_id
+    assert adapter_config["rollout_reference_model_path"] == str(tmp_path / "base-model")
+    assert adapter_config["rollout_trajectory_digest"] == result.metrics.rollout_trajectory_digest
+    assert trace_rows[0]["rollout_candidate_count"] == 2
+    assert trace_rows[0]["rollout_reward_policy_id"] == result.metrics.rollout_reward_policy_id
+    assert trace_rows[0]["rollout_reference_model_path"] == str(tmp_path / "base-model")
+    assert trace_rows[0]["rollout_trajectory_digest"] == result.metrics.rollout_trajectory_digest
 
 
 def test_lora_training_pipeline_records_grpo_reward_component_metrics(
@@ -166,6 +196,16 @@ def test_lora_training_pipeline_records_grpo_reward_component_metrics(
         Path(result.manifest["alignment_run_manifest_path"]).read_text(encoding="utf-8")
     )
     metrics = alignment_manifest["metrics"]
+    assert result.manifest["rollout_manifest_schema_version"] == "melix.alignment_rollout_manifest.v1"
+    assert result.manifest["rollout_candidate_count"] == 2
+    assert result.manifest["rollout_reward_policy_id"] == "melix.agentic_grpo_reward_components.v1"
+    assert result.manifest["rollout_reference_model_path"] == str(tmp_path / "base-model")
+    assert result.manifest["rollout_trajectory_digest"] == alignment_manifest["rollout_trajectory_digest"]
+    assert alignment_manifest["rollout_manifest_schema_version"] == "melix.alignment_rollout_manifest.v1"
+    assert alignment_manifest["rollout_candidate_count"] == 2
+    assert alignment_manifest["rollout_reward_policy_id"] == "melix.agentic_grpo_reward_components.v1"
+    assert alignment_manifest["rollout_reference_model_path"] == str(tmp_path / "base-model")
+    assert len(alignment_manifest["rollout_trajectory_digest"]) == 64
     assert metrics["reward_mean"] == pytest.approx(0.65)
     assert metrics["reward_component_final_answer_mean"] == pytest.approx(0.35)
     assert metrics["reward_component_tool_efficiency_mean"] == pytest.approx(0.2)
@@ -173,6 +213,65 @@ def test_lora_training_pipeline_records_grpo_reward_component_metrics(
     assert metrics["reward_component_fatal_failure_mean"] == pytest.approx(0.0)
     assert metrics["reward_component_total_mean"] == pytest.approx(0.65)
     assert metrics["fatal_trace_count"] == 0
+
+
+def test_alignment_rollout_manifest_fields_cover_rlhf_and_reward_model_defaults(
+    tmp_path: Path,
+) -> None:
+    rlhf_fields = build_alignment_rollout_manifest_fields_from_training_metrics(
+        metrics=_minimal_training_metrics(),
+        alignment_algorithm="rlhf",
+        configured_candidate_count=8,
+        candidate_scoring_mode="dataset",
+        explicit_reference_model_path="",
+        default_reference_model_path=str(tmp_path / "base-model"),
+        trajectory_provenance={},
+        trace_rows=[{"response": "Helpful answer.", "reward_score": 0.9}],
+    )
+    assert rlhf_fields["rollout_manifest_schema_version"] == "melix.alignment_rollout_manifest.v1"
+    assert rlhf_fields["rollout_candidate_count"] == 1
+    assert rlhf_fields["rollout_reward_policy_id"] == "melix.rlhf_dataset_reward.v1"
+    assert rlhf_fields["rollout_reference_model_path"] == str(tmp_path / "base-model")
+    assert len(rlhf_fields["rollout_trajectory_digest"]) == 64
+
+    reward_model_fields = build_alignment_rollout_manifest_fields_from_training_metrics(
+        metrics=_minimal_training_metrics(),
+        alignment_algorithm="grpo",
+        configured_candidate_count=2,
+        candidate_scoring_mode="reward_model",
+        explicit_reference_model_path="",
+        default_reference_model_path=str(tmp_path / "base-model"),
+        trajectory_provenance={},
+        trace_rows=[{"prompt": "Draft two answers."}],
+    )
+    assert reward_model_fields["rollout_candidate_count"] == 2
+    assert reward_model_fields["rollout_reward_policy_id"] == "melix.reward_model_scoring.v1"
+    assert reward_model_fields["rollout_reference_model_path"] == str(tmp_path / "base-model")
+    assert len(reward_model_fields["rollout_trajectory_digest"]) == 64
+
+    metrics_fields = build_alignment_rollout_manifest_fields_from_training_metrics(
+        metrics=_minimal_training_metrics(
+            rollout_manifest_schema_version="melix.alignment_rollout_manifest.v1",
+            rollout_candidate_count=3,
+            rollout_reward_policy_id="reward-policy.from-metrics",
+            rollout_reference_model_path=str(tmp_path / "reference-model"),
+            rollout_trajectory_digest="d" * 64,
+        ),
+        alignment_algorithm="grpo",
+        configured_candidate_count=2,
+        candidate_scoring_mode="dataset",
+        explicit_reference_model_path="",
+        default_reference_model_path=str(tmp_path / "base-model"),
+        trajectory_provenance={},
+        trace_rows=[],
+    )
+    assert metrics_fields == {
+        "rollout_manifest_schema_version": "melix.alignment_rollout_manifest.v1",
+        "rollout_candidate_count": 3,
+        "rollout_reward_policy_id": "reward-policy.from-metrics",
+        "rollout_reference_model_path": str(tmp_path / "reference-model"),
+        "rollout_trajectory_digest": "d" * 64,
+    }
 
 
 def test_grpo_reward_component_helpers_cover_explicit_and_edge_paths() -> None:

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -438,8 +438,13 @@ def test_alignment_rl_trace_runner_attaches_trajectory_provenance(tmp_path: Path
 
     assert adapter_config["trajectory_dataset_id"] == "opensearch-vl.dev"
     assert adapter_config["trajectory_reward_policy_id"] == "reward-policy.v1"
+    assert adapter_config["rollout_candidate_count"] == 2
+    assert adapter_config["rollout_reward_policy_id"] == "reward-policy.v1"
+    assert adapter_config["rollout_reference_model_path"] == str(tmp_path / "base-model")
+    assert adapter_config["rollout_trajectory_digest"] == "abc123"
     assert adapter_config["trajectory_provenance_field_count"] >= 8
     assert trace_rows[0]["trajectory_trace_digest"] == "abc123"
+    assert trace_rows[0]["rollout_trajectory_digest"] == "abc123"
     assert trace_rows[0]["trajectory_snapshot_manifest_path"] == str(
         normalized_dataset_dir / "manifest.json"
     )
@@ -525,6 +530,10 @@ def test_alignment_manifest_payload_records_trajectory_provenance_metrics(
     )
 
     assert payload["trajectory_trace_digest"] == "abc123"
+    assert payload["rollout_candidate_count"] == 2
+    assert payload["rollout_reward_policy_id"] == "reward-policy.v1"
+    assert payload["rollout_reference_model_path"] == str(tmp_path / "base-model")
+    assert payload["rollout_trajectory_digest"] == "abc123"
     assert payload["metrics"]["trajectory_provenance_field_count"] == len(provenance)
     assert payload["metrics"]["trajectory_reward_policy_present"] == 1
     assert payload["metrics"]["trajectory_reward_component_coverage"] == 1

--- a/services/mlx-worker-python/worker/model_ops/alignment_rollout_manifest.py
+++ b/services/mlx-worker-python/worker/model_ops/alignment_rollout_manifest.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+ROLLOUT_MANIFEST_SCHEMA_VERSION = "melix.alignment_rollout_manifest.v1"
+DEFAULT_GRPO_REWARD_POLICY_ID = "melix.agentic_grpo_reward_components.v1"
+DEFAULT_REWARD_MODEL_POLICY_ID = "melix.reward_model_scoring.v1"
+DEFAULT_RLHF_DATASET_REWARD_POLICY_ID = "melix.rlhf_dataset_reward.v1"
+DEFAULT_DATASET_REWARD_POLICY_ID = "melix.dataset_score_reward.v1"
+
+
+def build_alignment_rollout_manifest_fields(
+    *,
+    alignment_algorithm: str,
+    configured_candidate_count: int,
+    candidate_scoring_mode: str,
+    explicit_reference_model_path: str,
+    default_reference_model_path: str,
+    trajectory_provenance: Mapping[str, Any] | None,
+    trace_rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "rollout_manifest_schema_version": ROLLOUT_MANIFEST_SCHEMA_VERSION,
+        "rollout_candidate_count": _rollout_candidate_count(
+            alignment_algorithm=alignment_algorithm,
+            configured_candidate_count=configured_candidate_count,
+        ),
+        "rollout_reward_policy_id": _rollout_reward_policy_id(
+            alignment_algorithm=alignment_algorithm,
+            candidate_scoring_mode=candidate_scoring_mode,
+            trajectory_provenance=trajectory_provenance,
+        ),
+        "rollout_reference_model_path": _rollout_reference_model_path(
+            explicit_reference_model_path=explicit_reference_model_path,
+            default_reference_model_path=default_reference_model_path,
+        ),
+        "rollout_trajectory_digest": _rollout_trajectory_digest(
+            trajectory_provenance=trajectory_provenance,
+            trace_rows=trace_rows,
+        ),
+    }
+
+
+def build_alignment_rollout_manifest_fields_from_training_metrics(
+    *,
+    metrics: Any,
+    alignment_algorithm: str,
+    configured_candidate_count: int,
+    candidate_scoring_mode: str,
+    explicit_reference_model_path: str,
+    default_reference_model_path: str,
+    trajectory_provenance: Mapping[str, Any] | None,
+    trace_rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    schema_version = str(getattr(metrics, "rollout_manifest_schema_version", "") or "")
+    if schema_version:
+        return {
+            "rollout_manifest_schema_version": schema_version,
+            "rollout_candidate_count": int(getattr(metrics, "rollout_candidate_count")),
+            "rollout_reward_policy_id": str(getattr(metrics, "rollout_reward_policy_id")),
+            "rollout_reference_model_path": str(getattr(metrics, "rollout_reference_model_path")),
+            "rollout_trajectory_digest": str(getattr(metrics, "rollout_trajectory_digest")),
+        }
+    return build_alignment_rollout_manifest_fields(
+        alignment_algorithm=alignment_algorithm,
+        configured_candidate_count=configured_candidate_count,
+        candidate_scoring_mode=candidate_scoring_mode,
+        explicit_reference_model_path=explicit_reference_model_path,
+        default_reference_model_path=default_reference_model_path,
+        trajectory_provenance=trajectory_provenance,
+        trace_rows=trace_rows,
+    )
+
+
+def _rollout_candidate_count(
+    *,
+    alignment_algorithm: str,
+    configured_candidate_count: int,
+) -> int:
+    if alignment_algorithm == "grpo":
+        return int(configured_candidate_count)
+    if alignment_algorithm == "rlhf":
+        return 1
+    return max(0, int(configured_candidate_count))
+
+
+def _rollout_reward_policy_id(
+    *,
+    alignment_algorithm: str,
+    candidate_scoring_mode: str,
+    trajectory_provenance: Mapping[str, Any] | None,
+) -> str:
+    if trajectory_provenance:
+        policy_id = str(trajectory_provenance.get("trajectory_reward_policy_id") or "").strip()
+        if policy_id:
+            return policy_id
+    if candidate_scoring_mode == "reward_model":
+        return DEFAULT_REWARD_MODEL_POLICY_ID
+    if alignment_algorithm == "grpo":
+        return DEFAULT_GRPO_REWARD_POLICY_ID
+    if alignment_algorithm == "rlhf":
+        return DEFAULT_RLHF_DATASET_REWARD_POLICY_ID
+    return DEFAULT_DATASET_REWARD_POLICY_ID
+
+
+def _rollout_reference_model_path(
+    *,
+    explicit_reference_model_path: str,
+    default_reference_model_path: str,
+) -> str:
+    explicit = explicit_reference_model_path.strip()
+    if explicit:
+        return explicit
+    return default_reference_model_path.strip()
+
+
+def _rollout_trajectory_digest(
+    *,
+    trajectory_provenance: Mapping[str, Any] | None,
+    trace_rows: Sequence[Mapping[str, Any]],
+) -> str:
+    if trajectory_provenance:
+        trace_digest = str(trajectory_provenance.get("trajectory_trace_digest") or "").strip()
+        if trace_digest:
+            return trace_digest
+    digest = hashlib.sha256()
+    for row in trace_rows:
+        digest.update(
+            json.dumps(
+                row,
+                sort_keys=True,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+        digest.update(b"\n")
+    return digest.hexdigest()

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -11,6 +11,9 @@ from typing import Any, Callable
 
 from packages.protocol.python.worker.v1 import common_pb2
 
+from worker.model_ops.alignment_rollout_manifest import (
+    build_alignment_rollout_manifest_fields_from_training_metrics,
+)
 from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.lora_runtime_metadata import build_quantized_lora_manifest_fields
 from worker.model_ops.multimodal_lora_contracts import (
@@ -39,6 +42,14 @@ from worker.trajectory_provenance import (
 
 
 _NUMERIC_TOKEN_RE = re.compile(r"\d+")
+_ROLLOUT_ALIGNMENT_ALGORITHMS = frozenset({"grpo", "rlhf"})
+_ROLLOUT_MANIFEST_FIELD_KEYS = (
+    "rollout_manifest_schema_version",
+    "rollout_candidate_count",
+    "rollout_reward_policy_id",
+    "rollout_reference_model_path",
+    "rollout_trajectory_digest",
+)
 
 
 @dataclass(frozen=True)
@@ -356,6 +367,13 @@ class LoRATrainingPipeline:
                 trajectory_provenance=trajectory_provenance,
                 created_at_unix_ms=persisted_at_unix_ms,
             )
+            manifest.update(
+                {
+                    key: alignment_manifest[key]
+                    for key in _ROLLOUT_MANIFEST_FIELD_KEYS
+                    if key in alignment_manifest
+                }
+            )
             alignment_manifest_path.write_text(
                 json.dumps(alignment_manifest, indent=2) + "\n",
                 encoding="utf-8",
@@ -528,6 +546,17 @@ def _alignment_manifest_payload(
         metrics.update(reward_summary)
     provenance = normalize_trajectory_provenance(trajectory_provenance)
     metrics.update(alignment_metrics_trajectory_provenance(provenance))
+    rollout_manifest_fields = (
+        _rollout_manifest_fields_from_training_result(
+            source_model=source_model,
+            config=config,
+            training_result=training_result,
+            trajectory_provenance=provenance,
+            fallback_trace_rows=dataset.package.normalized_samples,
+        )
+        if alignment.alignment_algorithm in _ROLLOUT_ALIGNMENT_ALGORITHMS
+        else {}
+    )
     if alignment.dataset_contract in {"prompt_candidate", "reward_scored"}:
         metrics.update(
             {
@@ -606,8 +635,32 @@ def _alignment_manifest_payload(
         "created_at_unix_ms": created_at_unix_ms,
         "updated_at_unix_ms": created_at_unix_ms,
     }
+    if rollout_manifest_fields:
+        payload.update(rollout_manifest_fields)
     append_trajectory_provenance(payload, provenance)
     return payload
+
+
+def _rollout_manifest_fields_from_training_result(
+    *,
+    source_model: common_pb2.ModelSpec,
+    config: LoRATrainingConfig,
+    training_result: TrainingResult,
+    trajectory_provenance: dict[str, Any],
+    fallback_trace_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    alignment = config.alignment
+    assert alignment is not None
+    return build_alignment_rollout_manifest_fields_from_training_metrics(
+        metrics=training_result.metrics,
+        alignment_algorithm=alignment.alignment_algorithm,
+        configured_candidate_count=alignment.grpo_candidate_count,
+        candidate_scoring_mode=alignment.candidate_scoring_mode,
+        explicit_reference_model_path=alignment.reference_model_path,
+        default_reference_model_path=source_model.model_path,
+        trajectory_provenance=trajectory_provenance,
+        trace_rows=fallback_trace_rows,
+    )
 
 
 def _reward_summary(samples: list[dict[str, Any]]) -> dict[str, float | int]:

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -102,6 +102,11 @@ class TrainingMetrics:
     candidate_scoring_mode: str = ""
     reward_scoring_backend: str = ""
     generated_candidate_count: int = 0
+    rollout_manifest_schema_version: str = ""
+    rollout_candidate_count: int = 0
+    rollout_reward_policy_id: str = ""
+    rollout_reference_model_path: str = ""
+    rollout_trajectory_digest: str = ""
     multimodal_lora_nan_guard_triggered: bool = False
     unexpected_frozen_param_count: int = 0
     adapter_checkpoint_bytes: int = 0

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from packages.protocol.python.worker.v1 import common_pb2
 
+from worker.model_ops.alignment_rollout_manifest import build_alignment_rollout_manifest_fields
 from worker.model_ops.errors import ModelOperationError
 from worker.runtime.agentic_tools import execute_agentic_tool_calls
 from worker.trajectory_provenance import (
@@ -155,6 +156,17 @@ def train_alignment_rl_trace(
     if trajectory_provenance:
         for row in policy_updates.trace_rows:
             row.update(trajectory_provenance)
+    rollout_manifest_fields = build_alignment_rollout_manifest_fields(
+        alignment_algorithm=alignment.alignment_algorithm,
+        configured_candidate_count=alignment.grpo_candidate_count,
+        candidate_scoring_mode=policy_updates.candidate_scoring_mode,
+        explicit_reference_model_path=alignment.reference_model_path,
+        default_reference_model_path=str(request.model_path),
+        trajectory_provenance=trajectory_provenance,
+        trace_rows=policy_updates.trace_rows,
+    )
+    for row in policy_updates.trace_rows:
+        row.update(rollout_manifest_fields)
     _write_jsonl(policy_update_trace_path, policy_updates.trace_rows)
     adapter_config = _load_resume_adapter_config(request.resume_source_path) or {
         "fine_tune_type": "lora",
@@ -185,6 +197,7 @@ def train_alignment_rl_trace(
             ),
         }
     )
+    adapter_config.update(rollout_manifest_fields)
     if trajectory_provenance:
         append_trajectory_provenance(adapter_config, trajectory_provenance)
         adapter_config["trajectory_provenance_field_count"] = len(trajectory_provenance)
@@ -244,6 +257,15 @@ def train_alignment_rl_trace(
             candidate_scoring_mode=policy_updates.candidate_scoring_mode,
             reward_scoring_backend=policy_updates.reward_scoring_backend,
             generated_candidate_count=policy_updates.generated_candidate_count,
+            rollout_manifest_schema_version=str(
+                rollout_manifest_fields["rollout_manifest_schema_version"]
+            ),
+            rollout_candidate_count=int(rollout_manifest_fields["rollout_candidate_count"]),
+            rollout_reward_policy_id=str(rollout_manifest_fields["rollout_reward_policy_id"]),
+            rollout_reference_model_path=str(
+                rollout_manifest_fields["rollout_reference_model_path"]
+            ),
+            rollout_trajectory_digest=str(rollout_manifest_fields["rollout_trajectory_digest"]),
         ),
         execution_backend=policy_updates.execution_backend,
     )


### PR DESCRIPTION
## Summary
- Add a shared alignment rollout manifest projection for candidate count, reward policy id, reference model path, and trajectory digest.
- Persist the rollout fields consistently across adapter manifests, alignment manifests, adapter config, and policy update traces.
- Document the rollout field contract for OpenSearch-VL alignment artifacts.

## Plan or Spec
- `docs/plans/2026-05-20-agentic-grpo-rollout-manifest-fields.md`
- `docs/agentic-trajectory-dataset-contract.md`
- Closes #697

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_mlx_lm_runner_scores_generated_grpo_candidates_with_reward_model services/mlx-worker-python/tests/test_trajectory_provenance.py::test_alignment_rl_trace_runner_attaches_trajectory_provenance services/mlx-worker-python/tests/test_trajectory_provenance.py::test_alignment_manifest_payload_records_trajectory_provenance_metrics
# 9 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_records_runtime_generated_grpo_evidence
# 3 passed

git diff --cached --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_rollout_manifest.coverage uv run --frozen --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_rollout_manifest.coverage uv run --frozen --project services/mlx-worker-python coverage run --append -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py -k 'alignment_mode_contracts or runtime_generated_grpo_evidence or reward_model_scored_rlhf'
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_rollout_manifest.coverage uv run --frozen --project services/mlx-worker-python coverage run --append -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'grpo or rlhf or reward_model or rollout'
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_rollout_manifest.coverage uv run --frozen --project services/mlx-worker-python coverage run --append -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py -k 'alignment_rl_trace_runner or alignment_manifest_payload'
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_rollout_manifest.coverage uv run --frozen --project services/mlx-worker-python coverage json -o /tmp/agentic_rollout_manifest_coverage.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/agentic_rollout_manifest_coverage.json services/mlx-worker-python/worker/model_ops/alignment_rollout_manifest.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_trajectory_provenance.py
# TOTAL 98.37% (121/123)

git commit -m "Add alignment rollout manifest fields"
# pre-commit passed: make swift-test, make py-test, make integration-test, PR-scoped performance report

git merge --no-edit origin/main
# merged cca695cb / #1309 cleanly; no conflicts

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_mlx_lm_runner_scores_generated_grpo_candidates_with_reward_model services/mlx-worker-python/tests/test_trajectory_provenance.py::test_alignment_rl_trace_runner_attaches_trajectory_provenance services/mlx-worker-python/tests/test_trajectory_provenance.py::test_alignment_manifest_payload_records_trajectory_provenance_metrics
# 9 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_records_runtime_generated_grpo_evidence
# 3 passed

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/agentic_rollout_manifest_after_main_merge_coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/alignment_rollout_manifest.py services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_trajectory_provenance.py
# TOTAL 98.37% (121/123)
```

## Coverage and Metrics
- Changed-line coverage: 98.37% (121/123), confirmed again after merging latest `origin/main`.
- Full pre-commit gate:
  - `make swift-test`: passed.
  - `make py-test`: 2879 passed, 14 skipped, 2 warnings.
  - `make integration-test`: 114 passed, 1 skipped.
- PR-scoped performance report: `Status: ok`, 2 direct/gated probes, 0 regressions, 0 verification failures.
  - MLX-LM structured result tail parse: coverage 100%, elapsed delta +0.02%, peak bytes +0.81%, neutral.
  - LoRA reward summary candidate min/max reuse: coverage 100%, elapsed delta +1.54%, sorted calls unchanged, neutral.
- Observability mode: minimal artifact provenance only. The new digest computation reuses in-memory policy update rows and adds no serving-path model calls, network calls, broad filesystem scans, or debug artifact capture.

## Known Gaps
- This slice only adds deterministic rollout provenance fields. Later OpenSearch-VL alignment issues own online multi-turn tool trajectories, candidate reward traces, fatal masks/clamping, and rollout-specific evaluation surfaces.
- No protobuf, dependency, generated artifact, or lockfile changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
