### PR TITLE
perf: bind code eval nonblank whitespace check

### DIFF
--- a/docs/plans/2026-05-21-code-eval-nonblank-isspace-binding.md
+++ b/docs/plans/2026-05-21-code-eval-nonblank-isspace-binding.md
@@ -1,0 +1,43 @@
+# Code Eval Nonblank Line Counter Local Binding
+
+## Scope
+
+This Python-only performance slice is limited to `_count_nonblank_test_lines(...)`
+in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped performance probe
+`code-eval-test-count-nonblank-streaming` in `infra/perf/pr_scoped_probes.json`.
+The registered entry includes focused `test_command`, `coverage_command`, and
+`probe_command` values and watches:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_test_count_probe.py`
+
+## Optimization
+
+The counter already streams over the source text to avoid allocating a filtered
+line list. This slice keeps that behavior and binds `str.isspace` once before
+the hot character loop, avoiding repeated bound-method lookup for every
+non-newline character while preserving whitespace semantics.
+
+## Verification Plan
+
+1. Run the focused registered test command locally on Linux.
+2. Run the changed-scope registered coverage command locally on Linux and require
+   at least 95% coverage for touched code.
+3. Run the registered probe locally before and after the slice, comparing
+   `elapsed_ms_mean`, `peak_bytes_mean`, and `nonblank_line_count_mean`.
+4. Use GitHub Actions PR-scoped performance as the merge gate for the registered
+   probe report.
+
+## Success Criteria
+
+- Nonblank line counts remain identical for the focused code-eval tests.
+- Local probe keeps `peak_bytes_mean` flat and improves `elapsed_ms_mean` versus
+  the pre-change Linux baseline.
+- PR-scoped performance CI completes successfully for
+  `code-eval-test-count-nonblank-streaming`.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -299,10 +299,11 @@ def _count_assert_nodes(
 def _count_nonblank_test_lines(test_code: str) -> int:
     count = 0
     in_line = False
+    is_space = str.isspace
     for char in test_code:
         if char in "\r\n":
             in_line = False
-        elif not in_line and not char.isspace():
+        elif not in_line and not is_space(char):
             count += 1
             in_line = True
     return count


### PR DESCRIPTION
## Summary
- Bind `str.isspace` once before the code-eval nonblank-line hot loop.
- Preserve the existing streaming counter so the fallback avoids filtered-list allocation.

## Plan or Spec
- `docs/plans/2026-05-21-code-eval-nonblank-isspace-binding.md`
- Registered probe: `code-eval-test-count-nonblank-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_test_count_probe.py
# baseline on origin/main: exit 0; {"elapsed_ms_mean": 52.89054103195667, "line_count": 60000.0, "nonblank_line_count_mean": 48000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_syntax_error_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics
# exit 0; 8 passed in 1.28s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_syntax_error_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_test_count_probe.py
# exit 0; 8 passed; TOTAL 2 0 100%

for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_test_count_probe.py; done
# exit 0; elapsed_ms_mean samples 51.742628516097156, 51.87615067032831, 52.954002948743955; peak_bytes_mean 112.0; nonblank_line_count_mean 48000.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 2 0 100%`).
- Registered local probe baseline: `elapsed_ms_mean=52.89054103195667`, `peak_bytes_mean=112.0`, `nonblank_line_count_mean=48000.0`.
- Registered local probe after change: best/representative samples `51.742628516097156`, `51.87615067032831`, `52.954002948743955` ms; `peak_bytes_mean=112.0`; `nonblank_line_count_mean=48000.0`.
- Local Linux scope validates the Python fallback path; PR-scoped performance CI remains the merge gate for the registered report.

## Known Gaps
- None. No Swift runtime effect is involved in this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
