### PR TITLE
perf: skip float recast in wav sample iteration

### DIFF
--- a/docs/plans/cron-wav-pcm-recast-elision.md
+++ b/docs/plans/cron-wav-pcm-recast-elision.md
@@ -1,8 +1,8 @@
-# Cron WAV PCM Recast Elision
+# Cron WAV PCM Float Fast Path
 
 ## Goal
 
-Reduce redundant per-sample work in the MLX audio WAV PCM streaming path by avoiding an extra `float(...)` conversion after `iter_samples(...)` has already normalized values to floats.
+Reduce redundant per-sample work in the MLX audio WAV PCM streaming path by preserving already-float sample values from `iter_samples(...)` instead of calling `float(...)` again for every float value in nested lists, tuples, and flat array-like segments.
 
 ## Touched files
 
@@ -20,7 +20,7 @@ Registered probe: `mlx-audio-wav-streaming-pcm`
 Local probe command:
 
 ```bash
-PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/mlx_audio_wav_streaming_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_audio_wav_streaming_probe.py
 ```
 
 The probe builds a synthetic nested audio payload, converts it to WAV bytes repeatedly, and reports elapsed time, peak traced bytes, sample count, and output size.
@@ -28,6 +28,6 @@ The probe builds a synthetic nested audio payload, converts it to WAV bytes repe
 ## Success metrics
 
 - Preserve WAV PCM output shape and clamping behavior.
-- Add a focused regression test proving `audio_to_pcm_chunks(...)` does not re-cast the already-normalized values yielded by `iter_samples(...)`.
+- Add a focused regression test proving `iter_samples(...)` does not re-cast already-float sample values in nested and flat array-like inputs.
 - Achieve at least 95% changed executable line coverage for the touched Python files.
 - Keep the registered `mlx-audio-wav-streaming-pcm` probe green locally and in PR-scoped performance CI.

--- a/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_audio_runtime.py
@@ -921,6 +921,31 @@ def test_audio_to_wav_bytes_does_not_materialize_flat_sample_list(monkeypatch: p
     assert decoded == [16383, 32767, -32767]
 
 
+def test_iter_samples_preserves_already_float_samples_without_recast() -> None:
+    from worker.runtime.wav_helpers import iter_samples
+
+    class NormalizedFloat(float):
+        def __float__(self):  # pragma: no cover - covered only by regression failure
+            raise AssertionError("iter_samples should not re-cast float sample values")
+
+    class FlatAudio:
+        @property
+        def flat(self):
+            return iter((NormalizedFloat(0.5), NormalizedFloat(-0.25)))
+
+    nested_samples = list(
+        iter_samples(
+            [
+                NormalizedFloat(0.125),
+                (NormalizedFloat(0.25), FlatAudio()),
+            ]
+        )
+    )
+
+    assert nested_samples == [0.125, 0.25, 0.5, -0.25]
+    assert all(isinstance(sample, NormalizedFloat) for sample in nested_samples)
+
+
 def test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/runtime/wav_helpers.py
+++ b/services/mlx-worker-python/worker/runtime/wav_helpers.py
@@ -6,18 +6,26 @@ import sys
 
 
 def iter_samples(value):
-    if isinstance(value, (float, int)):
+    if isinstance(value, float):
+        yield value
+        return
+    if isinstance(value, int):
         yield float(value)
         return
     flat_values = getattr(value, "flat", None)
     if flat_values is not None and not isinstance(value, (list, tuple)):
         for item in flat_values:
-            yield float(item)
+            if isinstance(item, float):
+                yield item
+            else:
+                yield float(item)
         return
     if hasattr(value, "tolist"):
         value = value.tolist()
     for item in value:
-        if isinstance(item, (float, int)):
+        if isinstance(item, float):
+            yield item
+        elif isinstance(item, int):
             yield float(item)
         elif (
             isinstance(item, (list, tuple))


### PR DESCRIPTION
## Summary
- Optimize MLX audio WAV sample iteration by preserving already-float sample values instead of re-casting them with `float(...)`.
- Add a regression test that covers nested list/tuple inputs and flat array-like inputs.
- Update the WAV PCM performance slice plan to use the registered `mlx-audio-wav-streaming-pcm` probe with `python3`.

## Plan or Spec
- Updated `docs/plans/cron-wav-pcm-recast-elision.md`.
- Registered probe already exists: `mlx-audio-wav-streaming-pcm` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_iter_samples_preserves_already_float_samples_without_recast services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_wav_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_wav_streaming_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_iter_samples_preserves_already_float_samples_without_recast services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_wav_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_wav_streaming_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py services/mlx-worker-python/worker/runtime/wav_helpers.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_audio_wav_streaming_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_audio_wav_streaming_probe.py` (3 local registered-probe runs)
- Same-process baseline comparison using the origin-main `iter_samples(...)` implementation against the branch implementation.
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `7 passed in 3.84s`.
- Changed-scope coverage: `TOTAL 20 1 95%`.
- Registered local probe runs on branch:
  - `elapsed_ms_mean=317.221040`, `peak_bytes_mean=699680.6`, `sample_count=240000.0`, `wav_bytes=480044.0`
  - `elapsed_ms_mean=303.917755`, `peak_bytes_mean=699680.6`, `sample_count=240000.0`, `wav_bytes=480044.0`
  - `elapsed_ms_mean=319.816233`, `peak_bytes_mean=699680.6`, `sample_count=240000.0`, `wav_bytes=480044.0`
- Same-process old/new comparison: `old_mean=318.572900 ms`, `new_mean=300.041334 ms`, `delta_ms=-18.531566`, `speedup=5.817057%`, `peak_bytes_mean 699595.375 -> 699403.0`.

## Known Gaps
- This is a Python worker slice validated locally on Linux. No Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance validation is still required before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally.
- [ ] PR-scoped performance CI completed successfully.
- [ ] All required PR checks are green.
