### PR TITLE
perf: bind tool registry OpenAI copy helpers

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -63,12 +63,31 @@ Expected effect:
 - leave registry selection, protobuf config serialization, and tool definitions
   unchanged.
 
+## Follow-up Slice: OpenAI Tool Copy Local Bindings
+
+The 2026-05-23 follow-up keeps the `ToolRegistry.as_openai_tools()` API and
+copy-on-return behavior unchanged, but binds `dict.copy` and `list.copy` once
+per call before cloning cached OpenAI tool schema templates. The returned tool
+payloads remain independently mutable, while the inner hot loop avoids repeated
+method-attribute lookups for every schema property and required-argument list.
+
+Expected effect:
+
+- reduce repeated OpenAI tool payload construction overhead measured by
+  `tool-registry-openai-tools-template-cache` `elapsed_ms_mean`;
+- preserve mutation isolation for returned `parameters.properties` dictionaries
+  and `parameters.required` lists;
+- leave registry selection, schema payload construction, and protobuf config
+  serialization unchanged.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.
 2. Run the registered changed-scope coverage command locally and require at
    least 95% coverage for touched scope.
 3. Run the registered probe command locally before and after the slice and
-   compare `schema_payload_elapsed_ms_mean` over repeated samples.
+   compare the relevant registered metric (`schema_payload_elapsed_ms_mean` for
+   schema-payload slices, or `elapsed_ms_mean` for the OpenAI tool payload slice)
+   over repeated samples.
 4. Push only if local evidence is neutral-to-improved and rely on the GitHub
    PR-scoped performance workflow as the merge gate.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -11,6 +11,8 @@ from packages.protocol.python.worker.v1 import common_pb2
 _TOOL_CONFIG = common_pb2.ToolConfig
 _TOOL_CONFIG_FROM_BYTES = _TOOL_CONFIG.FromString
 _COMPACT_SORTED_JSON_ENCODER = json.JSONEncoder(separators=(",", ":"), sort_keys=True)
+_COPY_DICT = dict.copy
+_COPY_LIST = list.copy
 
 
 def _copy_tool_config(template: common_pb2.ToolConfig) -> common_pb2.ToolConfig:
@@ -290,6 +292,8 @@ class ToolRegistry:
         return selection
 
     def as_openai_tools(self) -> list[dict[str, Any]]:
+        copy_dict = _COPY_DICT
+        copy_list = _COPY_LIST
         return [
             {
                 "type": "function",
@@ -300,10 +304,10 @@ class ToolRegistry:
                         "type": "object",
                         "additionalProperties": False,
                         "properties": {
-                            argument_name: schema.copy()
+                            argument_name: copy_dict(schema)
                             for argument_name, schema in schema_properties
                         },
-                        "required": required_arguments.copy(),
+                        "required": copy_list(required_arguments),
                     },
                 },
                 "x-melix-tool-kind": tool_kind,


### PR DESCRIPTION
## Summary
- Bind `dict.copy` and `list.copy` once per `ToolRegistry.as_openai_tools()` call before cloning cached OpenAI tool schema templates.
- Preserve copy-on-return mutation isolation for returned OpenAI tool payloads.
- Update the tool-registry performance plan with the 2026-05-23 OpenAI tool copy-local-bindings slice.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md`
- Registered PR-scoped probe: `tool-registry-openai-tools-template-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Base probe, origin/main detached worktree (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_OPENAI_TOOLS_ITERATIONS=120000 MELIX_TOOL_REGISTRY_OPENAI_TOOLS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
{"elapsed_ms_mean": 1095.9729488007724, "descriptor_as_openai_tool_calls_mean": 0.0, "isolated_payload_calls_mean": 120000.0, ...}

# Head probe, this branch (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_OPENAI_TOOLS_ITERATIONS=120000 MELIX_TOOL_REGISTRY_OPENAI_TOOLS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
{"elapsed_ms_mean": 1072.8218825999647, "descriptor_as_openai_tool_calls_mean": 0.0, "isolated_payload_calls_mean": 120000.0, ...}

# Focused registered tests (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
53 passed in 0.80s

# Changed-scope coverage (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_openai_tools_probe.py
TOTAL 4 0 100%

# Registered probe command, direct local equivalent (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
{"elapsed_ms_mean": 451.87339833937585, "descriptor_as_openai_tool_calls_mean": 0.0, "isolated_payload_calls_mean": 50000.0, ...}
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Local base/head registered probe comparison (`MELIX_TOOL_REGISTRY_OPENAI_TOOLS_ITERATIONS=120000`, `SAMPLES=5`):
  - base `elapsed_ms_mean=1095.9729488007724`
  - head `elapsed_ms_mean=1072.8218825999647`
  - delta `-23.15106620080769 ms` (`-2.11%`, lower is better)
- Guard rails unchanged: `descriptor_as_openai_tool_calls_mean=0.0`, `isolated_payload_calls_mean=120000.0`.
- PR-scoped performance CI must run the registered `tool-registry-openai-tools-template-cache` probe before merge.

## Known Gaps
- Full `make py-test` / repository-wide gates were not run locally; this PR uses the registered focused Python test, changed-scope coverage, and local registered probe for the scoped hot path.
- No Swift runtime validation applies to this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped registered probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
