### PR TITLE
Document LoRA compare adapter targets

### DIFF
--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -1025,6 +1025,19 @@ The canonical comparison extension fields are:
 
 - `compare_mode: base_vs_targets`
 - `compare_target_model_ids: string[]`
+- `compare_target_adapter_manifest_paths: string[]`
+
+`compare_target_model_ids` names registered catalog targets that are already
+loadable by the local runtime. `compare_target_adapter_manifest_paths` names
+LoRA adapter package manifests with schema `melix.lora_adapter_package.v1`.
+During local compare execution, Melix resolves each adapter manifest into an
+ephemeral adapter-backed target using the manifest's source model, weights path,
+and adapter set hash. Those ephemeral targets are unloaded after compare
+execution finishes.
+
+A comparison request is valid when it has exactly one base target, expressed
+through `model_id` or `hf_repo_id`, and at least one comparison target across
+`compare_target_model_ids` and `compare_target_adapter_manifest_paths`.
 
 Comparison runs must persist through the same shared history and export bundle as `eval run`.
 
@@ -1058,6 +1071,8 @@ The canonical normalized request shape is:
 - `profile_threshold: number`
 - `output_schema_json: string`
 - `ignored_paths: string[]`
+- `compare_target_model_ids: string[]`
+- `compare_target_adapter_manifest_paths: string[]`
 
 ### Current Control Semantics
 

--- a/docs/plans/2026-05-22-lora-release-compare-target-resolution.md
+++ b/docs/plans/2026-05-22-lora-release-compare-target-resolution.md
@@ -1,0 +1,83 @@
+# LoRA Release Compare Target Resolution
+
+## Goal
+
+Complete issue #729 by aligning the canonical evaluation contract and operator
+runbook with the shipped `melix eval compare --target-adapter` surface. This
+surface resolves LoRA adapter package manifest paths into compare targets so a
+base model can be compared against adapter-backed targets without first
+activating every adapter as a long-lived catalog model.
+
+Parent direction: issue #724, "OpenSearch-VL alignment: gate LoRA release with
+paired compare evidence". Milestone direction: issue #728, "automate
+base-vs-adapter compare execution".
+
+## Current Shipped Surface
+
+- The Swift CLI accepts repeatable `--target-adapter PATH` values alongside
+  repeatable `--target-model-id MODEL_ID` values.
+- The CLI serializes adapter targets into
+  `compare_target_adapter_manifest_paths`.
+- The Python worker validates each `melix.lora_adapter_package.v1` manifest,
+  builds an adapter-backed ephemeral compare target from its source model,
+  weights path, and adapter set hash, and unloads that target when compare
+  execution finishes.
+- Compare evidence records target lineage so exported artifacts can identify
+  adapter-backed targets.
+
+## Scope
+
+This slice is documentation and contract alignment only:
+
+- update the benchmark/evaluation contract with the adapter-manifest compare
+  request field and target-resolution semantics
+- update the benchmark/matrix/evaluation/LoRA runbook with operator examples
+  for registered model targets and adapter-manifest targets
+- keep existing CLI, parser, runner, and worker behavior unchanged
+
+Out of scope:
+
+- adding new persisted artifact fields beyond the shipped target lineage
+- adding statistical release-gate verdict enforcement
+- changing LoRA training or adapter activation behavior
+- changing protobuf schemas
+
+## Performance And Metrics
+
+This path updates documentation for an already shipped control surface and does
+not change serving, training, evaluation, or compare execution code.
+
+Measurement points:
+
+- focused Swift CLI parser/runner tests that cover `--target-adapter`
+- focused Python compare/worker tests that cover adapter manifest parsing,
+  ephemeral target materialization, and cleanup
+- `git diff --check`
+
+Success metrics:
+
+- the canonical contract names `compare_target_adapter_manifest_paths`
+- the runbook no longer states that compare requires pre-activated target model
+  IDs
+- focused existing tests continue to pass
+- changed-scope coverage is `N/A` because no executable code changes
+
+## Implementation Plan
+
+- [x] Add adapter-manifest target semantics to the canonical benchmark/evaluation contract.
+- [x] Update the LoRA comparison runbook with `--target-adapter` examples and rules.
+- [x] Run focused Swift and Python tests that already exercise the shipped target-resolution path.
+- [x] Run `git diff --check`.
+
+## Verification
+
+- `HOME="$PWD/.swift-home/root-cli" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/root-cli" xcrun swift test --filter "parsesEvalCompareWithAdapterTargets|parsesEvalCompareMixedTargets|evalCompareForwardsAdapterTargetsToSubprocessArgv"`
+  - Result: passed; 3 Swift Testing tests selected and passed. Existing test
+    warnings were emitted from unrelated runner tests during compilation.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_compare.py services/mlx-worker-python/tests/test_evaluation_core.py -k "adapter_target or compare_target_adapter or load_adapter_target_spec or resolve_compare_target_adapters"`
+  - Result: 16 passed, 101 deselected.
+- `git diff --check`
+  - Result: passed.
+- Changed-scope coverage:
+  - Result: `N/A`; this slice changes documentation only and does not touch
+    executable code.

--- a/docs/runbooks/benchmark-matrix-evaluation-and-lora.md
+++ b/docs/runbooks/benchmark-matrix-evaluation-and-lora.md
@@ -13,7 +13,7 @@ This runbook is intentionally execution-focused. It explains:
 - how to run `bench matrix` sweeps
 - how to run `eval` jobs
 - how to use LoRA adapters with those workflows
-- how to run first-class `eval compare` jobs against activated derived models
+- how to run first-class `eval compare` jobs against registered derived models or adapter manifests
 
 ## Preconditions
 
@@ -51,8 +51,10 @@ Important target-selection rules:
 - `melix bench run` requires exactly one of `--model-id` or `--repo-id`
 - `melix bench matrix run` requires exactly one of `--model-id` or `--repo-id`
 - `melix eval run` requires exactly one of `--model-id` or `--repo-id`
-- `melix eval compare` requires exactly one base target (`--model-id` or `--repo-id`) plus at least one `--target-model-id`
-- benchmark, matrix, and evaluation do not accept an adapter path or adapter ID directly
+- `melix eval compare` requires exactly one base target (`--model-id` or `--repo-id`) plus at least
+  one compare target, either `--target-model-id` or `--target-adapter`
+- `melix bench run`, `melix bench matrix run`, and `melix eval run` do not accept an adapter path
+  or adapter ID directly
 
 ## Run A Standard Benchmark
 
@@ -490,12 +492,14 @@ Melix removes the product-owned derived model artifacts and prunes the removed m
 catalog snapshot. If you keep multiple adapters active in the catalog, remove each derived model
 explicitly when the session is complete.
 
-## Run Evaluation Compare Against Activated Derived Models
+## Run Evaluation Compare Against Derived Models Or Adapter Manifests
 
-Use `eval compare` when you want one base target and one or more activated derived models in the
-same evaluation job.
+Use `eval compare` when you want one base target and one or more derived targets in the same
+evaluation job. Use `--target-model-id` when the target already exists in the local catalog. Use
+`--target-adapter` when the target should be resolved from a `train_lora.adapter.json` package
+manifest for this compare job only.
 
-Example:
+Registered model target example:
 
 ```bash
 swift run melix eval compare \
@@ -511,10 +515,30 @@ swift run melix eval compare \
   --code-exec-policy sandboxed
 ```
 
+Adapter-manifest target example:
+
+```bash
+swift run melix eval compare \
+  --model-id mlx-community/Qwen3.5-0.8B-OptiQ-4bit \
+  --target-adapter /absolute/path/to/train_lora.adapter.json \
+  --suite mbpp \
+  --dataset-id mbpp.dev.v1 \
+  --sample-size 12 \
+  --batch-factor 2 \
+  --seed 9 \
+  --scoring-mode pass_at_1 \
+  --code-exec-policy sandboxed
+```
+
 Important compare rules:
 
-- `eval compare` still uses model IDs, not adapter paths
-- every `--target-model-id` must already exist in the local catalog
+- `--target-model-id` targets must already exist in the local catalog
+- `--target-adapter` targets must point to a `melix.lora_adapter_package.v1` manifest, usually
+  `train_lora.adapter.json`
+- each adapter manifest target is materialized as an ephemeral adapter-backed compare target and
+  unloaded after the compare job finishes
+- adapter manifest targets use the manifest's `source_model`, `weights_path`, and
+  `adapter_set_hash` fields to derive runtime target identity and lineage
 - compare results persist through the same evaluation export bundle as `eval run`, but compare exports use dedicated compare subcommands
 - compare sample exports preserve executable-code evidence for both the base and target responses when the suite executes code
 - human-readable compare output now includes `verdict`, observed delta, bootstrap CI, analytical CI,


### PR DESCRIPTION
## Summary
- Document that `melix eval compare` accepts adapter manifest targets through `--target-adapter`.
- Add the #729 plan and align the canonical evaluation contract plus operator runbook with the shipped adapter-target resolution path.

## Plan or Spec
- `docs/plans/2026-05-22-lora-release-compare-target-resolution.md`
- `docs/benchmark-evaluation-contract.md`
- `docs/runbooks/benchmark-matrix-evaluation-and-lora.md`

Closes #729.

## Commands Run
```text
HOME="$PWD/.swift-home/root-cli" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/root-cli" xcrun swift test --filter "parsesEvalCompareWithAdapterTargets|parsesEvalCompareMixedTargets|evalCompareForwardsAdapterTargetsToSubprocessArgv"
Result: passed; 3 Swift Testing tests selected and passed. Existing unrelated compile warnings were emitted from runner tests during compilation.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_compare.py services/mlx-worker-python/tests/test_evaluation_core.py -k "adapter_target or compare_target_adapter or load_adapter_target_spec or resolve_compare_target_adapters"
Result: 16 passed, 101 deselected.

git diff --check
Result: passed.

git merge origin/main
Result: passed; merged latest origin/main containing #1356 and #1358 without conflicts.

git diff --check origin/main...HEAD
Result: passed after merging origin/main.

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-bodies/opensearch-vl-lora-compare-targets.md
Result: passed.

HOME="$PWD/.swift-home/root-cli" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/root-cli" xcrun swift test --filter "parsesEvalCompareWithAdapterTargets|parsesEvalCompareMixedTargets|evalCompareForwardsAdapterTargetsToSubprocessArgv"
Result: passed after merging origin/main; 3 Swift Testing tests selected and passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_compare.py services/mlx-worker-python/tests/test_evaluation_core.py -k "adapter_target or compare_target_adapter or load_adapter_target_spec or resolve_compare_target_adapters"
Result: passed after merging origin/main; 16 passed, 101 deselected.

pre-commit hook
Result: passed before merging latest origin/main; make swift-test, make py-test, make integration-test, and PR-scoped performance report all passed.
```

## Coverage and Metrics
- Changed-scope coverage: `N/A`; documentation-only change with no executable code touched.
- Metrics report: `N/A`; documentation-only change with no serving, training, evaluation, or compare execution code touched.
- Observability mode and probe overhead: `N/A`; no observability or probe behavior changed.

## Known Gaps
- #730 remains for compare artifact lineage/stat verdict work beyond the already shipped adapter target lineage.
- #731, #732, and #733 remain for release-gate verdict enforcement and report output.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
