### PR TITLE
perf: cache event similarity bigram totals

### DIFF
--- a/docs/plans/2026-05-23-event-similarity-bigram-total-cache.md
+++ b/docs/plans/2026-05-23-event-similarity-bigram-total-cache.md
@@ -1,0 +1,35 @@
+# Event similarity bigram total cache
+
+## Goal
+
+Reduce repeated semantic event similarity scoring overhead by caching each normalized string's character-bigram total alongside the already cached bigram item tuple.
+
+## Scope
+
+This Python-only performance slice is limited to:
+
+- `services/mlx-worker-python/worker/productization/event_extraction.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+
+It preserves existing string similarity semantics and does not change event extraction prompts, scoring thresholds, protobuf schemas, or dependencies.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `event-extraction-alignment-accepted-edge-cache` in `infra/perf/pr_scoped_probes.json`. Its probe script includes `similarity_elapsed_ms_mean`, which exercises repeated `_string_similarity()` calls over deterministic text pairs.
+
+## Proposed Change
+
+1. Add a cached `_character_bigram_stats()` helper that returns both bigram items and their total count.
+2. Make `_bigram_dice()` consume the cached total instead of summing cached item tuples on every comparison.
+3. Keep `_character_bigram_items()` for compatibility by returning the item portion from the stats helper.
+4. Extend the focused event extraction test to assert the new cached stats helper matches the existing bigram output.
+
+## Verification
+
+- Focused event extraction test covering string similarity cache behavior.
+- Registered probe commands for `event-extraction-alignment-accepted-edge-cache`, including focused tests, changed-scope coverage, and local Linux probe metrics.
+- `git diff --check`.
+
+## Linux Boundary
+
+This is a Python worker change and is locally verifiable on Linux. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -285,6 +285,7 @@ def test_string_similarity_reuses_normalized_text_and_bigram_counts() -> None:
     event_extraction_module._string_similarity.cache_clear()
     event_extraction_module._normalize_similarity_text.cache_clear()
     event_extraction_module._character_bigram_items.cache_clear()
+    event_extraction_module._character_bigram_stats.cache_clear()
 
     assert event_extraction_module._normalize_similarity_text(" Delivered-SUPPLY, CRATE! ") == "deliveredsupplycrate"
     first = event_extraction_module._string_similarity("Delivered supply crate", "delivered supply crates")
@@ -297,6 +298,7 @@ def test_string_similarity_reuses_normalized_text_and_bigram_counts() -> None:
     assert first > 0.9
     assert third > 0.9
     assert event_extraction_module._string_similarity.cache_info().hits >= 2
+    assert event_extraction_module._character_bigram_stats("aba") == ((("ab", 1), ("ba", 1)), 2)
     assert event_extraction_module._character_bigrams("aba") == {"ab": 1, "ba": 1}
 
 

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2200,8 +2200,8 @@ def _is_group_actor_alias(value: str) -> bool:
 
 
 def _bigram_dice(left: str, right: str) -> float:
-    left_units = _character_bigram_items(left)
-    right_units = _character_bigram_items(right)
+    left_units, left_total = _character_bigram_stats(left)
+    right_units, right_total = _character_bigram_stats(right)
     if not left_units or not right_units:
         return 0.0
     overlap = 0
@@ -2211,10 +2211,7 @@ def _bigram_dice(left: str, right: str) -> float:
         overlap += matched
         if matched:
             remaining[unit] = remaining.get(unit, 0) - matched
-    return _safe_divide(
-        2.0 * overlap,
-        sum(count for _unit, count in left_units) + sum(count for _unit, count in right_units),
-    )
+    return _safe_divide(2.0 * overlap, left_total + right_total)
 
 
 def _character_bigrams(value: str) -> dict[str, int]:
@@ -2223,13 +2220,19 @@ def _character_bigrams(value: str) -> dict[str, int]:
 
 @lru_cache(maxsize=4096)
 def _character_bigram_items(value: str) -> tuple[tuple[str, int], ...]:
+    return _character_bigram_stats(value)[0]
+
+
+@lru_cache(maxsize=4096)
+def _character_bigram_stats(value: str) -> tuple[tuple[tuple[str, int], ...], int]:
     if len(value) <= 1:
-        return ((value, 1),) if value else ()
+        return (((value, 1),), 1) if value else ((), 0)
     counts: dict[str, int] = {}
-    for index in range(len(value) - 1):
+    total = len(value) - 1
+    for index in range(total):
         unit = value[index : index + 2]
         counts[unit] = counts.get(unit, 0) + 1
-    return tuple(counts.items())
+    return tuple(counts.items()), total
 
 
 def _accepted_event_matching_edges(


### PR DESCRIPTION
## Summary
- Cache each normalized event-similarity string's bigram total alongside its cached bigram items.
- Reuse the cached total in Dice scoring to avoid summing cached item tuples on repeated `_string_similarity()` calls.
- Preserve `_character_bigram_items()` and existing similarity semantics.

## Plan or Spec
- `docs/plans/2026-05-23-event-similarity-bigram-total-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_uses_global_optimum_not_greedy services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_precomputes_only_accepted_sparse_edges services/mlx-worker-python/tests/test_event_extraction.py::test_string_similarity_reuses_normalized_text_and_bigram_counts services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_reuses_alignment_payloads_for_matched_details services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_alignment_probe_script_emits_metrics
# 7 passed in 1.35s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_uses_global_optimum_not_greedy services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_precomputes_only_accepted_sparse_edges services/mlx-worker-python/tests/test_event_extraction.py::test_string_similarity_reuses_normalized_text_and_bigram_counts services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_reuses_alignment_payloads_for_matched_details services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_alignment_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_alignment_probe.py
# 7 passed in 0.52s; changed-scope coverage TOTAL 9 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_alignment_probe.py
# Ran locally on base and head, 3 samples each; metrics summarized below.

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`9/9` measurable changed lines covered).
- Registered probe: `event-extraction-alignment-accepted-edge-cache`.
- Local Linux probe comparison, 3 runs each:
  - `similarity_elapsed_ms_mean`: base mean `1.9130 ms`, head mean `1.8873 ms`, delta `-0.0258 ms` (`-1.35%`).
  - `elapsed_ms_mean`: base mean `2212.8896 ms`, head mean `2189.6114 ms`, delta `-23.2782 ms` (`-1.05%`).
- CI PR-scoped performance report is required before merge and is expected to validate the registered probe on GitHub Actions.

## Known Gaps
- No Swift runtime validation claimed; this is a Python-only event extraction scoring slice.
- Local probe deltas are small and noisy, so CI registered probe status remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
