### PR TITLE
perf: avoid text family metadata copy

### DIFF
--- a/docs/plans/2026-05-23-text-family-metadata-no-copy.md
+++ b/docs/plans/2026-05-23-text-family-metadata-no-copy.md
@@ -1,0 +1,15 @@
+# Text family metadata mapping no-copy slice
+
+## Scope
+
+Optimize the registered `text-family-config-copy-elision` Python path by avoiding an eager `dict()` copy of the `metadata` mapping in `resolve_text_family_config`.
+
+## Constraints
+
+- Preserve read-only mapping semantics; `resolve_text_family_config` must not mutate caller-provided metadata.
+- Keep the existing config mapping no-copy behavior intact.
+- Validate through the registered PR-scoped probe entry in `infra/perf/pr_scoped_probes.json`.
+
+## Evidence target
+
+Run focused text-family tests, changed-scope coverage, and `scripts/text_family_config_probe.py` locally on Linux. Accept only if the probe shows lower `elapsed_ms_mean` and lower or unchanged peak bytes versus `origin/main`, then rely on CI's registered PR-scoped performance report for final gate evidence.

--- a/services/mlx-worker-python/tests/test_text_family_adapters.py
+++ b/services/mlx-worker-python/tests/test_text_family_adapters.py
@@ -290,6 +290,31 @@ def test_inferred_expert_count_preserves_config_before_family_default() -> None:
     assert _inferred_expert_count({}, default=128) == 128
 
 
+def test_resolve_text_family_config_reads_metadata_mapping_without_copying() -> None:
+    metadata = _CopyCountingConfig(
+        {
+            **{f"unused_{index}": str(index) for index in range(512)},
+            "text_family_id": "qwen3moe",
+            "melix.capability.route_kind": "python_text_compatibility",
+            "tool_parser_namespaces": "tools.text, tools.vision",
+        }
+    )
+
+    resolved = resolve_text_family_config(
+        metadata,  # type: ignore[arg-type]
+        model_path="models/qwen3-moe-128e",
+        config_payload={"model_type": "qwen3_moe"},
+        default_route_kind="swift_text",
+    )
+
+    assert resolved.family_id == "qwen3moe"
+    assert resolved.route_kind == "python_text_compatibility"
+    assert resolved.tool_parser_namespaces == ("tools.text", "tools.vision")
+    assert metadata.copy_attempts == 0
+    assert dict(metadata)["text_family_id"] == "qwen3moe"
+    assert metadata.copy_attempts == 1
+
+
 def test_resolve_text_family_config_reads_config_mapping_without_copying() -> None:
     config = _CopyCountingConfig(
         {

--- a/services/mlx-worker-python/worker/runtime/text_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/text_family_adapters.py
@@ -232,7 +232,7 @@ def resolve_text_family_config(
     config_payload: Mapping[str, Any] | None = None,
     default_route_kind: str = "swift_text",
 ) -> ResolvedTextFamilyConfig:
-    metadata = dict(metadata or {})
+    metadata = metadata or _EMPTY_CONFIG_PAYLOAD
     detection = detect_text_family_identity(
         model_path=model_path,
         config_payload=config_payload,


### PR DESCRIPTION
## Summary
- Avoid an eager `dict()` copy of the `metadata` mapping in `resolve_text_family_config`.
- Add a regression test proving custom metadata mappings are read without copy attempts while preserving existing resolution behavior.

## Plan or Spec
- `docs/plans/2026-05-23-text-family-metadata-no-copy.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics
# 18 passed in 2.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/text_family_adapters.py services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/text_family_config_probe.py
# 18 passed; TOTAL 10 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py
# repeated on origin/main and branch; see metrics below
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Registered local probe: `scripts/text_family_config_probe.py` (`text-family-config-copy-elision`).
- Local Linux probe comparison, 5 repeated process samples:
  - old_mean=313.447449 ms
  - new_mean=311.092881 ms
  - delta_ms=-2.354568 ms
  - speedup=1.007569x
  - peak_bytes_mean: 3756.2 -> 1274.6 bytes
- CI PR-scoped performance report is required for final registered-probe validation before merge.

## Known Gaps
- None for the Python slice. No Swift/macOS runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
