### PR TITLE
perf: hoist audio voice mode membership

### DIFF
--- a/docs/plans/2026-05-21-mlx-audio-voice-mode-membership.md
+++ b/docs/plans/2026-05-21-mlx-audio-voice-mode-membership.md
@@ -1,0 +1,40 @@
+# MLX audio voice mode direct comparison fast path
+
+## Scope
+
+This Python-only performance slice targets the per-request MLX audio TTS speech
+keyword path in `services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py`.
+The behavior remains unchanged: `hybrid` and `named` voice modes accept a voice
+argument, while instructional/plain modes do not.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`mlx-audio-generate-signature-cache` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` values, and watches `mlx_audio_runtime.py`, the audio runtime
+protocols, focused tests, and `scripts/mlx_audio_generate_signature_probe.py`.
+
+## Optimization
+
+Avoid constructing a short set literal on every `_speech_generation_kwargs(...)`
+call by resolving `loaded_model.voice_mode` once and using direct string
+comparisons for the two supported voice modes. The change keeps the hot path
+local to one attribute read plus direct comparisons and does not change signature
+fallback behavior.
+
+## Verification plan
+
+- Run the registered focused test command for `mlx-audio-generate-signature-cache`.
+- Run the registered changed-scope coverage command and require at least 95% for
+  the changed scope.
+- Run the registered probe locally on Linux before and after the change with the
+  same workload and compare `elapsed_ms_mean`; `signature_calls_mean` must remain
+  `0.0` for the cached loaded-model path.
+- GitHub Actions PR-scoped performance must select and complete the registered
+  probe before merge.
+
+## Environment boundary
+
+This slice is entirely Python and locally verifiable on Linux. No Swift runtime
+performance claim is made.

--- a/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py
@@ -279,10 +279,11 @@ class MLXAudioSpeechRuntime:
         if requested_format != "wav":
             raise ValueError("mlx-audio speech backend only supports wav output.")
 
-        supports_voice = loaded_model.voice_mode in {"hybrid", "named"}
+        voice_mode = loaded_model.voice_mode
+        supports_voice = voice_mode == "hybrid" or voice_mode == "named"
         supports_instructions = loaded_model.supports_instructions
         if (
-            not loaded_model.voice_mode
+            not voice_mode
             and not loaded_model.speech_generate_parameters
             and not loaded_model.generate_parameter_names
         ):


### PR DESCRIPTION
## Summary
- Resolve `loaded_model.voice_mode` once in the MLX audio TTS speech keyword path.
- Replace per-request short set literal membership with direct comparisons for the two voice-capable modes.
- Keep speech keyword behavior unchanged and document the slice under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-05-21-mlx-audio-voice-mode-membership.md`
- Registered probe: `mlx-audio-generate-signature-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_signature_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_generate_signature_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_signature_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_generate_signature_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py services/mlx-worker-python/worker/runtime/audio_runtime_protocols.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_audio_generate_signature_probe.py`
- Baseline probe on `origin/main`: `MELIX_MLX_AUDIO_SIGNATURE_PROBE_ITERATIONS=5000 MELIX_MLX_AUDIO_SIGNATURE_PROBE_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_audio_generate_signature_probe.py`
- Optimized probe on this branch: `MELIX_MLX_AUDIO_SIGNATURE_PROBE_ITERATIONS=5000 MELIX_MLX_AUDIO_SIGNATURE_PROBE_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_audio_generate_signature_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests after final amend: `23 passed in 0.61s`.
- Changed-scope coverage after final amend: `TOTAL 2 0 100%`.
- Baseline registered probe: `elapsed_ms_mean=61.203249311074615`, `signature_calls_mean=0.0`, `sample_count=5`, `iterations_per_sample=5000`.
- Optimized registered probe after final amend: `elapsed_ms_mean=57.848501577973366`, `signature_calls_mean=0.0`, `sample_count=5`, `iterations_per_sample=5000`.
- Delta: `-3.354747733101249 ms`, speedup `5.481322042%`.

## Known Gaps
- Linux local verification covers the Python audio runtime and fake MLX audio path only.
- CI PR-scoped performance must select and complete the registered `mlx-audio-generate-signature-cache` probe before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows an improvement.
- [ ] GitHub Actions and the PR-scoped performance workflow are green.
