### PR TITLE
perf: bind code eval payload helpers locally

### DIFF
--- a/docs/plans/2026-05-23-code-eval-payload-local-bindings.md
+++ b/docs/plans/2026-05-23-code-eval-payload-local-bindings.md
@@ -1,0 +1,29 @@
+# Code Eval Payload Local Bindings Performance Slice
+
+## Goal
+
+Reduce repeated global helper lookups in the code-evaluation payload byte fast path without changing payload parsing behavior.
+
+## Scope
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `docs/plans/2026-05-23-code-eval-payload-local-bindings.md`
+
+## Registered Probe
+
+The affected path is already covered by the PR-scoped registered probe `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`. That probe has focused `test_command`, `coverage_command`, and `probe_command` entries and runs on `ubuntu-latest`.
+
+## Implementation Plan
+
+1. Keep the existing payload regression tests and registered probe unchanged.
+2. Bind `_json_field_value_start_for_token`, `_extract_json_string_field_at`, and `_extract_json_int_field_value_and_end` to local variables inside `_extract_code_eval_payload_fields(...)` before the hot field loop.
+3. Run the probe's focused tests, changed-scope coverage command, and probe command locally on Linux.
+4. Use PR-scoped performance CI as the final registered probe validation before merge.
+
+## Metrics
+
+Primary metric: `code-eval-payload-json-bytes` `elapsed_ms_mean` (reported as informational by the registry). Secondary metric: `peak_bytes_mean` (lower is better).
+
+## Validation Boundary
+
+This is a Python-only parsing-path slice. Local Linux validation covers the behavior, changed-scope coverage, and registered probe. No Swift runtime behavior is changed.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -416,8 +416,11 @@ def _extract_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, object]
 
     payload: dict[str, object] = {}
     search_start = 0
+    field_value_start = _json_field_value_start_for_token
+    extract_string = _extract_json_string_field_at
+    extract_int_and_end = _extract_json_int_field_value_and_end
     for key, key_token, value_kind in field_tokens:
-        value_start = _json_field_value_start_for_token(
+        value_start = field_value_start(
             payload_bytes,
             key_token,
             start=search_start,
@@ -425,13 +428,13 @@ def _extract_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, object]
         if value_start is None:
             return None
         if value_kind == "string":
-            value = _extract_json_string_field_at(payload_bytes, value_start)
+            value = extract_string(payload_bytes, value_start)
             if value is not None:
                 payload[key] = value
                 search_start = value_start + len(value) + 1
             continue
 
-        int_result = _extract_json_int_field_value_and_end(payload_bytes, value_start)
+        int_result = extract_int_and_end(payload_bytes, value_start)
         if int_result is None:
             return None
         value, value_end = int_result


### PR DESCRIPTION
## Summary
- Bind the code-evaluation payload byte-path helper functions to local variables before the hot field extraction loop.
- Add a scoped plan for the local-bindings performance slice.

## Plan or Spec
- `docs/plans/2026-05-23-code-eval-payload-local-bindings.md`
- Registered probe: `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json` (existing focused test, coverage, and probe commands).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_required_field_check_preserves_fast_path_gate services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py` (base and head worktrees)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 9 passed.
- Changed-scope coverage: `TOTAL 6 0 100%` (6/6 changed measurable lines covered).
- Local Linux registered probe samples:
  - Base `origin/main`: `elapsed_ms_mean=98.4193`, rerun `95.9229`; `peak_bytes_mean=60425.0`.
  - Head: `elapsed_ms_mean=94.3691`, rerun `90.9492`; `peak_bytes_mean=60425.0`.
  - Best paired rerun delta: `-4.9737 ms` (~5.19% faster); peak unchanged.
- CI PR-scoped performance is still required as the merge gate for the registered probe.

## Known Gaps
- This is a Python-only Linux-verified slice; it does not validate or change Swift runtime behavior.
- The local probe is microbenchmark-oriented and has normal host noise, so CI registered probe validation is the authoritative merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests ran locally.
- [x] Changed-scope coverage ran locally and is >=95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance completed successfully.
