### PR TITLE
perf: hoist model registry HF prune names

### DIFF
--- a/docs/plans/2026-05-23-model-registry-hf-prune-name-constant.md
+++ b/docs/plans/2026-05-23-model-registry-hf-prune-name-constant.md
@@ -1,0 +1,17 @@
+# Model registry HF prune name constant
+
+## Goal
+
+Reduce per-directory allocation in `WorkerModelCatalog._scan_registry_root_tree_with_hf_repos(...)` by hoisting the Hugging Face cache prune-name membership set out of the hot traversal loop.
+
+## Scope
+
+This Python-only slice is limited to `services/mlx-worker-python/worker/model_registry/catalog.py`. It preserves the existing behavior that only `snapshots` and `refs` directory names trigger `_is_hf_cache_pruned_subtree(...)`, while normal plain-local model directories continue to skip that relative-probe call.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe `model-registry-plain-local-manifest-stat-elision` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries covering the model-registry catalog path, focused tests, and `scripts/pr_scoped_performance` integration.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and registered probe locally on Linux before pushing. GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -53,6 +53,7 @@ _GENERATION_CONFIG_TOP_P_KEY = "melix.generation_config.top_p"
 _GENERATION_CONFIG_MAX_TOKENS_KEY = "melix.generation_config.max_tokens"
 _GENERATION_CONFIG_DO_SAMPLE_KEY = "melix.generation_config.do_sample"
 _REGISTRY_SCAN_PRUNED_DIR_NAMES = frozenset({"blobs", ".git", "__pycache__"})
+_HF_CACHE_PRUNED_SUBTREE_NAMES = frozenset({"snapshots", "refs"})
 
 
 @dataclass(frozen=True)
@@ -1498,7 +1499,7 @@ class WorkerModelCatalog:
             current = stack.pop()
             if current.name in _REGISTRY_SCAN_PRUNED_DIR_NAMES:
                 continue
-            if current.name in {"snapshots", "refs"} and _is_hf_cache_pruned_subtree(resolved_root, current):
+            if current.name in _HF_CACHE_PRUNED_SUBTREE_NAMES and _is_hf_cache_pruned_subtree(resolved_root, current):
                 continue
             try:
                 with os.scandir(os.fspath(current)) as entries:


### PR DESCRIPTION
## Summary
- Hoist the Hugging Face cache prune-name membership set out of `WorkerModelCatalog._scan_registry_root_tree_with_hf_repos(...)` so the registry traversal does not allocate a fresh `{"snapshots", "refs"}` set for every scanned directory.
- Keep the existing plain-local model and HF cache prune behavior unchanged.

## Plan or Spec
- `docs/plans/2026-05-23-model-registry-hf-prune-name-constant.md`

## Commands Run
```text
# Baseline registered probe on origin/main before the code change, run 3x:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c '<registered model-registry-plain-local-manifest-stat-elision probe_command>'
BASE elapsed_ms_mean: 123.750859, 119.355835, 124.064412

# Focused registered tests after the code change:
bash /tmp/model_registry_test_command.sh
19 passed in 2.08s

# Changed-scope coverage after the code change:
bash /tmp/model_registry_coverage_command.sh
19 passed in 1.38s
changed_line_coverage=100.00%; TOTAL 2 0 100%

# Registered probe after the code change, run 3x:
bash /tmp/model_registry_probe_command.sh
HEAD elapsed_ms_mean: 114.446880, 111.351716, 120.982194
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% for `services/mlx-worker-python/worker/model_registry/catalog.py` changed lines.
- Registered probe: `model-registry-plain-local-manifest-stat-elision`.
- Local Linux probe comparison (3 local runs each): old_mean=122.390369 ms, new_mean=115.593597 ms, delta=-6.796772 ms, speedup=5.55%.
- Probe invariants stayed stable: `config_load_calls_mean=400.0`, `discovered_model_count_mean=400.0`, `generation_config_stat_calls_mean=0.0`, `manifest_is_file_calls_mean=0.0`, `manifest_parse_calls_mean=0.0`.

## Known Gaps
- None. CI PR-scoped performance remains the registered merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no new probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
