### PR TITLE
perf: trim changed-scope diff marker parsing

### DIFF
--- a/docs/plans/2026-05-22-changed-scope-diff-parser-fast-marker.md
+++ b/docs/plans/2026-05-22-changed-scope-diff-parser-fast-marker.md
@@ -1,0 +1,53 @@
+# Changed-scope coverage diff marker fast path
+
+## Scope
+
+This slice keeps the changed-scope coverage behavior unchanged and only trims the
+hot diff-parser loop in `scripts/changed_scope_coverage.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.
+That probe already declares focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `scripts/changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_parse_probe.py`
+- `tests/test_changed_scope_coverage.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Change
+
+`_parse_changed_lines()` now binds `changed_by_path.setdefault` once before the
+loop and treats any diff line beginning with `\` as a metadata marker. Git emits
+these marker lines outside the old/new line streams (for example `\ No newline
+at end of file`), so skipping them directly avoids an extra `startswith()` call
+without changing added-line accounting.
+
+## Local evidence
+
+Baseline registered probe (`changed-scope-coverage-diff-parser`), three runs:
+
+- `elapsed_ms_mean=3.435669932514429`
+- `elapsed_ms_mean=2.9468576540239155`
+- `elapsed_ms_mean=3.06025294897457`
+
+Updated registered probe, three runs:
+
+- `elapsed_ms_mean=3.4006948311192295`
+- `elapsed_ms_mean=2.908959499715517`
+- `elapsed_ms_mean=2.921043293705831`
+
+Mean-of-means moved from `3.147593511837636` ms to `3.076899208846527` ms
+(`-0.070694302991109` ms, about `2.25%` faster). The probe output preserved
+`file_count=240` and `changed_line_count=7680`.
+
+## Verification
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py`
+- Registered probe command from `changed-scope-coverage-diff-parser`
+
+## Boundaries
+
+This is a Linux-local Python tooling slice. No Swift runtime behavior is changed.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -49,6 +49,7 @@ def _parse_hunk_new_start(line: str) -> int | None:
 
 def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     changed_by_path: dict[str, set[int]] = {}
+    changed_by_path_setdefault = changed_by_path.setdefault
     header_prefix = _DIFF_HEADER_PREFIX
     header_separator = _DIFF_HEADER_SEPARATOR
     header_prefix_len = len(header_prefix)
@@ -66,7 +67,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
             add_changed_line = None
             if separator_index >= 0:
                 current_path = line[separator_index + header_separator_len :]
-                add_changed_line = changed_by_path.setdefault(current_path, set()).add
+                add_changed_line = changed_by_path_setdefault(current_path, set()).add
             new_line = None
             continue
         if first_char == "@" and len(line) > 1 and line[1] == "@":
@@ -78,7 +79,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
             continue
         if add_changed_line is None or new_line is None:
             continue
-        if first_char == "\\" and line.startswith("\\ "):
+        if first_char == "\\":
             continue
         if first_char == "+":
             add_changed_line(new_line)


### PR DESCRIPTION
## Summary
- Trim the changed-scope coverage diff parser hot loop by binding `setdefault` once.
- Treat diff metadata marker lines beginning with `\\` as marker lines directly, avoiding an extra `startswith()` check in the per-line parser loop.

## Plan or Spec
- Updated `docs/plans/2026-05-22-changed-scope-diff-parser-fast-marker.md` with scope, registered probe, local baseline/new metrics, and Linux verification boundary.
- Registered probe coverage: `changed-scope-coverage-diff-parser` already covers `scripts/changed_scope_coverage.py` and declares focused test, coverage, and probe commands in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py`
- Registered `changed-scope-coverage-diff-parser` test command from `infra/perf/pr_scoped_probes.json`
- Registered `changed-scope-coverage-diff-parser` coverage command from `infra/perf/pr_scoped_probes.json`
- Registered `changed-scope-coverage-diff-parser` probe command from `infra/perf/pr_scoped_probes.json` (baseline and updated runs)
- `git diff --check`

## Coverage and Metrics
- Focused tests: `27 passed in 0.13s`
- Registered focused tests: `31 passed in 0.82s`
- Registered coverage command: `31 passed in 0.47s`; changed-scope coverage reported `TOTAL 0 0 100%`
- Baseline probe mean-of-means: `3.147593511837636 ms` from `3.435669932514429`, `2.9468576540239155`, `3.06025294897457`
- Updated probe mean-of-means: `3.076899208846527 ms` from `3.4006948311192295`, `2.908959499715517`, `2.921043293705831`
- Delta: `-0.070694302991109 ms`, about `2.25%` faster; final registered probe run after coverage: `elapsed_ms_mean=3.0256747462165854`, `file_count=240`, `changed_line_count=7680`

## Known Gaps
- This is a Linux-local Python tooling slice; no Swift runtime path is changed.
- The optimization is intentionally small and benchmarked through the registered synthetic diff parser probe.
- GitHub Actions PR-scoped performance report is required before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered probe includes focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage command passed.
- [x] Registered probe shows a positive local delta.
- [ ] GitHub Actions checks completed successfully.
- [ ] PR-scoped performance workflow completed successfully.
