### PR TITLE
perf: streamline code eval payload extraction

### DIFF
--- a/docs/plans/2026-05-22-code-eval-payload-monotonic-fast-path.md
+++ b/docs/plans/2026-05-22-code-eval-payload-monotonic-fast-path.md
@@ -1,0 +1,52 @@
+# Code Eval Payload Monotonic Fast Path Slice
+
+## Scope
+
+Optimize the Python code-evaluation payload JSON fast path in
+`services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+## Probe Coverage
+
+The affected path is already covered by the registered PR-scoped probe
+`code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`.
+The probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries and watches:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_payload_json_probe.py`
+
+## Change
+
+The fast-path field extractor now treats the recognized payload layouts as
+monotonic key-order layouts. It no longer performs per-field whole-payload
+fallback searches after the scan cursor has advanced. Unexpected key order still
+falls back to the full JSON loader, preserving correctness for non-standard
+payloads.
+
+For sorted payloads without `compile_status`, the fast path skips the optional
+`compile_status` token lookup. Runner payloads that start with `compile_status`
+still extract that field, including when object-leading whitespace is present.
+
+## Local Evidence
+
+Baseline local Linux probe before the change:
+
+- `elapsed_ms_mean`: 123.218, 118.213, 125.161 ms
+- `peak_bytes_mean`: 60425 bytes
+
+Post-change local Linux probe:
+
+- `elapsed_ms_mean`: 99.466, 94.525, 93.470 ms
+- `peak_bytes_mean`: 60425 bytes
+
+This slice reduces local probe elapsed mean from about 122.2 ms to about
+95.8 ms across three runs, a roughly 21.6% improvement, with unchanged peak
+allocation metric.
+
+## Verification Boundary
+
+This is a Python slice and is locally verified on Linux. The registered
+PR-scoped performance workflow remains the authoritative CI validation before
+merge.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -911,6 +911,22 @@ def test_load_payload_file_fast_path_reuses_precomputed_key_tokens(monkeypatch: 
         "tests_total": 2,
         "timeout_status": "ok",
     }
+
+    whitespace_payload_path = _BytesOnlyPayloadPath(
+        b'  {"compile_status":"compiled","runtime_status":"ok",'
+        b'"timeout_status":"ok","test_status":"passed",'
+        b'"tests_passed":1,"tests_total":1,"failure_detail":""}\n'
+    )
+    assert code_eval_runner._load_payload_file(whitespace_payload_path) == {
+        "compile_status": "compiled",
+        "runtime_status": "ok",
+        "timeout_status": "ok",
+        "test_status": "passed",
+        "tests_passed": 1,
+        "tests_total": 1,
+        "failure_detail": "",
+    }
+
     with pytest.raises(AssertionError, match="known code-eval payload keys"):
         code_eval_runner._json_field_value_start(b'{"other":1}', "other")
 

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -375,7 +375,10 @@ _CODE_EVAL_PAYLOAD_FIELD_TOKENS_SORTED_FRIENDLY = (
     ("tests_passed", _CODE_EVAL_PAYLOAD_KEY_TOKENS["tests_passed"], "int"),
     ("tests_total", _CODE_EVAL_PAYLOAD_KEY_TOKENS["tests_total"], "int"),
     ("timeout_status", _CODE_EVAL_PAYLOAD_KEY_TOKENS["timeout_status"], "string"),
+)
+_CODE_EVAL_PAYLOAD_FIELD_TOKENS_SORTED_WITH_COMPILE = (
     ("compile_status", _CODE_EVAL_PAYLOAD_KEY_TOKENS["compile_status"], "string"),
+    *_CODE_EVAL_PAYLOAD_FIELD_TOKENS_SORTED_FRIENDLY,
 )
 _CODE_EVAL_PAYLOAD_FIELD_TOKENS_RUNNER_FRIENDLY = (
     ("compile_status", _CODE_EVAL_PAYLOAD_KEY_TOKENS["compile_status"], "string"),
@@ -412,11 +415,17 @@ def _json_object_payload_bounds(payload_bytes: bytes) -> tuple[int, int] | None:
 
 
 def _extract_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, object] | None:
-    if _json_object_payload_bounds(payload_bytes) is None:
+    bounds = _json_object_payload_bounds(payload_bytes)
+    if bounds is None:
         return None
 
-    if payload_bytes.startswith(_CODE_EVAL_PAYLOAD_RUNNER_PREFIX):
-        field_tokens = _CODE_EVAL_PAYLOAD_FIELD_TOKENS_RUNNER_FRIENDLY
+    if payload_bytes.startswith(_CODE_EVAL_PAYLOAD_RUNNER_PREFIX, bounds[0]):
+        failure_index = payload_bytes.find(_CODE_EVAL_PAYLOAD_KEY_TOKENS["failure_detail"])
+        runtime_index = payload_bytes.find(_CODE_EVAL_PAYLOAD_KEY_TOKENS["runtime_status"])
+        if 0 <= failure_index < runtime_index:
+            field_tokens = _CODE_EVAL_PAYLOAD_FIELD_TOKENS_SORTED_WITH_COMPILE
+        else:
+            field_tokens = _CODE_EVAL_PAYLOAD_FIELD_TOKENS_RUNNER_FRIENDLY
     else:
         field_tokens = _CODE_EVAL_PAYLOAD_FIELD_TOKENS_SORTED_FRIENDLY
 
@@ -428,8 +437,8 @@ def _extract_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, object]
             key_token,
             start=search_start,
         )
-        if value_start is None and search_start:
-            value_start = _json_field_value_start_for_token(payload_bytes, key_token)
+        if value_start is None:
+            return None
         if value_kind == "string":
             value = _extract_json_string_field_at(payload_bytes, value_start)
             if value is not None:


### PR DESCRIPTION
## Summary
- Streamlines the code-eval payload JSON fast path by treating recognized payload layouts as monotonic key-order scans.
- Skips the optional `compile_status` lookup for sorted non-runner payloads while preserving runner payload extraction, including object-leading whitespace.
- Adds focused regression coverage for the whitespace runner-prefix fast path.

## Plan or Spec
- Updated `docs/plans/2026-05-22-code-eval-payload-monotonic-fast-path.md` with scope, registered probe coverage, and local before/after metrics.
- Registered probe: `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json` already covers this path with focused test, coverage, and probe commands.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py` (baseline, 3 runs)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_required_field_check_preserves_fast_path_gate services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py` (post-change registered probe script path)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 9 passed.
- Changed-scope coverage: 100.00% (`TOTAL 6 0 100%`).
- Baseline local Linux probe: elapsed means 123.218, 118.213, 125.161 ms; peak mean 60425 bytes.
- Post-change local Linux probe: elapsed means 99.466, 94.525, 93.470 ms, plus final registered probe script run 88.880 ms; peak mean 60425 bytes.
- Three-run mean delta: ~122.2 ms -> ~95.8 ms, about 21.6% faster, with unchanged peak allocation metric.

## Known Gaps
- This is a Python slice verified locally on Linux. The PR-scoped performance GitHub Actions report is still required before merge.
- The local environment emitted the expected `VIRTUAL_ENV` mismatch warning from `uv`; the project `.venv` was used.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe path was run locally on Linux.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
