### PR TITLE
perf: reuse inverse embedding projection norm

### DIFF
--- a/docs/plans/2026-05-23-embedding-project-invnorm.md
+++ b/docs/plans/2026-05-23-embedding-project-invnorm.md
@@ -1,0 +1,64 @@
+# Deterministic Embedding Projection Inverse-Norm Slice
+
+## Goal
+
+Reduce per-projection arithmetic overhead in deterministic embedding vector
+projection without changing vector values, normalization semantics, or public
+embedding runtime behavior.
+
+## Scope
+
+This is a Python-only slice limited to
+`services/mlx-worker-python/worker/runtime/embedding_backends.py`, its focused
+embedding runtime tests, and this plan. It does not change real MLX embedding
+model behavior or generated protocol artifacts.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`deterministic-embedding-project-digest-allocation` in
+`infra/perf/pr_scoped_probes.json`. That probe has focused `test_command`,
+`coverage_command`, and `probe_command` entries and measures repeated
+`_project_digest()` calls at 4096 dimensions with elapsed time, peak bytes, and
+checksum stability.
+
+## Implementation Plan
+
+1. Keep the existing regression parity test against the legacy projection values
+   across small, boundary, and large dimensions.
+2. Compute `1.0 / l2_norm` once per projected digest and multiply each base
+   value by that inverse during normalization, instead of dividing each base
+   value by the same norm repeatedly.
+3. Preserve the `l2_norm == 0.0` guard and the existing rounded values.
+4. Run focused pytest, changed-scope coverage, and the registered probe locally
+   on Linux before opening the PR. GitHub Actions PR-scoped performance remains
+   the merge gate.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_embedding_runtime.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_embedding_runtime.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/runtime/embedding_backends.py \
+  services/mlx-worker-python/tests/test_embedding_runtime.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/deterministic_embedding_project_digest_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py \
+  --registry infra/perf/pr_scoped_probes.json \
+  --probe-id deterministic-embedding-project-digest-allocation \
+  --base-repo <baseline-worktree> \
+  --head-repo "$PWD" \
+  --output /tmp/embedding-project-invnorm-probe.json
+```

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -60,7 +60,8 @@ class DeterministicEmbeddingBackend:
         l2_norm = math.sqrt(squared_sum)
         if l2_norm == 0.0:
             return [0.0] * dimensions
-        normalized_base = [round(value / l2_norm, 6) for value in base_values]
+        inverse_l2_norm = 1.0 / l2_norm
+        normalized_base = [round(value * inverse_l2_norm, 6) for value in base_values]
         result = normalized_base * full_repeats
         if remainder:
             result.extend(normalized_base[:remainder])


### PR DESCRIPTION
## Summary
- Reuses a single inverse L2 norm when normalizing deterministic embedding digest base values.
- Keeps the projection vector values unchanged while reducing repeated division work in `_project_digest()`.
- Adds the governing performance-slice plan for this registered probe path.

## Plan or Spec
- `docs/plans/2026-05-23-embedding-project-invnorm.md`
- Registered probe: `deterministic-embedding-project-digest-allocation`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
# 16 passed in 1.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
# 16 passed in 0.98s; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
# {"elapsed_ms_mean": 19.629793, "peak_bytes_mean": 66771.666667, "checksum": 0.348915, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-project-digest-allocation --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-embedding-invnorm-20260523084644 --head-repo "$PWD" --output /tmp/embedding-project-invnorm-probe-2.json
# Head verification: 17 passed in 46.51s; coverage TOTAL 2 0 100%
# Probe run 2: base elapsed_ms_mean=19.658526, head elapsed_ms_mean=17.963162, delta=-8.624%; checksum unchanged at 0.348915.

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%` for `embedding_backends.py` changed lines.
- Registered local probe `deterministic-embedding-project-digest-allocation` completed successfully.
- Metrics summary:
  - Initial direct probe baseline before edit: `elapsed_ms_mean=32.722396`, `peak_bytes_mean=66747.666667`, `checksum=0.348915`.
  - Direct head probe after edit: `elapsed_ms_mean=19.629793`, `peak_bytes_mean=66771.666667`, `checksum=0.348915`.
  - Registered base-vs-head rerun: `base elapsed_ms_mean=19.658526`, `head elapsed_ms_mean=17.963162`, speedup ~8.624%; `peak_bytes_mean` changed from `66747.666667` to `66771.666667` (~+0.036%, below the 5% warning threshold); checksum unchanged.

## Known Gaps
- Linux local validation covers the Python deterministic embedding fallback path only.
- GitHub Actions PR-scoped performance is still required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change; existing PR-scoped probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
