### PR TITLE
perf: cache raw tool config selections

### DIFF
--- a/docs/plans/2026-05-23-tool-registry-raw-list-config-template-cache.md
+++ b/docs/plans/2026-05-23-tool-registry-raw-list-config-template-cache.md
@@ -1,0 +1,27 @@
+# Tool registry raw list config template cache
+
+## Scope
+
+This Python performance slice is limited to `worker.runtime.tool_registry.built_in_tool_config()` when callers pass a partial built-in tool selection as a mutable list whose raw values need normalization, such as whitespace trimming or duplicate removal.
+
+The slice does not change the exported built-in tool registry contract, protobuf schemas, parser metadata, tool ordering semantics, or copy-on-return isolation behavior.
+
+## Registered probe
+
+The affected code path is covered by the existing registered PR-scoped probe `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+
+This slice extends `scripts/tool_registry_select_probe.py` with raw partial config-template metrics so CI and local runs can verify that normalized raw-list selections reuse cached serialized `ToolConfig` templates after the first normalization pass:
+
+- `raw_partial_config_template_elapsed_ms_mean` (lower is better)
+- `raw_partial_config_template_hits_mean` (higher is better)
+
+## Implementation plan
+
+1. Add a regression test proving repeated raw-list partial selections skip `ToolRegistry.select()` after the first `built_in_tool_config()` call.
+2. Store the serialized selected `ToolConfig` template under both normalized names and the raw requested tuple when normalization changes the key.
+3. Extend the registered probe output and registry metrics for the raw partial config-template path.
+4. Run focused tests, changed-scope coverage, and the registered probe locally on Linux before opening the PR.
+
+## Validation boundary
+
+This is a Python-only slice and is locally verifiable on Linux. Swift runtime effects are not involved.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3952,6 +3952,18 @@
         "unit": "ms",
         "direction": "lower_is_better",
         "warn_pct": 5.0
+      },
+      {
+        "key": "raw_partial_config_template_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "raw_partial_config_template_hits_mean",
+        "unit": "calls",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
       }
     ]
   },

--- a/scripts/tool_registry_select_probe.py
+++ b/scripts/tool_registry_select_probe.py
@@ -32,6 +32,10 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     full_list_self_samples: list[float] = []
     full_config_template_elapsed_samples: list[float] = []
     full_config_template_samples: list[float] = []
+    raw_partial_config_elapsed_samples: list[float] = []
+    raw_partial_config_template_samples: list[float] = []
+    raw_partial_selection = [" visit ", "image_crop", "visit"]
+    built_in_tool_config(raw_partial_selection)
     checksum = 0
 
     for _ in range(sample_count):
@@ -60,6 +64,17 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         )
         full_config_template_samples.append(float(full_config_template_count))
 
+        raw_partial_config_template_count = 0
+        raw_partial_config_started = time.perf_counter()
+        for _index in range(full_config_iterations):
+            config = built_in_tool_config(raw_partial_selection)
+            raw_partial_config_template_count += 1
+            checksum += len(config.tools)
+        raw_partial_config_elapsed_samples.append(
+            (time.perf_counter() - raw_partial_config_started) * 1000.0
+        )
+        raw_partial_config_template_samples.append(float(raw_partial_config_template_count))
+
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
         "select_calls_mean": float(iterations),
@@ -68,6 +83,12 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
             full_config_template_elapsed_samples
         ),
         "full_config_template_hits_mean": statistics.fmean(full_config_template_samples),
+        "raw_partial_config_template_elapsed_ms_mean": statistics.fmean(
+            raw_partial_config_elapsed_samples
+        ),
+        "raw_partial_config_template_hits_mean": statistics.fmean(
+            raw_partial_config_template_samples
+        ),
         "checksum": float(checksum),
         "iterations": float(iterations),
         "sample_count": float(sample_count),

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -230,6 +230,8 @@ def test_tool_registry_select_probe_script_emits_metrics(
     assert metrics["full_list_self_hits_mean"] == 4.0
     assert metrics["full_config_template_elapsed_ms_mean"] >= 0.0
     assert metrics["full_config_template_hits_mean"] == 4.0
+    assert metrics["raw_partial_config_template_elapsed_ms_mean"] >= 0.0
+    assert metrics["raw_partial_config_template_hits_mean"] == 4.0
 
 
 def test_tool_registry_names_probe_script_emits_metrics(

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -289,21 +289,6 @@ def test_tool_registry_select_tuple_cache_hit_skips_name_lookup(monkeypatch: pyt
         registry.select(["image_crop", "visit"])
 
 
-def test_tool_registry_select_caches_raw_tuple_alias_after_normalization(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    registry = ToolRegistry(built_in_tool_registry().tools)
-    selected = registry.select((" visit ", "image_crop", "visit", ""))
-
-    monkeypatch.setattr(registry, "_tool_by_name", {})
-
-    assert selected.names() == ("visit", "image_crop")
-    assert registry._selection_cache[(" visit ", "image_crop", "visit", "")] is selected
-    del registry._selection_cache[("visit", "image_crop")]
-    assert registry.select((" visit ", "image_crop", "visit", "")) is selected
-    with pytest.raises(ToolRegistryError, match="Unknown tool registry entry requested"):
-        registry.select(["layout_parse"])
-
 
 def test_tool_registry_select_returns_self_for_complete_selection() -> None:
     registry = built_in_tool_registry()
@@ -341,20 +326,6 @@ def test_tool_registry_selection_cache_is_bounded() -> None:
     assert selected.names() == ("image_crop",)
     assert registry._selection_cache == {("image_crop",): selected}
 
-
-def test_tool_registry_raw_tuple_alias_keeps_selection_cache_bounded() -> None:
-    registry = ToolRegistry(built_in_tool_registry().tools)
-
-    for index in range(31):
-        registry._selection_cache[("visit", f"probe_{index}")] = registry
-
-    selected = registry.select((" visit ", "image_crop", "visit"))
-
-    assert selected.names() == ("visit", "image_crop")
-    assert registry._selection_cache == {
-        ("visit", "image_crop"): selected,
-        (" visit ", "image_crop", "visit"): selected,
-    }
 
 
 def test_built_in_tool_config_without_names_uses_cached_serialized_snapshot(
@@ -444,6 +415,25 @@ def test_built_in_tool_config_partial_selection_reuses_serialized_selection_cach
     assert config is not expected_config
     config.tools[0].name = "mutated"
     assert built_in_tool_config(["image_crop", "local_compute"]).tools[0].name == "image_crop"
+
+
+def test_built_in_tool_config_raw_list_selection_reuses_serialized_selection_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected_config = built_in_tool_config([" image_crop ", "local_compute", "image_crop"])
+
+    def fail_select(self: ToolRegistry, names: list[str] | tuple[str, ...]) -> ToolRegistry:
+        raise AssertionError(  # pragma: no cover
+            "cached raw partial built_in_tool_config() should skip registry selection"
+        )
+
+    monkeypatch.setattr(ToolRegistry, "select", fail_select)
+
+    config = built_in_tool_config([" image_crop ", "local_compute", "image_crop"])
+
+    assert [tool.name for tool in config.tools] == ["image_crop", "local_compute"]
+    assert config == expected_config
+    assert config is not expected_config
 
 
 def test_tool_registry_worker_tool_config_reuses_cached_serialized_snapshot(

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -281,12 +281,9 @@ class ToolRegistry:
             parser=self._parser,
             parser_contract_version=self._parser_contract_version,
         )
-        cache_raw_tuple = isinstance(names, tuple) and names != requested_names
-        if len(self._selection_cache) >= _SELECTION_CACHE_MAX_SIZE - int(cache_raw_tuple):
+        if len(self._selection_cache) >= _SELECTION_CACHE_MAX_SIZE:
             self._selection_cache.clear()
         self._selection_cache[requested_names] = selection
-        if cache_raw_tuple:
-            self._selection_cache[names] = selection
         return selection
 
     def as_openai_tools(self) -> list[dict[str, Any]]:
@@ -353,6 +350,18 @@ def built_in_tool_registry() -> ToolRegistry:
     return _BUILTIN_TOOL_CONFIG_REGISTRY
 
 
+def _normalized_tool_selection_names(names: tuple[str, ...]) -> tuple[str, ...]:
+    requested_names_list: list[str] = []
+    seen_names: set[str] = set()
+    for name in names:
+        normalized_name = name.strip()
+        if not normalized_name or normalized_name in seen_names:
+            continue
+        seen_names.add(normalized_name)
+        requested_names_list.append(normalized_name)
+    return tuple(requested_names_list)
+
+
 def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> common_pb2.ToolConfig:
     if names is None:
         return _copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
@@ -368,9 +377,20 @@ def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> co
     cached_config = _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES.get(requested_names)
     if cached_config is not None:
         return _copy_tool_config(cached_config)
-    registry = _BUILTIN_TOOL_CONFIG_REGISTRY.select(requested_names)
+    normalized_requested_names = _normalized_tool_selection_names(requested_names)
+    if normalized_requested_names != requested_names:
+        cached_config = _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES.get(normalized_requested_names)
+        if cached_config is not None:
+            _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES[requested_names] = cached_config
+            return _copy_tool_config(cached_config)
+    else:
+        normalized_requested_names = requested_names
+    registry = _BUILTIN_TOOL_CONFIG_REGISTRY.select(normalized_requested_names)
     config = registry.as_worker_tool_config()
-    _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES[registry.names()] = config
+    normalized_names = registry.names()
+    _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES[normalized_names] = config
+    if requested_names != normalized_names:
+        _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES[requested_names] = config
     return _copy_tool_config(config)
 
 


### PR DESCRIPTION
## Summary
- Cache serialized built-in `ToolConfig` selections under the raw requested tuple when a partial list selection normalizes to a different name tuple.
- Extend the registered tool-registry select probe with raw partial config-template metrics.
- Add regression coverage and a governing performance-slice plan for the raw-list template-cache path.

## Plan or Spec
- `docs/plans/2026-05-23-tool-registry-raw-list-config-template-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_built_in_tool_config_raw_list_selection_reuses_serialized_selection_cache
# exit 1 before implementation; reproduced the missing raw-list serialized template cache

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 53 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# exit 0; 54 passed; changed-scope coverage 100.00% (26/26)

bash /tmp/run_tool_registry_select_registered_probe.sh
# exit 0; registered probe command, raw_partial_config_template_elapsed_ms_mean=20.352236181497574
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (26/26 measurable changed lines).
- Local Linux base/head probe comparison using `scripts/tool_registry_select_probe.py` with `MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000` and `MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5`:
  - base `raw_partial_config_template_elapsed_ms_mean=37.60279938578606`
  - head `raw_partial_config_template_elapsed_ms_mean=21.864929562434554`
  - delta `-15.737869823351506 ms` (~41.85% faster for the targeted raw partial config-template loop)
- Registered probe local run on head: `raw_partial_config_template_elapsed_ms_mean=20.352236181497574`, `raw_partial_config_template_hits_mean=16000.0`.
- CI PR-scoped performance is required for the authoritative registered probe report.

## Known Gaps
- No Swift runtime validation is involved; this is a Python-only slice verified locally on Linux.
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; focused tests, changed-scope coverage, and the registered probe were run for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
