### PR TITLE
Add LoRA release compare manifest policy

### DIFF
--- a/docs/plans/2026-05-21-lora-release-compare-bundle-policy.md
+++ b/docs/plans/2026-05-21-lora-release-compare-bundle-policy.md
@@ -1,0 +1,127 @@
+# LoRA Release Compare Bundle Policy
+
+## Goal
+
+Implement issue #726 by making every LoRA adapter manifest able to declare the
+compare evidence bundle required before an adapter is published or promoted.
+
+Parent direction: issue #724, "OpenSearch-VL alignment: gate LoRA release with
+paired compare evidence".
+
+## Scope
+
+This slice adds an additive adapter-manifest contract only:
+
+- in-domain evaluation suite IDs that must improve for the adapter's intended
+  domain
+- guard suite IDs that must not regress on general behavior
+- per-suite effect thresholds
+- per-suite minimum paired sample counts
+
+Out of scope:
+
+- automatically launching compare jobs after training
+- enforcing release-gate verdicts
+- adding new Swift, protobuf, or menu bar fields
+- changing existing `eval compare` scoring semantics
+
+## Manifest Contract
+
+`train_lora.adapter.json` keeps schema `melix.lora_adapter_package.v1` and adds
+`release_compare_bundle_policy`:
+
+```json
+{
+  "schema_version": "melix.lora_release_compare_bundle_policy.v1",
+  "in_domain_suite_ids": ["opensearch_vl_qa"],
+  "guard_suite_ids": ["mmlu", "gsm8k"],
+  "thresholds": {
+    "opensearch_vl_qa": 0.05,
+    "mmlu": 0.01,
+    "gsm8k": 0.01
+  },
+  "minimum_sample_counts": {
+    "opensearch_vl_qa": 80,
+    "mmlu": 40,
+    "gsm8k": 40
+  }
+}
+```
+
+The adapter manifest also exposes the same values through flat
+`release_compare_*` keys for registry snapshots, reports, and future release
+gate readers that avoid nested JSON traversal.
+
+## Operator Inputs
+
+The existing `train_lora` `ext` map accepts these additive keys:
+
+- `release_compare_in_domain_suite_ids`: comma-separated suite IDs
+- `release_compare_guard_suite_ids`: comma-separated suite IDs
+- `release_compare_thresholds`: comma-separated `suite_id=value` entries
+- `release_compare_default_threshold`: optional threshold applied to suites
+  without an explicit threshold
+- `release_compare_minimum_sample_counts`: comma-separated `suite_id=value`
+  entries
+- `release_compare_default_minimum_sample_count`: optional minimum applied to
+  suites without an explicit minimum
+
+The equivalent namespaced `melix.release_compare.*` keys are accepted for
+callers that already group ext fields by domain.
+
+## Validation
+
+- suite lists are de-duplicated while preserving order
+- threshold values must be numeric and `>= 0.0`
+- minimum sample counts must be integers and `>= 1`
+- empty policy fields remain valid so older training callers keep producing
+  backward-compatible manifests
+
+## Performance And Metrics
+
+This path only parses a handful of request strings and writes JSON fields during
+the offline `train_lora` manifest step. It adds no serving-path work and no
+compare execution work.
+
+Measurement points:
+
+- focused pytest runtime for LoRA training config and manifest persistence
+- changed-scope coverage for the Python files touched by this contract and the
+  relevant performance-probe coverage commands
+- `git diff --check`
+
+Success metrics:
+
+- focused LoRA tests pass
+- changed-scope coverage for touched Python files is at least 95%
+- generated adapter manifest records nested and flat release compare policy
+  fields
+
+## Implementation Plan
+
+- [x] Add a normalized release compare bundle policy to `LoRATrainingConfig`.
+- [x] Persist the normalized policy in `train_lora.adapter.json`.
+- [x] Document the operator ext keys in the LoRA adapter workflow runbook.
+- [x] Add focused tests for parsing, validation, and manifest persistence.
+- [x] Run focused pytest, changed-scope coverage, and `git diff --check`.
+
+## Verification
+
+- `python3 -m py_compile services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/model_ops/release_compare_policy.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_release_compare_policy.py`
+  - Result: passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_compare_policy.py`
+  - Result: 6 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/lora_release_compare_policy.coverage -m pytest -q services/mlx-worker-python/tests/test_release_compare_policy.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/lora_release_compare_policy.coverage -o /tmp/lora_release_compare_policy_coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json /tmp/lora_release_compare_policy_coverage.json services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/model_ops/release_compare_policy.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_release_compare_policy.py`
+  - Result: 6 passed; changed-line coverage 100% (117/117).
+- `python3 - <<'PY' ... pre_commit_gate.run_performance_report(...)`
+  - Result: Status ok; selected 2 direct probes
+    (`training-config-target-module-cache` and
+    `lora-reward-summary-candidate-minmax`); targeted tests passed; probe
+    coverage passed at 100%; no verification failures and no regressions.
+- `git diff --check`
+  - Result: passed.
+
+## Known Gaps
+
+Milestone 2 will consume this contract to automate base-versus-adapter compare
+execution. Milestone 3 will enforce the persisted verdicts in release gates.

--- a/docs/runbooks/phase-8-lora-adapter-workflow.md
+++ b/docs/runbooks/phase-8-lora-adapter-workflow.md
@@ -150,6 +150,12 @@ Use the following `ext` keys as the stable operator-facing inputs:
   "epochs": "1",
   "hf_valid_split": "test_sft",
   "derived_model_alias": "melix-qwen35-acceptance",
+  "release_compare_in_domain_suite_ids": "opensearch_vl_qa,opensearch_vl_grounding",
+  "release_compare_guard_suite_ids": "mmlu,gsm8k",
+  "release_compare_thresholds": "opensearch_vl_qa=0.05",
+  "release_compare_default_threshold": "0.01",
+  "release_compare_minimum_sample_counts": "opensearch_vl_qa=80",
+  "release_compare_default_minimum_sample_count": "40",
   "response_only": "true",
   "gradient_checkpointing": "false",
   "mask_prompt": "true",
@@ -222,6 +228,13 @@ Expected training behavior:
 - `cpt` requires `text_completion` datasets and records `training_objective=continual_pretraining`
 - this slice defines worker-owned mode and dataset contracts; DPO, ORPO, and CPT optimizer-loop breadth remains bounded by the active local runner implementation
 - if `hf_valid_split` is provided, the normalized dataset snapshot persists the explicit validation source
+- release compare policy fields are copied into `train_lora.adapter.json` under
+  `release_compare_bundle_policy` plus flat `release_compare_*` keys; use
+  in-domain suites for the adapter's target domain and guard suites for general
+  regression checks before publishing or promoting the adapter
+- release compare thresholds must be numeric and non-negative, while release
+  compare minimum sample counts must be positive integers; default values apply
+  to listed suites without an explicit per-suite entry
 - Melix expands compact target modules or preset groups into family-specific module paths
 - Gemma 4 VLM snapshots that expose `text_config.model_type == "gemma4_text"` are accepted through the
   component-scoped `text_backbone` LoRA surface; the source model remains a VLM entry, and adapter

--- a/services/mlx-worker-python/tests/test_release_compare_policy.py
+++ b/services/mlx-worker-python/tests/test_release_compare_policy.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from packages.protocol.python.worker.v1 import common_pb2
+
+from worker.model_ops import training_config as training_config_module
+from worker.model_ops.deterministic_lora_runner import DeterministicLoRARunner
+from worker.model_ops.errors import ModelOperationError
+from worker.model_ops.lora_training_pipeline import LoRATrainingPipeline
+from worker.model_ops.release_compare_policy import ReleaseCompareBundlePolicy
+
+
+def _write_dataset_package(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "melix-dev-dataset",
+                "format": "chat_messages",
+                "sample_count": 1,
+                "version": "1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "samples.jsonl").write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "world"},
+                ]
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def _text_model(*, family_id: str = "qwen") -> common_pb2.ModelSpec:
+    model = common_pb2.ModelSpec(
+        model_id="melix-test-text",
+        model_path="models/plain-qwen",
+        model_kind="text",
+        revision="main",
+        max_context=4096,
+    )
+    model.ext["text_family_id"] = family_id
+    model.ext["text_layer_count"] = "2"
+    return model
+
+
+def test_normalize_training_config_records_release_compare_bundle_policy() -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(),
+        ext={
+            "release_compare_in_domain_suite_ids": "opensearch_vl_qa, opensearch_vl_qa, opensearch_vl_grounding",
+            "release_compare_guard_suite_ids": "mmlu, gsm8k",
+            "release_compare_thresholds": "opensearch_vl_qa=0.04,mmlu=0.0",
+            "release_compare_default_threshold": "0.02",
+            "release_compare_minimum_sample_counts": "opensearch_vl_qa=64",
+            "release_compare_default_minimum_sample_count": "32",
+        },
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+
+    policy = config.release_compare_bundle_policy
+    assert policy.in_domain_suite_ids == [
+        "opensearch_vl_qa",
+        "opensearch_vl_grounding",
+    ]
+    assert policy.guard_suite_ids == ["mmlu", "gsm8k"]
+    assert policy.thresholds == {
+        "opensearch_vl_qa": 0.04,
+        "opensearch_vl_grounding": 0.02,
+        "mmlu": 0.0,
+        "gsm8k": 0.02,
+    }
+    assert policy.minimum_sample_counts == {
+        "opensearch_vl_qa": 64,
+        "opensearch_vl_grounding": 32,
+        "mmlu": 32,
+        "gsm8k": 32,
+    }
+
+
+def test_normalize_training_config_accepts_namespaced_release_compare_keys() -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(),
+        ext={
+            "melix.release_compare.in_domain_suite_ids": "opensearch_vl_qa",
+            "melix.release_compare.guard_suite_ids": "mmlu",
+            "melix.release_compare.thresholds": "opensearch_vl_qa=0.03",
+            "melix.release_compare.default_threshold": "0.01",
+            "melix.release_compare.minimum_sample_counts": "mmlu=48",
+            "melix.release_compare.default_minimum_sample_count": "24",
+        },
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+
+    policy = config.release_compare_bundle_policy
+    assert policy.in_domain_suite_ids == ["opensearch_vl_qa"]
+    assert policy.guard_suite_ids == ["mmlu"]
+    assert policy.thresholds == {"opensearch_vl_qa": 0.03, "mmlu": 0.01}
+    assert policy.minimum_sample_counts == {
+        "opensearch_vl_qa": 24,
+        "mmlu": 48,
+    }
+
+
+def test_normalize_training_config_rejects_invalid_release_compare_policy() -> None:
+    with pytest.raises(ModelOperationError) as threshold_exc:
+        training_config_module.normalize_training_config(
+            source_model=_text_model(),
+            ext={
+                "release_compare_in_domain_suite_ids": "opensearch_vl_qa",
+                "release_compare_thresholds": "opensearch_vl_qa=-0.01",
+            },
+            dataset_format="chat_messages",
+            response_only_supported=True,
+            sample_count=1,
+        )
+    assert threshold_exc.value.code == "invalid_argument"
+    assert threshold_exc.value.details["field"] == (
+        "release_compare_thresholds.opensearch_vl_qa"
+    )
+
+    with pytest.raises(ModelOperationError) as sample_count_exc:
+        training_config_module.normalize_training_config(
+            source_model=_text_model(),
+            ext={
+                "release_compare_guard_suite_ids": "mmlu",
+                "release_compare_minimum_sample_counts": "mmlu=0",
+            },
+            dataset_format="chat_messages",
+            response_only_supported=True,
+            sample_count=1,
+        )
+    assert sample_count_exc.value.code == "invalid_argument"
+    assert sample_count_exc.value.details["field"] == (
+        "release_compare_minimum_sample_counts.mmlu"
+    )
+
+
+def test_release_compare_policy_rejects_malformed_keyed_entries() -> None:
+    with pytest.raises(ModelOperationError) as exc:
+        training_config_module.normalize_training_config(
+            source_model=_text_model(),
+            ext={
+                "release_compare_in_domain_suite_ids": "opensearch_vl_qa",
+                "release_compare_thresholds": "opensearch_vl_qa",
+            },
+            dataset_format="chat_messages",
+            response_only_supported=True,
+            sample_count=1,
+        )
+
+    assert exc.value.code == "invalid_argument"
+    assert exc.value.details == {
+        "field": "release_compare_thresholds",
+        "raw_value": "opensearch_vl_qa",
+    }
+
+
+def test_release_compare_policy_manifest_has_schema_version() -> None:
+    policy = ReleaseCompareBundlePolicy(
+        in_domain_suite_ids=["opensearch_vl_qa"],
+        guard_suite_ids=["mmlu"],
+        thresholds={"opensearch_vl_qa": 0.04, "mmlu": 0.01},
+        minimum_sample_counts={"opensearch_vl_qa": 64, "mmlu": 32},
+    )
+
+    assert policy.as_manifest() == {
+        "schema_version": "melix.lora_release_compare_bundle_policy.v1",
+        "in_domain_suite_ids": ["opensearch_vl_qa"],
+        "guard_suite_ids": ["mmlu"],
+        "thresholds": {"opensearch_vl_qa": 0.04, "mmlu": 0.01},
+        "minimum_sample_counts": {"opensearch_vl_qa": 64, "mmlu": 32},
+    }
+
+
+def test_lora_training_manifest_records_release_compare_bundle_policy(
+    tmp_path: Path,
+) -> None:
+    dataset_dir = _write_dataset_package(tmp_path / "dataset")
+
+    result = LoRATrainingPipeline(runner=DeterministicLoRARunner()).run(
+        job_id="train-release-compare-policy",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "opensearch-vl-adapter",
+            "dataset_uri": str(dataset_dir),
+            "release_compare_in_domain_suite_ids": "opensearch_vl_qa",
+            "release_compare_guard_suite_ids": "mmlu,gsm8k",
+            "release_compare_thresholds": "opensearch_vl_qa=0.05",
+            "release_compare_default_threshold": "0.01",
+            "release_compare_minimum_sample_counts": "opensearch_vl_qa=80",
+            "release_compare_default_minimum_sample_count": "40",
+        },
+        source_model=_text_model(),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    manifest_payload = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    expected_thresholds = {
+        "opensearch_vl_qa": 0.05,
+        "mmlu": 0.01,
+        "gsm8k": 0.01,
+    }
+    expected_sample_counts = {
+        "opensearch_vl_qa": 80,
+        "mmlu": 40,
+        "gsm8k": 40,
+    }
+    assert manifest_payload["release_compare_bundle_policy"] == {
+        "schema_version": "melix.lora_release_compare_bundle_policy.v1",
+        "in_domain_suite_ids": ["opensearch_vl_qa"],
+        "guard_suite_ids": ["mmlu", "gsm8k"],
+        "thresholds": expected_thresholds,
+        "minimum_sample_counts": expected_sample_counts,
+    }
+    assert manifest_payload["release_compare_in_domain_suite_ids"] == [
+        "opensearch_vl_qa"
+    ]
+    assert manifest_payload["release_compare_guard_suite_ids"] == ["mmlu", "gsm8k"]
+    assert manifest_payload["release_compare_thresholds"] == expected_thresholds
+    assert manifest_payload["release_compare_minimum_sample_counts"] == (
+        expected_sample_counts
+    )

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -288,6 +288,19 @@ class LoRATrainingPipeline:
             "peak_memory_gb": peak_memory_gb,
             "adapter_artifact_bytes": adapter_artifact_bytes,
             "target_repo": config.target_repo,
+            "release_compare_bundle_policy": config.release_compare_bundle_policy.as_manifest(),
+            "release_compare_in_domain_suite_ids": list(
+                config.release_compare_bundle_policy.in_domain_suite_ids
+            ),
+            "release_compare_guard_suite_ids": list(
+                config.release_compare_bundle_policy.guard_suite_ids
+            ),
+            "release_compare_thresholds": dict(
+                config.release_compare_bundle_policy.thresholds
+            ),
+            "release_compare_minimum_sample_counts": dict(
+                config.release_compare_bundle_policy.minimum_sample_counts
+            ),
             "created_at_unix_ms": persisted_at_unix_ms,
             "updated_at_unix_ms": persisted_at_unix_ms,
         }

--- a/services/mlx-worker-python/worker/model_ops/release_compare_policy.py
+++ b/services/mlx-worker-python/worker/model_ops/release_compare_policy.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, TypeVar
+
+from worker.model_ops.errors import ModelOperationError
+
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True)
+class ReleaseCompareBundlePolicy:
+    in_domain_suite_ids: list[str] = field(default_factory=list)
+    guard_suite_ids: list[str] = field(default_factory=list)
+    thresholds: dict[str, float] = field(default_factory=dict)
+    minimum_sample_counts: dict[str, int] = field(default_factory=dict)
+
+    def as_manifest(self) -> dict[str, object]:
+        return {
+            "schema_version": "melix.lora_release_compare_bundle_policy.v1",
+            "in_domain_suite_ids": list(self.in_domain_suite_ids),
+            "guard_suite_ids": list(self.guard_suite_ids),
+            "thresholds": dict(self.thresholds),
+            "minimum_sample_counts": dict(self.minimum_sample_counts),
+        }
+
+
+def resolve_release_compare_bundle_policy(
+    ext: dict[str, str],
+    *,
+    float_value: Callable[[str, float, float, str], float],
+    int_value: Callable[[str, int, int, str], int],
+) -> ReleaseCompareBundlePolicy:
+    in_domain_suite_ids = _csv_values(
+        ext.get("release_compare_in_domain_suite_ids", "")
+        or ext.get("melix.release_compare.in_domain_suite_ids", "")
+    )
+    guard_suite_ids = _csv_values(
+        ext.get("release_compare_guard_suite_ids", "")
+        or ext.get("melix.release_compare.guard_suite_ids", "")
+    )
+    suite_ids = [*in_domain_suite_ids, *guard_suite_ids]
+    return ReleaseCompareBundlePolicy(
+        in_domain_suite_ids=in_domain_suite_ids,
+        guard_suite_ids=guard_suite_ids,
+        thresholds=_resolve_release_compare_thresholds(
+            ext,
+            suite_ids=suite_ids,
+            float_value=float_value,
+        ),
+        minimum_sample_counts=_resolve_release_compare_minimum_sample_counts(
+            ext,
+            suite_ids=suite_ids,
+            int_value=int_value,
+        ),
+    )
+
+
+def _resolve_release_compare_thresholds(
+    ext: dict[str, str],
+    *,
+    suite_ids: Iterable[str],
+    float_value: Callable[[str, float, float, str], float],
+) -> dict[str, float]:
+    raw = (
+        ext.get("release_compare_thresholds", "")
+        or ext.get("melix.release_compare.thresholds", "")
+    )
+    default_raw = (
+        ext.get("release_compare_default_threshold", "")
+        or ext.get("melix.release_compare.default_threshold", "")
+    )
+    return _keyed_release_compare_values(
+        raw,
+        default_raw=default_raw,
+        suite_ids=suite_ids,
+        field_name="release_compare_thresholds",
+        parse_value=lambda value, field_name: float_value(
+            value,
+            0.0,
+            0.0,
+            field_name,
+        ),
+    )
+
+
+def _resolve_release_compare_minimum_sample_counts(
+    ext: dict[str, str],
+    *,
+    suite_ids: Iterable[str],
+    int_value: Callable[[str, int, int, str], int],
+) -> dict[str, int]:
+    raw = (
+        ext.get("release_compare_minimum_sample_counts", "")
+        or ext.get("melix.release_compare.minimum_sample_counts", "")
+    )
+    default_raw = (
+        ext.get("release_compare_default_minimum_sample_count", "")
+        or ext.get("melix.release_compare.default_minimum_sample_count", "")
+    )
+    return _keyed_release_compare_values(
+        raw,
+        default_raw=default_raw,
+        suite_ids=suite_ids,
+        field_name="release_compare_minimum_sample_counts",
+        parse_value=lambda value, field_name: int_value(
+            value,
+            0,
+            1,
+            field_name,
+        ),
+    )
+
+
+def _keyed_release_compare_values(
+    raw_value: str,
+    *,
+    default_raw: str,
+    suite_ids: Iterable[str],
+    field_name: str,
+    parse_value: Callable[[str, str], _T],
+) -> dict[str, _T]:
+    values: dict[str, _T] = {}
+    for segment in raw_value.split(","):
+        item = segment.strip()
+        if not item:
+            continue
+        suite_id, separator, raw_suite_value = item.partition("=")
+        normalized_suite_id = suite_id.strip()
+        if not separator or not normalized_suite_id or not raw_suite_value.strip():
+            raise ModelOperationError(
+                code="invalid_argument",
+                message=f"{field_name} entries must use suite_id=value.",
+                details={"field": field_name, "raw_value": item},
+            )
+        values[normalized_suite_id] = parse_value(
+            raw_suite_value.strip(),
+            f"{field_name}.{normalized_suite_id}",
+        )
+
+    if default_raw.strip():
+        default_value = parse_value(default_raw.strip(), f"{field_name}.default")
+        for suite_id in suite_ids:
+            values.setdefault(suite_id, default_value)
+    return values
+
+
+def _csv_values(raw_value: str) -> list[str]:
+    values: list[str] = []
+    seen: set[str] = set()
+    for raw_item in raw_value.split(","):
+        value = raw_item.strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        values.append(value)
+    return values

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -17,6 +17,10 @@ from worker.model_ops.adapter_capabilities import (
 )
 from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.quantization_metadata import EXPLICIT_QUANTIZED_PROFILE_IDS
+from worker.model_ops.release_compare_policy import (
+    ReleaseCompareBundlePolicy,
+    resolve_release_compare_bundle_policy,
+)
 
 
 @dataclass(frozen=True)
@@ -84,6 +88,9 @@ class LoRATrainingConfig:
     preference_loss: str = ""
     dataset_contract: str = "sft"
     alignment: AlignmentTrainingConfig | None = None
+    release_compare_bundle_policy: ReleaseCompareBundlePolicy = field(
+        default_factory=ReleaseCompareBundlePolicy
+    )
 
 
 _DENSE_ATTENTION_TARGETS = ["q_proj", "k_proj", "v_proj", "o_proj"]
@@ -607,6 +614,21 @@ def normalize_training_config(
     steps_per_save = max(iters, 1)
     validation_split = ext.get("hf_valid_split", "").strip()
     validation_strategy = "hf_split" if validation_split and validation_sample_count > 0 else "none"
+    release_compare_bundle_policy = resolve_release_compare_bundle_policy(
+        ext,
+        float_value=lambda raw_value, default, minimum, field_name: _float_value(
+            raw_value,
+            default=default,
+            minimum=minimum,
+            field_name=field_name,
+        ),
+        int_value=lambda raw_value, default, minimum, field_name: _int_value(
+            raw_value,
+            default=default,
+            minimum=minimum,
+            field_name=field_name,
+        ),
+    )
 
     return LoRATrainingConfig(
         training_mode=training_mode,
@@ -660,6 +682,7 @@ def normalize_training_config(
         preference_loss=mode_contract["preference_loss"],
         dataset_contract=mode_contract["dataset_contract"],
         alignment=alignment,
+        release_compare_bundle_policy=release_compare_bundle_policy,
     )
 
 


### PR DESCRIPTION
## Summary
- Add a normalized LoRA release compare bundle policy to adapter training config and persisted adapter manifests.
- Record nested `release_compare_bundle_policy` plus flat `release_compare_*` fields for in-domain suites, guard suites, thresholds, and minimum sample counts.
- Document the operator ext keys in the Phase 8 LoRA adapter workflow runbook.

Closes #726.

## Plan or Spec
- `docs/plans/2026-05-21-lora-release-compare-bundle-policy.md`
- `docs/runbooks/phase-8-lora-adapter-workflow.md`

## Commands Run
```text
python3 -m py_compile services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/model_ops/release_compare_policy.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_release_compare_policy.py
Result: passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_compare_policy.py
Result: 6 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/lora_release_compare_policy.coverage -m pytest -q services/mlx-worker-python/tests/test_release_compare_policy.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/lora_release_compare_policy.coverage -o /tmp/lora_release_compare_policy_coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json /tmp/lora_release_compare_policy_coverage.json services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/worker/model_ops/release_compare_policy.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_release_compare_policy.py
Result: 6 passed; changed-line coverage 100% (117/117)

git diff --check origin/main...HEAD
Result: passed

pre-commit gate from git commit:
make swift-test: passed, elapsed 195.5s
make py-test: 2969 passed, 14 skipped, 2 warnings in 127.78s
make integration-test: 114 passed, 1 skipped in 312.31s
PR-scoped performance: Status ok; 2 direct probes selected; no regressions; no verification failures
```

## Coverage and Metrics
- Changed-scope coverage: 100% (117/117) for `training_config.py`, `release_compare_policy.py`, `lora_training_pipeline.py`, and `test_release_compare_policy.py`.
- PR-scoped performance report: Status ok, direct probes `training-config-target-module-cache` and `lora-reward-summary-candidate-minmax` passed targeted tests and coverage at 100%.
- Observability mode: evidence. This change writes release-compare policy evidence into adapter manifests; no serving-path runtime metrics or debug probes are added.
- Probe overhead: N/A. No new production probe or request-path instrumentation is introduced.

## Known Gaps
- Milestone 2 will consume this manifest contract to automate base-versus-adapter compare execution.
- Milestone 3 will enforce persisted compare verdicts in release gates.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
