### PR TITLE
perf: stat PR-scope registry key directly

### DIFF
--- a/docs/plans/2026-05-23-pr-scoped-registry-scope-os-stat.md
+++ b/docs/plans/2026-05-23-pr-scoped-registry-scope-os-stat.md
@@ -1,0 +1,42 @@
+# PR-scoped registry scope os.stat slice
+
+## Scope
+
+This Python-only slice targets the scope registry metadata check in
+`services/mlx-worker-python/worker/productization/pr_scoped_performance.py`.
+`build_scope_report()` calls `load_probe_registry_for_scope()` for every scoped
+PR-performance selection. The current hot path already normalizes the registry
+path to an absolute cache key, so this slice avoids constructing a `Path` and
+calling `Path.stat()` only to recover the same file metadata.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`pr-scoped-performance-registry-cache` in `infra/perf/pr_scoped_probes.json`.
+That registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Implementation
+
+Use `_probe_registry_cache_key(path)` directly in `load_probe_registry_for_scope()`
+and stat the resulting absolute string with `os.stat(cache_key)`. This keeps
+cache invalidation based on `(mtime_ns, size)` unchanged while removing the
+scope-only `Path(path)` allocation and `Path.stat()` method dispatch.
+
+## Verification plan
+
+Run the focused registry-cache tests, changed-scope coverage, and the registered
+local probe on Linux before pushing. The PR-scoped performance workflow remains
+the merge gate for the registered probe report in CI.
+
+## Success metric
+
+Accept the slice only if the registered probe reports directionally lower
+`build_scope_report_ms_mean` without regressing correctness tests or
+changed-scope coverage. `load_probe_registry_ms_mean` and
+`cold_load_probe_registry_ms_mean` are expected to be neutral because the slice
+only touches the scope loader path.

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -3000,20 +3000,28 @@ def test_build_scope_report_reuses_scope_cached_registry_without_double_stat(
         encoding="utf-8",
     )
     stat_calls = 0
-    original_stat = Path.stat
+    original_os_stat = os.stat
     cache = pr_scoped_performance_module._PROBE_REGISTRY_CACHE
     selected_cache = pr_scoped_performance_module._SCOPE_SELECTED_PROBES_WITH_COVERAGE_CACHE
     pr_scoped_performance_module._load_probe_registry_for_scope_cached.cache_clear()
     cache.clear()
     selected_cache.clear()
 
-    def tracked_stat(self: Path, *args: object, **kwargs: object) -> os.stat_result:
-        nonlocal stat_calls
-        if self == registry_path:
-            stat_calls += 1
-        return original_stat(self, *args, **kwargs)
+    def fail_path_stat(self: Path, *args: object, **kwargs: object) -> os.stat_result:  # pragma: no cover
+        raise AssertionError("scope registry loader should stat the cache-key string directly")
 
-    monkeypatch.setattr(Path, "stat", tracked_stat)
+    def tracked_os_stat(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        *args: object,
+        **kwargs: object,
+    ) -> os.stat_result:
+        nonlocal stat_calls
+        if os.fspath(path) == os.fspath(registry_path):
+            stat_calls += 1
+        return original_os_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", fail_path_stat)
+    monkeypatch.setattr(os, "stat", tracked_os_stat)
 
     try:
         first = build_scope_report(

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -215,9 +215,8 @@ def load_probe_registry(path: str | Path) -> tuple[ProbeDefinition, ...]:
 
 
 def load_probe_registry_for_scope(path: str | Path) -> tuple[ProbeDefinition, ...]:
-    registry_path = Path(path)
-    cache_key = _probe_registry_cache_key(registry_path)
-    stat_result = registry_path.stat()
+    cache_key = _probe_registry_cache_key(path)
+    stat_result = os.stat(cache_key)
     return _load_probe_registry_for_scope_cached(
         cache_key,
         stat_result.st_mtime_ns,


### PR DESCRIPTION
## Summary
- Optimize the PR-scoped performance registry scope loader by statting the normalized cache-key string directly.
- Preserve `(mtime_ns, size)` cache invalidation while avoiding a scope-only `Path(...)` allocation and `Path.stat()` dispatch.
- Update the focused regression test to assert the scope loader uses `os.stat` rather than `Path.stat`.

## Plan or Spec
- `docs/plans/2026-05-23-pr-scoped-registry-scope-os-stat.md`

## Commands Run
```text
git status --short && git branch --show-current && git fetch origin && git reset --hard origin/main
Result: pass; fresh worktree created from origin/main.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_uses_absolute_cache_key_without_resolving services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_build_scope_report_reuses_scope_cached_registry_without_double_stat services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_json_probe_rejects_missing_command_and_non_numeric_metrics
Result: pass, 8 passed in 2.81s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused registry-cache selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
Result: pass, 8 passed in 2.83s; changed-scope coverage 100%.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id pr-scoped-performance-registry-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/pr_registry_osstat_probe.json
Result: pass; head verification/test/coverage ok, base/head probes ok.

git diff --check
Result: pass.
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 8 0 100%`).
- Registered probe: `pr-scoped-performance-registry-cache`.
- Local Linux probe metrics:
  - `build_scope_report_ms_mean`: base `3.031627 ms`, head `1.418578 ms` (`-1.613049 ms`, ~`53.2%` lower).
  - `cold_load_probe_registry_ms_mean`: base `161.128263 ms`, head `156.766083 ms` (`-4.36218 ms`, ~`2.7%` lower; expected mostly neutral).
  - `load_probe_registry_ms_mean`: base `0.93094 ms`, head `0.886363 ms` (`-0.044577 ms`, ~`4.8%` lower; expected mostly neutral).
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- None for the Python/Linux scope. This slice does not touch Swift code.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
