### PR TITLE
perf: inline tool registry OpenAI template copies

### DIFF
--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -29,32 +29,6 @@ _OpenAIToolTemplate = tuple[
 ]
 
 
-def _copy_openai_tool_template(template: _OpenAIToolTemplate) -> dict[str, Any]:
-    (
-        name,
-        description,
-        tool_kind,
-        observation_kind,
-        schema_properties,
-        required_arguments,
-    ) = template
-    return {
-        "type": "function",
-        "function": {
-            "name": name,
-            "description": description,
-            "parameters": {
-                "type": "object",
-                "additionalProperties": False,
-                "properties": {
-                    name: schema.copy() for name, schema in schema_properties
-                },
-                "required": required_arguments.copy(),
-            },
-        },
-        "x-melix-tool-kind": tool_kind,
-        "x-melix-observation-kind": observation_kind,
-    }
 _TOOL_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 _SELECTION_CACHE_MAX_SIZE = 32
 
@@ -301,7 +275,36 @@ class ToolRegistry:
         return selection
 
     def as_openai_tools(self) -> list[dict[str, Any]]:
-        return [_copy_openai_tool_template(tool) for tool in self._openai_tool_templates]
+        tools: list[dict[str, Any]] = []
+        append_tool = tools.append
+        for (
+            name,
+            description,
+            tool_kind,
+            observation_kind,
+            schema_properties,
+            required_arguments,
+        ) in self._openai_tool_templates:
+            append_tool(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "description": description,
+                        "parameters": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": {
+                                name: schema.copy() for name, schema in schema_properties
+                            },
+                            "required": required_arguments.copy(),
+                        },
+                    },
+                    "x-melix-tool-kind": tool_kind,
+                    "x-melix-observation-kind": observation_kind,
+                }
+            )
+        return tools
 
     def as_worker_tool_config(self) -> common_pb2.ToolConfig:
         if self._worker_tool_config_bytes:


### PR DESCRIPTION
## Summary
- Inline `ToolRegistry.as_openai_tools()` template-copy construction so the hot path avoids a helper call per tool while preserving isolated mutable return payloads.
- Remove the now-unused OpenAI tool template copy helper.

## Plan or Spec
- `docs/unified-agentic-tool-runtime-contract.md` governs the tool registry runtime contract.
- No formal doc behavior change is required: this is a behavior-preserving performance slice for the registered `tool-registry-openai-tools-template-cache` probe.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
# baseline before change: exit 0; elapsed_ms_mean=534.5310244243592; descriptor_as_openai_tool_calls_mean=0.0; isolated_payload_calls_mean=50000.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 53 passed in 0.80s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_openai_tools_probe.py
# exit 0; 53 passed in 0.35s; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
# exit 0; head elapsed_ms_mean=465.5873717274517; descriptor_as_openai_tool_calls_mean=0.0; isolated_payload_calls_mean=50000.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered probe: `tool-registry-openai-tools-template-cache` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/runtime/tool_registry.py` and includes focused test, coverage, and probe commands.
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Local Linux probe: `elapsed_ms_mean` improved from `534.5310244243592` ms to `465.5873717274517` ms over 50,000 iterations/sample and 5 samples (`delta_ms=-68.94365269690751`, `speedup=1.1481x`, about `12.9%` faster).
- Isolation metric remains stable: `isolated_payload_calls_mean=50000.0`; descriptor fallback calls remain `0.0`.
- CI PR-scoped performance report is required as final registered-probe validation before merge.

## Known Gaps
- Local validation was Linux-only; no Swift runtime effects are involved.
- Broader repository gates are left to CI for this small Python registered-probe slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or no behavior/workflow doc change is required.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or N/A: no observability mode change; registered evidence probe is reused.
- [x] Deferred work and known gaps are stated explicitly.
