### PR TITLE
Enforce LoRA compare verdict policy

### DIFF
--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -1057,6 +1057,25 @@ release reviewer to verify which adapter was compared, which dataset slice was
 used, and why the statistical verdict was emitted without joining against
 process logs.
 
+### Release Gate Verdict Policy
+
+Release-gate policies select compare suites through the keys under
+`evaluation_compare`. For every selected suite, the release gate must find
+persisted paired compare evidence and apply that suite's verdict policy.
+
+Supported verdict policies are:
+
+- `required_verdict_mode: exact` with `required_verdict`: the compare verdict
+  must equal the configured verdict. Target-domain LoRA suites use this mode to
+  require a statistically supported `improvement`.
+- `required_verdict_mode: non_regression`: the compare verdict must not be
+  `regression`. Guard suites use this mode to block statistically supported
+  regressions while accepting `improvement`, `inconclusive`, or tie-like neutral
+  verdicts.
+
+When `required_verdict_mode` is omitted, `exact` is the compatibility default
+whenever `required_verdict` is present.
+
 ### Normalized Input Fields
 
 The canonical normalized request shape is:

--- a/docs/plans/2026-05-22-lora-release-gate-verdict-policy.md
+++ b/docs/plans/2026-05-22-lora-release-gate-verdict-policy.md
@@ -1,0 +1,104 @@
+# LoRA Release Gate Verdict Policy
+
+## Goal
+
+Complete issue #732 by making the Phase 8 release gate enforce the compare
+verdict policy for every selected LoRA release suite.
+
+Parent direction: issue #724, "OpenSearch-VL alignment: gate LoRA release with
+paired compare evidence". Milestone direction: issue #731, "enforce
+release-gate verdicts".
+
+## Current Shipped Surface
+
+- `eval compare` persists per-suite paired compare evidence with release
+  verdicts.
+- The Phase 8 release-gate policy has an `evaluation_compare` suite map.
+- The current gate can fail a single suite when its verdict does not exactly
+  match `required_verdict`.
+
+## Gap
+
+The policy map cannot yet express mixed release intent across selected suites:
+
+- target-domain suites should require a statistically supported `improvement`
+- guard suites should require `non_regression`, meaning `regression` is
+  blocking while an `improvement`, `inconclusive`, or tie-like neutral verdict
+  remains acceptable
+
+The collector also only loads one preferred compare suite, so a multi-suite
+policy does not fail closed when another selected suite is missing.
+
+## Scope
+
+This slice adds a backward-compatible compare verdict policy mode:
+
+- keep `required_verdict` for exact verdict requirements
+- add `required_verdict_mode: non_regression` for guard suites
+- treat each suite key under `evaluation_compare` as selected release evidence
+- collect persisted compare evidence for every selected suite
+- fail closed when a selected suite is missing, malformed, regressed, or does
+  not satisfy its policy mode
+- document the policy modes in the benchmark/evaluation contract and release
+  gate runbook
+
+Out of scope:
+
+- adding the human report grouping requested by issue #733
+- changing statistical verdict derivation
+- changing compare execution
+- changing protobuf schemas
+
+## Performance And Metrics
+
+The implementation adds bounded policy iteration over selected suite ids and
+reads the same persisted compare artifacts already scanned by the release gate.
+It must not add model execution, dataset materialization, or statistical
+resampling.
+
+Measurement points:
+
+- focused release-gate tests for single-suite compatibility, multi-suite
+  selected evidence, missing selected suite evidence, and non-regression verdict
+  mode
+- `git diff --check`
+- changed-scope coverage for modified Python executable files
+- PR-scoped performance report; this code path is release-gate focused, so a
+  release-gate probe may be selected and must remain non-regressing
+
+Success metrics:
+
+- policies with one `evaluation_compare` suite preserve the existing report
+  shape
+- policies with multiple selected suites emit one release-gate evidence object
+  per suite
+- `required_verdict_mode: non_regression` rejects `regression` and missing
+  verdicts, but accepts `improvement`, `inconclusive`, and `tie`
+- changed-scope coverage for modified executable Python files is at least 95
+  percent before handoff
+
+## Implementation Plan
+
+- [x] Update this plan and the governing contracts before broad code changes.
+- [x] Extend the release-gate collector to gather every selected compare suite.
+- [x] Extend evaluation compare policy enforcement with verdict modes.
+- [x] Update tests for exact improvement and non-regression suite policies.
+- [x] Run focused verification and changed-scope coverage.
+
+## Verification
+
+- `python3 -m py_compile services/mlx-worker-python/worker/productization/release_gates.py services/mlx-worker-python/tests/test_release_gates.py`
+  - Result: passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_gates.py -k "evaluation_compare or evaluation_section or release_gate_fails_on_compare"`
+  - Result: 16 passed, 47 deselected.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/lora_release_gate_verdict_policy.coverage -m pytest -q services/mlx-worker-python/tests/test_release_gates.py`
+  - Result: 64 passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/lora_release_gate_verdict_policy_coverage.json services/mlx-worker-python/worker/productization/release_gates.py`
+  - Result: `TOTAL 69 2 97%`.
+- `git diff --check`
+  - Result: passed.
+- Local PR-scoped performance via `scripts.pre_commit_gate.run_performance_report(...)` against `origin/main`
+  - Result: generated `.runtime/pre-commit-performance/20260521-200743-ce9e3421/report/report.md` with `Status: ok`, 2 selected direct probes, 0 regressions, 0 verification failures.
+  - Note: the wrapper command exited non-zero after report generation because it attempted to read a nonexistent `PerformanceOutcome.ok` attribute. The generated report and probe JSON are the performance evidence.
+- Current local disk state during verification:
+  - `df -h .`: about 3.2 GiB available, so full local Swift rebuild gates are high risk on this host.

--- a/docs/runbooks/phase-8-release-gates.md
+++ b/docs/runbooks/phase-8-release-gates.md
@@ -81,6 +81,15 @@ as `mmlu`. Each suite policy owns:
 - `bootstrap_seed`
 - `effect_threshold`
 - `required_verdict`
+- `required_verdict_mode`
+
+Each suite key under `evaluation_compare` is selected release evidence. The
+gate fails closed if any selected suite lacks persisted paired compare
+artifacts. `required_verdict_mode` defaults to `exact`, preserving the legacy
+behavior that compares `verdict` to `required_verdict`. Use
+`required_verdict_mode: non_regression` for guard suites where a statistical
+`regression` must block promotion while `improvement`, `inconclusive`, or
+tie-like neutral verdicts are acceptable.
 
 The compare release verdict is policy-backed and uses the same `CI + threshold` rule as runtime
 reporting:
@@ -142,9 +151,12 @@ uv run --project services/mlx-worker-python python scripts/m9_release_gate_smoke
 Use `--fixture-mode failing` to prove the gate fails closed on missing or regressed M9 evidence.
 
 When you inspect the emitted release-gate JSON, the top-level `evaluation_compare` section is the
-operator-facing summary for compare evidence. Verify:
+operator-facing summary for compare evidence. A single selected suite appears as one compare
+summary for backward compatibility. Multiple selected suites appear under `suites`, keyed by
+suite id. Verify:
 
-- `verdict` matches the policy-required verdict
+- every selected suite has evidence
+- `verdict` satisfies the suite's `required_verdict_mode`
 - `effect_threshold` is at least the checked-in policy value
 - both `bootstrap` and `analytical` intervals are present under `statistical_evidence`
 - `release_gate_summary` explains whether a compare was accepted or rejected

--- a/infra/release/phase8-release-gate-policy.json
+++ b/infra/release/phase8-release-gate-policy.json
@@ -231,7 +231,8 @@
       "bootstrap_seed": 9,
       "confidence_level": 0.95,
       "effect_threshold": 0.1,
-      "required_verdict": "improvement"
+      "required_verdict": "improvement",
+      "required_verdict_mode": "exact"
     }
   },
   "real_workload": {

--- a/services/mlx-worker-python/tests/test_release_gates.py
+++ b/services/mlx-worker-python/tests/test_release_gates.py
@@ -1840,6 +1840,7 @@ def test_default_policy_includes_evaluation_section() -> None:
     assert "evaluation_compare" in DEFAULT_RELEASE_GATE_POLICY
     assert DEFAULT_RELEASE_GATE_POLICY["evaluation_compare"]["mmlu"]["effect_threshold"] == 0.1
     assert DEFAULT_RELEASE_GATE_POLICY["evaluation_compare"]["mmlu"]["required_verdict"] == "improvement"
+    assert DEFAULT_RELEASE_GATE_POLICY["evaluation_compare"]["mmlu"]["required_verdict_mode"] == "exact"
     assert "observability" in DEFAULT_RELEASE_GATE_POLICY
     assert DEFAULT_RELEASE_GATE_POLICY["observability"]["probe_policy.production_sampler_invocations"]["max"] == 0.0
 
@@ -1855,6 +1856,7 @@ def test_checked_in_release_gate_policy_includes_evaluation_thresholds() -> None
     assert policy["evaluation"]["eval.mmlu.typed_score_mean"]["min"] == 0.5
     assert "evaluation_compare" in policy
     assert policy["evaluation_compare"]["mmlu"]["bootstrap_iterations"] == 400
+    assert policy["evaluation_compare"]["mmlu"]["required_verdict_mode"] == "exact"
     assert "m9" in policy
     assert policy["m9"]["agent_export"]["integration.export_generation_ms"]["min"] == 0.0
     assert policy["m9"]["shared_access"]["gateway.auth_validation_failures"]["min"] == 1.0
@@ -1985,6 +1987,61 @@ def test_collect_evaluation_compare_evidence_prefers_custom_policy_suite_when_pr
     assert evidence["suite_id"] == "gsm8k"
     assert evidence["job_id"] == "eval-compare-gsm8k-artifact"
     assert evidence["target_model_id"] == "melix-dev-text-lora-gsm8k"
+
+
+def test_collect_evaluation_compare_evidence_returns_selected_suite_map_for_multi_suite_policy(
+    tmp_path: Path,
+) -> None:
+    _write_persisted_evaluation_compare_evidence(
+        tmp_path / "jobs",
+        job_id="eval-compare-mmlu-artifact",
+        suite_id="mmlu",
+        target_model_id="melix-dev-text-lora-mmlu",
+        verdict="improvement",
+    )
+    _write_persisted_evaluation_compare_evidence(
+        tmp_path / "jobs",
+        job_id="eval-compare-gsm8k-artifact",
+        suite_id="gsm8k",
+        target_model_id="melix-dev-text-lora-gsm8k",
+        verdict="inconclusive",
+    )
+
+    evidence = collect_evaluation_compare_evidence(
+        tmp_path / "jobs",
+        policy={
+            "mmlu": {"required_verdict": "improvement"},
+            "gsm8k": {"required_verdict_mode": "non_regression"},
+        },
+    )
+
+    assert evidence["selected_suite_ids"] == ("mmlu", "gsm8k")
+    assert evidence["missing_suites"] == []
+    assert evidence["suites"]["mmlu"]["target_model_id"] == "melix-dev-text-lora-mmlu"
+    assert evidence["suites"]["gsm8k"]["verdict"] == "inconclusive"
+
+
+def test_collect_evaluation_compare_evidence_marks_missing_selected_suites(
+    tmp_path: Path,
+) -> None:
+    _write_persisted_evaluation_compare_evidence(
+        tmp_path / "jobs",
+        job_id="eval-compare-mmlu-artifact",
+        suite_id="mmlu",
+        verdict="improvement",
+    )
+
+    evidence = collect_evaluation_compare_evidence(
+        tmp_path / "jobs",
+        policy={
+            "mmlu": {"required_verdict": "improvement"},
+            "gsm8k": {"required_verdict_mode": "non_regression"},
+        },
+    )
+
+    assert set(evidence["suites"].keys()) == {"mmlu"}
+    assert evidence["missing_suites"][0]["suite_id"] == "gsm8k"
+    assert "persisted evaluation_compare artifacts" in evidence["missing_suites"][0]["reason"]
 
 
 def test_collect_evaluation_compare_evidence_returns_all_target_summaries_for_latest_job(
@@ -2130,6 +2187,114 @@ def test_evaluate_evaluation_compare_evidence_checks_each_target_summary() -> No
     assert (
         "evaluation_compare.mmlu target_model_id=melix-dev-text-lora-b verdict=regression "
         "did not satisfy required verdict improvement"
+        in failures
+    )
+
+
+def test_evaluate_evaluation_compare_evidence_enforces_non_regression_mode() -> None:
+    policy = {"mmlu": {"required_verdict_mode": "non_regression"}}
+
+    improvement_failures = release_gates_module._evaluate_evaluation_compare_evidence(
+        _passing_evaluation_compare_evidence(verdict="improvement"),
+        policy,
+    )
+    inconclusive_failures = release_gates_module._evaluate_evaluation_compare_evidence(
+        _passing_evaluation_compare_evidence(verdict="inconclusive"),
+        policy,
+    )
+    regression_failures = release_gates_module._evaluate_evaluation_compare_evidence(
+        _passing_evaluation_compare_evidence(verdict="regression"),
+        policy,
+    )
+    missing_verdict_report = _passing_evaluation_compare_evidence()
+    missing_verdict_report["verdict"] = ""
+
+    missing_verdict_failures = release_gates_module._evaluate_evaluation_compare_evidence(
+        missing_verdict_report,
+        policy,
+    )
+
+    assert improvement_failures == []
+    assert inconclusive_failures == []
+    assert (
+        "evaluation_compare.mmlu verdict=regression did not satisfy required verdict mode non_regression"
+        in regression_failures
+    )
+    assert (
+        "evaluation_compare.mmlu verdict= did not satisfy required verdict mode non_regression"
+        in missing_verdict_failures
+    )
+
+
+def test_evaluate_evaluation_compare_evidence_checks_every_selected_suite() -> None:
+    report = {
+        "selected_suite_ids": ("mmlu", "gsm8k"),
+        "suites": {
+            "mmlu": _passing_evaluation_compare_evidence(verdict="improvement"),
+            "gsm8k": {
+                **_passing_evaluation_compare_evidence(verdict="inconclusive"),
+                "suite_id": "gsm8k",
+            },
+        },
+        "missing_suites": [],
+    }
+
+    failures = release_gates_module._evaluate_evaluation_compare_evidence(
+        report,
+        {
+            "mmlu": {"required_verdict": "improvement"},
+            "gsm8k": {"required_verdict_mode": "non_regression"},
+        },
+    )
+
+    assert failures == []
+
+
+def test_evaluate_evaluation_compare_evidence_fails_closed_for_missing_selected_suite() -> None:
+    report = {
+        "selected_suite_ids": ("mmlu", "gsm8k"),
+        "suites": {
+            "mmlu": _passing_evaluation_compare_evidence(verdict="improvement"),
+        },
+        "missing_suites": [
+            {
+                "suite_id": "gsm8k",
+                "artifact_status": "missing",
+            }
+        ],
+    }
+
+    failures = release_gates_module._evaluate_evaluation_compare_evidence(
+        report,
+        {
+            "mmlu": {"required_verdict": "improvement"},
+            "gsm8k": {"required_verdict_mode": "non_regression"},
+        },
+    )
+
+    assert "evaluation_compare.gsm8k evidence is missing for selected suite" in failures
+
+
+def test_evaluate_evaluation_compare_evidence_single_report_shape_still_checks_multi_suite_policy() -> None:
+    failures = release_gates_module._evaluate_evaluation_compare_evidence(
+        _passing_evaluation_compare_evidence(verdict="improvement"),
+        {
+            "mmlu": {"required_verdict": "improvement"},
+            "gsm8k": {"required_verdict_mode": "non_regression"},
+        },
+    )
+
+    assert "evaluation_compare.gsm8k evidence is missing for selected suite" in failures
+
+
+def test_evaluate_evaluation_compare_evidence_reports_unsupported_verdict_mode() -> None:
+    failures = release_gates_module._evaluate_evaluation_compare_evidence(
+        _passing_evaluation_compare_evidence(verdict="improvement"),
+        {"mmlu": {"required_verdict_mode": "stricter-than-exact"}},
+    )
+
+    assert (
+        "evaluation_compare.mmlu required_verdict_mode=stricter-than-exact is unsupported"
         in failures
     )
 

--- a/services/mlx-worker-python/worker/productization/release_gates.py
+++ b/services/mlx-worker-python/worker/productization/release_gates.py
@@ -211,6 +211,7 @@ DEFAULT_RELEASE_GATE_POLICY: dict[str, Any] = {
             "bootstrap_iterations": 400,
             "bootstrap_seed": 9,
             "required_verdict": "improvement",
+            "required_verdict_mode": "exact",
         }
     },
     "real_workload": copy.deepcopy(DEFAULT_REAL_WORKLOAD_GATE_POLICY),
@@ -602,17 +603,43 @@ def collect_evaluation_compare_evidence(
     *,
     policy: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    suite_id = _preferred_evaluation_compare_suite_id(policy)
-    evidence, reason = _load_persisted_evaluation_compare_evidence(
-        jobs_root,
-        suite_id=suite_id,
-    )
-    if evidence is not None:
-        return evidence
+    suite_ids = _selected_evaluation_compare_suite_ids(policy)
+    if len(suite_ids) == 1:
+        suite_id = suite_ids[0]
+        evidence, reason = _load_persisted_evaluation_compare_evidence(
+            jobs_root,
+            suite_id=suite_id,
+        )
+        if evidence is not None:
+            return evidence
+        return {
+            "suite_id": suite_id,
+            "artifact_status": "missing",
+            "reason": reason,
+        }
+
+    selected_suites: dict[str, dict[str, Any]] = {}
+    missing_suites: list[dict[str, str]] = []
+    for suite_id in suite_ids:
+        evidence, reason = _load_persisted_evaluation_compare_evidence(
+            jobs_root,
+            suite_id=suite_id,
+        )
+        if evidence is None:
+            missing_suites.append(
+                {
+                    "suite_id": suite_id,
+                    "artifact_status": "missing",
+                    "reason": reason,
+                }
+            )
+        else:
+            selected_suites[suite_id] = evidence
+
     return {
-        "suite_id": suite_id,
-        "artifact_status": "missing",
-        "reason": reason,
+        "selected_suite_ids": suite_ids,
+        "suites": selected_suites,
+        "missing_suites": missing_suites,
     }
 
 
@@ -1217,6 +1244,31 @@ def _evaluate_evaluation_compare_evidence(
     report: dict[str, Any],
     policy: dict[str, Any],
 ) -> list[str]:
+    selected_suite_ids = _selected_evaluation_compare_suite_ids(policy)
+    suites = report.get("suites")
+    if isinstance(suites, dict):
+        return _evaluate_selected_evaluation_compare_suites(
+            suites,
+            policy,
+            selected_suite_ids=selected_suite_ids,
+        )
+    suite_id = str(report.get("suite_id", "")).strip()
+    if not suite_id:
+        return ["evaluation_compare.suite_id is missing"]
+    if len(selected_suite_ids) > 1:
+        return _evaluate_selected_evaluation_compare_suites(
+            {suite_id: report},
+            policy,
+            selected_suite_ids=selected_suite_ids,
+        )
+
+    return _evaluate_evaluation_compare_suite_payload(report, policy)
+
+
+def _evaluate_evaluation_compare_suite_payload(
+    report: dict[str, Any],
+    policy: dict[str, Any],
+) -> list[str]:
     suite_id = str(report.get("suite_id", "")).strip()
     if not suite_id:
         return ["evaluation_compare.suite_id is missing"]
@@ -1250,6 +1302,31 @@ def _evaluate_evaluation_compare_evidence(
     )
 
 
+def _evaluate_selected_evaluation_compare_suites(
+    suites: dict[Any, Any],
+    policy: dict[str, Any],
+    *,
+    selected_suite_ids: tuple[str, ...],
+) -> list[str]:
+    failures: list[str] = []
+    for suite_id in selected_suite_ids:
+        suite_report = suites.get(suite_id)
+        if not isinstance(suite_report, dict):
+            failures.append(
+                f"evaluation_compare.{suite_id} evidence is missing for selected suite"
+            )
+            continue
+        normalized_report = dict(suite_report)
+        normalized_report.setdefault("suite_id", suite_id)
+        failures.extend(
+            _evaluate_evaluation_compare_suite_payload(
+                normalized_report,
+                policy,
+            )
+        )
+    return failures
+
+
 def _evaluate_single_evaluation_compare_evidence(
     report: dict[str, Any],
     policy: dict[str, Any],
@@ -1272,11 +1349,16 @@ def _evaluate_single_evaluation_compare_evidence(
         return failures
 
     required_verdict = str(suite_policy.get("required_verdict", "")).strip()
+    verdict_mode = _evaluation_compare_verdict_mode(suite_policy)
     actual_verdict = str(report.get("verdict", "")).strip()
-    if required_verdict and actual_verdict != required_verdict:
-        failures.append(
-            f"{prefix} verdict={actual_verdict} did not satisfy required verdict {required_verdict}"
-        )
+    verdict_failure = _evaluation_compare_verdict_failure(
+        prefix=prefix,
+        actual_verdict=actual_verdict,
+        required_verdict=required_verdict,
+        verdict_mode=verdict_mode,
+    )
+    if verdict_failure:
+        failures.append(verdict_failure)
 
     effect_threshold = float(report.get("effect_threshold", 0.0) or 0.0)
     policy_threshold = float(suite_policy.get("effect_threshold", 0.0) or 0.0)
@@ -1315,6 +1397,41 @@ def _evaluate_single_evaluation_compare_evidence(
     return failures
 
 
+def _evaluation_compare_verdict_mode(suite_policy: dict[str, Any]) -> str:
+    raw_mode = str(suite_policy.get("required_verdict_mode", "")).strip()
+    if raw_mode:
+        normalized = raw_mode.replace("-", "_").lower()
+        if normalized in {"exact", "non_regression"}:
+            return normalized
+        return raw_mode
+    return "exact" if str(suite_policy.get("required_verdict", "")).strip() else ""
+
+
+def _evaluation_compare_verdict_failure(
+    *,
+    prefix: str,
+    actual_verdict: str,
+    required_verdict: str,
+    verdict_mode: str,
+) -> str:
+    if verdict_mode == "non_regression":
+        accepted_verdicts = {"improvement", "inconclusive", "tie"}
+        if actual_verdict in accepted_verdicts:
+            return ""
+        return (
+            f"{prefix} verdict={actual_verdict} did not satisfy required verdict mode "
+            "non_regression"
+        )
+    if verdict_mode not in {"", "exact"}:
+        return f"{prefix} required_verdict_mode={verdict_mode} is unsupported"
+    if required_verdict and actual_verdict != required_verdict:
+        return (
+            f"{prefix} verdict={actual_verdict} did not satisfy required verdict "
+            f"{required_verdict}"
+        )
+    return ""
+
+
 def _evaluation_compare_failure_prefix(
     report: dict[str, Any],
     *,
@@ -1330,23 +1447,28 @@ def _evaluation_compare_failure_prefix(
 
 
 def _preferred_evaluation_compare_suite_id(policy: dict[str, Any] | None) -> str:
+    suite_ids = _selected_evaluation_compare_suite_ids(policy)
+    if suite_ids:
+        return suite_ids[0]
+    return ""
+
+
+def _selected_evaluation_compare_suite_ids(policy: dict[str, Any] | None) -> tuple[str, ...]:
+    suite_ids: list[str] = []
     if isinstance(policy, dict):
-        custom_suite_ids = [
+        suite_ids = [
             str(suite_id)
             for suite_id, suite_policy in policy.items()
             if isinstance(suite_policy, dict)
         ]
-        if custom_suite_ids:
-            return custom_suite_ids[0]
-    default_policy = DEFAULT_RELEASE_GATE_POLICY.get("evaluation_compare", {})
-    default_suite_ids = [
-        str(suite_id)
-        for suite_id, suite_policy in default_policy.items()
-        if isinstance(suite_policy, dict)
-    ]
-    if default_suite_ids:
-        return default_suite_ids[0]
-    return ""
+    if not suite_ids:
+        default_policy = DEFAULT_RELEASE_GATE_POLICY.get("evaluation_compare", {})
+        suite_ids = [
+            str(suite_id)
+            for suite_id, suite_policy in default_policy.items()
+            if isinstance(suite_policy, dict)
+        ]
+    return tuple(suite_id for suite_id in suite_ids if suite_id)
 
 
 def _resolve_evaluation_compare_suite_policy(


### PR DESCRIPTION
## Summary
- Enforce `evaluation_compare` policy as a selected-suite map instead of only checking one preferred suite.
- Add `required_verdict_mode` with `exact` and `non_regression` modes so target-domain suites can require improvement while guard suites fail only on regressions.
- Document the release-gate verdict modes in the benchmark/evaluation contract and Phase 8 release-gate runbook.

Closes #732.

## Plan or Spec
- `docs/plans/2026-05-22-lora-release-gate-verdict-policy.md`
- `docs/benchmark-evaluation-contract.md`
- `docs/runbooks/phase-8-release-gates.md`

## Commands Run
```text
python3 -m py_compile services/mlx-worker-python/worker/productization/release_gates.py services/mlx-worker-python/tests/test_release_gates.py
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_gates.py -k "evaluation_compare or evaluation_section or release_gate_fails_on_compare"
# 16 passed, 47 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/lora_release_gate_verdict_policy.coverage -m pytest -q services/mlx-worker-python/tests/test_release_gates.py
# 64 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/lora_release_gate_verdict_policy.coverage -o /tmp/lora_release_gate_verdict_policy_coverage.json
# wrote coverage JSON

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/lora_release_gate_verdict_policy_coverage.json services/mlx-worker-python/worker/productization/release_gates.py
# TOTAL 69 2 97%

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python3 scripts/release_gates_m9_failure_count_probe.py
# {"elapsed_ms_mean": 3.749875002540648, "endswith_checks_mean": 0.0, "failure_count_mean": 12800.0, "failures_per_section": 80.0, "sample_count": 5.0, "section_count": 160.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python3 <quantization gate manifest event streaming probe>
# {"elapsed_ms_mean": 0.067583, "elapsed_ms_min": 0.053083, "events_consumed_mean": 12.0, "post_manifest_event_count": 2000.0, "profile_count": 6.0, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python3 - <<'PY' ... scripts.pre_commit_gate.run_performance_report(..., base_ref='origin/main') ... PY
# Generated .runtime/pre-commit-performance/20260521-200743-ce9e3421/report/report.md with Status: ok, 2 selected direct probes, 0 regressions, 0 verification failures.
# The wrapper command exited non-zero after report generation because it attempted to read a nonexistent PerformanceOutcome.ok attribute; the generated report and probe JSON are the performance evidence.
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 69 2 97%` for `services/mlx-worker-python/worker/productization/release_gates.py`.
- Local PR-scoped performance: `.runtime/pre-commit-performance/20260521-200743-ce9e3421/report/report.md`
  - Status: `ok`
  - Selected probes: `2`
  - Direct/gated probes: `2`
  - Regressions: `0`
  - Verification failures: `0`
  - `quantization-gate-manifest-event-streaming`: `events_consumed_mean` unchanged at `12.000`; `elapsed_ms_mean` improved from `0.069` to `0.066`.
  - `release-gates-m9-failure-count-single-pass`: `failure_count_mean` unchanged at `12800.000`; `endswith_checks_mean` unchanged at `0.000`; `elapsed_ms_mean` changed from `3.544` to `3.762` and remained neutral.
- Observability mode: `evidence`; this change consumes persisted compare evidence and release-gate policy, with no production request-path observability changes.
- Probe overhead: N/A; no runtime probe or production sampler behavior changed.

## Known Gaps
- Full local `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run in this worktree. The host had about 3.2 GiB free during verification, which is not enough for a reliable full Swift rebuild; the scoped Python release-gate checks and PR-scoped performance probes were run instead.
- Issue #733 remains open for human report output grouping of improvements, regressions, and inconclusive results.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
