### PR TITLE
perf: scan macos resource bundles with dir entries

### DIFF
--- a/docs/plans/2026-05-23-macos-resource-bundle-scandir.md
+++ b/docs/plans/2026-05-23-macos-resource-bundle-scandir.md
@@ -1,0 +1,34 @@
+# macOS App Resource Bundle Scandir Slice
+
+## Goal
+
+Reduce filesystem enumeration overhead while packaging SwiftPM resource bundles into the macOS app bundle.
+
+## Scope
+
+- `services/mlx-worker-python/worker/productization/macos_app_bundle.py`
+- `services/mlx-worker-python/tests/test_macos_app_bundle.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Registered Probe
+
+This slice registers `macos-app-resource-bundle-scandir` in `infra/perf/pr_scoped_probes.json`. The entry includes focused `test_command`, `coverage_command`, and `probe_command` fields and runs on `ubuntu-latest`.
+
+The probe creates a synthetic SwiftPM build-products directory with many `.bundle` directories plus non-bundle entries, monkeypatches `copytree` to isolate enumeration overhead, and records `elapsed_ms_mean`, `elapsed_ms_min`, and `copied_count`.
+
+## Implementation Plan
+
+1. Add regression coverage proving `_copy_swiftpm_resource_bundles(...)` does not call `Path.glob("*.bundle")` and preserves lexicographic copy order.
+2. Replace `sorted(source_root.glob("*.bundle"))` with `os.scandir(...)`, directory filtering, and a sorted bundle-name list.
+3. Register the PR-scoped probe and add a probe-selection regression test.
+4. Run the focused tests, changed-scope coverage, and registered probe locally on Linux.
+5. Use PR-scoped performance CI as the final registered probe gate before merge.
+
+## Metrics
+
+Primary metric: `macos-app-resource-bundle-scandir` `elapsed_ms_mean` (lower is better). Secondary metric: `elapsed_ms_min` (lower is better). `copied_count` must remain equal to the synthetic bundle count.
+
+## Validation Boundary
+
+This is a Python packaging-path slice. Local Linux validation covers the Python behavior and registered probe. It does not validate Swift runtime behavior.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2060,6 +2060,41 @@
     ]
   },
   {
+    "id": "macos-app-resource-bundle-scandir",
+    "name": "macOS app SwiftPM resource bundle scandir",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/macos_app_bundle.py",
+      "services/mlx-worker-python/tests/test_macos_app_bundle.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_copy_swiftpm_resource_bundles_restores_existing_bundle_on_copy_failure services/mlx-worker-python/tests/test_macos_app_bundle.py::test_copy_swiftpm_resource_bundles_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_macos_app_bundle.py::test_copy_swiftpm_resource_bundles_returns_empty_when_source_missing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_resource_bundle_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_copy_swiftpm_resource_bundles_restores_existing_bundle_on_copy_failure services/mlx-worker-python/tests/test_macos_app_bundle.py::test_copy_swiftpm_resource_bundles_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_macos_app_bundle.py::test_copy_swiftpm_resource_bundles_returns_empty_when_source_missing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_resource_bundle_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/macos_app_bundle.py services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PY'\nimport json\nimport statistics\nimport tempfile\nimport time\nfrom pathlib import Path\nfrom worker.productization import macos_app_bundle as module\n\nbundle_count = 900\nnon_bundle_count = 900\nsample_count = 9\nelapsed_samples = []\ncopied_count = 0\noriginal_copytree = module.shutil.copytree\ntry:\n    def fast_copytree(source, target, **kwargs):\n        target.mkdir(parents=True, exist_ok=False)\n        (target / \"marker.txt\").write_text(Path(source).name, encoding=\"utf-8\")\n    module.shutil.copytree = fast_copytree\n    with tempfile.TemporaryDirectory(prefix=\"melix-macos-resource-bundle-probe-\") as temp_dir:\n        root = Path(temp_dir)\n        source_root = root / \"source\"\n        target_root = root / \"target\"\n        source_root.mkdir()\n        target_root.mkdir()\n        for index in range(bundle_count):\n            (source_root / f\"Resource{index:04d}.bundle\").mkdir()\n        for index in range(non_bundle_count):\n            (source_root / f\"Ignored{index:04d}.txt\").write_text(\"x\", encoding=\"utf-8\")\n        for _ in range(sample_count):\n            for child in target_root.iterdir():\n                module.shutil.rmtree(child)\n            started = time.perf_counter()\n            copied_paths = module._copy_swiftpm_resource_bundles(source_root, [target_root])\n            elapsed_samples.append((time.perf_counter() - started) * 1000.0)\n            copied_count = len(copied_paths)\nfinally:\n    module.shutil.copytree = original_copytree\nif copied_count != bundle_count:\n    raise AssertionError(f\"expected {bundle_count} copied bundles, got {copied_count}\")\nprint(json.dumps({\"bundle_count\": float(bundle_count), \"copied_count\": float(copied_count), \"elapsed_ms_mean\": round(statistics.fmean(elapsed_samples), 6), \"elapsed_ms_min\": round(min(elapsed_samples), 6), \"non_bundle_count\": float(non_bundle_count), \"sample_count\": float(sample_count)}, sort_keys=True))\nPY",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "copied_count",
+        "unit": "bundles",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "package-macos-resolve-fallback-scandir",
     "name": "Package macOS fallback build product scandir",
     "runner": "ubuntu-latest",

--- a/services/mlx-worker-python/tests/test_macos_app_bundle.py
+++ b/services/mlx-worker-python/tests/test_macos_app_bundle.py
@@ -403,6 +403,39 @@ def test_copy_swiftpm_resource_bundles_restores_existing_bundle_on_copy_failure(
     assert (target_bundle / "existing.txt").exists() is False
 
 
+def test_copy_swiftpm_resource_bundles_uses_scandir_without_path_glob(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    first_bundle = source_root / "A.bundle"
+    second_bundle = source_root / "B.bundle"
+    first_bundle.mkdir()
+    second_bundle.mkdir()
+    (first_bundle / "first.txt").write_text("first", encoding="utf-8")
+    (second_bundle / "second.txt").write_text("second", encoding="utf-8")
+    (source_root / "C.bundle").write_text("not a directory", encoding="utf-8")
+    (source_root / "ignored.txt").write_text("ignored", encoding="utf-8")
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+
+    def fail_glob(self: Path, pattern: str):  # pragma: no cover - regression guard
+        raise AssertionError("_copy_swiftpm_resource_bundles() should not allocate Path.glob() results")
+
+    monkeypatch.setattr(Path, "glob", fail_glob)
+
+    copied_paths = _copy_swiftpm_resource_bundles(source_root, [target_root])
+
+    assert copied_paths == [target_root / "A.bundle", target_root / "B.bundle"]
+    assert (target_root / "A.bundle/first.txt").read_text(encoding="utf-8") == "first"
+    assert (target_root / "B.bundle/second.txt").read_text(encoding="utf-8") == "second"
+    assert (target_root / "C.bundle").exists() is False
+
+
+def test_copy_swiftpm_resource_bundles_returns_empty_when_source_missing(tmp_path: Path) -> None:
+    assert _copy_swiftpm_resource_bundles(tmp_path / "missing", [tmp_path / "target"]) == []
+
+
 def test_write_unsigned_macos_app_bundle_requires_an_icon_file(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     (repo_root / "services/mlx-worker-python/worker").mkdir(parents=True)

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1039,6 +1039,16 @@ def test_scope_report_selects_mlx_audio_local_uri_probe() -> None:
     assert "mlx-audio-local-uri-zero-copy-preprocess" in _selected_probe_ids(scope)
 
 
+def test_scope_report_selects_macos_app_resource_bundle_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/macos_app_bundle.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "macos-app-resource-bundle-scandir"
+
+
 def test_scope_report_selects_mlx_vlm_runtime_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -2551,6 +2561,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "multimodal-fast-path-signature-top-level-key-cache",
         "multimodal-preprocessing-local-uri-parse-elision",
         "multimodal-preprocessing-image-uri-single-parse",
+        "macos-app-resource-bundle-scandir",
         "package-macos-resolve-fallback-scandir",
         "pr-scoped-performance-scope-json-read-bytes",
         "pr-scoped-performance-scope-matcher",

--- a/services/mlx-worker-python/worker/productization/macos_app_bundle.py
+++ b/services/mlx-worker-python/worker/productization/macos_app_bundle.py
@@ -498,14 +498,26 @@ def write_unsigned_macos_app_bundle(
 
 def _copy_swiftpm_resource_bundles(source_root: Path, target_roots: list[Path]) -> list[Path]:
     copied_paths: list[Path] = []
-    if not source_root.is_dir():
+    try:
+        with os.scandir(source_root) as entries:
+            bundle_names = []
+            for entry in entries:
+                if not entry.name.endswith(".bundle"):
+                    continue
+                try:
+                    if not entry.is_dir(follow_symlinks=False):
+                        continue
+                except OSError:
+                    continue
+                bundle_names.append(entry.name)
+            bundle_names.sort()
+    except OSError:
         return copied_paths
 
-    for source in sorted(source_root.glob("*.bundle")):
-        if not source.is_dir():
-            continue
+    for bundle_name in bundle_names:
+        source = source_root / bundle_name
         for target_root in target_roots:
-            target = target_root / source.name
+            target = target_root / bundle_name
             backup = target.with_name(f"{target.name}.melix-backup")
             if backup.exists():
                 shutil.rmtree(backup)


### PR DESCRIPTION
## Summary
- Register the `macos-app-resource-bundle-scandir` PR-scoped performance probe.
- Replace `Path.glob("*.bundle")` in macOS app SwiftPM resource bundle packaging with `os.scandir()` plus sorted bundle names.
- Add focused regression coverage for no-`Path.glob` behavior and missing source roots.

## Plan or Spec
- `docs/plans/2026-05-23-macos-resource-bundle-scandir.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_copy_swiftpm_resource_bundles_restores_existing_bundle_on_copy_failure services/mlx-worker-python/tests/test_macos_app_bundle.py::test_copy_swiftpm_resource_bundles_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_macos_app_bundle.py::test_copy_swiftpm_resource_bundles_returns_empty_when_source_missing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_resource_bundle_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_copy_swiftpm_resource_bundles_restores_existing_bundle_on_copy_failure services/mlx-worker-python/tests/test_macos_app_bundle.py::test_copy_swiftpm_resource_bundles_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_macos_app_bundle.py::test_copy_swiftpm_resource_bundles_returns_empty_when_source_missing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_resource_bundle_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/macos_app_bundle.py services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id macos-app-resource-bundle-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/macos-resource-bundle-probe-result.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: 5 passed.
- Changed-scope coverage: 95% aggregate changed-line coverage.
- Registered probe local result: base `elapsed_ms_mean=122.132671`, head `elapsed_ms_mean=103.92085`, delta `-18.211821 ms`, speedup `1.175x`; base `elapsed_ms_min=110.640593`, head `elapsed_ms_min=97.063951`; `copied_count=900` preserved.

## Known Gaps
- This is a Python packaging-path slice validated locally on Linux. It does not validate Swift runtime effects.
- CI is required for the registered PR-scoped performance workflow report before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused behavior tests pass locally.
- [x] Changed-scope coverage meets the 95% threshold locally.
- [x] Registered probe shows a local improvement versus `origin/main`.
- [ ] GitHub Actions / PR-scoped performance CI completed successfully.
