### PR TITLE
perf: static dispatch probe policy parsing

### DIFF
--- a/docs/plans/2026-05-18-probe-policy-static-dispatch.md
+++ b/docs/plans/2026-05-18-probe-policy-static-dispatch.md
@@ -10,10 +10,11 @@ path is covered by the registered PR-scoped probe `probe-policy-noop-overhead` i
 
 ## Change
 
-Keep `ProbePolicy.evidence()` and `ProbePolicy.debug()` behavior unchanged while
-using static dispatch for the cached singleton helpers. These helpers do not use a
-class object, so avoiding classmethod binding removes unnecessary descriptor work
-from the hot no-op policy overhead probe.
+Keep `ProbePolicy.from_value(...)`, `ProbePolicy.evidence()`, and
+`ProbePolicy.debug()` behavior unchanged while using static dispatch for cached
+singleton helper paths that do not use a class object. Avoiding classmethod
+binding removes unnecessary descriptor work from repeated mode parsing in the hot
+no-op policy overhead probe.
 
 ## Verification plan
 

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -53,9 +53,8 @@ class ProbePolicy:
             return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
         return ProbePolicy.from_value(raw_value, default_mode=default_mode)
 
-    @classmethod
+    @staticmethod
     def from_value(
-        cls,
         value: str | ProbeMode | None,
         *,
         default_mode: ProbeMode = ProbeMode.MINIMAL,


### PR DESCRIPTION
## Summary
- Switch `ProbePolicy.from_value(...)` to static dispatch because it does not use a class object.
- Update the probe-policy static-dispatch plan to include repeated mode parsing.

## Plan or Spec
- `docs/plans/2026-05-18-probe-policy-static-dispatch.md`
- Registered probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json` already includes focused `test_command`, `coverage_command`, and `probe_command` entries for this path.

## Commands Run
```text
# Baseline metric from origin/main (a21baddb), exit 0
cd /root/.hermes/profiles/coder/workspace/melix && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=1000000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py

# Candidate metric, exit 0
cd /root/.hermes/profiles/coder/workspace/worktrees/melix-probe-policy-noop-identity-20260522034902 && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=1000000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py

# Focused registered tests, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
17 passed in 0.82s

# Changed-scope coverage, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py
TOTAL 1 0 100%

# Registered probe equivalent, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Local Linux probe comparison (`iterations=1,000,000`, `samples=5`):
  - `mode_parse_empty_call_ms_mean`: `0.000162453` -> `0.000134545` (`-17.18%`).
  - `mode_parse_valid_call_ms_mean`: `0.000168720` -> `0.000155341` (`-7.93%`).
  - `mode_parse_invalid_call_ms_mean`: `0.000382452` -> `0.000380912` (`-0.40%`).
  - `env_parse_empty_call_ms_mean`: `0.000130834` -> `0.000124828` (`-4.59%`).
  - `evidence_policy_call_ms_mean`: `0.000041912` -> `0.000040064` (`-4.41%`).
  - `debug_policy_call_ms_mean`: `0.000041668` -> `0.000039981` (`-4.05%`).
- Candidate registered probe output: `threshold_passed=1.0`.
- CI PR-scoped performance workflow is required for the registered probe validation before merge.

## Known Gaps
- None for the Python slice. No Swift runtime performance claim is made.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
