### PR TITLE
Add source leakage validators

### DIFF
--- a/docs/plans/2026-05-22-source-anchored-data-construction.md
+++ b/docs/plans/2026-05-22-source-anchored-data-construction.md
@@ -191,16 +191,27 @@ raw secrets, API keys, or live provider credentials.
 
 ## Leakage Controls Planned From This Contract
 
-The validator slice should consume the metadata above to check:
+The validator slice consumes the metadata above to check source-anchored rows
+before package materialization:
 
-- prompt or example overlap with excluded source fields
-- answer-in-observation leakage
-- train/eval source collision
+- prompt or example overlap with excluded source fields by resolving
+  `excluded_leakage_fields` against the generated row and scanning
+  prompt/example text that is visible before the target answer
+- answer-in-observation leakage by scanning tool observation payloads for the
+  same excluded raw values
+- train/eval source collision by comparing per-row `source_ids` across the
+  materialized training and validation splits
 - duplicate source ids across incompatible splits
 - exact or near-exact prompt duplication
 
-Validators should produce machine-readable summaries in dataset manifests and
-evaluation artifacts before any release-facing claim uses the generated data.
+The initial lexical leakage checks ignore excluded raw values shorter than
+three characters because single-character labels and very short aliases create
+high-noise substring matches in normal prompt text.
+
+The first validator implementation blocks invalid generated packages when these
+checks fail. Follow-up slices should add machine-readable summaries in dataset
+manifests and evaluation artifacts before any release-facing claim uses the
+generated data.
 
 ## Quality Metrics Planned From This Contract
 
@@ -259,8 +270,6 @@ For remaining implementation slices:
 
 ## Follow-Up Issues
 
-- Add validators for prompt/example overlap, answer-in-observation leakage, and
-  train/eval split collision.
 - Record leakage validation summaries in dataset manifests and evaluation
   artifacts.
 - Add quality metrics for tool necessity, multi-hop depth, evidence coverage,

--- a/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
@@ -651,6 +651,215 @@ def test_invalid_source_construction_row_metadata_is_rejected(tmp_path: Path) ->
     assert error.value.details["field"] == "source_ids"
 
 
+def test_source_construction_prompt_overlap_is_rejected(tmp_path: Path) -> None:
+    _fake_state.rows = [
+        {
+            "prompt": "Name the object whose answer is Crimson Beacon.",
+            "completion": "Crimson Beacon",
+            "answer": "Crimson Beacon",
+            "source_construction": {
+                "source_ids": ["source-1"],
+                "excluded_leakage_fields": ["answer"],
+            },
+        }
+    ]
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(num_records=1),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "synthetic_source_leakage_detected"
+    assert error.value.details == {
+        "row": "1",
+        "validator": "prompt_example_overlap",
+        "field": "answer",
+    }
+
+
+def test_source_construction_example_overlap_is_rejected(tmp_path: Path) -> None:
+    _fake_state.rows = [
+        {
+            "prompt": "Name the source entity.",
+            "completion": "Crimson Beacon",
+            "answer": "Crimson Beacon",
+            "examples": [{"input": "The answer is Crimson Beacon."}],
+            "source_construction": {
+                "source_ids": ["source-1"],
+                "excluded_leakage_fields": ["answer"],
+            },
+        }
+    ]
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(num_records=1),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "synthetic_source_leakage_detected"
+    assert error.value.details["validator"] == "prompt_example_overlap"
+    assert error.value.details["field"] == "answer"
+
+
+def test_source_construction_observation_leakage_is_rejected(tmp_path: Path) -> None:
+    _fake_state.rows = [
+        {
+            "sample_id": "one",
+            "system": "",
+            "input": "Use the tool result to answer.",
+            "target": {"label": "Crimson Beacon"},
+            "answer": "Crimson Beacon",
+            "tool_observations": [{"text": "The hidden answer is Crimson Beacon."}],
+            "source_construction": {
+                "source_ids": ["source-1"],
+                "excluded_leakage_fields": ["answer"],
+            },
+        }
+    ]
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(
+                output_kind="evaluation_final_result",
+                output_format="json",
+                num_records=1,
+            ),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "eval",
+        )
+
+    assert error.value.code == "synthetic_source_leakage_detected"
+    assert error.value.details == {
+        "row": "1",
+        "validator": "answer_in_observation",
+        "field": "answer",
+    }
+
+
+def test_source_construction_turn_observation_leakage_is_rejected(tmp_path: Path) -> None:
+    _fake_state.rows = [
+        {
+            "prompt": "Use the linked tool result.",
+            "completion": "Crimson Beacon",
+            "answer": "Crimson Beacon",
+            "turns": [{"observation": {"text": "The final answer is Crimson Beacon."}}],
+            "source_construction": {
+                "source_ids": ["source-1"],
+                "excluded_leakage_fields": ["answer"],
+            },
+        }
+    ]
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(num_records=1),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "synthetic_source_leakage_detected"
+    assert error.value.details["validator"] == "answer_in_observation"
+    assert error.value.details["field"] == "answer"
+
+
+def test_source_construction_top_level_observation_leakage_is_rejected(tmp_path: Path) -> None:
+    _fake_state.rows = [
+        {
+            "prompt": "Use the linked tool result.",
+            "completion": "Crimson Beacon",
+            "answer": "Crimson Beacon",
+            "observation": {"text": "The final answer is Crimson Beacon."},
+            "source_construction": {
+                "source_ids": ["source-1"],
+                "excluded_leakage_fields": ["answer"],
+            },
+        }
+    ]
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(num_records=1),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "synthetic_source_leakage_detected"
+    assert error.value.details["validator"] == "answer_in_observation"
+    assert error.value.details["field"] == "answer"
+
+
+def test_source_construction_train_eval_source_collision_is_rejected(tmp_path: Path) -> None:
+    _fake_state.rows = [
+        {
+            "prompt": "p1",
+            "completion": "c1",
+            "source_construction": {"source_ids": ["shared-source"]},
+        },
+        {
+            "prompt": "p2",
+            "completion": "c2",
+            "source_construction": {"source_ids": ["shared-source"]},
+        },
+    ]
+
+    with pytest.raises(ModelOperationError) as error:
+        generate_synthetic_dataset_package(
+            _request(num_records=2, validation_ratio=0.5),
+            jobs_root=tmp_path / "jobs",
+            output_dir=tmp_path / "out",
+        )
+
+    assert error.value.code == "synthetic_source_leakage_detected"
+    assert error.value.details["validator"] == "train_eval_source_collision"
+    assert error.value.details["source_id"] == "shared-source"
+
+
+def test_source_construction_validator_helpers_handle_noisy_metadata() -> None:
+    assert synthetic_module._row_excluded_leakage_values(  # noqa: SLF001
+        {"answer": "Crimson Beacon"},
+        {"excluded_leakage_fields": "answer"},
+    ) == []
+    assert synthetic_module._row_excluded_leakage_values(  # noqa: SLF001
+        {
+            "answer": 123,
+            "nested": {"values": ["ab", "Crimson Beacon"]},
+        },
+        {"excluded_leakage_fields": ["", "answer", "nested.values", "missing.path"]},
+    ) == [("answer", "123"), ("nested.values", "Crimson Beacon")]
+    assert synthetic_module._training_prompt_segments(  # noqa: SLF001
+        {
+            "system": "system field",
+            "prompt": "raw prompt",
+            "input": {"text": "input text"},
+        }
+    ) == ["system field", "raw prompt", "input text"]
+    assert synthetic_module._training_prompt_segments(  # noqa: SLF001
+        {
+            "messages": [
+                {"role": "assistant", "content": "ignored"},
+                "bad",
+                {"role": "system", "content": "system prompt"},
+                {"role": "user", "content": "user prompt"},
+            ]
+        }
+    ) == ["system prompt", "user prompt"]
+    assert synthetic_module._first_leakage_match(  # noqa: SLF001
+        [("answer", "Crimson Beacon")],
+        [],
+    ) is None
+    assert synthetic_module._source_ids_by_split(  # noqa: SLF001
+        [
+            {"source_construction": "bad"},
+            {"source_construction": {"source_ids": "bad"}},
+            {"source_construction": {"source_ids": ["source-1", ""]}},
+        ]
+    ) == {"source-1": 3}
+
+
 @pytest.mark.parametrize(
     ("metadata", "expected_field"),
     [

--- a/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
@@ -40,6 +40,7 @@ _SUPPORTED_TRAINING_FORMATS = {
 _SUPPORTED_EVALUATION_RESULT_KINDS = {"json", "text"}
 _SECRET_FIELD_MARKERS = ("api_key", "authorization", "token", "secret", "password")
 _TELEMETRY_ENV_VAR = "NEMO_TELEMETRY_ENABLED"
+_MIN_LEAKAGE_VALUE_LENGTH = 3
 
 
 @dataclass(frozen=True)
@@ -531,8 +532,10 @@ def _write_training_package(
     config_path: Path,
     timing: dict[str, float],
 ) -> SyntheticDatasetPackageResult:
+    _validate_source_anchored_rows(rows, output_kind="training")
     normalized = [_normalize_synthetic_training_row(row, request.output_format) for row in rows]
     train_rows, validation_rows = _split_validation(normalized, request.validation_ratio)
+    _validate_source_split_collision(train_rows, validation_rows)
     package_write_started = time.perf_counter()
     samples_path = package_path / "samples.jsonl"
     valid_path = package_path / "valid.jsonl"
@@ -598,6 +601,7 @@ def _write_evaluation_package(
     timing: dict[str, float],
 ) -> SyntheticDatasetPackageResult:
     serialized_rows = _parse_and_validate_evaluation_targets(rows, result_kind=request.output_format)
+    _validate_source_anchored_rows(serialized_rows, output_kind="evaluation_final_result")
     package_write_started = time.perf_counter()
     manifest_path = package_path / "manifest.json"
     samples_path = package_path / "samples.jsonl"
@@ -1037,6 +1041,193 @@ def _optional_string_list(payload: dict[str, Any], key: str, *, row: int | None)
             details=details,
         )
     payload[key] = [item for item in (str(raw).strip() for raw in value) if item]
+
+
+def _validate_source_anchored_rows(rows: list[dict[str, Any]], *, output_kind: str) -> None:
+    for index, row in enumerate(rows, start=1):
+        metadata = row.get("source_construction")
+        if not isinstance(metadata, Mapping):
+            continue
+        excluded_values = _row_excluded_leakage_values(row, metadata)
+        if not excluded_values:
+            continue
+        prompt_segments = _source_prompt_overlap_segments(row, output_kind=output_kind)
+        prompt_match = _first_leakage_match(excluded_values, prompt_segments)
+        if prompt_match is not None:
+            raise ModelOperationError(
+                code="synthetic_source_leakage_detected",
+                message="Synthetic source construction prompt or example text contains an excluded source field value.",
+                details={
+                    "row": str(index),
+                    "validator": "prompt_example_overlap",
+                    "field": prompt_match[0],
+                },
+            )
+        observation_segments = _source_observation_segments(row)
+        observation_match = _first_leakage_match(excluded_values, observation_segments)
+        if observation_match is not None:
+            raise ModelOperationError(
+                code="synthetic_source_leakage_detected",
+                message="Synthetic source construction tool observation contains an excluded source field value.",
+                details={
+                    "row": str(index),
+                    "validator": "answer_in_observation",
+                    "field": observation_match[0],
+                },
+            )
+
+
+def _row_excluded_leakage_values(row: Mapping[str, Any], metadata: Mapping[str, Any]) -> list[tuple[str, str]]:
+    fields = metadata.get("excluded_leakage_fields", [])
+    if not isinstance(fields, list):
+        return []
+    values: list[tuple[str, str]] = []
+    for raw_field in fields:
+        field = str(raw_field).strip()
+        if not field:
+            continue
+        resolved = _resolve_dotted_path(row, field)
+        for value in _flatten_string_values(resolved):
+            normalized = value.strip()
+            if len(normalized) >= _MIN_LEAKAGE_VALUE_LENGTH:
+                values.append((field, normalized))
+    return values
+
+
+def _resolve_dotted_path(payload: Mapping[str, Any], path: str) -> Any:
+    current: Any = payload
+    for part in path.split("."):
+        if isinstance(current, Mapping) and part in current:
+            current = current[part]
+            continue
+        return None
+    return current
+
+
+def _flatten_string_values(value: Any) -> Iterator[str]:
+    if value is None:
+        return
+    if isinstance(value, str):
+        yield value
+        return
+    if isinstance(value, Mapping):
+        for item in value.values():
+            yield from _flatten_string_values(item)
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from _flatten_string_values(item)
+        return
+    if isinstance(value, (bool, int, float)):
+        yield str(value)
+
+
+def _source_prompt_overlap_segments(row: Mapping[str, Any], *, output_kind: str) -> list[str]:
+    segments: list[str] = []
+    if output_kind == "training":
+        segments.extend(_training_prompt_segments(row))
+    elif output_kind == "evaluation_final_result":
+        segments.extend(_evaluation_prompt_segments(row))
+    for key in ("examples", "few_shot_examples", "demonstrations"):
+        if key in row:
+            segments.extend(_flatten_string_values(row[key]))
+    return [segment for segment in segments if segment]
+
+
+def _training_prompt_segments(row: Mapping[str, Any]) -> list[str]:
+    if "messages" in row and isinstance(row["messages"], list):
+        segments: list[str] = []
+        for message in row["messages"]:
+            if not isinstance(message, Mapping):
+                continue
+            if str(message.get("role", "")).strip() == "assistant":
+                continue
+            content = str(message.get("content", "")).strip()
+            if content:
+                segments.append(content)
+        return segments
+    segments = []
+    for key in ("system", "prompt", "text", "question", "instruction", "input"):
+        if key in row:
+            segments.extend(_flatten_string_values(row[key]))
+    return segments
+
+
+def _evaluation_prompt_segments(row: Mapping[str, Any]) -> list[str]:
+    segments: list[str] = []
+    if "system" in row:
+        segments.extend(_flatten_string_values(row["system"]))
+    if "input" in row:
+        segments.extend(_flatten_string_values(row["input"]))
+    return segments
+
+
+def _source_observation_segments(row: Mapping[str, Any]) -> list[str]:
+    segments: list[str] = []
+    for key in ("observation", "observations", "tool_observations", "agentic_tool_observations"):
+        if key in row:
+            segments.extend(_flatten_string_values(row[key]))
+    turns = row.get("turns")
+    if isinstance(turns, list):
+        for turn in turns:
+            if not isinstance(turn, Mapping):
+                continue
+            if "observation" in turn:
+                segments.extend(_flatten_string_values(turn["observation"]))
+    return [segment for segment in segments if segment]
+
+
+def _first_leakage_match(
+    excluded_values: Iterable[tuple[str, str]],
+    segments: Iterable[str],
+) -> tuple[str, str] | None:
+    searchable_text = "\n".join(segment.casefold() for segment in segments if segment)
+    if not searchable_text:
+        return None
+    for field, value in excluded_values:
+        if value.casefold() in searchable_text:
+            return field, value
+    return None
+
+
+def _validate_source_split_collision(
+    train_rows: list[dict[str, Any]],
+    validation_rows: list[dict[str, Any]],
+) -> None:
+    if not train_rows or not validation_rows:
+        return
+    train_source_ids = _source_ids_by_split(train_rows)
+    validation_source_ids = _source_ids_by_split(validation_rows)
+    shared_ids = sorted(set(train_source_ids) & set(validation_source_ids))
+    if not shared_ids:
+        return
+    source_id = shared_ids[0]
+    raise ModelOperationError(
+        code="synthetic_source_leakage_detected",
+        message="Synthetic source construction reuses a source id across training and validation splits.",
+        details={
+            "validator": "train_eval_source_collision",
+            "source_id": source_id,
+            "train_row": str(train_source_ids[source_id]),
+            "validation_row": str(validation_source_ids[source_id]),
+        },
+    )
+
+
+def _source_ids_by_split(rows: list[dict[str, Any]]) -> dict[str, int]:
+    source_ids: dict[str, int] = {}
+    for index, row in enumerate(rows, start=1):
+        metadata = row.get("source_construction")
+        if not isinstance(metadata, Mapping):
+            continue
+        raw_ids = metadata.get("source_ids", [])
+        if not isinstance(raw_ids, list):
+            continue
+        for raw_id in raw_ids:
+            source_id = str(raw_id).strip()
+            if source_id and source_id not in source_ids:
+                source_ids[source_id] = index
+    return source_ids
 
 
 def _split_validation(


### PR DESCRIPTION
## Summary
- Add source-anchored leakage validators before synthetic package materialization.
- Block prompt/example overlap and tool-observation leakage using row `source_construction.excluded_leakage_fields`.
- Block train/validation source-id collisions after deterministic split.
- Update the source construction plan with the validator contract and short-value threshold.

Closes #739.

## Plan or Spec
- `docs/plans/2026-05-22-source-anchored-data-construction.md`
- `docs/benchmark-evaluation-contract.md`

## Commands Run
```text
python3 -m py_compile services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
# passed

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py -k "source_construction or leakage or collision"
# 22 passed, 47 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
# 69 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/leakage_validators.coverage -m pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
# 69 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/leakage_validators.coverage -o /tmp/leakage_validators_coverage.json
# wrote /tmp/leakage_validators_coverage.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/leakage_validators_coverage.json services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
# TOTAL 138 1 99%

git diff --name-only origin/main | jq -R -s 'split("\n")[:-1]' > /tmp/leakage_validators_changed_files.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json /tmp/leakage_validators_changed_files.json --output /tmp/leakage_validators_scope.json
# selected_count: 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 138 1 99%` for `synthetic_dataset_generation.py`.
- Metrics report: local PR-scoped performance scope selected `0` probes. This is package-generation validation logic only; no production request path, runtime telemetry, or benchmark execution path changed.
- Observability mode: `evidence`; validators block invalid source-anchored package artifacts before they can back release-facing training or evaluation claims.
- Probe overhead: `N/A`; no runtime probes, counters, or debug instrumentation were added.

## Known Gaps
- Full local `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run on this host because the filesystem has about 3.0 GiB free.
- Manifest/evaluation-artifact leakage validation summaries are deferred to #740.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
