### PR TITLE
perf: trim serving diagnostics queue append hot path

### DIFF
--- a/docs/plans/2026-05-22-serving-diagnostics-queue-append-local.md
+++ b/docs/plans/2026-05-22-serving-diagnostics-queue-append-local.md
@@ -1,0 +1,45 @@
+# Serving diagnostics queue append local binding
+
+## Scope
+
+This Python-only performance slice is limited to the debug serving diagnostics
+queue append path in
+`services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`serving-diagnostics-debug-queue-bounds` in
+`infra/perf/pr_scoped_probes.json`. The registry entry defines focused
+`test_command`, `coverage_command`, and `probe_command` values and reports queue
+append elapsed time, serialization elapsed time, dropped/retained counts,
+serialization checksum, and serialized byte count.
+
+## Change
+
+`BoundedServingDiagnosticsEventQueue.append()` now binds the deque append method
+once per call before the saturated and unsaturated branches, and only writes the
+saturation flag when the queue first reaches capacity. This keeps the existing
+lock discipline, retained-count tracking, and bounded-drop semantics unchanged
+while reducing repeated instance attribute work on the hot append path.
+
+## Validation plan
+
+1. Run the focused serving diagnostics tests plus the PR-scoped probe registry
+   tests for this probe.
+2. Run changed-scope coverage for the changed source path and probe/test files.
+3. Run the registered probe locally on Linux against `origin/main` and this
+   branch before pushing.
+4. Use PR-scoped performance CI as the final registered probe gate before merge.
+
+## Local result
+
+Local Linux probe, `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20`:
+
+- base (`origin/main`, three runs): `elapsed_ms_mean=5.349750/5.420551/5.687914`,
+  `serialization_elapsed_ms_mean=0.947616/0.946771/1.074048`
+- head (three runs): `elapsed_ms_mean=5.501639/5.273962/5.428044`,
+  `serialization_elapsed_ms_mean=0.960166/0.936282/0.979539`
+- mean queue append delta: `-0.084857 ms` (`-1.55%`)
+- mean serialization delta: `-0.030816 ms` (`-3.12%`), with unchanged
+  `serialization_checksum=260064` and `serialized_bytes=10944`

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -86,14 +86,16 @@ class BoundedServingDiagnosticsEventQueue:
         lock = self._lock
         lock.acquire()
         try:
+            append_event = self._append_event
             if self._is_saturated:
-                self._append_event(event)
+                append_event(event)
                 self._dropped_count += 1
                 return False
-            self._append_event(event)
+            append_event(event)
             retained_count = self._retained_count + 1
             self._retained_count = retained_count
-            self._is_saturated = retained_count >= self._max_events
+            if retained_count >= self._max_events:
+                self._is_saturated = True
             return True
         finally:
             lock.release()


### PR DESCRIPTION
## Summary
- Trim the debug serving diagnostics queue append hot path by binding the append method once per call.
- Avoid rewriting the saturation flag after the queue has already reached capacity.
- Add the governing plan for this focused Python performance slice.

## Plan or Spec
- `docs/plans/2026-05-22-serving-diagnostics-queue-append-local.md`
- Registered PR-scoped probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` on `origin/main` baseline (3 runs)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` on this branch (3 comparison runs + final run)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 43 passed.
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Local Linux probe baseline (`origin/main`, 3 runs, queue `elapsed_ms_mean`): `5.349750 / 5.420551 / 5.687914` ms.
- Local Linux probe head (3 comparison runs, queue `elapsed_ms_mean`): `5.501639 / 5.273962 / 5.428044` ms.
- Mean queue append delta: `-0.084857 ms` (`-1.55%`).
- Mean serialization delta: `-0.030816 ms` (`-3.12%`).
- Invariant metrics unchanged: `dropped_count=4032`, `retained_count=64`, `serialization_checksum=260064`, `serialized_bytes=10944`.

## Known Gaps
- Local measurements are Linux-only Python microprobe measurements; PR-scoped performance CI is still required as the registered probe gate before merge.
- The final one-off head probe run reported `elapsed_ms_mean=5.564257` ms, so the local signal is modest and noisy but directionally positive across the 3-run comparison mean.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally on Linux.
- [ ] PR-scoped performance CI completed successfully.
- [ ] Required GitHub checks are green.
