### PR TITLE
perf: count benchmark adapter statuses once

### DIFF
--- a/docs/plans/2026-05-21-benchmark-report-adapter-status-counts.md
+++ b/docs/plans/2026-05-21-benchmark-report-adapter-status-counts.md
@@ -1,0 +1,35 @@
+# Benchmark report adapter status count slice
+
+This Python-only performance slice keeps benchmark/evaluation report semantics unchanged while reducing redundant scans over generated agentic-adapter delta rows.
+
+## Affected path
+
+- `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`
+- `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+- `infra/perf/pr_scoped_probes.json`
+
+The affected path is covered by the registered PR-scoped probe `benchmark-evaluation-report-running-aggregates`. The registry entry provides focused `test_command`, `coverage_command`, and `probe_command` entries. This slice also normalizes that registered probe command to invoke `python3` explicitly.
+
+## Optimization
+
+`build_benchmark_evaluation_report()` already computes primary metric-row status counts during the metric-row construction pass. Agentic-adapter delta rows, however, were scanned three separate times to count `warning`, `missing`, and `not_comparable` statuses.
+
+This slice adds one small status-count helper and uses it for the adapter delta rows so each row's status is read once. The behavior is intentionally equivalent:
+
+- the same three status classes feed the report summary;
+- `ok` and other statuses remain non-counted;
+- report status precedence remains `warning > missing > not_comparable > ok`.
+
+## Verification plan
+
+Run on Linux:
+
+1. Focused regression test for single-read status counting.
+2. Full benchmark-evaluation report tests through the registered focused command.
+3. Changed-scope coverage through the registered coverage command.
+4. Registered benchmark-evaluation report probe locally with the registry command.
+5. GitHub Actions PR-scoped performance as the merge gate.
+
+## Metrics
+
+Primary metric: `elapsed_ms_mean` from the registered `benchmark-evaluation-report-running-aggregates` probe. Secondary metrics: `load_input_ms_mean`, `peak_bytes_mean`, `row_count`, and `sample_count`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -636,7 +636,7 @@
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py",
     "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py",
-    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python -c \"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_evaluation_report as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))\"",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c \"import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_evaluation_report as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))\"",
     "probe_impl": "benchmark_evaluation_report",
     "coverage_replays_tests": true,
     "metrics": [

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -25,6 +25,7 @@ from worker.productization.benchmark_evaluation_report import (
     _metric_direction,
     _metric_key_direction,
     _report_rows,
+    _status_counts,
     _update_numeric_aggregate,
     _update_probe_aggregate_pairs,
     _update_probe_aggregates_by_label,
@@ -195,6 +196,32 @@ def test_load_report_input_accepts_batch_run_summary_bundle(tmp_path: Path) -> N
     metrics = {row["metric"]: row for row in report["metrics"]}
     assert metrics["bench.smoke.tokens_per_second"]["status"] == "ok"
     assert metrics["eval.event_extraction.semantic_f1"]["status"] == "ok"
+
+
+def test_status_counts_reads_each_row_status_once() -> None:
+    class SingleReadStatusRow(dict[str, object]):
+        def __init__(self, status: str) -> None:
+            super().__init__(status=status)
+            self.status_reads = 0
+
+        def get(self, key: str, default: object = None) -> object:
+            if key == "status":
+                self.status_reads += 1
+                if self.status_reads > 1:
+                    raise AssertionError("status was read more than once")
+            return super().get(key, default)
+
+    rows = [
+        SingleReadStatusRow("warning"),
+        SingleReadStatusRow("missing"),
+        SingleReadStatusRow("not_comparable"),
+        SingleReadStatusRow("ok"),
+    ]
+
+    assert _status_counts(rows) == (1, 1, 1)
+    assert [row.status_reads for row in rows] == [1, 1, 1, 1]
+    with pytest.raises(AssertionError, match="status was read more than once"):
+        rows[0].get("status")
 
 
 def _run_evidence(

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -424,11 +424,14 @@ def build_benchmark_evaluation_report(
         *_agentic_adapter_delta_rows(side="baseline", bundle=baseline),
         *_agentic_adapter_delta_rows(side="candidate", bundle=candidate),
     ]
-    warning_count += sum(1 for row in agentic_adapter_deltas if row.get("status") == "warning")
-    missing_count += sum(1 for row in agentic_adapter_deltas if row.get("status") == "missing")
-    not_comparable_count += sum(
-        1 for row in agentic_adapter_deltas if row.get("status") == "not_comparable"
-    )
+    (
+        agentic_adapter_warning_count,
+        agentic_adapter_missing_count,
+        agentic_adapter_not_comparable_count,
+    ) = _status_counts(agentic_adapter_deltas)
+    warning_count += agentic_adapter_warning_count
+    missing_count += agentic_adapter_missing_count
+    not_comparable_count += agentic_adapter_not_comparable_count
     if warning_count:
         status = "warning"
     elif missing_count:
@@ -876,6 +879,21 @@ def _target_summaries(side: str, evidence_rows: list[dict[str, object]]) -> list
                 summary[field_name] = value if value is not None else ""
         summaries.append(summary)
     return summaries
+
+
+def _status_counts(rows: list[dict[str, object]]) -> tuple[int, int, int]:
+    warning_count = 0
+    missing_count = 0
+    not_comparable_count = 0
+    for row in rows:
+        row_status = row.get("status")
+        if row_status == "warning":
+            warning_count += 1
+        elif row_status == "missing":
+            missing_count += 1
+        elif row_status == "not_comparable":
+            not_comparable_count += 1
+    return warning_count, missing_count, not_comparable_count
 
 
 def _report_metric_row(row: dict[str, object]) -> dict[str, object]:


### PR DESCRIPTION
## Summary
- Count benchmark/evaluation agentic-adapter delta statuses in one pass instead of scanning the same row list three times.
- Add a focused regression test proving each row status is read once.
- Normalize the registered benchmark report probe command to call `python3` explicitly.

## Plan or Spec
- `docs/plans/2026-05-21-benchmark-report-adapter-status-counts.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py::test_status_counts_reads_each_row_status_once
# 1 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 61 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 61 passed; TOTAL 33 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-evaluation-report-running-aggregates --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/benchmark_report_adapter_probe_$$.json
# head verification ok; base/head probes ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 33 0 100%`.
- Registered probe: `benchmark-evaluation-report-running-aggregates`.
- Local PR-scoped probe metrics:
  - `elapsed_ms_mean`: base `318.842862` ms, head `300.02585` ms, delta `-18.817012` ms (`~5.90%` faster; lower is better).
  - `load_input_ms_mean`: base `7.109354` ms, head `5.825764` ms, delta `-1.28359` ms.
  - `peak_bytes_mean`: base `13636836.8`, head `13636841.6`, delta `+4.8` bytes (effectively flat).
  - `row_count`: `5990.0`; `sample_count`: `5.0`.
- CI PR-scoped performance remains the merge gate for the registered probe result.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effects are changed or claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability-mode change.
- [x] Deferred work and known gaps are stated explicitly.
