### PR TITLE
perf: streamline OpenAI tool template materialization

### DIFF
--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -175,6 +175,21 @@ class ToolRegistryMetrics:
 
 
 class ToolRegistry:
+    __slots__ = (
+        "_metrics",
+        "_openai_tool_templates",
+        "_parser",
+        "_parser_contract_version",
+        "_schema_version",
+        "_selection_cache",
+        "_tool_by_name",
+        "_tool_names",
+        "_tool_names_list",
+        "_tools",
+        "_toolset_version",
+        "_worker_tool_config_bytes",
+    )
+
     def __init__(
         self,
         tools: list[ToolDescriptor] | tuple[ToolDescriptor, ...],
@@ -275,37 +290,34 @@ class ToolRegistry:
         return selection
 
     def as_openai_tools(self) -> list[dict[str, Any]]:
-        tools: list[dict[str, Any]] = []
-        append_tool = tools.append
-        for (
-            name,
-            description,
-            tool_kind,
-            observation_kind,
-            schema_properties,
-            required_arguments,
-        ) in self._openai_tool_templates:
-            append_tool(
-                {
-                    "type": "function",
-                    "function": {
-                        "name": name,
-                        "description": description,
-                        "parameters": {
-                            "type": "object",
-                            "additionalProperties": False,
-                            "properties": {
-                                name: schema.copy()
-                                for name, schema in schema_properties
-                            },
-                            "required": required_arguments.copy(),
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": description,
+                    "parameters": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            argument_name: schema.copy()
+                            for argument_name, schema in schema_properties
                         },
+                        "required": required_arguments.copy(),
                     },
-                    "x-melix-tool-kind": tool_kind,
-                    "x-melix-observation-kind": observation_kind,
-                }
-            )
-        return tools
+                },
+                "x-melix-tool-kind": tool_kind,
+                "x-melix-observation-kind": observation_kind,
+            }
+            for (
+                name,
+                description,
+                tool_kind,
+                observation_kind,
+                schema_properties,
+                required_arguments,
+            ) in self._openai_tool_templates
+        ]
 
     def as_worker_tool_config(self) -> common_pb2.ToolConfig:
         if self._worker_tool_config_bytes:


### PR DESCRIPTION
## Summary
- Adds slots to `ToolRegistry` so hot snapshot accessors avoid per-instance dictionaries.
- Streamlines `ToolRegistry.as_openai_tools()` by materializing OpenAI tool template payloads with a list comprehension instead of an append loop.
- Preserves per-call isolation for nested schema dictionaries and required-argument lists.

## Plan or Spec
- N/A: this is a narrow Python performance slice for an already registered PR-scoped probe path; it does not change behavior or workflow.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 52 passed in 0.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_openai_tools_probe.py
# 52 passed in 0.39s; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
# {"elapsed_ms_mean": 4.281707294285297, "schema_payload_elapsed_ms_mean": 164.58985675126314, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_names_probe.py
# {"elapsed_ms_mean": 29.38099941238761, "registry_factory_elapsed_ms_mean": 25.750292977318168, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
# {"elapsed_ms_mean": 445.12178115546703, "descriptor_as_openai_tool_calls_mean": 0.0, ...}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 1 0 100%`).
- Registered probes: `tool-registry-openai-tools-template-cache`, `tool-registry-names-snapshot-cache`, and `tool-registry-schema-bytes-cache` cover `services/mlx-worker-python/worker/runtime/tool_registry.py` and include focused `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json`.
- Local Linux spot metrics after final amendment:
  - `tool_registry_schema_bytes_probe.py`: `elapsed_ms_mean=4.282`, `schema_payload_elapsed_ms_mean=164.590`.
  - `tool_registry_names_probe.py`: `elapsed_ms_mean=29.381`, `registry_factory_elapsed_ms_mean=25.750`.
  - `tool_registry_openai_tools_probe.py`: `elapsed_ms_mean=445.122`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- None. This is a Linux-verified Python-only slice; no Swift runtime validation is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated.
- [x] Protocol changes include regenerated generated artifacts, or N/A is stated.
- [x] Dependency changes include updated lockfiles, or N/A is stated.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
