### PR TITLE
perf: slot prepared image inputs

### DIFF
--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3345,6 +3345,12 @@
         "unit": "calls",
         "direction": "lower_is_better",
         "warn_pct": 0.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
       }
     ]
   },

--- a/services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py
@@ -22,7 +22,7 @@ class MultimodalPreprocessError(ValueError):
     pass
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PreparedImageInput:
     bytes_data: bytes
     source_kind: str


### PR DESCRIPTION
## Summary
- Add slots to the Python `PreparedImageInput` multimodal preprocessing record to reduce per-image instance overhead.
- Extend the registered `multimodal-preprocessing-image-uri-single-parse` PR-scoped probe metrics to track `peak_bytes_mean`, which the probe already emits.

## Plan or Spec
- Governing spec/runbook: `docs/runbooks/phase-6-multimodal-ops.md`
- Performance probe: `infra/perf/pr_scoped_probes.json` entry `multimodal-preprocessing-image-uri-single-parse`

## Commands Run
```text
# Baseline probe on origin/main before code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/multimodal_image_uri_parse_probe.py
exit 0; {"elapsed_ms_mean": 43.42833301052451, "peak_bytes_mean": 315691.0, "prepared_image_count": 640.0, "sample_count": 5.0, "unquote_calls_mean": 0.0, "urlparse_calls_mean": 0.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_accepts_remote_http_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_percent_encoded_local_image_uri_still_decodes_path services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_remote_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_missing_remote_and_unsupported_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_image_uri_parse_probe_script_emits_metrics
exit 0; 10 passed in 1.85s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_accepts_remote_http_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_percent_encoded_local_image_uri_still_decodes_path services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_remote_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_missing_remote_and_unsupported_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_image_uri_parse_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/multimodal_preprocessing.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/multimodal_image_uri_parse_probe.py
exit 0; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/multimodal_image_uri_parse_probe.py
exit 0; {"elapsed_ms_mean": 43.45333226956427, "peak_bytes_mean": 289743.8, "prepared_image_count": 640.0, "sample_count": 5.0, "unquote_calls_mean": 0.0, "urlparse_calls_mean": 0.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 1 0 100%`).
- Registered probe local delta: `peak_bytes_mean` 315,691.0 -> 289,743.8 bytes (`-25,947.2`, `-8.22%`).
- Registered probe local elapsed: 43.428333 -> 43.453332 ms (`+0.0250 ms`, `+0.058%`, effectively flat locally).
- URI parse call metrics unchanged: `urlparse_calls_mean=0.0`, `unquote_calls_mean=0.0`.
- CI PR-scoped performance report is required as the merge gate for the registered probe comparison.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice.
- The optimization targets Python object memory overhead. No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or no behavior/docs change is required.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
