### PR TITLE
perf: bind response boundary truncation total

### DIFF
--- a/docs/plans/2026-05-22-response-boundary-truncation-limit.md
+++ b/docs/plans/2026-05-22-response-boundary-truncation-limit.md
@@ -1,0 +1,25 @@
+# Response-Only Boundary Truncation Limit Binding
+
+## Scope
+
+This slice covers `services/mlx-worker-python/worker/model_ops/response_only_boundary.py` and the registered PR-scoped probe `response-only-boundary-slotted-records`.
+
+## Optimization
+
+`aggregate_response_only_boundaries()` has a hot truncation path when `max_seq_length` is positive. The path already computes response-only boundary aggregates in one pass. This slice keeps the same algorithm and replaces the temporary `effective_total` assignment with an in-place capped `total_tokens` local before subtracting the assistant offset.
+
+The behavior is unchanged:
+
+- `response_tokens` is still computed from the original total token count before truncation.
+- trainable response tokens still clamp to `max_seq_length` and floor at zero.
+- truncated and fully truncated sample counters keep the same semantics.
+
+## Validation
+
+Use the existing registered probe entry in `infra/perf/pr_scoped_probes.json`:
+
+- focused response-only boundary tests from `test_command`
+- changed-scope coverage from `coverage_command`
+- `scripts/response_only_boundary_slots_probe.py` from `probe_command`
+
+The Linux local probe validates this Python-only slice before PR creation; CI must also run the registered PR-scoped probe before merge.

--- a/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
+++ b/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
@@ -175,8 +175,9 @@ def aggregate_response_only_boundaries(
             response_tokens = total_tokens - offset
             if response_tokens < 0:
                 response_tokens = 0
-            effective_total = total_tokens if total_tokens < effective_limit else effective_limit
-            trainable_response_tokens = effective_total - offset
+            if total_tokens > effective_limit:
+                total_tokens = effective_limit
+            trainable_response_tokens = total_tokens - offset
             if trainable_response_tokens < 0:
                 trainable_response_tokens = 0
             if sample_count == 0:


### PR DESCRIPTION
## Summary
- Optimizes the positive-`max_seq_length` response-only boundary aggregation path by capping the local token total in place before computing trainable response tokens.
- Keeps response token, truncation, and fully-truncated counter semantics unchanged.
- Adds a focused plan for this registered performance slice.

## Plan or Spec
- `docs/plans/2026-05-22-response-boundary-truncation-limit.md`
- Registered PR-scoped performance probe: `response-only-boundary-slotted-records` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Focused tests from registered test_command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_without_limit_updates_running_bounds services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
Result: 9 passed, 1 skipped in 2.89s

# Changed-scope coverage from registered coverage_command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/response_only_boundary.py services/mlx-worker-python/tests/test_response_only_boundary.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/response_only_boundary_slots_probe.py
Result: 9 passed, 1 skipped in 2.27s; TOTAL 3 0 100%

# Registered probe command (direct local equivalent of probe_command)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/response_only_boundary_slots_probe.py
Result: {"aggregation_elapsed_ms_mean": 262.9982020240277, "boundary_count": 50000.0, "checksum": 7970445.0, "construction_elapsed_ms_mean": 125.70363096892834, "instance_dict_count_mean": 0.0, "peak_bytes_mean": 3422112.0, "sample_count": 5.0}

# Local base-vs-head probe sampling at 80k boundaries / 5 samples, repeated 3x each
old aggregation means: 408.4791759494692, 416.23090701177716, 414.2457032110542 ms
new aggregation means: 405.62301743775606, 415.0493941269815, 410.60439818538725 ms
Result: old_mean=412.98526205743354 ms, new_mean=410.4256032500416 ms, delta=-2.5596588073919406 ms, speedup=0.6197942257406684%

git diff --check
Result: passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for the changed lines in `response_only_boundary.py`.
- Local registered probe metric: `aggregation_elapsed_ms_mean=262.9982020240277` ms at default 50k boundaries / 5 samples.
- Local base-vs-head probe comparison at 80k boundaries / 5 samples, repeated 3x: `old_mean=412.98526205743354 ms`, `new_mean=410.4256032500416 ms`, `delta=-2.5596588073919406 ms`, `speedup=0.6197942257406684%`.
- CI must run and pass the registered `response-only-boundary-slotted-records` PR-scoped performance probe before merge.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice.
- Observability mode: N/A (no runtime observability change). Probe overhead: N/A (uses existing registered synthetic PR-scoped probe).

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
