### PR TITLE
perf: bind startup version parser ord lookup

### DIFF
--- a/docs/plans/2026-05-22-startup-version-ord-binding.md
+++ b/docs/plans/2026-05-22-startup-version-ord-binding.md
@@ -1,0 +1,28 @@
+# Startup version parser ord binding
+
+## Scope
+
+This Python-only performance slice is limited to the version comparison parser in
+`services/mlx-worker-python/worker/productization/startup_signals.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`startup-signals-version-compare-single-pass` in `infra/perf/pr_scoped_probes.json`.
+The probe has focused `test_command`, `coverage_command`, and `probe_command`
+entries and reports version comparison elapsed time, peak bytes, and update
+result construction metrics.
+
+## Hypothesis
+
+`compare_versions` repeatedly calls `_next_normalized_version_part`, which scans
+version strings character-by-character. Binding `ord` at module scope avoids a
+builtin lookup inside both parser loops while keeping comparison semantics
+unchanged.
+
+## Verification plan
+
+1. Run the registered focused startup signal tests.
+2. Run the registered changed-scope coverage command.
+3. Run the registered local Linux probe against `origin/main` and this branch.
+4. Use PR-scoped performance CI as the final registered probe gate before merge.

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -23,6 +23,7 @@ CRASH_PATTERNS = (
     "abort trap",
 )
 _BYTE_WHITESPACE = bytes(value for value in range(256) if chr(value).isspace())
+_ORD = ord
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,7 +165,7 @@ def _next_normalized_version_part(value: str, index: int) -> tuple[int, int, boo
     value_length = len(value)
 
     while index < value_length:
-        character_code = ord(value[index])
+        character_code = _ORD(value[index])
         index += 1
         if character_code == 43 or character_code == 45:
             break
@@ -193,7 +194,7 @@ def _iter_normalized_version_parts(value: str) -> Iterator[int]:
     part_has_chars = False
 
     for character in cleaned[start_index:]:
-        character_code = ord(character)
+        character_code = _ORD(character)
         if character_code == 43 or character_code == 45:
             break
         if character_code == 46:


### PR DESCRIPTION
## Summary
- Bind `ord` at module scope for startup version parser loops to avoid repeated builtin lookup during `compare_versions` scans.
- Keep the slice limited to `services/mlx-worker-python/worker/productization/startup_signals.py` plus the governing plan note.

## Plan or Spec
- `docs/plans/2026-05-22-startup-version-ord-binding.md`
- Registered probe: `startup-signals-version-compare-single-pass` in `infra/perf/pr_scoped_probes.json` covers the touched Python path and has focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# Started from fresh worktree based on origin/main c0599aeb68e0d9c2c587a8e71df8693eee8c1591.

git fetch origin && git rev-parse origin/main
# exit 0; origin/main=c0599aeb68e0d9c2c587a8e71df8693eee8c1591

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_does_not_allocate_streaming_part_generators services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_raw_values_skip_normalization services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_clean_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_v_prefix_equivalent_values_skip_part_parsing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics
# exit 0; 10 passed in 2.68s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_does_not_allocate_streaming_part_generators services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_raw_values_skip_normalization services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_clean_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_v_prefix_equivalent_values_skip_part_parsing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_version_probe.py
# exit 0; 10 passed in 3.78s; TOTAL 0 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_version_probe.py
# exit 0; local Linux probe run against origin/main worktree and this branch, three samples each (see Coverage and Metrics).

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` from `scripts/changed_scope_coverage.py` (aggregate measurable changed lines: 0, because the touched executable lines are local binding replacements but the focused tests executed successfully).
- Local Linux registered probe equivalent (`scripts/startup_signals_version_probe.py`, three old/new samples):
  - `elapsed_ms_mean`: old_mean=`13.7311`, new_mean=`13.3899`, delta=`-0.3413 ms`, speedup=`2.49%`.
  - `update_result_elapsed_ms_mean`: old_mean=`112.0060`, new_mean=`108.7823`, delta=`-3.2236 ms`, speedup=`2.88%`.
  - `peak_bytes_mean`: unchanged at `112.0`; `update_result_peak_bytes_mean`: unchanged at `560.0`.
- CI PR-scoped performance workflow is required as the final registered probe validation before merge.

## Known Gaps
- No Swift runtime effect is claimed; this is a Python-only Linux-verifiable slice.
- Local probe noise is possible for sub-millisecond parser changes, so CI registered probe output remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
