### PR TITLE
perf: bind code eval config json loads

### DIFF
--- a/docs/plans/2026-05-23-code-eval-config-json-load-binding.md
+++ b/docs/plans/2026-05-23-code-eval-config-json-load-binding.md
@@ -1,0 +1,24 @@
+# Code evaluation config JSON load binding
+
+## Scope
+
+This performance slice targets the embedded code-evaluation runner's config
+loader in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+## Plan
+
+- Keep the registered `code-eval-runner-script-cache` PR-scoped performance
+  probe as the governing validation path.
+- Preserve the existing bytes-based JSON config load behavior.
+- Bind `json.loads` as a default argument inside the embedded `_load_config`
+  helper so repeated config-load loops avoid the module attribute lookup while
+  continuing to parse bytes from the config path.
+
+## Validation
+
+- Focused unit coverage: `test_runner_script_loads_config_from_bytes` confirms
+  the embedded runner still loads JSON config bytes and exposes the bound helper
+  expression.
+- Registered probe: `scripts/code_eval_runner_script_probe.py` reports
+  `config_load_elapsed_ms_mean` for repeated config loads under the same
+  PR-scoped probe used by CI.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -727,7 +727,7 @@ def test_runner_script_loads_config_from_bytes(tmp_path: Path) -> None:
         "payload_path": "/tmp/payload.json",
         "memory_limit_mb": 64,
     }
-    assert "json.loads(config_path.read_bytes())" in script
+    assert "payload = _json_loads(config_path.read_bytes())" in script
     assert "json.load(file)" not in script
 
     code_eval_runner._runner_script.cache_clear()

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -850,8 +850,11 @@ def _runner_script() -> str:
                 pass
 
 
-        def _load_config(config_path: Path) -> dict[str, object]:
-            payload = json.loads(config_path.read_bytes())
+        def _load_config(
+            config_path: Path,
+            _json_loads=json.loads,
+        ) -> dict[str, object]:
+            payload = _json_loads(config_path.read_bytes())
             if not isinstance(payload, dict):
                 raise TypeError("runner config must be a JSON object")
             return payload


### PR DESCRIPTION
## Summary
- Bind `json.loads` as a default argument inside the embedded code-eval runner `_load_config` helper.
- Preserve the existing bytes-based config read path and focused unit assertion.
- Add a governing plan for this micro-optimization slice.

## Plan or Spec
- `docs/plans/2026-05-23-code-eval-config-json-load-binding.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_runner_script_reuses_dedented_static_payload services/mlx-worker-python/tests/test_code_eval_runner.py::test_runner_script_loads_config_from_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_runner_script_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_runner_script_reuses_dedented_static_payload services/mlx-worker-python/tests/test_code_eval_runner.py::test_runner_script_loads_config_from_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_runner_script_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_runner_script_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_runner_script_probe.py`

## Coverage and Metrics
- Focused tests: 5 passed.
- Changed-scope coverage: 100% (1/1 measurable changed lines covered).
- Registered local probe (`code_eval-runner-script-cache`): before `config_load_elapsed_ms_mean=77.303 ms`, after `config_load_elapsed_ms_mean=71.202 ms`, delta `-6.101 ms` (`-7.89%`). Full after metrics: `elapsed_ms_mean=61.087`, `dedent_calls_mean=1.0`, `identity_reuse_mean=1.0`, `peak_bytes_mean=32985.714`, `config_load_iteration_count=5000`, `sample_count=7`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime behavior is touched.
- The probe's `peak_bytes_mean` changed with the embedded script text length and is not the target metric for this slice.

## Evidence Checklist
- [x] Registered PR-scoped probe covers `services/mlx-worker-python/worker/engine/code_eval_runner.py` via `code-eval-runner-script-cache`.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows the targeted config-load metric improved.
- [ ] GitHub Actions and PR-scoped performance report are green.
