### PR TITLE
Persist GRPO candidate reward traces

### DIFF
--- a/docs/agentic-trajectory-dataset-contract.md
+++ b/docs/agentic-trajectory-dataset-contract.md
@@ -247,6 +247,18 @@ turns. Candidate-group-wide reward trace persistence is owned by the
 candidate-level reward trace milestone, but the runtime generation slice must
 not copy one sample-level tool replay across all generated candidates.
 
+The candidate-level reward trace milestone persists one
+`melix.alignment_candidate_reward_trace.v1` JSONL row per generated GRPO
+candidate. The alignment run manifest and adapter config must expose the trace
+path, row count, and schema version. Each candidate trace row records the
+sample index, candidate index, generation and scoring modes, score, ordered
+reward components, fatal stage, group reward context, selected flag, replay
+fingerprint, tool-call count, observation count, and candidate-local tool
+metrics. The selected candidate trace row must also carry the selected
+candidate's registry receipt, tool calls, observations, metrics, and turns so
+release gates and compare workflows can audit the selected trajectory without
+reconstructing it from nested policy-update fields.
+
 `fatal_stage` records the first stage that invalidates later trajectory tokens
 or observations. Supported stage names are:
 

--- a/docs/plans/2026-05-20-agentic-grpo-candidate-reward-traces.md
+++ b/docs/plans/2026-05-20-agentic-grpo-candidate-reward-traces.md
@@ -1,0 +1,139 @@
+# Agentic GRPO Candidate Reward Traces
+
+## Goal
+
+Implement issue #700 by persisting candidate-level reward traces and selected
+candidate evidence for online GRPO rollout. This completes Milestone 2 of the
+OpenSearch-VL online GRPO/RL rollout direction by making every generated
+candidate auditable outside the selected policy-update row.
+
+## Scope
+
+- Governed issue: #700.
+- Parent direction: #694, OpenSearch-VL alignment: online GRPO/RL rollout for
+  tool-use LoRA.
+- Milestone issue: #698, online candidate generation and scoring.
+- Runtime boundary: Python worker alignment runner.
+- Artifact boundary: adapter output directory and LoRA alignment run manifest.
+
+## Architecture
+
+The #699 runtime-generation slice records generated candidates inside each
+`policy_updates.jsonl` row and projects the selected candidate tool trajectory
+onto the policy-update row. That proves the selected update is tool-aware, but
+it still makes group-wide candidate evidence hard to consume without parsing a
+nested policy row.
+
+This slice introduces a first-class candidate reward trace artifact:
+
+- `candidate_reward_traces.jsonl`
+- schema version `melix.alignment_candidate_reward_trace.v1`
+- one row per candidate in each GRPO group
+
+Each row records sample and candidate identity, candidate text, scalar score,
+ordered reward components, fatal stage, selection state, group reward context,
+scoring and generation backends, tool-call summary, selected candidate evidence
+for the winner, and a deterministic replay fingerprint. The policy-update row
+keeps the selected update and points to the candidate artifact through stable
+path/count fields. The adapter config and alignment run manifest also expose
+the path and count so downstream compare, release-gate, and evaluation slices
+can load the candidate evidence directly.
+
+The trace artifact is additive. Existing `policy_updates.jsonl` and embedded
+`generated_candidates` fields remain available for legacy consumers.
+
+## Performance And Metrics
+
+The new work serializes candidate evidence that is already produced by the
+runtime-generation path. It does not add policy model loads, reward model
+loads, tool executions, network calls, or broad filesystem scans. Runtime cost
+is proportional to candidate count and JSONL row size.
+
+Measurement points:
+
+- `candidate_reward_trace_count`
+- `candidate_reward_trace_path`
+- `candidate_reward_trace_schema_version`
+- existing `generated_candidate_count`
+- existing `agentic_tool.*` metrics inside candidate evidence
+
+Success metrics:
+
+- Every runtime-generated GRPO candidate has a row in
+  `candidate_reward_traces.jsonl`.
+- The selected candidate row carries `selected: true`, selected-candidate tool
+  evidence, and the same reward components as the policy-update row.
+- Alignment run metrics and adapter config expose the candidate trace path,
+  count, and schema version.
+- Existing text-only and reward-model scoring paths remain compatible.
+- Changed-line coverage for touched Python files is at least 95 percent.
+
+## Implementation Steps
+
+- [x] Create the issue-specific plan before broad code changes.
+- [x] Add candidate reward trace rows to the runtime GRPO policy update result.
+- [x] Write the candidate trace artifact beside `policy_updates.jsonl`.
+- [x] Surface candidate trace path/count/schema in adapter config and LoRA
+      alignment run metrics.
+- [x] Update governing contracts.
+- [x] Add focused tests for artifact persistence and selected-candidate
+      evidence.
+
+## Verification
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_records_runtime_generated_grpo_evidence
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'alignment_rl or grpo or rlhf or reward_model or rollout or structured_result'
+
+git diff --check
+```
+
+Current changed-line coverage:
+
+- `rl_alignment_training.py`: 97.56 percent, 40/41 measured changed lines.
+- `mlx_lm_runner.py`: 100 percent, 3/3 measured changed lines.
+- `lora_training_pipeline.py`: 100 percent, 3/3 measured changed lines.
+- `test_rl_alignment_runtime_tool_trajectories.py`: 100 percent, 29/29 measured
+  changed lines.
+- `test_lora_model_ops_unit.py`: 100 percent, 6/6 measured changed lines.
+- Aggregate: 98.78 percent, 81/82 measured changed lines.
+
+PR-scoped performance probes selected by the changed files:
+
+- `mlx-lm-structured-result-tail-parse`
+- `lora-reward-summary-candidate-minmax`
+
+Probe metric snapshots:
+
+- `mlx_lm_result_tail_probe.py`: `elapsed_ms_mean=0.045475`,
+  `peak_bytes_mean=1665.4`, `sample_count=5`.
+- `lora_reward_summary_probe.py`: `elapsed_ms_mean=20.95531237500836`,
+  `sorted_calls_mean=2`, `sample_count=5000`.
+
+Pre-commit gate:
+
+- `make swift-test`: pass.
+- `make py-test`: pass, 2881 passed, 14 skipped.
+- `make integration-test`: pass, 114 passed, 1 skipped.
+- PR-scoped performance report:
+  `.runtime/pre-commit-performance/20260520-095234-0a14599f/report/report.md`.
+  The report marked `mlx-lm-structured-result-tail-parse` as a direct
+  regression because `elapsed_ms_mean` moved from 0.071 ms to 0.076 ms
+  (+0.005 ms, +7.55 percent). This change only adds `TrainingMetrics`
+  dataclass fields and does not modify `_extract_structured_result_payload` or
+  the tail-parse hot path. Five immediate local reruns of
+  `scripts/mlx_lm_result_tail_probe.py` produced head samples between
+  0.071050 ms and 0.082133 ms, so the reported delta is within probe noise for
+  this microbenchmark. The LoRA reward summary probe remained ok.
+
+Review follow-up:
+
+- Applied the low-risk readability review items in
+  `rl_alignment_training.py` by removing redundant casts and guards in the
+  candidate trace row construction path.
+- Re-ran the focused tests plus `git diff --check`: 31 passed, 107 deselected.
+- Re-ran changed-line coverage: aggregate 98.78 percent, 81/82 measured changed
+  lines.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -210,6 +210,15 @@ the selected policy-update row must reflect the selected candidate's tool
 trajectory. Sample-level replay evidence may seed fixture context, but it must
 not be reused as the trajectory for every generated candidate.
 
+Online GRPO must also persist candidate-level reward traces as a first-class
+artifact. Each generated candidate row must bind the candidate text, score,
+reward components, fatal stage, tool-call sequence, observation summary,
+selected flag, and replay fingerprint to the same registry and observation
+contract used by the selected policy update. The selected candidate row must
+include the full selected tool trajectory; non-selected rows may include
+summaries plus candidate-local tool metrics unless a later milestone expands
+full non-selected observation retention.
+
 Fatal-aware behavior must distinguish:
 
 - valid pre-failure reasoning

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -2700,6 +2700,34 @@ def test_run_subprocess_extracts_terminal_structured_result_without_splitlines(
 
     assert runner._run_subprocess("train", payload_path, error_code="backend_training_failure") == structured_payload
 
+    metrics = TrainingMetrics(
+        job_duration_ms=10.0,
+        tokens_seen=4,
+        examples_seen=2,
+        loss_final=0.4,
+        loss_best=0.3,
+        learning_rate_final=1e-4,
+        candidate_reward_trace_path="/tmp/candidate_reward_traces.jsonl",
+        candidate_reward_trace_count=2,
+        candidate_reward_trace_schema_version="melix.alignment_candidate_reward_trace.v1",
+    )
+    result = TrainingResult(
+        weights_path=tmp_path / "adapters.safetensors",
+        adapter_config_path=tmp_path / "adapter_config.json",
+        metrics=metrics,
+        execution_backend="native",
+    )
+    restored = mlx_lm_runner_module._deserialize_training_result(
+        mlx_lm_runner_module._serialize_training_result(result)
+    )
+
+    assert restored.metrics.candidate_reward_trace_path == "/tmp/candidate_reward_traces.jsonl"
+    assert restored.metrics.candidate_reward_trace_count == 2
+    assert (
+        restored.metrics.candidate_reward_trace_schema_version
+        == "melix.alignment_candidate_reward_trace.v1"
+    )
+
 
 def test_run_subprocess_rejects_missing_structured_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     payload_path = tmp_path / "payload.json"

--- a/services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
+++ b/services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
@@ -121,6 +121,15 @@ def test_mlx_lm_runner_runtime_grpo_executes_candidate_tool_trajectories(
 
     assert row["selected_candidate_index"] == 0
     assert row["selected_candidate_text"] == "selected tool-backed answer"
+    assert row["candidate_reward_trace_schema_version"] == (
+        "melix.alignment_candidate_reward_trace.v1"
+    )
+    assert row["candidate_reward_trace_count"] == 2
+    assert row["candidate_reward_trace_total_count"] == 2
+    assert result.metrics.candidate_reward_trace_count == 2
+    assert result.metrics.candidate_reward_trace_schema_version == (
+        "melix.alignment_candidate_reward_trace.v1"
+    )
     assert row["selected_candidate_tool_call_count"] == 1
     assert row["agentic_tool_calls"][0]["id"] == "visit-selected"
     assert row["agentic_tool_observations"][0]["payload"]["text"] == "Selected source."
@@ -131,6 +140,41 @@ def test_mlx_lm_runner_runtime_grpo_executes_candidate_tool_trajectories(
     assert row["generated_candidates"][1]["tool_calls"][1]["name"] == "local_compute"
     assert row["generated_candidates"][1]["agentic_tool_metrics"]["agentic_tool.call_count"] == 2.0
     assert row["generated_candidates"][1]["reward_components"]["tool_efficiency"] == -1.0
+
+    candidate_trace_rows = [
+        json.loads(line)
+        for line in Path(result.metrics.candidate_reward_trace_path).read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+    adapter_config = json.loads(result.adapter_config_path.read_text(encoding="utf-8"))
+    selected_trace = candidate_trace_rows[0]
+    extra_trace = candidate_trace_rows[1]
+
+    assert adapter_config["candidate_reward_trace_path"] == (
+        result.metrics.candidate_reward_trace_path
+    )
+    assert adapter_config["candidate_reward_trace_count"] == 2
+    assert adapter_config["candidate_reward_trace_schema_version"] == (
+        "melix.alignment_candidate_reward_trace.v1"
+    )
+    assert row["candidate_reward_trace_path"] == result.metrics.candidate_reward_trace_path
+    assert selected_trace["schema_version"] == "melix.alignment_candidate_reward_trace.v1"
+    assert selected_trace["sample_index"] == 0
+    assert selected_trace["candidate_index"] == 0
+    assert selected_trace["selected"] is True
+    assert selected_trace["candidate_text"] == "selected tool-backed answer"
+    assert selected_trace["reward_components"] == row["reward_components"]
+    assert selected_trace["agentic_tool_calls"][0]["id"] == "visit-selected"
+    assert selected_trace["agentic_tool_observations"][0]["payload"]["text"] == "Selected source."
+    assert selected_trace["agentic_tool_metrics"]["agentic_tool.call_count"] == 1.0
+    assert len(selected_trace["replay_fingerprint"]) == 64
+    assert extra_trace["candidate_index"] == 1
+    assert extra_trace["selected"] is False
+    assert extra_trace["tool_call_count"] == 2
+    assert extra_trace["agentic_tool_observation_count"] == 2
+    assert extra_trace["tool_calls"][1]["name"] == "local_compute"
+    assert "agentic_tool_observations" not in extra_trace
 
 
 def test_alignment_runtime_tool_helpers_cover_namespaces_and_invalid_events() -> None:

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -590,6 +590,11 @@ def _alignment_manifest_payload(
             metrics["reward_scoring_backend"] = training_result.metrics.reward_scoring_backend
         if training_result.metrics.generated_candidate_count:
             metrics["generated_candidate_count"] = training_result.metrics.generated_candidate_count
+        metrics["candidate_reward_trace_path"] = training_result.metrics.candidate_reward_trace_path
+        metrics["candidate_reward_trace_count"] = training_result.metrics.candidate_reward_trace_count
+        metrics["candidate_reward_trace_schema_version"] = (
+            training_result.metrics.candidate_reward_trace_schema_version
+        )
         if training_result.metrics.policy_update_count or training_result.metrics.policy_update_trace_path:
             metrics["reward_mean"] = training_result.metrics.reward_mean
             metrics["reward_p50"] = training_result.metrics.reward_p50

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -97,6 +97,9 @@ class TrainingMetrics:
     candidate_group_reward_margin_mean: float = 0.0
     candidate_group_reward_variance_mean: float = 0.0
     policy_update_trace_path: str = ""
+    candidate_reward_trace_path: str = ""
+    candidate_reward_trace_count: int = 0
+    candidate_reward_trace_schema_version: str = ""
     candidate_generation_mode: str = ""
     candidate_generation_backend: str = ""
     candidate_scoring_mode: str = ""

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -20,10 +20,13 @@ from worker.trajectory_provenance import (
     load_trajectory_provenance_from_snapshot_dir,
 )
 
+CANDIDATE_REWARD_TRACE_SCHEMA_VERSION = "melix.alignment_candidate_reward_trace.v1"
+
 
 @dataclass(frozen=True)
 class PolicyUpdateResult:
     trace_rows: list[dict[str, Any]]
+    candidate_reward_trace_rows: list[dict[str, Any]]
     reward_values: list[float]
     reward_component_summaries: list[dict[str, float]]
     group_margins: list[float]
@@ -157,6 +160,7 @@ def train_alignment_rl_trace(
     weights_path = request.adapter_output_dir / "adapters.safetensors"
     adapter_config_path = request.adapter_output_dir / "adapter_config.json"
     policy_update_trace_path = request.adapter_output_dir / "policy_updates.jsonl"
+    candidate_reward_trace_path = request.adapter_output_dir / "candidate_reward_traces.jsonl"
     checkpoint_dir = request.adapter_output_dir / "checkpoint-1"
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
     latest_checkpoint_path = checkpoint_dir / "adapters.safetensors"
@@ -175,7 +179,18 @@ def train_alignment_rl_trace(
     )
     for row in policy_updates.trace_rows:
         row.update(rollout_manifest_fields)
+        if policy_updates.candidate_reward_trace_rows:
+            row["candidate_reward_trace_path"] = str(candidate_reward_trace_path)
+            row["candidate_reward_trace_total_count"] = len(
+                policy_updates.candidate_reward_trace_rows
+            )
     _write_jsonl(policy_update_trace_path, policy_updates.trace_rows)
+    if policy_updates.candidate_reward_trace_rows:
+        for row in policy_updates.candidate_reward_trace_rows:
+            if trajectory_provenance:
+                row.update(trajectory_provenance)
+            row.update(rollout_manifest_fields)
+        _write_jsonl(candidate_reward_trace_path, policy_updates.candidate_reward_trace_rows)
     adapter_config = _load_resume_adapter_config(request.resume_source_path) or {
         "fine_tune_type": "lora",
         "lora_parameters": {
@@ -192,6 +207,17 @@ def train_alignment_rl_trace(
             "alignment_algorithm": alignment.alignment_algorithm,
             "execution_backend": policy_updates.execution_backend,
             "policy_update_trace_path": str(policy_update_trace_path),
+            "candidate_reward_trace_path": (
+                str(candidate_reward_trace_path)
+                if policy_updates.candidate_reward_trace_rows
+                else ""
+            ),
+            "candidate_reward_trace_count": len(policy_updates.candidate_reward_trace_rows),
+            "candidate_reward_trace_schema_version": (
+                CANDIDATE_REWARD_TRACE_SCHEMA_VERSION
+                if policy_updates.candidate_reward_trace_rows
+                else ""
+            ),
             "reward_model_manifest_path": alignment.reward_model_manifest_path,
             "reference_model_path": alignment.reference_model_path,
             "kl_penalty": alignment.kl_penalty,
@@ -260,6 +286,17 @@ def train_alignment_rl_trace(
             candidate_group_reward_margin_mean=_mean(policy_updates.group_margins),
             candidate_group_reward_variance_mean=_mean(policy_updates.group_variances),
             policy_update_trace_path=str(policy_update_trace_path),
+            candidate_reward_trace_path=(
+                str(candidate_reward_trace_path)
+                if policy_updates.candidate_reward_trace_rows
+                else ""
+            ),
+            candidate_reward_trace_count=len(policy_updates.candidate_reward_trace_rows),
+            candidate_reward_trace_schema_version=(
+                CANDIDATE_REWARD_TRACE_SCHEMA_VERSION
+                if policy_updates.candidate_reward_trace_rows
+                else ""
+            ),
             candidate_generation_mode=policy_updates.candidate_generation_mode,
             candidate_generation_backend=policy_updates.candidate_generation_backend,
             candidate_scoring_mode=policy_updates.candidate_scoring_mode,
@@ -469,6 +506,7 @@ def _grpo_policy_updates(
             trace_rows[-1]["reward_model_id"] = reward_scorer.reward_model_id
     return PolicyUpdateResult(
         trace_rows=trace_rows,
+        candidate_reward_trace_rows=[],
         reward_values=reward_values,
         reward_component_summaries=reward_component_summaries,
         group_margins=group_margins,
@@ -510,6 +548,7 @@ def _grpo_runtime_policy_updates(
     cancel_event = threading.Event()
 
     trace_rows: list[dict[str, Any]] = []
+    candidate_reward_trace_rows: list[dict[str, Any]] = []
     reward_values: list[float] = []
     reward_component_summaries: list[dict[str, float]] = []
     group_margins: list[float] = []
@@ -557,11 +596,13 @@ def _grpo_runtime_policy_updates(
                 tool_run=generated.tool_run,
                 include_sample_fatal=True,
             )
+            fatal_stage = _fatal_stage_for_candidate(sample, {"text": generated.text})
             generated_candidate = {
                 "index": candidate_index,
                 "text": generated.text,
                 "score": score,
                 "reward_components": reward_components,
+                "fatal_stage": fatal_stage,
                 "generation_prompt": generation_prompt,
                 "source": "policy_runtime",
             }
@@ -577,6 +618,7 @@ def _grpo_runtime_policy_updates(
         reward_values.extend(scores)
         selected = max(generated_candidates, key=lambda candidate: candidate["reward_components"]["total"])
         selected_components = dict(selected["reward_components"])
+        selected_index = selected["index"]
         reward_component_summaries.extend(
             dict(candidate["reward_components"]) for candidate in generated_candidates
         )
@@ -592,7 +634,7 @@ def _grpo_runtime_policy_updates(
                 "candidate_generation_backend": runtime_name,
                 "candidate_scoring_mode": request.config.alignment.candidate_scoring_mode,
                 "prompt": prompt,
-                "selected_candidate_index": selected["index"],
+                "selected_candidate_index": selected_index,
                 "selected_candidate_text": selected["text"],
                 "selected_text": selected["text"],
                 "selected_reward": selected_components["total"],
@@ -606,15 +648,34 @@ def _grpo_runtime_policy_updates(
                 "generated_candidates": generated_candidates,
             }
         )
-        selected_tool_run = generated_tool_runs.get(selected["index"])
+        selected_tool_run = generated_tool_runs.get(selected_index)
         _attach_agentic_tool_run(trace_rows[-1], selected_tool_run)
         if selected.get("tool_calls"):
             trace_rows[-1]["selected_candidate_tool_call_count"] = len(selected["tool_calls"])
         if reward_scorer is not None:
             trace_rows[-1]["reward_scoring_backend"] = reward_scorer.runtime_name
             trace_rows[-1]["reward_model_id"] = reward_scorer.reward_model_id
+        sample_candidate_rows = _runtime_candidate_reward_trace_rows(
+            sample_index=sample_index,
+            prompt=prompt,
+            generated_candidates=generated_candidates,
+            generated_tool_runs=generated_tool_runs,
+            selected_index=selected_index,
+            group_reward_mean=group_mean,
+            group_reward_margin=group_margins[-1],
+            group_reward_variance=group_variances[-1],
+            candidate_generation_backend=runtime_name,
+            candidate_scoring_mode=request.config.alignment.candidate_scoring_mode,
+            reward_scorer=reward_scorer,
+        )
+        candidate_reward_trace_rows.extend(sample_candidate_rows)
+        trace_rows[-1]["candidate_reward_trace_schema_version"] = (
+            CANDIDATE_REWARD_TRACE_SCHEMA_VERSION
+        )
+        trace_rows[-1]["candidate_reward_trace_count"] = len(sample_candidate_rows)
     return PolicyUpdateResult(
         trace_rows=trace_rows,
+        candidate_reward_trace_rows=candidate_reward_trace_rows,
         reward_values=reward_values,
         reward_component_summaries=reward_component_summaries,
         group_margins=group_margins,
@@ -700,6 +761,7 @@ def _rlhf_policy_updates(
         trace_rows.append(row)
     return PolicyUpdateResult(
         trace_rows=trace_rows,
+        candidate_reward_trace_rows=[],
         reward_values=reward_values,
         reward_component_summaries=reward_component_summaries,
         group_margins=[],
@@ -751,6 +813,84 @@ def _attach_runtime_candidate_tool_evidence(
         return
     candidate["agentic_tool_metrics"] = dict(tool_run.metrics)
     candidate["agentic_tool_observation_count"] = len(tool_run.observations)
+
+
+def _runtime_candidate_reward_trace_rows(
+    *,
+    sample_index: int,
+    prompt: str,
+    generated_candidates: list[dict[str, Any]],
+    generated_tool_runs: dict[int, Any],
+    selected_index: int,
+    group_reward_mean: float,
+    group_reward_margin: float,
+    group_reward_variance: float,
+    candidate_generation_backend: str,
+    candidate_scoring_mode: str,
+    reward_scorer: RewardModelScorer | None,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for candidate in generated_candidates:
+        candidate_index = int(candidate["index"])
+        reward_components = dict(candidate["reward_components"])
+        tool_run = generated_tool_runs.get(candidate_index)
+        row = {
+            "schema_version": CANDIDATE_REWARD_TRACE_SCHEMA_VERSION,
+            "sample_index": sample_index,
+            "candidate_index": candidate_index,
+            "selected": candidate_index == selected_index,
+            "alignment_algorithm": "grpo",
+            "candidate_generation_mode": "runtime_generate",
+            "candidate_generation_backend": candidate_generation_backend,
+            "candidate_scoring_mode": candidate_scoring_mode,
+            "prompt": prompt,
+            "candidate_text": str(candidate.get("text", "")),
+            "score": float(candidate["score"]),
+            "reward_components": reward_components,
+            "reward_total": float(reward_components["total"]),
+            "fatal_stage": candidate.get("fatal_stage", "").strip(),
+            "fatal_penalty_applied": float(reward_components["fatal_failure"]) < 0.0,
+            "group_reward_mean": group_reward_mean,
+            "group_reward_margin": group_reward_margin,
+            "group_reward_variance": group_reward_variance,
+            "candidate_count": len(generated_candidates),
+            "source": str(candidate.get("source", "")),
+            "generation_prompt": str(candidate.get("generation_prompt", "")),
+            "tool_call_count": len(candidate.get("tool_calls", [])),
+            "agentic_tool_observation_count": candidate.get(
+                "agentic_tool_observation_count", 0
+            ),
+            "replay_fingerprint": _candidate_replay_fingerprint(candidate),
+        }
+        if isinstance(candidate.get("tool_calls"), list):
+            row["tool_calls"] = [dict(call) for call in candidate["tool_calls"]]
+        if isinstance(candidate.get("agentic_tool_metrics"), dict):
+            row["agentic_tool_metrics"] = dict(candidate["agentic_tool_metrics"])
+        if reward_scorer is not None:
+            row["reward_scoring_backend"] = reward_scorer.runtime_name
+            row["reward_model_id"] = reward_scorer.reward_model_id
+        if candidate_index == selected_index:
+            _attach_agentic_tool_run(row, tool_run)
+        rows.append(row)
+    return rows
+
+
+def _candidate_replay_fingerprint(candidate: dict[str, Any]) -> str:
+    payload = {
+        "text": candidate.get("text", ""),
+        "score": candidate.get("score"),
+        "reward_components": candidate.get("reward_components", {}),
+        "tool_calls": candidate.get("tool_calls", []),
+        "agentic_tool_metrics": candidate.get("agentic_tool_metrics", {}),
+    }
+    return hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
 
 
 _REWARD_COMPONENT_KEYS = (


### PR DESCRIPTION
## Summary
- Persist `candidate_reward_traces.jsonl` for runtime-generated GRPO with one row per generated candidate.
- Link policy-update rows, adapter config, and LoRA alignment manifest metrics to the candidate trace artifact.
- Update the agentic trajectory/runtime contracts and add focused tests for candidate evidence retention.

## Plan or Spec
- Governing plan: `docs/plans/2026-05-20-agentic-grpo-candidate-reward-traces.md`
- Updated contracts: `docs/agentic-trajectory-dataset-contract.md`, `docs/unified-agentic-tool-runtime-contract.md`
- Closes #700.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_records_runtime_generated_grpo_evidence
# 3 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'alignment_rl or grpo or rlhf or reward_model or rollout or structured_result'
# 29 passed, 106 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage ... && python scripts/python_changed_line_coverage.py ...
# Aggregate changed-line coverage: 98.78% (81/82)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_lm_result_tail_probe.py
# elapsed_ms_mean=0.045475, peak_bytes_mean=1665.4, sample_count=5

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/lora_reward_summary_probe.py
# elapsed_ms_mean=20.95531237500836, sorted_calls_mean=2, sample_count=5000

git diff --check
# pass

pre-commit gate during commit:
# make swift-test: pass
# make py-test: pass, 2881 passed, 14 skipped
# make integration-test: pass, 114 passed, 1 skipped
# PR-scoped performance report: Status ok, 2 direct/gated probes, 0 regressions
```

## Coverage and Metrics
- Changed-line coverage: 98.78% aggregate, 81/82 measured changed lines.
- `rl_alignment_training.py`: 97.56%, 40/41.
- `mlx_lm_runner.py`: 100%, 3/3.
- `lora_training_pipeline.py`: 100%, 3/3.
- `test_rl_alignment_runtime_tool_trajectories.py`: 100%, 29/29.
- `test_lora_model_ops_unit.py`: 100%, 6/6.
- Final pre-commit performance report: `.runtime/pre-commit-performance/20260520-100510-0a14599f/report/report.md`, `Status: ok`.
- `mlx-lm-structured-result-tail-parse`: base `0.070 ms`, head `0.073 ms`, neutral; peak bytes `+0.81%`, neutral.
- `lora-reward-summary-candidate-minmax`: base `20.208 ms`, head `20.165 ms`, neutral; sorted calls unchanged.
- Observability mode: evidence artifact. Probe overhead is proportional to generated candidate count and JSONL row size; no new model loads, reward model loads, tool executions, network calls, or broad filesystem scans.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
