### PR TITLE
perf: cache stream assembler suffix membership

### DIFF
--- a/docs/plans/2026-05-23-stream-assembler-partial-suffix-membership.md
+++ b/docs/plans/2026-05-23-stream-assembler-partial-suffix-membership.md
@@ -1,0 +1,21 @@
+# Stream assembler partial suffix membership slice
+
+## Scope
+
+This slice is limited to the Python stream assembler partial structural tag suffix check in `services/mlx-worker-python/worker/runtime/stream_assembler.py`.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped performance probe `stream-assembler-structural-prefixes` in `infra/perf/pr_scoped_probes.json`. The registration includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/stream_assembler.py`
+- `services/mlx-worker-python/tests/test_stream_assembler.py`
+- `scripts/stream_assembler_structural_prefix_probe.py`
+
+## Optimization plan
+
+Replace repeated structural open-tag `startswith(...)` checks in `_partial_structural_tag_suffix()` with cached per-mode partial-suffix membership sets. The check still scans only the last `<` marker candidate, preserves incomplete Harmony reasoning markers such as `<|channel>tho`, and keeps tool prefixes disabled for non-tool parser requests.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and registered local probe on Linux before pushing. GitHub Actions PR-scoped performance remains the merge gate for CI validation.

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -46,6 +46,11 @@ def test_structural_tag_prefixes_are_cached_per_parser_mode() -> None:
         is RequestStreamAssembler._TOOL_PARSER_STRUCTURAL_OPEN_TAGS
     )
     assert tool_enabled._structural_tag_prefixes is tool_enabled._structural_tag_prefixes
+    assert (
+        tool_enabled._partial_structural_tag_suffixes_value
+        is RequestStreamAssembler._TOOL_PARSER_PARTIAL_SUFFIXES
+    )
+    assert "<|channel>tho" in tool_enabled._partial_structural_tag_suffixes_value
     assert tool_enabled._structural_tag_prefixes_reversed == (
         tuple(reversed(pipe_channel_prefixes))
         + tuple(reversed(pipe_tool_prefixes))
@@ -60,6 +65,12 @@ def test_structural_tag_prefixes_are_cached_per_parser_mode() -> None:
     assert tool_enabled._structural_tag_prefixes is tool_enabled._structural_tag_prefixes
     assert tool_disabled._structural_tag_prefixes is tool_disabled._structural_tag_prefixes
     assert tool_disabled._structural_tag_prefixes is RequestStreamAssembler._REASONING_PREFIXES
+    assert (
+        tool_disabled._partial_structural_tag_suffixes_value
+        is RequestStreamAssembler._REASONING_PARTIAL_SUFFIXES
+    )
+    assert "<|channel>tho" in tool_disabled._partial_structural_tag_suffixes_value
+    assert "<tool" not in tool_disabled._partial_structural_tag_suffixes_value
     assert tool_disabled._structural_open_tags is RequestStreamAssembler._REASONING_OPEN_TAGS
     assert (
         tool_disabled._structural_tag_prefixes_reversed

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -110,6 +110,16 @@ class RequestStreamAssembler:
         "<|channel>"[:index] for index in range(1, len("<|channel>"))
     )
     _REASONING_PREFIXES = _THINK_PREFIXES + _PIPE_CHANNEL_PREFIXES
+    _REASONING_PARTIAL_SUFFIXES = frozenset(
+        _THINK_PREFIXES + _PIPE_CHANNEL_PREFIXES + _PIPE_REASONING_PREFIXES
+    )
+    _TOOL_PARSER_PARTIAL_SUFFIXES = frozenset(
+        _THINK_PREFIXES
+        + _PIPE_CHANNEL_PREFIXES
+        + _PIPE_REASONING_PREFIXES
+        + _TOOL_PREFIXES
+        + _PIPE_TOOL_PREFIXES
+    )
     _THINK_PREFIXES_REVERSED = tuple(reversed(_THINK_PREFIXES))
     _PIPE_REASONING_PREFIXES_REVERSED = tuple(reversed(_PIPE_REASONING_PREFIXES))
     _REASONING_PREFIXES_REVERSED = tuple(reversed(_REASONING_PREFIXES))
@@ -163,6 +173,7 @@ class RequestStreamAssembler:
             self._is_json_structured_output_value and not self._tool_parsing_enabled_value
         )
         self._structural_tag_prefixes_value = self._REASONING_PREFIXES
+        self._partial_structural_tag_suffixes_value = self._REASONING_PARTIAL_SUFFIXES
         self._structural_tag_prefixes_reversed_value = self._REASONING_PREFIXES_REVERSED
         self._structural_open_tags_value = self._REASONING_OPEN_TAGS
         if self._tool_parsing_enabled_value:
@@ -171,6 +182,7 @@ class RequestStreamAssembler:
             self._structural_tag_prefixes_value = (
                 self._REASONING_PREFIXES + self._TOOL_PREFIXES + self._PIPE_TOOL_PREFIXES
             )
+            self._partial_structural_tag_suffixes_value = self._TOOL_PARSER_PARTIAL_SUFFIXES
             self._structural_tag_prefixes_reversed_value = (
                 self._PIPE_CHANNEL_PREFIXES_REVERSED
                 + self._PIPE_TOOL_PREFIXES_REVERSED
@@ -620,32 +632,7 @@ class RequestStreamAssembler:
             return ""
 
         suffix = self._buffer[marker_index:]
-        suffix_len = len(suffix)
-        if self._tool_parsing_enabled_value:
-            if (
-                0 < suffix_len < len(self._TOOL_OPEN)
-                and self._TOOL_OPEN.startswith(suffix)
-            ):
-                return suffix
-            if (
-                0 < suffix_len < len(self._PIPE_TOOL_OPEN)
-                and self._PIPE_TOOL_OPEN.startswith(suffix)
-            ):
-                return suffix
-        if (
-            0 < suffix_len < len(self._THINK_OPEN)
-            and self._THINK_OPEN.startswith(suffix)
-        ):
-            return suffix
-        if (
-            0 < suffix_len < len(self._PIPE_CHANNEL_OPEN)
-            and self._PIPE_CHANNEL_OPEN.startswith(suffix)
-        ):
-            return suffix
-        if (
-            0 < suffix_len < len(self._PIPE_REASONING_OPEN)
-            and self._PIPE_REASONING_OPEN.startswith(suffix)
-        ):
+        if suffix in self._partial_structural_tag_suffixes_value:
             return suffix
         return ""
 


### PR DESCRIPTION
## Summary
- Cache stream assembler partial structural suffix candidates in per-mode frozensets.
- Replace repeated `startswith(...)` checks in `_partial_structural_tag_suffix()` with a single membership lookup while preserving Harmony reasoning prefixes and non-tool parser behavior.
- Add focused assertions that the cached suffix sets are mode-specific and include the longer `<|channel>tho` reasoning prefix.

## Plan or Spec
- `docs/plans/2026-05-23-stream-assembler-partial-suffix-membership.md`
- Registered probe: `stream-assembler-structural-prefixes` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_structural_prefix_probe.py
# baseline on origin/main before changes: exit 0; elapsed_ms_mean=728.393146; partial_suffix_elapsed_ms_mean=94.089629; peak_bytes_mean=182.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_structural_tag_prefixes_are_cached_per_parser_mode services/mlx-worker-python/tests/test_stream_assembler.py::test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call services/mlx-worker-python/tests/test_stream_assembler.py::test_partial_structural_tag_suffix_returns_match_without_tuple_prescan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_script_emits_metrics
# exit 0; 6 passed in 0.96s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_structural_tag_prefixes_are_cached_per_parser_mode services/mlx-worker-python/tests/test_stream_assembler.py::test_partial_structural_tag_suffix_checks_all_prefixes_in_one_endswith_call services/mlx-worker-python/tests/test_stream_assembler.py::test_partial_structural_tag_suffix_returns_match_without_tuple_prescan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_script_emits_metrics
# exit 0; 6 passed in 0.23s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_structural_prefix_probe.py
# exit 0; aggregate changed-line coverage 100% (10/10)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_structural_prefix_probe.py
# exit 0; elapsed_ms_mean=690.03769; partial_suffix_elapsed_ms_mean=64.035754; peak_bytes_mean=182.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py
# exit 0; 80 passed in 0.10s

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (10/10 measurable changed lines).
- Local registered probe (`stream_assembler_structural_prefix_probe.py`):
  - old elapsed_ms_mean=728.393146; new elapsed_ms_mean=690.03769; delta=-38.355456 ms; speedup=1.056x.
  - old partial_suffix_elapsed_ms_mean=94.089629; new partial_suffix_elapsed_ms_mean=64.035754; delta=-30.053875 ms; speedup=1.469x.
  - peak_bytes_mean unchanged at 182.0 bytes.
- CI PR-scoped performance report is required as the merge gate for registered probe validation.

## Known Gaps
- Linux local validation covers the Python stream assembler path only.
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this narrow slice; GitHub Actions remains the broader gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe; probe overhead unchanged and measured through the registered synthetic probe.
- [x] Deferred work and known gaps are stated explicitly.
