### PR TITLE
perf: trim response boundary construction

### DIFF
--- a/docs/plans/2026-05-22-response-boundary-custom-init.md
+++ b/docs/plans/2026-05-22-response-boundary-custom-init.md
@@ -1,0 +1,28 @@
+# Response-only Boundary Custom Init Fast Path
+
+## Scope
+
+This Python-only performance slice touches only the `ResponseOnlyBoundary` record construction path in `services/mlx-worker-python/worker/model_ops/response_only_boundary.py`.
+
+## Rationale
+
+The registered `response-only-boundary-slotted-records` probe spends a measurable share of time constructing many frozen, slotted `ResponseOnlyBoundary` records before aggregation. The generated frozen dataclass initializer performs repeated generic frozen-assignment setup. A tiny hand-written initializer can keep the same frozen/slotted dataclass semantics while binding `object.__setattr__` once and assigning the two fields directly.
+
+## Implementation
+
+- Keep `ResponseOnlyBoundary` as a frozen, slotted dataclass.
+- Disable the generated initializer with `init=False`.
+- Add a minimal initializer that assigns `assistant_offset` and `total_tokens` through a module-level bound `object.__setattr__`.
+- Do not change aggregate semantics, manifest field names, or truncation behavior.
+
+## Validation
+
+The registered PR-scoped probe `response-only-boundary-slotted-records` covers this path and includes focused tests, changed-scope coverage, and `scripts/response_only_boundary_slots_probe.py` metrics.
+
+Local Linux validation for this slice must run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_without_limit_updates_running_bounds services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_without_limit_updates_running_bounds services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/response_only_boundary.py services/mlx-worker-python/tests/test_response_only_boundary.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/response_only_boundary_slots_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/response_only_boundary_slots_probe.py
+```

--- a/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
+++ b/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
@@ -17,6 +17,9 @@ from dataclasses import dataclass
 from typing import Any, Iterable, Protocol, runtime_checkable
 
 
+_SET_FROZEN_ATTR = object.__setattr__
+
+
 @runtime_checkable
 class _ChatTemplateTokenizer(Protocol):
     """Minimal tokenizer surface we depend on.
@@ -40,12 +43,21 @@ class _ChatTemplateTokenizer(Protocol):
         ...
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, init=False)
 class ResponseOnlyBoundary:
     """Per-sample response-only boundary record persisted in the manifest."""
 
     assistant_offset: int
     total_tokens: int
+
+    def __init__(
+        self,
+        assistant_offset: int,
+        total_tokens: int,
+        _set_attr: Any = _SET_FROZEN_ATTR,
+    ) -> None:
+        _set_attr(self, "assistant_offset", assistant_offset)
+        _set_attr(self, "total_tokens", total_tokens)
 
     @property
     def response_tokens(self) -> int:


### PR DESCRIPTION
## Summary
- Adds a minimal hand-written initializer for `ResponseOnlyBoundary` while preserving frozen/slotted dataclass semantics.
- Keeps aggregation, manifest fields, and truncation behavior unchanged.
- Uses the existing registered PR-scoped probe `response-only-boundary-slotted-records` for validation.

## Plan or Spec
- `docs/plans/2026-05-22-response-boundary-custom-init.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_without_limit_updates_running_bounds services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` → 9 passed, 1 skipped
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/response_only_boundary.py services/mlx-worker-python/tests/test_response_only_boundary.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/response_only_boundary_slots_probe.py` → TOTAL 5 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/response_only_boundary_slots_probe.py` → repeated locally for baseline/head comparison
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`services/mlx-worker-python/worker/model_ops/response_only_boundary.py` changed lines 20, 46, 53, 59, 60 all covered).
- Baseline probe samples from `origin/main`:
  - construction mean samples: 121.206 ms, 129.776 ms, 125.581 ms (mean 125.521 ms)
  - aggregation mean samples: 253.284 ms, 258.761 ms, 255.746 ms (mean 255.930 ms)
- Head probe samples from this branch:
  - construction mean samples: 123.646 ms, 120.120 ms, 120.521 ms (mean 121.429 ms; delta -4.092 ms, ~3.26% faster)
  - aggregation mean samples: 264.857 ms, 259.916 ms, 264.066 ms (mean 262.946 ms; delta +7.016 ms, ~2.74% slower/noise on unchanged aggregation loop)
- Registered CI probe validation is required before merge: `response-only-boundary-slotted-records`.

## Known Gaps
- Linux local validation covers Python behavior and probe metrics only.
- The unchanged aggregation-loop metric showed local run-to-run noise and must be checked against the registered CI probe report before merging.

## Evidence Checklist
- [x] Registered PR-scoped probe exists for the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage reached 100% locally.
- [x] Local registered probe ran with baseline/head evidence.
- [ ] GitHub Actions completed successfully.
- [ ] Registered PR-scoped performance report completed successfully.
