### PR TITLE
perf: bind OpenAI tool payload copy methods

### DIFF
--- a/docs/plans/2026-05-22-tool-registry-openai-properties-template.md
+++ b/docs/plans/2026-05-22-tool-registry-openai-properties-template.md
@@ -46,3 +46,26 @@ Local Linux registered probe (`tool-registry-openai-tools-template-cache`,
 - delta: `-8.486369 ms` (`-1.82%`)
 - guard rails unchanged: `descriptor_as_openai_tool_calls_mean=0.0`,
   `isolated_payload_calls_mean=50000.0`, `checksum=1500000.0`
+
+## Follow-up slice: OpenAI copy method bindings
+
+This follow-up Python-only slice keeps the same registered probe and narrows the
+optimization to the remaining per-call copy overhead in `as_openai_tools()`. The
+emitted payload must stay freshly mutable, so the slice does not cache returned
+dictionaries or lists. Instead, it binds `dict.copy` and `list.copy` once before
+the list comprehension and calls those bound descriptors for each copied schema
+property and required-argument list. This preserves the previous isolation
+semantics while avoiding repeated method lookup in the hot path.
+
+Validation remains the same: focused tool-registry tests, changed-scope coverage,
+and the registered local Linux probe before opening the PR; PR-scoped
+performance CI remains the final merge gate.
+
+Local Linux registered probe (`tool-registry-openai-tools-template-cache`,
+`MELIX_TOOL_REGISTRY_OPENAI_TOOLS_ITERATIONS=50000`, default samples=5):
+
+- base (`origin/main`): `elapsed_ms_mean=452.945446`
+- head: `elapsed_ms_mean=442.232800`
+- delta: `-10.712646 ms` (`-2.36%`)
+- guard rails unchanged: `descriptor_as_openai_tool_calls_mean=0.0`,
+  `isolated_payload_calls_mean=50000.0`, `checksum=1500000.0`

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -290,6 +290,8 @@ class ToolRegistry:
         return selection
 
     def as_openai_tools(self) -> list[dict[str, Any]]:
+        dict_copy = dict.copy
+        list_copy = list.copy
         return [
             {
                 "type": "function",
@@ -300,10 +302,10 @@ class ToolRegistry:
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            argument_name: schema.copy()
+                            argument_name: dict_copy(schema)
                             for argument_name, schema in schema_properties
                         },
-                        "required": required_arguments.copy(),
+                        "required": list_copy(required_arguments),
                     },
                 },
                 "x-melix-tool-kind": tool_kind,


### PR DESCRIPTION
## Summary
- Bind `dict.copy` and `list.copy` once in `ToolRegistry.as_openai_tools()` before the hot list comprehension.
- Preserve fresh mutable OpenAI tool payloads while avoiding repeated copy-method lookups.
- Record the follow-up slice and local registered probe result in the governing plan.

## Plan or Spec
- `docs/plans/2026-05-22-tool-registry-openai-properties-template.md`
- Registered probe: `tool-registry-openai-tools-template-cache` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 53 passed in 0.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 53 passed in 0.34s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_openai_tools_probe.py
# TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-openai-tools-template-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/tool_registry_openai_copy_bindings_probe.json
# test_ok=true coverage_ok=true base/head probes ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`2/2` changed measurable lines covered).
- Local Linux registered probe `tool-registry-openai-tools-template-cache`:
  - `elapsed_ms_mean`: base `452.945446`, head `442.232800`, delta `-10.712646 ms` (`-2.36%`), lower is better.
  - `descriptor_as_openai_tool_calls_mean`: base/head `0.0`.
  - `isolated_payload_calls_mean`: base/head `50000.0`.
  - `checksum`: base/head `1500000.0`.
- PR-scoped performance CI is still required as the final registered-probe validation before merge.

## Known Gaps
- None. This is a Python-only slice validated locally on Linux; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change; existing PR-scoped probe remains the evidence path.
- [x] Deferred work and known gaps are stated explicitly.
