### PR TITLE
perf: guard statistical evidence equality scan

### DIFF
--- a/docs/plans/2026-05-22-statistical-evidence-endpoint-equality-guard.md
+++ b/docs/plans/2026-05-22-statistical-evidence-endpoint-equality-guard.md
@@ -1,0 +1,51 @@
+# Statistical Evidence Endpoint Equality Guard
+
+## Scope
+
+This Python-only performance slice is limited to the paired-outcome equality
+classification path in
+`services/mlx-worker-python/worker/productization/statistical_evidence.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`statistical-evidence-bootstrap-single-sort` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for the
+statistical evidence implementation, focused tests, PR-scoped performance tests,
+and `scripts/statistical_evidence_bootstrap_probe.py`.
+
+## Change
+
+Before running the full constant-outcome scan, `build_paired_statistical_evidence`
+now checks the first and last normalized outcomes. If those endpoints differ, the
+sample cannot be constant, so the helper skips the full equality walk and passes
+`all_values_equal=False` into both interval builders. Constant and singleton
+samples keep the existing short-circuit behavior.
+
+## Verification plan
+
+1. Run the registered focused statistical-evidence tests locally on Linux.
+2. Run changed-scope coverage for the touched source, focused tests, registry
+   tests, and probe script.
+3. Run the registered local Linux probe against `origin/main` and the branch.
+4. Use GitHub Actions PR-scoped performance as the final registered probe gate
+   before merge.
+
+## Local evidence
+
+Baseline `origin/main` registered probe, three runs:
+
+- `elapsed_ms_mean`: 143.597, 147.072, 139.525 ms (mean 143.398 ms)
+- `peak_bytes_mean`: 44553.6, 44635.2, 44635.2 bytes
+- `sorted_calls_mean`: 0.0
+
+Branch registered probe, three runs:
+
+- `elapsed_ms_mean`: 135.225, 137.518, 137.300 ms (mean 136.681 ms)
+- `peak_bytes_mean`: 44635.2, 44635.2, 44635.2 bytes
+- `sorted_calls_mean`: 0.0
+
+The local Linux registered probe shows a 6.717 ms mean reduction, roughly 4.7%
+faster for the mixed-outcome probe workload, with unchanged sorted-call count and
+stable peak allocation within the probe tolerance.

--- a/services/mlx-worker-python/tests/test_statistical_evidence.py
+++ b/services/mlx-worker-python/tests/test_statistical_evidence.py
@@ -295,6 +295,28 @@ def test_build_paired_statistical_evidence_reuses_constant_scan_between_interval
     assert evidence["analytical"]["upper_bound"] == 1.0
 
 
+def test_build_paired_statistical_evidence_skips_equality_scan_when_endpoints_differ(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        statistical_evidence_module,
+        "_all_values_equal",
+        lambda values: (_ for _ in ()).throw(
+            AssertionError(f"unexpected full equality scan for {len(values)} values")
+        ),
+    )
+
+    evidence = build_paired_statistical_evidence(
+        paired_outcomes=(1.0, 1.0, 0.0),
+        confidence_level=0.95,
+        bootstrap_iterations=16,
+        bootstrap_seed=17,
+    )
+
+    assert evidence["sample_size"] == 3
+    assert evidence["bootstrap"]["lower_bound"] < evidence["bootstrap"]["upper_bound"]
+
+
 def test_constant_outcome_detection_avoids_tail_slice_allocation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -18,7 +18,7 @@ def build_paired_statistical_evidence(
     outcomes = _normalized_outcomes(paired_outcomes)
     sample_size = len(outcomes)
     mean_value = _mean(outcomes)
-    all_values_equal = bool(outcomes) and _all_values_equal(outcomes)
+    all_values_equal = _outcome_values_equal(outcomes)
     delta_accuracy = _rounded(mean_value)
     bootstrap_interval = _paired_bootstrap_interval(
         outcomes=outcomes,
@@ -184,6 +184,16 @@ def _paired_bootstrap_interval(
         iterations=int(bootstrap_iterations),
         seed=int(bootstrap_seed),
     )
+
+
+def _outcome_values_equal(values: tuple[float, ...]) -> bool:
+    if not values:
+        return False
+    if len(values) == 1:
+        return True
+    if values[0] != values[-1]:
+        return False
+    return _all_values_equal(values)
 
 
 def _all_values_equal(values: tuple[float, ...]) -> bool:


### PR DESCRIPTION
## Summary
- Add an endpoint guard before the statistical evidence constant-outcome scan.
- Skip the full equality walk when the first and last normalized outcomes differ, while preserving constant and singleton short-circuit behavior.
- Add focused regression coverage for the skipped-scan path.

## Plan or Spec
- `docs/plans/2026-05-22-statistical-evidence-endpoint-equality-guard.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics
# 20 passed in 0.14s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics
# 20 passed in 0.22s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_bootstrap_probe.py
# TOTAL 14 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_bootstrap_probe.py
# origin/main runs: elapsed_ms_mean=143.597, 147.072, 139.525 ms
# branch runs: elapsed_ms_mean=135.225, 137.518, 137.300 ms

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Registered probe: `statistical-evidence-bootstrap-single-sort` is already registered in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.
- Local Linux registered probe delta: old_mean=143.398 ms, new_mean=136.681 ms, delta=-6.717 ms, speedup=4.7%.
- `sorted_calls_mean` remained `0.0`; peak allocation stayed within probe tolerance.
- CI PR-scoped performance report is required as the final registered-probe validation before merge.

## Known Gaps
- Full repository gates were not run locally; this slice used the registered focused statistical-evidence gate.
- Local validation covers the Python path on Linux only.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
