### PR TITLE
perf: scan changed-scope hunk integers directly

### DIFF
--- a/docs/plans/2026-05-23-changed-scope-hunk-int-scan.md
+++ b/docs/plans/2026-05-23-changed-scope-hunk-int-scan.md
@@ -1,0 +1,42 @@
+# Changed-Scope Coverage Hunk Integer Scan Slice
+
+## Scope
+
+Optimize one small Python hot path in `scripts/changed_scope_coverage.py`: parsing the new-file start line number from unified-diff hunk headers.
+
+The behavior stays unchanged for supported hunk forms:
+
+- `@@ -a,b +c,d @@`
+- `@@ -a +c @@`
+
+Malformed hunk headers still return `None` and are ignored by the changed-line parser.
+
+## Registered Probe
+
+The affected path is covered by registered PR-scoped probe `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.
+
+The probe already declares:
+
+- `test_command` for `tests/test_changed_scope_coverage.py` and PR-scoped registry tests.
+- `coverage_command` that runs changed-scope coverage over the parser/probe/test files.
+- `probe_command` through `scripts/changed_scope_coverage_parse_probe.py`.
+
+## Implementation Plan
+
+Replace the current substring extraction plus `int(...)` conversion in `_parse_hunk_new_start_from_digit` with a single-pass digit scan that accumulates the integer until the existing comma/space delimiters. This avoids temporary substring allocation and exception setup for normal hunk headers while preserving the same malformed-header behavior.
+
+## Verification Plan
+
+Run, from this worktree:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-diff-parser --base-repo <base-worktree> --head-repo "$PWD" --output <json-output>
+```
+
+## Success Criteria
+
+- Focused tests pass.
+- Changed-scope coverage is at least 95%.
+- The registered probe reports a non-regressing parser metric with a clear local Linux comparison.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -13,6 +13,10 @@ import sys
 
 _DIFF_HEADER_PREFIX = "diff --git a/"
 _DIFF_HEADER_SEPARATOR = " b/"
+_ASCII_ZERO = ord("0")
+_ASCII_NINE = ord("9")
+_ASCII_COMMA = ord(",")
+_ASCII_SPACE = ord(" ")
 
 
 def _is_diff_file_marker(line: str) -> bool:
@@ -29,15 +33,18 @@ def _parse_diff_header_new_path(line: str) -> str | None:
 
 
 def _parse_hunk_new_start_from_digit(line: str, digit_index: int) -> int | None:
-    end_index = line.find(",", digit_index)
-    if end_index < 0:
-        end_index = line.find(" ", digit_index)
-    if end_index < 0:
+    value = 0
+    digit_seen = False
+    for index in range(digit_index, len(line)):
+        character_code = ord(line[index])
+        if _ASCII_ZERO <= character_code <= _ASCII_NINE:
+            value = value * 10 + (character_code - _ASCII_ZERO)
+            digit_seen = True
+            continue
+        if character_code == _ASCII_COMMA or character_code == _ASCII_SPACE:
+            return value if digit_seen else None
         return None
-    try:
-        return int(line[digit_index:end_index])
-    except ValueError:
-        return None
+    return None
 
 
 def _parse_hunk_new_start(line: str) -> int | None:


### PR DESCRIPTION
## Summary
- Optimizes changed-scope coverage hunk start parsing with a direct digit scan instead of substring extraction plus `int(...)`.
- Keeps malformed hunk behavior unchanged (`None` for unsupported headers).
- Adds a slice plan documenting the registered probe and verification path.
- Follow-up update: keeps the parser as a `for` loop with named ASCII constants to address maintainability feedback without reintroducing substring allocation.

## Plan or Spec
- `docs/plans/2026-05-23-changed-scope-hunk-int-scan.md`
- Registered probe: `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` — `31 passed in 0.19s` before review follow-up.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py` — `TOTAL 5 0 100%` before review follow-up.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-diff-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-changed-scope-hunk-int-scan-20260523095000 --head-repo "$PWD" --output /tmp/changed-scope-hunk-int-review-probe2.json` — local registered probe completed successfully after review follow-up.
- `git diff --check` — passed.

## Coverage and Metrics
- Focused tests: `31 passed`.
- Changed-scope coverage after review follow-up: `TOTAL 8 0 100%`.
- Local registered probe (`changed-scope-coverage-diff-parser`, Linux) after review follow-up:
  - base `elapsed_ms_mean=3.0285592656582594`
  - head `elapsed_ms_mean=3.0890801766266427`
  - delta `+0.06052091096838327 ms` (`+2.00%`, within the probe's 5% warning gate / neutral)
  - changed line count unchanged: `7680`

## Known Gaps
- CI registered probe completed successfully; local metrics are Linux-only and small-sample PR-scoped measurements.
- No Swift runtime validation is involved in this Python-only slice.

## Evidence Checklist
- [x] Worktree created from `origin/main`.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe run locally with base/head comparison.
- [x] GitHub Actions PR-scoped performance probe completed successfully.


CI PR-scoped performance report: `Status: ok`, `Regressions: 0`, `Verification failures: 0`; diff parser CI metric `elapsed_ms_mean` base `3.391`, head `3.444`, delta `+0.053 ms` (`+1.56%`, neutral).