### PR TITLE
perf: accelerate code eval payload string fields

### DIFF
--- a/docs/plans/2026-05-21-code-eval-payload-string-find.md
+++ b/docs/plans/2026-05-21-code-eval-payload-string-find.md
@@ -1,0 +1,39 @@
+# Code Eval Payload String Field Find
+
+## Scope
+
+This Python-only performance slice is limited to the code-evaluation payload fast
+path in `services/mlx-worker-python/worker/engine/code_eval_runner.py`. It does
+not change sandbox execution, code-block extraction, stdio tail handling,
+protobuf artifacts, Swift, or macOS runtime behavior.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe
+`code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`. The probe
+entry includes focused `test_command`, `coverage_command`, and `probe_command`
+values and reports `elapsed_ms_mean`, `peak_bytes_mean`, `payload_bytes`,
+`sample_count`, and `iteration_count`.
+
+## Optimization
+
+`_extract_json_string_field_at()` now uses `bytes.find()` to locate the closing
+quote and any escape byte in C-backed scans instead of stepping through each
+byte in Python. Escaped strings still fall back to the full JSON loader so the
+fast path only accepts the same unescaped status/detail fields as before.
+
+## Verification plan
+
+- Run the registered focused pytest command locally on Linux.
+- Run the registered changed-scope coverage command locally on Linux and require
+  at least 95% for the changed executable scope.
+- Run the registered `code-eval-payload-json-bytes` probe locally before and
+  after the change and compare `elapsed_ms_mean` and `peak_bytes_mean`.
+- Use the PR-scoped performance workflow as the merge gate after push.
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage remains at or above 95%.
+- The local registered probe preserves payload semantics and shows a clear or
+  noise-bounded improvement in `elapsed_ms_mean` without increasing peak memory.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -976,7 +976,9 @@ def test_payload_fast_path_field_extractors_cover_malformed_edges() -> None:
     assert code_eval_runner._json_field_value_start(b'{"runtime_status" : "ok"}', "runtime_status") == 20
     assert code_eval_runner._json_field_value_start(b'{"runtime_status" "ok"}', "runtime_status") is None
     assert code_eval_runner._json_field_value_start(b'{"runtime_status": ', "runtime_status") is None
+    assert code_eval_runner._extract_json_string_field(b'{"failure_detail":"ok"}', "failure_detail") == "ok"
     assert code_eval_runner._extract_json_string_field(b'{"failure_detail":"oops}', "failure_detail") is None
+    assert code_eval_runner._extract_json_string_field(b'{"failure_detail":"line\\nbreak"}', "failure_detail") is None
     assert code_eval_runner._extract_json_int_field(b'{"tests_passed":-7}', "tests_passed") == -7
     assert code_eval_runner._extract_json_int_field(b'{"tests_total":12345}', "tests_total") == 12345
     assert code_eval_runner._extract_json_int_field_value_and_end(b'-42, "next": 1', 0) == (-42, 3)

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -490,17 +490,13 @@ def _extract_json_string_field_with_token(payload_bytes: bytes, key_token: bytes
 def _extract_json_string_field_at(payload_bytes: bytes, start: int | None) -> str | None:
     if start is None or payload_bytes[start] != ord('"'):
         return None
-    cursor = start + 1
-    value_start = cursor
-    payload_length = len(payload_bytes)
-    while cursor < payload_length:
-        char = payload_bytes[cursor]
-        if char == ord('"'):
-            return payload_bytes[value_start:cursor].decode("utf-8")
-        if char == ord("\\"):
-            return None
-        cursor += 1
-    return None
+    value_start = start + 1
+    value_end = payload_bytes.find(b'"', value_start)
+    if value_end < 0:
+        return None
+    if payload_bytes.find(b"\\", value_start, value_end) >= 0:
+        return None
+    return payload_bytes[value_start:value_end].decode("utf-8")
 
 
 def _extract_json_int_field(payload_bytes: bytes, key: str) -> int | None:


### PR DESCRIPTION
## Summary
- Optimize the code-evaluation payload fast-path string extractor by replacing a Python byte-by-byte loop with C-backed `bytes.find()` scans for the closing quote and escape byte.
- Preserve fallback behavior for escaped JSON strings and malformed string fields.
- Add a governing performance-slice plan for the string-field lookup change.

## Plan or Spec
- `docs/plans/2026-05-21-code-eval-payload-string-find.md`
- Registered PR-scoped probe: `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_required_field_check_preserves_fast_path_gate services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
# 9 passed in 1.88s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py
# 9 passed in 5.87s; TOTAL 9 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c '... code-eval-payload-json-bytes probe ...'
# head-only probe: {"elapsed_ms_mean": 114.72154458585594, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 60425.0, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-payload-json-bytes --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/code-eval-string-find-probe.json
# base elapsed_ms_mean=131.75359947074736; head elapsed_ms_mean=114.08504900256438; peak_bytes_mean unchanged at 60425.0; coverage 100%

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%`.
- Local registered probe (`code-eval-payload-json-bytes`, Linux):
  - `elapsed_ms_mean`: base `131.75359947074736` ms → head `114.08504900256438` ms (`-17.66855046818298` ms, ~`13.41%` faster).
  - `peak_bytes_mean`: base `60425.0` bytes → head `60425.0` bytes (unchanged).
  - `payload_bytes`: `55474.0`; `sample_count`: `7`; `iteration_count`: `1200`.
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally for this focused Python slice; GitHub Actions is the broad gate.
- No Swift runtime effect is claimed; this is Python-only and locally verified on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
