### PR TITLE
perf: tighten OCR single-image token count clamp

### DIFF
--- a/docs/plans/2026-05-22-ocr-single-image-token-count-clamp.md
+++ b/docs/plans/2026-05-22-ocr-single-image-token-count-clamp.md
@@ -1,0 +1,26 @@
+# OCR single-image token-count clamp fast path
+
+## Goal
+
+Reduce overhead in `DeterministicOCRRuntime.prompt_token_count()` for the common OCR path: one inline image, no videos, and precomputed `preprocess_input_bytes`.
+
+## Scope
+
+- Keep OCR prompt-token semantics unchanged.
+- Touch only `services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py` and this plan.
+- Reuse the registered PR-scoped probe `deterministic-ocr-token-count-scan`.
+
+## Registered probe
+
+`infra/perf/pr_scoped_probes.json` already registers `deterministic-ocr-token-count-scan` with focused `test_command`, `coverage_command`, and `probe_command` entries. Its `probe_command` runs `scripts/deterministic_ocr_token_count_probe.py`; the primary slice metric is `elapsed_ms_mean` over repeated `prompt_token_count()` calls.
+
+## Implementation plan
+
+1. Preserve the cached whitespace prompt-token count behavior.
+2. Keep the single-image/no-video fast path based on precomputed `preprocess_input_bytes`.
+3. Replace the branchy minimum-token clamp with an expression clamp in the return path, avoiding a mutable local update on the hot path.
+4. Run the registered focused tests, changed-scope coverage, and local Linux registered probe before opening the PR.
+
+## Validation boundary
+
+This is a Python runtime slice and is locally verifiable on Linux. CI remains required for the registered PR-scoped performance report before merge.

--- a/services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py
@@ -67,11 +67,9 @@ class DeterministicOCRRuntime:
     def prompt_token_count(self, prepared_request: PreparedVisionRequest) -> int:
         images = prepared_request.images
         prompt_tokens = _whitespace_token_count(prepared_request.prompt_text)
-        if len(images) == 1 and not prepared_request.videos:
+        if not prepared_request.videos and len(images) == 1:
             input_tokens = prepared_request.preprocess_input_bytes // 8
-            if input_tokens < 1:
-                input_tokens = 1
-            return prompt_tokens + input_tokens
+            return prompt_tokens + (input_tokens if input_tokens > 0 else 1)
         image_tokens = sum(max(1, image.byte_length // 8) for image in images)
         if image_tokens:
             return prompt_tokens + image_tokens


### PR DESCRIPTION
## Summary
- Tightens the deterministic OCR single-image token-count fast path by returning the minimum image-token clamp inline.
- Keeps OCR token-count semantics unchanged while reducing the hot-path branch/local update used by `prompt_token_count()`.

## Plan or Spec
- `docs/plans/2026-05-22-ocr-single-image-token-count-clamp.md`
- Registered PR-scoped probe: `deterministic-ocr-token-count-scan` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py
exit 0; elapsed_ms_mean=149.232038; peak_bytes_mean=147.2

# Focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once
exit 0; 9 passed in 1.19s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_ocr_token_count_probe.py
exit 0; TOTAL 2 0 100%

# Registered probe after implementation (3 local samples)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py
exit 0; elapsed_ms_mean=138.441291; peak_bytes_mean=147.2
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py
exit 0; elapsed_ms_mean=142.607283; peak_bytes_mean=147.2
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py
exit 0; elapsed_ms_mean=138.744325; peak_bytes_mean=147.2

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Local Linux registered probe (`deterministic_ocr_token_count_probe.py`): baseline `elapsed_ms_mean=149.232038 ms`; post-change samples `138.441291`, `142.607283`, `138.744325 ms` (post mean `139.930966 ms`, delta `-9.301072 ms`, about `1.066x` faster). `peak_bytes_mean` stayed `147.2`.
- CI PR-scoped performance report is required before merge and is the registered probe validation source for the PR.

## Known Gaps
- Full `make py-test`/`make integration-test` not run locally; this PR uses the registered focused test, changed-scope coverage, and probe for the touched Python path.
- No protocol or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode changes; existing PR-scoped probe reused.
- [x] Deferred work and known gaps are stated explicitly.
