### PR TITLE
perf: prefilter runtime weight suffix checks

### DIFF
--- a/docs/plans/2026-05-11-runtime-utils-top-level-weight-streaming.md
+++ b/docs/plans/2026-05-11-runtime-utils-top-level-weight-streaming.md
@@ -32,3 +32,16 @@ selection, and the probe script smoke test.
 - Behavior remains unchanged for indexed bundles, flat bundles, missing paths, and stat/list errors.
 - `_top_level_weight_file_bytes()` streams `Path.iterdir()` entries instead of materializing a tuple.
 - Local registered probe shows lower peak allocation and no worse resident-byte guard rails.
+
+## 2026-05-23 suffix prefilter slice
+
+The follow-up Python slice keeps the same registered probe and narrows only the
+model-weight filename classification hot path. `_is_model_weight_filename(...)`
+now rejects names whose final character cannot match any supported model-weight
+suffix before running tuple `endswith(...)`, `islower()`, or lowercase fallback
+work. This preserves existing case-sensitive and case-insensitive suffix behavior
+while avoiding extra string checks for common non-weight files in flat bundles.
+
+Validation remains the focused runtime-utils pytest selection, changed-scope
+coverage for `runtime_utils.py`, `test_runtime_utils.py`, and the registered probe
+script, plus the local and CI `runtime-utils-top-level-weight-streaming` probe.

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -12,6 +12,7 @@ from typing import Any
 
 
 _MODEL_WEIGHT_SUFFIXES = (".safetensors", ".npz", ".bin", ".gguf")
+_MODEL_WEIGHT_SUFFIX_LAST_CHARS = frozenset("sSzZnNfF")
 
 
 @dataclass(frozen=True, slots=True)
@@ -181,6 +182,8 @@ def _top_level_weight_file_bytes(model_dir: Path) -> int:
 
 
 def _is_model_weight_filename(name: str) -> bool:
+    if not name or name[-1] not in _MODEL_WEIGHT_SUFFIX_LAST_CHARS:
+        return False
     if name.endswith(_MODEL_WEIGHT_SUFFIXES):
         return name not in _MODEL_WEIGHT_SUFFIXES
     if name.islower():


### PR DESCRIPTION
## Summary
- Add a last-character prefilter before runtime model-weight suffix checks.
- Keep the existing case-sensitive fast path and case-insensitive fallback semantics unchanged.
- Document the suffix-prefilter optimization slice in the runtime-utils plan.

## Plan or Spec
- Updated `docs/plans/2026-05-11-runtime-utils-top-level-weight-streaming.md` with the 2026-05-23 suffix prefilter slice.
- The affected path is already covered by the registered `runtime-utils-top-level-weight-streaming` PR-scoped probe with focused test, coverage, and probe commands.

## Commands Run
- `git diff --check`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-utils-top-level-weight-streaming --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-runtime-utils-20260523185314 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-tool-registry-openai-tools-loop-20260523182937 --output /tmp/runtime_utils_suffix_prefilter_probe.json`

## Coverage and Metrics
- Focused pytest: 9 passed.
- Changed-scope coverage from the registered probe run: 100.00% (`runtime_utils.py`, runtime-utils tests, PR-scoped performance tests, and the probe script scope).
- Local registered probe (`runtime-utils-top-level-weight-streaming`): base `elapsed_ms_mean=191.67606602422893`, head `elapsed_ms_mean=176.05375829152763`, delta `-15.622307732701302 ms` (~8.15% faster); `peak_bytes_mean` unchanged at `2040.8` bytes; guard rails unchanged (`file_count=3000`, `iterations=8`, `expected_bytes=13480`, `checksum=107840`).
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime path is touched.
- The local probe is synthetic and must be confirmed by the registered CI probe before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before the slice (`HEAD == origin/main` before edits).
- [x] Confirmed affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Ran focused tests locally.
- [x] Ran changed-scope coverage locally via the registered probe runner.
- [x] Ran the registered probe locally against `origin/main` baseline.
- [ ] GitHub Actions and PR-scoped performance workflow completed successfully.
