### PR TITLE
Add fatal-aware GRPO regression tests

### DIFF
--- a/docs/plans/2026-05-20-agentic-fatal-aware-grpo-tests.md
+++ b/docs/plans/2026-05-20-agentic-fatal-aware-grpo-tests.md
@@ -1,0 +1,77 @@
+# Agentic Fatal-Aware GRPO Test Coverage
+
+## Goal
+
+Implement issue #703 by strengthening tests for Milestone 3 fatal-aware GRPO
+semantics after the metadata slice landed in #702.
+
+## Scope
+
+- Governed issue: #703.
+- Parent milestone: #701, fatal-aware GRPO semantics.
+- Parent direction: #694, OpenSearch-VL alignment online GRPO/RL rollout for
+  tool-use LoRA.
+- Runtime boundary: Python worker alignment runner tests only.
+
+## Coverage Targets
+
+Existing tests cover positive fatal advantage clamping and runtime timeout
+metadata for a selected fatal candidate. This slice adds tests for the remaining
+contract edge cases:
+
+- Fatal candidates with negative raw advantage stay tracked and penalized, but
+  are not clamped.
+- A fatal candidate can lose selection because the fatal penalty lowers its
+  total reward below a nonfatal candidate.
+- Runtime-generated fatal candidates are still written to
+  `candidate_reward_traces.jsonl` when they are not selected.
+- Aggregate fatal/clamp counters distinguish tracked fatal candidates from
+  selected fatal candidates.
+
+## Performance And Metrics
+
+This is test-only coverage. It does not change runtime code, data structures, or
+production observability. The affected measurement is changed-scope test
+coverage for the modified test files.
+
+## Implementation Steps
+
+- [x] Read #703, #701, the #702 plan, runner code, and existing GRPO tests.
+- [x] Add a scored-trace regression test for fatal penalty without clamping.
+- [x] Add a runtime-generated regression test for an unselected fatal timeout
+      candidate in candidate reward traces.
+- [x] Run focused tests, changed-scope coverage, `git diff --check`, and the
+      relevant pre-commit/performance gate.
+
+## Verification
+
+Completed commands:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'alignment_rl or grpo or rlhf or reward_model or rollout or structured_result'
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/fatal_grpo_tests.coverage -m pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'alignment_rl or grpo or rlhf or reward_model or rollout or structured_result'
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/fatal_grpo_tests.coverage -o /tmp/fatal_grpo_tests_coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json /tmp/fatal_grpo_tests_coverage.json services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
+
+git diff --check
+
+python3 scripts/pre_commit_gate.py
+```
+
+Results:
+
+- Focused fatal-aware GRPO tests: `12 passed`.
+- Wider LoRA alignment subset: `29 passed, 106 deselected`.
+- Combined touched Python subset: `40 passed, 107 deselected`.
+- Changed-scope coverage: aggregate `100%` (`94` measurable changed lines,
+  `0` missed lines).
+- `git diff --check`: pass.
+- Full pre-commit gate: `make swift-test` passed, `make py-test` passed with
+  `2886 passed, 14 skipped`, and `make integration-test` passed with
+  `114 passed, 1 skipped`.
+- Performance report: `Status: ok`, `Selected probes: 0`,
+  `Direct/gated probes: 0`, `Regressions: 0`; report written to
+  `.runtime/pre-commit-performance/20260520-125013-20523388/report/report.md`.

--- a/services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
+++ b/services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py
@@ -225,6 +225,86 @@ def test_grpo_policy_updates_clamp_fatal_positive_advantage_metadata(
     assert adapter_config["advantage_clamped_candidate_count"] == 1
 
 
+def test_grpo_policy_updates_track_penalized_unselected_fatal_without_clamp(
+    tmp_path: Path,
+) -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"training_mode": "grpo", "grpo_candidate_count": "2"},
+        dataset_format="prompt_candidate",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    normalized_dataset_dir = tmp_path / "normalized"
+    normalized_dataset_dir.mkdir()
+    (normalized_dataset_dir / "train.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Pick the safe response.",
+                "candidates": [
+                    {
+                        "text": "High scalar answer with a fatal tool failure.",
+                        "score": 0.6,
+                        "fatal_stage": "tool_execution_failure",
+                    },
+                    {
+                        "text": "Lower scalar answer that is safe after penalties.",
+                        "score": 0.1,
+                    },
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-grpo-fatal-penalty-not-selected",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dataset_dir,
+        config=config,
+        dataset_format="prompt_candidate",
+    )
+
+    result = mlx_lm_runner_module.MLXLMRunner().train(request)
+    trace_rows = [
+        json.loads(line)
+        for line in Path(result.metrics.policy_update_trace_path).read_text(encoding="utf-8").splitlines()
+    ]
+    row = trace_rows[0]
+    fatal_candidate = row["scored_candidates"][0]
+    selected_candidate = row["scored_candidates"][1]
+    adapter_config = json.loads(result.adapter_config_path.read_text(encoding="utf-8"))
+
+    assert row["selected_candidate_index"] == 1
+    assert row["fatal_state_mask"] is False
+    assert row["fatal_stage"] == ""
+    assert row["selected_reward"] == pytest.approx(0.1)
+    assert row["group_reward_mean"] == pytest.approx(-0.15)
+    assert row["group_fatal_candidate_count"] == 1
+    assert row["group_advantage_clamped_candidate_count"] == 0
+    assert fatal_candidate["reward_components"]["fatal_failure"] == pytest.approx(-1.0)
+    assert fatal_candidate["reward_components"]["total"] == pytest.approx(-0.4)
+    assert fatal_candidate["fatal_state_mask"] is True
+    assert fatal_candidate["fatal_state_mask_reason"] == "tool_execution_failure"
+    assert fatal_candidate["grpo_advantage_raw"] == pytest.approx(-0.25)
+    assert fatal_candidate["grpo_advantage_clamped"] == pytest.approx(-0.25)
+    assert fatal_candidate["grpo_advantage_clamp_applied"] is False
+    assert fatal_candidate["grpo_advantage_clamp_reason"] == ""
+    assert selected_candidate["fatal_state_mask"] is False
+    assert selected_candidate["grpo_advantage_raw"] == pytest.approx(0.25)
+    assert selected_candidate["grpo_advantage_clamped"] == pytest.approx(0.25)
+    assert result.metrics.fatal_candidate_count == 1
+    assert result.metrics.selected_fatal_candidate_count == 0
+    assert result.metrics.advantage_clamped_candidate_count == 0
+    assert result.metrics.reward_component_fatal_failure_mean == pytest.approx(-0.5)
+    assert adapter_config["fatal_candidate_count"] == 1
+    assert adapter_config["selected_fatal_candidate_count"] == 0
+    assert adapter_config["advantage_clamped_candidate_count"] == 0
+
+
 def test_lora_training_pipeline_records_grpo_reward_component_metrics(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
+++ b/services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
@@ -287,6 +287,128 @@ def test_runtime_grpo_marks_tool_timeout_candidate_as_fatal_mask(
     assert result.metrics.advantage_clamped_candidate_count == 1
 
 
+def test_runtime_grpo_keeps_unselected_fatal_timeout_trace_penalized_without_clamp(
+    tmp_path: Path,
+) -> None:
+    class PenalizedTimeoutPolicyBackend:
+        runtime_name = "penalized-timeout-policy-runtime"
+
+        def load_model(self, model_spec):
+            return {"model_id": model_spec.model_id, "model_path": model_spec.model_path}
+
+        def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event, execution_ext=None):
+            del loaded_model, sampling, cancel_event, execution_ext
+            if "candidate 1" in prompt:
+                yield RuntimeToolCallEvent(
+                    call_id="timeout-safe-answer",
+                    tool_name="visit",
+                    arguments_json_fragment=json.dumps({"url": "fixture://timeout"}),
+                )
+                yield RuntimeTokenEvent(text="safe answer")
+            else:
+                yield RuntimeTokenEvent(text="safe answer fallback")
+
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={
+            "training_mode": "grpo",
+            "grpo_candidate_count": "2",
+            "candidate_generation_mode": "runtime_generate",
+            "candidate_generation_max_tokens": "16",
+        },
+        dataset_format="prompt_candidate",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    normalized_dataset_dir = tmp_path / "normalized"
+    normalized_dataset_dir.mkdir()
+    (normalized_dataset_dir / "train.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": "Use tools and answer.",
+                "tool_fixture_context": {
+                    "tool_status_overrides": {
+                        "timeout-safe-answer": {
+                            "status": "timeout",
+                            "message": "visit timeout",
+                        },
+                    },
+                    },
+                    "candidates": [
+                        {"text": "safe answer", "score": 1.0},
+                        {"text": "fallback", "score": 0.2},
+                    ],
+                }
+            )
+        + "\n",
+        encoding="utf-8",
+    )
+    request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-grpo-runtime-fatal-unselected",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dataset_dir,
+        config=config,
+        dataset_format="prompt_candidate",
+    )
+
+    result = mlx_lm_runner_module.MLXLMRunner(
+        policy_runtime=MLXTextRuntime(backend=PenalizedTimeoutPolicyBackend())
+    ).train(request)
+
+    trace_rows = [
+        json.loads(line)
+        for line in Path(result.metrics.policy_update_trace_path).read_text(encoding="utf-8").splitlines()
+    ]
+    candidate_trace_rows = [
+        json.loads(line)
+        for line in Path(result.metrics.candidate_reward_trace_path).read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+    row = trace_rows[0]
+    timeout_candidate = row["generated_candidates"][0]
+    selected_candidate = row["generated_candidates"][1]
+    timeout_trace = candidate_trace_rows[0]
+    selected_trace = candidate_trace_rows[1]
+    adapter_config = json.loads(result.adapter_config_path.read_text(encoding="utf-8"))
+
+    assert row["selected_candidate_index"] == 1
+    assert row["fatal_state_mask"] is False
+    assert row["fatal_stage"] == ""
+    assert row["selected_reward"] == pytest.approx(1.0)
+    assert row["group_reward_mean"] == pytest.approx(0.5)
+    assert row["group_fatal_candidate_count"] == 1
+    assert row["group_advantage_clamped_candidate_count"] == 0
+    assert timeout_candidate["fatal_state_mask"] is True
+    assert timeout_candidate["fatal_state_mask_reason"] == "tool_timeout"
+    assert timeout_candidate["reward_components"]["fatal_failure"] == pytest.approx(-1.0)
+    assert timeout_candidate["reward_components"]["total"] == pytest.approx(0.0)
+    assert timeout_candidate["grpo_advantage_raw"] == pytest.approx(-0.5)
+    assert timeout_candidate["grpo_advantage_clamped"] == pytest.approx(-0.5)
+    assert timeout_candidate["grpo_advantage_clamp_applied"] is False
+    assert selected_candidate["fatal_state_mask"] is False
+    assert selected_candidate["grpo_advantage_raw"] == pytest.approx(0.5)
+    assert timeout_trace["selected"] is False
+    assert timeout_trace["fatal_state_mask"] is True
+    assert timeout_trace["fatal_state_mask_reason"] == "tool_timeout"
+    assert timeout_trace["fatal_penalty_applied"] is True
+    assert timeout_trace["grpo_advantage_clamped"] == pytest.approx(-0.5)
+    assert timeout_trace["grpo_advantage_clamp_applied"] is False
+    assert timeout_trace["agentic_tool_metrics"]["agentic_tool.timeout_count"] == 1.0
+    assert "agentic_tool_observations" not in timeout_trace
+    assert selected_trace["selected"] is True
+    assert selected_trace["fatal_state_mask"] is False
+    assert result.metrics.fatal_candidate_count == 1
+    assert result.metrics.selected_fatal_candidate_count == 0
+    assert result.metrics.advantage_clamped_candidate_count == 0
+    assert adapter_config["fatal_candidate_count"] == 1
+    assert adapter_config["selected_fatal_candidate_count"] == 0
+    assert adapter_config["advantage_clamped_candidate_count"] == 0
+
+
 def test_alignment_runtime_tool_helpers_cover_namespaces_and_invalid_events() -> None:
     from worker.model_ops.rl_alignment_training import (
         _agentic_tool_run_for_generated_candidate,


### PR DESCRIPTION
## Summary
- Add regression coverage for the remaining fatal-aware GRPO edge cases in #703.
- Cover penalized fatal candidates that lose selection without clamping, plus runtime timeout candidates preserved in `candidate_reward_traces.jsonl` when unselected.
- Record the test-only implementation and verification evidence in a new plan document.

## Plan or Spec
- Governing plan: `docs/plans/2026-05-20-agentic-fatal-aware-grpo-tests.md`.
- Parent milestone: #701.
- Parent direction: #694.

Closes #703.

## Commands Run
```text
make bootstrap
Result: passed; configured `.githooks` and confirmed the locked Python environment.

make proto
Result: passed; no generated artifact diff remained.

git diff --check
Result: passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
Result: 12 passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'alignment_rl or grpo or rlhf or reward_model or rollout or structured_result'
Result: 29 passed, 106 deselected.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/fatal_grpo_tests.coverage -m pytest -q services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k 'alignment_rl or grpo or rlhf or reward_model or rollout or structured_result'
Result: 40 passed, 107 deselected.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/fatal_grpo_tests.coverage -o /tmp/fatal_grpo_tests_coverage.json
Result: wrote coverage JSON.

python3 scripts/changed_scope_coverage.py --coverage-json /tmp/fatal_grpo_tests_coverage.json services/mlx-worker-python/tests/test_agentic_grpo_reward_components.py services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
Result: aggregate changed-scope coverage 100% (94 measurable changed lines, 0 missed lines).

python3 scripts/pre_commit_gate.py
Result: passed; make swift-test rc=0, make py-test 2886 passed / 14 skipped, make integration-test 114 passed / 1 skipped.
```

## Coverage and Metrics
- Changed-scope coverage: `100%` across the modified Python test files (`94` measurable changed lines, `0` missed lines).
- Metrics report: `.runtime/pre-commit-performance/20260520-125013-20523388/report/report.md`.
- Performance status: `ok`; selected probes `0`, direct/gated probes `0`, regressions `0`, verification failures `0`.
- Observability mode: `N/A`; this is test-only coverage and does not change production observability, debug probes, or runtime metrics.
- Probe overhead: `N/A`; no observability/probe implementation changed.

## Known Gaps
None for #703. #701 and #694 will be updated after this unit PR is merged.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.