### PR TITLE
perf: batch lora reward candidate scores

### DIFF
--- a/docs/plans/2026-05-20-lora-reward-summary-direct-score-append.md
+++ b/docs/plans/2026-05-20-lora-reward-summary-direct-score-append.md
@@ -1,0 +1,49 @@
+# LoRA Reward Summary Batch Candidate Score Collection
+
+## Goal
+
+Reduce overhead in the LoRA alignment reward summary path by collecting each
+sample's candidate scores with a comprehension before extending the aggregate
+score list, while preserving candidate group margin and variance semantics.
+
+## Scope
+
+This slice is limited to `worker.model_ops.lora_training_pipeline._reward_summary`.
+It does not change training behavior, manifest fields, scoring formulas, or
+alignment dataset contracts.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`lora-reward-summary-candidate-minmax` in `infra/perf/pr_scoped_probes.json`.
+The entry includes focused `test_command`, `coverage_command`, and
+`probe_command` values for:
+
+- `services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py`
+- `services/mlx-worker-python/tests/test_lora_model_ops.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/lora_reward_summary_probe.py`
+
+## Implementation Plan
+
+- Reuse the existing behavior coverage for reward summary percentile, margin,
+  and variance calculations.
+- Collect per-sample `candidate_scores` with a comprehension and retain the
+  existing aggregate `extend` step.
+- Keep a scalar candidate count plus running totals, min, and max for group
+  metrics.
+- Run the registered focused tests, changed-scope coverage, and local registered
+  probe on Linux before opening the PR.
+
+## Verification Boundary
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime
+performance claims are made.
+
+## Success Criteria
+
+- Focused tests pass.
+- Changed-scope coverage remains at least 95%.
+- The registered probe reports a clear local improvement in `elapsed_ms_mean`.
+- GitHub Actions and the PR-scoped performance workflow complete successfully
+  before merge.

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -683,26 +683,27 @@ def _reward_summary(samples: list[dict[str, Any]]) -> dict[str, float | int]:
             score_total += reward_score
         candidates = sample.get("candidates")
         candidate_scores: list[float] = []
-        candidate_scores_append = candidate_scores.append
-        candidate_score_min: float | None = None
-        candidate_score_max: float | None = None
-        candidate_score_total = 0.0
-        candidate_score_square_total = 0.0
         if is_instance(candidates, list_type):
-            for candidate in candidates:
-                if is_instance(candidate, dict_type) and "score" in candidate:
-                    candidate_score = to_float(candidate["score"])
-                    candidate_scores_append(candidate_score)
-                    candidate_score_total += candidate_score
-                    candidate_score_square_total += candidate_score * candidate_score
-                    if candidate_score_min is None or candidate_score < candidate_score_min:
-                        candidate_score_min = candidate_score
-                    if candidate_score_max is None or candidate_score > candidate_score_max:
-                        candidate_score_max = candidate_score
-        if candidate_scores:
-            scores_extend(candidate_scores)
-            score_total += candidate_score_total
+            candidate_scores = [
+                to_float(candidate["score"])
+                for candidate in candidates
+                if is_instance(candidate, dict_type) and "score" in candidate
+            ]
         candidate_score_count = len(candidate_scores)
+        if candidate_score_count:
+            scores_extend(candidate_scores)
+            candidate_score_total = 0.0
+            candidate_score_square_total = 0.0
+            candidate_score_min = candidate_scores[0]
+            candidate_score_max = candidate_score_min
+            for candidate_score in candidate_scores:
+                candidate_score_total += candidate_score
+                candidate_score_square_total += candidate_score * candidate_score
+                if candidate_score < candidate_score_min:
+                    candidate_score_min = candidate_score
+                if candidate_score > candidate_score_max:
+                    candidate_score_max = candidate_score
+            score_total += candidate_score_total
         if candidate_score_count >= 2:
             assert candidate_score_min is not None
             assert candidate_score_max is not None


### PR DESCRIPTION
## Summary
- Batch LoRA reward candidate score collection with a comprehension before the existing aggregate extend step.
- Preserve reward summary percentile, candidate margin, and variance semantics.

## Plan or Spec
- `docs/plans/2026-05-20-lora-reward-summary-direct-score-append.md`
- Registered PR-scoped probe: `lora-reward-summary-candidate-minmax` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics
# 74 passed in 2.62s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_reward_summary_probe.py
# 9 passed in 4.29s; changed-line coverage TOTAL 14 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/lora_reward_summary_probe.py
# Base 5-run mean from origin/main worktree: elapsed_ms_mean=57.38824188010767
# Head 5-run mean from this worktree: elapsed_ms_mean=52.132555277785286

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (14/14 changed measurable lines).
- Local registered probe (`lora-reward-summary-candidate-minmax`, Linux): old_mean=57.38824188010767 ms, new_mean=52.132555277785286 ms, delta_ms=-5.255686602322385, speedup=1.1008139074387926, delta_pct=-9.158124434796719%.
- `sorted_calls_mean` stayed at 2; checksum stayed `7.809919999999644`.
- CI PR-scoped performance workflow is required as the authoritative registered probe validation before merge.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime effects are claimed.
- Probe timings are small and somewhat noisy, so merge waits on the registered CI probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
