### PR TITLE
Add source quality metrics summaries

### DIFF
--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -472,6 +472,13 @@ minimum raw-value length used for lexical leakage matching. It must not persist
 raw excluded field values, prompt text, observations, source spans, or other
 payload text that could reintroduce answer leakage into release artifacts.
 
+When source-quality metrics are available, package manifests must also include a
+`source_quality_metrics` object that reports tool necessity, multi-hop depth,
+evidence coverage, answer ambiguity, source diversity, and transformation
+diversity from sanitized `source_construction` metadata. These metrics are
+descriptive evidence only; sample accept/reject reports remain a separate
+selection artifact.
+
 ## Benchmark Fixture Sources
 
 Benchmark suites may also materialize from repository-owned fixture packages

--- a/docs/plans/2026-05-22-source-anchored-data-construction.md
+++ b/docs/plans/2026-05-22-source-anchored-data-construction.md
@@ -255,6 +255,35 @@ The sample-selection slice should compute:
 - source diversity
 - transformation diversity
 
+Successful source-anchored package materialization must write a
+`source_quality_metrics` summary in the package `manifest.json` when at least
+one row carries `source_construction` metadata. The summary is descriptive
+evidence for downstream selection and release review; it does not accept or
+reject samples by itself.
+
+The summary fields are:
+
+- `schema_version`
+- `output_kind`
+- `source_row_count`
+- `tool_required_row_count`
+- `tool_required_rate`
+- `multi_hop_row_count`
+- `max_hop_count`
+- `average_hop_count`
+- `evidence_chain_row_count`
+- `evidence_coverage_rate`
+- `ambiguous_row_count`
+- `ambiguity_rate`
+- `unique_source_id_count`
+- `unique_transformation_kind_count`
+
+The metrics are computed from sanitized per-row `source_construction` metadata
+only. They must not persist raw prompts, observations, source text, answer
+values, or provider secrets. Selection reports that explain accepted and
+rejected samples are a follow-up slice and should consume this summary rather
+than redefining the metric names.
+
 Selection reports should explain why each accepted sample was kept and why each
 rejected sample was rejected.
 

--- a/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
@@ -399,6 +399,22 @@ def test_create_training_package_preserves_source_construction_metadata(tmp_path
         "shared_source_id_count": 0,
     }
     assert "Crimson Beacon" not in json.dumps(manifest["source_leakage_validation"])
+    assert manifest["source_quality_metrics"] == {
+        "schema_version": "melix.source_quality_metrics.v1",
+        "output_kind": "training",
+        "source_row_count": 1,
+        "tool_required_row_count": 1,
+        "tool_required_rate": 1.0,
+        "multi_hop_row_count": 1,
+        "max_hop_count": 2,
+        "average_hop_count": 2.0,
+        "evidence_chain_row_count": 1,
+        "evidence_coverage_rate": 1.0,
+        "ambiguous_row_count": 1,
+        "ambiguity_rate": 1.0,
+        "unique_source_id_count": 1,
+        "unique_transformation_kind_count": 2,
+    }
 
 
 def test_training_source_leakage_validation_summary_records_split_counts(tmp_path: Path) -> None:
@@ -430,6 +446,8 @@ def test_training_source_leakage_validation_summary_records_split_counts(tmp_pat
     assert summary["train_source_id_count"] == 3
     assert summary["validation_source_id_count"] == 1
     assert summary["shared_source_id_count"] == 0
+    assert result.manifest_payload["source_quality_metrics"]["source_row_count"] == 4
+    assert result.manifest_payload["source_quality_metrics"]["unique_source_id_count"] == 4
 
 
 def test_create_training_package_removes_stale_valid_jsonl_without_validation(tmp_path: Path) -> None:
@@ -562,6 +580,63 @@ def test_create_evaluation_package_preserves_sample_source_construction(tmp_path
         "minimum_value_length": 3,
     }
     assert "alpha" not in json.dumps(result.manifest_payload["source_leakage_validation"])
+
+
+def test_source_quality_metrics_summarize_evaluation_metadata(tmp_path: Path) -> None:
+    _fake_state.rows = [
+        {
+            "sample_id": "tool-rich",
+            "system": "",
+            "input": "Find the linked source fact.",
+            "target": {"label": "alpha"},
+            "source_construction": {
+                "source_ids": ["source-1", "source-2"],
+                "required_tool_families": ["image_inspection", "search"],
+                "transformation_kinds": ["paraphrase", "entity_alias"],
+                "evidence_chain": [{"source_id": "source-1"}, {"source_id": "source-2"}],
+                "hop_count": 3,
+                "ambiguity_notes": "accept alias",
+            },
+        },
+        {
+            "sample_id": "source-only",
+            "system": "",
+            "input": "Answer from the source.",
+            "target": {"label": "beta"},
+            "source_construction": {
+                "source_ids": ["source-2"],
+                "transformation_kinds": ["paraphrase"],
+                "hop_count": 1,
+            },
+        },
+    ]
+
+    result = generate_synthetic_dataset_package(
+        _request(
+            output_kind="evaluation_final_result",
+            output_format="json",
+            num_records=2,
+        ),
+        jobs_root=tmp_path / "jobs",
+        output_dir=tmp_path / "eval",
+    )
+
+    assert result.manifest_payload["source_quality_metrics"] == {
+        "schema_version": "melix.source_quality_metrics.v1",
+        "output_kind": "evaluation_final_result",
+        "source_row_count": 2,
+        "tool_required_row_count": 1,
+        "tool_required_rate": 0.5,
+        "multi_hop_row_count": 1,
+        "max_hop_count": 3,
+        "average_hop_count": 2.0,
+        "evidence_chain_row_count": 1,
+        "evidence_coverage_rate": 0.5,
+        "ambiguous_row_count": 1,
+        "ambiguity_rate": 0.5,
+        "unique_source_id_count": 2,
+        "unique_transformation_kind_count": 2,
+    }
 
 
 def test_invalid_evaluation_source_construction_reports_row_index(tmp_path: Path) -> None:
@@ -926,6 +1001,7 @@ def test_source_construction_validator_helpers_handle_noisy_metadata() -> None:
             {"source_construction": {"source_ids": ["source-1", ""]}},
         ]
     ) == {"source-1": 3}
+    assert synthetic_module._ratio(1, 0) == 0.0  # noqa: SLF001
 
 
 @pytest.mark.parametrize(

--- a/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
@@ -148,6 +148,20 @@ class _SourceLeakageValidationSummary:
     shared_source_id_count: int | None = None
 
 
+@dataclass
+class _SourceQualityMetricAccumulator:
+    output_kind: str
+    source_row_count: int = 0
+    tool_required_row_count: int = 0
+    multi_hop_row_count: int = 0
+    hop_count_total: int = 0
+    max_hop_count: int = 0
+    evidence_chain_row_count: int = 0
+    ambiguous_row_count: int = 0
+    source_ids: set[str] = field(default_factory=set)
+    transformation_kinds: set[str] = field(default_factory=set)
+
+
 @dataclass(frozen=True)
 class _DataDesignerAPI:
     DataDesigner: type[Any]
@@ -596,6 +610,9 @@ def _write_training_package(
     )
     if leakage_summary.source_row_count:
         manifest_payload["source_leakage_validation"] = _source_leakage_validation_manifest(leakage_summary)
+    quality_metrics = _source_quality_metrics_manifest([*train_rows, *validation_rows], output_kind="training")
+    if quality_metrics:
+        manifest_payload["source_quality_metrics"] = quality_metrics
     timing["melix_package_write_ms"] = _elapsed_ms(package_write_started)
     manifest_payload["timing"] = dict(timing)
     _rewrite_manifest(manifest_path, manifest_payload)
@@ -680,6 +697,12 @@ def _write_evaluation_package(
     )
     if leakage_summary.source_row_count:
         manifest_payload["source_leakage_validation"] = _source_leakage_validation_manifest(leakage_summary)
+    quality_metrics = _source_quality_metrics_manifest(
+        serialized_rows,
+        output_kind="evaluation_final_result",
+    )
+    if quality_metrics:
+        manifest_payload["source_quality_metrics"] = quality_metrics
     timing["melix_package_write_ms"] = _elapsed_ms(package_write_started)
     manifest_payload["timing"] = dict(timing)
     _rewrite_manifest(manifest_path, manifest_payload)
@@ -1139,6 +1162,62 @@ def _source_leakage_validation_manifest(summary: _SourceLeakageValidationSummary
             }
         )
     return payload
+
+
+def _source_quality_metrics_manifest(rows: list[dict[str, Any]], *, output_kind: str) -> dict[str, Any] | None:
+    accumulator = _SourceQualityMetricAccumulator(output_kind=output_kind)
+    for row in rows:
+        metadata = row.get("source_construction")
+        if not isinstance(metadata, Mapping):
+            continue
+        accumulator.source_row_count += 1
+        source_ids = metadata.get("source_ids", [])
+        if isinstance(source_ids, list):
+            accumulator.source_ids.update(str(raw).strip() for raw in source_ids if str(raw).strip())
+        transformation_kinds = metadata.get("transformation_kinds", [])
+        if isinstance(transformation_kinds, list):
+            accumulator.transformation_kinds.update(
+                str(raw).strip() for raw in transformation_kinds if str(raw).strip()
+            )
+        required_tool_families = metadata.get("required_tool_families", [])
+        if isinstance(required_tool_families, list) and any(str(raw).strip() for raw in required_tool_families):
+            accumulator.tool_required_row_count += 1
+        hop_count = metadata.get("hop_count", 0)
+        if isinstance(hop_count, int):
+            accumulator.hop_count_total += hop_count
+            accumulator.max_hop_count = max(accumulator.max_hop_count, hop_count)
+            if hop_count >= 2:
+                accumulator.multi_hop_row_count += 1
+        evidence_chain = metadata.get("evidence_chain", [])
+        if isinstance(evidence_chain, list) and evidence_chain:
+            accumulator.evidence_chain_row_count += 1
+        if str(metadata.get("ambiguity_notes", "")).strip():
+            accumulator.ambiguous_row_count += 1
+    if accumulator.source_row_count == 0:
+        return None
+    source_row_count = accumulator.source_row_count
+    return {
+        "schema_version": "melix.source_quality_metrics.v1",
+        "output_kind": accumulator.output_kind,
+        "source_row_count": source_row_count,
+        "tool_required_row_count": accumulator.tool_required_row_count,
+        "tool_required_rate": _ratio(accumulator.tool_required_row_count, source_row_count),
+        "multi_hop_row_count": accumulator.multi_hop_row_count,
+        "max_hop_count": accumulator.max_hop_count,
+        "average_hop_count": _ratio(accumulator.hop_count_total, source_row_count),
+        "evidence_chain_row_count": accumulator.evidence_chain_row_count,
+        "evidence_coverage_rate": _ratio(accumulator.evidence_chain_row_count, source_row_count),
+        "ambiguous_row_count": accumulator.ambiguous_row_count,
+        "ambiguity_rate": _ratio(accumulator.ambiguous_row_count, source_row_count),
+        "unique_source_id_count": len(accumulator.source_ids),
+        "unique_transformation_kind_count": len(accumulator.transformation_kinds),
+    }
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(numerator / denominator, 6)
 
 
 def _row_excluded_leakage_values(row: Mapping[str, Any], metadata: Mapping[str, Any]) -> list[tuple[str, str]]:


### PR DESCRIPTION
## Summary
- Add `source_quality_metrics` manifest summaries for source-anchored training and final-result evaluation packages.
- Measure tool necessity, multi-hop depth, evidence coverage, answer ambiguity, source diversity, and transformation diversity from sanitized `source_construction` metadata.
- Update the source construction plan and benchmark/evaluation contract with the additive quality-metrics artifact contract.

Closes #742.

## Plan or Spec
- `docs/plans/2026-05-22-source-anchored-data-construction.md`
- `docs/benchmark-evaluation-contract.md`

## Commands Run
```text
python3 -m py_compile services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
# passed

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py -k "source_quality_metrics or source_construction"
# 23 passed, 48 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
# 71 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/quality_metrics.coverage -m pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
# 71 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/quality_metrics.coverage -o /tmp/quality_metrics_coverage.json
# wrote /tmp/quality_metrics_coverage.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/quality_metrics_coverage.json services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
# TOTAL 53 0 100%

git diff --name-only origin/main | jq -R -s 'split("\n")[:-1]' > /tmp/quality_metrics_changed_files.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json /tmp/quality_metrics_changed_files.json --output /tmp/quality_metrics_scope.json
# selected_count: 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 53 0 100%` for `synthetic_dataset_generation.py`.
- Metrics report: local PR-scoped performance scope selected `0` probes. This change adds manifest summary aggregation over already materialized synthetic dataset rows; it does not touch runtime serving, model execution, benchmark scoring, or evaluation scoring loops.
- Observability mode: `evidence`; quality metrics are persisted in package manifests for downstream selection and release review.
- Probe overhead: `N/A`; no runtime probes, counters, or debug instrumentation were added.

## Known Gaps
- Full local `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run on this host because the filesystem has about 3.0 GiB free.
- Accept/reject selection reports are intentionally deferred to #743.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
