### PR TITLE
perf: fast-path stream pipe channel names

### DIFF
--- a/docs/plans/2026-05-23-stream-pipe-channel-name-fastpath.md
+++ b/docs/plans/2026-05-23-stream-pipe-channel-name-fastpath.md
@@ -1,0 +1,41 @@
+# Stream pipe-channel name fast path
+
+## Scope
+
+This Python performance slice is limited to Harmony-style pipe-channel header
+parsing in `services/mlx-worker-python/worker/runtime/stream_assembler.py`.
+It keeps stream assembly behavior unchanged while reducing work in
+`RequestStreamAssembler._pipe_channel_name()`.
+
+## Optimization hypothesis
+
+Pipe-channel headers may contain metadata after the channel token, for example
+`<|channel>analysis metadata`. The previous helper lowercased the full stripped
+header and then split it, which allocated/lowercased metadata that is never used
+for channel dispatch. Scanning to the first whitespace and lowercasing only the
+channel token should preserve behavior while reducing string work on channel
+boundaries.
+
+## Registered probe
+
+Affected path coverage is already registered under PR-scoped probe
+`stream-assembler-parser-mode-cache` in `infra/perf/pr_scoped_probes.json`. The
+entry includes focused `test_command`, `coverage_command`, and `probe_command`
+fields for:
+
+- `services/mlx-worker-python/worker/runtime/stream_assembler.py`
+- `services/mlx-worker-python/tests/test_stream_assembler.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/stream_assembler_parser_mode_probe.py`
+
+The probe reports `elapsed_ms_mean`, `channel_name_calls_mean`, and stream
+parser correctness counters. Local Linux verification uses that registered probe;
+CI remains the source of truth for the PR-scoped performance report.
+
+## Verification plan
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_parser_mode_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_parser_mode_probe.py
+```

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -83,6 +83,13 @@ def test_parser_mode_flags_are_computed_once_at_initialization() -> None:
     assert assembler._structural_open_tags is assembler._structural_open_tags_value
 
 
+def test_pipe_channel_name_lowercases_only_the_channel_token() -> None:
+    assert RequestStreamAssembler._pipe_channel_name(" thought metadata") == "thought"
+    assert RequestStreamAssembler._pipe_channel_name("FINAL\nvisible") == "final"
+    assert RequestStreamAssembler._pipe_channel_name("Analysis\tdebug") == "analysis"
+    assert RequestStreamAssembler._pipe_channel_name("\r\n") == ""
+
+
 def test_next_structural_tag_prefers_the_earliest_tool_tag() -> None:
     assembler = RequestStreamAssembler(
         request_id="req-tool-first",

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -731,10 +731,13 @@ class RequestStreamAssembler:
 
     @staticmethod
     def _pipe_channel_name(header: str) -> str:
-        stripped = header.strip().lower()
+        stripped = header.strip()
         if not stripped:
             return ""
-        return stripped.split(maxsplit=1)[0]
+        for index, character in enumerate(stripped):
+            if character.isspace():
+                return stripped[:index].lower()
+        return stripped.lower()
 
     @classmethod
     def _legacy_pipe_channel_header_body(cls, header: str, channel_name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Fast-path Harmony pipe-channel name parsing by scanning to the first whitespace before lowercasing.
- Preserve parser behavior for space, newline, tab, and empty headers with focused regression coverage.

## Plan or Spec
- `docs/plans/2026-05-23-stream-pipe-channel-name-fastpath.md`
- Registered PR-scoped probe: `stream-assembler-parser-mode-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics
# 83 passed in 0.93s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_parser_mode_probe.py
# TOTAL 10 0 100%

MELIX_STREAM_ASSEMBLER_PARSER_MODE_CHUNKS=12000 MELIX_STREAM_ASSEMBLER_PARSER_MODE_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_parser_mode_probe.py
# before: elapsed_ms_mean=92.58354236371815, channel_name_calls_mean=133.0
# after:  elapsed_ms_mean=87.57017976604402, channel_name_calls_mean=133.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (10/10 changed measurable lines).
- Local Linux registered-probe comparison: `elapsed_ms_mean` improved from 92.5835 ms to 87.5702 ms on 12,000 chunks / 5 samples (`delta_ms=-5.0134`, `speedup=1.057x`, about 5.42% lower). `channel_name_calls_mean` stayed at 133.0 and parser correctness counters stayed stable.
- CI PR-scoped performance report is required as the merge validation source.

## Known Gaps
- No Swift runtime validation is involved; this is a Python-only slice verified locally on Linux.
- CI PR-scoped probe report is pending until GitHub Actions completes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability-mode changes; existing registered probe overhead only.
- [x] Deferred work and known gaps are stated explicitly.
