### PR TITLE
Label serving benchmark measurement profiles

### DIFF
--- a/docs/plans/2026-05-23-three-way-gemma4-31b-128k-serving-comparison.md
+++ b/docs/plans/2026-05-23-three-way-gemma4-31b-128k-serving-comparison.md
@@ -140,3 +140,76 @@ Export the final stakeholder-readable report bundle to:
 - Focused regression evidence: `WorkerScaffoldTests/testGemma4TextFullAttentionCacheUsesLongContextGrowthStep` first failed with both full-attention caches reporting `step = 256`, then passed after the Gemma 4 cache growth change.
 
 Current bottleneck conclusion: Melix is no longer blocked by Gemma 4 loading, text-only routing, or context-limit rejection. The remaining blocker to beating SwiftLM/OMLX is the Swift Gemma 4 long-context prefill path, plus missing prompt-prefill cancellation. Melix must optimize that path before claiming success against the user's 128k requirement.
+
+## 2026-05-24 Follow-Up Diagnosis
+
+The short `1024/16/c1` smoke artifact at
+`~/Downloads/live-smoke-c1-20260523-2217` is useful only as a startup
+compatibility check. It must not be used as a warm inference comparison:
+
+- Melix reported benchmark TTFT around `12.0s`, but its control-plane metrics
+  snapshot recorded `http.ttfd_ms ~= 3.45s` and
+  `control_plane.text_first_load_ms ~= 8.55s`.
+- The roughly `8.55s` gap matches first model load time, so this smoke run
+  mixed cold model loading into the first text-token latency.
+- SwiftLM's peer health snapshot already showed the model resident in memory;
+  OMLX and SwiftLM were therefore not proven to be in the same cold/warm state.
+
+Before making runtime changes from this smoke result, the benchmark tooling must
+record the measurement profile explicitly:
+
+- `warm` when the run performs warmup streaming requests before measured
+  scenarios, or when the operator explicitly marks a reused hot service as
+  warm.
+- `cold` when measured scenarios intentionally include first-load behavior.
+- `mixed` only when cold and warm endpoints are intentionally compared and the
+  report calls that out.
+
+The report must include Melix first-load and worker prefill/decode metrics beside
+the request timing table. Otherwise the benchmark can incorrectly attribute model
+load time to prefill or decode performance.
+
+This is the next implementation slice. After it lands, rerun a same-host
+three-way smoke with warmups enabled and use that artifact to decide whether the
+remaining gap is runtime prefill/decode behavior or only previous cold-load
+contamination.
+
+## 2026-05-24 Warm Smoke Result
+
+The follow-up warm smoke was exported to
+`~/Downloads/live-warm-smoke-current-metrics-20260524-0600` and staged at
+`.runtime/three-way-gemma31b128k/live-warm-smoke-current-metrics-20260524-0600`.
+
+Scenario: `1024` prompt target, `16` output tokens, concurrency `1`, one
+streaming warmup per endpoint, `--include-usage`, measurement profile `warm`.
+All measured scenario rows used endpoint-reported usage token counts for both
+prompt and completion tokens.
+
+| Endpoint | Prompt Usage Tokens | TTFT ms | Total ms | Decode tok/s | Aggregate tok/s |
+|---|---:|---:|---:|---:|---:|
+| Melix | 659 | 2933.24 | 3866.34 | 17.15 | 4.14 |
+| OMLX | 658 | 2894.18 | 3769.68 | 18.28 | 4.24 |
+| SwiftLM | 658 | 2700.01 | 3518.33 | 19.55 | 4.55 |
+
+This validates that the earlier `~12s` Melix TTFT from the short smoke was not
+a fair warm-inference result. Under the warm profile, Melix is within about
+`1.3%` of OMLX TTFT and about `8.6%` of SwiftLM TTFT for this short scenario,
+with decode throughput still behind the fastest peer by about `12.3%`.
+
+The merged Melix metrics snapshot in `melix-metrics.json` records the split:
+
+- `control_plane.text_first_load_ms = 7259.02`, retained as historical first
+  load evidence but excluded from the measured warm scenario timing.
+- `http.ttfd_ms = 2915.67`, matching the measured Melix TTFT.
+- `swift_text.prefill_ms = 1902`, `swift_text.decode_ttft_ms = 816`, and
+  `swift_text.decode_ms = 1727` for the current measured request.
+- `swift_text.decode_tokens_per_second = 9` is lower than the client-side
+  usage-token decode value because the worker metric uses its internal token
+  accounting cadence; the report must keep both values visible rather than
+  replacing one with the other.
+
+Conclusion: for short warm requests, the previous apparent OMLX tok/s and
+SwiftLM TTFT advantage was mostly measurement-profile and token-accounting
+contamination. Melix still has a small warm-path gap, but the next runtime
+optimization should be justified with longer decode or long-context scenarios,
+not with the old cold-loaded short smoke.

--- a/scripts/omlx_melix_compare_benchmark.py
+++ b/scripts/omlx_melix_compare_benchmark.py
@@ -30,6 +30,7 @@ DEFAULT_WARMUP_PROMPT_TOKEN_TARGET = 128
 DEFAULT_PREFLIGHT_WAIT_SECONDS = 0.0
 DEFAULT_PREFLIGHT_RETRY_INTERVAL_SECONDS = 2.0
 PROMPT_STYLES = ("concise", "saturating")
+MEASUREMENT_PROFILES = ("auto", "cold", "warm", "mixed")
 REPORT_SCHEMA_VERSION = 1
 MELIX_VLM_BATCHING_BLOCKED_REASON_CODES = {
     1: "multimodal route does not expose a streaming continuous batching path",
@@ -105,6 +106,8 @@ class ScenarioSummary:
     median_aggregate_output_tokens_per_second: float | None
     median_completion_tokens: float | None
     prompt_style: str = "concise"
+    prompt_token_sources: str = "unknown"
+    completion_token_sources: str = "unknown"
 
 
 def normalize_base_url(value: str) -> str:
@@ -531,6 +534,7 @@ def summarize_observations(observations: list[RequestObservation]) -> list[Scena
     for key, rows in sorted(grouped.items()):
         endpoint, model, prompt_token_target, max_tokens, concurrency, cache_profile, prompt_style = key
         successes = [row for row in rows if row.status == "ok"]
+        source_rows = successes if successes else rows
         group_tps = aggregate_output_tps_by_group(successes)
         summaries.append(
             ScenarioSummary(
@@ -554,9 +558,18 @@ def summarize_observations(observations: list[RequestObservation]) -> list[Scena
                 median_aggregate_output_tokens_per_second=median(group_tps),
                 median_completion_tokens=median([row.completion_tokens for row in successes]),
                 prompt_style=prompt_style,
+                prompt_token_sources=_source_summary(row.prompt_token_source for row in source_rows),
+                completion_token_sources=_source_summary(
+                    row.completion_token_source for row in source_rows
+                ),
             )
         )
     return summaries
+
+
+def _source_summary(values: Iterable[str]) -> str:
+    sources = sorted({value for value in values if value})
+    return ",".join(sources) if sources else "unknown"
 
 
 def aggregate_output_tps_by_group(rows: list[RequestObservation]) -> list[float]:
@@ -712,6 +725,66 @@ def load_metrics_snapshot(path: Path | None) -> dict[str, Any] | None:
     }
 
 
+def load_melix_metrics_snapshot(
+    *,
+    control_plane_path: Path | None,
+    swift_text_worker_path: Path | None,
+) -> dict[str, Any] | None:
+    source_paths = {
+        "control_plane": control_plane_path,
+        "swift_text_worker": swift_text_worker_path,
+    }
+    source_snapshots = {
+        name: load_metrics_snapshot(path)
+        for name, path in source_paths.items()
+        if path is not None
+    }
+    if not source_snapshots:
+        return None
+
+    values: dict[str, Any] = {}
+    sources: dict[str, dict[str, Any]] = {}
+    updated_at_values: list[Any] = []
+    errors: list[str] = []
+    primary_path: str | None = None
+    ok = True
+    for name, snapshot in source_snapshots.items():
+        if snapshot is None:
+            continue
+        if primary_path is None:
+            primary_path = snapshot.get("path")
+        source = {
+            "ok": snapshot.get("ok"),
+            "path": snapshot.get("path"),
+            "updated_at_unix_ms": snapshot.get("updated_at_unix_ms"),
+        }
+        if snapshot.get("error"):
+            source["error"] = snapshot.get("error")
+        sources[name] = source
+        if snapshot.get("ok") is True:
+            snapshot_values = snapshot.get("values")
+            if isinstance(snapshot_values, dict):
+                values.update(snapshot_values)
+            updated_at_values.append(snapshot.get("updated_at_unix_ms"))
+        else:
+            ok = False
+            errors.append(f"{name}: {snapshot.get('error', 'unknown')}")
+
+    numeric_updates = [
+        value
+        for value in updated_at_values
+        if isinstance(value, (int, float)) and not isinstance(value, bool)
+    ]
+    return {
+        "path": primary_path,
+        "ok": ok,
+        "updated_at_unix_ms": max(numeric_updates) if numeric_updates else None,
+        "sources": sources,
+        "values": values,
+        **({"error": "; ".join(errors)} if errors else {}),
+    }
+
+
 def enrich_hints_with_metrics(
     hints: list[dict[str, Any]],
     metrics_snapshot: dict[str, Any] | None,
@@ -755,6 +828,29 @@ def enrich_hints_with_metrics(
     return hints
 
 
+def metrics_manifest_entries(metrics_snapshot: dict[str, Any] | None, *, artifact_name: str) -> dict[str, Any]:
+    if metrics_snapshot is None:
+        return {}
+    entry = {
+        "ok": metrics_snapshot.get("ok"),
+        "path": metrics_snapshot.get("path"),
+        "sources": metrics_snapshot.get("sources"),
+        "updated_at_unix_ms": metrics_snapshot.get("updated_at_unix_ms"),
+        "artifact": artifact_name,
+    }
+    entries: dict[str, Any] = {"melix": entry}
+    sources = metrics_snapshot.get("sources")
+    if isinstance(sources, dict) and isinstance(sources.get("control_plane"), dict):
+        control_plane = sources["control_plane"]
+        entries["melix_control_plane"] = {
+            "ok": control_plane.get("ok"),
+            "path": control_plane.get("path"),
+            "updated_at_unix_ms": control_plane.get("updated_at_unix_ms"),
+            "artifact": artifact_name,
+        }
+    return entries
+
+
 def _numeric_metric(values: dict[str, Any], key: str) -> float | None:
     value = values.get(key)
     if isinstance(value, (int, float)) and not isinstance(value, bool):
@@ -775,6 +871,7 @@ def write_artifacts(
     summaries: list[ScenarioSummary],
     hints: list[dict[str, Any]],
     dry_run: bool,
+    measurement_profile: dict[str, Any],
 ) -> dict[str, str]:
     staging_dir.mkdir(parents=True, exist_ok=True)
     generated_at = datetime.now(timezone.utc).isoformat()
@@ -788,11 +885,12 @@ def write_artifacts(
     if warmups:
         paths["warmups"] = staging_dir / "warmups.jsonl"
     if metrics_snapshot is not None:
-        paths["melix_metrics"] = staging_dir / "melix-control-plane-metrics.json"
+        paths["melix_metrics"] = staging_dir / "melix-metrics.json"
     manifest = {
         "schema_version": REPORT_SCHEMA_VERSION,
         "generated_at": generated_at,
         "dry_run": dry_run,
+        "measurement_profile": measurement_profile,
         "endpoints": [
             {
                 "name": endpoint.name,
@@ -810,14 +908,10 @@ def write_artifacts(
         "warmup_settings": warmup_settings,
         "observation_count": len(observations),
         "preflight": preflight,
-        "metrics": {
-            "melix_control_plane": {
-                "ok": metrics_snapshot.get("ok"),
-                "path": metrics_snapshot.get("path"),
-                "updated_at_unix_ms": metrics_snapshot.get("updated_at_unix_ms"),
-                "artifact": paths["melix_metrics"].name,
-            }
-        } if metrics_snapshot is not None else {},
+        "metrics": metrics_manifest_entries(
+            metrics_snapshot,
+            artifact_name=paths["melix_metrics"].name,
+        ) if metrics_snapshot is not None else {},
         "artifacts": {key: path.name for key, path in paths.items()},
     }
     paths["manifest"].write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -836,6 +930,7 @@ def write_artifacts(
     summary_payload = {
         "schema_version": REPORT_SCHEMA_VERSION,
         "generated_at": generated_at,
+        "measurement_profile": measurement_profile,
         "melix_metrics_snapshot": metrics_snapshot,
         "warmups": [asdict(observation) for observation in warmups],
         "summaries": [asdict(summary) for summary in summaries],
@@ -854,6 +949,7 @@ def write_artifacts(
             warmups=warmups,
             metrics_snapshot=metrics_snapshot,
             dry_run=dry_run,
+            measurement_profile=measurement_profile,
         ),
         encoding="utf-8",
     )
@@ -877,9 +973,13 @@ def render_markdown_summary(
     warmups: list[RequestObservation],
     metrics_snapshot: dict[str, Any] | None,
     dry_run: bool,
+    measurement_profile: dict[str, Any],
 ) -> str:
     lines = ["# OMLX And Melix Serving Benchmark Summary", ""]
     lines.append(f"- Dry run: `{str(dry_run).lower()}`")
+    lines.append(f"- Measurement profile: `{measurement_profile.get('profile', 'unknown')}`")
+    if measurement_profile.get("operator_note"):
+        lines.append(f"- Measurement note: {measurement_profile['operator_note']}")
     lines.append("")
     lines.append("## Preflight")
     lines.append("")
@@ -918,16 +1018,19 @@ def render_markdown_summary(
     lines.append("## Scenario Summary")
     lines.append("")
     lines.append(
-        "| Endpoint | Prompt Target | Prompt Style | Max Tokens | Concurrency | Errors | Median TTFT ms | "
-        "Median Total ms | Median Decode tok/s | Median Aggregate tok/s |"
+        "| Endpoint | Prompt Target | Prompt Style | Prompt Token Source | Completion Token Source | "
+        "Max Tokens | Concurrency | Errors | Median TTFT ms | Median Total ms | "
+        "Median Decode tok/s | Median Aggregate tok/s |"
     )
-    lines.append("|---|---:|---|---:|---:|---:|---:|---:|---:|---:|")
+    lines.append("|---|---:|---|---|---|---:|---:|---:|---:|---:|---:|---:|")
     for summary in summaries:
         lines.append(
-            "| {endpoint} | {prompt} | {prompt_style} | {max_tokens} | {concurrency} | {errors} | {ttft} | {total} | {decode} | {aggregate} |".format(
+            "| {endpoint} | {prompt} | {prompt_style} | {prompt_token_sources} | {completion_token_sources} | {max_tokens} | {concurrency} | {errors} | {ttft} | {total} | {decode} | {aggregate} |".format(
                 endpoint=summary.endpoint,
                 prompt=summary.prompt_token_target,
                 prompt_style=summary.prompt_style,
+                prompt_token_sources=summary.prompt_token_sources,
+                completion_token_sources=summary.completion_token_sources,
                 max_tokens=summary.max_tokens,
                 concurrency=summary.concurrency,
                 errors=summary.error_count,
@@ -952,6 +1055,14 @@ def render_markdown_summary(
                 "scheduler.multimodal_continuous_batch_blocked_count",
                 "scheduler.multimodal_continuous_batch_blocked_reason_code",
                 "scheduler.continuous_batch_size",
+                "control_plane.text_first_load_ms",
+                "control_plane.text_first_load_estimated_resident_bytes",
+                "control_plane.text_first_load_resident_bytes",
+                "swift_text.prefill_ms",
+                "swift_text.prefill_prompt_tokens",
+                "swift_text.decode_ttft_ms",
+                "swift_text.decode_ms",
+                "swift_text.decode_tokens_per_second",
                 "scheduler.multimodal_queue_delay_ms",
                 "vision.vlm_first_token_ms",
                 "vision.multimodal_decode_mode_code",
@@ -1018,6 +1129,23 @@ def _fmt_metric(value: Any) -> str:
     if value is None:
         return "n/a"
     return str(value)
+
+
+def measurement_profile_metadata(
+    *,
+    requested_profile: str,
+    warmup_requests: int,
+    operator_note: str = "",
+) -> dict[str, Any]:
+    if requested_profile == "auto":
+        profile = "warm" if warmup_requests > 0 else "cold"
+    else:
+        profile = requested_profile
+    return {
+        "profile": profile,
+        "warmup_requests_per_endpoint": warmup_requests,
+        "operator_note": operator_note,
+    }
 
 
 def export_bundle(staging_dir: Path, export_dir: Path | None) -> Path | None:
@@ -1098,6 +1226,11 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
     )
     run_id = args.run_id or datetime.now(timezone.utc).strftime("omlx-melix-benchmark-%Y%m%d-%H%M%S")
     staging_dir = args.staging_root.expanduser() / run_id
+    measurement_profile = measurement_profile_metadata(
+        requested_profile=args.measurement_profile,
+        warmup_requests=args.warmup_requests,
+        operator_note=args.measurement_profile_note,
+    )
 
     if args.dry_run:
         preflight = [
@@ -1158,7 +1291,10 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
                         )
                     )
 
-    metrics_snapshot = load_metrics_snapshot(args.melix_control_plane_metrics)
+    metrics_snapshot = load_melix_metrics_snapshot(
+        control_plane_path=args.melix_control_plane_metrics,
+        swift_text_worker_path=args.melix_swift_text_worker_metrics,
+    )
     summaries = summarize_observations(observations)
     hints = enrich_hints_with_metrics(comparison_hints(summaries), metrics_snapshot)
     warmup_settings = {
@@ -1179,6 +1315,7 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
         summaries=summaries,
         hints=hints,
         dry_run=args.dry_run,
+        measurement_profile=measurement_profile,
     )
     exported_to = None if args.no_export else export_bundle(staging_dir, args.export_dir)
     return {
@@ -1188,6 +1325,7 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
         "preflight": preflight,
         "scenario_count": len(scenarios),
         "warmup_count": len(warmups),
+        "measurement_profile": measurement_profile["profile"],
         "observation_count": len(observations),
         "summary_count": len(summaries),
         "optimization_hint_count": len(hints),
@@ -1264,6 +1402,23 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help="Optional Melix control-plane metrics JSON to snapshot into the report.",
+    )
+    parser.add_argument(
+        "--melix-swift-text-worker-metrics",
+        type=Path,
+        default=None,
+        help="Optional Melix Swift text worker metrics JSON to merge into the report.",
+    )
+    parser.add_argument(
+        "--measurement-profile",
+        choices=MEASUREMENT_PROFILES,
+        default="auto",
+        help="Label measured scenarios as cold, warm, or mixed. 'auto' uses warm when warmups are run, otherwise cold.",
+    )
+    parser.add_argument(
+        "--measurement-profile-note",
+        default="",
+        help="Optional note describing how endpoint residency was prepared before measurement.",
     )
     parser.add_argument("--allow-failed-preflight", action="store_true")
     parser.add_argument("--preflight-only", action="store_true")

--- a/scripts/three_way_serving_compare.py
+++ b/scripts/three_way_serving_compare.py
@@ -369,6 +369,11 @@ def run_comparison(args: argparse.Namespace) -> dict[str, Any]:
     )
     run_id = args.run_id or datetime.now(timezone.utc).strftime("three-way-gemma31b128k-%Y%m%d-%H%M%S")
     staging_dir = args.staging_root.expanduser() / run_id
+    measurement_profile = base.measurement_profile_metadata(
+        requested_profile=args.measurement_profile,
+        warmup_requests=args.warmup_requests,
+        operator_note=args.measurement_profile_note,
+    )
 
     if args.dry_run:
         preflight = [
@@ -434,7 +439,10 @@ def run_comparison(args: argparse.Namespace) -> dict[str, Any]:
                         )
                     )
 
-    metrics_snapshot = base.load_metrics_snapshot(args.melix_control_plane_metrics)
+    metrics_snapshot = base.load_melix_metrics_snapshot(
+        control_plane_path=args.melix_control_plane_metrics,
+        swift_text_worker_path=args.melix_swift_text_worker_metrics,
+    )
     summaries = base.summarize_observations(observations)
     prompt_evidence = prompt_token_evidence(observations)
     comparisons, peer_hints = peer_comparisons(summaries, target_endpoint=args.target_endpoint)
@@ -461,6 +469,7 @@ def run_comparison(args: argparse.Namespace) -> dict[str, Any]:
         hints=hints,
         dry_run=args.dry_run,
         target_endpoint=args.target_endpoint,
+        measurement_profile=measurement_profile,
     )
     exported_to = None if args.no_export else export_bundle(staging_dir, args.export_dir)
     return {
@@ -471,6 +480,7 @@ def run_comparison(args: argparse.Namespace) -> dict[str, Any]:
         "preflight": preflight,
         "scenario_count": len(scenarios),
         "warmup_count": len(warmups),
+        "measurement_profile": measurement_profile["profile"],
         "observation_count": len(observations),
         "summary_count": len(summaries),
         "comparison_count": len(comparisons),
@@ -496,6 +506,7 @@ def write_artifacts(
     hints: list[dict[str, Any]],
     dry_run: bool,
     target_endpoint: str,
+    measurement_profile: dict[str, Any],
 ) -> dict[str, str]:
     staging_dir.mkdir(parents=True, exist_ok=True)
     generated_at = datetime.now(timezone.utc).isoformat()
@@ -510,13 +521,14 @@ def write_artifacts(
     if warmups:
         paths["warmups"] = staging_dir / "warmups.jsonl"
     if metrics_snapshot is not None:
-        paths["melix_metrics"] = staging_dir / "melix-control-plane-metrics.json"
+        paths["melix_metrics"] = staging_dir / "melix-metrics.json"
 
     manifest = {
         "schema_version": 1,
         "generated_at": generated_at,
         "dry_run": dry_run,
         "target_endpoint": target_endpoint,
+        "measurement_profile": measurement_profile,
         "endpoints": [
             {
                 "name": endpoint.name,
@@ -557,6 +569,7 @@ def write_artifacts(
         "schema_version": 1,
         "generated_at": generated_at,
         "target_endpoint": target_endpoint,
+        "measurement_profile": measurement_profile,
         "runtime_snapshots": runtime_snapshots,
         "melix_metrics_snapshot": metrics_snapshot,
         "warmups": [asdict(observation) for observation in warmups],
@@ -582,6 +595,7 @@ def write_artifacts(
             metrics_snapshot=metrics_snapshot,
             dry_run=dry_run,
             target_endpoint=target_endpoint,
+            measurement_profile=measurement_profile,
         ),
         encoding="utf-8",
     )
@@ -600,10 +614,14 @@ def render_markdown_summary(
     metrics_snapshot: dict[str, Any] | None,
     dry_run: bool,
     target_endpoint: str,
+    measurement_profile: dict[str, Any],
 ) -> str:
     lines = ["# Three-Way Gemma 4 31B 128K Serving Comparison", ""]
     lines.append(f"- Dry run: `{str(dry_run).lower()}`")
     lines.append(f"- Target endpoint: `{target_endpoint}`")
+    lines.append(f"- Measurement profile: `{measurement_profile.get('profile', 'unknown')}`")
+    if measurement_profile.get("operator_note"):
+        lines.append(f"- Measurement note: {measurement_profile['operator_note']}")
     lines.append("")
     lines.append("## Preflight")
     lines.append("")
@@ -623,16 +641,19 @@ def render_markdown_summary(
     lines.append("## Scenario Summary")
     lines.append("")
     lines.append(
-        "| Endpoint | Prompt Target | Style | Max Tokens | Concurrency | Errors | Median TTFT ms | "
-        "Median Total ms | Median Decode tok/s | Median Aggregate tok/s |"
+        "| Endpoint | Prompt Target | Style | Prompt Source | Completion Source | Max Tokens | "
+        "Concurrency | Errors | Median TTFT ms | Median Total ms | Median Decode tok/s | "
+        "Median Aggregate tok/s |"
     )
-    lines.append("|---|---:|---|---:|---:|---:|---:|---:|---:|---:|")
+    lines.append("|---|---:|---|---|---|---:|---:|---:|---:|---:|---:|---:|")
     for summary in summaries:
         lines.append(
-            "| {endpoint} | {prompt} | {style} | {max_tokens} | {concurrency} | {errors} | {ttft} | {total} | {decode} | {aggregate} |".format(
+            "| {endpoint} | {prompt} | {style} | {prompt_source} | {completion_source} | {max_tokens} | {concurrency} | {errors} | {ttft} | {total} | {decode} | {aggregate} |".format(
                 endpoint=summary.endpoint,
                 prompt=summary.prompt_token_target,
                 style=summary.prompt_style,
+                prompt_source=summary.prompt_token_sources,
+                completion_source=summary.completion_token_sources,
                 max_tokens=summary.max_tokens,
                 concurrency=summary.concurrency,
                 errors=summary.error_count,
@@ -715,6 +736,14 @@ def render_markdown_summary(
                 "scheduler.multimodal_continuous_batch_blocked_count",
                 "scheduler.multimodal_continuous_batch_blocked_reason_code",
                 "scheduler.continuous_batch_size",
+                "control_plane.text_first_load_ms",
+                "control_plane.text_first_load_estimated_resident_bytes",
+                "control_plane.text_first_load_resident_bytes",
+                "swift_text.prefill_ms",
+                "swift_text.prefill_prompt_tokens",
+                "swift_text.decode_ttft_ms",
+                "swift_text.decode_ms",
+                "swift_text.decode_tokens_per_second",
                 "vision.text_batch_generator.peak_active_batch_size",
                 "vision.text_batch_generator.queue_wait_ms_total",
                 "vision.text_batch_generator.executor_step_ms_total",
@@ -792,6 +821,18 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--preflight-wait-seconds", type=float, default=0.0)
     parser.add_argument("--preflight-retry-interval-seconds", type=float, default=2.0)
     parser.add_argument("--melix-control-plane-metrics", type=Path, default=None)
+    parser.add_argument("--melix-swift-text-worker-metrics", type=Path, default=None)
+    parser.add_argument(
+        "--measurement-profile",
+        choices=base.MEASUREMENT_PROFILES,
+        default="auto",
+        help="Label measured scenarios as cold, warm, or mixed. 'auto' uses warm when warmups are run, otherwise cold.",
+    )
+    parser.add_argument(
+        "--measurement-profile-note",
+        default="",
+        help="Optional note describing how endpoint residency was prepared before measurement.",
+    )
     parser.add_argument("--allow-failed-preflight", action="store_true")
     parser.add_argument("--preflight-only", action="store_true")
     parser.add_argument("--dry-run", action="store_true")

--- a/tests/test_omlx_melix_compare_benchmark.py
+++ b/tests/test_omlx_melix_compare_benchmark.py
@@ -258,6 +258,55 @@ def test_metrics_snapshot_adds_multimodal_batching_hint(tmp_path: Path) -> None:
     assert "cooperative text-only token-step batching" in hints[0]["melix_blocked_reason"]
 
 
+def test_melix_metrics_snapshot_merges_control_plane_and_swift_worker(tmp_path: Path) -> None:
+    control_plane_path = tmp_path / "control-plane-metrics.json"
+    swift_worker_path = tmp_path / "swift-text-worker-metrics.json"
+    control_plane_path.write_text(
+        json.dumps({
+            "updated_at_unix_ms": 100,
+            "values": {
+                "control_plane.text_first_load_ms": 8547.46,
+                "http.ttfd_ms": 3447.17,
+            },
+        }),
+        encoding="utf-8",
+    )
+    swift_worker_path.write_text(
+        json.dumps({
+            "updated_at_unix_ms": 200,
+            "values": {
+                "swift_text.prefill_ms": 3706,
+                "swift_text.decode_ttft_ms": 1910,
+                "swift_text.decode_tokens_per_second": 2,
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    snapshot = bench.load_melix_metrics_snapshot(
+        control_plane_path=control_plane_path,
+        swift_text_worker_path=swift_worker_path,
+    )
+
+    assert snapshot["ok"] is True
+    assert snapshot["updated_at_unix_ms"] == 200
+    assert snapshot["sources"] == {
+        "control_plane": {
+            "ok": True,
+            "path": str(control_plane_path),
+            "updated_at_unix_ms": 100,
+        },
+        "swift_text_worker": {
+            "ok": True,
+            "path": str(swift_worker_path),
+            "updated_at_unix_ms": 200,
+        },
+    }
+    assert snapshot["values"]["control_plane.text_first_load_ms"] == 8547.46
+    assert snapshot["values"]["swift_text.prefill_ms"] == 3706
+    assert snapshot["values"]["swift_text.decode_tokens_per_second"] == 2
+
+
 def test_markdown_summary_lists_text_batch_generator_metrics() -> None:
     markdown = bench.render_markdown_summary(
         [],
@@ -275,6 +324,11 @@ def test_markdown_summary_lists_text_batch_generator_metrics() -> None:
             },
         },
         dry_run=False,
+        measurement_profile={
+            "profile": "cold",
+            "warmup_requests_per_endpoint": 0,
+            "operator_note": "",
+        },
     )
 
     assert "`vision.text_batch_generator.step_count` | 16.00" in markdown
@@ -282,6 +336,185 @@ def test_markdown_summary_lists_text_batch_generator_metrics() -> None:
     assert "`vision.text_batch_generator.first_empty_segment_count` | 0.00" in markdown
     assert "`vision.text_batch_generator.next_ms_total` | 120.50" in markdown
     assert "`vision.text_batch_generator.emit_ms_total` | 4.25" in markdown
+
+
+def test_warmup_requests_mark_measurements_as_warm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_preflight(endpoint: bench.EndpointConfig, *, timeout_seconds: float) -> dict[str, object]:
+        return {
+            "endpoint": endpoint.name,
+            "base_url": endpoint.base_url,
+            "status_code": 200,
+            "ok": True,
+            "model": endpoint.model,
+            "model_listed": True,
+            "model_count": 1,
+            "models": [endpoint.model],
+            "error": None,
+        }
+
+    def fake_run_group(
+        endpoint: bench.EndpointConfig,
+        scenario: bench.BenchmarkScenario,
+        *,
+        include_usage: bool,
+        temperature: float,
+        timeout_seconds: float,
+    ) -> list[bench.RequestObservation]:
+        return [
+            bench.RequestObservation(
+                endpoint=endpoint.name,
+                model=endpoint.model,
+                scenario_id=scenario.scenario_id,
+                group_id=f"{endpoint.name}-{scenario.scenario_id}",
+                prompt_token_target=scenario.prompt_token_target,
+                prompt_token_source="usage",
+                max_tokens=scenario.max_tokens,
+                concurrency=scenario.concurrency,
+                cache_profile=scenario.cache_profile,
+                repeat_index=scenario.repeat_index,
+                request_index=0,
+                status="ok",
+                http_status=200,
+                error="",
+                ttft_ms=10.0 if scenario.scenario_id.startswith("warmup") else 100.0,
+                total_ms=20.0 if scenario.scenario_id.startswith("warmup") else 200.0,
+                decode_ms=10.0,
+                completion_tokens=5.0,
+                completion_token_source="usage",
+                prompt_tokens=20.0,
+                streamed_chunks=1,
+                completion_chars=20,
+                decode_tokens_per_second=500.0,
+                group_elapsed_ms=20.0,
+            )
+        ]
+
+    monkeypatch.setattr(bench, "preflight_endpoint", fake_preflight)
+    monkeypatch.setattr(bench, "run_group", fake_run_group)
+    control_plane_path = tmp_path / "control-plane-metrics.json"
+    swift_worker_path = tmp_path / "swift-text-worker-metrics.json"
+    control_plane_path.write_text(
+        json.dumps({
+            "updated_at_unix_ms": 100,
+            "values": {"control_plane.text_first_load_ms": 8547.46},
+        }),
+        encoding="utf-8",
+    )
+    swift_worker_path.write_text(
+        json.dumps({
+            "updated_at_unix_ms": 200,
+            "values": {"swift_text.prefill_ms": 3706},
+        }),
+        encoding="utf-8",
+    )
+    args = bench.build_arg_parser().parse_args(
+        [
+            "--model",
+            "local-model",
+            "--run-id",
+            "warm-run",
+            "--staging-root",
+            str(tmp_path),
+            "--no-export",
+            "--warmup-requests",
+            "1",
+            "--repeats",
+            "1",
+            "--melix-control-plane-metrics",
+            str(control_plane_path),
+            "--melix-swift-text-worker-metrics",
+            str(swift_worker_path),
+        ]
+    )
+    bench.validate_args(args)
+
+    result = bench.run_benchmark(args)
+
+    staging_dir = tmp_path / "warm-run"
+    manifest = json.loads((staging_dir / "manifest.json").read_text(encoding="utf-8"))
+    summary = json.loads((staging_dir / "summary.json").read_text(encoding="utf-8"))
+    markdown = (staging_dir / "summary.md").read_text(encoding="utf-8")
+
+    assert result["measurement_profile"] == "warm"
+    assert manifest["measurement_profile"]["profile"] == "warm"
+    assert summary["measurement_profile"]["warmup_requests_per_endpoint"] == 1
+    assert manifest["metrics"]["melix"]["artifact"] == "melix-metrics.json"
+    assert manifest["metrics"]["melix_control_plane"]["path"] == str(control_plane_path)
+    assert manifest["metrics"]["melix_control_plane"]["artifact"] == "melix-metrics.json"
+    assert summary["melix_metrics_snapshot"]["values"]["swift_text.prefill_ms"] == 3706
+    assert "- Measurement profile: `warm`" in markdown
+    assert "`swift_text.prefill_ms` | 3706.00" in markdown
+
+
+def test_markdown_summary_lists_text_first_load_metrics() -> None:
+    markdown = bench.render_markdown_summary(
+        [],
+        [],
+        preflight=[],
+        warmups=[],
+        metrics_snapshot={
+            "ok": True,
+            "values": {
+                "control_plane.text_first_load_ms": 8547.46,
+                "control_plane.text_first_load_resident_bytes": 32942997504,
+                "swift_text.prefill_ms": 3447.17,
+                "swift_text.decode_ttft_ms": 8554.38,
+            },
+        },
+        dry_run=False,
+        measurement_profile={
+            "profile": "cold",
+            "warmup_requests_per_endpoint": 0,
+            "operator_note": "first measured request includes model load",
+        },
+    )
+
+    assert "- Measurement profile: `cold`" in markdown
+    assert "`control_plane.text_first_load_ms` | 8547.46" in markdown
+    assert "`swift_text.prefill_ms` | 3447.17" in markdown
+    assert "`swift_text.decode_ttft_ms` | 8554.38" in markdown
+
+
+def test_markdown_summary_lists_token_count_sources() -> None:
+    markdown = bench.render_markdown_summary(
+        [
+            bench.ScenarioSummary(
+                endpoint="omlx",
+                model="model",
+                prompt_token_target=1024,
+                max_tokens=16,
+                concurrency=1,
+                cache_profile="cold_unique",
+                request_count=1,
+                success_count=1,
+                error_count=0,
+                error_rate=0.0,
+                median_ttft_ms=100.0,
+                p95_ttft_ms=100.0,
+                median_total_ms=200.0,
+                p95_total_ms=200.0,
+                median_decode_tokens_per_second=16.0,
+                median_aggregate_output_tokens_per_second=8.0,
+                median_completion_tokens=16.0,
+                prompt_token_sources="estimated_chars",
+                completion_token_sources="usage",
+            )
+        ],
+        [],
+        preflight=[],
+        warmups=[],
+        metrics_snapshot=None,
+        dry_run=False,
+        measurement_profile={
+            "profile": "warm",
+            "warmup_requests_per_endpoint": 1,
+            "operator_note": "",
+        },
+    )
+
+    assert "Prompt Token Source" in markdown
+    assert "Completion Token Source" in markdown
+    assert "| omlx | 1024 | concise | estimated_chars | usage | 16 | 1 | 0 |" in markdown
 
 
 def test_dry_run_writes_artifacts_without_export(tmp_path: Path) -> None:

--- a/tests/test_three_way_serving_compare.py
+++ b/tests/test_three_way_serving_compare.py
@@ -245,3 +245,286 @@ def test_dry_run_writes_three_way_artifacts(tmp_path: Path) -> None:
         "swiftlm",
     ]
     assert manifest["scenario_count"] == 3
+
+
+def test_warmup_requests_mark_three_way_measurements_as_warm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_preflight(endpoint: three_way.base.EndpointConfig, *, timeout_seconds: float) -> dict[str, object]:
+        return {
+            "endpoint": endpoint.name,
+            "base_url": endpoint.base_url,
+            "status_code": 200,
+            "ok": True,
+            "model": endpoint.model,
+            "model_listed": True,
+            "model_count": 1,
+            "models": [endpoint.model],
+            "error": None,
+        }
+
+    def fake_run_group(
+        endpoint: three_way.base.EndpointConfig,
+        scenario: three_way.base.BenchmarkScenario,
+        *,
+        include_usage: bool,
+        temperature: float,
+        timeout_seconds: float,
+    ) -> list[three_way.base.RequestObservation]:
+        return [
+            three_way.base.RequestObservation(
+                endpoint=endpoint.name,
+                model=endpoint.model,
+                scenario_id=scenario.scenario_id,
+                group_id=f"{endpoint.name}-{scenario.scenario_id}",
+                prompt_token_target=scenario.prompt_token_target,
+                prompt_token_source="usage",
+                max_tokens=scenario.max_tokens,
+                concurrency=scenario.concurrency,
+                cache_profile=scenario.cache_profile,
+                repeat_index=scenario.repeat_index,
+                request_index=0,
+                status="ok",
+                http_status=200,
+                error="",
+                ttft_ms=10.0 if scenario.scenario_id.startswith("warmup") else 100.0,
+                total_ms=20.0 if scenario.scenario_id.startswith("warmup") else 200.0,
+                decode_ms=10.0,
+                completion_tokens=5.0,
+                completion_token_source="usage",
+                prompt_tokens=20.0,
+                streamed_chunks=1,
+                completion_chars=20,
+                decode_tokens_per_second=500.0,
+                group_elapsed_ms=20.0,
+                prompt_style=scenario.prompt_style,
+            )
+        ]
+
+    monkeypatch.setattr(three_way.base, "preflight_endpoint", fake_preflight)
+    monkeypatch.setattr(three_way.base, "run_group", fake_run_group)
+    args = three_way.build_arg_parser().parse_args(
+        [
+            "--endpoint",
+            "melix=http://127.0.0.1:12441/v1::model",
+            "--endpoint",
+            "omlx=http://127.0.0.1:18061/v1::model",
+            "--endpoint",
+            "swiftlm=http://127.0.0.1:18062/v1::model",
+            "--warmup-requests",
+            "1",
+            "--prompt-token-targets",
+            "1024",
+            "--max-tokens",
+            "16",
+            "--run-id",
+            "three-way-warm",
+            "--staging-root",
+            str(tmp_path),
+            "--no-export",
+        ]
+    )
+    three_way.validate_args(args)
+
+    result = three_way.run_comparison(args)
+
+    staging_dir = tmp_path / "three-way-warm"
+    manifest = json.loads((staging_dir / "manifest.json").read_text(encoding="utf-8"))
+    summary = json.loads((staging_dir / "summary.json").read_text(encoding="utf-8"))
+    markdown = (staging_dir / "summary.md").read_text(encoding="utf-8")
+
+    assert result["measurement_profile"] == "warm"
+    assert manifest["measurement_profile"] == {
+        "profile": "warm",
+        "warmup_requests_per_endpoint": 1,
+        "operator_note": "",
+    }
+    assert summary["measurement_profile"]["profile"] == "warm"
+    assert "- Measurement profile: `warm`" in markdown
+
+
+def test_three_way_run_writes_merged_melix_metrics_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_preflight(endpoint: three_way.base.EndpointConfig, *, timeout_seconds: float) -> dict[str, object]:
+        return {
+            "endpoint": endpoint.name,
+            "base_url": endpoint.base_url,
+            "status_code": 200,
+            "ok": True,
+            "model": endpoint.model,
+            "model_listed": True,
+            "model_count": 1,
+            "models": [endpoint.model],
+            "error": None,
+        }
+
+    def fake_run_group(
+        endpoint: three_way.base.EndpointConfig,
+        scenario: three_way.base.BenchmarkScenario,
+        *,
+        include_usage: bool,
+        temperature: float,
+        timeout_seconds: float,
+    ) -> list[three_way.base.RequestObservation]:
+        return [
+            three_way.base.RequestObservation(
+                endpoint=endpoint.name,
+                model=endpoint.model,
+                scenario_id=scenario.scenario_id,
+                group_id=f"{endpoint.name}-{scenario.scenario_id}",
+                prompt_token_target=scenario.prompt_token_target,
+                prompt_token_source="usage",
+                max_tokens=scenario.max_tokens,
+                concurrency=scenario.concurrency,
+                cache_profile=scenario.cache_profile,
+                repeat_index=scenario.repeat_index,
+                request_index=0,
+                status="ok",
+                http_status=200,
+                error="",
+                ttft_ms=100.0,
+                total_ms=200.0,
+                decode_ms=100.0,
+                completion_tokens=5.0,
+                completion_token_source="usage",
+                prompt_tokens=20.0,
+                streamed_chunks=1,
+                completion_chars=20,
+                decode_tokens_per_second=50.0,
+                group_elapsed_ms=200.0,
+                prompt_style=scenario.prompt_style,
+            )
+        ]
+
+    control_plane_path = tmp_path / "control-plane-metrics.json"
+    swift_worker_path = tmp_path / "swift-text-worker-metrics.json"
+    control_plane_path.write_text(
+        json.dumps({
+            "updated_at_unix_ms": 100,
+            "values": {"control_plane.text_first_load_ms": 8547.46},
+        }),
+        encoding="utf-8",
+    )
+    swift_worker_path.write_text(
+        json.dumps({
+            "updated_at_unix_ms": 200,
+            "values": {"swift_text.prefill_ms": 3706},
+        }),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(three_way.base, "preflight_endpoint", fake_preflight)
+    monkeypatch.setattr(three_way.base, "run_group", fake_run_group)
+    args = three_way.build_arg_parser().parse_args(
+        [
+            "--endpoint",
+            "melix=http://127.0.0.1:12441/v1::model",
+            "--endpoint",
+            "omlx=http://127.0.0.1:18061/v1::model",
+            "--endpoint",
+            "swiftlm=http://127.0.0.1:18062/v1::model",
+            "--prompt-token-targets",
+            "1024",
+            "--max-tokens",
+            "16",
+            "--run-id",
+            "three-way-metrics",
+            "--staging-root",
+            str(tmp_path),
+            "--melix-control-plane-metrics",
+            str(control_plane_path),
+            "--melix-swift-text-worker-metrics",
+            str(swift_worker_path),
+            "--no-export",
+        ]
+    )
+    three_way.validate_args(args)
+
+    three_way.run_comparison(args)
+
+    staging_dir = tmp_path / "three-way-metrics"
+    metrics_snapshot = json.loads((staging_dir / "melix-metrics.json").read_text(encoding="utf-8"))
+    markdown = (staging_dir / "summary.md").read_text(encoding="utf-8")
+
+    assert metrics_snapshot["values"]["control_plane.text_first_load_ms"] == 8547.46
+    assert metrics_snapshot["values"]["swift_text.prefill_ms"] == 3706
+    assert "`swift_text.prefill_ms` | 3706.00" in markdown
+
+
+def test_three_way_markdown_surfaces_melix_first_load_metrics() -> None:
+    markdown = three_way.render_markdown_summary(
+        [],
+        [],
+        [],
+        preflight=[],
+        runtime_snapshots={},
+        prompt_evidence=[],
+        warmups=[],
+        metrics_snapshot={
+            "ok": True,
+            "values": {
+                "control_plane.text_first_load_ms": 8547.46,
+                "control_plane.text_first_load_resident_bytes": 32942997504,
+                "swift_text.prefill_ms": 3447.17,
+                "swift_text.decode_ttft_ms": 8554.38,
+            },
+        },
+        dry_run=False,
+        target_endpoint="melix",
+        measurement_profile={
+            "profile": "cold",
+            "warmup_requests_per_endpoint": 0,
+            "operator_note": "first measured request includes model load",
+        },
+    )
+
+    assert "- Measurement profile: `cold`" in markdown
+    assert "`control_plane.text_first_load_ms` | 8547.46" in markdown
+    assert "`swift_text.prefill_ms` | 3447.17" in markdown
+    assert "`swift_text.decode_ttft_ms` | 8554.38" in markdown
+
+
+def test_three_way_markdown_lists_token_count_sources() -> None:
+    markdown = three_way.render_markdown_summary(
+        [
+            three_way.base.ScenarioSummary(
+                endpoint="swiftlm",
+                model="model",
+                prompt_token_target=1024,
+                max_tokens=16,
+                concurrency=1,
+                cache_profile="cold_unique",
+                request_count=1,
+                success_count=1,
+                error_count=0,
+                error_rate=0.0,
+                median_ttft_ms=100.0,
+                p95_ttft_ms=100.0,
+                median_total_ms=200.0,
+                p95_total_ms=200.0,
+                median_decode_tokens_per_second=16.0,
+                median_aggregate_output_tokens_per_second=8.0,
+                median_completion_tokens=16.0,
+                prompt_token_sources="usage",
+                completion_token_sources="estimated_chars",
+            )
+        ],
+        [],
+        [],
+        preflight=[],
+        runtime_snapshots={},
+        prompt_evidence=[],
+        warmups=[],
+        metrics_snapshot=None,
+        dry_run=False,
+        target_endpoint="melix",
+        measurement_profile={
+            "profile": "warm",
+            "warmup_requests_per_endpoint": 1,
+            "operator_note": "",
+        },
+    )
+
+    assert "Prompt Source" in markdown
+    assert "Completion Source" in markdown
+    assert "| swiftlm | 1024 | concise | usage | estimated_chars | 16 | 1 | 0 |" in markdown


### PR DESCRIPTION
## Summary
- Label serving comparison runs with an explicit measurement profile (`cold`, `warm`, `mixed`, or `auto`) so cold model-load timing is not compared against already-warm peers.
- Merge Melix control-plane and Swift text-worker metrics into the benchmark artifact, including first-load, prefill, decode, and token-source evidence.
- Update the Gemma 4 31B 128K serving comparison plan with the diagnosis and the new warm smoke result.

## Plan or Spec
- `docs/plans/2026-05-23-three-way-gemma4-31b-128k-serving-comparison.md`

## Commands Run
```text
make git-hooks-install
# passed; configured core.hooksPath=.githooks

git diff --check
# passed

python3 -m py_compile scripts/omlx_melix_compare_benchmark.py scripts/three_way_serving_compare.py
# passed

UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py -q
# passed: 28 passed in 0.05s

UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/three_way_serving_compare.py --endpoint melix=http://127.0.0.1:1/v1::mlx-community/gemma-4-31b-it-8bit --endpoint omlx=http://127.0.0.1:2/v1::gemma-4-31b-it-8bit --endpoint swiftlm=http://127.0.0.1:3/v1::mlx-community/gemma-4-31b-it-8bit --target-endpoint melix --prompt-token-targets 1024 --max-tokens 16 --repeats 1 --concurrency 1 --measurement-profile cold --no-export --dry-run --json
# passed; dry-run manifest included "measurement_profile": "cold"

UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/omlx_melix_compare_benchmark.py --melix-url http://127.0.0.1:1/v1 --omlx-url http://127.0.0.1:2/v1 --model mlx-community/gemma-4-31b-it-8bit --omlx-model gemma-4-31b-it-8bit --prompt-token-targets 1024 --max-tokens 16 --repeats 1 --concurrency 1 --measurement-profile cold --no-export --dry-run --json
# passed; dry-run manifest included "measurement_profile": "cold"

UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/three_way_serving_compare.py --endpoint melix=http://127.0.0.1:12443/v1::mlx-community/gemma-4-31b-it-8bit --endpoint omlx=http://127.0.0.1:18061/v1::gemma-4-31b-it-8bit --endpoint swiftlm=http://127.0.0.1:18062/v1::mlx-community/gemma-4-31b-it-8bit --target-endpoint melix --prompt-token-targets 1024 --max-tokens 16 --repeats 1 --concurrency 1 --warmup-requests 1 --warmup-prompt-token-target 1024 --warmup-max-tokens 16 --include-usage --timeout-seconds 300 --preflight-timeout-seconds 10 --preflight-wait-seconds 60 --melix-control-plane-metrics .runtime/sidecars/gemma31b-warm-current-release/control-plane-metrics.json --melix-swift-text-worker-metrics .runtime/sidecars/gemma31b-warm-current-release/swift-text-worker-metrics.json --measurement-profile warm --measurement-profile-note "Current Melix branch served from release binaries on 12443; each endpoint receives one streaming warmup before measured 1024/16 scenario; Melix metrics merge control-plane and Swift text-worker snapshots." --run-id live-warm-smoke-current-metrics-20260524-0600 --staging-root .runtime/three-way-gemma31b128k --export-dir ~/Downloads --json
# passed; exported /Users/chenyu/Downloads/live-warm-smoke-current-metrics-20260524-0600

UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py --cov=scripts --cov-report=term-missing
# not measurable locally: pytest exited before collection with "unrecognized arguments: --cov=scripts --cov-report=term-missing"

git commit -m "perf: label serving benchmark measurement profiles"
# passed; pre-commit hook ran make swift-test, make py-test, make integration-test, and the PR scoped performance report
# make py-test: 3031 passed, 14 skipped, 2 warnings
# make integration-test: 114 passed, 1 skipped
```

## Coverage and Metrics
- Changed-scope coverage: not measurable in this local environment because `pytest-cov` is unavailable; the coverage command failed before collection with `unrecognized arguments: --cov=scripts --cov-report=term-missing`.
- Focused tests for the changed benchmark scripts passed: `28 passed in 0.05s`.
- PR scoped performance report: `/Users/chenyu/Documents/github/melix/.runtime/worktrees/optimize-gemma31b-serving/.runtime/pre-commit-performance/20260523-205800-46968cc3/report/report.md`
  - Status: `ok`
  - Changed files: `5`
  - Selected probes: `0`
  - Regressions: `0`
  - Verification failures: `0`
  - Note: no registered performance probes were selected for this change set.
- Warm live smoke artifact: `/Users/chenyu/Downloads/live-warm-smoke-current-metrics-20260524-0600`
  - Profile: `warm`; each endpoint received one streaming warmup before the measured 1024-prompt-token / 16-output-token scenario.
  - Melix: TTFT `2933.24 ms`, total `3866.34 ms`, decode `17.15 tok/s`, aggregate `4.14 tok/s`.
  - OMLX: TTFT `2894.18 ms`, total `3769.68 ms`, decode `18.28 tok/s`, aggregate `4.24 tok/s`.
  - SwiftLM: TTFT `2700.01 ms`, total `3518.33 ms`, decode `19.55 tok/s`, aggregate `4.55 tok/s`.
  - Melix merged metrics include `control_plane.text_first_load_ms=7259.02`, `http.ttfd_ms=2915.67`, `swift_text.prefill_ms=1902`, `swift_text.decode_ttft_ms=816`, and `swift_text.decode_ms=1727`.

## Known Gaps
- This PR improves benchmark labeling, metrics evidence, and documentation. It does not change the Melix runtime hot path.
- The warm smoke still shows Melix behind the fastest peer on this short decode scenario: `17.15 tok/s` vs SwiftLM `19.55 tok/s`.
- Long-context 128K runtime optimization remains deferred to a separate measured runtime change.
- Observability mode: `evidence`.
- Probe overhead: `N/A`; the new metrics are benchmark artifact capture/reporting changes, not new production request-path probes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
