### PR TITLE
perf: trim statistical category breakdown overhead

### DIFF
--- a/docs/plans/2026-05-21-statistical-category-local-bindings.md
+++ b/docs/plans/2026-05-21-statistical-category-local-bindings.md
@@ -1,0 +1,43 @@
+# Statistical Evidence Category Breakdown Local Bindings
+
+## Goal
+
+Reduce per-row overhead in `build_category_breakdown()` while preserving category
+filtering, missing-key handling, deterministic ordering, and rounded accuracy
+payloads.
+
+## Linux constraint
+
+This is a Python worker/productization slice and is locally verifiable on Linux
+with focused pytest, changed-scope coverage, and the registered PR-scoped
+performance probe.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`statistical-evidence-category-breakdown-single-pass` in
+`infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`,
+`coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/statistical_evidence.py`
+- `services/mlx-worker-python/tests/test_statistical_evidence.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/statistical_evidence_category_breakdown_probe.py`
+
+## Optimization
+
+Bind the category totals lookup, string type, and rounding helper once per
+function call instead of resolving them repeatedly in the hot row loop or output
+materialization loop. For the common probe workload where included rows carry
+both correctness keys, use direct key reads with `KeyError` fallback so missing
+correctness fields still count as false without paying `dict.get()` method
+lookup overhead on every included row.
+
+## Success metrics
+
+- Focused statistical evidence pytest and PR-scoped probe tests pass.
+- Changed-scope coverage for touched executable Python/test/probe files remains
+  at least 95%.
+- The local registered probe reports lower `elapsed_ms_mean` versus the
+  pre-change baseline while preserving checksum, row count, and category count.
+- GitHub Actions PR-scoped performance completes successfully before merge.

--- a/services/mlx-worker-python/tests/test_statistical_evidence.py
+++ b/services/mlx-worker-python/tests/test_statistical_evidence.py
@@ -323,16 +323,24 @@ def test_build_category_breakdown_aggregates_supported_categories_only() -> None
             {"category_label": "math", "base_correct": False, "target_correct": True},
             {"category_label": "math", "base_correct": True, "target_correct": True},
             {"category_label": "history", "base_correct": True, "target_correct": False},
+            {"category_label": "history"},
+            {"category_label": 7, "base_correct": False, "target_correct": True},
             {"category_label": "", "base_correct": True, "target_correct": True},
         )
     )
 
     assert breakdown == {
-        "history": {
+        "7": {
             "sample_size": 1,
-            "base_accuracy": 1.0,
+            "base_accuracy": 0.0,
+            "target_accuracy": 1.0,
+            "delta_accuracy": 1.0,
+        },
+        "history": {
+            "sample_size": 2,
+            "base_accuracy": 0.5,
             "target_accuracy": 0.0,
-            "delta_accuracy": -1.0,
+            "delta_accuracy": -0.5,
         },
         "math": {
             "sample_size": 2,

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -83,39 +83,47 @@ def build_category_breakdown(
     rows: tuple[dict[str, object], ...],
 ) -> dict[str, dict[str, object]]:
     category_totals: dict[str, list[int]] = {}
+    category_totals_get = category_totals.get
+    string_type = str
     for row in rows:
         try:
             raw_category_label = row["category_label"]
         except KeyError:
             continue
-        category_label = (
-            raw_category_label.strip()
-            if isinstance(raw_category_label, str)
-            else str(raw_category_label).strip()
-        )
+        if isinstance(raw_category_label, string_type):
+            category_label = raw_category_label.strip()
+        else:
+            category_label = string_type(raw_category_label).strip()
         if not category_label:
             continue
-        totals = category_totals.get(category_label)
+        totals = category_totals_get(category_label)
         if totals is None:
             totals = [0, 0, 0]
             category_totals[category_label] = totals
         totals[0] += 1
-        if row.get("base_correct", False):
-            totals[1] += 1
-        if row.get("target_correct", False):
-            totals[2] += 1
+        try:
+            if row["base_correct"]:
+                totals[1] += 1
+        except KeyError:
+            pass
+        try:
+            if row["target_correct"]:
+                totals[2] += 1
+        except KeyError:
+            pass
 
     breakdown: dict[str, dict[str, object]] = {}
+    rounded = _rounded
     for category_label, totals in sorted(category_totals.items()):
         sample_size, base_correct, target_correct = totals
         inverse_sample_size = 1.0 / sample_size
-        base_accuracy = _rounded(base_correct * inverse_sample_size)
-        target_accuracy = _rounded(target_correct * inverse_sample_size)
+        base_accuracy = rounded(base_correct * inverse_sample_size)
+        target_accuracy = rounded(target_correct * inverse_sample_size)
         breakdown[category_label] = {
             "sample_size": sample_size,
             "base_accuracy": base_accuracy,
             "target_accuracy": target_accuracy,
-            "delta_accuracy": _rounded(target_accuracy - base_accuracy),
+            "delta_accuracy": rounded(target_accuracy - base_accuracy),
         }
     return breakdown
 


### PR DESCRIPTION
## Summary
- Trim `build_category_breakdown()` hot-loop overhead by binding repeated lookups once per call.
- Preserve missing correctness-key fallback behavior and non-string category label normalization.
- Add a focused plan for the category-breakdown performance slice.

## Plan or Spec
- `docs/plans/2026-05-21-statistical-category-local-bindings.md`

## Commands Run
```text
# Baseline registered probe samples on origin/main (local Linux)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_category_breakdown_probe.py
# 3 runs: elapsed_ms_mean=[13.163383165374398, 11.206014966592193, 11.273659719154239], mean=11.881019283706943

# Head registered probe samples (local Linux)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_category_breakdown_probe.py
# 3 runs: elapsed_ms_mean=[12.08991901949048, 10.68567642942071, 10.44983584433794], mean=11.075143764416376

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_statistical_evidence.py::test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics
# 6 passed in 0.13s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_statistical_evidence.py::test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_category_breakdown_probe.py
# TOTAL 19 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_category_breakdown_probe.py
# {"category_count": 64.0, "checksum": 250365.72, "elapsed_ms_mean": 10.675412975251675, "peak_bytes_mean": 17040.0, "row_count": 50000.0, "sample_count": 5.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 19 0 100%`.
- Registered local probe: `statistical-evidence-category-breakdown-single-pass`.
- Local elapsed comparison: old_mean=11.881019 ms, new_mean=11.075144 ms, delta=-0.805876 ms, speedup=6.78%.
- Structural parity: checksum stayed `250365.72`, row_count stayed `50000`, category_count stayed `64`.
- Peak memory: old_mean=16968 bytes, new_mean=17040 bytes (+72 bytes, within the probe's 5% tolerance).
- CI PR-scoped performance is still required as the merge gate.

## Known Gaps
- Local validation is Linux/Python-only; GitHub Actions registered probe report remains the source of truth before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
