### PR TITLE
Document LoRA compare bundle release preflight

### DIFF
--- a/docs/runbooks/phase-8-lora-adapter-workflow.md
+++ b/docs/runbooks/phase-8-lora-adapter-workflow.md
@@ -347,6 +347,30 @@ Melix now treats adapter-only export and merged-model export as separate distrib
 Use adapter export when you want a reusable LoRA package for downstream activation. Use merged export
 only when you intentionally want to distribute a fused derived model directory.
 
+### Required Compare Bundle Before Publishing Or Promotion
+
+Before publishing or promoting a LoRA adapter, inspect `train_lora.adapter.json` and confirm the
+adapter is backed by a release compare evidence bundle:
+
+1. `release_compare_bundle_policy.schema_version` is
+   `melix.lora_release_compare_bundle_policy.v1`.
+2. `release_compare_in_domain_suite_ids` names the target-domain suites that the adapter is
+   expected to improve.
+3. `release_compare_guard_suite_ids` names the regression-guard suites that must not degrade.
+4. `release_compare_thresholds` covers each required suite, either explicitly or through
+   `release_compare_default_threshold`.
+5. `release_compare_minimum_sample_counts` covers each required suite, either explicitly or
+   through `release_compare_default_minimum_sample_count`.
+6. Paired base-vs-adapter compare artifacts for those suites are attached to the release evidence
+   and identify the base model, adapter manifest path, dataset lineage, metric deltas, and verdicts.
+
+Do not treat a published or promoted adapter candidate as release-ready when the compare policy is
+empty for the target release, when paired compare artifacts are missing, or when the compare
+verdicts are not yet available. Exploratory local adapters may intentionally skip release gating,
+but their release evidence must record that the artifact is not promotion-ready. This runbook
+requirement remains operator-enforced until the later compare-execution and release-gate milestones
+make those checks automatic.
+
 Adapter publish request:
 
 ```json


### PR DESCRIPTION
## Summary
- Add a publish/promotion preflight checklist to the Phase 8 LoRA runbook requiring release compare policy fields and paired base-vs-adapter compare evidence.
- Clarify that the runbook requirement is operator-enforced until later milestones automate compare execution and release-gate verdicts.

Closes #727.

## Plan or Spec
- `docs/plans/2026-05-21-lora-release-compare-bundle-policy.md`
- `docs/runbooks/phase-8-lora-adapter-workflow.md`

## Commands Run
```text
git diff --check
Result: passed

rg -n "Required Compare Bundle|release_compare_bundle_policy|not promotion-ready|operator-enforced" docs/runbooks/phase-8-lora-adapter-workflow.md
Result: passed; new runbook section and required policy references present.

git diff --cached --check
Result: passed

git diff --check HEAD~1..HEAD
Result: passed

pre-commit hook on commit:
- make swift-test: passed
- make py-test: passed, 2969 passed, 14 skipped, 2 warnings
- make integration-test: passed, 114 passed, 1 skipped
- PR scoped performance report: Status ok, changed files 1, selected probes 0, direct/gated probes 0, regressions 0
```

## Coverage and Metrics
- Coverage: `N/A` - documentation-only runbook change; no Python or Swift executable scope changed.
- Metrics: `N/A` - documentation-only runbook change; no runtime path, benchmark path, or measured behavior changed.
- Observability mode: `N/A` - no observability code or probe behavior changed.
- Probe overhead: `N/A` - pre-commit performance report selected 0 probes for this docs-only change.

## Known Gaps
- Later OpenSearch-VL alignment milestones still need to automate compare execution and release-gate verdict enforcement.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or `N/A` is stated explicitly: N/A, no protocol changes.
- [x] Dependency changes include updated lockfiles, or `N/A` is stated explicitly: N/A, no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
