### PR TITLE
Add runtime GRPO tool trajectories

### DIFF
--- a/docs/agentic-trajectory-dataset-contract.md
+++ b/docs/agentic-trajectory-dataset-contract.md
@@ -238,6 +238,15 @@ The rollout manifest projection is additive. Existing fields such as
 `candidate_generation_mode`, and `candidate_scoring_mode` remain stable for
 legacy consumers.
 
+For `candidate_generation_mode: runtime_generate`, GRPO candidates may include
+runtime-emitted tool calls. Melix must execute those calls through the unified
+agentic tool runtime and use the resulting candidate-local tool metrics when
+building reward components. The selected policy-update row must project the
+selected candidate's registry receipt, tool calls, observations, metrics, and
+turns. Candidate-group-wide reward trace persistence is owned by the
+candidate-level reward trace milestone, but the runtime generation slice must
+not copy one sample-level tool replay across all generated candidates.
+
 `fatal_stage` records the first stage that invalidates later trajectory tokens
 or observations. Supported stage names are:
 

--- a/docs/plans/2026-05-20-agentic-grpo-runtime-tool-trajectories.md
+++ b/docs/plans/2026-05-20-agentic-grpo-runtime-tool-trajectories.md
@@ -1,0 +1,110 @@
+# Agentic GRPO Runtime Tool Trajectories
+
+## Goal
+
+Implement issue #699 by extending GRPO `runtime_generate` from text-only
+candidates to per-candidate multi-turn tool trajectories. This begins
+Milestone 2 for the OpenSearch-VL online GRPO/RL rollout direction after the
+Milestone 1 reward and rollout manifest contracts landed.
+
+## Scope
+
+- Governed issue: #699.
+- Parent direction: #694, OpenSearch-VL alignment: online GRPO/RL rollout for
+  tool-use LoRA.
+- Milestone issue: #698, online candidate generation and scoring.
+- Runtime boundary: Python worker alignment runner.
+- Tool boundary: existing deterministic agentic tool runtime and observation
+  contract.
+
+## Architecture
+
+The existing `runtime_generate` path loads the policy runtime once and asks it
+for multiple candidate responses. Before this slice, the path treated every
+candidate as plain text and attached only sample-level tool replay evidence to
+the selected policy-update row.
+
+This slice keeps the policy runtime and reward paths unchanged, but changes the
+candidate object produced by the runner:
+
+- collect assistant text from `RuntimeTokenEvent` values;
+- collect tool calls from `RuntimeToolCallEvent` values;
+- parse each tool-call argument fragment as a JSON object;
+- execute the generated tool calls through
+  `worker.runtime.agentic_tools.execute_agentic_tool_calls`;
+- score each candidate with its own executed tool run so tool-efficiency
+  components reflect the candidate trajectory;
+- project the selected candidate's registry, calls, observations, metrics, and
+  turns onto the policy-update row.
+
+Candidate-level reward trace persistence remains the next unit (#700). This
+unit records enough candidate-local fields to prove that online generation can
+produce and execute multi-turn tool trajectories, while the full candidate
+evidence surface remains intentionally narrow.
+
+## Performance And Metrics
+
+The new work only runs the deterministic local tool adapter layer for generated
+tool calls. It does not add model loads, network calls, broad filesystem scans,
+or additional reward-runtime calls. Tool execution cost is proportional to the
+number of generated tool calls and is measured through existing tool metrics:
+
+- `agentic_tool.call_count`
+- `agentic_tool.completed_count`
+- `agentic_tool.timeout_count`
+- `agentic_tool.failed_count`
+- `agentic_tool.observation_emitted_bytes`
+
+Success metrics:
+
+- Runtime-generated candidates may include tool calls and per-candidate
+  observations.
+- The selected policy-update row uses the selected candidate's tool trajectory,
+  not sample-level replay copied across the group.
+- Tool-efficiency reward components use the candidate-local call count.
+- Existing text-only `runtime_generate` behavior remains compatible.
+- Changed-line coverage for touched Python files is at least 95 percent.
+
+## Implementation Steps
+
+- [x] Create the issue-specific plan before broad code changes.
+- [x] Add a runtime candidate structure that collects text and tool-call
+      events from the policy runtime stream.
+- [x] Execute generated tool calls through the shared agentic tool runtime.
+- [x] Attach the selected candidate trajectory to the policy-update row.
+- [x] Add focused tests for runtime-generated tool trajectories.
+
+## Verification
+
+Results:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_mlx_lm_runner_generates_grpo_candidates_with_policy_runtime services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_mlx_lm_runner_scores_generated_grpo_candidates_with_reward_model
+# 4 passed
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'alignment_rl or grpo or rlhf or reward_model or rollout'
+# 25 passed, 110 deselected
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
+# 2 passed
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_records_runtime_generated_grpo_evidence services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts
+# 3 passed
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_trajectory_provenance.py::test_alignment_rl_trace_runner_attaches_trajectory_provenance services/mlx-worker-python/tests/test_trajectory_provenance.py::test_alignment_manifest_payload_records_trajectory_provenance_metrics
+# 8 passed
+
+git diff --check
+# passed
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_runtime_tool_trajectories.coverage uv run --frozen --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'alignment_rl or grpo or rlhf or reward_model or rollout'
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_runtime_tool_trajectories.coverage uv run --frozen --project services/mlx-worker-python coverage run --append -m pytest -q services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_runtime_tool_trajectories.coverage uv run --frozen --project services/mlx-worker-python coverage run --append -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py -k 'alignment_mode_contracts or runtime_generated_grpo_evidence'
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_runtime_tool_trajectories.coverage uv run --frozen --project services/mlx-worker-python coverage run --append -m pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_runtime_tool_trajectories.coverage uv run --frozen --project services/mlx-worker-python coverage run --append -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py -k 'alignment_rl_trace_runner or alignment_manifest_payload'
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" COVERAGE_FILE=/tmp/agentic_runtime_tool_trajectories.coverage uv run --frozen --project services/mlx-worker-python coverage json -o /tmp/agentic_runtime_tool_trajectories_coverage.json
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json /tmp/agentic_runtime_tool_trajectories_coverage.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
+# TOTAL 100.00% (121/121)
+```
+
+The final pre-commit gate remains pending for the commit.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -203,6 +203,13 @@ trajectory must record:
 - reward components
 - replay fingerprint for deterministic reruns
 
+For online GRPO `runtime_generate`, tool-call events emitted by the policy
+runtime are candidate-local. The rollout runner must execute each candidate's
+tool calls through the shared adapter layer before scoring that candidate, and
+the selected policy-update row must reflect the selected candidate's tool
+trajectory. Sample-level replay evidence may seed fixture context, but it must
+not be reused as the trajectory for every generated candidate.
+
 Fatal-aware behavior must distinguish:
 
 - valid pre-failure reasoning

--- a/services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
+++ b/services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from packages.protocol.python.worker.v1 import common_pb2
+
+from worker.model_ops.errors import ModelOperationError
+from worker.model_ops import mlx_lm_runner as mlx_lm_runner_module
+from worker.model_ops import training_config as training_config_module
+from worker.runtime.mlx_text_runtime import MLXTextRuntime, RuntimeTokenEvent, RuntimeToolCallEvent
+
+
+def _text_model(*, model_path: str = "models/plain-llama") -> common_pb2.ModelSpec:
+    model = common_pb2.ModelSpec(
+        model_id="melix-test-text",
+        model_path=model_path,
+        model_kind="text",
+        revision="main",
+        max_context=4096,
+    )
+    model.ext["text_layer_count"] = "2"
+    return model
+
+
+def test_mlx_lm_runner_runtime_grpo_executes_candidate_tool_trajectories(
+    tmp_path: Path,
+) -> None:
+    class ToolCallingPolicyBackend:
+        runtime_name = "tool-calling-policy-runtime"
+
+        def load_model(self, model_spec):
+            return {"model_id": model_spec.model_id, "model_path": model_spec.model_path}
+
+        def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event, execution_ext=None):
+            del loaded_model, sampling, cancel_event
+            assert execution_ext["melix.tool_parser.mode"] == "qwen"
+            assert "visit" in execution_ext["melix.tool_parser.namespaces"]
+            if "candidate 1" in prompt:
+                yield RuntimeToolCallEvent(
+                    call_id="visit-selected",
+                    tool_name="visit",
+                    arguments_json_fragment=json.dumps({"url": "fixture://selected"}),
+                )
+                yield RuntimeTokenEvent(text="selected tool-backed answer")
+            else:
+                yield RuntimeToolCallEvent(
+                    call_id="visit-extra",
+                    tool_name="visit",
+                    arguments_json_fragment=json.dumps({"url": "fixture://extra"}),
+                )
+                yield RuntimeToolCallEvent(
+                    call_id="compute-extra",
+                    tool_name="local_compute",
+                    arguments_json_fragment=json.dumps({"code": "1 + 1"}),
+                )
+                yield RuntimeTokenEvent(text="extra tool answer")
+
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={
+            "training_mode": "grpo",
+            "grpo_candidate_count": "2",
+            "candidate_generation_mode": "runtime_generate",
+            "candidate_generation_max_tokens": "16",
+        },
+        dataset_format="prompt_candidate",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    normalized_dataset_dir = tmp_path / "normalized"
+    normalized_dataset_dir.mkdir()
+    (normalized_dataset_dir / "train.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Use tools and answer.",
+                "tool_budget": 1,
+                "tool_fixture_context": {
+                    "pages": {
+                        "fixture://selected": {
+                            "title": "Selected",
+                            "text": "Selected source.",
+                        },
+                        "fixture://extra": {
+                            "title": "Extra",
+                            "text": "Extra source.",
+                        },
+                    }
+                },
+                "candidates": [
+                    {"text": "selected tool-backed answer", "score": 1.0},
+                    {"text": "extra tool answer", "score": 0.9},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-grpo-runtime-tools",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dataset_dir,
+        config=config,
+        dataset_format="prompt_candidate",
+    )
+
+    result = mlx_lm_runner_module.MLXLMRunner(
+        policy_runtime=MLXTextRuntime(backend=ToolCallingPolicyBackend())
+    ).train(request)
+
+    trace_rows = [
+        json.loads(line)
+        for line in Path(result.metrics.policy_update_trace_path).read_text(encoding="utf-8").splitlines()
+    ]
+    row = trace_rows[0]
+
+    assert row["selected_candidate_index"] == 0
+    assert row["selected_candidate_text"] == "selected tool-backed answer"
+    assert row["selected_candidate_tool_call_count"] == 1
+    assert row["agentic_tool_calls"][0]["id"] == "visit-selected"
+    assert row["agentic_tool_observations"][0]["payload"]["text"] == "Selected source."
+    assert row["agentic_tool_metrics"]["agentic_tool.call_count"] == 1.0
+    assert row["reward_components"]["tool_efficiency"] == 0.0
+    assert row["generated_candidates"][0]["tool_calls"][0]["name"] == "visit"
+    assert row["generated_candidates"][0]["agentic_tool_observation_count"] == 1
+    assert row["generated_candidates"][1]["tool_calls"][1]["name"] == "local_compute"
+    assert row["generated_candidates"][1]["agentic_tool_metrics"]["agentic_tool.call_count"] == 2.0
+    assert row["generated_candidates"][1]["reward_components"]["tool_efficiency"] == -1.0
+
+
+def test_alignment_runtime_tool_helpers_cover_namespaces_and_invalid_events() -> None:
+    from worker.model_ops.rl_alignment_training import (
+        _agentic_tool_run_for_generated_candidate,
+        _attach_runtime_candidate_tool_evidence,
+        _runtime_tool_namespaces,
+        _tool_call_from_runtime_event,
+    )
+
+    assert _runtime_tool_namespaces({"tools": [{"name": "visit"}, {"name": "visit"}]}) == "visit"
+    assert "local_compute" in _runtime_tool_namespaces({})
+    assert _agentic_tool_run_for_generated_candidate({}, []) is None
+
+    candidate: dict[str, object] = {}
+    _attach_runtime_candidate_tool_evidence(candidate, [], None)
+    assert candidate == {}
+    _attach_runtime_candidate_tool_evidence(
+        candidate,
+        [{"id": "call-1", "name": "visit", "arguments": {}}],
+        None,
+    )
+    assert candidate == {"tool_calls": [{"id": "call-1", "name": "visit", "arguments": {}}]}
+
+    with pytest.raises(ModelOperationError) as invalid_json_exc:
+        _tool_call_from_runtime_event(
+            RuntimeToolCallEvent(
+                call_id="bad-json",
+                tool_name="visit",
+                arguments_json_fragment="{",
+            )
+        )
+    assert invalid_json_exc.value.code == "alignment_generation_failed"
+
+    with pytest.raises(ModelOperationError) as non_object_exc:
+        _tool_call_from_runtime_event(
+            RuntimeToolCallEvent(
+                call_id="bad-args",
+                tool_name="visit",
+                arguments_json_fragment="[]",
+            )
+        )
+    assert non_object_exc.value.details["tool_name"] == "visit"

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -14,6 +14,7 @@ from packages.protocol.python.worker.v1 import common_pb2
 from worker.model_ops.alignment_rollout_manifest import build_alignment_rollout_manifest_fields
 from worker.model_ops.errors import ModelOperationError
 from worker.runtime.agentic_tools import execute_agentic_tool_calls
+from worker.runtime.tool_registry import BUILTIN_AGENTIC_TOOL_NAMES
 from worker.trajectory_provenance import (
     append_trajectory_provenance,
     load_trajectory_provenance_from_snapshot_dir,
@@ -34,6 +35,13 @@ class PolicyUpdateResult:
     candidate_generation_backend: str = ""
     reward_scoring_backend: str = ""
     generated_candidate_count: int = 0
+
+
+@dataclass(frozen=True)
+class RuntimeGeneratedCandidate:
+    text: str
+    tool_calls: list[dict[str, Any]]
+    tool_run: Any | None
 
 
 @dataclass(frozen=True)
@@ -515,49 +523,56 @@ def _grpo_runtime_policy_updates(
             else _scored_seed_candidates(sample, sample_index=sample_index)
         )
         generated_candidates: list[dict[str, Any]] = []
-        tool_run = _agentic_tool_run_for_sample(sample)
+        generated_tool_runs: dict[int, Any] = {}
         for candidate_index in range(candidate_count):
             generation_prompt = _runtime_generation_prompt(
                 prompt,
                 candidate_index=candidate_index,
                 candidate_count=candidate_count,
             )
-            generated_text = _generate_candidate_text(
+            generated = _generate_runtime_candidate(
                 policy_runtime,
                 loaded_model,
                 generation_prompt,
                 sampling,
                 cancel_event,
+                sample=sample,
             )
             if request.config.alignment.candidate_scoring_mode == "reward_model":
                 if reward_scorer is None:
                     raise _missing_reward_scorer_error()
                 score = reward_scorer.score_response(
                     prompt=prompt,
-                    response=generated_text,
+                    response=generated.text,
                     alignment_algorithm="grpo",
                     sample_index=sample_index,
                     candidate_index=candidate_index,
                 )
             else:
-                score = _seed_overlap_proxy_score(generated_text, seed_candidates)
+                score = _seed_overlap_proxy_score(generated.text, seed_candidates)
             reward_components = _reward_components_for_candidate(
                 sample=sample,
-                candidate={"text": generated_text},
+                candidate={"text": generated.text},
                 score=score,
-                tool_run=tool_run,
+                tool_run=generated.tool_run,
                 include_sample_fatal=True,
             )
-            generated_candidates.append(
-                {
-                    "index": candidate_index,
-                    "text": generated_text,
-                    "score": score,
-                    "reward_components": reward_components,
-                    "generation_prompt": generation_prompt,
-                    "source": "policy_runtime",
-                }
+            generated_candidate = {
+                "index": candidate_index,
+                "text": generated.text,
+                "score": score,
+                "reward_components": reward_components,
+                "generation_prompt": generation_prompt,
+                "source": "policy_runtime",
+            }
+            _attach_runtime_candidate_tool_evidence(
+                generated_candidate,
+                generated.tool_calls,
+                generated.tool_run,
             )
+            if generated.tool_run is not None:
+                generated_tool_runs[candidate_index] = generated.tool_run
+            generated_candidates.append(generated_candidate)
         scores = [candidate["reward_components"]["total"] for candidate in generated_candidates]
         reward_values.extend(scores)
         selected = max(generated_candidates, key=lambda candidate: candidate["reward_components"]["total"])
@@ -583,7 +598,7 @@ def _grpo_runtime_policy_updates(
                 "selected_reward": selected_components["total"],
                 "reward_components": selected_components,
                 "reward_total": selected_components["total"],
-                "fatal_stage": _fatal_stage_for_candidate(sample, {"text": selected["text"]}),
+                "fatal_stage": _fatal_stage_for_candidate(sample, selected),
                 "fatal_penalty_applied": selected_components["fatal_failure"] < 0.0,
                 "group_reward_mean": group_mean,
                 "group_reward_margin": group_margins[-1],
@@ -591,7 +606,10 @@ def _grpo_runtime_policy_updates(
                 "generated_candidates": generated_candidates,
             }
         )
-        _attach_agentic_tool_run(trace_rows[-1], tool_run)
+        selected_tool_run = generated_tool_runs.get(selected["index"])
+        _attach_agentic_tool_run(trace_rows[-1], selected_tool_run)
+        if selected.get("tool_calls"):
+            trace_rows[-1]["selected_candidate_tool_call_count"] = len(selected["tool_calls"])
         if reward_scorer is not None:
             trace_rows[-1]["reward_scoring_backend"] = reward_scorer.runtime_name
             trace_rows[-1]["reward_model_id"] = reward_scorer.reward_model_id
@@ -719,6 +737,20 @@ def _attach_agentic_tool_run(row: dict[str, Any], tool_run: Any | None) -> None:
     ]
     row["agentic_tool_metrics"] = dict(tool_run.metrics)
     row["turns"] = [dict(turn) for turn in tool_run.trace_turns]
+
+
+def _attach_runtime_candidate_tool_evidence(
+    candidate: dict[str, Any],
+    tool_calls: list[dict[str, Any]],
+    tool_run: Any | None,
+) -> None:
+    if not tool_calls:
+        return
+    candidate["tool_calls"] = [dict(call) for call in tool_calls]
+    if tool_run is None:
+        return
+    candidate["agentic_tool_metrics"] = dict(tool_run.metrics)
+    candidate["agentic_tool_observation_count"] = len(tool_run.observations)
 
 
 _REWARD_COMPONENT_KEYS = (
@@ -1001,21 +1033,31 @@ def _runtime_generation_prompt(prompt: str, *, candidate_index: int, candidate_c
     )
 
 
-def _generate_candidate_text(
+def _generate_runtime_candidate(
     policy_runtime: Any,
     loaded_model: Any,
     generation_prompt: str,
     sampling: SimpleNamespace,
     cancel_event: threading.Event,
-) -> str:
+    *,
+    sample: dict[str, Any],
+) -> RuntimeGeneratedCandidate:
     chunks: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
     for event in policy_runtime.generate_tokens(
         loaded_model,
         generation_prompt,
         sampling,
         cancel_event,
-        execution_ext={"melix.alignment.candidate_generation": "grpo"},
+        execution_ext={
+            "melix.alignment.candidate_generation": "grpo",
+            "melix.tool_parser.mode": "qwen",
+            "melix.tool_parser.namespaces": _runtime_tool_namespaces(sample),
+        },
     ):
+        if _is_runtime_tool_call_event(event):
+            tool_calls.append(_tool_call_from_runtime_event(event))
+            continue
         text = str(getattr(event, "text", event) or "")
         if text:
             chunks.append(text)
@@ -1026,7 +1068,91 @@ def _generate_candidate_text(
             message="GRPO runtime candidate generation returned an empty candidate.",
             details={"candidate_generation_mode": "runtime_generate"},
         )
-    return generated_text
+    return RuntimeGeneratedCandidate(
+        text=generated_text,
+        tool_calls=tool_calls,
+        tool_run=_agentic_tool_run_for_generated_candidate(sample, tool_calls),
+    )
+
+
+def _generate_candidate_text(
+    policy_runtime: Any,
+    loaded_model: Any,
+    generation_prompt: str,
+    sampling: SimpleNamespace,
+    cancel_event: threading.Event,
+) -> str:
+    return _generate_runtime_candidate(
+        policy_runtime,
+        loaded_model,
+        generation_prompt,
+        sampling,
+        cancel_event,
+        sample={},
+    ).text
+
+
+def _is_runtime_tool_call_event(event: Any) -> bool:
+    return (
+        hasattr(event, "tool_name")
+        and hasattr(event, "arguments_json_fragment")
+        and hasattr(event, "call_id")
+    )
+
+
+def _tool_call_from_runtime_event(event: Any) -> dict[str, Any]:
+    raw_arguments = str(getattr(event, "arguments_json_fragment", "") or "{}").strip() or "{}"
+    try:
+        arguments = json.loads(raw_arguments)
+    except json.JSONDecodeError as exc:
+        raise ModelOperationError(
+            code="alignment_generation_failed",
+            message="GRPO runtime candidate generation emitted invalid tool-call JSON.",
+            details={
+                "candidate_generation_mode": "runtime_generate",
+                "tool_name": str(getattr(event, "tool_name", "")),
+            },
+        ) from exc
+    if not isinstance(arguments, dict):
+        raise ModelOperationError(
+            code="alignment_generation_failed",
+            message="GRPO runtime candidate generation emitted non-object tool-call arguments.",
+            details={
+                "candidate_generation_mode": "runtime_generate",
+                "tool_name": str(getattr(event, "tool_name", "")),
+            },
+        )
+    return {
+        "id": str(getattr(event, "call_id", "") or ""),
+        "name": str(getattr(event, "tool_name", "") or ""),
+        "arguments": arguments,
+    }
+
+
+def _agentic_tool_run_for_generated_candidate(
+    sample: dict[str, Any],
+    tool_calls: list[dict[str, Any]],
+) -> Any | None:
+    if not tool_calls:
+        return None
+    fixture_context = sample.get("tool_fixture_context") or sample.get("tool_context")
+    return execute_agentic_tool_calls(
+        tool_calls,
+        fixture_context=fixture_context if isinstance(fixture_context, dict) else {},
+    )
+
+
+def _runtime_tool_namespaces(sample: dict[str, Any]) -> str:
+    tools = sample.get("tools")
+    if isinstance(tools, list):
+        names = [
+            str(tool.get("name", "")).strip()
+            for tool in tools
+            if isinstance(tool, dict) and str(tool.get("name", "")).strip()
+        ]
+        if names:
+            return ",".join(dict.fromkeys(names))
+    return ",".join(BUILTIN_AGENTIC_TOOL_NAMES)
 
 
 def _scored_seed_candidates(sample: dict[str, Any], *, sample_index: int) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Add candidate-local runtime GRPO tool trajectories from `RuntimeToolCallEvent` output.
- Execute generated candidate tool calls through the shared agentic tool runtime and score candidates with candidate-local tool metrics.
- Document the #699 behavior contract across the GRPO runtime plan and the existing agentic trajectory/runtime contracts.

Closes #699.

## Plan or Spec
- `docs/plans/2026-05-20-agentic-grpo-runtime-tool-trajectories.md`
- `docs/agentic-trajectory-dataset-contract.md`
- `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_mlx_lm_runner_generates_grpo_candidates_with_policy_runtime services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_mlx_lm_runner_scores_generated_grpo_candidates_with_reward_model
# 4 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'alignment_rl or grpo or rlhf or reward_model or rollout'
# 25 passed, 110 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
# 2 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_records_runtime_generated_grpo_evidence services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts
# 3 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_trajectory_provenance.py::test_alignment_rl_trace_runner_attaches_trajectory_provenance services/mlx-worker-python/tests/test_trajectory_provenance.py::test_alignment_manifest_payload_records_trajectory_provenance_metrics
# 8 passed

git diff --check
# passed

COVERAGE_FILE=/tmp/agentic_runtime_tool_trajectories.coverage coverage run/json + scripts/python_changed_line_coverage.py --diff-from origin/main services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
# TOTAL 100.00% (121/121)

git commit -m "Add runtime GRPO tool trajectories"
# first attempt: make swift-test passed; make py-test passed (2881 passed, 14 skipped, 2 warnings); make integration-test passed (114 passed, 1 skipped); performance verification selected an unrelated probe after test placement and failed its coverage check. Tests were split into a dedicated file so the unrelated probe was no longer selected.
# second attempt: make swift-test passed; make py-test passed (2881 passed, 14 skipped, 2 warnings); make integration-test passed (114 passed, 1 skipped); PR scoped performance status ok, selected probes 0, direct/gated probes 0, regressions 0, verification failures 0.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_mlx_lm_runner_generates_grpo_candidates_with_policy_runtime services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_mlx_lm_runner_scores_generated_grpo_candidates_with_reward_model && git diff --check
# review follow-up: 4 passed; git diff --check passed

git commit --amend --no-edit
# review follow-up: make swift-test passed; make py-test passed (2881 passed, 14 skipped, 2 warnings); make integration-test passed (114 passed, 1 skipped); PR scoped performance status ok, selected probes 0, direct/gated probes 0, regressions 0, verification failures 0.
```

## Coverage and Metrics
- Changed-line coverage: `100.00% (121/121)` for `rl_alignment_training.py` and `test_rl_alignment_runtime_tool_trajectories.py` changed lines.
- Local PR-scoped performance report: `Status: ok`; changed files `5`; selected probes `0`; direct/gated probes `0`; regressions `0`; verification failures `0`. Report: `.runtime/pre-commit-performance/20260520-084015-d8b1d8fb/report/report.md`.
- Review follow-up local performance report: `Status: ok`; changed files `1`; selected probes `0`; direct/gated probes `0`; regressions `0`; verification failures `0`. Report: `.runtime/pre-commit-performance/20260520-085717-c6805698/report/report.md`.
- Observability mode: `minimal`. This reuses existing `agentic_tool.*` metrics and selected-candidate trajectory rows; no new broad scans, model loads, network calls, or reward-runtime calls were added. Runtime cost is proportional to generated tool-call count and the existing tool budget.
- `make bootstrap` was not rerun in this worktree; repository hooks were already installed and enforced during commit. `make proto` was not run because this change does not touch protobuf schemas or generated protocol artifacts.

## Known Gaps
- #700 owns full candidate-level reward trace persistence beyond the selected candidate row and candidate-local scoring metadata added here.
- #702/#703 own fatal trajectory masks and reward clamping.
- No dependency, lockfile, protobuf schema, or generated protocol changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
