### PR TITLE
perf: simplify code fence tag matching

### DIFF
--- a/docs/plans/2026-05-22-code-eval-code-fence-tag-casefold.md
+++ b/docs/plans/2026-05-22-code-eval-code-fence-tag-casefold.md
@@ -1,0 +1,17 @@
+# Code eval code fence tag casefold
+
+## Goal
+
+Reduce Python code-fence extraction overhead in `worker.engine.code_eval_runner` by replacing the import-time mixed-case `python` tag variant table with a direct lower-case comparison for the six-character fence language tag.
+
+## Scope
+
+This Python-only slice is limited to `extract_candidate_code(...)` and `_code_block_content_start(...)` in `services/mlx-worker-python/worker/engine/code_eval_runner.py`. It preserves extraction semantics for lowercase, uppercase, and mixed-case `python` fences, unknown language tags, empty fenced blocks, incomplete trailing fences, and the last-complete-block selection behavior.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `code-eval-code-block-last-match-streaming` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for this file, the focused code-eval tests, the PR-scoped performance tests, and `scripts/code_eval_code_block_extract_probe.py`.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage command, and registered probe locally on Linux before pushing. GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -18,23 +18,6 @@ _JSON_LOADS = json.loads
 _JSON_DECODE_ERROR = json.JSONDecodeError
 _PYTHON_CODE_BLOCK_TAG = "python"
 _PYTHON_CODE_BLOCK_TAG_LENGTH = len(_PYTHON_CODE_BLOCK_TAG)
-_PYTHON_CODE_BLOCK_TAG_VARIANTS = (
-    "Python",
-    "PYTHON",
-    "PyThOn",
-    "pYtHoN",
-    *(
-        variant
-        for variant in (
-            "".join(
-                upper if bitmask & (1 << offset) else lower
-                for offset, (lower, upper) in enumerate(zip("python", "PYTHON"))
-            )
-            for bitmask in range(1 << _PYTHON_CODE_BLOCK_TAG_LENGTH)
-        )
-        if variant not in {"python", "Python", "PYTHON", "PyThOn", "pYtHoN"}
-    ),
-)
 
 
 @dataclass(frozen=True)
@@ -84,7 +67,7 @@ def extract_candidate_code(raw_response: str) -> tuple[str, str]:
 def _code_block_content_start(text: str, start: int) -> int:
     if text.startswith(_PYTHON_CODE_BLOCK_TAG, start):
         start += _PYTHON_CODE_BLOCK_TAG_LENGTH
-    elif text.startswith(_PYTHON_CODE_BLOCK_TAG_VARIANTS, start):
+    elif text[start:start + _PYTHON_CODE_BLOCK_TAG_LENGTH].lower() == _PYTHON_CODE_BLOCK_TAG:
         start += _PYTHON_CODE_BLOCK_TAG_LENGTH
     while start < len(text) and text[start].isspace():
         start += 1


### PR DESCRIPTION
## Summary
- Replace the precomputed mixed-case `python` fence tag variant table with a direct six-character lowercase comparison in `_code_block_content_start(...)`.
- Preserve lowercase, uppercase, and mixed-case Python code-fence extraction semantics while reducing hot-path extraction work.

## Plan or Spec
- `docs/plans/2026-05-22-code-eval-code-fence-tag-casefold.md`

## Commands Run
```text
# Baseline probe before this slice
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py
# exit 0; elapsed_ms_mean=0.033527047240308354, peak_bytes_mean=245.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks
# exit 0; 1 passed

# Registered probe test_command for code-eval-code-block-last-match-streaming
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 4 passed

# Registered probe coverage_command for code-eval-code-block-last-match-streaming
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py
# exit 0; 4 passed; changed_line_coverage=100.00%; TOTAL 0 0 100%

# Registered probe_command for code-eval-code-block-last-match-streaming
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py
# exit 0; elapsed_ms_mean=0.029671471565961838, peak_bytes_mean=245.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` from `scripts/changed_scope_coverage.py` for the registered probe scope.
- Local registered probe (`code-eval-code-block-last-match-streaming`, Linux): `elapsed_ms_mean` improved from `0.033527047240308354` ms to `0.029671471565961838` ms (`delta=-0.003855575674346516` ms, about `11.50%` faster); `peak_bytes_mean` stayed `245.0` bytes.
- CI PR-scoped performance report is required before merge and is the registered probe validation source on GitHub Actions.

## Known Gaps
- Local verification was Linux-only; no Swift/runtime effect is claimed for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
