### PR TITLE
perf: resolve tool registry selections in one lookup pass

### DIFF
--- a/docs/plans/2026-05-20-tool-registry-select-single-lookup.md
+++ b/docs/plans/2026-05-20-tool-registry-select-single-lookup.md
@@ -1,0 +1,32 @@
+# Tool registry selection single lookup slice
+
+## Scope
+
+This Python performance slice is limited to `worker.runtime.tool_registry.ToolRegistry.select()`.
+It preserves tool-selection behavior, ordering, duplicate suppression, and error reporting while reducing
+per-selection name-index work after the selected name tuple has been normalized and cache misses.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped registered probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+That registry entry already includes focused `test_command`, `coverage_command`, and `probe_command`
+entries for:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_select_probe.py`
+
+## Implementation plan
+
+- Add a focused regression test proving selected names are resolved through the cached name index once per
+  selected name and without a separate membership pass.
+- Replace the separate missing-name comprehension plus selected-tool comprehension with one explicit lookup
+  pass that accumulates missing names for the existing error message.
+- Run the registered focused tests, changed-scope coverage command, and registered probe locally on Linux.
+
+## Validation boundary
+
+This is a Python-only slice and is locally verifiable on Linux. CI must still run the registered
+PR-scoped performance workflow before merge.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -214,6 +214,34 @@ def test_tool_registry_select_reuses_cached_name_index() -> None:
     assert selected.names() == ("visit", "image_crop")
 
 
+def test_tool_registry_select_looks_up_each_selected_name_once() -> None:
+    class CountingIndex(dict[str, ToolDescriptor]):
+        def __init__(self, values: dict[str, ToolDescriptor]) -> None:
+            super().__init__(values)
+            self.get_calls = 0
+            self.contains_calls = 0
+
+        def get(self, key: str, default: object = None) -> ToolDescriptor | object:
+            self.get_calls += 1
+            return super().get(key, default)
+
+        def __contains__(self, key: object) -> bool:
+            self.contains_calls += 1
+            return super().__contains__(key)
+
+    registry = ToolRegistry(built_in_tool_registry().tools)
+    index = CountingIndex(registry._tool_by_name)
+    assert "visit" in index
+    index.contains_calls = 0
+    object.__setattr__(registry, "_tool_by_name", index)
+
+    selected = registry.select(["visit", "image_crop", "visit"])
+
+    assert selected.names() == ("visit", "image_crop")
+    assert index.get_calls == 2
+    assert index.contains_calls == 0
+
+
 def test_tool_registry_select_reuses_cached_selected_registry() -> None:
     registry = ToolRegistry(built_in_tool_registry().tools)
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -222,11 +222,19 @@ class ToolRegistry:
         cached_selection = self._selection_cache.get(requested_names)
         if cached_selection is not None:
             return cached_selection
-        missing_names = [name for name in requested_names if name not in self._tool_by_name]
+        tool_by_name = self._tool_by_name
+        missing_sentinel = object()
+        selected: list[ToolDescriptor] = []
+        missing_names: list[str] = []
+        for name in requested_names:
+            tool = tool_by_name.get(name, missing_sentinel)
+            if tool is missing_sentinel:
+                missing_names.append(name)
+            else:
+                selected.append(tool)
         if missing_names:
             joined = ", ".join(missing_names)
             raise ToolRegistryError(f"Unknown tool registry entry requested: {joined}")
-        selected = [self._tool_by_name[name] for name in requested_names]
         selection = ToolRegistry(
             selected,
             schema_version=self._schema_version,


### PR DESCRIPTION
## Summary
- Optimize `ToolRegistry.select()` cache-miss materialization by resolving selected names through the cached name index in one lookup pass.
- Add a focused regression test that proves selection avoids a separate membership pass while preserving ordering and de-duplication.
- Document the slice and registered probe coverage in `docs/plans/2026-05-20-tool-registry-select-single-lookup.md`.

## Plan or Spec
- `docs/plans/2026-05-20-tool-registry-select-single-lookup.md`
- Registered PR-scoped probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 52 passed.
- Changed-scope coverage: `TOTAL 30 0 100%`.
- Local registered probe (Linux): baseline `elapsed_ms_mean=23.352647805586457`; new `elapsed_ms_mean=21.989129623398185`; delta `-1.3635181821882725 ms` (`~5.84%` faster). The probe reports `select_calls_mean=80000.0` and `selection_case_count=5.0`.
- CI PR-scoped performance workflow is required before merge to validate the registered probe in GitHub Actions.

## Known Gaps
- This is a Python-only slice; no Swift runtime effect is claimed.
- Local probe timing is Linux-only and may have noise, so the registered CI probe report remains the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused behavior test added before implementation and now passes.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows an improvement direction.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
