### PR TITLE
perf: reuse OpenAI tool schema property templates

### DIFF
--- a/docs/plans/2026-05-22-tool-registry-openai-properties-template.md
+++ b/docs/plans/2026-05-22-tool-registry-openai-properties-template.md
@@ -1,0 +1,48 @@
+# Tool registry OpenAI properties template reuse
+
+## Scope
+
+This Python-only performance slice targets `ToolRegistry.as_openai_tools()` in
+`services/mlx-worker-python/worker/runtime/tool_registry.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`tool-registry-openai-tools-template-cache` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries covering the
+runtime source, focused tool-registry tests, PR-scoped performance selection,
+and `scripts/tool_registry_openai_tools_probe.py`.
+
+## Change
+
+`ToolRegistry.__init__()` previously converted each descriptor's cached schema
+property dictionaries into `(name, type, description)` tuples, then
+`as_openai_tools()` rebuilt the tiny `{"type": ..., "description": ...}`
+dictionaries on every call. This slice keeps the descriptor's cached property
+templates in the OpenAI tool template and uses `schema.copy()` per emitted tool
+payload.
+
+Behavior remains unchanged: callers still receive fresh mutable payloads, and
+mutating a returned `properties` entry or `required` list does not alter the next
+`as_openai_tools()` result. The slice only removes repeated literal-dict
+reconstruction in the hot path.
+
+## Validation plan
+
+1. Run the focused tool-registry tests and PR-scoped performance registry tests.
+2. Run changed-scope coverage for the changed source path, focused tests, probe
+   tests, and probe script.
+3. Run the registered local Linux probe against `origin/main` and this branch.
+4. Use PR-scoped performance CI as the final registered probe gate before merge.
+
+## Local result
+
+Local Linux registered probe (`tool-registry-openai-tools-template-cache`,
+`MELIX_TOOL_REGISTRY_OPENAI_TOOLS_ITERATIONS=50000`, default samples=5):
+
+- base (`origin/main`): `elapsed_ms_mean=467.417690`
+- head: `elapsed_ms_mean=458.931321`
+- delta: `-8.486369 ms` (`-1.82%`)
+- guard rails unchanged: `descriptor_as_openai_tool_calls_mean=0.0`,
+  `isolated_payload_calls_mean=50000.0`, `checksum=1500000.0`

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -24,7 +24,7 @@ _OpenAIToolTemplate = tuple[
     str,
     str,
     str,
-    tuple[tuple[str, str, str], ...],
+    tuple[tuple[str, dict[str, Any]], ...],
     list[str],
 ]
 
@@ -199,10 +199,7 @@ class ToolRegistry:
                 tool.description,
                 tool.tool_kind,
                 tool.observation_kind,
-                tuple(
-                    (name, schema["type"], schema["description"])
-                    for name, schema in tool._cached_schema_properties
-                ),
+                tool._cached_schema_properties,
                 tool._cached_required_arguments_list,
             )
             for tool in self._tools
@@ -298,8 +295,8 @@ class ToolRegistry:
                             "type": "object",
                             "additionalProperties": False,
                             "properties": {
-                                name: {"type": json_type, "description": description}
-                                for name, json_type, description in schema_properties
+                                name: schema.copy()
+                                for name, schema in schema_properties
                             },
                             "required": required_arguments.copy(),
                         },


### PR DESCRIPTION
## Summary
- Reuse `ToolDescriptor` cached schema property templates inside `ToolRegistry` OpenAI tool templates.
- Keep `as_openai_tools()` output isolated by copying each property schema into the returned mutable payload.
- Add a focused plan documenting the registered probe and local base-vs-head metrics.

## Plan or Spec
- `docs/plans/2026-05-22-tool-registry-openai-properties-template.md`

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
53 passed in 0.90s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_openai_tools_probe.py
53 passed in 0.39s
TOTAL 0 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-openai-tools-template-cache --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-tool-registry-openai-properties-template-20260522 --head-repo "$PWD" --output /tmp/tool_registry_openai_properties_probe.json
head verification ok; base probe ok; head probe ok

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`TOTAL 0 0 100%`; no newly measurable changed lines, focused coverage command succeeded).
- Registered probe: `tool-registry-openai-tools-template-cache`.
- Local Linux probe metrics:
  - base `elapsed_ms_mean=467.417690`
  - head `elapsed_ms_mean=458.931321`
  - delta `-8.486369 ms` (`-1.82%`)
  - guard rails unchanged: `descriptor_as_openai_tool_calls_mean=0.0`, `isolated_payload_calls_mean=50000.0`, `checksum=1500000.0`
- CI PR-scoped performance remains the merge gate for the registered probe report.

## Known Gaps
- Full repository gates were not run locally; this is a narrow Python slice with focused tests, changed-scope coverage, and the registered local probe.
- No Swift runtime validation is applicable for this Python-only change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change; uses existing PR-scoped performance probe.
- [x] Deferred work and known gaps are stated explicitly.
