### PR TITLE
perf: inline runtime kwarg membership checks

### DIFF
--- a/docs/plans/2026-05-21-runtime-kwarg-inline-membership.md
+++ b/docs/plans/2026-05-21-runtime-kwarg-inline-membership.md
@@ -1,0 +1,31 @@
+# Runtime Kwarg Accepts Inline Membership Slice
+
+## Scope
+
+This slice targets the Python runtime helper path in
+`services/mlx-worker-python/worker/runtime/runtime_utils.py`.
+
+The affected path is already covered by the registered PR-scoped probe
+`runtime-utils-kwarg-signature-cache` in `infra/perf/pr_scoped_probes.json`, with
+focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Change
+
+Inline the `CallableKwargSignature` membership checks used by
+`callable_declares_kwarg` and `callable_accepts_kwarg`. The cached signature
+lookup remains unchanged; the hot path avoids an additional bound method call on
+every keyword acceptance check.
+
+## Verification Plan
+
+- Run the registered focused runtime-utils tests through the probe registry
+  command.
+- Run changed-scope coverage for the registered runtime-utils probe.
+- Run `scripts/runtime_utils_kwarg_cache_probe.py` locally on Linux before and
+after the change and compare `elapsed_ms_mean` and
+  `inspect_signature_calls_mean`.
+
+## Boundary
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime
+effect is claimed.

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -91,11 +91,12 @@ def callable_kwarg_signature(callable_obj: Any) -> CallableKwargSignature:
 
 
 def callable_declares_kwarg(callable_obj: Any, keyword: str) -> bool:
-    return callable_kwarg_signature(callable_obj).declares(keyword)
+    return keyword in callable_kwarg_signature(callable_obj).keyword_accessible_params
 
 
 def callable_accepts_kwarg(callable_obj: Any, keyword: str) -> bool:
-    return callable_kwarg_signature(callable_obj).accepts(keyword)
+    signature = callable_kwarg_signature(callable_obj)
+    return keyword in signature.keyword_accessible_params or signature.accepts_var_keyword
 
 
 def first_declared_kwarg(callable_obj: Any, keywords: tuple[str, ...]) -> str:


### PR DESCRIPTION
## Summary
- Inline runtime kwarg membership checks in `callable_declares_kwarg` and `callable_accepts_kwarg`.
- Keep cached signature lookup semantics unchanged while avoiding a bound method call in the hot keyword-acceptance path.

## Plan or Spec
- `docs/plans/2026-05-21-runtime-kwarg-inline-membership.md`

## Commands Run
```text
# Baseline probe before the accepted slice
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_kwarg_cache_probe.py
# exit 0; elapsed_ms_mean=19.119727751240134; inspect_signature_calls_mean=1.0

# Focused registered test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics
# exit 0; 19 passed in 0.84s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_kwarg_cache_probe.py
# exit 0; TOTAL 3 0 100%

# Accepted-slice local registered probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_kwarg_cache_probe.py
# exit 0; elapsed_ms_mean=17.788437427952886; inspect_signature_calls_mean=1.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Registered local probe: `runtime-utils-kwarg-signature-cache`.
- Local Linux probe delta: `elapsed_ms_mean` 19.119727751240134 ms -> 17.788437427952886 ms (`-1.3312903232872486 ms`, `-6.96%`); `inspect_signature_calls_mean` stayed at `1.0`.
- PR-scoped performance CI is required as the canonical registered probe validation before merge.

## Known Gaps
- Linux-only local validation for this Python slice; no Swift runtime effect is claimed.
- An earlier attempted event-alignment terminal-state cache slice was rejected locally because the probe regressed (`elapsed_ms_mean` 2233.747890405357 ms -> 2419.4958060979843 ms) and was fully reverted before this commit.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
