### PR TITLE
Add source selection report artifacts

### DIFF
--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -479,6 +479,13 @@ diversity from sanitized `source_construction` metadata. These metrics are
 descriptive evidence only; sample accept/reject reports remain a separate
 selection artifact.
 
+When sample selection is reported, package manifests must include a
+`source_selection_report` object with the package-relative path to
+`source_selection_report.jsonl` and accepted/rejected row counts. The JSONL
+report explains each source-anchored row with stable reason codes and sanitized
+metadata only; it must not persist prompts, answers, observations, source text,
+or secrets.
+
 ## Benchmark Fixture Sources
 
 Benchmark suites may also materialize from repository-owned fixture packages

--- a/docs/plans/2026-05-22-source-anchored-data-construction.md
+++ b/docs/plans/2026-05-22-source-anchored-data-construction.md
@@ -287,6 +287,34 @@ than redefining the metric names.
 Selection reports should explain why each accepted sample was kept and why each
 rejected sample was rejected.
 
+Successful source-anchored package materialization must also write a
+package-local `source_selection_report.jsonl` when at least one row carries
+`source_construction` metadata. Each report row must be publishable with release
+evidence and must not include prompt, answer, observation, source text, or
+secret values.
+
+Report row fields:
+
+- `schema_version`
+- `row_index`
+- `row_id`
+- `status`
+- `reason_codes`
+- `summary`
+- `source_ids`
+- `required_tool_families`
+- `hop_count`
+- `evidence_chain_count`
+- `ambiguity_flag`
+
+The initial deterministic selection policy accepts rows that declare at least
+one required tool family, `hop_count >= 2`, and a non-empty `evidence_chain`.
+Rows missing one or more of those signals are reported as `rejected` with
+stable reason codes. Rows with `ambiguity_notes` keep the accepted or rejected
+status derived from the hard signals and add `answer_ambiguity_review` as a
+review reason. The package manifest records the relative report path plus
+accepted and rejected row counts.
+
 ## Performance And Measurement Points
 
 Construction must be measurable before implementation. The first implementation

--- a/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
@@ -415,6 +415,29 @@ def test_create_training_package_preserves_source_construction_metadata(tmp_path
         "unique_source_id_count": 1,
         "unique_transformation_kind_count": 2,
     }
+    assert manifest["source_selection_report"] == {
+        "schema_version": "melix.source_selection_report.v1",
+        "path": "source_selection_report.jsonl",
+        "row_count": 1,
+        "accepted_row_count": 1,
+        "rejected_row_count": 0,
+    }
+    report_row = json.loads((tmp_path / "out" / "source_selection_report.jsonl").read_text(encoding="utf-8"))
+    assert report_row == {
+        "schema_version": "melix.source_selection_report_row.v1",
+        "output_kind": "training",
+        "row_index": 1,
+        "row_id": "rewrite-1",
+        "status": "accepted",
+        "reason_codes": ["answer_ambiguity_review"],
+        "summary": "Accepted for quality threshold with review notes.",
+        "source_ids": ["source-1"],
+        "required_tool_families": ["image_inspection"],
+        "hop_count": 2,
+        "evidence_chain_count": 1,
+        "ambiguity_flag": True,
+    }
+    assert "Crimson Beacon" not in json.dumps(report_row)
 
 
 def test_training_source_leakage_validation_summary_records_split_counts(tmp_path: Path) -> None:
@@ -637,6 +660,33 @@ def test_source_quality_metrics_summarize_evaluation_metadata(tmp_path: Path) ->
         "unique_source_id_count": 2,
         "unique_transformation_kind_count": 2,
     }
+    assert result.manifest_payload["source_selection_report"] == {
+        "schema_version": "melix.source_selection_report.v1",
+        "path": "source_selection_report.jsonl",
+        "row_count": 2,
+        "accepted_row_count": 1,
+        "rejected_row_count": 1,
+    }
+    report_rows = [
+        json.loads(line)
+        for line in (tmp_path / "eval" / "source_selection_report.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert report_rows[0]["row_id"] == "tool-rich"
+    assert report_rows[0]["status"] == "accepted"
+    assert report_rows[0]["reason_codes"] == ["answer_ambiguity_review"]
+    assert report_rows[0]["source_ids"] == ["source-1", "source-2"]
+    assert report_rows[1]["row_id"] == "source-only"
+    assert report_rows[1]["status"] == "rejected"
+    assert report_rows[1]["reason_codes"] == [
+        "missing_required_tool",
+        "insufficient_hop_depth",
+        "missing_evidence_chain",
+    ]
+    assert report_rows[1]["summary"] == (
+        "Rejected: missing_required_tool, insufficient_hop_depth, missing_evidence_chain."
+    )
+    assert "alpha" not in json.dumps(report_rows)
+    assert "beta" not in json.dumps(report_rows)
 
 
 def test_invalid_evaluation_source_construction_reports_row_index(tmp_path: Path) -> None:
@@ -1002,6 +1052,37 @@ def test_source_construction_validator_helpers_handle_noisy_metadata() -> None:
         ]
     ) == {"source-1": 3}
     assert synthetic_module._ratio(1, 0) == 0.0  # noqa: SLF001
+    assert synthetic_module._metadata_string_list(  # noqa: SLF001
+        {"source_ids": "bad"},
+        "source_ids",
+    ) == []
+    accepted_row = synthetic_module._source_selection_report_row(  # noqa: SLF001
+        7,
+        {},
+        {
+            "source_ids": ["source-1"],
+            "required_tool_families": ["search"],
+            "hop_count": "2",
+            "evidence_chain": [{"source_id": "source-1"}],
+        },
+        output_kind="training",
+    )
+    assert accepted_row["row_id"] == "row-7"
+    assert accepted_row["hop_count"] == 0
+    assert accepted_row["status"] == "rejected"
+    accepted_row = synthetic_module._source_selection_report_row(  # noqa: SLF001
+        8,
+        {},
+        {
+            "source_ids": ["source-1"],
+            "required_tool_families": ["search"],
+            "hop_count": 2,
+            "evidence_chain": [{"source_id": "source-1"}],
+        },
+        output_kind="training",
+    )
+    assert accepted_row["reason_codes"] == ["meets_source_quality_threshold"]
+    assert accepted_row["summary"] == "Accepted: declares required tools, multi-hop depth, and source evidence."
 
 
 @pytest.mark.parametrize(

--- a/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
+++ b/services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
@@ -163,6 +163,14 @@ class _SourceQualityMetricAccumulator:
 
 
 @dataclass(frozen=True)
+class _SourceSelectionReportSummary:
+    path: str
+    row_count: int
+    accepted_row_count: int
+    rejected_row_count: int
+
+
+@dataclass(frozen=True)
 class _DataDesignerAPI:
     DataDesigner: type[Any]
     DataDesignerConfigBuilder: type[Any]
@@ -613,6 +621,13 @@ def _write_training_package(
     quality_metrics = _source_quality_metrics_manifest([*train_rows, *validation_rows], output_kind="training")
     if quality_metrics:
         manifest_payload["source_quality_metrics"] = quality_metrics
+    selection_summary = _write_source_selection_report(
+        package_path,
+        [*train_rows, *validation_rows],
+        output_kind="training",
+    )
+    if selection_summary is not None:
+        manifest_payload["source_selection_report"] = _source_selection_report_manifest(selection_summary)
     timing["melix_package_write_ms"] = _elapsed_ms(package_write_started)
     manifest_payload["timing"] = dict(timing)
     _rewrite_manifest(manifest_path, manifest_payload)
@@ -703,6 +718,13 @@ def _write_evaluation_package(
     )
     if quality_metrics:
         manifest_payload["source_quality_metrics"] = quality_metrics
+    selection_summary = _write_source_selection_report(
+        package_path,
+        serialized_rows,
+        output_kind="evaluation_final_result",
+    )
+    if selection_summary is not None:
+        manifest_payload["source_selection_report"] = _source_selection_report_manifest(selection_summary)
     timing["melix_package_write_ms"] = _elapsed_ms(package_write_started)
     manifest_payload["timing"] = dict(timing)
     _rewrite_manifest(manifest_path, manifest_payload)
@@ -1218,6 +1240,120 @@ def _ratio(numerator: int, denominator: int) -> float:
     if denominator <= 0:
         return 0.0
     return round(numerator / denominator, 6)
+
+
+def _write_source_selection_report(
+    package_path: Path,
+    rows: list[dict[str, Any]],
+    *,
+    output_kind: str,
+) -> _SourceSelectionReportSummary | None:
+    report_rows = _source_selection_report_rows(rows, output_kind=output_kind)
+    if not report_rows:
+        return None
+    report_path = package_path / "source_selection_report.jsonl"
+    _write_jsonl_rows(report_path, report_rows)
+    accepted_count = sum(1 for row in report_rows if row["status"] == "accepted")
+    rejected_count = len(report_rows) - accepted_count
+    return _SourceSelectionReportSummary(
+        path="source_selection_report.jsonl",
+        row_count=len(report_rows),
+        accepted_row_count=accepted_count,
+        rejected_row_count=rejected_count,
+    )
+
+
+def _source_selection_report_manifest(summary: _SourceSelectionReportSummary) -> dict[str, Any]:
+    return {
+        "schema_version": "melix.source_selection_report.v1",
+        "path": summary.path,
+        "row_count": summary.row_count,
+        "accepted_row_count": summary.accepted_row_count,
+        "rejected_row_count": summary.rejected_row_count,
+    }
+
+
+def _source_selection_report_rows(rows: list[dict[str, Any]], *, output_kind: str) -> list[dict[str, Any]]:
+    report_rows: list[dict[str, Any]] = []
+    for index, row in enumerate(rows, start=1):
+        metadata = row.get("source_construction")
+        if not isinstance(metadata, Mapping):
+            continue
+        report_rows.append(_source_selection_report_row(index, row, metadata, output_kind=output_kind))
+    return report_rows
+
+
+def _source_selection_report_row(
+    row_index: int,
+    row: Mapping[str, Any],
+    metadata: Mapping[str, Any],
+    *,
+    output_kind: str,
+) -> dict[str, Any]:
+    source_ids = _metadata_string_list(metadata, "source_ids")
+    required_tool_families = _metadata_string_list(metadata, "required_tool_families")
+    hop_count = metadata.get("hop_count", 0)
+    if not isinstance(hop_count, int):
+        hop_count = 0
+    evidence_chain = metadata.get("evidence_chain", [])
+    evidence_chain_count = len(evidence_chain) if isinstance(evidence_chain, list) else 0
+    ambiguity_flag = bool(str(metadata.get("ambiguity_notes", "")).strip())
+
+    reason_codes: list[str] = []
+    if not required_tool_families:
+        reason_codes.append("missing_required_tool")
+    if hop_count < 2:
+        reason_codes.append("insufficient_hop_depth")
+    if evidence_chain_count == 0:
+        reason_codes.append("missing_evidence_chain")
+    status = "rejected" if reason_codes else "accepted"
+    if ambiguity_flag:
+        reason_codes.append("answer_ambiguity_review")
+    if not reason_codes:
+        reason_codes.append("meets_source_quality_threshold")
+
+    return {
+        "schema_version": "melix.source_selection_report_row.v1",
+        "output_kind": output_kind,
+        "row_index": row_index,
+        "row_id": _source_selection_row_id(row, row_index),
+        "status": status,
+        "reason_codes": reason_codes,
+        "summary": _source_selection_summary(status, reason_codes),
+        "source_ids": source_ids,
+        "required_tool_families": required_tool_families,
+        "hop_count": hop_count,
+        "evidence_chain_count": evidence_chain_count,
+        "ambiguity_flag": ambiguity_flag,
+    }
+
+
+def _metadata_string_list(metadata: Mapping[str, Any], key: str) -> list[str]:
+    raw_values = metadata.get(key, [])
+    if not isinstance(raw_values, list):
+        return []
+    return [value for value in (str(raw).strip() for raw in raw_values) if value]
+
+
+def _source_selection_row_id(row: Mapping[str, Any], row_index: int) -> str:
+    for key in ("id", "sample_id"):
+        value = str(row.get(key, "")).strip()
+        if value:
+            return value
+    metadata = row.get("source_construction")
+    if isinstance(metadata, Mapping):
+        rewrite_id = str(metadata.get("rewrite_id", "")).strip()
+        if rewrite_id:
+            return rewrite_id
+    return f"row-{row_index}"
+
+
+def _source_selection_summary(status: str, reason_codes: list[str]) -> str:
+    if status == "accepted":
+        if reason_codes == ["meets_source_quality_threshold"]:
+            return "Accepted: declares required tools, multi-hop depth, and source evidence."
+        return "Accepted for quality threshold with review notes."
+    return "Rejected: " + ", ".join(reason_codes) + "."
 
 
 def _row_excluded_leakage_values(row: Mapping[str, Any], metadata: Mapping[str, Any]) -> list[tuple[str, str]]:


### PR DESCRIPTION
## Summary
- Add package-local `source_selection_report.jsonl` artifacts for source-anchored training and final-result evaluation packages.
- Record per-row accepted/rejected status, stable reason codes, and sanitized source-construction signals without persisting prompts, answers, observations, or source text.
- Update the source construction plan and benchmark/evaluation contract with the selection-report manifest contract.

Closes #743.

## Plan or Spec
- `docs/plans/2026-05-22-source-anchored-data-construction.md`
- `docs/benchmark-evaluation-contract.md`

## Commands Run
```text
python3 -m py_compile services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
# passed

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py -k "source_selection_report or source_quality_metrics or source_construction"
# 23 passed, 48 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
# 71 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage run --data-file=/tmp/selection_reports.coverage -m pytest -q services/mlx-worker-python/tests/test_synthetic_dataset_generation.py
# 71 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python coverage json --data-file=/tmp/selection_reports.coverage -o /tmp/selection_reports_coverage.json
# wrote /tmp/selection_reports_coverage.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/changed_scope_coverage.py --coverage-json /tmp/selection_reports_coverage.json services/mlx-worker-python/worker/productization/synthetic_dataset_generation.py
# TOTAL 75 0 100%

git diff --name-only origin/main | jq -R -s 'split("\n")[:-1]' > /tmp/selection_reports_changed_files.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json /tmp/selection_reports_changed_files.json --output /tmp/selection_reports_scope.json
# selected_count: 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 75 0 100%` for `synthetic_dataset_generation.py`.
- Metrics report: local PR-scoped performance scope selected `0` probes. This change writes package-local JSONL evidence from already materialized synthetic dataset rows; it does not touch runtime serving, model execution, benchmark scoring, or evaluation scoring loops.
- Observability mode: `evidence`; selection reports are persisted package artifacts for downstream release review.
- Probe overhead: `N/A`; no runtime probes, counters, or debug instrumentation were added.

## Known Gaps
- Full local `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run on this host because the filesystem has about 3.0 GiB free.
- The deterministic accept/reject policy is intentionally limited to source-construction metadata signals; no model-quality scoring or human review workflow is added here.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
