### PR TITLE
perf: cache worker tool config templates

### DIFF
--- a/docs/plans/2026-05-21-tool-registry-worker-config-template.md
+++ b/docs/plans/2026-05-21-tool-registry-worker-config-template.md
@@ -1,0 +1,23 @@
+# Tool registry worker config template copy slice
+
+## Scope
+
+This Python-only performance slice targets `services/mlx-worker-python/worker/runtime/tool_registry.py` and is limited to `ToolRegistry.as_worker_tool_config()` cache reuse.
+
+The affected path is covered by the registered PR-scoped probes in `infra/perf/pr_scoped_probes.json` for `services/mlx-worker-python/worker/runtime/tool_registry.py`. The primary local metric for this slice comes from `tool-registry-schema-bytes-cache`, whose focused `test_command`, `coverage_command`, and `probe_command` include the built-in and partial worker tool config paths. The registry also selects the related tool registry probes for name selection, names snapshot, and OpenAI tool template behavior when this source path changes.
+
+## Optimization
+
+Before this slice, repeated `as_worker_tool_config()` calls cached serialized protobuf bytes and reparsed them on every call. The new path caches a protobuf template object and returns isolated `CopyFrom` copies from that template. Local micro-measurement showed template `CopyFrom` is faster than reparsing the serialized bytes for this small hot config, while still preserving mutation isolation for every returned `ToolConfig`.
+
+## Verification plan
+
+- Add focused regression coverage proving the cached path avoids descriptor rebuilds and serialized-byte reparsing.
+- Verify the first returned `ToolConfig` is also isolated from the cached template.
+- Run the registered tool registry focused test command.
+- Run changed-scope coverage for the modified source, tests, registry, and probe script.
+- Run the registered `tool-registry-schema-bytes-cache` PR-scoped probe locally on Linux against `origin/main` vs this worktree.
+
+## Boundaries
+
+This slice is Python-only and locally verifiable on Linux. No Swift runtime performance claim is made.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -446,7 +446,7 @@ def test_built_in_tool_config_partial_selection_reuses_serialized_selection_cach
     assert built_in_tool_config(["image_crop", "local_compute"]).tools[0].name == "image_crop"
 
 
-def test_tool_registry_worker_tool_config_reuses_cached_serialized_snapshot(
+def test_tool_registry_worker_tool_config_reuses_cached_template_snapshot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     registry = built_in_tool_registry().select(["image_crop", "local_compute"])
@@ -454,16 +454,31 @@ def test_tool_registry_worker_tool_config_reuses_cached_serialized_snapshot(
 
     def fail_as_worker_tool_definition(self: ToolDescriptor) -> common_pb2.ToolDefinition:
         raise AssertionError(  # pragma: no cover
-            "as_worker_tool_config() should reuse cached serialized config"
+            "as_worker_tool_config() should reuse cached config template"
+        )
+
+    def fail_from_bytes(payload: bytes) -> common_pb2.ToolConfig:
+        raise AssertionError(  # pragma: no cover
+            "as_worker_tool_config() should copy the cached template without reparsing bytes"
         )
 
     monkeypatch.setattr(ToolDescriptor, "as_worker_tool_definition", fail_as_worker_tool_definition)
+    monkeypatch.setattr(tool_registry_module, "_TOOL_CONFIG_FROM_BYTES", fail_from_bytes)
 
     config = registry.as_worker_tool_config()
 
     assert config == expected_config
     assert config is not expected_config
     config.tools[0].name = "mutated"
+    assert registry.as_worker_tool_config().tools[0].name == "image_crop"
+
+
+def test_tool_registry_worker_tool_config_first_call_returns_isolated_copy() -> None:
+    registry = ToolRegistry(built_in_tool_registry().tools)
+
+    config = registry.as_worker_tool_config()
+    config.tools[0].name = "mutated"
+
     assert registry.as_worker_tool_config().tools[0].name == "image_crop"
 
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -205,7 +205,7 @@ class ToolRegistry:
             for tool in self._tools
         )
         self._selection_cache: dict[tuple[str, ...], ToolRegistry] = {}
-        self._worker_tool_config_bytes: bytes = b""
+        self._worker_tool_config_template: common_pb2.ToolConfig | None = None
         self._metrics = ToolRegistryMetrics(
             tool_count=len(self._tools),
             schema_bytes=sum(tool.schema_byte_count() for tool in self._tools),
@@ -307,8 +307,9 @@ class ToolRegistry:
         return tools
 
     def as_worker_tool_config(self) -> common_pb2.ToolConfig:
-        if self._worker_tool_config_bytes:
-            return _TOOL_CONFIG_FROM_BYTES(self._worker_tool_config_bytes)
+        template = self._worker_tool_config_template
+        if template is not None:
+            return _copy_tool_config(template)
         config = common_pb2.ToolConfig(
             tools=[tool.as_worker_tool_definition() for tool in self._tools],
             schema_format="openai-function",
@@ -317,8 +318,8 @@ class ToolRegistry:
             parser=self._parser,
             parser_contract_version=self._parser_contract_version,
         )
-        self._worker_tool_config_bytes = config.SerializeToString()
-        return config
+        self._worker_tool_config_template = config
+        return _copy_tool_config(config)
 
     def _validate(self) -> None:
         if not self._schema_version:


### PR DESCRIPTION
## Summary
- Cache `ToolRegistry.as_worker_tool_config()` as a protobuf template object instead of reparsing serialized bytes on repeated calls.
- Preserve mutation isolation by returning `CopyFrom` copies from the cached template, including the first public return.
- Add focused regression coverage for cached template reuse and first-call isolation.

## Plan or Spec
- `docs/plans/2026-05-21-tool-registry-worker-config-template.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 54 passed in 0.76s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py infra/perf/pr_scoped_probes.json docs/plans/2026-05-21-tool-registry-worker-config-template.md
# 54 passed; TOTAL 14 0 100%

MELIX_TOOL_REGISTRY_METRICS_SAMPLES=12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-schema-bytes-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/tool_registry_worker_config_probe_12.json
# ok; head verification 54 passed; coverage TOTAL 14 0 100%
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Registered local PR-scoped probe: `tool-registry-schema-bytes-cache`.
- 12-sample local Linux probe metrics:
  - `elapsed_ms_mean`: base `4.489 ms`, head `4.123 ms`, delta `-0.366 ms` (`-8.15%`).
  - `schema_payload_elapsed_ms_mean`: base `148.212 ms`, head `148.238 ms`, delta `+0.026 ms` (`+0.02%`).
  - `built_in_tool_config_elapsed_ms_mean`: base `57.191 ms`, head `57.364 ms`, delta `+0.173 ms` (`+0.30%`).
  - `full_selection_tool_config_elapsed_ms_mean`: base `61.658 ms`, head `62.674 ms`, delta `+1.016 ms` (`+1.65%`).
  - `partial_selection_tool_config_elapsed_ms_mean`: base `52.464 ms`, head `51.632 ms`, delta `-0.833 ms` (`-1.59%`).
- CI PR-scoped performance report is required as the merge validation source.

## Known Gaps
- Linux local verification covers the Python worker path only; no Swift runtime effect is claimed.
- The focused probe shows the targeted partial worker config path improving modestly and no registered warning-threshold regression in adjacent tool-config metrics.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; runtime observability unchanged.
- [x] Deferred work and known gaps are stated explicitly.
