### PR TITLE
perf: shortcut labeled hub size hints

### DIFF
--- a/docs/plans/2026-05-21-hub-catalog-size-hint-direct-label.md
+++ b/docs/plans/2026-05-21-hub-catalog-size-hint-direct-label.md
@@ -1,0 +1,32 @@
+# Hub Catalog Direct Model-Size Label Performance Slice
+
+## Scope
+
+Optimize only the Hub catalog `cardData.model_size` parsing path in
+`services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+
+## Registered Probe
+
+The governing PR-scoped registered probe is
+`hub-catalog-size-hint-regex-precompile` in
+`infra/perf/pr_scoped_probes.json`. It already defines focused
+`test_command`, `coverage_command`, and `probe_command` entries for the Hub
+catalog size-hint path.
+
+## Slice Plan
+
+1. Keep the existing regex-backed fallback semantics for non-direct text fields.
+2. Add a direct parser for common `cardData.model_size` values that include the
+   literal `Model size` label before the numeric size.
+3. Update the registered probe payload to include the labeled direct-card form so
+   CI and local reports measure the regex-call elision.
+4. Verify focused Hub catalog tests, changed-scope coverage, and the registered
+   probe locally on Linux before opening the PR.
+
+## Success Metrics
+
+- `size_hint_calls_mean` should drop for the updated registered probe because
+  labeled direct-card values no longer need `_size_hint_from_text`.
+- `elapsed_ms_mean` is lower-is-better and should not regress materially.
+- Behavior remains equivalent for direct-card labeled model-size values and for
+  fallback parsing of non-direct text fields.

--- a/scripts/hub_catalog_size_hint_probe.py
+++ b/scripts/hub_catalog_size_hint_probe.py
@@ -22,7 +22,7 @@ def _payload(index: int) -> tuple[dict[str, Any], int]:
     if mode == 0:
         return {"cardData": {}}, 0
     if mode == 1:
-        return {"cardData": {"model_size": f"{value} MB"}}, value * 1024 * 1024
+        return {"cardData": {"model_size": f"Model size: {value} MB"}}, value * 1024 * 1024
     if mode == 2:
         return {"cardData": {}, "readme": f"README\nMODEL SIZE | {value} kb\nother metadata"}, value * 1024
     if mode == 3:

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -709,14 +709,14 @@ def test_size_hint_bytes_uses_direct_card_model_size_without_regex(
     parser.assert_not_called()
 
 
-def test_size_hint_bytes_falls_back_for_labeled_direct_card_model_size(
+def test_size_hint_bytes_uses_direct_parser_for_labeled_card_model_size(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     parser = Mock(return_value=7 * MB)
     monkeypatch.setattr(hub_catalog_module, "_size_hint_from_text", parser)
 
     assert hub_catalog_module._size_hint_bytes({"cardData": {"model_size": "Model size: 7 MB"}}) == 7 * MB
-    parser.assert_called_once_with("Model size: 7 MB", allow_bare=True)
+    parser.assert_not_called()
 
 
 def test_size_hint_parsers_cover_units_and_invalid_values() -> None:
@@ -727,6 +727,10 @@ def test_size_hint_parsers_cover_units_and_invalid_values() -> None:
     assert hub_catalog_module._direct_size_hint_from_text("512 tb") == 0
     assert hub_catalog_module._direct_size_hint_from_text("not-a-number MB") == 0
     assert hub_catalog_module._direct_size_hint_from_text("model size 512 MB") == 0
+    assert hub_catalog_module._direct_card_size_hint_from_text("model size 512 MB") == 512 * MB
+    assert hub_catalog_module._direct_card_size_hint_from_text("Model size | 2 GB") == 2 * GB
+    assert hub_catalog_module._direct_card_size_hint_from_text("approx 512 MB") == 0
+    assert hub_catalog_module._direct_card_size_hint_from_text("Model size:") == 0
     assert hub_catalog_module._direct_size_hint_from_text("512 MB extra") == 0
 
     assert _size_hint_from_text("Model size: 512 kb", allow_bare=False) == 512 * KB

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -579,7 +579,7 @@ def _size_hint_bytes(payload: dict[str, Any]) -> int:
     card_data = raw_card_data if isinstance(raw_card_data, dict) else {}
     direct_card_text = _string(card_data.get("model_size"))
     if direct_card_text:
-        direct_card_hint = _direct_size_hint_from_text(direct_card_text)
+        direct_card_hint = _direct_card_size_hint_from_text(direct_card_text)
         if direct_card_hint > 0:
             return direct_card_hint
         direct_card_hint = _size_hint_from_text(direct_card_text, allow_bare=True)
@@ -646,6 +646,30 @@ def _direct_size_hint_from_text(text: str) -> int:
         return int(float(value_text) * multiplier)
     except ValueError:
         return 0
+
+
+def _direct_card_size_hint_from_text(text: str) -> int:
+    hint = _direct_size_hint_from_text(text)
+    if hint > 0:
+        return hint
+    stripped_text = _strip_model_size_label(text)
+    if not stripped_text:
+        return 0
+    return _direct_size_hint_from_text(stripped_text)
+
+
+def _strip_model_size_label(text: str) -> str:
+    if len(text) < 10 or text[:10].lower() != "model size":
+        return ""
+    cursor = 10
+    text_length = len(text)
+    while cursor < text_length and text[cursor].isspace():
+        cursor += 1
+    if cursor < text_length and text[cursor] in {":", "|"}:
+        cursor += 1
+    while cursor < text_length and text[cursor].isspace():
+        cursor += 1
+    return text[cursor:]
 
 
 def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:


### PR DESCRIPTION
## Summary
- Add a direct parser for labeled `cardData.model_size` values such as `Model size: 7 MB` before falling back to the regex path.
- Update the registered Hub catalog size-hint probe fixture so the PR-scoped probe measures labeled direct-card size hints.
- Document this performance slice under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-05-21-hub-catalog-size-hint-direct-label.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py::test_size_hint_bytes_uses_direct_card_model_size_without_regex services/mlx-worker-python/tests/test_hub_catalog.py::test_size_hint_bytes_uses_direct_parser_for_labeled_card_model_size services/mlx-worker-python/tests/test_hub_catalog.py::test_size_hint_parsers_cover_units_and_invalid_values services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- Registered `test_command` for `hub-catalog-size-hint-regex-precompile`.
- Registered `coverage_command` for `hub-catalog-size-hint-regex-precompile`.
- Registered `probe_command` for `hub-catalog-size-hint-regex-precompile`.
- Comparison probe with `MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=100000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=5` before and after implementation.
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `4 passed`.
- Registered test command: `54 passed`.
- Registered coverage command: `54 passed`; changed-scope coverage `100%` (`TOTAL 28 0 100%`).
- Baseline comparison probe on the updated fixture before code change: `elapsed_ms_mean=984.2048458289355`, `size_hint_calls_mean=40000.0`, `peak_bytes_mean=1833.0`.
- Post-change comparison probe: `elapsed_ms_mean=955.2471410483122`, `size_hint_calls_mean=20000.0`, `peak_bytes_mean=1833.0`.
- Delta: `size_hint_calls_mean -50%`, `elapsed_ms_mean -28.957704780623317 ms` (`~2.94%` faster) on the local Linux probe comparison.
- Registered default probe after change: `elapsed_ms_mean=1446.8771416228265`, `size_hint_calls_mean=40000.0`, `peak_bytes_mean=1833.0`, `sample_count=5.0`.

## Known Gaps
- Linux local validation covers the Python worker path only; CI must validate the registered PR-scoped performance workflow for this PR.
- This slice only handles the direct `cardData.model_size` label form and intentionally leaves broader free-text parsing on the existing regex fallback.

## Evidence Checklist
- [x] Scoped to one optimization slice.
- [x] Registered probe with focused test, coverage, and probe commands exists.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe run locally with before/after metrics.
- [ ] GitHub Actions and registered PR-scoped performance report complete successfully.
