### PR TITLE
Record source leakage validation summaries

### DIFF
--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -464,6 +464,14 @@ manifests and sample rows. Later leakage-validation slices should consume that
 metadata and write validation summaries to the existing package contracts rather
 than creating a separate runtime dataset format.
 
+When source-anchored validation is applied, package manifests must include a
+`source_leakage_validation` object with a publishable summary of the checks that
+ran. The summary reports validator names, status, checked row and segment
+counts, split source-id counts when a training validation split exists, and the
+minimum raw-value length used for lexical leakage matching. It must not persist
+raw excluded field values, prompt text, observations, source spans, or other
+payload text that could reintroduce answer leakage into release artifacts.
+
 ## Benchmark Fixture Sources
 
 Benchmark suites may also materialize from repository-owned fixture packages

--- a/docs/plans/2026-05-22-source-anchored-data-construction.md
+++ b/docs/plans/2026-05-22-source-anchored-data-construction.md
@@ -213,6 +213,37 @@ checks fail. Follow-up slices should add machine-readable summaries in dataset
 manifests and evaluation artifacts before any release-facing claim uses the
 generated data.
 
+Successful source-anchored package materialization must write a
+`source_leakage_validation` summary in the package `manifest.json`. The summary
+must be machine-readable and safe to publish with release evidence. It must not
+include raw excluded field values, prompts, observations, source text spans, or
+secrets.
+
+The summary fields are:
+
+- `schema_version`
+- `status`
+- `output_kind`
+- `validators`
+- `source_row_count`
+- `excluded_field_reference_count`
+- `checked_prompt_segment_count`
+- `checked_observation_segment_count`
+- `minimum_value_length`
+
+Training packages with a validation split also record:
+
+- `train_row_count`
+- `validation_row_count`
+- `train_source_id_count`
+- `validation_source_id_count`
+- `shared_source_id_count`
+
+Evaluation final-result packages record the same summary under their existing
+evaluation package manifest contract. The sample rows keep their per-row
+`source_construction` metadata, but they do not duplicate package-level
+validation totals.
+
 ## Quality Metrics Planned From This Contract
 
 The sample-selection slice should compute:

--- a/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
@@ -325,6 +325,7 @@ def test_create_training_package_preserves_source_construction_metadata(tmp_path
         {
             "prompt": "What color is the visible signal?",
             "completion": "red",
+            "answer": "Crimson Beacon",
             "source_construction": {
                 "source_ids": ["source-1"],
                 "source_asset_paths": ["media/signal.png"],
@@ -377,6 +378,58 @@ def test_create_training_package_preserves_source_construction_metadata(tmp_path
     assert sample["source_construction"]["hop_count"] == 2
     assert sample["source_construction"]["excluded_leakage_fields"] == ["answer"]
     assert "raw_answer" not in sample["source_construction"]
+    assert manifest["source_leakage_validation"] == {
+        "schema_version": "melix.source_leakage_validation.v1",
+        "status": "passed",
+        "output_kind": "training",
+        "validators": [
+            "prompt_example_overlap",
+            "answer_in_observation",
+            "train_eval_source_collision",
+        ],
+        "source_row_count": 1,
+        "excluded_field_reference_count": 1,
+        "checked_prompt_segment_count": 1,
+        "checked_observation_segment_count": 0,
+        "minimum_value_length": 3,
+        "train_row_count": 1,
+        "validation_row_count": 0,
+        "train_source_id_count": 1,
+        "validation_source_id_count": 0,
+        "shared_source_id_count": 0,
+    }
+    assert "Crimson Beacon" not in json.dumps(manifest["source_leakage_validation"])
+
+
+def test_training_source_leakage_validation_summary_records_split_counts(tmp_path: Path) -> None:
+    _fake_state.rows = [
+        {
+            "prompt": f"Question {index}",
+            "completion": f"Completion {index}",
+            "source_construction": {
+                "source_ids": [f"source-{index}"],
+            },
+        }
+        for index in range(1, 5)
+    ]
+
+    result = generate_synthetic_dataset_package(
+        _request(num_records=4, validation_ratio=0.25),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "out",
+    )
+
+    summary = result.manifest_payload["source_leakage_validation"]
+    assert summary["status"] == "passed"
+    assert summary["source_row_count"] == 4
+    assert summary["excluded_field_reference_count"] == 0
+    assert summary["checked_prompt_segment_count"] == 0
+    assert summary["checked_observation_segment_count"] == 0
+    assert summary["train_row_count"] == 3
+    assert summary["validation_row_count"] == 1
+    assert summary["train_source_id_count"] == 3
+    assert summary["validation_source_id_count"] == 1
+    assert summary["shared_source_id_count"] == 0
 
 
 def test_create_training_package_removes_stale_valid_jsonl_without_validation(tmp_path: Path) -> None:
@@ -469,9 +522,9 @@ def test_create_evaluation_package_preserves_sample_source_construction(tmp_path
     _fake_state.rows = [
         {
             "sample_id": "one",
-            "system": "",
+            "system": "Follow the answer format.",
             "input": "Find the linked source fact.",
-            "target": {"label": "a"},
+            "target": {"label": "alpha"},
             "source_construction": {
                 "source_ids": ["source-1"],
                 "transformation_kinds": ["paraphrase"],
@@ -481,7 +534,7 @@ def test_create_evaluation_package_preserves_sample_source_construction(tmp_path
         },
     ]
 
-    generate_synthetic_dataset_package(
+    result = generate_synthetic_dataset_package(
         _request(
             output_kind="evaluation_final_result",
             output_format="json",
@@ -494,6 +547,21 @@ def test_create_evaluation_package_preserves_sample_source_construction(tmp_path
     sample = json.loads((tmp_path / "eval" / "samples.jsonl").read_text(encoding="utf-8"))
     assert sample["source_construction"]["source_ids"] == ["source-1"]
     assert sample["source_construction"]["excluded_leakage_fields"] == ["target.label"]
+    assert result.manifest_payload["source_leakage_validation"] == {
+        "schema_version": "melix.source_leakage_validation.v1",
+        "status": "passed",
+        "output_kind": "evaluation_final_result",
+        "validators": [
+            "prompt_example_overlap",
+            "answer_in_observation",
+        ],
+        "source_row_count": 1,
+        "excluded_field_reference_count": 1,
+        "checked_prompt_segment_count": 2,
+        "checked_observation_segment_count": 0,
+        "minimum_value_length": 3,
+    }
+    assert "alpha" not in json.dumps(result.manifest_payload["source_leakage_validation"])
 
 
 def test_invalid_evaluation_source_construction_reports_row_index(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
@@ -41,6 +41,10 @@ _SUPPORTED_EVALUATION_RESULT_KINDS = {"json", "text"}
 _SECRET_FIELD_MARKERS = ("api_key", "authorization", "token", "secret", "password")
 _TELEMETRY_ENV_VAR = "NEMO_TELEMETRY_ENABLED"
 _MIN_LEAKAGE_VALUE_LENGTH = 3
+_SOURCE_ROW_LEAKAGE_VALIDATORS = [
+    "prompt_example_overlap",
+    "answer_in_observation",
+]
 
 
 @dataclass(frozen=True)
@@ -128,6 +132,20 @@ class SyntheticDatasetPackageResult:
     validation_row_count: int
     output_kind: str
     preview_only: bool
+
+
+@dataclass
+class _SourceLeakageValidationSummary:
+    output_kind: str
+    source_row_count: int = 0
+    excluded_field_reference_count: int = 0
+    checked_prompt_segment_count: int = 0
+    checked_observation_segment_count: int = 0
+    train_row_count: int | None = None
+    validation_row_count: int | None = None
+    train_source_id_count: int | None = None
+    validation_source_id_count: int | None = None
+    shared_source_id_count: int | None = None
 
 
 @dataclass(frozen=True)
@@ -532,10 +550,14 @@ def _write_training_package(
     config_path: Path,
     timing: dict[str, float],
 ) -> SyntheticDatasetPackageResult:
-    _validate_source_anchored_rows(rows, output_kind="training")
+    leakage_summary = _validate_source_anchored_rows(rows, output_kind="training")
     normalized = [_normalize_synthetic_training_row(row, request.output_format) for row in rows]
     train_rows, validation_rows = _split_validation(normalized, request.validation_ratio)
-    _validate_source_split_collision(train_rows, validation_rows)
+    _validate_source_split_collision(
+        train_rows,
+        validation_rows,
+        summary=leakage_summary,
+    )
     package_write_started = time.perf_counter()
     samples_path = package_path / "samples.jsonl"
     valid_path = package_path / "valid.jsonl"
@@ -572,6 +594,8 @@ def _write_training_package(
             "response_only_supported": request.output_format in {"chat_messages", "prompt_completion"},
         }
     )
+    if leakage_summary.source_row_count:
+        manifest_payload["source_leakage_validation"] = _source_leakage_validation_manifest(leakage_summary)
     timing["melix_package_write_ms"] = _elapsed_ms(package_write_started)
     manifest_payload["timing"] = dict(timing)
     _rewrite_manifest(manifest_path, manifest_payload)
@@ -601,7 +625,7 @@ def _write_evaluation_package(
     timing: dict[str, float],
 ) -> SyntheticDatasetPackageResult:
     serialized_rows = _parse_and_validate_evaluation_targets(rows, result_kind=request.output_format)
-    _validate_source_anchored_rows(serialized_rows, output_kind="evaluation_final_result")
+    leakage_summary = _validate_source_anchored_rows(serialized_rows, output_kind="evaluation_final_result")
     package_write_started = time.perf_counter()
     manifest_path = package_path / "manifest.json"
     samples_path = package_path / "samples.jsonl"
@@ -654,6 +678,8 @@ def _write_evaluation_package(
             },
         }
     )
+    if leakage_summary.source_row_count:
+        manifest_payload["source_leakage_validation"] = _source_leakage_validation_manifest(leakage_summary)
     timing["melix_package_write_ms"] = _elapsed_ms(package_write_started)
     manifest_payload["timing"] = dict(timing)
     _rewrite_manifest(manifest_path, manifest_payload)
@@ -1043,15 +1069,23 @@ def _optional_string_list(payload: dict[str, Any], key: str, *, row: int | None)
     payload[key] = [item for item in (str(raw).strip() for raw in value) if item]
 
 
-def _validate_source_anchored_rows(rows: list[dict[str, Any]], *, output_kind: str) -> None:
+def _validate_source_anchored_rows(
+    rows: list[dict[str, Any]],
+    *,
+    output_kind: str,
+) -> _SourceLeakageValidationSummary:
+    summary = _SourceLeakageValidationSummary(output_kind=output_kind)
     for index, row in enumerate(rows, start=1):
         metadata = row.get("source_construction")
         if not isinstance(metadata, Mapping):
             continue
+        summary.source_row_count += 1
         excluded_values = _row_excluded_leakage_values(row, metadata)
+        summary.excluded_field_reference_count += len(excluded_values)
         if not excluded_values:
             continue
         prompt_segments = _source_prompt_overlap_segments(row, output_kind=output_kind)
+        summary.checked_prompt_segment_count += len(prompt_segments)
         prompt_match = _first_leakage_match(excluded_values, prompt_segments)
         if prompt_match is not None:
             raise ModelOperationError(
@@ -1064,6 +1098,7 @@ def _validate_source_anchored_rows(rows: list[dict[str, Any]], *, output_kind: s
                 },
             )
         observation_segments = _source_observation_segments(row)
+        summary.checked_observation_segment_count += len(observation_segments)
         observation_match = _first_leakage_match(excluded_values, observation_segments)
         if observation_match is not None:
             raise ModelOperationError(
@@ -1075,6 +1110,35 @@ def _validate_source_anchored_rows(rows: list[dict[str, Any]], *, output_kind: s
                     "field": observation_match[0],
                 },
             )
+    return summary
+
+
+def _source_leakage_validation_manifest(summary: _SourceLeakageValidationSummary) -> dict[str, Any]:
+    validators = list(_SOURCE_ROW_LEAKAGE_VALIDATORS)
+    if summary.train_row_count is not None:
+        validators.append("train_eval_source_collision")
+    payload: dict[str, Any] = {
+        "schema_version": "melix.source_leakage_validation.v1",
+        "status": "passed",
+        "output_kind": summary.output_kind,
+        "validators": validators,
+        "source_row_count": summary.source_row_count,
+        "excluded_field_reference_count": summary.excluded_field_reference_count,
+        "checked_prompt_segment_count": summary.checked_prompt_segment_count,
+        "checked_observation_segment_count": summary.checked_observation_segment_count,
+        "minimum_value_length": _MIN_LEAKAGE_VALUE_LENGTH,
+    }
+    if summary.train_row_count is not None:
+        payload.update(
+            {
+                "train_row_count": summary.train_row_count,
+                "validation_row_count": summary.validation_row_count or 0,
+                "train_source_id_count": summary.train_source_id_count or 0,
+                "validation_source_id_count": summary.validation_source_id_count or 0,
+                "shared_source_id_count": summary.shared_source_id_count or 0,
+            }
+        )
+    return payload
 
 
 def _row_excluded_leakage_values(row: Mapping[str, Any], metadata: Mapping[str, Any]) -> list[tuple[str, str]]:
@@ -1193,12 +1257,24 @@ def _first_leakage_match(
 def _validate_source_split_collision(
     train_rows: list[dict[str, Any]],
     validation_rows: list[dict[str, Any]],
+    *,
+    summary: _SourceLeakageValidationSummary | None = None,
 ) -> None:
-    if not train_rows or not validation_rows:
-        return
     train_source_ids = _source_ids_by_split(train_rows)
     validation_source_ids = _source_ids_by_split(validation_rows)
+    if summary is not None:
+        summary.train_row_count = len(train_rows)
+        summary.validation_row_count = len(validation_rows)
+        summary.train_source_id_count = len(train_source_ids)
+        summary.validation_source_id_count = len(validation_source_ids)
+        summary.shared_source_id_count = 0
+    if not train_rows or not validation_rows:
+        return
     shared_ids = sorted(set(train_source_ids) & set(validation_source_ids))
+    if summary is not None:
+        summary.train_source_id_count = len(train_source_ids)
+        summary.validation_source_id_count = len(validation_source_ids)
+        summary.shared_source_id_count = len(shared_ids)
     if not shared_ids:
         return
     source_id = shared_ids[0]


### PR DESCRIPTION
## Summary
- Record publishable `source_leakage_validation` summaries in source-anchored training and final-result evaluation package manifests.
- Capture validator names, row/segment counts, split source-id counts, and the lexical threshold without persisting raw excluded values or prompt/observation text.
- Update the source-anchored construction plan and benchmark/evaluation contract with the artifact summary contract.

Closes #740.

## Plan or Spec
- `docs/plans/2026-05-22-source-anchored-data-construction.md`
- `docs/benchmark-evaluation-contract.md`

## Commands Run
```text
python3 -m py_compile services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
# passed

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py -k "source_leakage_validation or source_construction"
# 23 passed, 47 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
# 70 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/leakage_summaries.coverage -m pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
# 70 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/leakage_summaries.coverage -o /tmp/leakage_summaries_coverage.json
# wrote /tmp/leakage_summaries_coverage.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/leakage_summaries_coverage.json services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
# TOTAL 41 0 100%

git diff --name-only origin/main | jq -R -s 'split("\n")[:-1]' > /tmp/leakage_summaries_changed_files.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json /tmp/leakage_summaries_changed_files.json --output /tmp/leakage_summaries_scope.json
# selected_count: 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 41 0 100%` for `synthetic_dataset_generation.py`.
- Metrics report: local PR-scoped performance scope selected `0` probes. This change persists package-manifest evidence for already-running validation logic; it does not change runtime request paths, model execution, or benchmark/evaluation scoring loops.
- Observability mode: `evidence`; manifest summaries make leakage validation outcomes auditable in release-facing dataset artifacts.
- Probe overhead: `N/A`; no runtime probes, counters, or debug instrumentation were added.

## Known Gaps
- Full local `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run on this host because the filesystem has about 3.0 GiB free.
- No benchmark/evaluation runtime artifact was generated because this change is limited to synthetic package manifest materialization.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
