### PR TITLE
perf: fast path statistical percentile indexes

### DIFF
--- a/docs/plans/2026-05-22-statistical-percentile-index-fastpath.md
+++ b/docs/plans/2026-05-22-statistical-percentile-index-fastpath.md
@@ -1,0 +1,37 @@
+# Statistical Evidence Percentile Index Fast Path
+
+## Goal
+
+Reduce avoidable helper calls in the paired statistical evidence bootstrap
+percentile path without changing percentile interpolation semantics.
+
+## Scope
+
+This slice only touches `worker.productization.statistical_evidence` and the
+focused statistical evidence tests. It does not change release verdict logic,
+bootstrap sampling, category breakdown aggregation, or report schemas.
+
+## Registered Probe
+
+The affected path is covered by the PR-scoped performance probe
+`statistical-evidence-bootstrap-single-sort` in
+`infra/perf/pr_scoped_probes.json`. The probe includes a focused test command,
+coverage command, and `scripts/statistical_evidence_bootstrap_probe.py` command.
+
+## Optimization
+
+`_paired_bootstrap_interval` now builds bootstrap replicate values with a list
+comprehension before sorting them in place, avoiding the per-replicate bound
+`append` call and keeping the sum helper local while preserving the existing
+deterministic `Random.choices` sampling sequence. `_ordered_percentile` also
+derives the lower index with `int(position)` and only computes the upper value
+when interpolation is needed. This removes the paired `math.floor`/`math.ceil`
+helper calls from each percentile lookup while preserving bounded-percentile
+behavior for empty inputs, singleton inputs, integer positions, interpolated
+positions, and the upper endpoint.
+
+## Verification
+
+Run the registered probe's focused test, coverage command, and probe command on
+Linux before opening the PR. Compare the probe output against the pre-change
+baseline and rely on PR-scoped CI for the repository registered probe report.

--- a/services/mlx-worker-python/tests/test_statistical_evidence.py
+++ b/services/mlx-worker-python/tests/test_statistical_evidence.py
@@ -317,6 +317,21 @@ def test_statistical_helper_edges_cover_percentiles_and_interval_sign_fallbacks(
     assert _interval_sign({"lower_bound": -0.2, "upper_bound": 0.3, "crosses_zero": False}) == 0
 
 
+def test_ordered_percentile_computes_indexes_without_math_floor_or_ceil(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_index_helper(_: float) -> int:
+        raise AssertionError(  # pragma: no cover - must stay uncalled on the fast path
+            "ordered percentile should derive integer bounds directly"
+        )
+
+    monkeypatch.setattr(statistical_evidence_module.math, "floor", fail_index_helper)
+    monkeypatch.setattr(statistical_evidence_module.math, "ceil", fail_index_helper)
+
+    assert _ordered_percentile([0.0, 10.0, 20.0, 30.0], 0.25) == 7.5
+    assert _ordered_percentile([0.0, 10.0, 20.0, 30.0], 1.0) == 30.0
+
+
 def test_build_category_breakdown_aggregates_supported_categories_only() -> None:
     breakdown = build_category_breakdown(
         rows=(

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -161,10 +161,11 @@ def _paired_bootstrap_interval(
     sample_size = len(outcomes)
     inverse_sample_size = 1.0 / sample_size
     choices = sampler.choices
-    replicates: list[float] = []
-    append_replicate = replicates.append
-    for _ in range(bootstrap_iterations):
-        append_replicate(sum(choices(outcomes, k=sample_size)) * inverse_sample_size)
+    sum_values = sum
+    replicates = [
+        sum_values(choices(outcomes, k=sample_size)) * inverse_sample_size
+        for _ in range(bootstrap_iterations)
+    ]
 
     alpha = (1.0 - confidence_level) / 2.0
     replicates.sort()
@@ -279,13 +280,12 @@ def _ordered_percentile(ordered: list[float], percentile: float) -> float:
     if len(ordered) == 1:
         return ordered[0]
     position = bounded_percentile * (len(ordered) - 1)
-    lower_index = int(math.floor(position))
-    upper_index = int(math.ceil(position))
-    lower_value = ordered[lower_index]
-    upper_value = ordered[upper_index]
-    if lower_index == upper_index:
-        return lower_value
+    lower_index = int(position)
     fraction = position - lower_index
+    lower_value = ordered[lower_index]
+    if fraction == 0.0:
+        return lower_value
+    upper_value = ordered[lower_index + 1]
     return lower_value + (upper_value - lower_value) * fraction
 
 


### PR DESCRIPTION
## Summary
- Fast-path the statistical evidence bootstrap percentile path by building replicate values directly and avoiding `math.floor`/`math.ceil` in `_ordered_percentile`.
- Add a focused regression test that proves percentile index interpolation no longer calls the math helpers.

## Plan or Spec
- Updated `docs/plans/2026-05-22-statistical-percentile-index-fastpath.md` with the slice scope, registered probe, and verification plan.
- Registered probe already covers this path: `statistical-evidence-bootstrap-single-sort` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_bootstrap_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_bootstrap_probe.py`

## Coverage and Metrics
- Focused tests: 18 passed.
- Changed-scope coverage: 100.00% (10/10 measurable changed lines).
- Local Linux probe baseline from `origin/main` (`dd44f43b`): `elapsed_ms_mean=152.3062943480909`, `peak_bytes_mean=47153.6`, `sample_count=5`, `sample_size=320`, `bootstrap_iterations=1200`.
- Local Linux probe after change (`d5ebf912`): `elapsed_ms_mean=140.69653041660786`, `peak_bytes_mean=47131.2`, `sample_count=5`, `sample_size=320`, `bootstrap_iterations=1200`.
- Delta: `-11.60976393148303 ms` (`~7.62%` faster) with unchanged lower/upper bound means.
- CI PR-scoped performance workflow is required for the registered probe validation before merge.

## Known Gaps
- Local validation is Linux-only and covers the Python statistical evidence path. No Swift runtime effect is claimed.
- Probe timing is synthetic and should be confirmed by the registered PR-scoped performance workflow.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe command ran locally on Linux.
- [ ] GitHub Actions completed successfully, including the registered PR-scoped performance report.
