### PR TITLE
Add source construction metadata

### DIFF
--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -458,9 +458,11 @@ Melix-owned training or evaluation packages before training, `eval`, or
 
 That plan defines the required construction path for source inventory,
 image/entity selection, fuzzy rewrites, multi-hop question assembly, and package
-materialization. Later implementation slices should add machine-readable
-construction metadata and leakage validation summaries to the existing package
-contracts rather than creating a separate runtime dataset format.
+materialization. DataDesigner-backed generation may persist optional
+`source_construction` metadata in training and final-result evaluation package
+manifests and sample rows. Later leakage-validation slices should consume that
+metadata and write validation summaries to the existing package contracts rather
+than creating a separate runtime dataset format.
 
 ## Benchmark Fixture Sources
 

--- a/docs/plans/2026-05-22-source-anchored-data-construction.md
+++ b/docs/plans/2026-05-22-source-anchored-data-construction.md
@@ -146,16 +146,18 @@ The final materialized package remains a Melix package:
 - evaluation output uses `melix.evaluation_dataset_package.v2`
 - media and documents remain package-local assets referenced from sample rows
 
-The package manifest should later include a source-anchored construction summary.
-Sample rows may carry per-row construction metadata once the metadata slice is
-implemented. Until then, this plan is the governing contract for how those
-fields should be shaped.
+Generated packages may include a source-anchored construction summary in the
+package manifest and per-sample construction metadata in rows created by this
+pipeline. DataDesigner-backed generation accepts this metadata through the
+`source_construction` request contract and preserves per-row
+`source_construction` objects in generated training and final-result evaluation
+packages.
 
 ## Minimum Metadata Contract
 
-Follow-up implementation should add a `source_construction` object to generated
-package manifests and a per-sample construction object to rows that were created
-by this pipeline.
+Generated packages use a `source_construction` object for manifest-level
+construction metadata and a per-sample `source_construction` object for rows
+that were created by this pipeline.
 
 Manifest-level fields:
 
@@ -239,23 +241,24 @@ Success metrics:
 
 ## Verification Plan
 
-For this documentation slice:
+For the initial documentation slice:
 
 - `git diff --check`
 - PR evidence validation
 - metrics report: `N/A`, documentation-only contract slice
 
-For follow-up implementation slices:
+For this metadata implementation slice:
 
 - focused Python tests for manifest and sample metadata serialization
-- focused Python tests for leakage validator edge cases
 - changed-scope coverage for modified Python files
+
+For remaining implementation slices:
+
+- focused Python tests for leakage validator edge cases
 - a synthetic construction probe that records the measurement points above
 
 ## Follow-Up Issues
 
-- Add pipeline metadata for source ids, transformations, and excluded leakage
-  fields.
 - Add validators for prompt/example overlap, answer-in-observation leakage, and
   train/eval split collision.
 - Record leakage validation summaries in dataset manifests and evaluation

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -951,6 +951,54 @@ def test_synthetic_dataset_request_uses_defaults_and_column_shortcuts(tmp_path: 
     assert request.columns[4].params == {}
 
 
+def test_synthetic_dataset_request_parses_source_construction_metadata() -> None:
+    request = maintenance_core_module._synthetic_dataset_request_from_ext(
+        _synthetic_dataset_base_ext(
+            source_construction_json=json.dumps(
+                {
+                    "construction_method": "source_anchored_multihop",
+                    "source_bundle_id": "bundle-1",
+                    "source_bundle_revision": "rev-a",
+                    "source_count": 3,
+                    "transformation_kinds": ["paraphrase", "entity_alias"],
+                    "excluded_leakage_field_kinds": ["answer"],
+                    "split_policy": "source_id_holdout",
+                }
+            )
+        ),
+        job_id="job-source-construction",
+    )
+
+    assert request.source_construction is not None
+    assert request.source_construction.construction_method == "source_anchored_multihop"
+    assert request.source_construction.source_bundle_id == "bundle-1"
+    assert request.source_construction.source_count == 3
+    assert request.source_construction.transformation_kinds == ("paraphrase", "entity_alias")
+    assert request.source_construction.excluded_leakage_field_kinds == ("answer",)
+
+
+def test_synthetic_dataset_request_accepts_empty_source_construction_lists() -> None:
+    request = maintenance_core_module._synthetic_dataset_request_from_ext(
+        _synthetic_dataset_base_ext(
+            source_construction_json=json.dumps(
+                {
+                    "construction_method": "source_anchored_multihop",
+                    "source_bundle_id": "bundle-1",
+                    "source_count": "",
+                    "transformation_kinds": "",
+                    "excluded_leakage_field_kinds": None,
+                }
+            )
+        ),
+        job_id="job-source-construction-empty",
+    )
+
+    assert request.source_construction is not None
+    assert request.source_construction.source_count == 0
+    assert request.source_construction.transformation_kinds == ()
+    assert request.source_construction.excluded_leakage_field_kinds == ()
+
+
 def test_synthetic_dataset_column_shortcuts_only_read_explicit_at_files(tmp_path: Path) -> None:
     prompt_file = tmp_path / "prompt.txt"
     prompt_file.write_text("file-backed prompt", encoding="utf-8")
@@ -987,6 +1035,14 @@ def test_synthetic_dataset_column_shortcuts_only_read_explicit_at_files(tmp_path
         ({"disable_datadesigner_telemetry": "maybe"}, "disable_datadesigner_telemetry must be a boolean"),
         ({"extra_body_json": "{"}, "extra_body_json must be valid JSON"),
         ({"extra_body_json": "[]"}, "extra_body_json must be a JSON object"),
+        (
+            {"source_construction_json": '{"source_count":"many"}'},
+            "source_construction_json.source_count must be an integer",
+        ),
+        (
+            {"source_construction_json": '{"transformation_kinds":"paraphrase"}'},
+            "source_construction_json.transformation_kinds must be a JSON array",
+        ),
         ({"headers_json": "{"}, "headers_json must be valid JSON"),
         ({"headers_json": "{}"}, "headers_json must be a JSON array"),
         ({"headers_json": json.dumps(["bad"])}, "Synthetic provider headers must use KEY=VALUE syntax"),

--- a/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
@@ -12,6 +12,7 @@ import pytest
 from worker.model_ops.errors import ModelOperationError
 from worker.productization import synthetic_dataset_generation as synthetic_module
 from worker.productization.synthetic_dataset_generation import (
+    SourceConstructionMetadata,
     SyntheticColumnSpec,
     SyntheticDatasetRequest,
     SyntheticModelConfig,
@@ -319,6 +320,65 @@ def test_create_training_package_writes_melix_contract_and_redacts_secrets(
     assert synthetic_module.os.environ["NEMO_TELEMETRY_ENABLED"] == "true"
 
 
+def test_create_training_package_preserves_source_construction_metadata(tmp_path: Path) -> None:
+    _fake_state.rows = [
+        {
+            "prompt": "What color is the visible signal?",
+            "completion": "red",
+            "source_construction": {
+                "source_ids": ["source-1"],
+                "source_asset_paths": ["media/signal.png"],
+                "image_ids": ["image-1"],
+                "entity_ids": ["signal"],
+                "rewrite_id": "rewrite-1",
+                "transformation_kinds": ["paraphrase", "entity_alias"],
+                "excluded_leakage_fields": ["answer"],
+                "evidence_chain": [{"source_id": "source-1", "field": "caption"}],
+                "required_tool_families": ["image_inspection"],
+                "hop_count": "2",
+                "answer_aliases": ["red signal"],
+                "ambiguity_notes": "single visible signal",
+                "raw_answer": "red",
+            },
+        }
+    ]
+
+    result = generate_synthetic_dataset_package(
+        _request(
+            num_records=1,
+            source_construction=SourceConstructionMetadata(
+                construction_method="source_anchored_multihop",
+                source_bundle_id="bundle-1",
+                source_bundle_revision="rev-a",
+                source_count=1,
+                transformation_kinds=("paraphrase", "entity_alias"),
+                excluded_leakage_field_kinds=("answer",),
+                split_policy="source_id_holdout",
+            ),
+        ),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+    )
+
+    manifest = result.manifest_payload
+    assert manifest["source_construction"] == {
+        "schema_version": "melix.source_construction.v1",
+        "construction_method": "source_anchored_multihop",
+        "source_bundle_id": "bundle-1",
+        "source_bundle_revision": "rev-a",
+        "source_count": 1,
+        "sample_count": 1,
+        "transformation_kinds": ["paraphrase", "entity_alias"],
+        "excluded_leakage_field_kinds": ["answer"],
+        "split_policy": "source_id_holdout",
+    }
+    sample = json.loads((tmp_path / "out" / "samples.jsonl").read_text(encoding="utf-8"))
+    assert sample["source_construction"]["source_ids"] == ["source-1"]
+    assert sample["source_construction"]["hop_count"] == 2
+    assert sample["source_construction"]["excluded_leakage_fields"] == ["answer"]
+    assert "raw_answer" not in sample["source_construction"]
+
+
 def test_create_training_package_removes_stale_valid_jsonl_without_validation(tmp_path: Path) -> None:
     (tmp_path / "out").mkdir()
     (tmp_path / "out" / "valid.jsonl").write_text("stale\n", encoding="utf-8")
@@ -403,6 +463,63 @@ def test_create_evaluation_final_result_package_validates_json_targets(tmp_path:
         '{"id": "two", "system": "", "input": {"text": "extract b"}, "target": {"label": "b"}}\n'
     )
     assert source_rows[1]["target"] == '{"label":"b"}'
+
+
+def test_create_evaluation_package_preserves_sample_source_construction(tmp_path: Path) -> None:
+    _fake_state.rows = [
+        {
+            "sample_id": "one",
+            "system": "",
+            "input": "Find the linked source fact.",
+            "target": {"label": "a"},
+            "source_construction": {
+                "source_ids": ["source-1"],
+                "transformation_kinds": ["paraphrase"],
+                "excluded_leakage_fields": ["target.label"],
+                "hop_count": 2,
+            },
+        },
+    ]
+
+    generate_synthetic_dataset_package(
+        _request(
+            output_kind="evaluation_final_result",
+            output_format="json",
+            num_records=1,
+        ),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "eval",
+    )
+
+    sample = json.loads((tmp_path / "eval" / "samples.jsonl").read_text(encoding="utf-8"))
+    assert sample["source_construction"]["source_ids"] == ["source-1"]
+    assert sample["source_construction"]["excluded_leakage_fields"] == ["target.label"]
+
+
+def test_invalid_evaluation_source_construction_reports_row_index(tmp_path: Path) -> None:
+    _fake_state.rows = [
+        {
+            "sample_id": "one",
+            "system": "",
+            "input": "Find the linked source fact.",
+            "target": {"label": "a"},
+            "source_construction": {"source_ids": [" "]},
+        },
+    ]
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(
+                output_kind="evaluation_final_result",
+                output_format="json",
+                num_records=1,
+            ),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "eval",
+        )
+
+    assert error.value.code == "invalid_synthetic_source_construction"
+    assert error.value.details == {"field": "source_ids", "row": "1"}
 
 
 def test_create_evaluation_text_package_and_resume_mode(tmp_path: Path) -> None:
@@ -512,6 +629,107 @@ def test_invalid_training_row_is_reported_as_synthetic_output_error(tmp_path: Pa
         )
 
     assert error.value.code == "invalid_synthetic_output_row"
+
+
+def test_invalid_source_construction_row_metadata_is_rejected(tmp_path: Path) -> None:
+    _fake_state.rows = [
+        {
+            "prompt": "p",
+            "completion": "c",
+            "source_construction": {"source_ids": "source-1"},
+        }
+    ]
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(num_records=1),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "invalid_synthetic_source_construction"
+    assert error.value.details["field"] == "source_ids"
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected_field"),
+    [
+        (
+            SourceConstructionMetadata(
+                construction_method="",
+                source_bundle_id="bundle-1",
+            ),
+            "source_construction.construction_method",
+        ),
+        (
+            SourceConstructionMetadata(
+                construction_method="source_anchored_multihop",
+                source_bundle_id="",
+            ),
+            "source_construction.source_bundle_id",
+        ),
+        (
+            SourceConstructionMetadata(
+                construction_method="source_anchored_multihop",
+                source_bundle_id="bundle-1",
+                source_count=-1,
+            ),
+            "source_construction.source_count",
+        ),
+    ],
+)
+def test_invalid_source_construction_manifest_metadata_is_rejected(
+    tmp_path: Path,
+    metadata: SourceConstructionMetadata,
+    expected_field: str,
+) -> None:
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(num_records=1, source_construction=metadata),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "invalid_synthetic_dataset_request"
+    assert error.value.details["field"] == expected_field
+
+
+@pytest.mark.parametrize(
+    ("source_construction", "expected_field"),
+    [
+        ("not-object", ""),
+        ({}, "source_ids"),
+        ({"source_ids": []}, "source_ids"),
+        ({"source_ids": [" ", ""]}, "source_ids"),
+        ({"source_ids": ["source-1"], "evidence_chain": "bad"}, "evidence_chain"),
+        ({"source_ids": ["source-1"], "hop_count": "two"}, "hop_count"),
+        ({"source_ids": ["source-1"], "hop_count": -1}, "hop_count"),
+        ({"source_ids": ["source-1"], "image_ids": "image-1"}, "image_ids"),
+    ],
+)
+def test_invalid_source_construction_metadata_shapes_are_rejected(
+    tmp_path: Path,
+    source_construction: Any,
+    expected_field: str,
+) -> None:
+    _fake_state.rows = [
+        {
+            "prompt": "p",
+            "completion": "c",
+            "source_construction": source_construction,
+        }
+    ]
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(num_records=1),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "invalid_synthetic_source_construction"
+    if expected_field:
+        assert error.value.details["field"] == expected_field
 
 
 def test_missing_datadesigner_dependency_reports_optional_extra(

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -41,6 +41,7 @@ from worker.model_ops.upload_receipt_pipeline import UploadReceiptPipeline
 from worker.productization.benchmark_queue import BenchmarkQueueRecord, BenchmarkQueueStore
 from worker.productization.benchmark_suites import BenchmarkSuiteCatalog, ResolvedBenchmarkSuite
 from worker.productization.synthetic_dataset_generation import (
+    SourceConstructionMetadata,
     SyntheticColumnSpec,
     SyntheticDatasetRequest,
     SyntheticModelConfig,
@@ -329,6 +330,7 @@ def _synthetic_dataset_request_from_ext(
         random_seed=_optional_int_ext(ext, "random_seed"),
         data_designer_resume_mode=ext.get("resume", "").strip() or "never",
         disable_data_designer_telemetry=_boolean_ext(ext, "disable_datadesigner_telemetry", default=True),
+        source_construction=_synthetic_source_construction_from_ext(ext),
     )
 
 
@@ -458,6 +460,48 @@ def _json_string_list_ext(ext: dict[str, str], key: str) -> list[str]:
             details={"field": key},
         )
     return [str(item) for item in payload]
+
+
+def _synthetic_source_construction_from_ext(ext: dict[str, str]) -> SourceConstructionMetadata | None:
+    payload = _json_object_ext(ext, "source_construction_json", default={})
+    if not payload:
+        return None
+    return SourceConstructionMetadata(
+        construction_method=str(payload.get("construction_method", "")).strip(),
+        source_bundle_id=str(payload.get("source_bundle_id", "")).strip(),
+        source_bundle_revision=str(payload.get("source_bundle_revision", "")).strip(),
+        source_count=_json_int(payload, "source_count"),
+        transformation_kinds=_json_string_tuple(payload, "transformation_kinds"),
+        excluded_leakage_field_kinds=_json_string_tuple(payload, "excluded_leakage_field_kinds"),
+        split_policy=str(payload.get("split_policy", "")).strip(),
+    )
+
+
+def _json_string_tuple(payload: dict[str, Any], key: str) -> tuple[str, ...]:
+    value = payload.get(key, [])
+    if value in ("", None):
+        return ()
+    if not isinstance(value, list):
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message=f"source_construction_json.{key} must be a JSON array.",
+            details={"field": f"source_construction_json.{key}"},
+        )
+    return tuple(item for item in (str(raw).strip() for raw in value) if item)
+
+
+def _json_int(payload: dict[str, Any], key: str) -> int:
+    value = payload.get(key, 0)
+    if value in ("", None):
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message=f"source_construction_json.{key} must be an integer.",
+            details={"field": f"source_construction_json.{key}"},
+        ) from exc
 
 
 def _synthetic_headers_from_ext(ext: dict[str, str]) -> dict[str, str]:

--- a/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
@@ -83,6 +83,17 @@ class SyntheticSeedSource:
 
 
 @dataclass(frozen=True)
+class SourceConstructionMetadata:
+    construction_method: str
+    source_bundle_id: str
+    source_bundle_revision: str = ""
+    source_count: int = 0
+    transformation_kinds: tuple[str, ...] = ()
+    excluded_leakage_field_kinds: tuple[str, ...] = ()
+    split_policy: str = ""
+
+
+@dataclass(frozen=True)
 class SyntheticDatasetRequest:
     dataset_id: str
     dataset_name: str
@@ -100,6 +111,7 @@ class SyntheticDatasetRequest:
     random_seed: int | None = None
     data_designer_resume_mode: Literal["never", "if_possible", "always"] = "never"
     disable_data_designer_telemetry: bool = True
+    source_construction: SourceConstructionMetadata | None = None
 
 
 @dataclass(frozen=True)
@@ -344,6 +356,29 @@ def _validate_request(request: SyntheticDatasetRequest) -> None:
             message="preview_count must be greater than zero.",
             details={"preview_count": str(request.preview_count)},
         )
+    if request.source_construction is not None:
+        _validate_source_construction_metadata(request.source_construction)
+
+
+def _validate_source_construction_metadata(metadata: SourceConstructionMetadata) -> None:
+    if not metadata.construction_method.strip():
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message="source_construction.construction_method is required.",
+            details={"field": "source_construction.construction_method"},
+        )
+    if not metadata.source_bundle_id.strip():
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message="source_construction.source_bundle_id is required.",
+            details={"field": "source_construction.source_bundle_id"},
+        )
+    if metadata.source_count < 0:
+        raise ModelOperationError(
+            code="invalid_synthetic_dataset_request",
+            message="source_construction.source_count must be non-negative.",
+            details={"field": "source_construction.source_count"},
+        )
 
 
 def _load_data_designer_api() -> _DataDesignerAPI:
@@ -579,7 +614,7 @@ def _write_evaluation_package(
         target_path="target",
         sample_id_path="sample_id",
     )
-    _write_jsonl_rows(samples_path, _iter_serialized_samples(serialized_rows, field_mapping))
+    _write_jsonl_rows(samples_path, _iter_serialized_evaluation_rows(serialized_rows, field_mapping))
     manifest_payload = _base_manifest(
         request,
         rows=serialized_rows,
@@ -748,7 +783,7 @@ def _base_manifest(
     config_path: Path,
     timing: dict[str, float],
 ) -> dict[str, Any]:
-    return {
+    manifest = {
         "source_kind": "datadesigner",
         "operation": "generate_synthetic_dataset",
         "dataset_name": request.dataset_name,
@@ -784,17 +819,25 @@ def _base_manifest(
             "telemetry_disabled": request.disable_data_designer_telemetry,
         },
     }
+    if request.source_construction is not None:
+        manifest["source_construction"] = _source_construction_manifest(
+            request.source_construction,
+            sample_count=len(rows),
+        )
+    return manifest
 
 
 def _normalize_synthetic_training_row(row: dict[str, Any], output_format: str) -> dict[str, Any]:
     try:
-        return _normalize_sample(row, format_name=output_format, max_characters_per_sample=0)
+        normalized = _normalize_sample(row, format_name=output_format, max_characters_per_sample=0)
     except ModelOperationError as exc:
         raise ModelOperationError(
             code="invalid_synthetic_output_row",
             message=f"Synthetic DataDesigner row is invalid for {output_format} training output.",
             details={"format": output_format, **exc.details},
         ) from exc
+    _copy_row_source_construction(normalized, row)
+    return normalized
 
 
 def _parse_and_validate_evaluation_targets(
@@ -830,8 +873,170 @@ def _parse_and_validate_evaluation_targets(
                     message="Synthetic final-result text target must be non-empty.",
                     details={"row": str(index)},
                 )
+        _validate_row_source_construction(parsed_row, row_index=index)
         parsed_rows.append(parsed_row)
     return parsed_rows
+
+
+def _iter_serialized_evaluation_rows(
+    rows: list[dict[str, Any]],
+    field_mapping: EvaluationFieldMapping,
+) -> Iterator[dict[str, Any]]:
+    for row, serialized in zip(rows, _iter_serialized_samples(rows, field_mapping), strict=True):
+        _copy_row_source_construction(serialized, row)
+        yield serialized
+
+
+def _source_construction_manifest(
+    metadata: SourceConstructionMetadata,
+    *,
+    sample_count: int,
+) -> dict[str, Any]:
+    payload = {
+        "schema_version": "melix.source_construction.v1",
+        "construction_method": metadata.construction_method.strip(),
+        "source_bundle_id": metadata.source_bundle_id.strip(),
+        "source_bundle_revision": metadata.source_bundle_revision.strip(),
+        "source_count": int(metadata.source_count),
+        "sample_count": int(sample_count),
+        "transformation_kinds": _string_list(metadata.transformation_kinds),
+        "excluded_leakage_field_kinds": _string_list(metadata.excluded_leakage_field_kinds),
+        "split_policy": metadata.split_policy.strip(),
+    }
+    return _compact_dict(payload)
+
+
+def _copy_row_source_construction(target: dict[str, Any], source: Mapping[str, Any]) -> None:
+    if "source_construction" not in source:
+        return
+    target["source_construction"] = _validated_row_source_construction(
+        source["source_construction"],
+    )
+
+
+def _string_list(values: Iterable[Any]) -> list[str]:
+    return [item for item in (str(raw).strip() for raw in values) if item]
+
+
+_ROW_SOURCE_CONSTRUCTION_KEYS = (
+    "source_ids",
+    "source_asset_paths",
+    "image_ids",
+    "entity_ids",
+    "transformation_kinds",
+    "excluded_leakage_fields",
+    "required_tool_families",
+    "answer_aliases",
+    "evidence_chain",
+    "hop_count",
+    "rewrite_id",
+    "ambiguity_notes",
+)
+
+
+def _validate_row_source_construction(payload: dict[str, Any], *, row_index: int) -> None:
+    if "source_construction" not in payload:
+        return
+    payload["source_construction"] = _validated_row_source_construction(
+        payload["source_construction"],
+        row=row_index,
+    )
+
+
+def _validated_row_source_construction(value: Any, *, row: int | None = None) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        details = {} if row is None else {"row": str(row)}
+        raise ModelOperationError(
+            code="invalid_synthetic_source_construction",
+            message="Synthetic source_construction metadata must be a JSON object.",
+            details=details,
+        )
+    payload = {key: value[key] for key in _ROW_SOURCE_CONSTRUCTION_KEYS if key in value}
+    _require_string_list(payload, "source_ids", row=row)
+    for key in (
+        "source_asset_paths",
+        "image_ids",
+        "entity_ids",
+        "transformation_kinds",
+        "excluded_leakage_fields",
+        "required_tool_families",
+        "answer_aliases",
+    ):
+        _optional_string_list(payload, key, row=row)
+    if "evidence_chain" in payload and not isinstance(payload["evidence_chain"], list):
+        details = {"field": "evidence_chain"}
+        if row is not None:
+            details["row"] = str(row)
+        raise ModelOperationError(
+            code="invalid_synthetic_source_construction",
+            message="Synthetic source_construction evidence_chain must be an array.",
+            details=details,
+        )
+    if "hop_count" in payload:
+        try:
+            hop_count = int(payload["hop_count"])
+        except (TypeError, ValueError) as exc:
+            details = {"field": "hop_count"}
+            if row is not None:
+                details["row"] = str(row)
+            raise ModelOperationError(
+                code="invalid_synthetic_source_construction",
+                message="Synthetic source_construction hop_count must be an integer.",
+                details=details,
+            ) from exc
+        if hop_count < 0:
+            details = {"field": "hop_count"}
+            if row is not None:
+                details["row"] = str(row)
+            raise ModelOperationError(
+                code="invalid_synthetic_source_construction",
+                message="Synthetic source_construction hop_count must be non-negative.",
+                details=details,
+            )
+        payload["hop_count"] = hop_count
+    if "rewrite_id" in payload:
+        payload["rewrite_id"] = str(payload["rewrite_id"]).strip()
+    if "ambiguity_notes" in payload:
+        payload["ambiguity_notes"] = str(payload["ambiguity_notes"]).strip()
+    return _compact_dict(payload)
+
+
+def _require_string_list(payload: dict[str, Any], key: str, *, row: int | None) -> None:
+    if key not in payload:
+        details = {"field": key}
+        if row is not None:
+            details["row"] = str(row)
+        raise ModelOperationError(
+            code="invalid_synthetic_source_construction",
+            message=f"Synthetic source_construction {key} is required.",
+            details=details,
+        )
+    _optional_string_list(payload, key, row=row)
+    if not payload.get(key):
+        details = {"field": key}
+        if row is not None:
+            details["row"] = str(row)
+        raise ModelOperationError(
+            code="invalid_synthetic_source_construction",
+            message=f"Synthetic source_construction {key} must not be empty.",
+            details=details,
+        )
+
+
+def _optional_string_list(payload: dict[str, Any], key: str, *, row: int | None) -> None:
+    if key not in payload:
+        return
+    value = payload[key]
+    if not isinstance(value, list):
+        details = {"field": key}
+        if row is not None:
+            details["row"] = str(row)
+        raise ModelOperationError(
+            code="invalid_synthetic_source_construction",
+            message=f"Synthetic source_construction {key} must be an array.",
+            details=details,
+        )
+    payload[key] = [item for item in (str(raw).strip() for raw in value) if item]
 
 
 def _split_validation(


### PR DESCRIPTION
## Summary
- Add optional `source_construction` metadata to DataDesigner-backed synthetic dataset requests.
- Persist manifest-level source construction metadata in generated training and final-result evaluation packages.
- Preserve per-row source ids, transformations, excluded leakage fields, evidence chain, hop/tool metadata, and answer aliases.
- Parse `source_construction_json` from maintenance ext payloads.

Closes #737.

## Plan or Spec
- `docs/plans/2026-05-22-source-anchored-data-construction.md`
- `docs/benchmark-evaluation-contract.md`

## Commands Run
```text
python3 -m py_compile services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_synthetic_dataset_generation.py services/mlx-worker-python/tests/test_maintenance_service.py
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py services/mlx-worker-python/tests/test_maintenance_service.py -k "source_construction or invalid_source_construction"
# 19 passed, 233 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py services/mlx-worker-python/tests/test_maintenance_service.py
# 252 passed in 6.69s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/source_metadata.coverage -m pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py services/mlx-worker-python/tests/test_maintenance_service.py
# 252 passed in 7.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/source_metadata.coverage -o /tmp/source_metadata_coverage.json
# wrote /tmp/source_metadata_coverage.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/source_metadata_coverage.json services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py services/mlx-worker-python/worker/engine/maintenance_core.py
# TOTAL 7 0 100%

git diff --check
# passed

git merge --no-edit origin/main
# merged 69f3a2a7 perf: streamline audio voice mode check (#1363)

python3 -m py_compile services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_synthetic_dataset_generation.py services/mlx-worker-python/tests/test_maintenance_service.py
# passed after merging origin/main

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py services/mlx-worker-python/tests/test_maintenance_service.py -k "source_construction or invalid_source_construction"
# 19 passed, 233 deselected after merging origin/main

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py services/mlx-worker-python/tests/test_maintenance_service.py
# 252 passed in 6.73s after merging origin/main

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/source_metadata.coverage -m pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py services/mlx-worker-python/tests/test_maintenance_service.py
# 252 passed in 7.62s after merging origin/main

git merge --no-edit origin/main
# merged 6d8cbc65 perf: fast-path code eval JSON bounds (#1368)

python3 -m py_compile services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_synthetic_dataset_generation.py services/mlx-worker-python/tests/test_maintenance_service.py
# passed after merging latest origin/main

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py services/mlx-worker-python/tests/test_maintenance_service.py -k "source_construction or invalid_source_construction"
# 19 passed, 233 deselected after merging latest origin/main

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py services/mlx-worker-python/tests/test_maintenance_service.py
# 252 passed in 7.02s after merging latest origin/main

git diff --name-only origin/main | jq -R -s 'split("\n")[:-1]' > /tmp/source_metadata_changed_files.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json /tmp/source_metadata_changed_files.json --output /tmp/source_metadata_scope.json
# selected_count: 6
# matched_probe_ids: maintenance-bench-report-readback, maintenance-percentile-vector-reuse, maintenance-prompt-shape-vector-repeat, maintenance-benchmark-parameter-normalization-single-convert, upload-receipt-published-files-scandir, model-ops-bundle-artifact-byte-accounting
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%` for the review-fix delta in `synthetic_dataset_generation.py` and `maintenance_core.py`; initial PR coverage before the review fix was `TOTAL 113 5 96%`.
- Metrics report: local PR-scoped performance scope selected 6 probes: `maintenance-bench-report-readback`, `maintenance-percentile-vector-reuse`, `maintenance-prompt-shape-vector-repeat`, `maintenance-benchmark-parameter-normalization-single-convert`, `upload-receipt-published-files-scandir`, and `model-ops-bundle-artifact-byte-accounting`.
- Local base/head probe replay: `N/A` before PR because the macOS host has about 3.0 GiB free, and `pr_scoped_performance_run.py` needs separate base and head snapshots. The PR `pr-scoped-performance` workflow will run the authoritative base/head report.
- Observability mode: `evidence`; this change preserves package construction metadata for dataset/evaluation evidence artifacts and does not add production request-path telemetry.
- Probe overhead: `N/A`; no runtime probes, counters, or debug instrumentation were added.

## Known Gaps
- Full local `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run on this host because the filesystem has about 3.0 GiB free.
- Leakage validators and manifest validation summaries remain in follow-up slices.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
