### PR TITLE
perf: slot plain model registry scan records

### DIFF
--- a/docs/plans/2026-05-20-model-registry-plain-scan-slots.md
+++ b/docs/plans/2026-05-20-model-registry-plain-scan-slots.md
@@ -1,0 +1,25 @@
+# Model Registry Plain Scan Slots
+
+## Goal
+
+Reduce transient allocation overhead in the plain-local model registry scan path by removing the per-instance `__dict__` from `_PlainLocalModelScan` records.
+
+## Scope
+
+This slice is intentionally limited to the Python model registry scan bookkeeping path:
+
+- add `slots=True` to the private `_PlainLocalModelScan` dataclass;
+- pin the allocation contract in the existing plain-local scan regression test;
+- reuse the existing registered PR-scoped performance probe for `model-registry-plain-local-manifest-stat-elision`.
+
+It does not change model discovery order, descriptor parsing, Hugging Face cache pruning, manifest parsing, JSON cache behavior, or protobuf outputs.
+
+## Performance Probe
+
+Registered probe: `model-registry-plain-local-manifest-stat-elision` in `infra/perf/pr_scoped_probes.json`.
+
+The probe builds a synthetic plain-local registry, runs `WorkerModelCatalog.snapshot()`, and reports scan elapsed time plus manifest/generation-config stat and config-load counts. This slice keeps the semantic counters unchanged while reducing per-scan record allocation overhead.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, and registered probe locally on Linux before opening the PR. CI remains the source of truth for the PR-scoped base-vs-head performance report.

--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -1028,6 +1028,7 @@ def test_registry_root_tree_records_plain_local_weight_presence_during_single_sc
     assert [(scan.model_dir, scan.has_model_weight_files, scan.has_generation_config) for scan in plain_scans] == [
         (config_dir.resolve(), True, False)
     ]
+    assert not hasattr(plain_scans[0], "__dict__")
 
 
 

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -73,7 +73,7 @@ class RegistrySnapshot:
     scanned_at_unix_ms: int
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _PlainLocalModelScan:
     model_dir: Path
     has_model_weight_files: bool


### PR DESCRIPTION
## Summary
- Add `slots=True` to the private `_PlainLocalModelScan` scan-record dataclass so plain-local registry scans avoid a per-instance `__dict__`.
- Pin the no-`__dict__` allocation contract in the existing single-scandir plain-local registry test.
- Document the slice under `docs/plans/2026-05-20-model-registry-plain-scan-slots.md`.

## Plan or Spec
- `docs/plans/2026-05-20-model-registry-plain-scan-slots.md`
- Registered probe: `model-registry-plain-local-manifest-stat-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` via the registered probe `test_command` — 19 passed, exit 0.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json ... && python3 scripts/changed_scope_coverage.py ...` via the registered probe `coverage_command` — 19 passed, changed-line coverage 100%, exit 0.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'python3 ...'` via the registered `probe_command` — exit 0.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id model-registry-plain-local-manifest-stat-elision --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base --head-repo "$PWD" --output /tmp/model_registry_scan_slots_perf.json` — exit 0; repeated 3 times for stability.
- `git diff --check` — exit 0.

## Coverage and Metrics
- Focused changed-line coverage: 100% (`2/2` measurable changed lines covered).
- Registered probe counters stayed semantically unchanged: `config_load_calls_mean=400.0`, `discovered_model_count_mean=400.0`, `generation_config_stat_calls_mean=0.0`, `manifest_is_file_calls_mean=0.0`, `manifest_parse_calls_mean=0.0`.
- Local repeated base-vs-head elapsed samples for `elapsed_ms_mean`:
  - Run 1: base `115.892416 ms`, head `115.977015 ms` (`+0.073%`).
  - Run 2: base `117.306003 ms`, head `116.073762 ms` (`-1.050%`).
  - Run 3: base `126.505745 ms`, head `112.247224 ms` (`-11.271%`).
  - Mean across the three repeated runs: base `119.901388 ms`, head `114.766000 ms`, delta `-4.283%`.
- CI PR-scoped performance remains the source of truth for the registered base-vs-head report.

## Known Gaps
- This is a Python-only Linux-verified slice. No Swift runtime behavior is touched.
- The elapsed probe has visible run-to-run noise, so the allocation contract and CI registered probe report should be used together when judging the slice.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage was measured and is at least 95% for changed lines.
- [x] Registered local probe ran successfully.
- [x] Scope is limited to one optimization slice.
