### PR TITLE
Add adapter identity to benchmark request rows

### DIFF
--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -741,7 +741,9 @@ target identity explicit without requiring readers to inspect runtime state.
 row was produced by an adapter-backed LoRA target. `base_model_id` identifies
 the source model used as the comparison baseline. Adapter rows must include the
 adapter package manifest path, adapter set hash, and activation mode when those
-values are available from benchmark job parameters.
+values are available from benchmark job parameters. Base rows must clear
+adapter-only fields during persistence and export collection so stale adapter
+metadata from older request rows cannot be interpreted as LoRA lineage.
 
 ### Compatibility Aliases
 

--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -721,6 +721,11 @@ Each request-level phase row must include:
 - `observation_bytes`
 - `fatal_rate`
 - `turn_count`
+- `compare_target_kind`
+- `base_model_id`
+- `adapter_manifest_path`
+- `adapter_set_hash`
+- `adapter_activation_mode`
 - `created_at_unix_ms`
 
 `phase` is `tool_turn` for deterministic local tool execution and
@@ -729,6 +734,14 @@ emit only `final_answer`. For `tool_turn` rows, `tool_arguments_json` and
 `tool_observation_json` are compact JSON object strings derived from the shared
 agentic tool runtime. For `final_answer`, tool-specific fields default to empty
 strings while aggregate tool-turn fields may summarize the request.
+
+For base-vs-adapter benchmark comparison, request rows must make the comparison
+target identity explicit without requiring readers to inspect runtime state.
+`compare_target_kind` is `base` for ordinary model rows and `adapter` when the
+row was produced by an adapter-backed LoRA target. `base_model_id` identifies
+the source model used as the comparison baseline. Adapter rows must include the
+adapter package manifest path, adapter set hash, and activation mode when those
+values are available from benchmark job parameters.
 
 ### Compatibility Aliases
 

--- a/docs/plans/2026-05-21-agentic-lora-benchmark-identity.md
+++ b/docs/plans/2026-05-21-agentic-lora-benchmark-identity.md
@@ -13,6 +13,8 @@ identity to request-level and tool-turn performance.
   and their CSV export.
 - Automatically annotates collected request rows from `bench-job.json`
   parameters when persisted rows predate the new fields.
+- Normalizes base request rows by clearing adapter-only fields during store
+  persistence and export collection.
 - Keeps PR/report delta rendering out of scope for issue #713.
 
 ## Architecture
@@ -44,6 +46,8 @@ registry during export.
   - adapter-backed rows expose adapter lineage without parsing nested runtime
     metadata.
   - base rows expose `compare_target_kind: base` and stable `base_model_id`.
+  - base rows clear adapter-only fields even when an older persisted row
+    contains stale adapter identity.
   - CSV exports include the new identity columns.
   - existing request-row exports remain backward compatible when no adapter
     metadata exists.

--- a/docs/plans/2026-05-21-agentic-lora-benchmark-identity.md
+++ b/docs/plans/2026-05-21-agentic-lora-benchmark-identity.md
@@ -1,0 +1,74 @@
+# Agentic LoRA Benchmark Identity Plan
+
+## Goal
+
+Implement issue #712 by adding benchmark export request rows that link adapter
+identity to request-level and tool-turn performance.
+
+## Scope
+
+- Covers the first executable unit under issue #711, Milestone 3 of the
+  OpenSearch-VL agentic benchmark metrics direction.
+- Adds additive base/adapter identity fields to serving benchmark request rows
+  and their CSV export.
+- Automatically annotates collected request rows from `bench-job.json`
+  parameters when persisted rows predate the new fields.
+- Keeps PR/report delta rendering out of scope for issue #713.
+
+## Architecture
+
+Request rows are already the canonical phase-level benchmark artifact for
+tool-turn and final-answer performance. This slice extends that artifact with
+comparison identity:
+
+- `compare_target_kind`: `base` for ordinary model rows, `adapter` for
+  adapter-backed LoRA rows.
+- `base_model_id`: the source model being compared against.
+- `adapter_manifest_path`, `adapter_set_hash`, and `adapter_activation_mode`:
+  adapter lineage needed to group rows by adapter package and runtime mode.
+
+Rows built directly by benchmark schema helpers accept the fields explicitly.
+Rows collected from disk are enriched from serving benchmark job parameters.
+This keeps the export bundle self-contained and avoids requiring a live
+registry during export.
+
+## Performance Probes And Metrics
+
+- Measurement points:
+  - request-row JSONL/CSV write path
+  - export collection enrichment from one job payload plus request rows
+  - tool-turn fields already present on enriched rows:
+    `tool_call_count`, `tool_latency_ms`, `observation_bytes`, `fatal_rate`,
+    and `turn_count`
+- Success metrics:
+  - adapter-backed rows expose adapter lineage without parsing nested runtime
+    metadata.
+  - base rows expose `compare_target_kind: base` and stable `base_model_id`.
+  - CSV exports include the new identity columns.
+  - existing request-row exports remain backward compatible when no adapter
+    metadata exists.
+
+## Implementation Plan
+
+1. Add failing schema and export tests for adapter identity on request rows.
+2. Extend `ServingBenchmarkRequestRow` and
+   `build_serving_benchmark_request_row` with additive identity fields.
+3. Add the new fields to canonical benchmark request CSV columns.
+4. Enrich collected benchmark request rows from matching job parameters during
+   export collection.
+5. Update `docs/benchmark-evaluation-contract.md`.
+6. Run focused tests, changed-scope coverage, and `git diff --check`.
+
+## Verification
+
+- `git diff --check`
+- Focused pytest:
+  - `services/mlx-worker-python/tests/test_benchmark_schemas.py`
+  - `services/mlx-worker-python/tests/test_benchmark_export.py`
+  - `services/mlx-worker-python/tests/test_benchmark_store.py`
+- Changed-scope coverage for modified Python files.
+
+## Known Gaps
+
+- This slice does not render base-vs-adapter delta tables in PR or benchmark
+  reports. That remains issue #713.

--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -694,6 +694,136 @@ def test_build_benchmark_requests_csv_exports_phase_rows(tmp_path: Path) -> None
     assert rows[0]["duration_ms"] == "24.45"
 
 
+def test_collect_benchmark_artifacts_enriches_request_rows_with_adapter_identity(
+    tmp_path: Path,
+) -> None:
+    _write_bench_fixtures(tmp_path)
+    (tmp_path / "bench-summary.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.serving_benchmark_job.v1",
+                "job_id": "bench-1",
+                "model_id": "melix-dev-text-lora-deadbeef",
+                "task_kind": "text-generation",
+                "source_repo": "local",
+                "parameters": {
+                    "runtime_model_id": "melix-dev-text-lora-deadbeef",
+                    "runtime_model_handle": "melix-dev-text-lora-deadbeef::loaded",
+                    "melix.derived_from_model_id": "melix-dev-text",
+                    "melix.adapter_manifest_path": "/tmp/melix/train_lora.adapter.json",
+                    "melix.adapter_set_hash": "deadbeefcafebabe",
+                    "melix.activation_mode": "adapter_backed_runtime",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = collect_benchmark_artifacts(tmp_path)
+    row = result["benchmark_request_rows"][0]
+
+    assert row["compare_target_kind"] == "adapter"
+    assert row["base_model_id"] == "melix-dev-text"
+    assert row["adapter_manifest_path"] == "/tmp/melix/train_lora.adapter.json"
+    assert row["adapter_set_hash"] == "deadbeefcafebabe"
+    assert row["adapter_activation_mode"] == "adapter_backed_runtime"
+
+    csv_rows = list(csv.DictReader(io.StringIO(build_benchmark_requests_csv(result))))
+    assert csv_rows[0]["compare_target_kind"] == "adapter"
+    assert csv_rows[0]["adapter_set_hash"] == "deadbeefcafebabe"
+    assert csv_rows[0]["tool_call_count"] == ""
+
+
+def test_collect_benchmark_artifacts_overrides_default_base_identity_for_adapter_rows(
+    tmp_path: Path,
+) -> None:
+    _write_bench_fixtures(tmp_path)
+    (tmp_path / "bench-summary.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.serving_benchmark_job.v1",
+                "job_id": "bench-1",
+                "model_id": "melix-dev-text-lora-deadbeef",
+                "parameters": {
+                    "derived_from_model_id": "melix-dev-text",
+                    "adapter_set_hash": "deadbeefcafebabe",
+                    "activation_mode": "adapter_backed_runtime",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    request_path = tmp_path / "bench-request-rows.jsonl"
+    request_row = json.loads(request_path.read_text(encoding="utf-8"))
+    request_row["model_id"] = "melix-dev-text-lora-deadbeef"
+    request_row["compare_target_kind"] = "base"
+    request_row["base_model_id"] = "melix-dev-text-lora-deadbeef"
+    request_path.write_text(json.dumps(request_row) + "\n", encoding="utf-8")
+
+    result = collect_benchmark_artifacts(tmp_path)
+    row = result["benchmark_request_rows"][0]
+
+    assert row["compare_target_kind"] == "adapter"
+    assert row["base_model_id"] == "melix-dev-text"
+    assert row["adapter_set_hash"] == "deadbeefcafebabe"
+
+
+def test_collect_benchmark_artifacts_does_not_treat_family_hash_as_adapter_identity(
+    tmp_path: Path,
+) -> None:
+    _write_bench_fixtures(tmp_path)
+    summary_path = tmp_path / "bench-summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["parameters"] = {"melix.adapter_set_hash": "text-family-llama"}
+    summary_path.write_text(json.dumps(summary) + "\n", encoding="utf-8")
+
+    result = collect_benchmark_artifacts(tmp_path)
+    row = result["benchmark_request_rows"][0]
+
+    assert row["compare_target_kind"] == "base"
+    assert row["base_model_id"] == "melix-dev-text"
+    assert row["adapter_set_hash"] == ""
+
+
+def test_collect_benchmark_artifacts_skips_request_row_annotation_without_metadata() -> None:
+    rows: list[dict[str, object]] = [
+        {
+            "schema_version": "melix.serving_benchmark_request_row.v1",
+            "job_id": "missing",
+            "model_id": "melix-dev-text",
+        },
+        {
+            "schema_version": "legacy.row",
+            "job_id": "bench-1",
+            "model_id": "melix-dev-text",
+        },
+    ]
+
+    benchmark_export_module._annotate_benchmark_request_rows(
+        rows,
+        summary_rows=[],
+    )
+    benchmark_export_module._annotate_benchmark_request_rows(
+        rows,
+        summary_rows=[{"job_id": "bench-1", "model_id": "melix-dev-text"}],
+    )
+
+    assert rows == [
+        {
+            "schema_version": "melix.serving_benchmark_request_row.v1",
+            "job_id": "missing",
+            "model_id": "melix-dev-text",
+        },
+        {
+            "schema_version": "legacy.row",
+            "job_id": "bench-1",
+            "model_id": "melix-dev-text",
+        },
+    ]
+
+
 def test_collect_benchmark_run_uses_single_directory_scan_without_path_is_file_probes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/services/mlx-worker-python/tests/test_benchmark_export.py
+++ b/services/mlx-worker-python/tests/test_benchmark_export.py
@@ -787,6 +787,29 @@ def test_collect_benchmark_artifacts_does_not_treat_family_hash_as_adapter_ident
     assert row["adapter_set_hash"] == ""
 
 
+def test_collect_benchmark_artifacts_clears_stale_adapter_identity_for_base_rows(
+    tmp_path: Path,
+) -> None:
+    _write_bench_fixtures(tmp_path)
+    request_path = tmp_path / "bench-request-rows.jsonl"
+    request_row = json.loads(request_path.read_text(encoding="utf-8"))
+    request_row["compare_target_kind"] = "adapter"
+    request_row["base_model_id"] = "melix-dev-text-base"
+    request_row["adapter_manifest_path"] = "/tmp/stale.adapter.json"
+    request_row["adapter_set_hash"] = "text-family-llama"
+    request_row["adapter_activation_mode"] = "stale"
+    request_path.write_text(json.dumps(request_row) + "\n", encoding="utf-8")
+
+    result = collect_benchmark_artifacts(tmp_path)
+    row = result["benchmark_request_rows"][0]
+
+    assert row["compare_target_kind"] == "base"
+    assert row["base_model_id"] == "melix-dev-text"
+    assert row["adapter_manifest_path"] == ""
+    assert row["adapter_set_hash"] == ""
+    assert row["adapter_activation_mode"] == ""
+
+
 def test_collect_benchmark_artifacts_skips_request_row_annotation_without_metadata() -> None:
     rows: list[dict[str, object]] = [
         {

--- a/services/mlx-worker-python/tests/test_benchmark_schemas.py
+++ b/services/mlx-worker-python/tests/test_benchmark_schemas.py
@@ -614,12 +614,50 @@ def test_serving_benchmark_request_rows_preserve_tool_turn_and_final_answer_phas
         "observation_bytes": 42,
         "fatal_rate": 0.0,
         "turn_count": 2,
+        "compare_target_kind": "base",
+        "base_model_id": "melix-dev-text",
+        "adapter_manifest_path": "",
+        "adapter_set_hash": "",
+        "adapter_activation_mode": "",
         "created_at_unix_ms": 101,
     }
     assert final_answer["phase"] == "final_answer"
     assert final_answer["tool_call_id"] == ""
     assert final_answer["tool_call_count"] == 1
     assert final_answer["tokens_out"] == 16
+
+
+def test_serving_benchmark_request_rows_preserve_adapter_compare_identity() -> None:
+    row = build_serving_benchmark_request_row(
+        job_id="bench-adapter",
+        model_id="melix-dev-text-lora-deadbeef",
+        task_kind="text-generation",
+        source_repo="local",
+        suite="agentic_visit",
+        context_length=64,
+        generation_length=16,
+        batch_size=1,
+        repeat_index=0,
+        request_index=0,
+        phase="tool_turn",
+        phase_index=0,
+        status="completed",
+        tool_call_count=1,
+        tool_latency_ms=5.5,
+        compare_target_kind="adapter",
+        base_model_id="melix-dev-text",
+        adapter_manifest_path="/tmp/melix/train_lora.adapter.json",
+        adapter_set_hash="deadbeefcafebabe",
+        adapter_activation_mode="adapter_backed_runtime",
+    ).to_dict()
+
+    assert row["compare_target_kind"] == "adapter"
+    assert row["base_model_id"] == "melix-dev-text"
+    assert row["adapter_manifest_path"] == "/tmp/melix/train_lora.adapter.json"
+    assert row["adapter_set_hash"] == "deadbeefcafebabe"
+    assert row["adapter_activation_mode"] == "adapter_backed_runtime"
+    assert row["tool_call_count"] == 1
+    assert row["tool_latency_ms"] == 5.5
 
 
 def test_benchmark_matrix_tool_turn_summary_fields_aggregate_requests() -> None:

--- a/services/mlx-worker-python/tests/test_benchmark_store.py
+++ b/services/mlx-worker-python/tests/test_benchmark_store.py
@@ -240,7 +240,70 @@ def test_persist_serving_benchmark_writes_request_phase_rows_and_exports(
     ]
     request_csv_rows = list(csv.DictReader(build_benchmark_requests_csv(export_bundle).splitlines()))
     assert request_csv_rows[0]["tool_call_id"] == "visit-1"
+    assert request_csv_rows[0]["compare_target_kind"] == "base"
+    assert request_csv_rows[0]["base_model_id"] == "melix-dev-text"
     assert request_csv_rows[1]["phase"] == "final_answer"
+
+
+def test_persist_serving_benchmark_request_rows_attach_adapter_identity(
+    tmp_path: Path,
+) -> None:
+    store = BenchmarkStore(telemetry_collector=fixture_telemetry_collector())
+    jobs_root = tmp_path / "bench"
+    job = build_serving_benchmark_job(
+        job_id="bench-adapter",
+        model_id="melix-dev-text-lora-deadbeef",
+        task_kind="text-generation",
+        source_repo="local",
+        suites=("agentic_visit",),
+        parameters={
+            "melix.derived_from_model_id": "melix-dev-text",
+            "melix.adapter_manifest_path": "/tmp/melix/train_lora.adapter.json",
+            "melix.adapter_set_hash": "deadbeefcafebabe",
+            "melix.activation_mode": "adapter_backed_runtime",
+        },
+        status="completed",
+        output_dir=str(jobs_root),
+    )
+    results = build_serving_benchmark_results(
+        job_id="bench-adapter",
+        metrics={"bench.agentic_visit.ttft_ms": 24.45},
+        units={"bench.agentic_visit.ttft_ms": "ms"},
+        report_path=str(jobs_root / "bench-report.md"),
+        report_markdown="# Melix Bench\n",
+    )
+    request_row = build_serving_benchmark_request_row(
+        job_id="bench-adapter",
+        model_id="melix-dev-text-lora-deadbeef",
+        task_kind="text-generation",
+        source_repo="local",
+        suite="agentic_visit",
+        context_length=64,
+        generation_length=16,
+        batch_size=1,
+        repeat_index=0,
+        request_index=0,
+        phase="tool_turn",
+        phase_index=0,
+        status="completed",
+        tool_call_count=1,
+        tool_latency_ms=5.5,
+        created_at_unix_ms=101,
+    )
+
+    persisted = store.persist_serving_benchmark(
+        jobs_root=jobs_root,
+        job=job,
+        results=results,
+        request_rows=(request_row,),
+    )
+
+    jsonl_row = json.loads(persisted["request_rows_jsonl"].read_text(encoding="utf-8").splitlines()[0])
+    assert jsonl_row["compare_target_kind"] == "adapter"
+    assert jsonl_row["base_model_id"] == "melix-dev-text"
+    assert jsonl_row["adapter_manifest_path"] == "/tmp/melix/train_lora.adapter.json"
+    assert jsonl_row["adapter_set_hash"] == "deadbeefcafebabe"
+    assert jsonl_row["adapter_activation_mode"] == "adapter_backed_runtime"
 
 
 def test_persist_serving_benchmark_derives_request_phase_rows_from_context_rows(
@@ -334,6 +397,8 @@ def test_persist_serving_benchmark_derives_request_phase_rows_from_context_rows(
     assert request_rows[0]["observation_bytes"] == 64
     assert request_rows[0]["tool_latency_ms"] == 5.5
     assert request_rows[0]["trajectory_dataset_id"] == "opensearch-vl.dev"
+    assert request_rows[0]["compare_target_kind"] == "base"
+    assert request_rows[0]["base_model_id"] == "melix-dev-text"
     assert request_rows[1]["phase_index"] == 1
     assert request_rows[1]["request_latency_ms"] == 42.8
     assert request_rows[1]["tokens_out"] == 16

--- a/services/mlx-worker-python/tests/test_benchmark_store.py
+++ b/services/mlx-worker-python/tests/test_benchmark_store.py
@@ -306,6 +306,64 @@ def test_persist_serving_benchmark_request_rows_attach_adapter_identity(
     assert jsonl_row["adapter_activation_mode"] == "adapter_backed_runtime"
 
 
+def test_persist_serving_benchmark_clears_stale_adapter_identity_for_base_rows(
+    tmp_path: Path,
+) -> None:
+    store = BenchmarkStore(telemetry_collector=fixture_telemetry_collector())
+    jobs_root = tmp_path / "bench"
+    job = build_serving_benchmark_job(
+        job_id="bench-base",
+        model_id="melix-dev-text",
+        task_kind="text-generation",
+        source_repo="local",
+        suites=("agentic_visit",),
+        parameters={},
+        status="completed",
+        output_dir=str(jobs_root),
+    )
+    results = build_serving_benchmark_results(
+        job_id="bench-base",
+        metrics={"bench.agentic_visit.ttft_ms": 24.45},
+        units={"bench.agentic_visit.ttft_ms": "ms"},
+        report_path=str(jobs_root / "bench-report.md"),
+        report_markdown="# Melix Bench\n",
+    )
+    request_row = build_serving_benchmark_request_row(
+        job_id="bench-base",
+        model_id="melix-dev-text",
+        task_kind="text-generation",
+        source_repo="local",
+        suite="agentic_visit",
+        context_length=64,
+        generation_length=16,
+        batch_size=1,
+        repeat_index=0,
+        request_index=0,
+        phase="final_answer",
+        phase_index=0,
+        status="completed",
+        compare_target_kind="adapter",
+        base_model_id="melix-dev-text-base",
+        adapter_manifest_path="/tmp/stale.adapter.json",
+        adapter_set_hash="text-family-llama",
+        adapter_activation_mode="stale",
+    )
+
+    persisted = store.persist_serving_benchmark(
+        jobs_root=jobs_root,
+        job=job,
+        results=results,
+        request_rows=(request_row,),
+    )
+
+    jsonl_row = json.loads(persisted["request_rows_jsonl"].read_text(encoding="utf-8").splitlines()[0])
+    assert jsonl_row["compare_target_kind"] == "base"
+    assert jsonl_row["base_model_id"] == "melix-dev-text"
+    assert jsonl_row["adapter_manifest_path"] == ""
+    assert jsonl_row["adapter_set_hash"] == ""
+    assert jsonl_row["adapter_activation_mode"] == ""
+
+
 def test_persist_serving_benchmark_derives_request_phase_rows_from_context_rows(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -779,7 +779,13 @@ def _collect_benchmark_run(
         batch_rows.extend(_try_iter_jsonl_dict_rows(batch_path))
 
     if request_rows is not None and request_path is not None:
-        request_rows.extend(_try_iter_jsonl_dict_rows(request_path))
+        current_request_rows = list(_try_iter_jsonl_dict_rows(request_path))
+        request_rows.extend(current_request_rows)
+        if current_request_rows:
+            _annotate_benchmark_request_rows(
+                current_request_rows,
+                summary_rows=summary_rows,
+            )
 
     for result_path in result_paths:
         result_row = _try_load_json_object(result_path)
@@ -830,6 +836,96 @@ def _collect_benchmark_matrix_run(
 
     if requests_path is not None:
         request_rows.extend(_iter_jsonl_dict_rows(requests_path))
+
+
+def _annotate_benchmark_request_rows(
+    request_rows: list[dict[str, object]],
+    *,
+    summary_rows: list[dict[str, object]],
+) -> None:
+    if not request_rows or not summary_rows:
+        return
+    metadata_by_job_id = {
+        str(row.get("job_id", "")): _benchmark_compare_identity(row)
+        for row in summary_rows
+        if isinstance(row, dict) and row.get("job_id")
+    }
+    for row in request_rows:
+        if not isinstance(row, dict):
+            continue
+        if row.get("schema_version") != "melix.serving_benchmark_request_row.v1":
+            continue
+        metadata = metadata_by_job_id.get(str(row.get("job_id", "")))
+        if not metadata:
+            continue
+        metadata_is_adapter = metadata["compare_target_kind"] == "adapter"
+        for key, value in metadata.items():
+            if (
+                metadata_is_adapter
+                and key == "compare_target_kind"
+                and row.get(key) == "base"
+            ):
+                row[key] = value
+                continue
+            if (
+                metadata_is_adapter
+                and key == "base_model_id"
+                and row.get(key) == row.get("model_id")
+            ):
+                row[key] = value
+                continue
+            if row.get(key):
+                continue
+            row[key] = value
+
+
+def _benchmark_compare_identity(job_row: dict[str, object]) -> dict[str, str]:
+    parameters = job_row.get("parameters")
+    params = parameters if isinstance(parameters, dict) else {}
+    adapter_manifest_path = _metadata_value(
+        params,
+        "melix.adapter_manifest_path",
+        "adapter_manifest_path",
+        "runtime_adapter_manifest_path",
+    )
+    adapter_set_hash = _metadata_value(
+        params,
+        "melix.adapter_set_hash",
+        "adapter_set_hash",
+        "runtime_adapter_set_hash",
+    )
+    activation_mode = _metadata_value(
+        params,
+        "melix.activation_mode",
+        "adapter_activation_mode",
+        "activation_mode",
+    )
+    base_model_id = _metadata_value(
+        params,
+        "melix.derived_from_model_id",
+        "derived_from_model_id",
+        "base_model_id",
+    )
+    has_adapter_lineage = bool(adapter_manifest_path or activation_mode or base_model_id)
+    compare_target_kind = "adapter" if has_adapter_lineage else "base"
+    if not base_model_id:
+        base_model_id = str(job_row.get("model_id", ""))
+    return {
+        "compare_target_kind": compare_target_kind,
+        "base_model_id": base_model_id,
+        "adapter_manifest_path": adapter_manifest_path,
+        "adapter_set_hash": adapter_set_hash if has_adapter_lineage else "",
+        "adapter_activation_mode": activation_mode,
+    }
+
+
+def _metadata_value(payload: dict[object, object], *keys: str) -> str:
+    for key in keys:
+        raw_value = payload.get(key, "")
+        value = str(raw_value or "").strip()
+        if value:
+            return value
+    return ""
 
 
 def _iter_jsonl_dict_rows(path: Path) -> Iterator[dict[str, object]]:
@@ -975,6 +1071,11 @@ def _canonical_benchmark_request_columns() -> list[str]:
         "observation_bytes",
         "fatal_rate",
         "turn_count",
+        "compare_target_kind",
+        "base_model_id",
+        "adapter_manifest_path",
+        "adapter_set_hash",
+        "adapter_activation_mode",
         "created_at_unix_ms",
         *TRAJECTORY_PROVENANCE_CSV_FIELDS,
     ]

--- a/services/mlx-worker-python/worker/productization/benchmark_export.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_export.py
@@ -859,17 +859,22 @@ def _annotate_benchmark_request_rows(
         if not metadata:
             continue
         metadata_is_adapter = metadata["compare_target_kind"] == "adapter"
+        if not metadata_is_adapter:
+            row["compare_target_kind"] = "base"
+            row["base_model_id"] = metadata["base_model_id"] or str(row.get("model_id", ""))
+            row["adapter_manifest_path"] = ""
+            row["adapter_set_hash"] = ""
+            row["adapter_activation_mode"] = ""
+            continue
         for key, value in metadata.items():
             if (
-                metadata_is_adapter
-                and key == "compare_target_kind"
+                key == "compare_target_kind"
                 and row.get(key) == "base"
             ):
                 row[key] = value
                 continue
             if (
-                metadata_is_adapter
-                and key == "base_model_id"
+                key == "base_model_id"
                 and row.get(key) == row.get("model_id")
             ):
                 row[key] = value

--- a/services/mlx-worker-python/worker/productization/benchmark_schemas.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_schemas.py
@@ -386,6 +386,11 @@ class ServingBenchmarkRequestRow:
     observation_bytes: int = 0
     fatal_rate: float = 0.0
     turn_count: int = 0
+    compare_target_kind: str = "base"
+    base_model_id: str = ""
+    adapter_manifest_path: str = ""
+    adapter_set_hash: str = ""
+    adapter_activation_mode: str = ""
     created_at_unix_ms: int = 0
     trajectory_provenance: dict[str, object] | None = None
 
@@ -432,6 +437,11 @@ class ServingBenchmarkRequestRow:
             "observation_bytes": self.observation_bytes,
             "fatal_rate": self.fatal_rate,
             "turn_count": self.turn_count,
+            "compare_target_kind": self.compare_target_kind,
+            "base_model_id": self.base_model_id,
+            "adapter_manifest_path": self.adapter_manifest_path,
+            "adapter_set_hash": self.adapter_set_hash,
+            "adapter_activation_mode": self.adapter_activation_mode,
             "created_at_unix_ms": self.created_at_unix_ms,
         }
         append_trajectory_provenance(payload, self.trajectory_provenance)
@@ -879,6 +889,11 @@ def build_serving_benchmark_request_row(
     observation_bytes: int = 0,
     fatal_rate: float = 0.0,
     turn_count: int = 0,
+    compare_target_kind: str = "base",
+    base_model_id: str = "",
+    adapter_manifest_path: str = "",
+    adapter_set_hash: str = "",
+    adapter_activation_mode: str = "",
     agentic_tool_metrics: dict[str, float] | None = None,
     created_at_unix_ms: int = 0,
     trajectory_provenance: dict[str, object] | None = None,
@@ -890,6 +905,14 @@ def build_serving_benchmark_request_row(
         observation_bytes=observation_bytes,
         fatal_rate=fatal_rate,
         turn_count=turn_count,
+    )
+    resolved_compare_target_kind = (
+        compare_target_kind
+        or ("adapter" if adapter_manifest_path or adapter_set_hash else "base")
+    )
+    resolved_base_model_id = (
+        base_model_id
+        or (model_id if resolved_compare_target_kind == "base" else "")
     )
     return ServingBenchmarkRequestRow(
         schema_version=_SERVING_BENCHMARK_REQUEST_ROW_SCHEMA_VERSION,
@@ -933,6 +956,11 @@ def build_serving_benchmark_request_row(
         observation_bytes=int(agentic_fields["observation_bytes"]),
         fatal_rate=float(agentic_fields["fatal_rate"]),
         turn_count=int(agentic_fields["turn_count"]),
+        compare_target_kind=resolved_compare_target_kind,
+        base_model_id=resolved_base_model_id,
+        adapter_manifest_path=adapter_manifest_path,
+        adapter_set_hash=adapter_set_hash,
+        adapter_activation_mode=adapter_activation_mode,
         created_at_unix_ms=created_at_unix_ms,
         trajectory_provenance=dict(trajectory_provenance or {}),
     )

--- a/services/mlx-worker-python/worker/productization/benchmark_store.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_store.py
@@ -357,26 +357,41 @@ class BenchmarkStore:
     ) -> tuple[ServingBenchmarkRequestRow, ...]:
         metadata = _benchmark_compare_identity(job.to_dict())
         metadata_is_adapter = metadata["compare_target_kind"] == "adapter"
-        return tuple(
-            replace(
-                row,
-                compare_target_kind=(
-                    metadata["compare_target_kind"]
-                    if metadata_is_adapter and row.compare_target_kind == "base"
-                    else row.compare_target_kind or metadata["compare_target_kind"]
-                ),
-                base_model_id=(
-                    metadata["base_model_id"]
-                    if metadata_is_adapter and row.base_model_id == row.model_id
-                    else row.base_model_id or metadata["base_model_id"]
-                ),
-                adapter_manifest_path=row.adapter_manifest_path or metadata["adapter_manifest_path"],
-                adapter_set_hash=row.adapter_set_hash or metadata["adapter_set_hash"],
-                adapter_activation_mode=row.adapter_activation_mode or metadata["adapter_activation_mode"],
+        rows: list[ServingBenchmarkRequestRow] = []
+        for row in (row for row in request_rows if isinstance(row, ServingBenchmarkRequestRow)):
+            if not metadata_is_adapter:
+                rows.append(
+                    replace(
+                        row,
+                        compare_target_kind="base",
+                        base_model_id=metadata["base_model_id"] or row.model_id,
+                        adapter_manifest_path="",
+                        adapter_set_hash="",
+                        adapter_activation_mode="",
+                    )
+                )
+                continue
+            rows.append(
+                replace(
+                    row,
+                    compare_target_kind=(
+                        metadata["compare_target_kind"]
+                        if row.compare_target_kind == "base"
+                        else row.compare_target_kind or metadata["compare_target_kind"]
+                    ),
+                    base_model_id=(
+                        metadata["base_model_id"]
+                        if row.base_model_id == row.model_id
+                        else row.base_model_id or metadata["base_model_id"]
+                    ),
+                    adapter_manifest_path=row.adapter_manifest_path
+                    or metadata["adapter_manifest_path"],
+                    adapter_set_hash=row.adapter_set_hash or metadata["adapter_set_hash"],
+                    adapter_activation_mode=row.adapter_activation_mode
+                    or metadata["adapter_activation_mode"],
+                )
             )
-            for row in request_rows
-            if isinstance(row, ServingBenchmarkRequestRow)
-        )
+        return tuple(rows)
 
     def persist_benchmark_matrix(
         self,

--- a/services/mlx-worker-python/worker/productization/benchmark_store.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_store.py
@@ -13,6 +13,7 @@ from worker.productization.apple_silicon_telemetry import (
     NoOpAppleSiliconTelemetryCollector,
 )
 from worker.productization.benchmark_export import (
+    _benchmark_compare_identity,
     _canonical_benchmark_request_columns,
     _canonical_benchmark_matrix_request_columns,
     _canonical_benchmark_matrix_summary_columns,
@@ -171,6 +172,11 @@ class BenchmarkStore:
         request_rows_tuple = tuple(request_rows)
         if not request_rows_tuple:
             request_rows_tuple = self._request_rows_from_context_rows(context_rows_tuple)
+        if request_rows_tuple:
+            request_rows_tuple = self._attach_request_compare_identity(
+                job=job,
+                request_rows=request_rows_tuple,
+            )
         if request_rows_tuple:
             request_rows_jsonl_path = jobs_root / "bench-request-rows.jsonl"
             request_rows_csv_path = jobs_root / "bench-request-rows.csv"
@@ -342,6 +348,35 @@ class BenchmarkStore:
             )
             request_index += 1
         return tuple(rows)
+
+    @staticmethod
+    def _attach_request_compare_identity(
+        *,
+        job: ServingBenchmarkJob,
+        request_rows: tuple[ServingBenchmarkRequestRow, ...],
+    ) -> tuple[ServingBenchmarkRequestRow, ...]:
+        metadata = _benchmark_compare_identity(job.to_dict())
+        metadata_is_adapter = metadata["compare_target_kind"] == "adapter"
+        return tuple(
+            replace(
+                row,
+                compare_target_kind=(
+                    metadata["compare_target_kind"]
+                    if metadata_is_adapter and row.compare_target_kind == "base"
+                    else row.compare_target_kind or metadata["compare_target_kind"]
+                ),
+                base_model_id=(
+                    metadata["base_model_id"]
+                    if metadata_is_adapter and row.base_model_id == row.model_id
+                    else row.base_model_id or metadata["base_model_id"]
+                ),
+                adapter_manifest_path=row.adapter_manifest_path or metadata["adapter_manifest_path"],
+                adapter_set_hash=row.adapter_set_hash or metadata["adapter_set_hash"],
+                adapter_activation_mode=row.adapter_activation_mode or metadata["adapter_activation_mode"],
+            )
+            for row in request_rows
+            if isinstance(row, ServingBenchmarkRequestRow)
+        )
 
     def persist_benchmark_matrix(
         self,


### PR DESCRIPTION
## Summary
- Add additive base/adapter comparison identity fields to serving benchmark request rows and request CSV exports.
- Enrich collected benchmark request rows from matching benchmark job parameters so exported tool-turn performance rows can be grouped by base model, adapter manifest, adapter hash, and activation mode.
- Normalize base benchmark request rows by clearing stale adapter-only fields, with regression coverage for store persistence and export collection.

Closes #712.

## Plan or Spec
- `docs/plans/2026-05-21-agentic-lora-benchmark-identity.md`
- `docs/benchmark-evaluation-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_store.py::test_persist_serving_benchmark_clears_stale_adapter_identity_for_base_rows services/mlx-worker-python/tests/test_benchmark_export.py::test_collect_benchmark_artifacts_clears_stale_adapter_identity_for_base_rows
# RED before fix: 2 failed
# GREEN after fix: 2 passed in 0.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_schemas.py services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_benchmark_store.py
# 106 passed in 0.64s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/agentic_lora_benchmark_identity_review.coverage -m pytest -q services/mlx-worker-python/tests/test_benchmark_schemas.py services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_benchmark_store.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/agentic_lora_benchmark_identity_review.coverage -o /tmp/agentic_lora_benchmark_identity_review_coverage.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/agentic_lora_benchmark_identity_review_coverage.json services/mlx-worker-python/worker/productization/benchmark_export.py services/mlx-worker-python/worker/productization/benchmark_store.py services/mlx-worker-python/tests/test_benchmark_export.py services/mlx-worker-python/tests/test_benchmark_store.py
# TOTAL 44 0 100%

git diff --check
# pass

git commit -m "Normalize base benchmark request identity"
# pre-commit ran make swift-test, make py-test, make integration-test, and PR-scoped performance
# make swift-test: rc=0, elapsed=191.1s
# make py-test: 2921 passed, 14 skipped, 2 warnings in 123.77s
# make integration-test: 114 passed, 1 skipped in 314.80s
# PR-scoped performance: status ok, regressions 0, verification failures 0
```

GitHub Actions after `3053d239`:
```text
actionlint-and-diffcheck: pass
pr-evidence: pass
ci-scope: pass
python-tests: pass
swift-tests-report: pass
pr-scoped-performance scope/probes/report: pass
```

## Coverage and Metrics
- Changed-scope coverage for the review fix:
  - `benchmark_export.py`: 100.00%
  - `benchmark_store.py`: 100.00%
  - `test_benchmark_export.py`: 100.00%
  - `test_benchmark_store.py`: 100.00%
  - Aggregate: `TOTAL 44 0 100%`
- Local pre-commit performance report: `.runtime/pre-commit-performance/20260520-231603-6fc065ff/report/report.md`
- Local performance report status: `ok`; selected probes `2`; direct/gated probes `2`; regressions `0`; verification failures `0`.
- Latest GitHub PR-scoped performance comment after `3053d239`: `Status: ok`; regressions `0`; verification failures `0`.
- Latest GitHub probe metrics:
  - Benchmark export run-scan single pass: elapsed -0.48%, per-run -0.48%, CSV elapsed +0.46%; all neutral.
  - Benchmark store matrix streaming: peak bytes +0.62%; neutral.

## Known Gaps
- Base-vs-adapter delta table rendering remains out of scope for this unit and is tracked by #713.
- This slice uses benchmark job parameters as the adapter metadata source; it does not change runtime evidence collection.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema change.
- [x] Dependency changes include updated lockfiles. N/A: no dependency change.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
