### PR TITLE
Group LoRA compare report verdicts

### DIFF
--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -1562,6 +1562,17 @@ Melix must classify comparison verdicts with the same `CI + threshold` rule ever
   interval families stay below zero
 - emit `inconclusive` otherwise
 
+Human-readable compare reports must separate target summaries into:
+
+- quality improvements
+- regressions
+- inconclusive results
+
+Each report group must include target model id, verdict, delta accuracy,
+effect threshold, regression count, and interval detail. Empty groups must be
+explicitly rendered so release reviewers can distinguish "no results in this
+group" from a missing report section.
+
 ### Category Breakdown
 
 When the suite supports category or subject scoring, the result must also include:
@@ -1891,6 +1902,7 @@ The evaluation surface must expose:
 - suite comparison table
 - sample preview
 - compare verdict, threshold, and confidence-interval detail when statistical evidence is present
+- compare report groups for quality improvements, regressions, and inconclusive results
 - summary CSV export
 - sample CSV export
 - sample JSONL export

--- a/docs/plans/2026-05-22-lora-release-gate-report-groups.md
+++ b/docs/plans/2026-05-22-lora-release-gate-report-groups.md
@@ -1,0 +1,92 @@
+# LoRA Release Gate Report Groups
+
+## Goal
+
+Complete issue #733 by making human-readable LoRA compare reports separate
+quality improvements, regressions, and inconclusive results.
+
+Parent direction: issue #724, "OpenSearch-VL alignment: gate LoRA release with
+paired compare evidence". Milestone direction: issue #731, "enforce
+release-gate verdicts".
+
+## Current Shipped Surface
+
+- `evaluation-compare-report.md` includes verdict, delta accuracy, bootstrap CI,
+  analytical CI, effect threshold, and per-target details.
+- Compare summary JSON and run records persist statistical verdict payloads for
+  release-gate automation.
+- The release gate enforces selected-suite verdict policy, including exact
+  improvement and non-regression modes.
+
+## Gap
+
+The Markdown compare report still renders targets in input order only.
+Operators reviewing a release candidate must visually scan the whole table to
+separate targets that improved, regressed, or remained inconclusive.
+
+## Scope
+
+This slice changes only the human-readable compare report:
+
+- add a verdict-grouped release summary before per-target details
+- group targets into quality improvements, regressions, and inconclusive
+  results
+- preserve the existing top-level target table and per-target detail sections
+- update the benchmark/evaluation contract and operator runbook
+
+Out of scope:
+
+- changing statistical verdict derivation
+- changing release-gate pass/fail policy
+- changing persisted JSON/CSV schemas
+- changing Swift or protobuf surfaces
+
+## Performance And Metrics
+
+The implementation groups already-materialized summary objects. It must not add
+model execution, dataset materialization, artifact scans, or additional
+statistical passes.
+
+Measurement points:
+
+- focused report-builder tests for all three verdict groups and empty-group
+  behavior
+- focused store test coverage for persisted report Markdown integration
+- `git diff --check`
+- changed-scope coverage for modified Python executable files
+- PR-scoped performance report; report-generation changes are expected to
+  select evaluation/report or store-adjacent probes and must remain
+  non-regressing
+
+Success metrics:
+
+- report Markdown has explicit sections for quality improvements, regressions,
+  and inconclusive results
+- each section summarizes target model, verdict, delta accuracy, effect
+  threshold, regression count, and interval detail
+- empty sections render an explicit `None` row so reviewers can distinguish no
+  results from a rendering failure
+- changed-scope coverage for modified executable Python files is at least 95
+  percent before handoff
+
+## Implementation Plan
+
+- [x] Update this plan and the governing contracts before broad code changes.
+- [x] Add grouped release-summary rendering to `evaluation_reports.py`.
+- [x] Add focused tests for grouped report output.
+- [x] Run focused verification and changed-scope coverage.
+
+## Verification
+
+- `python3 -m py_compile services/mlx-worker-python/worker/productization/evaluation_reports.py services/mlx-worker-python/tests/test_evaluation_reports.py`
+  - Result: passed.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_reports.py services/mlx-worker-python/tests/test_evaluation_store.py -k "compare_report or persist_compare_result_writes_expected_artifact_names_and_payloads"`
+  - Result: 2 passed, 21 deselected.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/lora_release_report_groups.coverage -m pytest -q services/mlx-worker-python/tests/test_evaluation_reports.py services/mlx-worker-python/tests/test_evaluation_store.py -k "compare_report or persist_compare_result_writes_expected_artifact_names_and_payloads"`
+  - Result: 2 passed, 21 deselected.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/lora_release_report_groups_coverage.json services/mlx-worker-python/worker/productization/evaluation_reports.py`
+  - Result: `TOTAL 26 1 96%`.
+- `git diff --check`
+  - Result: passed.
+- Current local disk state during verification:
+  - `df -h .`: about 3.1 GiB available, so full local Swift rebuild gates are high risk on this host.

--- a/docs/runbooks/benchmark-matrix-evaluation-and-lora.md
+++ b/docs/runbooks/benchmark-matrix-evaluation-and-lora.md
@@ -543,6 +543,8 @@ Important compare rules:
 - compare sample exports preserve executable-code evidence for both the base and target responses when the suite executes code
 - human-readable compare output now includes `verdict`, observed delta, bootstrap CI, analytical CI,
   and the configured effect threshold for each target model
+- human-readable compare output groups target summaries into quality improvements, regressions,
+  and inconclusive results before the per-target detail sections
 - `improvement` and `regression` are only emitted when delta clears the effect threshold and both
   interval families remain on the same side of zero; otherwise the result is `inconclusive`
 

--- a/services/mlx-worker-python/tests/test_evaluation_reports.py
+++ b/services/mlx-worker-python/tests/test_evaluation_reports.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from worker.productization.evaluation_reports import build_evaluation_compare_report_markdown
+from worker.productization.evaluation_schemas import (
+    build_evaluation_compare_job_record,
+    build_evaluation_compare_summary_record,
+)
+
+
+def _compare_job() -> object:
+    return build_evaluation_compare_job_record(
+        job_id="eval-compare-release-report",
+        base_model_id="melix-dev-text",
+        target_model_ids=(
+            "melix-dev-text-lora-improved",
+            "melix-dev-text-lora-regressed",
+            "melix-dev-text-lora-inconclusive",
+        ),
+        task_kind="text-generation",
+        source_repo="melix.report.fixture",
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_size=8,
+        scoring_mode="multiple_choice_accuracy",
+        parameters={"compare_mode": "base_vs_targets"},
+        status="completed",
+    )
+
+
+def _compare_summary(
+    *,
+    target_model_id: str,
+    verdict: str,
+    delta_accuracy: float,
+    regression_count: int,
+) -> object:
+    return build_evaluation_compare_summary_record(
+        job_id="eval-compare-release-report",
+        base_model_id="melix-dev-text",
+        target_model_id=target_model_id,
+        suite_id="mmlu",
+        dataset_id="mmlu-dev",
+        sample_size=8,
+        scoring_mode="multiple_choice_accuracy",
+        win_count=6 if verdict == "improvement" else 1,
+        loss_count=1 if verdict == "regression" else 0,
+        tie_count=1,
+        regression_count=regression_count,
+        base_accuracy=0.5,
+        target_accuracy=0.5 + delta_accuracy,
+        delta_accuracy=delta_accuracy,
+        effect_threshold=0.1,
+        verdict=verdict,
+        category_breakdown={},
+        statistical_evidence={
+            "sample_size": 8,
+            "delta_accuracy": delta_accuracy,
+            "bootstrap": {
+                "method": "paired_bootstrap_percentile",
+                "confidence_level": 0.95,
+                "lower_bound": delta_accuracy - 0.05,
+                "upper_bound": delta_accuracy + 0.05,
+                "crosses_zero": verdict == "inconclusive",
+                "iterations": 400,
+                "seed": 9,
+            },
+            "analytical": {
+                "method": "paired_difference_normal_approximation",
+                "confidence_level": 0.95,
+                "lower_bound": delta_accuracy - 0.04,
+                "upper_bound": delta_accuracy + 0.04,
+                "crosses_zero": verdict == "inconclusive",
+            },
+        },
+        release_gate_summary={
+            "verdict": verdict,
+            "reason": "confidence_intervals_cross_zero"
+            if verdict == "inconclusive"
+            else "delta_exceeds_threshold_with_supported_intervals",
+            "effect_threshold": 0.1,
+            "delta_accuracy": delta_accuracy,
+            "threshold_passed": verdict != "inconclusive",
+            "both_intervals_same_side": verdict != "inconclusive",
+        },
+        duration_seconds=0.25,
+        metrics={"eval.compare.delta_accuracy": delta_accuracy},
+        report_path="/tmp/evaluation-compare-report.md",
+    )
+
+
+def test_evaluation_compare_report_groups_release_verdicts() -> None:
+    markdown = build_evaluation_compare_report_markdown(
+        job=_compare_job(),
+        summaries=(
+            _compare_summary(
+                target_model_id="melix-dev-text-lora-improved",
+                verdict="improvement",
+                delta_accuracy=0.25,
+                regression_count=0,
+            ),
+            _compare_summary(
+                target_model_id="melix-dev-text-lora-regressed",
+                verdict="regression",
+                delta_accuracy=-0.25,
+                regression_count=5,
+            ),
+            _compare_summary(
+                target_model_id="melix-dev-text-lora-inconclusive",
+                verdict="inconclusive",
+                delta_accuracy=0.02,
+                regression_count=0,
+            ),
+        ),
+    )
+
+    assert "## Release Verdict Groups" in markdown
+    assert "### Quality Improvements" in markdown
+    assert (
+        "| melix-dev-text-lora-improved | improvement | +0.2500 | 0.1000 | 0 | "
+        in markdown
+    )
+    assert "### Regressions" in markdown
+    assert (
+        "| melix-dev-text-lora-regressed | regression | -0.2500 | 0.1000 | 5 | "
+        in markdown
+    )
+    assert "### Inconclusive Results" in markdown
+    assert (
+        "| melix-dev-text-lora-inconclusive | inconclusive | +0.0200 | 0.1000 | 0 | "
+        in markdown
+    )
+    assert "## melix-dev-text-lora-improved" in markdown
+    assert "## melix-dev-text-lora-regressed" in markdown
+    assert "## melix-dev-text-lora-inconclusive" in markdown
+
+
+def test_evaluation_compare_report_marks_empty_verdict_groups() -> None:
+    markdown = build_evaluation_compare_report_markdown(
+        job=_compare_job(),
+        summaries=(
+            _compare_summary(
+                target_model_id="melix-dev-text-lora-improved",
+                verdict="improvement",
+                delta_accuracy=0.25,
+                regression_count=0,
+            ),
+        ),
+    )
+
+    assert "### Quality Improvements" in markdown
+    assert "| melix-dev-text-lora-improved | improvement | +0.2500 | 0.1000 | 0 | " in markdown
+    assert "### Regressions\n\n| Target Model | Verdict" in markdown
+    assert "| None |  |  |  |  |  |  |" in markdown
+    assert "### Inconclusive Results\n\n| Target Model | Verdict" in markdown

--- a/services/mlx-worker-python/worker/productization/evaluation_reports.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_reports.py
@@ -102,14 +102,15 @@ def _verdict_group_sections(summaries: tuple[EvaluationCompareSummary, ...]) -> 
         "",
         "## Release Verdict Groups",
     ]
-    grouped_summary_ids: set[int] = set()
+    handled_verdicts = {
+        verdict for _group_id, _label, verdicts in _VERDICT_GROUPS for verdict in verdicts
+    }
     for _group_id, label, verdicts in _VERDICT_GROUPS:
         grouped = tuple(summary for summary in summaries if summary.verdict in verdicts)
-        grouped_summary_ids.update(id(summary) for summary in grouped)
         lines.extend(_verdict_group_section(label=label, summaries=grouped))
 
     other_summaries = tuple(
-        summary for summary in summaries if id(summary) not in grouped_summary_ids
+        summary for summary in summaries if summary.verdict not in handled_verdicts
     )
     if other_summaries:
         lines.extend(_verdict_group_section(label="Other Verdicts", summaries=other_summaries))

--- a/services/mlx-worker-python/worker/productization/evaluation_reports.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_reports.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 from worker.productization.evaluation_schemas import EvaluationCompareJob, EvaluationCompareSummary
 
+_VERDICT_GROUPS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    ("quality_improvements", "Quality Improvements", ("improvement",)),
+    ("regressions", "Regressions", ("regression",)),
+    ("inconclusive_results", "Inconclusive Results", ("inconclusive",)),
+)
+
 
 def build_evaluation_compare_report_markdown(
     *,
@@ -42,6 +48,10 @@ def build_evaluation_compare_report_markdown(
             )
             + " |"
         )
+    lines.extend(_verdict_group_sections(summaries))
+    for summary in summaries:
+        bootstrap_interval = summary.statistical_evidence.get("bootstrap", {})
+        analytical_interval = summary.statistical_evidence.get("analytical", {})
         lines.extend(
             [
                 "",
@@ -85,6 +95,62 @@ def build_evaluation_compare_report_markdown(
                 )
     lines.append("")
     return "\n".join(lines)
+
+
+def _verdict_group_sections(summaries: tuple[EvaluationCompareSummary, ...]) -> list[str]:
+    lines: list[str] = [
+        "",
+        "## Release Verdict Groups",
+    ]
+    grouped_summary_ids: set[int] = set()
+    for _group_id, label, verdicts in _VERDICT_GROUPS:
+        grouped = tuple(summary for summary in summaries if summary.verdict in verdicts)
+        grouped_summary_ids.update(id(summary) for summary in grouped)
+        lines.extend(_verdict_group_section(label=label, summaries=grouped))
+
+    other_summaries = tuple(
+        summary for summary in summaries if id(summary) not in grouped_summary_ids
+    )
+    if other_summaries:
+        lines.extend(_verdict_group_section(label="Other Verdicts", summaries=other_summaries))
+    return lines
+
+
+def _verdict_group_section(
+    *,
+    label: str,
+    summaries: tuple[EvaluationCompareSummary, ...],
+) -> list[str]:
+    lines = [
+        "",
+        f"### {label}",
+        "",
+        "| Target Model | Verdict | Delta Accuracy | Effect Threshold | Regressions | Bootstrap CI | Analytical CI |",
+        "| --- | --- | ---: | ---: | ---: | --- | --- |",
+    ]
+    if not summaries:
+        lines.append("| None |  |  |  |  |  |  |")
+        return lines
+
+    for summary in summaries:
+        bootstrap_interval = summary.statistical_evidence.get("bootstrap", {})
+        analytical_interval = summary.statistical_evidence.get("analytical", {})
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    summary.target_model_id,
+                    summary.verdict,
+                    _signed_ratio(summary.delta_accuracy),
+                    _ratio(summary.effect_threshold),
+                    str(summary.regression_count),
+                    _interval(bootstrap_interval),
+                    _interval(analytical_interval),
+                ]
+            )
+            + " |"
+        )
+    return lines
 
 
 def _ratio(value: float) -> str:


### PR DESCRIPTION
## Summary
- Add release verdict groups to `evaluation-compare-report.md` so quality improvements, regressions, and inconclusive results are separated before per-target details.
- Keep existing compare summary and per-target detail sections intact.
- Document the grouped report requirement in the benchmark/evaluation contract and LoRA evaluation runbook.

Closes #733.

## Plan or Spec
- `docs/plans/2026-05-22-lora-release-gate-report-groups.md`
- `docs/benchmark-evaluation-contract.md`
- `docs/runbooks/benchmark-matrix-evaluation-and-lora.md`

## Commands Run
```text
python3 -m py_compile services/mlx-worker-python/worker/productization/evaluation_reports.py services/mlx-worker-python/tests/test_evaluation_reports.py
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_reports.py services/mlx-worker-python/tests/test_evaluation_store.py -k "compare_report or persist_compare_result_writes_expected_artifact_names_and_payloads"
# 2 passed, 21 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/lora_release_report_groups.coverage -m pytest -q services/mlx-worker-python/tests/test_evaluation_reports.py services/mlx-worker-python/tests/test_evaluation_store.py -k "compare_report or persist_compare_result_writes_expected_artifact_names_and_payloads"
# 2 passed, 21 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/lora_release_report_groups.coverage -o /tmp/lora_release_report_groups_coverage.json
# wrote coverage JSON

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/lora_release_report_groups_coverage.json services/mlx-worker-python/worker/productization/evaluation_reports.py
# TOTAL 26 1 96%

git diff --check
# passed

git diff --check HEAD^1 HEAD
# passed after review fix

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files /tmp/lora_release_report_groups_changed_files.json --output /tmp/lora_release_report_groups_scope.json
# selected_count=0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 26 1 96%` for `services/mlx-worker-python/worker/productization/evaluation_reports.py`.
- PR-scoped performance scope: `selected_count=0`; no registered probe matched this Markdown report-rendering path.
- Observability mode: `evidence`; this only changes human-readable compare evidence rendering and does not add runtime request-path observability.
- Probe overhead: `N/A`; no runtime probe, telemetry sampler, or production metrics behavior changed.

## Known Gaps
- Full local `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run in this worktree. The host had about 3.1 GiB free during verification, which is not enough for a reliable full Swift rebuild; focused Python checks were run instead.
- No JSON/CSV schema changes are included; this PR only changes human-readable Markdown grouping.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
