### PR TITLE
perf: simplify response boundary no-limit aggregation

### DIFF
--- a/docs/plans/2026-05-21-response-boundary-no-limit-minmax.md
+++ b/docs/plans/2026-05-21-response-boundary-no-limit-minmax.md
@@ -1,0 +1,28 @@
+# Response-only Boundary No-limit Aggregate Min/Max Fast Path
+
+## Scope
+
+This performance slice only touches `worker.model_ops.response_only_boundary.aggregate_response_only_boundaries()` for the no-truncation path (`max_seq_length is None` or non-positive).
+
+## Rationale
+
+When there is no truncation limit, trainable response-token bounds and totals are exactly the response-token bounds and totals. The previous loop maintained separate `trainable_response_tokens_*` running values even though they could not diverge from `response_tokens_*` in this branch.
+
+## Implementation
+
+- Keep the existing truncation-limit branch unchanged.
+- In the no-limit branch, seed running bounds from the first entry so the hot loop no longer checks `sample_count == 0` on every sample.
+- Compute only response-token bounds/totals in the hot loop.
+- After the loop, mirror those values into the trainable response-token aggregate fields.
+
+## Validation
+
+The registered PR-scoped probe `response-only-boundary-slotted-records` covers this path and includes focused tests, changed-scope coverage, and `scripts/response_only_boundary_slots_probe.py` metrics.
+
+Local Linux validation for this slice must run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_without_limit_updates_running_bounds services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_without_limit_updates_running_bounds services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/response_only_boundary.py services/mlx-worker-python/tests/test_response_only_boundary.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/response_only_boundary_slots_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/response_only_boundary_slots_probe.py
+```

--- a/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
+++ b/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
@@ -208,37 +208,41 @@ def aggregate_response_only_boundaries(
                 fully_truncated_response_sample_count += 1
             sample_count += 1
     else:
-        for entry in boundaries:
+        iterator = iter(boundaries)
+        for entry in iterator:
             offset = entry.assistant_offset
             total_tokens = entry.total_tokens
             response_tokens = total_tokens - offset
             if response_tokens < 0:
                 response_tokens = 0
-            trainable_response_tokens = response_tokens
-            if sample_count == 0:
+            sample_count = 1
+            boundary_min = offset
+            boundary_max = offset
+            response_tokens_min = response_tokens
+            response_tokens_max = response_tokens
+            total_offset = offset
+            total_response_tokens = response_tokens
+            break
+        for entry in iterator:
+            offset = entry.assistant_offset
+            total_tokens = entry.total_tokens
+            response_tokens = total_tokens - offset
+            if response_tokens < 0:
+                response_tokens = 0
+            if offset < boundary_min:
                 boundary_min = offset
+            if offset > boundary_max:
                 boundary_max = offset
+            if response_tokens < response_tokens_min:
                 response_tokens_min = response_tokens
+            if response_tokens > response_tokens_max:
                 response_tokens_max = response_tokens
-                trainable_response_tokens_min = trainable_response_tokens
-                trainable_response_tokens_max = trainable_response_tokens
-            else:
-                if offset < boundary_min:
-                    boundary_min = offset
-                if offset > boundary_max:
-                    boundary_max = offset
-                if response_tokens < response_tokens_min:
-                    response_tokens_min = response_tokens
-                if response_tokens > response_tokens_max:
-                    response_tokens_max = response_tokens
-                if trainable_response_tokens < trainable_response_tokens_min:
-                    trainable_response_tokens_min = trainable_response_tokens
-                if trainable_response_tokens > trainable_response_tokens_max:
-                    trainable_response_tokens_max = trainable_response_tokens
             total_offset += offset
             total_response_tokens += response_tokens
-            total_trainable_response_tokens += trainable_response_tokens
             sample_count += 1
+        trainable_response_tokens_min = response_tokens_min
+        trainable_response_tokens_max = response_tokens_max
+        total_trainable_response_tokens = total_response_tokens
     if sample_count == 0:
         return ResponseOnlyBoundaryAggregate(
             sample_count=0,


### PR DESCRIPTION
## Summary
- Simplifies the no-truncation branch of `aggregate_response_only_boundaries()` by seeding bounds from the first entry and removing redundant trainable-token min/max updates from the hot loop.
- Preserves the truncation-limit branch and manifest output semantics.

## Plan or Spec
- `docs/plans/2026-05-21-response-boundary-no-limit-minmax.md`
- Registered PR-scoped probe: `response-only-boundary-slotted-records` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe on origin/main before editing
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/response_only_boundary_slots_probe.py
# exit 0; aggregation_elapsed_ms_mean=255.1374590024352, construction_elapsed_ms_mean=121.73803853802383

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_without_limit_updates_running_bounds services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 9 passed, 1 skipped

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_without_limit_updates_running_bounds services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/response_only_boundary.py services/mlx-worker-python/tests/test_response_only_boundary.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/response_only_boundary_slots_probe.py
# exit 0; changed-scope coverage TOTAL 23 0 100%

# Registered local probe after change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/response_only_boundary_slots_probe.py
# exit 0; aggregation_elapsed_ms_mean=265.991168981418, construction_elapsed_ms_mean=127.75156102143228

# Alternating base/head probe comparison, three runs each
# base aggregation_elapsed_ms_mean: 275.29453937895596, 267.2688421327621, 255.41824540123343
# head aggregation_elapsed_ms_mean: 258.32289778627455, 268.52482934482396, 256.001762393862
# old_mean=265.9938756376505 ms; new_mean=260.9498298416535 ms; delta=-5.044045795996965 ms; speedup=1.019329561544676x

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 23 0 100%`.
- Local registered probe metric: `aggregation_elapsed_ms_mean` old_mean=`265.9938756376505` ms, new_mean=`260.9498298416535` ms, delta=`-5.044045795996965` ms, speedup=`1.019329561544676x` across three alternating base/head runs.
- Other probe invariants: `boundary_count=50000.0`, `checksum=7970445.0`, `instance_dict_count_mean=0.0`, `peak_bytes_mean=3422112.0`.
- CI PR-scoped performance workflow is required for the registered probe report before merge.

## Known Gaps
- Local Linux validation covers the Python path only; no Swift runtime effect is claimed.
- The probe is somewhat noisy, so the PR-scoped CI report remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
