### PR TITLE
perf: speed deterministic OCR token counts

### DIFF
--- a/docs/plans/2026-05-21-ocr-token-count-local-bindings.md
+++ b/docs/plans/2026-05-21-ocr-token-count-local-bindings.md
@@ -1,0 +1,49 @@
+# Deterministic OCR Token Count Local Arithmetic Slice
+
+## Scope
+
+Optimize the deterministic OCR prompt token-count hot path without changing
+reported token counts. The slice is limited to
+`DeterministicOCRRuntime.prompt_token_count()` and its focused regression
+coverage.
+
+## Probe
+
+Registered PR-scoped probe:
+`deterministic-ocr-token-count-scan` in
+`infra/perf/pr_scoped_probes.json`.
+
+The registered probe provides:
+
+- `test_command` for OCR token-count and PR-scoped performance selection tests.
+- `coverage_command` for changed-scope coverage on the touched OCR/probe files.
+- `probe_command` for repeated local Linux timing of
+  `scripts/deterministic_ocr_token_count_probe.py`.
+
+## Implementation Plan
+
+1. Preserve the existing whitespace token-count helper behavior.
+2. Keep the single-image OCR fast path on precomputed
+   `preprocess_input_bytes` so it does not read image byte lengths.
+3. Remove redundant outer `max(1, ...)` work once an image-token minimum has
+   already been applied.
+4. Keep the zero-image fallback clamped to at least one token.
+5. Verify focused tests, changed-scope coverage, and the registered probe before
+   opening the PR.
+
+## Local Evidence
+
+Baseline from `origin/main`:
+
+```json
+{"checksum": 80000000.0, "elapsed_ms_mean": 248.70167, "iterations": 80000.0, "peak_bytes_mean": 163.2, "sample_count": 5.0, "token_count": 200.0}
+```
+
+Candidate branch:
+
+```json
+{"checksum": 80000000.0, "elapsed_ms_mean": 147.018257, "iterations": 80000.0, "peak_bytes_mean": 147.2, "sample_count": 5.0, "token_count": 200.0}
+```
+
+Local delta: -101.683413 ms mean, about 40.9% lower elapsed time for the
+registered probe workload; peak traced bytes decreased from 163.2 to 147.2.

--- a/services/mlx-worker-python/tests/test_vision_runtime.py
+++ b/services/mlx-worker-python/tests/test_vision_runtime.py
@@ -199,6 +199,32 @@ def test_ocr_token_count_scans_whitespace_without_split_list() -> None:
         fallback_request.images[0].byte_length // 8,
     ) + max(1, fallback_request.images[1].byte_length // 8)
 
+    tiny_image_request = PreparedVisionRequest(
+        prompt_text="",
+        images=[request.images[0]],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=1,
+        preprocess_peak_memory_bytes=1,
+        prompt_hash_hex="p" * 64,
+        multimodal_hash_hex="m" * 64,
+    )
+    assert runtime.prompt_token_count(tiny_image_request) == 1
+
+    text_only_request = PreparedVisionRequest(
+        prompt_text="",
+        images=[],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=0,
+        preprocess_peak_memory_bytes=0,
+        prompt_hash_hex="p" * 64,
+        multimodal_hash_hex="m" * 64,
+    )
+    assert runtime.prompt_token_count(text_only_request) == 1
+
 
 class ByteLengthTrackingImage:
     def __init__(self, byte_length: int) -> None:

--- a/services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py
@@ -68,12 +68,14 @@ class DeterministicOCRRuntime:
         images = prepared_request.images
         prompt_tokens = _whitespace_token_count(prepared_request.prompt_text)
         if len(images) == 1 and not prepared_request.videos:
-            return max(
-                1,
-                prompt_tokens + max(1, prepared_request.preprocess_input_bytes // 8),
-            )
+            input_tokens = prepared_request.preprocess_input_bytes // 8
+            if input_tokens < 1:
+                input_tokens = 1
+            return prompt_tokens + input_tokens
         image_tokens = sum(max(1, image.byte_length // 8) for image in images)
-        return max(1, prompt_tokens + image_tokens)
+        if image_tokens:
+            return prompt_tokens + image_tokens
+        return max(1, prompt_tokens)
 
     def generate_tokens(
         self,


### PR DESCRIPTION
## Summary
- Optimizes `DeterministicOCRRuntime.prompt_token_count()` by removing redundant clamping from the single-image OCR fast path after the image-token minimum is already applied.
- Adds regression coverage for tiny-image and empty-image token-count clamps.
- Records the slice plan and local probe evidence under `docs/plans/2026-05-21-ocr-token-count-local-bindings.md`.

## Plan or Spec
- Plan: `docs/plans/2026-05-21-ocr-token-count-local-bindings.md`
- Registered probe: `deterministic-ocr-token-count-scan` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_ocr_token_count_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py`

## Coverage and Metrics
- Focused tests: 9 passed.
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Baseline probe from `origin/main`: `elapsed_ms_mean=248.70167`, `peak_bytes_mean=163.2`, `iterations=80000`, `sample_count=5`.
- Candidate probe: `elapsed_ms_mean=147.018257`, `peak_bytes_mean=147.2`, `iterations=80000`, `sample_count=5`.
- Local delta: `-101.683413 ms` mean elapsed, about `40.9%` lower; peak traced bytes decreased by `16.0` bytes.
- CI PR-scoped performance workflow must still validate the registered probe on the PR branch before merge.

## Known Gaps
- This is a Python-only deterministic OCR micro-optimization validated locally on Linux; no Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance report is required before merge.

## Evidence Checklist
- [x] Registered PR-scoped probe exists with focused `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused local tests passed.
- [x] Changed-scope coverage met the 95% requirement.
- [x] Registered probe ran locally with an improving elapsed-time metric.
- [ ] GitHub Actions checks are green.
- [ ] PR-scoped performance report completed successfully.
