### PR TITLE
perf: avoid statistical outcome tuple copy

### DIFF
--- a/docs/plans/2026-05-05-statistical-evidence-bootstrap-single-sort.md
+++ b/docs/plans/2026-05-05-statistical-evidence-bootstrap-single-sort.md
@@ -31,6 +31,7 @@ Register `statistical-evidence-bootstrap-single-sort` in the PR-scoped performan
 - Preserve bootstrap and analytical interval payload semantics.
 - Sort bootstrap replicates once per interval instead of once per percentile bound.
 - Preserve the existing per-bootstrap equal-weight-with-replacement sampling semantics while reducing duplicate percentile work and using `random.Random.choices(...)` for the inner draw loop.
+- Reuse an already-normalized all-`float` paired-outcome tuple instead of allocating a duplicate normalization tuple on the registered bootstrap probe path; continue converting `int`, `bool`, and mixed numeric inputs through `float(...)`.
 - Changed-scope automated coverage is at least 95%.
 - Local base-vs-head probe shows lower elapsed time and/or peak traced bytes while preserving valid interval guard ordering.
 - `git diff --check` passes.

--- a/services/mlx-worker-python/tests/test_statistical_evidence.py
+++ b/services/mlx-worker-python/tests/test_statistical_evidence.py
@@ -17,6 +17,68 @@ from worker.productization.statistical_evidence import (
 )
 
 
+def test_build_paired_statistical_evidence_reuses_float_tuple_without_normalization_copy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_outcomes: list[tuple[float, ...]] = []
+    original_bootstrap_interval = statistical_evidence_module._paired_bootstrap_interval
+
+    def tracking_bootstrap_interval(**kwargs: object) -> dict[str, object]:
+        outcomes = kwargs["outcomes"]
+        assert isinstance(outcomes, tuple)
+        captured_outcomes.append(outcomes)  # type: ignore[arg-type]
+        return original_bootstrap_interval(**kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        statistical_evidence_module,
+        "_paired_bootstrap_interval",
+        tracking_bootstrap_interval,
+    )
+    outcomes = (1.0, 0.0, -1.0, 1.0)
+
+    evidence = build_paired_statistical_evidence(
+        paired_outcomes=outcomes,
+        confidence_level=0.95,
+        bootstrap_iterations=16,
+        bootstrap_seed=17,
+    )
+
+    assert captured_outcomes == [outcomes]
+    assert captured_outcomes[0] is outcomes
+    assert evidence["sample_size"] == 4
+
+
+def test_build_paired_statistical_evidence_still_normalizes_non_float_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_outcomes: list[tuple[float, ...]] = []
+    original_bootstrap_interval = statistical_evidence_module._paired_bootstrap_interval
+
+    def tracking_bootstrap_interval(**kwargs: object) -> dict[str, object]:
+        outcomes = kwargs["outcomes"]
+        assert isinstance(outcomes, tuple)
+        captured_outcomes.append(outcomes)  # type: ignore[arg-type]
+        return original_bootstrap_interval(**kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        statistical_evidence_module,
+        "_paired_bootstrap_interval",
+        tracking_bootstrap_interval,
+    )
+    outcomes = (1, True, 0.5)
+
+    evidence = build_paired_statistical_evidence(
+        paired_outcomes=outcomes,
+        confidence_level=0.95,
+        bootstrap_iterations=16,
+        bootstrap_seed=17,
+    )
+
+    assert captured_outcomes == [(1.0, 1.0, 0.5)]
+    assert captured_outcomes[0] is not outcomes
+    assert evidence["sample_size"] == 3
+
+
 def test_build_paired_statistical_evidence_reports_bootstrap_and_analytical_intervals() -> None:
     evidence = build_paired_statistical_evidence(
         paired_outcomes=(1, 1, 1, 0, 1, 1),

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -15,7 +15,7 @@ def build_paired_statistical_evidence(
     bootstrap_iterations: int,
     bootstrap_seed: int,
 ) -> dict[str, object]:
-    outcomes = tuple(float(value) for value in paired_outcomes)
+    outcomes = _normalized_outcomes(paired_outcomes)
     sample_size = len(outcomes)
     mean_value = _mean(outcomes)
     all_values_equal = bool(outcomes) and _all_values_equal(outcomes)
@@ -126,6 +126,14 @@ def build_category_breakdown(
             "delta_accuracy": rounded(target_accuracy - base_accuracy),
         }
     return breakdown
+
+
+def _normalized_outcomes(values: tuple[int | float, ...]) -> tuple[float, ...]:
+    if not values:
+        return ()
+    if all(type(value) is float for value in values):
+        return values  # type: ignore[return-value]
+    return tuple(float(value) for value in values)
 
 
 def _paired_bootstrap_interval(


### PR DESCRIPTION
## Summary
- Avoid duplicate normalization allocation in `build_paired_statistical_evidence(...)` when callers already pass an all-`float` paired-outcome tuple.
- Preserve the existing `float(...)` normalization path for ints, bools, and mixed numeric inputs.
- Add regression coverage that proves the float-tuple fast path reuses the input object and mixed inputs are still normalized.

## Plan or Spec
- `docs/plans/2026-05-05-statistical-evidence-bootstrap-single-sort.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics
# 19 passed in 0.71s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_bootstrap_probe.py
# 19 passed; changed-scope TOTAL 35 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_bootstrap_probe.py
# head samples: elapsed_ms_mean 134.5269, 133.7257, 140.3437; peak_bytes_mean 44635.2 each

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id statistical-evidence-bootstrap-single-sort --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-stat-evidence-base-20260522201636 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-cron-python-slice-20260522201636 --output /tmp/stat-evidence-pr-probe.json
# head verification ok; base elapsed_ms_mean=146.8272, head elapsed_ms_mean=137.8769; base peak_bytes_mean=47153.6, head peak_bytes_mean=44635.2

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 35 0 100%`).
- Registered probe: `statistical-evidence-bootstrap-single-sort` has focused `test_command`, `coverage_command`, and `probe_command` entries and covers the touched path.
- Local registered base-vs-head probe: `elapsed_ms_mean` 146.8272 ms -> 137.8769 ms (`-8.9502 ms`, ~6.10% faster); `peak_bytes_mean` 47153.6 -> 44635.2 bytes (`-2518.4 bytes`, ~5.34% lower); `sorted_calls_mean` unchanged at 0.0.
- Three repeated direct head probe samples: mean of `elapsed_ms_mean` 136.1988 ms; mean peak 44635.2 bytes. Earlier base samples averaged 149.1204 ms and 47208.0 bytes.

## Known Gaps
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally; this is a focused Python performance slice on Linux.
- GitHub Actions PR-scoped performance workflow is required as the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; runtime observability changes N/A.
- [x] Deferred work and known gaps are stated explicitly.
