### PR TITLE
perf: cache invalid probe policy strings

### DIFF
--- a/docs/plans/2026-05-23-probe-policy-invalid-string-cache.md
+++ b/docs/plans/2026-05-23-probe-policy-invalid-string-cache.md
@@ -1,0 +1,19 @@
+# Probe Policy Invalid String Cache
+
+## Goal
+
+Reduce repeated `ProbePolicy.from_value(...)` overhead for unsupported string values while preserving the existing exact lowercase fast path and normalized fallback semantics.
+
+## Slice
+
+This slice is limited to `worker.productization.probe_policy` and the existing registered `probe-policy-noop-overhead` PR-scoped probe. The probe already covers `services/mlx-worker-python/worker/productization/probe_policy.py`, `services/mlx-worker-python/worker/productization/probe_policy_overhead.py`, focused tests, and `scripts/probe_policy_noop_overhead_probe.py` with test, coverage, and probe commands in `infra/perf/pr_scoped_probes.json`.
+
+## Implementation
+
+- Keep exact supported lowercase strings on the direct dictionary lookup path.
+- Add a bounded cached helper for non-exact string values so repeated unsupported probe mode values reuse the normalized fallback policy without repeating `strip().lower()`.
+- Preserve subclass `str` behavior through the existing normalization branch.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and `probe-policy-noop-overhead` probe locally on Linux. CI remains the source of truth for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -4,7 +4,12 @@ from worker.productization.probe_policy_overhead import (
     NoOpProbeRecorder,
     measure_no_op_probe_policy_overhead,
 )
-from worker.productization.probe_policy import ProbeMode, ProbePolicy, probe_policy_from_env
+from worker.productization.probe_policy import (
+    ProbeMode,
+    ProbePolicy,
+    _probe_policy_from_uncached_string,
+    probe_policy_from_env,
+)
 
 
 class _EmptyEnvMapping(dict[str, str]):
@@ -79,6 +84,18 @@ def test_probe_policy_empty_env_uses_production_default() -> None:
     assert policy.source_value == ""
     assert policy.fallback_applied is False
     assert policy.telemetry_enabled is False
+
+
+def test_probe_policy_reuses_normalized_string_cache_for_invalid_values() -> None:
+    _probe_policy_from_uncached_string.cache_clear()
+    invalid_policy = ProbePolicy.from_value("Definitely-Not-Valid")
+
+    assert invalid_policy.mode is ProbeMode.MINIMAL
+    assert invalid_policy.source_value == "definitely-not-valid"
+    assert invalid_policy.fallback_applied is True
+    assert ProbePolicy.from_value("Definitely-Not-Valid") is invalid_policy
+    assert _probe_policy_from_uncached_string.cache_info().hits == 1
+    assert ProbePolicy.from_value("   ") is ProbePolicy.from_value("")
 
 
 def test_probe_policy_empty_values_reuse_default_policy_cache() -> None:

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -65,7 +65,7 @@ class ProbePolicy:
             policy = _PROBE_POLICY_BY_VALUE_GET(value)
             if policy is not None:
                 return policy
-            raw_value = value.strip().lower()
+            return _probe_policy_from_uncached_string(value, default_mode)
         elif isinstance(value, ProbeMode):
             return _PROBE_POLICY_BY_MODE[value]
         elif isinstance(value, str):
@@ -103,6 +103,17 @@ _PROBE_POLICY_BY_DEFAULT_MODE: dict[ProbeMode, ProbePolicy] = {
 }
 _EVIDENCE_PROBE_POLICY = _PROBE_POLICY_BY_MODE[ProbeMode.EVIDENCE]
 _DEBUG_PROBE_POLICY = _PROBE_POLICY_BY_MODE[ProbeMode.DEBUG]
+
+
+@lru_cache(maxsize=64)
+def _probe_policy_from_uncached_string(value: str, default_mode: ProbeMode) -> ProbePolicy:
+    raw_value = value.strip().lower()
+    if not raw_value:
+        return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
+    policy = _PROBE_POLICY_BY_VALUE_GET(raw_value)
+    if policy is not None:
+        return policy
+    return _invalid_probe_policy(raw_value, default_mode)
 
 
 @lru_cache(maxsize=64)


### PR DESCRIPTION
## Summary
- Cache normalized non-exact `ProbePolicy.from_value(...)` string lookups with a bounded helper.
- Preserve the exact lowercase supported-mode fast path and existing fallback semantics.
- Add a regression test proving repeated invalid string inputs hit the normalized string cache.

## Plan or Spec
- `docs/plans/2026-05-23-probe-policy-invalid-string-cache.md`
- Registered probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main (a98294d6), exit 0
MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=500000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=7 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py

# Focused tests, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 18 passed in 1.11s

# Changed-scope coverage, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py
# TOTAL 20 0 100%

# Post-change registered probe, exit 0
MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=500000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=7 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py

# Diff hygiene, exit 0
git diff --check
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 20 0 100%`.
- Local registered probe comparison (`MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=500000`, `MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=7`):
  - Baseline `mode_parse_invalid_call_ms_mean=0.000349484`.
  - Post-change `mode_parse_invalid_call_ms_mean=0.000223335`.
  - Delta `-0.000126149 ms/call`, about `36.096%` lower for repeated invalid mode parsing.
  - Post-change `threshold_passed=1.0`.
- CI PR-scoped performance is required as the registered probe validation source before merge.

## Known Gaps
- Linux-local validation only; no Swift runtime behavior is changed.
- Exact valid mode parse timings are expected to remain behavior-equivalent; the primary measured target is repeated invalid string normalization.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
