### PR TITLE
Persist LoRA compare release evidence

### DIFF
--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -1039,7 +1039,23 @@ A comparison request is valid when it has exactly one base target, expressed
 through `model_id` or `hf_repo_id`, and at least one comparison target across
 `compare_target_model_ids` and `compare_target_adapter_manifest_paths`.
 
-Comparison runs must persist through the same shared history and export bundle as `eval run`.
+Comparison runs must persist through the same shared history and export bundle
+as `eval run`. The persisted compare bundle must also expose one
+machine-readable release evidence view:
+
+- `dataset_lineage` records the materialized dataset root and normalized dataset
+  source fields used for the paired base and target samples.
+- `target_lineage` records each comparison target's materialization kind. For
+  adapter targets, it includes the adapter manifest path, adapter weights path,
+  adapter set hash, and source model id used to derive the ephemeral target.
+- `statistical_verdicts` records each target's verdict, effect threshold, delta
+  accuracy, statistical evidence, and release-gate summary.
+
+`evaluation-compare-job.json`, `evaluation-compare-summary.json`, and
+`run-record.json` must preserve enough of this lineage/verdict data for a
+release reviewer to verify which adapter was compared, which dataset slice was
+used, and why the statistical verdict was emitted without joining against
+process logs.
 
 ### Normalized Input Fields
 

--- a/docs/plans/2026-05-22-lora-release-compare-artifacts-lineage.md
+++ b/docs/plans/2026-05-22-lora-release-compare-artifacts-lineage.md
@@ -1,0 +1,121 @@
+# LoRA Release Compare Artifact Lineage
+
+## Goal
+
+Complete issue #730 by making `eval compare` artifacts carry the release-gate
+evidence needed for base-vs-adapter LoRA review: adapter target lineage, dataset
+lineage, and statistical verdicts in the persisted compare bundle.
+
+Parent direction: issue #724, "OpenSearch-VL alignment: gate LoRA release with
+paired compare evidence". Milestone direction: issue #728, "automate
+base-vs-adapter compare execution".
+
+## Current Shipped Surface
+
+- Compare jobs already support registered targets and adapter manifest targets.
+- `EvaluationCompareJob.target_lineage` records registered versus ephemeral
+  adapter targets, including adapter manifest paths and adapter set hashes.
+- The compare summary CSV carries adapter manifest and adapter set hash columns.
+- Per-target summaries already include statistical evidence and
+  `release_gate_summary`.
+
+## Gap
+
+The compare artifact bundle does not yet expose one stable machine-readable
+view that joins dataset lineage, target lineage, and statistical verdicts. A
+release reviewer currently has to read multiple artifacts and infer the dataset
+materialization context from job parameters.
+
+## Scope
+
+This slice persists structured lineage and verdict fields without changing
+compare execution:
+
+- add a typed compare dataset-lineage record
+- attach dataset lineage to compare jobs created by local and event-extraction
+  compare paths
+- expose dataset lineage, target lineage, and statistical verdicts in
+  `evaluation-compare-summary.json`
+- expose the same release-gate evidence in `run-record.json`
+- update the benchmark/evaluation contract
+
+Out of scope:
+
+- enforcing the release gate as a blocking publish step
+- changing statistical verdict rules
+- changing CSV column order
+- changing adapter materialization or unload behavior
+- changing protobuf schemas
+
+## Performance And Metrics
+
+The implementation adds small JSON payloads to already-written compare
+artifacts. It must not add model execution, dataset scanning, or additional
+statistics passes.
+
+Measurement points:
+
+- focused store tests for compare artifact JSON and run-record payloads
+- focused evaluation-core tests for dataset-lineage construction
+- `git diff --check`
+- changed-scope coverage for the touched Python files
+- PR-scoped performance report; the artifact path touches evaluation/store
+  watch globs, so selected direct probes are expected, but the changed code must
+  not regress job-id allocation, sample aggregation, answer normalization,
+  latency percentile aggregation, dialogue diagnostics, compare target lookup,
+  or CSV streaming probes
+
+Success metrics:
+
+- every compare job produced by the worker has `dataset_lineage`
+- `evaluation-compare-summary.json` includes `dataset_lineage`,
+  `target_lineage`, and `statistical_verdicts`
+- `run-record.json` includes the same lineage/verdict evidence for evidence
+  collectors
+- changed-scope coverage for modified executable Python files is at least 95
+  percent before handoff
+
+## Implementation Plan
+
+- [x] Update the benchmark/evaluation contract with the compare artifact
+  lineage bundle fields.
+- [x] Add a compare dataset-lineage schema and include it in compare jobs.
+- [x] Populate dataset lineage in the local and event-extraction compare paths.
+- [x] Persist lineage and statistical verdicts in compare summary JSON and
+  run-record artifacts.
+- [x] Add focused tests and run verification.
+
+## Verification
+
+- `python3 -m py_compile services/mlx-worker-python/worker/productization/evaluation_schemas.py services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/run_records.py services/mlx-worker-python/worker/engine/evaluation_core.py`
+  - Result: passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_evaluation_core.py -k "compare"`
+  - Result: 25 passed, 103 deselected.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/lora_compare_artifacts.coverage -m pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_evaluation_core.py -k "compare or payload_helpers or lineage_helpers"`
+  - Result: 27 passed, 103 deselected.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/lora_compare_artifacts_coverage.json services/mlx-worker-python/worker/productization/evaluation_schemas.py services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/run_records.py services/mlx-worker-python/worker/engine/evaluation_core.py`
+  - Result: `TOTAL 87 0 100%`.
+- `git diff --check`
+  - Result: passed.
+- Local PR-scoped performance report via `scripts.pre_commit_gate.run_performance_report(...)`
+  against `origin/main`
+  - Result: selected 8 direct probes; 7 passed, and 1 initial
+    `evaluation-job-id-high-water-mark` regression was not stable on isolated
+    registered-probe rerun.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-job-id-high-water-mark --base-repo /tmp/melix-jobid-rerun.i5kKO9/base --head-repo /tmp/melix-jobid-rerun.i5kKO9/head --output /tmp/evaluation-job-id-high-water-mark-rerun.json`
+  - Result: passed; base `elapsed_ms_mean=8.858`, head
+    `elapsed_ms_mean=8.899`, delta `+0.46%`, below the 5 percent threshold.
+- `git commit -m "Persist LoRA compare release evidence"` with the local
+  pre-commit hook
+  - Result: blocked by local disk exhaustion during `make swift-test`,
+    specifically `swift-test-text-worker`. The first attempt reached code
+    signing and reported `internal error in Code Signing subsystem`; an
+    immediate focused rerun then failed with `No space left on device` while
+    writing Swift build/index artifacts. No Python compare tests failed.
+- Review follow-up verification after deduplicating compare payload helpers:
+  - `python3 -m py_compile services/mlx-worker-python/worker/productization/evaluation_schemas.py services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/run_records.py services/mlx-worker-python/worker/engine/evaluation_core.py`
+    - Result: passed.
+  - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_evaluation_core.py -k "compare or payload_helpers or lineage_helpers"`
+    - Result: 27 passed, 103 deselected.
+  - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/lora_compare_artifacts_review_coverage.json services/mlx-worker-python/worker/productization/evaluation_schemas.py services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/run_records.py services/mlx-worker-python/worker/engine/evaluation_core.py`
+    - Result: `TOTAL 4 0 100%`.

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -1901,8 +1901,16 @@ def test_event_extraction_compare_uses_adapter_target_and_persists_compare_artif
     assert run.results[0].base_accuracy == 0.0
     assert run.results[0].target_accuracy == 1.0
     assert run.results[0].delta_accuracy == 1.0
+    assert run.job.dataset_lineage is not None
+    assert run.job.dataset_lineage.dataset_id == "local.event.v1"
+    assert run.job.dataset_lineage.source_path == str(source_jsonl.resolve())
+    assert run.job.dataset_lineage.scoring_mode == "event_extraction_weighted_f1"
     assert run.samples[0].target_typed_score == 1.0
     assert run.samples[0].base_typed_score == 0.0
+    summary_payload = json.loads(run.persisted_paths["summary_json"].read_text(encoding="utf-8"))
+    assert summary_payload["dataset_lineage"]["source_path"] == str(source_jsonl.resolve())
+    assert summary_payload["target_lineage"][0]["materialization_kind"] == "ephemeral_adapter"
+    assert summary_payload["statistical_verdicts"][0]["target_model_id"] == ephemeral_id
     compare_summary = Path(run.persisted_paths["summary_csv"]).read_text(encoding="utf-8")
     assert "evaluation-compare-summary" not in compare_summary
     assert ephemeral_id in compare_summary
@@ -2041,6 +2049,12 @@ def test_event_extraction_compare_logs_ephemeral_unload_failure(
     assert isinstance(run.job, EvaluationCompareJob)
     assert len(registry.unload_model_calls) == 1
     assert "Failed to unload ephemeral adapter compare target" in caplog.text
+
+
+def test_compare_lineage_helpers_handle_empty_and_invalid_parameters() -> None:
+    assert EvaluationCore._first_parameter({}, "missing") == ""
+    assert EvaluationCore._int_parameter_from_mapping({"seed": "11"}, "seed") == 11
+    assert EvaluationCore._int_parameter_from_mapping({"seed": "not-an-int"}, "seed") == 0
 
 
 def test_event_extraction_sample_records_normalize_invalid_event_fields_and_traces(
@@ -2589,6 +2603,11 @@ def test_run_local_suite_compares_base_against_target_models_and_persists_compar
     compare_results = {result.target_model_id: result for result in run.results}
     assert run.job.base_model_id == "melix-dev-text"
     assert run.job.target_model_ids == ("melix-dev-text-lora-a", "melix-dev-text-lora-b")
+    assert run.job.dataset_lineage is not None
+    assert run.job.dataset_lineage.dataset_id == "mmlu-dev"
+    assert run.job.dataset_lineage.dataset_root == str(dataset_root.resolve())
+    assert run.job.dataset_lineage.sample_size == 2
+    assert run.job.dataset_lineage.scoring_mode == "multiple_choice_accuracy"
     assert compare_results["melix-dev-text-lora-a"].win_count == 1
     assert compare_results["melix-dev-text-lora-a"].loss_count == 0
     assert compare_results["melix-dev-text-lora-a"].tie_count == 1
@@ -2629,7 +2648,35 @@ def test_run_local_suite_compares_base_against_target_models_and_persists_compar
     assert run.persisted_paths["report_markdown"] == jobs_root / "runs" / "eval-0001" / "evaluation-compare-report.md"
     summary_payload = json.loads(run.persisted_paths["summary_json"].read_text(encoding="utf-8"))
     assert summary_payload["job_id"] == "eval-0001"
+    assert summary_payload["dataset_lineage"]["dataset_root"] == str(dataset_root.resolve())
+    assert summary_payload["dataset_lineage"]["sample_size"] == 2
+    assert summary_payload["target_lineage"] == [
+        {
+            "target_model_id": "melix-dev-text-lora-a",
+            "materialization_kind": "registered",
+            "adapter_manifest_path": "",
+            "adapter_weights_path": "",
+            "adapter_set_hash": "",
+            "derived_from_model_id": "",
+        },
+        {
+            "target_model_id": "melix-dev-text-lora-b",
+            "materialization_kind": "registered",
+            "adapter_manifest_path": "",
+            "adapter_weights_path": "",
+            "adapter_set_hash": "",
+            "derived_from_model_id": "",
+        },
+    ]
+    assert [row["target_model_id"] for row in summary_payload["statistical_verdicts"]] == [
+        "melix-dev-text-lora-a",
+        "melix-dev-text-lora-b",
+    ]
     assert len(summary_payload["target_summaries"]) == 2
+    run_record = json.loads(run.persisted_paths["run_record"].read_text(encoding="utf-8"))
+    assert run_record["dataset"]["dataset_lineage"]["dataset_root"] == str(dataset_root.resolve())
+    assert run_record["target"]["target_lineage"][0]["target_model_id"] == "melix-dev-text-lora-a"
+    assert run_record["evaluation"]["statistical_verdicts"][0]["target_model_id"] == "melix-dev-text-lora-a"
     compare_samples = [
         json.loads(line)
         for line in run.persisted_paths["samples_jsonl"].read_text(encoding="utf-8").splitlines()

--- a/services/mlx-worker-python/tests/test_evaluation_store.py
+++ b/services/mlx-worker-python/tests/test_evaluation_store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from worker.productization.evaluation_schemas import (
+    EvaluationCompareDatasetLineage,
     EvaluationCompareTargetLineage,
     build_evaluation_compare_job_record,
     build_evaluation_compare_sample_record,
@@ -16,6 +17,7 @@ from worker.productization.evaluation_schemas import (
     build_evaluation_result_record,
     build_evaluation_sample_record,
 )
+from worker.productization import run_records
 from worker.productization.benchmark_export import (
     build_evaluation_samples_csv,
     build_evaluation_summary_csv,
@@ -852,6 +854,28 @@ def test_persist_compare_result_writes_expected_compare_artifact_names_and_paylo
         output_dir=str(run_root),
         created_at_unix_ms=101,
         updated_at_unix_ms=202,
+        dataset_lineage=EvaluationCompareDatasetLineage(
+            dataset_id="mmlu-dev",
+            suite_id="mmlu",
+            dataset_root=str(tmp_path / "datasets" / "mmlu-dev"),
+            source_kind="hf_dataset",
+            source_dataset_path="cais/mmlu",
+            source_split="validation",
+            sample_size=2,
+            seed=7,
+            few_shot=1,
+            scoring_mode="multiple_choice_accuracy",
+        ),
+        target_lineage=(
+            EvaluationCompareTargetLineage(
+                target_model_id="melix-dev-text-lora-a",
+                materialization_kind="ephemeral_adapter",
+                adapter_manifest_path="/tmp/melix-adapters/lora-a.adapter.json",
+                adapter_weights_path="/tmp/melix-adapters/lora-a/adapters.safetensors",
+                adapter_set_hash="loraahash12345678",
+                derived_from_model_id="melix-dev-text",
+            ),
+        ),
     )
     compare_summary = build_evaluation_compare_summary_record(
         job_id="eval-compare-1",
@@ -964,6 +988,13 @@ def test_persist_compare_result_writes_expected_compare_artifact_names_and_paylo
         summary_payload["target_summaries"][0]["release_gate_summary"]["both_intervals_same_side"]
         is True
     )
+    assert summary_payload["dataset_lineage"]["source_dataset_path"] == "cais/mmlu"
+    assert summary_payload["dataset_lineage"]["seed"] == 7
+    assert summary_payload["target_lineage"][0]["adapter_set_hash"] == "loraahash12345678"
+    assert summary_payload["statistical_verdicts"][0]["target_model_id"] == "melix-dev-text-lora-a"
+    assert summary_payload["statistical_verdicts"][0]["delta_accuracy"] == 0.5
+    assert summary_payload["statistical_verdicts"][0]["statistical_evidence"]["bootstrap"]["iterations"] == 400
+    assert summary_payload["statistical_verdicts"][0]["release_gate_summary"]["threshold_passed"] is True
     assert json.loads(persisted["samples_jsonl"].read_text(encoding="utf-8").strip()) == compare_sample.to_dict()
     assert persisted["summary_csv"].read_text(encoding="utf-8").startswith(
         "job_id,base_model_id,target_model_id,suite_id,dataset_id,sample_size,win_count,loss_count,tie_count,regression_count,base_accuracy,target_accuracy,delta_accuracy,effect_threshold,verdict,bootstrap_lower_bound,bootstrap_upper_bound,analytical_lower_bound,analytical_upper_bound,duration_seconds,created_at_unix_ms,target_adapter_manifest_path,target_adapter_set_hash\n"
@@ -978,8 +1009,15 @@ def test_persist_compare_result_writes_expected_compare_artifact_names_and_paylo
     assert run_record["schema_version"] == "melix.run_record.v1"
     assert run_record["run_kind"] == "evaluation_compare"
     assert run_record["target"]["base_model_id"] == "melix-dev-text"
+    assert run_record["target"]["target_lineage"][0]["adapter_manifest_path"] == "/tmp/melix-adapters/lora-a.adapter.json"
+    assert run_record["dataset"]["dataset_lineage"]["source_dataset_path"] == "cais/mmlu"
     assert run_record["evaluation"]["win_count"] == 1
     assert run_record["evaluation"]["verdicts"] == ["improvement"]
+    assert run_record["evaluation"]["statistical_verdicts"][0]["verdict"] == "improvement"
+    assert (
+        run_record["evaluation"]["statistical_verdicts"][0]["release_gate_summary"]["both_intervals_same_side"]
+        is True
+    )
     assert run_record["known_gaps"] == ["Apple Silicon telemetry artifact was not present for this run."]
     assert run_record["probes"][0]["phase"] == "run_record_write"
 
@@ -1176,6 +1214,9 @@ def test_compare_job_persists_adapter_target_lineage(tmp_path: Path) -> None:
     job_payload = json.loads(persisted["job"].read_text(encoding="utf-8"))
     assert "target_lineage" in job_payload
     assert len(job_payload["target_lineage"]) == 2
+    summary_payload = json.loads(persisted["summary_json"].read_text(encoding="utf-8"))
+    assert len(summary_payload["target_lineage"]) == 2
+    assert summary_payload["target_lineage"][1]["adapter_manifest_path"] == "/tmp/melix-adapters/demo.adapter.json"
     assert persisted["samples_jsonl"].read_text(encoding="utf-8") == ""
     registered, ephemeral = job_payload["target_lineage"]
     assert registered["materialization_kind"] == "registered"
@@ -1286,6 +1327,11 @@ def test_compare_summary_csv_carries_adapter_columns_per_target(tmp_path: Path) 
     assert header.endswith("target_adapter_manifest_path,target_adapter_set_hash")
     assert registered_row.endswith(",,")  # both adapter columns empty
     assert adapter_row.endswith(",/tmp/melix-adapters/bee.adapter.json,beefface12345678")
+
+
+def test_compare_artifact_payload_helpers_handle_mapping_and_unknown_values() -> None:
+    assert run_records.object_payload({"kind": "mapping"}) == {"kind": "mapping"}
+    assert run_records.object_payload(object()) == {}
 
 
 @pytest.mark.parametrize("probe_mode", ("off", "minimal", "definitely-not-a-mode", ""))

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -64,6 +64,7 @@ from worker.productization.event_extraction import (
     prompt_snapshot_payload,
 )
 from worker.productization.evaluation_schemas import (
+    EvaluationCompareDatasetLineage,
     EvaluationCompareJob,
     EvaluationCompareSample,
     EvaluationCompareSummary,
@@ -1389,15 +1390,42 @@ class EvaluationCore:
                     )
                 )
             compare_parameters.setdefault("sample_size", str(len(base_run.samples)))
+            base_job_parameters = getattr(base_run.job, "parameters", {})
+            if isinstance(base_job_parameters, dict):
+                for key in (
+                    "dataset_root",
+                    "source_kind",
+                    "source_path",
+                    "source_dataset_path",
+                    "source_dataset_name",
+                    "source_dataset_revision",
+                    "source_split",
+                    "few_shot",
+                    "seed",
+                    "scoring_mode",
+                ):
+                    if base_job_parameters.get(key) not in (None, ""):
+                        compare_parameters.setdefault(key, str(base_job_parameters[key]))
+            compare_dataset_id = str(getattr(base_run.job, "dataset_id", "") or dataset_id or "top200")
             compare_job = build_evaluation_compare_job_record(
                 job_id=job_id,
                 base_model_id=resolved_model_id,
                 target_model_ids=combined_target_ids,
+                dataset_lineage=self._compare_dataset_lineage(
+                    dataset_id=compare_dataset_id,
+                    suite_id=suite_id,
+                    dataset_root=Path(str(compare_parameters.get("dataset_root", "."))).resolve(),
+                    parameters=compare_parameters,
+                    sample_size=len(base_run.samples),
+                    seed=self._int_parameter_from_mapping(compare_parameters, "seed"),
+                    few_shot=self._int_parameter_from_mapping(compare_parameters, "few_shot"),
+                    scoring_mode=scoring_mode,
+                ),
                 target_lineage=tuple(target_lineage_entries),
                 task_kind=str(getattr(base_run.job, "task_kind", "event_extraction") or "event_extraction"),
                 source_repo=str(getattr(base_run.job, "source_repo", "") or ""),
                 suite_id=suite_id,
-                dataset_id=str(getattr(base_run.job, "dataset_id", "") or dataset_id or "top200"),
+                dataset_id=compare_dataset_id,
                 sample_size=len(base_run.samples),
                 scoring_mode=scoring_mode,
                 parameters=compare_parameters,
@@ -2170,6 +2198,16 @@ class EvaluationCore:
             job_id=job_id,
             base_model_id=resolved_model_id,
             target_model_ids=combined_target_ids,
+            dataset_lineage=self._compare_dataset_lineage(
+                dataset_id=dataset_id,
+                suite_id=suite_id,
+                dataset_root=dataset_root,
+                parameters=compare_job_parameters,
+                sample_size=len(base_samples),
+                seed=resolved_seed,
+                few_shot=len(few_shot_examples),
+                scoring_mode=resolved_scoring_mode,
+            ),
             target_lineage=tuple(target_lineage_entries),
             task_kind=compare_job_parameters.get("task_kind", resolved_task_kind),
             source_repo=compare_job_parameters.get("source_repo", ""),
@@ -3250,6 +3288,83 @@ class EvaluationCore:
         context = dict(raw_context) if isinstance(raw_context, dict) else {}
         context.setdefault("dataset_root", str(dataset_root))
         return context
+
+    @staticmethod
+    def _compare_dataset_lineage(
+        *,
+        dataset_id: str,
+        suite_id: str,
+        dataset_root: Path,
+        parameters: dict[str, str],
+        sample_size: int,
+        seed: int,
+        few_shot: int,
+        scoring_mode: str,
+    ) -> EvaluationCompareDatasetLineage:
+        return EvaluationCompareDatasetLineage(
+            dataset_id=dataset_id,
+            suite_id=suite_id,
+            dataset_root=str(Path(dataset_root).resolve()),
+            source_kind=EvaluationCore._first_parameter(
+                parameters,
+                "source_kind",
+                "evaluation_source_kind",
+            ),
+            source_path=EvaluationCore._first_parameter(
+                parameters,
+                "source_path",
+                "evaluation_source_path",
+                "event_source_jsonl",
+                "dataset_root",
+            ),
+            source_dataset_path=EvaluationCore._first_parameter(
+                parameters,
+                "source_dataset_path",
+                "hf_dataset_path",
+                "dataset_path",
+            ),
+            source_dataset_name=EvaluationCore._first_parameter(
+                parameters,
+                "source_dataset_name",
+                "hf_dataset_name",
+                "dataset_name",
+            ),
+            source_dataset_revision=EvaluationCore._first_parameter(
+                parameters,
+                "source_dataset_revision",
+                "hf_dataset_revision",
+                "dataset_revision",
+            ),
+            source_split=EvaluationCore._first_parameter(
+                parameters,
+                "source_split",
+                "hf_dataset_split",
+                "dataset_split",
+                "split",
+            ),
+            sample_size=sample_size,
+            seed=seed,
+            few_shot=few_shot,
+            scoring_mode=scoring_mode,
+        )
+
+    @staticmethod
+    def _first_parameter(parameters: dict[str, str], *keys: str) -> str:
+        for key in keys:
+            value = str(parameters.get(key, "") or "").strip()
+            if value:
+                return value
+        return ""
+
+    @staticmethod
+    def _int_parameter_from_mapping(parameters: dict[str, str], key: str) -> int:
+        value = str(parameters.get(key, "") or "").strip()
+        if not value:
+            return 0
+        try:
+            return int(value)
+        except ValueError:
+            return 0
 
     @staticmethod
     def _agentic_tool_metric_totals(samples: tuple[EvaluationSample, ...]) -> dict[str, float]:

--- a/services/mlx-worker-python/worker/productization/evaluation_schemas.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_schemas.py
@@ -290,6 +290,48 @@ class EvaluationCompareTargetLineage:
 
 
 @dataclass(frozen=True)
+class EvaluationCompareDatasetLineage:
+    """Dataset provenance for paired compare artifacts.
+
+    Compare release evidence needs one stable view of the dataset slice used by
+    the base and every target. The normalized source fields mirror the
+    evaluation request contract; empty strings are used when a legacy caller did
+    not provide the corresponding source detail.
+    """
+
+    dataset_id: str
+    suite_id: str
+    dataset_root: str = ""
+    source_kind: str = ""
+    source_path: str = ""
+    source_dataset_path: str = ""
+    source_dataset_name: str = ""
+    source_dataset_revision: str = ""
+    source_split: str = ""
+    sample_size: int = 0
+    seed: int = 0
+    few_shot: int = 0
+    scoring_mode: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "dataset_id": self.dataset_id,
+            "suite_id": self.suite_id,
+            "dataset_root": self.dataset_root,
+            "source_kind": self.source_kind,
+            "source_path": self.source_path,
+            "source_dataset_path": self.source_dataset_path,
+            "source_dataset_name": self.source_dataset_name,
+            "source_dataset_revision": self.source_dataset_revision,
+            "source_split": self.source_split,
+            "sample_size": self.sample_size,
+            "seed": self.seed,
+            "few_shot": self.few_shot,
+            "scoring_mode": self.scoring_mode,
+        }
+
+
+@dataclass(frozen=True)
 class EvaluationCompareJob:
     schema_version: str
     job_id: str
@@ -306,6 +348,7 @@ class EvaluationCompareJob:
     output_dir: str
     created_at_unix_ms: int
     updated_at_unix_ms: int
+    dataset_lineage: EvaluationCompareDatasetLineage | None = None
     # Module 2 — optional per-target lineage. Empty tuple for legacy jobs
     # that pre-date the adapter-native compare surface; ``to_dict``/``from_dict``
     # handle that as a clean default.
@@ -331,6 +374,8 @@ class EvaluationCompareJob:
             "updated_at_unix_ms": self.updated_at_unix_ms,
             "target_lineage": [entry.to_dict() for entry in self.target_lineage],
         }
+        if self.dataset_lineage is not None:
+            payload["dataset_lineage"] = self.dataset_lineage.to_dict()
         append_trajectory_provenance(payload, self.trajectory_provenance)
         return payload
 
@@ -733,6 +778,7 @@ def build_evaluation_compare_job_record(
     output_dir: str = "",
     created_at_unix_ms: int = 0,
     updated_at_unix_ms: int = 0,
+    dataset_lineage: EvaluationCompareDatasetLineage | None = None,
     target_lineage: tuple[EvaluationCompareTargetLineage, ...] = (),
     trajectory_provenance: dict[str, object] | None = None,
 ) -> EvaluationCompareJob:
@@ -752,6 +798,7 @@ def build_evaluation_compare_job_record(
         output_dir=output_dir,
         created_at_unix_ms=created_at_unix_ms,
         updated_at_unix_ms=updated_at_unix_ms,
+        dataset_lineage=dataset_lineage,
         target_lineage=tuple(target_lineage),
         trajectory_provenance=dict(trajectory_provenance or {}),
     )

--- a/services/mlx-worker-python/worker/productization/evaluation_store.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_store.py
@@ -26,8 +26,10 @@ from worker.productization.run_evidence import (
 )
 from worker.productization.run_records import (
     attach_run_record_write_probe,
+    build_evaluation_compare_statistical_verdict,
     build_evaluation_compare_run_record,
     build_evaluation_run_record,
+    object_payload,
     write_run_record,
 )
 
@@ -319,6 +321,7 @@ class EvaluationStore:
         job: EvaluationCompareJob,
         summaries: tuple[EvaluationCompareSummary, ...],
     ) -> dict[str, object]:
+        dataset_lineage = object_payload(getattr(job, "dataset_lineage", None))
         return {
             "schema_version": "melix.evaluation_compare_summary_bundle.v1",
             "job_id": job.job_id,
@@ -327,6 +330,11 @@ class EvaluationStore:
             "dataset_id": job.dataset_id,
             "sample_size": job.sample_size,
             "created_at_unix_ms": job.created_at_unix_ms,
+            "dataset_lineage": dataset_lineage,
+            "target_lineage": [entry.to_dict() for entry in job.target_lineage],
+            "statistical_verdicts": [
+                build_evaluation_compare_statistical_verdict(summary) for summary in summaries
+            ],
             "target_summaries": [summary.to_dict() for summary in summaries],
         }
 
@@ -513,4 +521,4 @@ class EvaluationStore:
     def _csv_field(value: str) -> str:
         if "," not in value and "\n" not in value and "\"" not in value:
             return value
-        return f"\"{value.replace('\"', '\"\"')}\""
+        return '"' + value.replace('"', '""') + '"'

--- a/services/mlx-worker-python/worker/productization/run_records.py
+++ b/services/mlx-worker-python/worker/productization/run_records.py
@@ -181,6 +181,7 @@ def build_evaluation_compare_run_record(
         target={
             "base_model_id": str(getattr(job, "base_model_id", "")),
             "target_model_ids": list(getattr(job, "target_model_ids", ())),
+            "target_lineage": _target_lineage(job),
             "task_kind": str(getattr(job, "task_kind", "")),
             "source_repo": str(getattr(job, "source_repo", "")),
             "runtime_backend": str(parameters.get("runtime_kind", "")),
@@ -190,6 +191,7 @@ def build_evaluation_compare_run_record(
             "dataset_id": str(getattr(job, "dataset_id", "")),
             "sample_size": int(getattr(job, "sample_size", 0) or 0),
             "scoring_mode": str(getattr(job, "scoring_mode", "")),
+            "dataset_lineage": _dataset_lineage(job),
         },
         parameters=parameters,
         metrics=metrics,
@@ -202,6 +204,7 @@ def build_evaluation_compare_run_record(
             "tie_count": sum(int(getattr(summary, "tie_count", 0) or 0) for summary in summaries),
             "regression_count": sum(int(getattr(summary, "regression_count", 0) or 0) for summary in summaries),
             "verdicts": sorted({str(getattr(summary, "verdict", "")) for summary in summaries if str(getattr(summary, "verdict", ""))}),
+            "statistical_verdicts": build_evaluation_compare_statistical_verdicts(summaries),
         },
     )
 
@@ -466,6 +469,56 @@ def _evaluation_compare_metrics(summaries: tuple[Any, ...]) -> list[dict[str, ob
             payload["name"] = f"{target_model_id}.{payload['name']}"
             metrics.append(payload)
     return metrics
+
+
+def _dataset_lineage(job: Any) -> dict[str, object]:
+    return object_payload(getattr(job, "dataset_lineage", None))
+
+
+def _target_lineage(job: Any) -> list[dict[str, object]]:
+    lineage: list[dict[str, object]] = []
+    for entry in getattr(job, "target_lineage", ()):
+        payload = object_payload(entry)
+        if payload:
+            lineage.append(payload)
+    return lineage
+
+
+def build_evaluation_compare_statistical_verdicts(summaries: tuple[Any, ...]) -> list[dict[str, object]]:
+    verdicts: list[dict[str, object]] = []
+    for summary in summaries:
+        verdicts.append(build_evaluation_compare_statistical_verdict(summary))
+    return verdicts
+
+
+def build_evaluation_compare_statistical_verdict(summary: Any) -> dict[str, object]:
+    return {
+        "target_model_id": str(getattr(summary, "target_model_id", "")),
+        "verdict": str(getattr(summary, "verdict", "")),
+        "effect_threshold": float(getattr(summary, "effect_threshold", 0.0) or 0.0),
+        "delta_accuracy": float(getattr(summary, "delta_accuracy", 0.0) or 0.0),
+        "base_accuracy": float(getattr(summary, "base_accuracy", 0.0) or 0.0),
+        "target_accuracy": float(getattr(summary, "target_accuracy", 0.0) or 0.0),
+        "win_count": int(getattr(summary, "win_count", 0) or 0),
+        "loss_count": int(getattr(summary, "loss_count", 0) or 0),
+        "tie_count": int(getattr(summary, "tie_count", 0) or 0),
+        "regression_count": int(getattr(summary, "regression_count", 0) or 0),
+        "statistical_evidence": object_payload(getattr(summary, "statistical_evidence", {})),
+        "release_gate_summary": object_payload(getattr(summary, "release_gate_summary", {})),
+    }
+
+
+def object_payload(value: object) -> dict[str, object]:
+    if value is None:
+        return {}
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        payload = to_dict()
+        if isinstance(payload, Mapping):
+            return dict(payload)
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
 
 
 def _metric_values(metrics: tuple[Any, ...]) -> list[dict[str, object]]:


### PR DESCRIPTION
## Summary
- Persist compare dataset lineage on `EvaluationCompareJob` and populate it from local and event-extraction compare execution.
- Add `dataset_lineage`, `target_lineage`, and `statistical_verdicts` to `evaluation-compare-summary.json` and `run-record.json` so LoRA release reviewers can verify the adapter, dataset slice, and statistical verdict from persisted artifacts.
- Update the benchmark/evaluation contract and the #730 implementation plan with the new artifact evidence requirements.

## Plan or Spec
- `docs/plans/2026-05-22-lora-release-compare-artifacts-lineage.md`
- `docs/benchmark-evaluation-contract.md`
- Issue: #730

## Commands Run
```text
python3 -m py_compile services/mlx-worker-python/worker/productization/evaluation_schemas.py services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/run_records.py services/mlx-worker-python/worker/engine/evaluation_core.py
Result: passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_evaluation_core.py -k "compare"
Result: 25 passed, 103 deselected.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/lora_compare_artifacts.coverage -m pytest -q services/mlx-worker-python/tests/test_evaluation_store.py services/mlx-worker-python/tests/test_evaluation_core.py -k "compare or payload_helpers or lineage_helpers"
Result: 27 passed, 103 deselected.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/lora_compare_artifacts.coverage -o /tmp/lora_compare_artifacts_coverage.json
Result: wrote coverage JSON.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/lora_compare_artifacts_coverage.json services/mlx-worker-python/worker/productization/evaluation_schemas.py services/mlx-worker-python/worker/productization/evaluation_store.py services/mlx-worker-python/worker/productization/run_records.py services/mlx-worker-python/worker/engine/evaluation_core.py
Result: TOTAL 87 0 100%.

git diff --check
Result: passed.

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-bodies/pr-730.md
Result: passed.
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 87 0 100%` for `evaluation_schemas.py`, `evaluation_store.py`, `run_records.py`, and `evaluation_core.py`.
- Local PR-scoped performance report against `origin/main`: selected 8 direct probes; 7 passed; one initial `evaluation-job-id-high-water-mark` regression did not reproduce on isolated registered-probe rerun.
- Isolated `evaluation-job-id-high-water-mark` rerun: passed; base `elapsed_ms_mean=8.858`, head `elapsed_ms_mean=8.899`, delta `+0.46%`, below the 5 percent threshold.
- Observability mode: evidence-mode persisted artifacts only. Probe overhead: N/A; this change adds JSON fields during existing artifact writes and does not add runtime probes, model execution, dataset scanning, or extra statistics passes.

## Known Gaps
- Local pre-commit full gate was attempted but did not complete because this Mac ran out of disk space during `make swift-test` / `swift-test-text-worker`. The initial failure surfaced as a code-signing internal error; an immediate focused rerun reported `No space left on device` while writing Swift build/index artifacts. No Python compare tests failed.
- No protobuf or dependency changes; no generated artifacts or lockfiles were updated.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
