### PR TITLE
perf: snapshot startup failure reports directly

### DIFF
--- a/docs/plans/2026-05-15-startup-failure-report-slots.md
+++ b/docs/plans/2026-05-15-startup-failure-report-slots.md
@@ -28,3 +28,17 @@ The change intentionally does not modify log-reading decisions, classification l
 Run the registered focused tests, changed-scope coverage, and registered probe locally on Linux before pushing. Compare the registered probe output against a pre-change baseline captured from `origin/main` in the same worktree.
 
 CI remains the merge gate for the registered PR-scoped performance report.
+
+## Follow-up Slice: Manual `to_dict()` Snapshot
+
+The next startup-report micro-slice keeps the same registered probe and narrows
+scope to `StartupFailureReport.to_dict()`. The previous implementation used
+`dataclasses.asdict()`, which recursively walks dataclass fields even though the
+report payload contains only scalar values. This slice replaces that generic
+walk with an explicit field dictionary while preserving the public keys and
+values.
+
+The registered probe now also reports `report_to_dict_elapsed_ms_mean`,
+`report_to_dict_peak_bytes_mean`, and an informational
+`report_to_dict_checksum` so the PR-scoped performance workflow measures the
+serialization hot path directly.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2911,6 +2911,23 @@
         "warn_pct": 5.0
       },
       {
+        "key": "report_to_dict_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "report_to_dict_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "report_to_dict_checksum",
+        "unit": "checksum",
+        "direction": "informational"
+      },
+      {
         "key": "report_has_dict_mean",
         "unit": "bool",
         "direction": "lower_is_better",

--- a/scripts/startup_signals_log_probe.py
+++ b/scripts/startup_signals_log_probe.py
@@ -119,6 +119,32 @@ def _measure_report_allocations(*, iterations: int) -> tuple[float, float, float
     )
 
 
+def _measure_report_to_dict(*, iterations: int) -> tuple[float, float, float]:
+    report = startup_signals.StartupFailureReport(
+        classification="control_plane_crash",
+        summary="Control plane crashed before startup completed.",
+        detail="Inspect the control-plane logs for the crash cause.",
+        http_port=12436,
+        ready_probe_url="http://127.0.0.1:12436/v1/models",
+        primary_log_path="control-plane.stderr.log",
+        log_excerpt="fatal error: control plane crashed",
+    )
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    checksum = 0
+    for _ in range(5):
+        tracemalloc.start()
+        started = time.perf_counter()
+        for _ in range(iterations):
+            payload = report.to_dict()
+            checksum += int(payload["http_port"]) + len(str(payload["log_excerpt"]))
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_samples.append(float(peak))
+    return statistics.fmean(elapsed_samples), statistics.fmean(peak_samples), float(checksum)
+
+
 def main() -> int:
     iterations = 400
     samples = 5
@@ -187,6 +213,9 @@ def main() -> int:
         report_alloc_elapsed_mean, report_alloc_peak_mean, report_has_dict_mean = (
             _measure_report_allocations(iterations=iterations * 10)
         )
+        report_to_dict_elapsed_mean, report_to_dict_peak_mean, report_to_dict_checksum = (
+            _measure_report_to_dict(iterations=iterations * 100)
+        )
 
     print(
         json.dumps(
@@ -213,6 +242,9 @@ def main() -> int:
                 "report_alloc_elapsed_ms_mean": round(report_alloc_elapsed_mean, 6),
                 "report_alloc_peak_bytes_mean": round(report_alloc_peak_mean, 6),
                 "report_has_dict_mean": round(report_has_dict_mean, 6),
+                "report_to_dict_checksum": report_to_dict_checksum,
+                "report_to_dict_elapsed_ms_mean": round(report_to_dict_elapsed_mean, 6),
+                "report_to_dict_peak_bytes_mean": round(report_to_dict_peak_mean, 6),
                 "sample_count": float(samples),
                 "tail_scan_elapsed_ms_mean": round(tail_elapsed_mean, 6),
                 "tail_scan_peak_bytes_mean": round(tail_peak_mean, 6),

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -3635,6 +3635,9 @@ def test_startup_signals_probe_script_emits_metrics(capsys: pytest.CaptureFixtur
     assert payload["report_alloc_elapsed_ms_mean"] > 0
     assert payload["report_alloc_peak_bytes_mean"] > 0
     assert payload["report_has_dict_mean"] == 0.0
+    assert payload["report_to_dict_checksum"] > 0
+    assert payload["report_to_dict_elapsed_ms_mean"] > 0
+    assert payload["report_to_dict_peak_bytes_mean"] > 0
     assert payload["tail_scan_elapsed_ms_mean"] > 0
     assert payload["tail_scan_peak_bytes_mean"] > 0
     assert payload["trailing_whitespace_bytes"] == 80000.0

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -8,6 +8,7 @@ import pytest
 
 import worker.productization.startup_signals as startup_signals_module
 from worker.productization.startup_signals import (
+    StartupFailureReport,
     _read_last_nonempty_line,
     check_for_updates,
     classify_startup_failure,
@@ -248,6 +249,29 @@ def test_startup_failure_report_uses_slots_without_changing_dict_payload(tmp_pat
         "ready_probe_url": "http://127.0.0.1:11434/v1/models",
         "primary_log_path": str(control_plane_stderr),
         "log_excerpt": "fatal error: boot failed",
+    }
+
+
+def test_startup_failure_report_to_dict_uses_direct_field_snapshot() -> None:
+    report = StartupFailureReport(
+        classification="control_plane_crash",
+        summary="Control plane crashed before startup completed.",
+        detail="Inspect the control-plane logs for the crash cause.",
+        http_port=12436,
+        ready_probe_url="http://127.0.0.1:12436/v1/models",
+        primary_log_path="control-plane.stderr.log",
+        log_excerpt="fatal error: control plane crashed",
+    )
+
+    assert not hasattr(startup_signals_module, "asdict")
+    assert report.to_dict() == {
+        "classification": "control_plane_crash",
+        "summary": "Control plane crashed before startup completed.",
+        "detail": "Inspect the control-plane logs for the crash cause.",
+        "http_port": 12436,
+        "ready_probe_url": "http://127.0.0.1:12436/v1/models",
+        "primary_log_path": "control-plane.stderr.log",
+        "log_excerpt": "fatal error: control plane crashed",
     }
 
 

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 import socket
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator, Mapping
 
@@ -48,7 +48,15 @@ class StartupFailureReport:
     log_excerpt: str
 
     def to_dict(self) -> dict[str, object]:
-        return asdict(self)
+        return {
+            "classification": self.classification,
+            "summary": self.summary,
+            "detail": self.detail,
+            "http_port": self.http_port,
+            "ready_probe_url": self.ready_probe_url,
+            "primary_log_path": self.primary_log_path,
+            "log_excerpt": self.log_excerpt,
+        }
 
 
 def read_product_version(repo_root: str | Path) -> str:


### PR DESCRIPTION
## Summary
- Replace `StartupFailureReport.to_dict()`'s generic `dataclasses.asdict()` walk with an explicit scalar field snapshot.
- Extend the registered startup-signals PR-scoped probe with direct `to_dict()` timing, peak-memory, and checksum metrics.
- Add focused regression coverage proving the payload is unchanged and the generic `asdict` helper is no longer imported.

## Plan or Spec
- `docs/plans/2026-05-15-startup-failure-report-slots.md` — extended with the follow-up manual `to_dict()` snapshot slice.

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.valid.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_startup_failure_report_to_dict_uses_direct_field_snapshot services/mlx-worker-python/tests/test_startup_signals.py::test_startup_failure_report_uses_slots_without_changing_dict_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# 3 passed in 2.56s

# Registered startup-signals focused test_command from infra/perf/pr_scoped_probes.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# 39 passed in 1.82s

# Registered startup-signals coverage_command from infra/perf/pr_scoped_probes.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
# 39 passed in 2.84s; TOTAL 26 0 100%

# Registered startup-signals probe_command from infra/perf/pr_scoped_probes.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/startup_signals_log_probe.py ]; then python3 scripts/startup_signals_log_probe.py; else ...; fi'
# See Coverage and Metrics.

git diff --check
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 26 0 100%`.
- Registered probe (`startup-signals-lazy-worker-log-excerpts`, Linux/head): `report_to_dict_elapsed_ms_mean=104.230181`, `report_to_dict_peak_bytes_mean=522.4`, `report_to_dict_checksum=2494000000.0`.
- Local before/after micro comparison on the same report object: `old_asdict_elapsed_ms_mean=493.3442097622901`, `new_manual_elapsed_ms_mean=119.69557795673609`, `delta_ms=-373.64863180555403`, `speedup=4.121657777036752`, peak bytes `39191.2 -> 522.4`.
- CI PR-scoped performance report is required as the merge gate for the registered probe validation.

## Known Gaps
- Local validation is Linux-only for this Python slice; GitHub Actions remains the source of truth for the registered PR-scoped performance workflow.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
