### PR TITLE
perf: slim openai tool property templates

### DIFF
--- a/docs/plans/2026-05-22-tool-registry-openai-property-template.md
+++ b/docs/plans/2026-05-22-tool-registry-openai-property-template.md
@@ -1,0 +1,55 @@
+# Tool Registry OpenAI Property Template
+
+Date: 2026-05-22
+
+## Scope
+
+This Python performance slice is limited to `ToolRegistry.as_openai_tools()` in
+`services/mlx-worker-python/worker/runtime/tool_registry.py`.
+
+## Problem
+
+The OpenAI tool schema path must return fresh mutable dictionaries on every call,
+but the cached registry template previously stored small per-argument schema
+dictionaries and copied each one while building the returned payload. The hot
+path only needs the stable argument name, JSON type, and description values to
+reconstruct isolated response dictionaries.
+
+## Optimization slice
+
+Store each cached OpenAI tool property template as `(name, json_type,
+description)` strings when the registry is initialized. `as_openai_tools()` then
+constructs the required fresh nested dictionaries directly from those immutable
+strings instead of copying cached dictionaries.
+
+Behavior remains unchanged:
+
+- `ToolDescriptor.as_openai_tool()` is still bypassed by registry-level cached
+  templates.
+- Returned OpenAI tool payloads remain independently mutable.
+- Tool names, descriptions, kinds, observation kinds, and schema fields are
+  unchanged.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`tool-registry-openai-tools-template-cache` in
+`infra/perf/pr_scoped_probes.json`. The probe entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for this source
+file, the focused tool-registry tests, the PR-scoped probe tests, and
+`scripts/tool_registry_openai_tools_probe.py`.
+
+## Verification plan
+
+- Run the registered focused pytest command locally on Linux.
+- Run the registered changed-scope coverage command and require at least 95%
+  changed-line coverage for touched scope.
+- Run `scripts/tool_registry_openai_tools_probe.py` before and after the change
+  and compare `elapsed_ms_mean` while preserving checksum,
+  `descriptor_as_openai_tool_calls_mean == 0`, and mutation isolation.
+- Use GitHub Actions PR-scoped performance as the merge gate after pushing.
+
+## Linux validation boundary
+
+This slice is entirely Python and locally verifiable on Linux. No Swift runtime
+performance claims are made.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -24,7 +24,7 @@ _OpenAIToolTemplate = tuple[
     str,
     str,
     str,
-    tuple[tuple[str, dict[str, Any]], ...],
+    tuple[tuple[str, str, str], ...],
     list[str],
 ]
 
@@ -199,7 +199,10 @@ class ToolRegistry:
                 tool.description,
                 tool.tool_kind,
                 tool.observation_kind,
-                tool._cached_schema_properties,
+                tuple(
+                    (name, schema["type"], schema["description"])
+                    for name, schema in tool._cached_schema_properties
+                ),
                 tool._cached_required_arguments_list,
             )
             for tool in self._tools
@@ -295,7 +298,8 @@ class ToolRegistry:
                             "type": "object",
                             "additionalProperties": False,
                             "properties": {
-                                name: schema.copy() for name, schema in schema_properties
+                                name: {"type": json_type, "description": description}
+                                for name, json_type, description in schema_properties
                             },
                             "required": required_arguments.copy(),
                         },


### PR DESCRIPTION
## Summary
- Slims the cached OpenAI tool property templates to immutable `(name, json_type, description)` triples.
- Reconstructs fresh returned schema dictionaries from those triples instead of copying cached property dictionaries on each `as_openai_tools()` call.
- Preserves tool payload mutation isolation and the existing registry-level template cache behavior.

## Plan or Spec
- `docs/plans/2026-05-22-tool-registry-openai-property-template.md`

## Commands Run
```text
# Baseline from origin/main
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_OPENAI_TOOLS_ITERATIONS=50000 MELIX_TOOL_REGISTRY_OPENAI_TOOLS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
exit 0; elapsed_ms_mean=479.5488352421671; checksum=1500000.0; descriptor_as_openai_tool_calls_mean=0.0; isolated_payload_calls_mean=50000.0

# Focused regression smoke after change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_openai_tools_reuses_cached_templates
exit 0; 1 passed

# Registered focused test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
exit 0; 53 passed

# Registered changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
exit 0; 53 passed
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
exit 0
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_openai_tools_probe.py
exit 0; TOTAL 0 0 100%

# Registered probe after change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_OPENAI_TOOLS_ITERATIONS=50000 MELIX_TOOL_REGISTRY_OPENAI_TOOLS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
exit 0; elapsed_ms_mean=464.22945838421583; checksum=1500000.0; descriptor_as_openai_tool_calls_mean=0.0; isolated_payload_calls_mean=50000.0

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 0 0 100%` for `tool_registry.py`, `test_tool_registry.py`, `test_pr_scoped_performance.py`, and `tool_registry_openai_tools_probe.py`.
- Local Linux registered probe: old_mean=`479.5488352421671` ms, new_mean=`464.22945838421583` ms, delta=`-15.31937685795128` ms, speedup=`1.0330x` for 50,000 iterations x 5 samples.
- Registered CI PR-scoped performance validation is required before merge.

## Known Gaps
- Linux local validation covers the Python path only; no Swift runtime performance claim is made.
- GitHub Actions PR-scoped performance is the final registered probe gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
