### PR TITLE
perf: fast path runtime utils function signatures

### DIFF
--- a/docs/plans/2026-05-22-runtime-utils-function-cache-target.md
+++ b/docs/plans/2026-05-22-runtime-utils-function-cache-target.md
@@ -1,0 +1,28 @@
+# Runtime utils function cache-target fast path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.runtime.runtime_utils._callable_cache_target()` and the hot `callable_accepts_kwarg()` path used for repeated generation/runtime capability checks.
+
+## Registered Probe
+
+The affected path is already covered by the PR-scoped probe `runtime-utils-kwarg-signature-cache` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and reports:
+
+- `elapsed_ms_mean` (lower is better)
+- `inspect_signature_calls_mean` (lower is better)
+
+## Implementation Plan
+
+1. Preserve bound-method normalization and non-introspectable callable fallback behavior.
+2. Add a plain-Python function fast path before bound-method attribute probing so the common repeated function case skips two attribute lookups per call.
+3. Slot the cached signature record to reduce per-cache-entry object overhead while preserving the frozen dataclass API.
+4. Add focused regression coverage for the plain-function cache target and slotted signature record behavior.
+5. Run the registered focused tests, changed-scope coverage, and local registered probe on Linux before opening the PR. CI PR-scoped performance remains the merge gate for base-vs-head probe validation.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_kwarg_cache_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_kwarg_cache_probe.py
+```

--- a/services/mlx-worker-python/tests/test_runtime_utils.py
+++ b/services/mlx-worker-python/tests/test_runtime_utils.py
@@ -39,12 +39,24 @@ def test_callable_kwarg_signature_caches_structured_lookup(monkeypatch: pytest.M
     assert runtime_utils.callable_accepts_kwarg(sample, "top_p") is False
     assert runtime_utils.callable_declares_kwarg(sample, "top_p") is False
     capabilities = runtime_utils.callable_kwarg_signature(sample)
+    assert not hasattr(capabilities, "__dict__")
     assert capabilities.parameter_names == ("temperature",)
     assert capabilities.keyword_accessible_params == frozenset({"temperature"})
     assert capabilities.accepts_var_keyword is False
     assert signature_calls == 1
 
     runtime_utils.clear_callable_kwarg_signature_cache()
+
+
+def test_callable_cache_target_fast_paths_plain_functions() -> None:
+    def sample(*, temperature: float = 0.0) -> None:
+        _ = temperature
+
+    sample()
+    cache_target, skip_first_parameter = runtime_utils._callable_cache_target(sample)
+
+    assert cache_target is sample
+    assert skip_first_parameter is False
 
 
 def test_callable_accepts_kwarg_caches_bound_methods_by_underlying_function(

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -7,13 +7,14 @@ import inspect
 import json
 import os
 from pathlib import Path
+from types import FunctionType
 from typing import Any
 
 
 _MODEL_WEIGHT_SUFFIXES = (".safetensors", ".npz", ".bin", ".gguf")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CallableKwargSignature:
     parameter_names: tuple[str, ...]
     keyword_accessible_params: frozenset[str]
@@ -61,6 +62,8 @@ def _callable_kwarg_signature_uncached(
 
 
 def _callable_cache_target(callable_obj: Any) -> tuple[Any, bool]:
+    if type(callable_obj) is FunctionType:
+        return callable_obj, False
     bound_function = getattr(callable_obj, "__func__", None)
     if bound_function is not None and getattr(callable_obj, "__self__", None) is not None:
         return bound_function, True


### PR DESCRIPTION
## Summary
- Add a plain `FunctionType` cache-target fast path for runtime kwarg signature checks so repeated function probes skip bound-method attribute probing.
- Slot the cached `CallableKwargSignature` record to reduce per-cache-entry object overhead without changing the frozen dataclass API.
- Add focused regression coverage for the function cache target and slotted signature snapshot.

## Plan or Spec
- `docs/plans/2026-05-22-runtime-utils-function-cache-target.md`
- Registered PR-scoped probe: `runtime-utils-kwarg-signature-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics
# 20 passed in 0.27s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_kwarg_cache_probe.py
# TOTAL 11 0 100%

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Local Linux registered probe (`scripts/runtime_utils_kwarg_cache_probe.py`, 3 process runs):
  - baseline `origin/main` elapsed means: `16.7429`, `19.2628`, `17.6202` ms; old_mean=`17.8753` ms
  - head elapsed means: `16.0574`, `15.4331`, `15.7397` ms; new_mean=`15.7434` ms
  - delta=`-2.1319` ms, speedup=`1.1354x` (`11.93%` lower)
  - `inspect_signature_calls_mean`: `1.0` before and after
- CI PR-scoped performance is required as the merge-gate validation for the registered base-vs-head probe report.

## Known Gaps
- Local verification is Linux/Python-only; no Swift runtime effect is claimed or expected for this slice.
- The PR-scoped performance workflow must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
