### PR TITLE
perf: bind code eval fence length

### DIFF
--- a/docs/plans/2026-05-22-code-eval-content-start-length-binding.md
+++ b/docs/plans/2026-05-22-code-eval-content-start-length-binding.md
@@ -1,0 +1,38 @@
+# Code eval content-start length binding
+
+## Scope
+
+This Python-only performance slice is limited to `_code_block_content_start(...)`
+in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`code-eval-code-block-last-match-streaming` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for the code eval
+runner, focused tests, PR-scoped performance tests, and
+`scripts/code_eval_code_block_extract_probe.py`.
+
+## Change
+
+Bind `len(text)` once before the whitespace-skip loop after a fenced code block
+language tag is handled. This preserves extraction semantics while avoiding a
+repeated global length call during whitespace-heavy fence headers.
+
+## Verification plan
+
+1. Run the registered focused code-eval tests locally on Linux.
+2. Run changed-scope coverage for the touched source, focused tests, registry
+   tests, and probe script.
+3. Run the registered local Linux probe against `origin/main` and the branch.
+4. Use GitHub Actions PR-scoped performance as the final registered probe gate
+   before merge.
+
+## Rejected adjacent slice
+
+During candidate selection, the OpenAI tool-registry property tuple experiment
+was measured and rejected before commit because the local registered probe was
+slower than `origin/main` (`441.853 ms` base versus `472.988 ms` candidate for
+50,000 iterations, five samples). This PR therefore contains only the code-eval
+length-binding slice.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -69,7 +69,8 @@ def _code_block_content_start(text: str, start: int) -> int:
         start += _PYTHON_CODE_BLOCK_TAG_LENGTH
     elif text[start:start + _PYTHON_CODE_BLOCK_TAG_LENGTH].lower() == _PYTHON_CODE_BLOCK_TAG:
         start += _PYTHON_CODE_BLOCK_TAG_LENGTH
-    while start < len(text) and text[start].isspace():
+    text_length = len(text)
+    while start < text_length and text[start].isspace():
         start += 1
     return start
 


### PR DESCRIPTION
## Summary
- Bind `len(text)` once in the code-fence content-start whitespace loop.
- Keep code-fence extraction behavior unchanged while reducing repeated length calls in whitespace-heavy fenced block headers.

## Plan or Spec
- `docs/plans/2026-05-22-code-eval-content-start-length-binding.md`
- Registered PR-scoped probe: `code-eval-code-block-last-match-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# focused tests (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# 4 passed in 0.11s

# changed-scope coverage (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py
# TOTAL 2 0 100%

# local registered probe, origin/main baseline (exit 0)
cd /root/.hermes/profiles/coder/workspace/melix
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py
# {"block_count": 2500.0, "elapsed_ms_mean": 0.02979739968265806, "extracted_chars_mean": 37.0, "peak_bytes_mean": 245.0, "sample_count": 7.0}

# local registered probe, branch (exit 0)
cd /root/.hermes/profiles/coder/workspace/worktrees/melix-tool-registry-openai-property-tuples-cron-202605221245
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py
# {"block_count": 2500.0, "elapsed_ms_mean": 0.02859596029988357, "extracted_chars_mean": 37.0, "peak_bytes_mean": 245.0, "sample_count": 7.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Local registered probe (`code-eval-code-block-last-match-streaming`):
  - base `elapsed_ms_mean=0.02979739968265806`
  - head `elapsed_ms_mean=0.02859596029988357`
  - delta `-0.00120143938277449 ms` (`~4.03%` faster)
  - guard rails unchanged: `block_count=2500.0`, `extracted_chars_mean=37.0`, `peak_bytes_mean=245.0`, `sample_count=7.0`.
- Observability mode: `N/A` (no runtime observability behavior changed; existing PR-scoped probe is the evidence path).
- Probe overhead: existing registered synthetic PR-scoped probe only; no new production overhead.

## Known Gaps
- Full repository gates (`make py-test`, `make swift-test`, `make integration-test`) were not run locally for this one-line Python slice.
- CI PR-scoped performance must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
