### PR TITLE
Fix LoRA layer count for nested text configs

### DIFF
--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -29,6 +29,7 @@ from worker.model_registry.catalog import (
     _local_model_id,
     _metadata_payload_has_mlx_signal,
     _read_text_prefix,
+    _text_layer_count,
     _text_lora_support_metadata,
 )
 
@@ -2301,6 +2302,53 @@ def test_registry_snapshot_applies_text_family_adapter_metadata_from_local_confi
     assert qwen3moe.ext["melix.lora.support_tier"] == "experimental"
     assert qwen3moe.ext["melix.lora.training_ready"] == "true"
     assert qwen3moe.ext["melix.lora.default_target_preset"] == "attention"
+
+
+def test_registry_snapshot_records_text_config_layer_count_for_text_model(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    variant_dir = root / "mlx-community" / "Qwen3.5-9B-MLX-8bit" / "main"
+    _write_registry_manifest(
+        variant_dir,
+        model_id="mlx-community/Qwen3.5-9B-MLX-8bit",
+        model_kind="text",
+    )
+    _write_model_config(
+        variant_dir,
+        {
+            "model_type": "qwen3_5",
+            "text_config": {
+                "model_type": "qwen3_5_text",
+                "num_hidden_layers": 32,
+            },
+        },
+    )
+
+    catalog = WorkerModelCatalog(environment={"MELIX_MODEL_ROOTS": str(root)})
+
+    snapshot = catalog.registry_snapshot()
+    discovered = {model.model_id: model for model in snapshot.models}
+    model = discovered["mlx-community/Qwen3.5-9B-MLX-8bit"]
+
+    assert model.model_kind == "text"
+    assert model.ext["text_layer_count"] == "32"
+
+
+def test_text_layer_count_metadata_prefers_top_level_count() -> None:
+    assert _text_layer_count(
+        {
+            "num_hidden_layers": 24,
+            "text_config": {"num_hidden_layers": 32},
+        }
+    ) == 24
+
+
+def test_text_layer_count_metadata_falls_back_to_nested_text_config() -> None:
+    assert _text_layer_count(
+        {
+            "model_type": "qwen3_5",
+            "text_config": {"num_hidden_layers": 32},
+        }
+    ) == 32
 
 
 def test_registry_snapshot_marks_dflash_draft_metadata_from_local_config(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -534,6 +534,22 @@ def _text_capability_metadata(
     }
 
 
+def _text_layer_count(config_payload: Mapping[str, object] | None) -> int:
+    layer_count = _config_positive_int(config_payload, "num_hidden_layers")
+    if layer_count == 0 and isinstance(config_payload, Mapping):
+        layer_count = _config_positive_int(config_payload.get("text_config"), "num_hidden_layers")
+    return layer_count
+
+
+def _merge_text_layer_count_metadata(
+    ext: dict[str, str],
+    config_payload: Mapping[str, object] | None,
+) -> None:
+    layer_count = _text_layer_count(config_payload)
+    if layer_count > 0:
+        ext["text_layer_count"] = str(layer_count)
+
+
 def _text_lora_support_metadata(
     family_id: str,
     *,
@@ -1593,6 +1609,7 @@ class WorkerModelCatalog:
                     default_route_kind="python_text_compatibility",
                 )
             )
+            _merge_text_layer_count_metadata(ext, config_payload)
         else:
             ext.update(
                 _vlm_capability_metadata(
@@ -1701,6 +1718,7 @@ class WorkerModelCatalog:
                     default_route_kind="python_text_compatibility",
                 )
             )
+            _merge_text_layer_count_metadata(normalized_ext, config_payload)
         if model_kind == "vlm":
             normalized_ext.update(
                 _vlm_capability_metadata(


### PR DESCRIPTION
## Summary
- record text model layer counts from `text_config.num_hidden_layers` when the top-level config has no `num_hidden_layers`
- apply the layer-count metadata to both raw local model specs and manifest-backed text model specs
- cover nested text config layer-count discovery with focused registry tests

## Plan or Spec
Some text models, including Qwen3.5-style configs, keep their backbone layer count under `text_config.num_hidden_layers`. Without this metadata, LoRA training falls back to the family profile default total layer count, which can clamp `--num-layers 8` down to 2 layers.

The fix keeps the registry behavior narrow: derive `text_layer_count` from the top-level config when present, otherwise fall back to nested `text_config.num_hidden_layers`, then reuse that metadata when building text model specs from local directories or registry manifests.

## Commands Run
- `PYTHONPATH=/private/tmp/melix-num-layers-pr:/private/tmp/melix-num-layers-pr/services/mlx-worker-python uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -k 'text_config_layer_count or text_layer_count_metadata'`
- `git diff --check`

## Coverage and Metrics
- Added unit coverage for nested `text_config.num_hidden_layers` on a Qwen3.5-style text model registry snapshot.
- Added helper-level coverage for preferring top-level `num_hidden_layers` and falling back to nested `text_config.num_hidden_layers`.
- Scoped performance report from the initial PR run was `Status: ok`, with no regressions reported for the selected model registry probe.

## Known Gaps
- Full LoRA training is not part of CI; this PR only fixes the registry metadata path that drives the LoRA training layer-count cap.
- Existing model-family detection is unchanged.
