### PR TITLE
perf: fast-path lora reward candidate scores

### DIFF
--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -101,6 +101,8 @@ def test_reward_summary_reuses_candidate_group_minmax(
                 {"score": 0.4},
                 {"score": 0.1},
                 {"score": 0.9},
+                {"ignored": True},
+                "invalid-candidate",
             ],
         },
         {

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -712,11 +712,14 @@ def _reward_summary(samples: list[dict[str, Any]]) -> dict[str, float | int]:
         candidates = sample.get("candidates")
         candidate_scores: list[float] = []
         if is_instance(candidates, list_type):
-            candidate_scores = [
-                to_float(candidate["score"])
-                for candidate in candidates
-                if is_instance(candidate, dict_type) and "score" in candidate
-            ]
+            try:
+                candidate_scores = [to_float(candidate["score"]) for candidate in candidates]
+            except (KeyError, TypeError):
+                candidate_scores = [
+                    to_float(candidate["score"])
+                    for candidate in candidates
+                    if is_instance(candidate, dict_type) and "score" in candidate
+                ]
         candidate_score_count = len(candidate_scores)
         if candidate_score_count:
             scores_extend(candidate_scores)


### PR DESCRIPTION
## Summary
- Adds a common-case fast path for normalized LoRA reward candidate score extraction.
- Preserves the existing tolerant fallback for malformed candidate rows.

## Plan or Spec
- Registered PR-scoped probe: `lora-reward-summary-candidate-minmax` in `infra/perf/pr_scoped_probes.json`.
- Governing behavior is unchanged; no docs/spec update required for this implementation-only performance slice.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_reward_summary_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/lora_reward_summary_probe.py` (baseline before change, then 3 post-change samples)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 9 passed.
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Registered local probe baseline: `elapsed_ms_mean=42.65317463432439`, `sorted_calls_mean=2`.
- Registered local probe post-change samples: `36.66169862844981`, `36.64346839650534`, `38.30986615503207` ms.
- Post-change mean: `37.205011` ms; delta: `-5.448164` ms; speedup: `1.1464x` (~12.77% faster); sorted calls unchanged at `2`.
- CI PR-scoped performance workflow is required for registered probe validation before merge.

## Known Gaps
- Local validation was Linux/Python only.
- Full repository test gates were not run locally; this PR is intentionally scoped to the registered LoRA reward summary probe and focused tests.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the touched path.
- [x] Focused regression tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe shows improved elapsed time.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
