### PR TITLE
perf: avoid embedding input list materialization

### DIFF
--- a/docs/plans/2026-05-23-embedding-core-inputs-view.md
+++ b/docs/plans/2026-05-23-embedding-core-inputs-view.md
@@ -1,0 +1,27 @@
+# Embedding Core Request Inputs View Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to the worker embedding request path. `EmbeddingCore.embed()` previously materialized `list(request.inputs)` before calling the embedding runtime. For large embedding batches this adds an avoidable per-request allocation before the runtime can process or cache repeated inputs.
+
+## Probe Registration
+
+This slice registers `embedding-core-inputs-view` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries. The probe exercises `EmbeddingCore.embed()` with a large protobuf repeated input container and records:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `runtime_input_type`
+
+The existing deterministic embedding probe remains registered for runtime duplicate-input cache coverage. The new probe covers the service boundary that hands request inputs into the runtime.
+
+## Implementation
+
+Pass the protobuf repeated input view directly from `EmbedRequest.inputs` into the embedding runtime instead of converting it to a list first. Widen the deterministic embedding runtime type hints to `Sequence[str]` because it only requires length, slicing, and iteration semantics.
+
+## Verification Plan
+
+Run the registered focused test command, changed-scope coverage command, and local registered probe on Linux before opening the PR. CI remains the merge gate for the registered PR-scoped performance report.
+
+## Expected Result
+
+Behavior stays unchanged for embedding responses while large request batches avoid one list materialization at the service boundary. The registered probe should show lower peak allocation and/or elapsed time for the embedding-core request path.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4063,5 +4063,37 @@
         "warn_pct": 0.0
       }
     ]
+  },
+  {
+    "id": "embedding-core-inputs-view",
+    "name": "Embedding core request inputs view",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/embedding_core.py",
+      "services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py",
+      "services/mlx-worker-python/tests/test_embedding_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/embedding_core_inputs_probe.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_passes_request_inputs_without_list_materialization services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_returns_stable_vectors_for_loaded_embedding_models services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_runtime_reuses_duplicate_inputs_within_one_request services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_core_inputs_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_embedding_core_inputs_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_passes_request_inputs_without_list_materialization services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_returns_stable_vectors_for_loaded_embedding_models services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_runtime_reuses_duplicate_inputs_within_one_request services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_core_inputs_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_embedding_core_inputs_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/embedding_core.py services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/embedding_core_inputs_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_EMBEDDING_CORE_INPUTS_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/embedding_core_inputs_probe.py ]; then python3 scripts/embedding_core_inputs_probe.py; else for PREFIX in \"${MELIX_EMBEDDING_CORE_INPUTS_HEAD_REPO:-}\" \"${GITHUB_WORKSPACE:-}/head\" \"../head\"; do CANDIDATE=\"$PREFIX/scripts/embedding_core_inputs_probe.py\"; if [ -f \"$CANDIDATE\" ]; then MELIX_EMBEDDING_CORE_INPUTS_REPO_ROOT=\"$PWD\" python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for scripts/embedding_core_inputs_probe.py\" >&2; exit 2; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
   }
 ]

--- a/scripts/embedding_core_inputs_probe.py
+++ b/scripts/embedding_core_inputs_probe.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(os.environ.get("MELIX_EMBEDDING_CORE_INPUTS_REPO_ROOT", Path.cwd()))
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from packages.protocol.python.worker.v1 import common_pb2, inference_pb2  # noqa: E402
+from worker.engine.embedding_core import EmbeddingCore  # noqa: E402
+from worker.registry import LoadedModel  # noqa: E402
+
+
+class ProbeEmbeddingRuntime:
+    def __init__(self, dimensions: int) -> None:
+        self.dimensions = dimensions
+        self.input_type_names: list[str] = []
+        self.input_lengths: list[int] = []
+
+    def embed_inputs(
+        self,
+        loaded_model: dict[str, object],
+        inputs: Sequence[str],
+    ) -> list[list[float]]:
+        self.input_type_names.append(type(inputs).__name__)
+        input_count = len(inputs)
+        self.input_lengths.append(input_count)
+        dimensions = int(loaded_model.get("dimensions", self.dimensions))
+        return [[float((index % 17) + offset) for offset in range(dimensions)] for index in range(input_count)]
+
+
+class ProbeRegistry:
+    def __init__(self, runtime: ProbeEmbeddingRuntime) -> None:
+        self.embedding_runtime = runtime
+        self.loaded_model = LoadedModel(
+            handle="embedding-probe-handle",
+            spec=common_pb2.ModelSpec(model_id="embedding-probe-model"),
+            runtime_model={"dimensions": runtime.dimensions},
+            runtime=runtime,
+            estimated_resident_bytes=1,
+            runtime_kind="embedding",
+            residency=common_pb2.ResidencyInfo(),
+            load_trust=common_pb2.ModelLoadTrustPolicy(),
+        )
+
+    def get_loaded_model(self, model_handle: str) -> LoadedModel | None:
+        if model_handle != self.loaded_model.handle:
+            return None
+        return self.loaded_model
+
+
+def _build_request(input_count: int) -> inference_pb2.EmbedRequest:
+    request = inference_pb2.EmbedRequest(
+        id=common_pb2.RequestIdentity(request_id="embedding-core-inputs-probe"),
+        model_handle="embedding-probe-handle",
+    )
+    request.inputs.extend(f"document-{index % 4096}-payload" for index in range(input_count))
+    return request
+
+
+def measure(iterations: int, sample_count: int, input_count: int, dimensions: int) -> dict[str, float | str]:
+    request = _build_request(input_count)
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    checksum = 0.0
+    input_type_name = ""
+
+    for _ in range(sample_count):
+        runtime = ProbeEmbeddingRuntime(dimensions=dimensions)
+        service = EmbeddingCore(ProbeRegistry(runtime))  # type: ignore[arg-type]
+        tracemalloc.start()
+        started = time.perf_counter()
+        for _iteration in range(iterations):
+            response = service.embed(request)
+            if response.error.code:
+                raise RuntimeError(response.error.message)
+            checksum += len(response.embeddings)
+            if response.embeddings:
+                checksum += response.embeddings[-1].values[-1]
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_samples.append(float(peak))
+        if runtime.input_type_names:
+            input_type_name = runtime.input_type_names[-1]
+
+    return {
+        "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+        "elapsed_ms_min": round(min(elapsed_samples), 6),
+        "peak_bytes_mean": round(statistics.fmean(peak_samples), 6),
+        "iterations": float(iterations),
+        "sample_count": float(sample_count),
+        "input_count": float(input_count),
+        "dimensions": float(dimensions),
+        "checksum": round(checksum, 6),
+        "runtime_input_is_list": 1.0 if input_type_name == "list" else 0.0,
+        "runtime_input_is_view": 0.0 if input_type_name == "list" else 1.0,
+    }
+
+
+def main() -> int:
+    iterations = int(os.environ.get("MELIX_EMBEDDING_CORE_INPUTS_ITERATIONS", "150"))
+    sample_count = int(os.environ.get("MELIX_EMBEDDING_CORE_INPUTS_SAMPLES", "5"))
+    input_count = int(os.environ.get("MELIX_EMBEDDING_CORE_INPUTS_COUNT", "4096"))
+    dimensions = int(os.environ.get("MELIX_EMBEDDING_CORE_INPUTS_DIMENSIONS", "4"))
+    print(json.dumps(measure(iterations, sample_count, input_count, dimensions), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_embedding_runtime.py
+++ b/services/mlx-worker-python/tests/test_embedding_runtime.py
@@ -63,9 +63,24 @@ class CountingEmbeddingFamilyAdapter(DeterministicEmbeddingFamilyAdapter):
         return backend.embed_text(text, dimensions)
 
 
-def build_services(model_catalog: WorkerModelCatalog | None = None):
+class RecordingEmbeddingRuntime(DeterministicEmbeddingRuntime):
+    def __init__(self) -> None:
+        super().__init__()
+        self.received_inputs_type_name = ""
+
+    def embed_inputs(self, loaded_model, inputs):
+        self.received_inputs_type_name = type(inputs).__name__
+        return super().embed_inputs(loaded_model, inputs)
+
+
+def build_services(
+    model_catalog: WorkerModelCatalog | None = None,
+    *,
+    embedding_runtime: DeterministicEmbeddingRuntime | None = None,
+):
     registry = WorkerRegistry(
         runtime=MLXTextRuntime(backend=PassiveTextBackend()),
+        embedding_runtime=embedding_runtime,
         model_catalog=model_catalog or WorkerModelCatalog(),
     )
     runtime_service = WorkerRuntimeService(registry)
@@ -138,6 +153,29 @@ def test_embed_returns_stable_vectors_for_loaded_embedding_models() -> None:
     assert first.embeddings[0].values == second.embeddings[0].values
     assert first.embeddings[1].values == second.embeddings[1].values
     assert first.embeddings[0].values != first.embeddings[1].values
+
+
+def test_embed_passes_request_inputs_without_list_materialization() -> None:
+    recording_runtime = RecordingEmbeddingRuntime()
+    _, runtime_service, inference_service = build_services(embedding_runtime=recording_runtime)
+    model_handle = load_model(runtime_service, WorkerModelCatalog.dev_embedding_model())
+
+    response = inference_service.Embed(
+        inference_pb2.EmbedRequest(
+            id=common_pb2.RequestIdentity(request_id="embed-no-input-list-copy"),
+            model_handle=model_handle,
+            inputs=["alpha", "beta", "alpha"],
+        ),
+        context=None,
+    )
+
+    assert response.error.code == ""
+    assert [list(embedding.values) for embedding in response.embeddings] == [
+        [*response.embeddings[0].values],
+        [*response.embeddings[1].values],
+        [*response.embeddings[0].values],
+    ]
+    assert recording_runtime.received_inputs_type_name != "list"
 
 
 def test_embed_rejects_missing_and_wrong_model_kinds() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1230,8 +1230,22 @@ def test_scope_report_selects_deterministic_embedding_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py"],
     )
 
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert scope["selected_count"] == 2
+    assert probe_ids == {
+        "deterministic-embedding-duplicate-input-cache",
+        "embedding-core-inputs-view",
+    }
+
+
+def test_scope_report_selects_embedding_core_inputs_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/engine/embedding_core.py"],
+    )
+
     assert scope["selected_count"] == 1
-    assert scope["selected_probes"][0]["id"] == "deterministic-embedding-duplicate-input-cache"
+    assert scope["selected_probes"][0]["id"] == "embedding-core-inputs-view"
 
 
 def test_scope_report_selects_benchmark_export_probe() -> None:
@@ -2046,6 +2060,30 @@ def test_deterministic_embedding_duplicate_probe_script_emits_metrics(
     assert metrics["checksum"] > 0
 
 
+def test_embedding_core_inputs_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_EMBEDDING_CORE_INPUTS_ITERATIONS", "2")
+    monkeypatch.setenv("MELIX_EMBEDDING_CORE_INPUTS_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_EMBEDDING_CORE_INPUTS_COUNT", "8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/embedding_core_inputs_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["input_count"] == 8.0
+    assert metrics["iterations"] == 2.0
+    assert metrics["runtime_input_is_list"] == 0.0
+    assert metrics["runtime_input_is_view"] == 1.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_stream_assembler_parser_mode_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -2547,6 +2585,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "evaluation-compare-target-lookup-early-stop",
         "evaluation-store-samples-csv-streaming",
         "engine-generate-usage-token-elision",
+        "embedding-core-inputs-view",
         "job-registry-derived-model-single-pass",
         "job-registry-restore-sort-elision",
         "lora-experiment-run-dir-name-scan",

--- a/services/mlx-worker-python/worker/engine/embedding_core.py
+++ b/services/mlx-worker-python/worker/engine/embedding_core.py
@@ -27,7 +27,7 @@ class EmbeddingCore:
         try:
             vectors = self._registry.embedding_runtime.embed_inputs(
                 loaded_model.runtime_model,
-                list(request.inputs),
+                request.inputs,
             )
         except Exception as exc:  # pragma: no cover - defensive branch
             return inference_pb2.EmbedResponse(

--- a/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from worker.runtime.embedding_backends import (
     resolve_embedding_backend,
     resolve_embedding_family,
 )
 
 
-def _repeated_input_cycle_length(inputs: list[str]) -> int:
+def _repeated_input_cycle_length(inputs: Sequence[str]) -> int:
     input_count = len(inputs)
     if input_count < 1024:
         return 0
@@ -49,7 +51,7 @@ class DeterministicEmbeddingRuntime:
         backend = resolve_embedding_backend(model_spec.ext.get("embedding_backend_id", "bert-v1"))
         return int(backend.descriptor.estimated_resident_bytes)
 
-    def embed_inputs(self, loaded_model, inputs: list[str]) -> list[list[float]]:
+    def embed_inputs(self, loaded_model, inputs: Sequence[str]) -> list[list[float]]:
         dimensions = int(loaded_model.get("dimensions", self.dimensions))
         backend = loaded_model.get("embedding_backend")
         if backend is None:


### PR DESCRIPTION
## Summary
- Avoid materializing `list(request.inputs)` in the Python embedding service boundary.
- Pass the protobuf repeated input view directly into the deterministic embedding runtime and widen runtime typing to `Sequence[str]`.
- Register the `embedding-core-inputs-view` PR-scoped performance probe with focused tests, coverage, and command-json metrics.

## Plan or Spec
- `docs/plans/2026-05-23-embedding-core-inputs-view.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_passes_request_inputs_without_list_materialization services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_returns_stable_vectors_for_loaded_embedding_models services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_runtime_reuses_duplicate_inputs_within_one_request services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_core_inputs_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_embedding_core_inputs_probe_script_emits_metrics
# 7 passed in 1.15s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/embedding_core.py services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/embedding_core_inputs_probe.py
# 7 passed in 0.73s; changed-scope coverage TOTAL 39 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_CORE_INPUTS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/embedding_core_inputs_probe.py
# head local metrics: elapsed_ms_mean=8118.345445, peak_bytes_mean=1253450.2, runtime_input_is_view=1.0

MELIX_EMBEDDING_CORE_INPUTS_HEAD_REPO="$HEAD" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id embedding-core-inputs-view --base-repo "$BASE" --head-repo "$HEAD" --output /tmp/embedding-core-inputs-view-result.json
# ok; head verification passed; base/head probes passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 39 0 100%`.
- Registered local probe `embedding-core-inputs-view`:
  - `elapsed_ms_mean`: base `8399.751794` ms → head `7981.785291` ms (`-417.966503` ms, `4.976%` faster).
  - `peak_bytes_mean`: base `1260196.2` bytes → head `1253450.2` bytes (`-6746.0` bytes, `0.535%` lower).
  - Runtime input type signal: base `runtime_input_is_list=1.0`, head `runtime_input_is_view=1.0`.
- CI PR-scoped performance report is required as the merge gate for the registered probe.

## Known Gaps
- Local validation covers the Python/Linux slice only; no Swift runtime effect is claimed.
- The base probe needs the head repo fallback (`MELIX_EMBEDDING_CORE_INPUTS_HEAD_REPO`) because the probe script is introduced by this PR.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
