### PR TITLE
perf: skip startup version suffix tails

### DIFF
--- a/docs/plans/2026-05-13-startup-version-ascii-digit-fast-path.md
+++ b/docs/plans/2026-05-13-startup-version-ascii-digit-fast-path.md
@@ -17,7 +17,9 @@ The probe includes focused `test_command`, `coverage_command`, and `probe_comman
 
 ## Optimization
 
-Use direct ASCII character-code checks inside the normalized version parser for separators (`+`, `-`, `.`) and digit bounds (`0` through `9`). Melix product versions and update-channel versions are ASCII semantic-version strings, and the parser already treats non-prefix suffix text as a zero-valued suffix component.
+Use direct ASCII character-code checks inside the normalized version parser for separators (`+`, `-`, `.`) and digit bounds (`0` through `9`). Melix product versions and update-channel versions are ASCII semantic-version strings, and the parser treats non-prefix suffix text as build/prerelease metadata rather than ordering input.
+
+This follow-up slice also makes the streaming comparator skip the remainder of a version after the first `+` or `-` suffix marker. That keeps the streaming comparator aligned with `normalized_version_parts()` for left-hand build metadata and avoids scanning suffix tails that cannot affect update ordering.
 
 ## Validation Plan
 

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -93,6 +93,7 @@ def test_default_update_channel_path_uses_stable_channel_json(tmp_path: Path) ->
 
 def test_compare_versions_ignores_build_metadata_suffix() -> None:
     assert normalized_version_parts("v1.2.3+abcdef1") == [1, 2, 3]
+    assert compare_versions("1.2.3+build.4", "1.2.3") == 0
     assert compare_versions("1.2.3", "1.2.3+abcdef1") == 0
     assert compare_versions("1.2.4", "1.2.3+abcdef1") == 1
     assert compare_versions("1.2.2", "1.2.3") == -1

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -168,6 +168,7 @@ def _next_normalized_version_part(value: str, index: int) -> tuple[int, int, boo
         character_code = _ORD(value[index])
         index += 1
         if character_code == 43 or character_code == 45:
+            index = value_length
             break
         if character_code == 46:
             if part_has_chars:


### PR DESCRIPTION
## Summary
- Skip the remaining suffix tail in the startup version streaming comparator once `+` or `-` metadata begins.
- Add a regression case for left-hand build metadata with digits (`1.2.3+build.4`) comparing equal to the base version.
- Update the startup version performance plan with the suffix-tail fast path.

## Plan or Spec
- `docs/plans/2026-05-13-startup-version-ascii-digit-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_does_not_allocate_streaming_part_generators services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_raw_values_skip_normalization services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_clean_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_v_prefix_equivalent_values_skip_part_parsing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics
# 10 passed in 2.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_version_probe.py
# 10 passed in 3.64s; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_version_probe.py
# {"comparison_total": -32.0, "elapsed_ms_mean": 14.143507861133132, "pair_count": 12000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0, "update_result_available_count": 12500.0, "update_result_elapsed_ms_mean": 112.12404345029167, "update_result_iterations": 25000.0, "update_result_peak_bytes_mean": 560.0}

git diff --check
# passed
```

## Coverage and Metrics
- Registered probe: `startup-signals-version-compare-single-pass` (has focused test, coverage, and probe commands in `infra/perf/pr_scoped_probes.json`).
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Local registered probe output: `elapsed_ms_mean=14.143507861133132`, `comparison_total=-32.0`, `peak_bytes_mean=112.0`.
- Focused old/new suffix-heavy microprobe: `old_mean=310.7170797884464ms`, `new_mean=201.04939914825889ms`, `delta_ms=-109.66768064018754ms`, `speedup=1.5454762914228648x`.
- CI PR-scoped performance is required as the merge gate.

## Known Gaps
- Linux local validation covers the Python path only. CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
