### PR TITLE
perf: fast-path code eval JSON bounds

### DIFF
--- a/docs/plans/2026-05-21-code-eval-json-bounds-fast-path.md
+++ b/docs/plans/2026-05-21-code-eval-json-bounds-fast-path.md
@@ -1,0 +1,23 @@
+# Code Evaluation JSON Bounds Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to the code-evaluation payload fast path in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+## Goal
+
+Avoid byte-by-byte leading/trailing whitespace scans when `_load_payload_file()` receives the common compact JSON object payload emitted by the sandbox runner or by sorted-key probe fixtures. Payloads whose first byte is `{` and final byte is `}` can return object bounds immediately; payloads with surrounding whitespace or malformed delimiters keep the existing validation path.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped registered probe `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Linux validation boundary
+
+This slice is entirely Python and locally verifiable on Linux. No Swift runtime behavior is changed.
+
+## Success metrics
+
+- Focused code-eval tests and PR-scoped probe registry tests pass.
+- Changed-scope coverage for touched executable Python scope remains at least 95%.
+- `scripts/code_eval_payload_json_probe.py` reports lower `elapsed_ms_mean` with unchanged payload size and peak memory.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -970,6 +970,7 @@ def test_load_payload_file_fast_path_falls_back_for_escaped_fields(tmp_path: Pat
 
 
 def test_payload_fast_path_field_extractors_cover_malformed_edges() -> None:
+    assert code_eval_runner._json_object_payload_bounds(b'{"runtime_status":"ok"}') == (0, 22)
     assert code_eval_runner._json_object_payload_bounds(b' \n {"runtime_status":"ok"}\t ') == (3, 25)
     assert code_eval_runner._json_object_payload_bounds(b"   ") is None
     assert code_eval_runner._json_object_payload_bounds(b' {"runtime_status":"ok"] ') is None

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -394,6 +394,9 @@ _JSON_PAYLOAD_WHITESPACE = b" \t\r\n"
 
 def _json_object_payload_bounds(payload_bytes: bytes) -> tuple[int, int] | None:
     payload_length = len(payload_bytes)
+    if payload_length >= 2 and payload_bytes[0] == ord("{") and payload_bytes[-1] == ord("}"):
+        return 0, payload_length - 1
+
     start = 0
     while start < payload_length and payload_bytes[start] in _JSON_PAYLOAD_WHITESPACE:
         start += 1


### PR DESCRIPTION
## Summary
- Adds a compact JSON object bounds fast path for code-evaluation payload loading.
- Preserves existing whitespace-tolerant and malformed-payload fallback behavior.
- Adds a regression assertion for compact object bounds and documents the performance slice.

## Plan or Spec
- `docs/plans/2026-05-21-code-eval-json-bounds-fast-path.md`

## Commands Run
```text
# Baseline registered probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
exit 0; elapsed_ms_mean=120.68860342593065; peak_bytes_mean=60425.0

# Post-change exploratory probe before full verification
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
exit 0; elapsed_ms_mean=110.1199277743165; peak_bytes_mean=60425.0

# Registered focused test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_required_field_check_preserves_fast_path_gate services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
exit 0; 9 passed in 1.74s

# Registered changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_required_field_check_preserves_fast_path_gate services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py
exit 0; TOTAL 3 0 100%

# Registered probe command after full verification
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/code_eval_payload_json_probe.py ]; then python3 scripts/code_eval_payload_json_probe.py; else ...; fi'
exit 0; elapsed_ms_mean=119.36707069565144; peak_bytes_mean=60425.0

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Registered probe: `code-eval-payload-json-bytes`.
- Local Linux probe metrics:
  - baseline `elapsed_ms_mean=120.68860342593065`, `peak_bytes_mean=60425.0`
  - post-change exploratory `elapsed_ms_mean=110.1199277743165`, `peak_bytes_mean=60425.0`
  - post-change registered verification `elapsed_ms_mean=119.36707069565144`, `peak_bytes_mean=60425.0`
- CI PR-scoped performance report is required for base-vs-head registered probe validation before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this Python-only slice used the registered focused test, coverage, and probe commands. GitHub Actions remains the full validation gate.
- No Swift runtime effects are claimed or changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
