### PR TITLE
perf: slot text family config records

### DIFF
--- a/docs/plans/2026-05-22-text-family-slotted-configs.md
+++ b/docs/plans/2026-05-22-text-family-slotted-configs.md
@@ -1,0 +1,26 @@
+# Text family slotted config records
+
+## Goal
+
+Reduce per-resolution Python object overhead on the text-family configuration path by making the immutable text-family dataclasses slotted. This keeps behavior unchanged while avoiding per-instance `__dict__` allocation for descriptors, detection records, and resolved runtime configs.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `text-family-config-copy-elision` in `infra/perf/pr_scoped_probes.json`. The registry entry already provides focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/text_family_config_probe.py`
+
+The probe reports elapsed time, peak bytes, and config copy attempts across repeated `resolve_text_family_config(...)` calls.
+
+## Slice
+
+- Add `slots=True` to the frozen text-family dataclasses.
+- Add a regression test proving the public dataclass instances no longer expose `__dict__` while preserving existing resolution behavior.
+- Do not change config parsing, routing decisions, metadata keys, or probe semantics.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage command, and local registered probe on Linux before opening the PR. The PR-scoped performance workflow remains the merge gate for the registered probe result in CI.

--- a/services/mlx-worker-python/tests/test_text_family_adapters.py
+++ b/services/mlx-worker-python/tests/test_text_family_adapters.py
@@ -6,6 +6,9 @@ from typing import Any
 import pytest
 
 from worker.runtime.text_family_adapters import (
+    ResolvedTextFamilyConfig,
+    TextFamilyDescriptor,
+    TextFamilyDetection,
     _inferred_expert_count,
     _split_csv,
     detect_text_family_identity,
@@ -30,6 +33,34 @@ class _CopyCountingConfig(Mapping[str, Any]):
     def keys(self):  # type: ignore[override]
         self.copy_attempts += 1
         return self._payload.keys()
+
+
+def test_text_family_dataclasses_are_slotted_for_repeated_resolution_memory() -> None:
+    resolved = resolve_text_family_config(
+        {"text_family_id": "qwen3moe"},
+        model_path="models/qwen3-moe-128e",
+        config_payload={"model_type": "qwen3_moe"},
+    )
+    detected = detect_text_family_identity(
+        model_path="models/qwen3-moe-128e",
+        config_payload={"model_type": "qwen3_moe"},
+    )
+
+    assert isinstance(resolved, ResolvedTextFamilyConfig)
+    assert isinstance(detected, TextFamilyDetection)
+    assert not hasattr(resolved, "__dict__")
+    assert not hasattr(detected, "__dict__")
+    assert not hasattr(
+        TextFamilyDescriptor(
+            family_id="probe",
+            default_architecture="probe",
+            preferred_route_kind=None,
+            supported_parsers=("text",),
+            attention_profile="gqa",
+            rope_profile="standard",
+        ),
+        "__dict__",
+    )
 
 
 def test_split_csv_short_circuits_empty_values_without_split() -> None:

--- a/services/mlx-worker-python/worker/runtime/text_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/text_family_adapters.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class TextFamilyDescriptor:
     family_id: str
     default_architecture: str
@@ -20,14 +20,14 @@ class TextFamilyDescriptor:
     tool_parser_xml_fallback: bool = False
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class TextFamilyDetection:
     architecture: str
     family_id: str
     source: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ResolvedTextFamilyConfig:
     family_id: str
     architecture: str


### PR DESCRIPTION
## Summary
- Add `slots=True` to immutable text-family descriptor/detection/resolved-config dataclasses.
- Add a regression test proving repeated text-family config records no longer allocate per-instance `__dict__` storage.
- Add a focused plan for this registered performance slice.

## Plan or Spec
- `docs/plans/2026-05-22-text-family-slotted-configs.md`
- Registered probe: `text-family-config-copy-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main (3 local Linux probe runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py
old elapsed_ms_mean samples: 357.81831657513976, 328.37144853547215, 327.75671374984086
old peak_bytes_mean: 3884.2
exit code: 0

# New branch local Linux probe (3 local probe runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py
new elapsed_ms_mean samples: 339.37040539458394, 311.10309357754886, 321.9602302182466
new peak_bytes_mean: 3756.2
exit code: 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics
17 passed in 2.76s
exit code: 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/text_family_adapters.py services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/text_family_config_probe.py
17 passed in 19.66s; changed-scope coverage TOTAL 10 0 100%
exit code: 0

git diff --check
exit code: 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Registered local probe (`text_family_config_probe.py`, 3 run mean of each run's `elapsed_ms_mean`):
  - `old_mean=337.9821596201509 ms`
  - `new_mean=324.1445763967931 ms`
  - `delta_ms=-13.837583223357797 ms`
  - `speedup=1.0426895411213633x`
  - `peak_bytes_mean`: `3884.2 -> 3756.2` (`-128.0 bytes`, `-3.295401884557953%`)
  - `config_copy_calls_mean`: `0.0 -> 0.0`
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Linux local verification covers the Python text-family path only; full repository gates and the registered PR-scoped performance workflow must complete in GitHub Actions before merge.
- No protocol, dependency, generated artifact, or Swift runtime changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing registered PR-scoped probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
