### PR TITLE
perf: bind tool config constructor for template copies

### DIFF
--- a/docs/plans/2026-05-20-tool-config-template-constructor-binding.md
+++ b/docs/plans/2026-05-20-tool-config-template-constructor-binding.md
@@ -1,0 +1,39 @@
+# Tool config template constructor binding slice
+
+## Scope
+
+This Python-only performance slice targets repeated built-in tool config copies in
+`services/mlx-worker-python/worker/runtime/tool_registry.py`.
+
+The behavior remains unchanged: `built_in_tool_config(...)` still returns an
+isolated protobuf `ToolConfig` instance for the default registry and for cached
+selections. The optimization only binds the protobuf `ToolConfig` constructor at
+module import time so the hot copy helper avoids a repeated nested module
+attribute lookup before `CopyFrom(...)`.
+
+## Registered probe
+
+Affected path coverage is provided by the registered PR-scoped probe
+`tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`.
+The entry already includes focused `test_command`, `coverage_command`, and
+`probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_schema_bytes_probe.py`
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage command, and registered
+probe locally on Linux before opening the PR. The PR-scoped performance workflow
+must select and complete the registered probe in CI before merge.
+
+## Success criteria
+
+- Focused tool registry tests pass.
+- Changed-scope coverage for touched Python files remains at or above the
+  repository threshold.
+- The registered probe reports a lower or non-regressed
+  `built_in_tool_config_elapsed_ms_mean` / related tool-config copy metrics.
+- GitHub Actions and the PR-scoped performance workflow are green before merge.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -8,12 +8,13 @@ from typing import Any
 from packages.protocol.python.worker.v1 import common_pb2
 
 
-_TOOL_CONFIG_FROM_BYTES = common_pb2.ToolConfig.FromString
+_TOOL_CONFIG = common_pb2.ToolConfig
+_TOOL_CONFIG_FROM_BYTES = _TOOL_CONFIG.FromString
 _COMPACT_SORTED_JSON_ENCODER = json.JSONEncoder(separators=(",", ":"), sort_keys=True)
 
 
 def _copy_tool_config(template: common_pb2.ToolConfig) -> common_pb2.ToolConfig:
-    config = common_pb2.ToolConfig()
+    config = _TOOL_CONFIG()
     config.CopyFrom(template)
     return config
 _TOOL_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")


### PR DESCRIPTION
## Summary
- Bind the protobuf `ToolConfig` constructor once in `tool_registry.py`.
- Reuse that binding in the hot `_copy_tool_config(...)` helper used by built-in tool config template copies.
- Add the governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-05-20-tool-config-template-constructor-binding.md`
- Registered probe: `tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=80000 MELIX_TOOL_REGISTRY_METRICS_SAMPLES=9 uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-schema-bytes-cache --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-tool-config-template-frombytes-20260520 --head-repo "$PWD" --output /tmp/tool_config_template_probe_80k.json`

## Coverage and Metrics
- Focused tests: 52 passed.
- Changed-scope coverage: 100% (`TOTAL 3 0 100%`).
- Local registered probe (`tool-registry-schema-bytes-cache`, 80k iterations x 9 samples):
  - `built_in_tool_config_elapsed_ms_mean`: 113.496438 -> 109.724303 ms (-3.324%)
  - `full_selection_tool_config_elapsed_ms_mean`: 124.026251 -> 115.588450 ms (-6.803%)
  - `partial_selection_tool_config_elapsed_ms_mean`: 100.194361 -> 97.651858 ms (-2.538%)
  - `elapsed_ms_mean`: 8.679405 -> 8.525904 ms (-1.769%)
  - `schema_payload_elapsed_ms_mean`: 293.141969 -> 307.169282 ms (+4.785%, unrelated measurement path and under the 5% warn threshold)

## Known Gaps
- Python-only change; no Swift runtime performance claim is made.
- CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally on Linux.
- [x] Changed-scope coverage passed locally on Linux.
- [x] Registered probe ran locally on Linux with base/head metrics.
- [ ] GitHub Actions completed successfully.
- [ ] PR-scoped performance workflow completed successfully.
