### PR TITLE
perf: cache evaluation ignored path sets

### DIFF
--- a/docs/plans/2026-05-22-evaluation-json-ignored-path-cache.md
+++ b/docs/plans/2026-05-22-evaluation-json-ignored-path-cache.md
@@ -1,0 +1,35 @@
+# Evaluation JSON Ignored Path Set Cache
+
+## Scope
+
+This Python-only performance slice is limited to final-result JSON scoring in
+`services/mlx-worker-python/worker/productization/evaluation_final_result.py`.
+The behavior stays equivalent: default ignored paths and profile-level ignored
+paths are still applied before recursive typed-score aggregation.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped probe
+`evaluation-final-result-json-typed-score-aggregate` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries that cover:
+
+- `services/mlx-worker-python/worker/productization/evaluation_final_result.py`
+- `services/mlx-worker-python/tests/test_evaluation_final_result.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/evaluation_json_typed_score_probe.py`
+
+## Implementation Plan
+
+1. Add a focused regression test proving repeated JSON scoring reuses the
+   combined ignored-path set while preserving default and profile ignored paths.
+2. Cache the immutable combined ignored-path set by the profile ignored-path
+   tuple, avoiding repeated set construction in repeated scoring loops.
+3. Run the focused pytest command, changed-scope coverage command, and the
+   registered probe locally on Linux before pushing.
+4. Use the PR-scoped performance GitHub Actions report as the merge gate.
+
+## Validation Boundary
+
+This slice is pure Python and locally verifiable on Linux. No Swift runtime
+performance claim is made.

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -317,6 +317,42 @@ def test_score_final_result_reuses_cached_parsed_json_payloads(monkeypatch: pyte
     evaluation_final_result_module._loads_json_payload.cache_clear()
 
 
+def test_score_final_result_reuses_cached_ignored_path_sets() -> None:
+    evaluation_final_result_module._ignored_paths_for_profile.cache_clear()
+    target = json.dumps(
+        {
+            "answer": "A",
+            "confidence": 0.9,
+            "metadata": {"evidence": ["gold"]},
+        }
+    )
+    extracted = json.dumps(
+        {
+            "answer": "A",
+            "confidence": 0.1,
+            "metadata": {"evidence": ["candidate"]},
+        }
+    )
+    profile = EvaluationProfileDefinition(
+        profile_type="final_result",
+        result_kind="json",
+        extraction_mode="strict_full_response",
+        scoring_mode="json_field_match",
+        threshold=1.0,
+        ignored_paths=("metadata",),
+    )
+
+    first = score_final_result(extracted_result=extracted, target=target, profile=profile)
+    second = score_final_result(extracted_result=extracted, target=target, profile=profile)
+
+    assert first == second == evaluation_final_result_module.ScoringOutcome(
+        typed_score=1.0,
+        validation_status="validated",
+    )
+    assert evaluation_final_result_module._ignored_paths_for_profile.cache_info().hits >= 1
+    evaluation_final_result_module._ignored_paths_for_profile.cache_clear()
+
+
 def test_score_final_result_rejects_invalid_json_shape_before_scoring() -> None:
     score = score_final_result(
         extracted_result=json.dumps([{"label": "A"}]),

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import re
 import shutil
 import tempfile
-from collections.abc import Iterable, Iterator
+from collections.abc import Collection, Iterable, Iterator
 from functools import lru_cache
 from typing import Any, Callable
 from urllib.error import HTTPError, URLError
@@ -328,7 +328,7 @@ def _score_json_result(
     score = _json_typed_score(
         expected=parsed_target,
         actual=parsed_result,
-        ignored_paths=_DEFAULT_IGNORED_PATHS | set(profile.ignored_paths),
+        ignored_paths=_ignored_paths_for_profile(profile.ignored_paths),
     )
     return ScoringOutcome(typed_score=round(score, 4), validation_status="validated")
 
@@ -336,6 +336,11 @@ def _score_json_result(
 @lru_cache(maxsize=128)
 def _loads_json_payload(payload: str) -> Any:
     return json.loads(payload)
+
+
+@lru_cache(maxsize=128)
+def _ignored_paths_for_profile(profile_ignored_paths: tuple[str, ...]) -> frozenset[str]:
+    return _DEFAULT_IGNORED_PATHS | frozenset(profile_ignored_paths)
 
 
 def _score_text_result(
@@ -456,7 +461,7 @@ def _matches_json_schema_pattern(pattern_properties: Any, key: str) -> bool:
     return isinstance(pattern_properties, dict) and bool(_json_schema_pattern_schemas(pattern_properties, key))
 
 
-def _json_typed_score(*, expected: Any, actual: Any, ignored_paths: set[str], path: str = "") -> float:
+def _json_typed_score(*, expected: Any, actual: Any, ignored_paths: Collection[str], path: str = "") -> float:
     if isinstance(expected, dict):
         total = 0.0
         count = 0


### PR DESCRIPTION
## Summary
- Cache the combined default/profile ignored-path set used by final-result JSON typed scoring.
- Add a focused regression test proving repeated scoring reuses the ignored-path cache while preserving ignored-path behavior.
- Document the slice plan and validation boundary for the registered probe.

## Plan or Spec
- `docs/plans/2026-05-22-evaluation-json-ignored-path-cache.md`
- Registered probe: `evaluation-final-result-json-typed-score-aggregate`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_json_typed_score_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_json_typed_score_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `39 passed`.
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Local Linux registered probe baseline before change: `elapsed_ms_mean=1337.1057496406138`, `peak_bytes_mean=871437.0`.
- Local Linux registered probe after change: `elapsed_ms_mean=1320.1001369860023`, `peak_bytes_mean=714057.0`.
- Local delta: `-17.00561265461147 ms` (`1.0128820626391555x` speedup), peak memory `-157380 bytes` (`-18.059825323000975%`).
- PR-scoped performance CI is required as the final registered probe validation before merge.

## Known Gaps
- This is a Python-only slice validated locally on Linux; no Swift runtime effect is claimed.
- Local probe numbers are synthetic and can vary by runner; the registered CI probe remains the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused commands.
- [x] Focused behavior tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe was run locally on Linux.
- [ ] GitHub Actions and PR-scoped performance workflow completed successfully.
