### PR TITLE
perf: slot PR scoped registry definitions

### DIFF
--- a/docs/plans/2026-05-21-pr-scoped-definition-slots.md
+++ b/docs/plans/2026-05-21-pr-scoped-definition-slots.md
@@ -1,0 +1,24 @@
+# PR-scoped definition slots slice
+
+## Scope
+
+This Python-only performance slice targets the PR-scoped performance registry definition objects in `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`.
+
+## Probe coverage
+
+The affected path is already covered by the registered PR-scoped performance probe `pr-scoped-performance-registry-cache` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for registry loading and scope-report construction.
+
+## Optimization
+
+`MetricDefinition` and `ProbeDefinition` are allocated for every parsed registry entry and metric. This slice adds dataclass slots to remove per-instance `__dict__` allocation while preserving frozen dataclass behavior and existing `to_dict()` / `to_scope_dict()` output semantics.
+
+## Verification plan
+
+- Extend the existing registry-cache focused test to assert loaded metric and probe definitions are slotted and still serialize to the same public dictionaries.
+- Run the registered `pr-scoped-performance-registry-cache` focused tests.
+- Run changed-scope coverage for `pr_scoped_performance.py` and the focused test file.
+- Run the registered local probe and compare against `origin/main` using `scripts/pr_scoped_performance_run.py` before pushing.
+
+## Acceptance
+
+Accept only if focused tests pass, changed-scope coverage remains at least 95%, and the registered probe shows lower cold registry-load time without a material cached-load or scope-report regression. The CI registered probe remains the source of truth before merge.

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1473,6 +1473,18 @@ def test_scope_report_selects_registry_cache_probe(tmp_path: Path) -> None:
         changed_files=["src/c.py", "src/a.py", "src/b.py", "other.py"],
     )
 
+    loaded_probes = load_probe_registry(registry_path)
+    assert not hasattr(loaded_probes[0], "__dict__")
+    assert not hasattr(loaded_probes[0].metrics[0], "__dict__")
+    assert loaded_probes[0].to_scope_dict()["metrics"] == [
+        {
+            "key": "elapsed_ms_mean",
+            "unit": "value",
+            "direction": "lower_is_better",
+            "warn_pct": 5.0,
+        }
+    ]
+
     assert sparse_scope["matched_probe_ids"] == ["alpha", "beta", "gamma"]
     assert [probe["id"] for probe in sparse_scope["selected_probes"]] == ["alpha", "beta", "gamma"]
     assert sparse_scope["selected_count"] == 3

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -86,7 +86,7 @@ def _summarize_command(command: str, *, max_length: int = 180) -> str:
     return summary
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class MetricDefinition:
     key: str
     unit: str
@@ -106,7 +106,7 @@ class MetricDefinition:
         return payload
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ProbeDefinition:
     probe_id: str
     name: str


### PR DESCRIPTION
## Summary
- Add `slots=True` to PR-scoped registry `MetricDefinition` and `ProbeDefinition` dataclasses to remove per-instance `__dict__` allocation during registry parsing.
- Extend the focused registry-cache test to prove loaded definitions are slotted while preserving public metric serialization.

## Plan or Spec
- `docs/plans/2026-05-21-pr-scoped-definition-slots.md`
- Registered probe: `pr-scoped-performance-registry-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_uses_absolute_cache_key_without_resolving services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_build_scope_report_reuses_scope_cached_registry_without_double_stat services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_json_probe_rejects_missing_command_and_non_numeric_metrics
# 8 passed in 2.76s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_uses_absolute_cache_key_without_resolving services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_build_scope_report_reuses_scope_cached_registry_without_double_stat services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_json_probe_rejects_missing_command_and_non_numeric_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 8 passed in 2.93s; changed-scope coverage TOTAL 5/5 100%

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (5/5 measurable changed lines).
- Local registered probe comparison against `origin/main`, 8 repeated runs each:
  - `build_scope_report_ms_mean`: old_mean=3.273650, new_mean=3.240555, delta=-0.033094 ms, speedup=1.010x.
  - `cold_load_probe_registry_ms_mean`: old_mean=183.440798, new_mean=177.183322, delta=-6.257477 ms, speedup=1.035x.
  - `load_probe_registry_ms_mean`: old_mean=0.933061, new_mean=0.962235, delta=+0.029174 ms, speedup=0.970x (small local variance on cached path; CI registered probe is the merge gate).

## Known Gaps
- Linux local validation only. This is a Python-only slice; GitHub Actions PR-scoped performance remains the registered CI validation source before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
