### PR TITLE
Include KV cache in Hub local-fit estimates

### DIFF
--- a/docs/plans/2026-05-24-hub-catalog-kv-cache-fit-evidence.md
+++ b/docs/plans/2026-05-24-hub-catalog-kv-cache-fit-evidence.md
@@ -1,0 +1,36 @@
+# Hub Catalog KV Cache Fit Evidence
+
+## Scope
+
+This Python-only slice improves Hub catalog local-fit evidence for MLX text models. It applies the guide principle that local fit is not just model weights: the live resident estimate must include the KV cache implied by the advertised context window when Hub config metadata provides enough architecture fields.
+
+Affected implementation path:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+
+Affected tests:
+
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+
+## Behavior
+
+When Hub payload `config` metadata includes text-model architecture values, Melix should estimate FP16/BF16 KV-cache bytes with:
+
+```text
+context_tokens * layers * kv_heads * head_dim * bytes_per_element * 2
+```
+
+The estimate should use the model's key/value head count when available, otherwise attention heads, and should derive `head_dim` from `hidden_size / num_attention_heads` when an explicit head dimension is absent. The estimate is added to the existing resident-byte estimate before local-fit status is chosen. Local-fit reasons should mention the KV-cache estimate so operators can see that long-context memory is included.
+
+If the required config metadata is missing, existing behavior remains unchanged.
+
+## Metrics And Verification
+
+- Focused behavior: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py`
+- Changed-scope coverage: run the registered Hub catalog coverage command from `infra/perf/pr_scoped_probes.json`.
+- Performance: the existing Hub catalog PR-scoped probes still cover the changed file and should run in CI.
+
+## Acceptance
+
+- A small 4-bit model with a large advertised context can be marked `heavy` when estimated KV-cache bytes push resident memory beyond the comfort budget.
+- Existing local-fit behavior for payloads without usable config metadata stays unchanged.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 from unittest.mock import Mock
 from urllib.error import HTTPError, URLError
 from urllib.request import Request
@@ -625,6 +626,116 @@ def test_search_models_marks_large_mlx_model_as_heavy_not_blocked() -> None:
     assert model.recommended_action == "review_risk"
     assert model.estimated_resident_bytes > int(64 * 1024 * 1024 * 1024 * 0.60)
     assert any("memory comfort budget" in reason for reason in model.local_fit_reasons)
+
+
+def test_search_models_includes_kv_cache_in_local_fit_for_long_context_configs() -> None:
+    payload = [
+        {
+            "id": "mlx-community/long-context-4bit",
+            "author": "mlx-community",
+            "pipeline_tag": "text-generation",
+            "tags": ["mlx", "4-bit"],
+            "library_name": "mlx",
+            "usedStorage": 512 * MB,
+            "config": {
+                "hidden_size": 4096,
+                "num_attention_heads": 32,
+                "num_key_value_heads": 32,
+                "num_hidden_layers": 64,
+                "max_position_embeddings": 131_072,
+                "torch_dtype": "bfloat16",
+            },
+            "siblings": [{"rfilename": "model.safetensors", "size": 512 * MB}],
+            "cardData": {},
+        }
+    ]
+
+    def opener(_request: Request):
+        return FakeHTTPResponse(payload)
+
+    catalog = HubCatalog(opener=opener, local_memory_gb=64.0)
+    page = catalog.search_models(query="long-context", page_size=10, cursor="", mlx_only=True)
+
+    model = page.items[0]
+    expected_kv_bytes = 131_072 * 64 * 32 * 128 * 2 * 2
+    assert model.local_fit_status == "heavy"
+    assert model.recommended_action == "review_risk"
+    assert model.estimated_resident_bytes >= expected_kv_bytes
+    assert any("Estimated KV cache bytes" in reason for reason in model.local_fit_reasons)
+
+
+def test_search_models_uses_text_config_string_values_and_gqa_heads_for_kv_cache() -> None:
+    payload = [
+        {
+            "id": "mlx-community/gqa-string-config-4bit",
+            "author": "mlx-community",
+            "pipeline_tag": "text-generation",
+            "tags": ["mlx", "4-bit"],
+            "library_name": "mlx",
+            "usedStorage": 256 * MB,
+            "config": {
+                "max_position_embeddings": 2048,
+                "text_config": {
+                    "hidden_size": "4096",
+                    "num_attention_heads": "32",
+                    "num_key_value_heads": "8",
+                    "num_hidden_layers": "4",
+                    "torch_dtype": "float32",
+                },
+            },
+            "siblings": [{"rfilename": "model.safetensors", "size": 256 * MB}],
+            "cardData": {},
+        }
+    ]
+
+    def opener(_request: Request):
+        return FakeHTTPResponse(payload)
+
+    catalog = HubCatalog(opener=opener, local_memory_gb=64.0)
+    page = catalog.search_models(query="gqa-string-config", page_size=10, cursor="", mlx_only=True)
+
+    model = page.items[0]
+    expected_kv_bytes = 2048 * 4 * 8 * 128 * 4 * 2
+    expected_weight_bytes = math.ceil((256 * MB) * hub_catalog_module.RESIDENT_MEMORY_OVERHEAD_FACTOR)
+    assert model.estimated_resident_bytes == expected_weight_bytes + expected_kv_bytes
+    assert any(str(expected_kv_bytes) in reason for reason in model.local_fit_reasons)
+
+
+def test_search_models_skips_kv_cache_estimate_for_incompatible_records(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = [
+        {
+            "id": "plain-community/plain-transformer",
+            "author": "plain-community",
+            "pipeline_tag": "text-generation",
+            "tags": ["transformers", "4-bit"],
+            "library_name": "transformers",
+            "safetensors": {"total": 2_000_000_000},
+            "config": {
+                "hidden_size": 4096,
+                "num_attention_heads": 32,
+                "num_key_value_heads": 32,
+                "num_hidden_layers": 64,
+                "max_position_embeddings": 131_072,
+            },
+            "siblings": [{"rfilename": "config.json"}],
+            "cardData": {},
+        }
+    ]
+    estimate_kv_cache = Mock(return_value=123)
+    monkeypatch.setattr(hub_catalog_module, "_estimated_kv_cache_bytes", estimate_kv_cache)
+
+    def opener(_request: Request):
+        return FakeHTTPResponse(payload)
+
+    catalog = HubCatalog(opener=opener, local_memory_gb=64.0)
+    page = catalog.search_models(query="plain-transformer", page_size=10, cursor="", mlx_only=False)
+
+    model = page.items[0]
+    assert model.local_fit_status == "blocked"
+    assert model.estimated_resident_bytes > 0
+    estimate_kv_cache.assert_not_called()
 
 
 def test_size_hint_from_empty_text_skips_regex_search(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -701,6 +701,42 @@ def test_search_models_uses_text_config_string_values_and_gqa_heads_for_kv_cache
     assert any(str(expected_kv_bytes) in reason for reason in model.local_fit_reasons)
 
 
+def test_search_models_resolves_text_config_once_for_kv_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = [
+        {
+            "id": "mlx-community/single-config-parse-4bit",
+            "author": "mlx-community",
+            "pipeline_tag": "text-generation",
+            "tags": ["mlx", "4-bit"],
+            "library_name": "mlx",
+            "usedStorage": 256 * MB,
+            "config": {
+                "hidden_size": 1024,
+                "num_attention_heads": 16,
+                "num_key_value_heads": 4,
+                "num_hidden_layers": 2,
+                "max_position_embeddings": 1024,
+                "torch_dtype": "bfloat16",
+            },
+            "siblings": [{"rfilename": "model.safetensors", "size": 256 * MB}],
+            "cardData": {},
+        }
+    ]
+    text_config = Mock(wraps=hub_catalog_module._text_config)
+    monkeypatch.setattr(hub_catalog_module, "_text_config", text_config)
+
+    def opener(_request: Request):
+        return FakeHTTPResponse(payload)
+
+    catalog = HubCatalog(opener=opener, local_memory_gb=64.0)
+    page = catalog.search_models(query="single-config-parse", page_size=10, cursor="", mlx_only=True)
+
+    assert page.items[0].local_fit_status == "good"
+    text_config.assert_called_once_with(payload[0])
+
+
 def test_search_models_skips_kv_cache_estimate_for_incompatible_records(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -774,6 +774,13 @@ def test_search_models_skips_kv_cache_estimate_for_incompatible_records(
     estimate_kv_cache.assert_not_called()
 
 
+def test_positive_config_int_continues_to_next_key_when_string_value_is_zero() -> None:
+    # "0" passes isdecimal() but is not positive; the loop must continue to the fallback key
+    config = {"primary_key": "0", "fallback_key": 8}
+    result = hub_catalog_module._positive_config_int(config, "primary_key", "fallback_key")
+    assert result == 8
+
+
 def test_size_hint_from_empty_text_skips_regex_search(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(hub_catalog_module, "_BARE_SIZE_HINT_RE", object())
     monkeypatch.setattr(hub_catalog_module, "_EXPLICIT_SIZE_HINT_RE", object())

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -781,8 +781,11 @@ def _positive_config_int(config: dict[str, Any], *keys: str) -> int:
         value = _int(raw_value)
         if value > 0:
             return value
+        # _int() does not coerce strings; handle string-typed config fields explicitly
         if isinstance(raw_value, str) and raw_value.isdecimal():
-            return int(raw_value)
+            parsed = int(raw_value)
+            if parsed > 0:
+                return parsed
     return 0
 
 

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -503,11 +503,13 @@ def _local_fit_evidence(
             "recommended_action": "inspect_metadata",
         }
 
-    kv_cache_bytes = _estimated_kv_cache_bytes(payload)
+    config = _text_config(payload)
+    kv_cache_bytes = _estimated_kv_cache_bytes(config)
     if kv_cache_bytes > 0:
         estimated_resident_bytes += kv_cache_bytes
+        context_tokens = _context_token_count_from_config(config)
         reasons.append(
-            f"Estimated KV cache bytes for {_context_token_count(payload)} context tokens: {kv_cache_bytes}."
+            f"Estimated KV cache bytes for {context_tokens} context tokens: {kv_cache_bytes}."
         )
 
     memory_budget_bytes = int(max(local_memory_gb, 0.0) * (1024 ** 3) * MEMORY_COMFORT_BUDGET_FACTOR)
@@ -734,8 +736,7 @@ def _estimated_resident_bytes(
     return math.ceil(base_size * RESIDENT_MEMORY_OVERHEAD_FACTOR)
 
 
-def _estimated_kv_cache_bytes(payload: dict[str, Any]) -> int:
-    config = _text_config(payload)
+def _estimated_kv_cache_bytes(config: dict[str, Any]) -> int:
     context_tokens = _context_token_count_from_config(config)
     layers = _positive_config_int(config, "num_hidden_layers", "n_layer", "num_layers")
     attention_heads = _positive_config_int(config, "num_attention_heads", "n_head", "n_heads")
@@ -760,10 +761,6 @@ def _text_config(payload: dict[str, Any]) -> dict[str, Any]:
     merged = dict(config)
     merged.update(text_config)
     return merged
-
-
-def _context_token_count(payload: dict[str, Any]) -> int:
-    return _context_token_count_from_config(_text_config(payload))
 
 
 def _context_token_count_from_config(config: dict[str, Any]) -> int:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -503,6 +503,13 @@ def _local_fit_evidence(
             "recommended_action": "inspect_metadata",
         }
 
+    kv_cache_bytes = _estimated_kv_cache_bytes(payload)
+    if kv_cache_bytes > 0:
+        estimated_resident_bytes += kv_cache_bytes
+        reasons.append(
+            f"Estimated KV cache bytes for {_context_token_count(payload)} context tokens: {kv_cache_bytes}."
+        )
+
     memory_budget_bytes = int(max(local_memory_gb, 0.0) * (1024 ** 3) * MEMORY_COMFORT_BUDGET_FACTOR)
     if memory_budget_bytes > 0 and estimated_resident_bytes > memory_budget_bytes:
         reasons.append("Estimated resident bytes exceed the memory comfort budget.")
@@ -725,6 +732,70 @@ def _estimated_resident_bytes(
     else:
         return 0
     return math.ceil(base_size * RESIDENT_MEMORY_OVERHEAD_FACTOR)
+
+
+def _estimated_kv_cache_bytes(payload: dict[str, Any]) -> int:
+    config = _text_config(payload)
+    context_tokens = _context_token_count_from_config(config)
+    layers = _positive_config_int(config, "num_hidden_layers", "n_layer", "num_layers")
+    attention_heads = _positive_config_int(config, "num_attention_heads", "n_head", "n_heads")
+    kv_heads = _positive_config_int(config, "num_key_value_heads", "n_kv_heads") or attention_heads
+    head_dim = _positive_config_int(config, "head_dim")
+    if head_dim <= 0 and attention_heads > 0:
+        hidden_size = _positive_config_int(config, "hidden_size", "n_embd", "d_model")
+        if hidden_size > 0 and hidden_size % attention_heads == 0:
+            head_dim = hidden_size // attention_heads
+    if context_tokens <= 0 or layers <= 0 or kv_heads <= 0 or head_dim <= 0:
+        return 0
+    return context_tokens * layers * kv_heads * head_dim * _kv_cache_bytes_per_element(config) * 2
+
+
+def _text_config(payload: dict[str, Any]) -> dict[str, Any]:
+    config = payload.get("config")
+    if not isinstance(config, dict):
+        return {}
+    text_config = config.get("text_config")
+    if not isinstance(text_config, dict):
+        return config
+    merged = dict(config)
+    merged.update(text_config)
+    return merged
+
+
+def _context_token_count(payload: dict[str, Any]) -> int:
+    return _context_token_count_from_config(_text_config(payload))
+
+
+def _context_token_count_from_config(config: dict[str, Any]) -> int:
+    return _positive_config_int(
+        config,
+        "max_position_embeddings",
+        "model_max_length",
+        "max_seq_len",
+        "max_sequence_length",
+        "context_length",
+        "seq_length",
+    )
+
+
+def _positive_config_int(config: dict[str, Any], *keys: str) -> int:
+    for key in keys:
+        raw_value = config.get(key)
+        value = _int(raw_value)
+        if value > 0:
+            return value
+        if isinstance(raw_value, str) and raw_value.isdecimal():
+            return int(raw_value)
+    return 0
+
+
+def _kv_cache_bytes_per_element(config: dict[str, Any]) -> int:
+    dtype = _string(config.get("torch_dtype") or config.get("dtype")).lower()
+    if dtype in {"float32", "fp32", "f32"}:
+        return 4
+    if dtype in {"float8", "fp8", "int8", "uint8"}:
+        return 1
+    return 2
 
 
 def _bytes_per_parameter(tags: list[str], *, lowered_tags: set[str] | None = None) -> float:


### PR DESCRIPTION
## Summary
- Include estimated KV-cache bytes in Hub catalog local-fit evidence after MLX compatibility, pipeline, gating, and artifact metadata checks pass.
- Parse common text-model config fields, nested `text_config`, GQA key/value heads, context length aliases, and dtype bytes-per-element for the KV estimate.
- Add focused coverage for long-context fit ranking, nested/string-backed config values, and the lazy incompatible-record path.

## Plan or Spec
- `docs/plans/2026-05-24-hub-catalog-kv-cache-fit-evidence.md`

## Commands Run
```text
make bootstrap
# passed: git hooks configured; uv sync checked 79 packages

make proto
# passed: ./scripts/proto_gen.sh completed with no tracked diff

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py::test_search_models_includes_kv_cache_in_local_fit_for_long_context_configs
# red phase before implementation: failed as expected because the long-context model still ranked as "good" without KV-cache bytes

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py::test_search_models_includes_kv_cache_in_local_fit_for_long_context_configs services/mlx-worker-python/tests/test_hub_catalog.py::test_search_models_uses_text_config_string_values_and_gqa_heads_for_kv_cache services/mlx-worker-python/tests/test_hub_catalog.py::test_search_models_skips_kv_cache_estimate_for_incompatible_records
# passed: 3 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py
# passed before merge: 54 passed in 0.23s
# passed after merging origin/main: 54 passed in 0.21s

git commit -m "feat: include kv cache in hub local fit"
# passed full macOS pre-commit hook before the origin/main merge:
# make swift-test: passed, 767 tests
# make py-test: passed, 3033 passed, 14 skipped, 2 warnings
# make integration-test: passed, 114 passed, 1 skipped
# PR-scoped performance: ok, report .runtime/pre-commit-performance/20260523-194519-4cd78b04/report/report.md

UV_PYTHON=3.12 UV_CACHE_DIR="$PWD/.uv-cache" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts.pre_commit_gate import run_performance_report
changed_files = [
    'docs/plans/2026-05-24-hub-catalog-kv-cache-fit-evidence.md',
    'services/mlx-worker-python/tests/test_hub_catalog.py',
    'services/mlx-worker-python/worker/model_ops/hub_catalog.py',
]
outcome = run_performance_report(Path.cwd(), changed_files, base_ref='origin/main')
print(f'OUTCOME status={outcome.status} selected={outcome.selected_probe_count} report_dir={outcome.report_dir}')
raise SystemExit(0 if outcome.status == 'ok' else 1)
PY
# passed after merging origin/main: status=ok, selected=3
# report .runtime/pre-commit-performance/20260523-194940-6b882c40/report/report.md
```

## Coverage and Metrics
- Changed-scope coverage: 99.0% in the post-merge PR-scoped performance verification.
- Hub catalog tag normalization single pass: neutral, elapsed +3.67%, calls unchanged.
- Hub catalog next cursor fast parse: neutral, elapsed +1.03%, calls unchanged, peak bytes -2.58%.
- Hub catalog size hint regex precompile: improvement, elapsed -5.31%, calls unchanged.
- Observability mode: `evidence`; this change uses existing PR-scoped synthetic probes only and adds no runtime observability overhead.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
