### PR TITLE
perf: fast-path empty sampling stops

### DIFF
--- a/docs/plans/2026-05-20-engine-empty-stop-fastpath.md
+++ b/docs/plans/2026-05-20-engine-empty-stop-fastpath.md
@@ -1,0 +1,25 @@
+# Engine empty stop sequence fast path
+
+## Scope
+
+This Python performance slice targets `EngineCore._sampling_with_resolved_stop()` in `services/mlx-worker-python/worker/engine/engine_core.py`.
+
+The generate hot path resolves sampling stop sequences for every request. Most deterministic and probe requests carry no explicit stop strings and no runtime-resolved stop sequences, so the helper can return the original `SamplingConfig` before materializing `tuple(sampling.stop)`.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped `engine-generate-usage-token-elision` probe in `infra/perf/pr_scoped_probes.json`. The entry includes focused `test_command`, `coverage_command`, and `probe_command` values for the generate engine path, the focused unit tests, and `scripts/engine_generate_usage_token_probe.py`.
+
+## Implementation plan
+
+1. Preserve the existing identity behavior when the incoming sampling stops and resolved stop sequence are both empty.
+2. Add a direct empty/empty branch before tuple materialization.
+3. Keep all non-empty and changed-stop behavior unchanged.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and the registered probe locally on Linux. The PR-scoped performance workflow remains the merge gate for the registered probe result in CI.
+
+## Environment boundary
+
+This slice is Python-only and locally verifiable on Linux. No Swift runtime performance claim is made.

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -488,6 +488,8 @@ class EngineCore:
         sampling: common_pb2.SamplingConfig,
         stop_sequences: tuple[str, ...],
     ) -> common_pb2.SamplingConfig:
+        if not stop_sequences and not sampling.stop:
+            return sampling
         if tuple(sampling.stop) == stop_sequences:
             return sampling
         resolved = common_pb2.SamplingConfig()


### PR DESCRIPTION
## Summary
- Adds an empty/empty stop-sequence fast path in `EngineCore._sampling_with_resolved_stop()` to avoid tuple materialization on the common generate request path.
- Documents the scoped Python performance slice and its registered PR-scoped probe.

## Plan or Spec
- `docs/plans/2026-05-20-engine-empty-stop-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_generate_stream.py::test_generate_without_usage_skips_prompt_token_count_fallback services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_reuses_sampling_when_stop_sequences_match services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_clones_when_stop_sequences_change services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_reuses_runtime_event_prompt_tokens_without_fallback_count services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_counts_prompt_tokens_only_for_missing_event_total services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_request_token_accumulation services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_usage_preserves_finish_reason services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion services/mlx-worker-python/tests/test_generate_stream.py::test_generate_stream_exports_stop_contract_metrics_and_stops_at_turn_boundary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics
# 12 passed in 1.59s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/engine_core.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/engine_generate_usage_token_probe.py
# 12 passed in 0.70s; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id engine-generate-usage-token-elision --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base --head-repo "$PWD" --output /tmp/engine_empty_stop_probe.json
# head verification passed; base/head probe completed successfully
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%` for `services/mlx-worker-python/worker/engine/engine_core.py`.
- Registered probe: `engine-generate-usage-token-elision`.
- Local Linux probe metrics:
  - `elapsed_ms_mean`: base `21.4126` ms → head `19.5243` ms (`-1.8883` ms, `+8.82%` faster).
  - `elapsed_ms_min`: base `19.3425` ms → head `18.6417` ms.
  - `prompt_token_count_calls_per_request`: base `0.0` → head `0.0`.
  - `request_state_append_calls_per_request`: base `0.0` → head `0.0`.
  - `fallback_elapsed_ms_mean`: base `111.2327` ms → head `111.9160` ms (`+0.61%`, below the 5% warning threshold and outside the empty-stop fast path target).
- CI PR-scoped performance report is still required as the registered merge gate.

## Known Gaps
- None for the Python slice. No Swift runtime performance claim is made.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol change.
- [x] Dependency changes include updated lockfiles. N/A: no dependency change.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
