### PR TITLE
perf: speed up hub catalog next cursor lookup

### DIFF
--- a/docs/plans/2026-05-06-hub-catalog-next-cursor-fast-parse.md
+++ b/docs/plans/2026-05-06-hub-catalog-next-cursor-fast-parse.md
@@ -32,3 +32,13 @@ The probe parses synthetic Hub `Link` headers repeatedly and emits:
 - Changed-scope coverage is at least 95% for touched executable Python scope.
 - Local base-vs-head probe preserves cursor parsing correctness and improves elapsed time and/or peak allocation.
 - `git diff --check` passes.
+
+## 2026-05-23 slice: direct `rel="next"` marker lookup
+
+This follow-up keeps the same registered probe (`hub-catalog-next-cursor-fast-parse`) and narrows `_next_cursor_from_link()` to search for the `rel="next"` marker first, then locate the immediately preceding bracketed URL with reverse searches. The cursor query parser remains unchanged, preserving boundary handling for `cursor` versus `notcursor`/`mycursor` parameters.
+
+Behavior guard:
+
+- Add a regression case where an encoded `rel="next"` marker appears inside the previous URL; the parser must skip it and use the actual next segment.
+
+Validation remains Linux-local for Python tests, changed-scope coverage, and the registered command-json probe; CI must rerun the registered probe before merge.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -446,12 +446,22 @@ def test_next_cursor_from_link_accepts_cursor_at_query_start() -> None:
     assert hub_catalog_module._next_cursor_from_link(link_header) == "page/start"
 
 
+def test_next_cursor_from_link_ignores_rel_marker_inside_previous_url() -> None:
+    link_header = (
+        '<https://huggingface.co/api/models?cursor=prev&note=rel%3D%22next%22>; rel="prev", '
+        '<https://huggingface.co/api/models?limit=10&cursor=real%2Fnext>; rel="next"'
+    )
+
+    assert hub_catalog_module._next_cursor_from_link(link_header) == "real/next"
+
+
 def test_next_cursor_from_link_returns_empty_for_missing_or_malformed_next_cursor() -> None:
     assert hub_catalog_module._next_cursor_from_link('<https://huggingface.co/api/models?cursor=prev>; rel="prev"') == ""
     assert hub_catalog_module._next_cursor_from_link('<https://huggingface.co/api/models>; rel="next"') == ""
     assert hub_catalog_module._next_cursor_from_link('<https://huggingface.co/api/models?limit=10>; rel="next"') == ""
     assert hub_catalog_module._next_cursor_from_link('<https://huggingface.co/api/models?cursor>; rel="next"') == ""
     assert hub_catalog_module._next_cursor_from_link('https://huggingface.co/api/models?cursor=broken; rel="next"') == ""
+    assert hub_catalog_module._next_cursor_from_link('https://huggingface.co/api/models?cursor=broken>; rel="next"') == ""
 
 
 def test_next_cursor_from_link_requires_cursor_parameter_boundary() -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -26,6 +26,7 @@ _SIZE_HINT_MULTIPLIERS = {
 
 _BARE_SIZE_HINT_RE = re.compile(r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _EXPLICIT_SIZE_HINT_RE = re.compile(r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
+_NEXT_LINK_REL_MARKER = 'rel="next"'
 @dataclass(frozen=True, slots=True)
 class HubModelSummaryRecord:
     repo_id: str
@@ -266,20 +267,22 @@ class HubCatalog:
 
 
 def _next_cursor_from_link(link_header: str) -> str:
+    marker = _NEXT_LINK_REL_MARKER
+    marker_len = len(marker)
     search_start = 0
     while True:
-        url_start = link_header.find("<", search_start)
-        if url_start < 0:
+        relation_start = link_header.find(marker, search_start)
+        if relation_start < 0:
             return ""
-        url_end = link_header.find(">", url_start + 1)
+        url_end = link_header.rfind(">", 0, relation_start)
         if url_end < 0:
-            return ""
-        next_url_start = link_header.find("<", url_end + 1)
-        relation_start = url_end + 1
-        relation_end = next_url_start if next_url_start >= 0 else len(link_header)
-        if link_header.find('rel="next"', relation_start, relation_end) >= 0:
-            return _cursor_query_value(link_header, url_start + 1, url_end)
-        search_start = relation_end
+            search_start = relation_start + marker_len
+            continue
+        url_start = link_header.rfind("<", 0, url_end)
+        if url_start < 0:
+            search_start = relation_start + marker_len
+            continue
+        return _cursor_query_value(link_header, url_start + 1, url_end)
 
 
 def _cursor_query_value(url: str, start: int, end: int) -> str:


### PR DESCRIPTION
## Summary
- Speed up Hub catalog `Link` header pagination by finding the `rel="next"` marker first, then reverse-locating the bracketed URL for cursor extraction.
- Add a regression guard for an encoded `rel="next"` marker inside the previous URL so the actual next segment is still selected.
- Update the governing Hub catalog cursor plan for this follow-up slice.

## Plan or Spec
- `docs/plans/2026-05-06-hub-catalog-next-cursor-fast-parse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_ignores_rel_marker_inside_previous_url services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_returns_empty_for_missing_or_malformed_next_cursor
# exit 0; 2 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics
# exit 0; 55 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_next_cursor_probe.py
# exit 0; TOTAL 17 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_next_cursor_probe.py
# head samples: 1373.207 ms, 1327.899 ms, 1514.042 ms, 1468.435 ms, 1402.910 ms, 1366.560 ms, 1400.842 ms, 1399.169 ms

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 17 0 100%` for `hub_catalog.py`, `test_hub_catalog.py`, `test_pr_scoped_performance.py`, and `scripts/hub_catalog_next_cursor_probe.py`.
- Registered local probe: `hub-catalog-next-cursor-fast-parse` via `scripts/hub_catalog_next_cursor_probe.py`.
- Local baseline samples from an `origin/main` worktree: `elapsed_ms_mean` 1462.510, 1463.071, 1405.097 ms (mean 1443.559 ms).
- Local head samples: `elapsed_ms_mean` 1373.207, 1327.899, 1514.042, 1468.435, 1402.910, 1366.560, 1400.842, 1399.169 ms (mean 1406.633 ms; delta -36.926 ms, ~2.56% faster). CI PR-scoped performance is the merge gate for the registered probe report.

## Known Gaps
- Linux local validation covers the Python slice only; no Swift runtime effect is claimed.
- Probe timings are noisy on this shared runner, so merge waits for the registered GitHub Actions performance workflow/checks.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
