### PR TITLE
perf: reuse parsed video URI metadata

### DIFF
--- a/docs/plans/2026-05-23-video-uri-parsed-reference-reuse.md
+++ b/docs/plans/2026-05-23-video-uri-parsed-reference-reuse.md
@@ -1,0 +1,49 @@
+# Video URI Parsed Reference Reuse Slice
+
+## Scope
+
+This slice keeps Python video URI preprocessing behavior unchanged while trimming
+per-call overhead in `worker.runtime.video_preprocessing.prepare_video_input` for
+URI-backed video inputs.
+
+## Registered Probe
+
+The affected Python path is covered by the registered PR-scoped performance probe
+`video-preprocessing-uri-byte-length-reuse` in
+`infra/perf/pr_scoped_probes.json`. The registry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/video_preprocessing_uri_probe.py`
+
+## Optimization Hypothesis
+
+`prepare_video_input(...)` already parses each URI once into
+`ParsedVideoReference`. The hot path still allocates a temporary candidate tuple
+for format inference and then calls `_filename_from_reference(...)`, which must
+perform a type dispatch even when the parsed reference already carries the path
+name. Branching on whether an explicit filename exists lets the URI path pass the
+parsed reference directly to format resolution and reuse `parsed_reference.path_name`
+for the fallback filename.
+
+## Behavior Guard
+
+The existing parsed-URI reuse test now also monkeypatches
+`_filename_from_reference(...)` to fail, proving the URI path consumes the parsed
+reference metadata directly while preserving format and filename behavior.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage, and registered probe
+locally on Linux before opening the PR. The PR-scoped performance workflow must
+select and complete the registered probe in CI before merge.
+
+## Success Criteria
+
+- Focused video preprocessing tests pass.
+- Changed-scope coverage remains at or above 95%.
+- Registered probe shows a clear local improvement in `elapsed_ms_mean` without
+  increasing `byte_length_getattrs_per_call` or `parse_calls_per_call`.
+- GitHub Actions and the PR-scoped performance workflow are green.

--- a/services/mlx-worker-python/tests/test_video_preprocessing.py
+++ b/services/mlx-worker-python/tests/test_video_preprocessing.py
@@ -164,6 +164,23 @@ def test_prepare_video_input_reuses_uri_byte_length_for_metadata_and_identity_ha
     assert len(prepared.sha256_hex) == 64
 
 
+def test_prepare_video_input_prefers_explicit_filename_for_uri_format() -> None:
+    part = common_pb2.MessagePart(
+        video_uri="https://example.com/media/download",
+        media=common_pb2.MediaMetadata(
+            media_type=common_pb2.MEDIA_TYPE_VIDEO,
+            source_kind=common_pb2.MEDIA_SOURCE_URI,
+            filename="clip.webm",
+        ),
+    )
+
+    prepared = prepare_video_input(part)
+
+    assert prepared.format == "webm"
+    assert prepared.filename == "clip.webm"
+
+
+
 def test_prepare_video_input_reuses_parsed_uri_when_filename_is_absent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -175,7 +192,13 @@ def test_prepare_video_input_reuses_parsed_uri_when_filename_is_absent(
         parse_calls += 1
         return original_parse(reference)
 
+    def fail_filename_lookup(reference: str) -> str:  # pragma: no cover - regression only
+        raise AssertionError(
+            f"prepare_video_input should reuse parsed path metadata: {reference}"
+        )
+
     monkeypatch.setattr(video_preprocessing, "_parse_video_reference", counting_parse)
+    monkeypatch.setattr(video_preprocessing, "_filename_from_reference", fail_filename_lookup)
     part = common_pb2.MessagePart(
         video_uri="https://example.com/media/demo.mov",
         media=common_pb2.MediaMetadata(

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -83,13 +83,14 @@ def prepare_video_input(part) -> PreparedVideoInput:
         raise VideoPreprocessError("No video input provided.")
     parsed_reference = _parse_video_reference(uri)
     _validate_parsed_video_uri(parsed_reference)
-    format_candidates: tuple[str | ParsedVideoReference, ...] = (
-        (filename, parsed_reference) if filename else (parsed_reference,)
-    )
-    resolved_format = _resolve_video_format(format_name, mime_type, *format_candidates)
-    resolved_filename = (
-        filename or _filename_from_reference(parsed_reference) or f"remote-video.{resolved_format}"
-    )
+    if filename:
+        resolved_format = _resolve_video_format(
+            format_name, mime_type, filename, parsed_reference
+        )
+        resolved_filename = filename
+    else:
+        resolved_format = _resolve_video_format(format_name, mime_type, parsed_reference)
+        resolved_filename = parsed_reference.path_name or f"remote-video.{resolved_format}"
     byte_length = int(getattr(media, "byte_length", 0) or 0)
     return PreparedVideoInput(
         source_kind="uri",


### PR DESCRIPTION
## Summary
- Reuse `ParsedVideoReference.path_name` directly in URI video preprocessing instead of routing through the filename helper after parsing.
- Avoid the temporary format-candidate tuple on the URI hot path while preserving explicit filename precedence.
- Add regression coverage for explicit filename inference and parsed-reference metadata reuse.

## Plan or Spec
- `docs/plans/2026-05-23-video-uri-parsed-reference-reuse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py::test_validate_video_uri_accepts_parsed_and_string_remote_references services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics
# 34 passed in 3.22s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py::test_validate_video_uri_accepts_parsed_and_string_remote_references services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m --include='services/mlx-worker-python/worker/runtime/video_preprocessing.py'
# services/mlx-worker-python/worker/runtime/video_preprocessing.py: 95% coverage

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/video_preprocessing_uri_probe.py
# baseline before change: elapsed_ms_mean=620.4295629635453, byte_length_getattrs_per_call=1.0, parse_calls_per_call=1.0
# after change: elapsed_ms_mean=584.3204281758517, byte_length_getattrs_per_call=1.0, parse_calls_per_call=1.0
```

## Coverage and Metrics
- Changed-scope source coverage: `services/mlx-worker-python/worker/runtime/video_preprocessing.py` = 95%.
- Registered local probe: `video-preprocessing-uri-byte-length-reuse`.
- Probe delta: `elapsed_ms_mean` 620.430 ms -> 584.320 ms (`-36.109 ms`, `1.0618x`, `5.82%` faster).
- Probe counters unchanged: `byte_length_getattrs_per_call=1.0`, `parse_calls_per_call=1.0`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Linux local verification covers the Python path only. CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
