### PR TITLE
Add Issue 42 position metadata receipts

### DIFF
--- a/docs/plans/2026-05-24-issue-42-u2-1-1-position-metadata-receipts.md
+++ b/docs/plans/2026-05-24-issue-42-u2-1-1-position-metadata-receipts.md
@@ -1,0 +1,46 @@
+# Issue 42 Unit 2.1.1 Position Metadata Receipts
+
+## Source
+
+- Parent issue: <https://github.com/Keith-CY/melix/issues/1447>
+- Governing roadmap: `docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md`
+
+## Scope
+
+Add worker-local VLM position metadata receipts without changing public HTTP,
+protobuf, or chat payload shapes. The receipt is shape-only: it records scalar
+counts and fallback reasons, never full tensor payloads.
+
+## Design
+
+- Add a small runtime helper that records `position_ids` presence/count,
+  `rope_deltas` presence/count, media position count, cache offset, sequence
+  length, rebuild count, mismatch fallback count, and fallback reason.
+- Store the receipt on `VisionProbeSnapshot` for deterministic and MLX-VLM
+  runtimes.
+- Emit receipts for normal media requests, prompt-only baseline requests, and
+  fallback requests.
+- Keep health, CLI, diagnostics, benchmark, and protocol surfaces unchanged in
+  this unit. Public projection can be added after the Milestone 1 route/load
+  receipt PR lands.
+
+## Performance And Metrics
+
+The hot path work is constant-time over scalar metadata plus a count over media
+items already present in `PreparedVisionRequest`. Success metrics:
+
+- No heavyweight tensor tracing is introduced.
+- Existing VLM fast-path probe tests remain green.
+- Changed-line coverage for touched Python worker files is at least 95 percent.
+
+## Verification
+
+Run focused Python tests for:
+
+- `services/mlx-worker-python/tests/test_multimodal_position_receipts.py`
+- `services/mlx-worker-python/tests/test_mlx_vlm_runtime.py`
+- `services/mlx-worker-python/tests/test_vision_runtime.py`
+
+Before handoff, run `git diff --check`, changed-line coverage for touched files,
+and a metrics report. A full milestone PR still requires the repository gate
+specified in `AGENTS.md`.

--- a/services/mlx-worker-python/tests/test_multimodal_position_receipts.py
+++ b/services/mlx-worker-python/tests/test_multimodal_position_receipts.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+from threading import Event
+from types import SimpleNamespace
+
+from packages.protocol.python.worker.v1 import common_pb2
+
+from worker.model_registry.catalog import WorkerModelCatalog
+from worker.runtime.deterministic_vlm_runtime import DeterministicVLMRuntime
+from worker.runtime.mlx_vlm_runtime import AutoMLXVLMBackend, MLXVLMRuntime
+from worker.runtime.multimodal_position_receipts import build_position_metadata_receipt
+from worker.runtime.multimodal_preprocessing import (
+    PreparedImageInput,
+    PreparedVideoFramePolicy,
+    PreparedVisionRequest,
+)
+from worker.runtime.video_preprocessing import PreparedVideoInput
+from worker.runtime.vision_family_adapters import resolve_vision_family_config
+
+
+def _imported_gemma4_vlm_model() -> common_pb2.ModelSpec:
+    return common_pb2.ModelSpec(
+        model_id="unsloth/gemma-4-E4B-it-MLX-8bit",
+        model_path="unsloth/gemma-4-E4B-it-MLX-8bit",
+        model_kind="vlm",
+        revision="main",
+        tokenizer_hash="hf.unsloth.gemma-4-E4B-it-MLX-8bit",
+        quant_profile_id="q8",
+        parser_mode="text",
+        reasoning_mode="off",
+        max_context=4096,
+        ext={
+            "melix.vlm.backend_id": "mlx_vlm",
+            "vision_family_id": "gemma4-v1",
+            "vision_prompt_profile_id": "gemma4-chatml-v1",
+            "vision_tokenization_mode": "interleaved",
+            "vision_max_images_per_prompt": "8",
+            "vision_supports_tool_calls": "true",
+            "melix.multimodal_adapter_hash": "vision-family-gemma4-v1",
+        },
+    )
+
+
+def test_position_metadata_receipt_counts_tensor_shapes_and_media_positions() -> None:
+    request = PreparedVisionRequest(
+        prompt_text="Describe both.",
+        images=[
+            PreparedImageInput(
+                bytes_data=b"image",
+                source_kind="inline",
+                reference="inline:image",
+                mime_type="image/jpeg",
+                format="jpg",
+                filename="image.jpg",
+                sha256_hex="abc123",
+            )
+        ],
+        videos=[
+            PreparedVideoInput(
+                bytes_data=b"video",
+                source_kind="inline",
+                reference="inline:video",
+                mime_type="video/mp4",
+                format="mp4",
+                filename="video.mp4",
+                byte_length=5,
+                sha256_hex="def456",
+                duration_ms=2_000,
+                frame_budget=0,
+                start_ms=0,
+                end_ms=2_000,
+            )
+        ],
+        video_frame_policies=[
+            PreparedVideoFramePolicy(
+                reference="inline:video",
+                sampling_strategy="uniform_sample",
+                requested_frame_budget=4,
+                effective_frame_count=4,
+                clip_start_ms=0,
+                clip_end_ms=2_000,
+                clip_duration_ms=2_000,
+            )
+        ],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=10,
+        preprocess_peak_memory_bytes=10,
+    )
+
+    receipt = build_position_metadata_receipt(
+        prepared_request=request,
+        seq_len=64,
+        cache_offset=16,
+        position_ids=SimpleNamespace(shape=(1, 64)),
+        rope_deltas=SimpleNamespace(shape=(1, 3)),
+        fallback_reason="shape_mismatch",
+    )
+
+    assert receipt == {
+        "position_ids_present": True,
+        "position_ids_count": 64,
+        "rope_deltas_present": True,
+        "rope_deltas_count": 3,
+        "media_position_count": 5,
+        "cache_offset": 16,
+        "seq_len": 64,
+        "rebuild_count": 1,
+        "mismatch_fallback_count": 1,
+        "fallback_reason": "shape_mismatch",
+    }
+
+
+def test_position_metadata_receipt_defaults_to_shape_only_baseline() -> None:
+    assert build_position_metadata_receipt(seq_len=7) == {
+        "position_ids_present": False,
+        "position_ids_count": 0,
+        "rope_deltas_present": False,
+        "rope_deltas_count": 0,
+        "media_position_count": 0,
+        "cache_offset": 0,
+        "seq_len": 7,
+        "rebuild_count": 0,
+        "mismatch_fallback_count": 0,
+        "fallback_reason": "",
+    }
+
+
+def test_position_metadata_receipt_counts_flat_metadata_values() -> None:
+    receipt = build_position_metadata_receipt(
+        seq_len=4,
+        position_ids=[0, 1, 2, 3],
+        rope_deltas={"row0": 1, "row1": 2},
+    )
+
+    assert receipt["position_ids_count"] == 4
+    assert receipt["rope_deltas_count"] == 2
+
+
+def test_position_metadata_receipt_counts_video_without_expanded_frame_policy() -> None:
+    request = PreparedVisionRequest(
+        prompt_text="Describe video.",
+        images=[],
+        videos=[
+            PreparedVideoInput(
+                bytes_data=b"",
+                source_kind="uri",
+                reference="https://example.com/video.mp4",
+                mime_type="video/mp4",
+                format="mp4",
+                filename="video.mp4",
+                byte_length=0,
+                duration_ms=0,
+                frame_budget=0,
+                start_ms=0,
+                end_ms=0,
+                sha256_hex="video-uri",
+            )
+        ],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=0,
+        preprocess_peak_memory_bytes=0,
+    )
+
+    receipt = build_position_metadata_receipt(
+        prepared_request=request,
+        seq_len=4,
+        position_ids=object(),
+    )
+
+    assert receipt["position_ids_count"] == 1
+    assert receipt["media_position_count"] == 1
+
+
+def test_deterministic_vlm_runtime_records_position_metadata_receipt() -> None:
+    runtime = DeterministicVLMRuntime()
+    loaded_model = runtime.load_model(WorkerModelCatalog.dev_vlm_model())
+    prepared = resolve_vision_family_config(loaded_model).shape_request(
+        PreparedVisionRequest(
+            prompt_text="Describe the image.",
+            images=[
+                PreparedImageInput(
+                    bytes_data=b"deterministic receipt image",
+                    source_kind="inline",
+                    reference="inline:image",
+                    mime_type="image/jpeg",
+                    format="jpg",
+                    filename="image.jpg",
+                    sha256_hex="deadbeef",
+                )
+            ],
+            videos=[],
+            video_frame_policies=[],
+            preprocess_latency_ms=0.0,
+            preprocess_input_bytes=len(b"deterministic receipt image"),
+            preprocess_peak_memory_bytes=len(b"deterministic receipt image"),
+            prompt_hash_hex="1" * 64,
+            multimodal_hash_hex="2" * 64,
+        )
+    )
+
+    list(runtime.generate_tokens(loaded_model, prepared, None, Event()))
+    receipt = runtime.last_probe_snapshot().position_metadata_receipt
+
+    assert receipt["media_position_count"] == 1
+    assert receipt["seq_len"] > 1
+    assert receipt["rebuild_count"] == 1
+    assert receipt["mismatch_fallback_count"] == 0
+
+
+def test_mlx_vlm_runtime_records_position_metadata_receipt_for_media_requests() -> None:
+    def fake_load(model_path: str, revision: str = "main"):
+        _ = model_path
+        _ = revision
+        model = SimpleNamespace(
+            config=SimpleNamespace(model_type="gemma4"),
+            vision_tower=object(),
+            embed_vision=object(),
+        )
+        processor = SimpleNamespace(image_processor=object())
+        return model, processor
+
+    def fake_apply_chat_template(processor, config, prompt: str, num_images: int = 0, **kwargs):
+        _ = processor
+        _ = config
+        _ = num_images
+        _ = kwargs
+        return f"formatted::{prompt}"
+
+    def fake_stream_generate(model, processor, prompt: str, image=None, **kwargs):
+        _ = model
+        _ = processor
+        _ = prompt
+        _ = image
+        _ = kwargs
+        yield SimpleNamespace(text="ok", prompt_tokens=9, generation_tokens=1)
+
+    runtime = MLXVLMRuntime(
+        backend=AutoMLXVLMBackend(
+            load_fn=fake_load,
+            stream_generate_fn=fake_stream_generate,
+            apply_chat_template_fn=fake_apply_chat_template,
+        )
+    )
+    loaded_model = runtime.load_model(_imported_gemma4_vlm_model())
+    prepared = runtime.render_prompt(
+        [
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[
+                    common_pb2.MessagePart(text="Describe the image."),
+                    common_pb2.MessagePart(
+                        image_bytes=b"receipt-image",
+                        media=common_pb2.MediaMetadata(
+                            media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                            source_kind=common_pb2.MEDIA_SOURCE_INLINE_BYTES,
+                            filename="receipt.jpg",
+                            format="jpg",
+                        ),
+                    ),
+                ],
+            )
+        ],
+        loaded_model=loaded_model,
+    )
+
+    list(
+        runtime.generate_tokens(
+            loaded_model,
+            prepared,
+            common_pb2.SamplingConfig(max_output_tokens=8),
+            Event(),
+        )
+    )
+    receipt = runtime.last_probe_snapshot().position_metadata_receipt
+
+    assert receipt == {
+        "position_ids_present": False,
+        "position_ids_count": 0,
+        "rope_deltas_present": False,
+        "rope_deltas_count": 0,
+        "media_position_count": 1,
+        "cache_offset": 0,
+        "seq_len": 5,
+        "rebuild_count": 1,
+        "mismatch_fallback_count": 0,
+        "fallback_reason": "",
+    }
+
+
+def test_mlx_vlm_runtime_position_receipt_records_fallback_reason_for_text_backed_media() -> None:
+    runtime = MLXVLMRuntime()
+    loaded_model = {
+        "metadata": {
+            "vision_family_id": "gemma4-v1",
+            "melix.vlm.execution_mode": "text_backed",
+        },
+        "model": SimpleNamespace(config=SimpleNamespace(model_type="gemma4")),
+    }
+    prepared = PreparedVisionRequest(
+        prompt_text="Describe.",
+        images=[
+            PreparedImageInput(
+                bytes_data=b"image",
+                source_kind="inline",
+                reference="inline:image",
+                mime_type="image/jpeg",
+                format="jpg",
+                filename="image.jpg",
+                sha256_hex="deadbeef",
+            )
+        ],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=len(b"image"),
+        preprocess_peak_memory_bytes=len(b"image"),
+        prompt_hash_hex="1" * 64,
+        multimodal_hash_hex="2" * 64,
+    )
+
+    runtime._record_fast_path_probe(loaded_model, prepared)
+    receipt = runtime.last_probe_snapshot().position_metadata_receipt
+
+    assert receipt["media_position_count"] == 1
+    assert receipt["seq_len"] == 3
+    assert receipt["mismatch_fallback_count"] == 1
+    assert receipt["fallback_reason"] == "text_backed_no_vision_weights"
+
+
+def test_mlx_vlm_runtime_position_receipt_records_baseline_for_prompt_only_turns() -> None:
+    runtime = MLXVLMRuntime()
+    loaded_model = {
+        "metadata": {
+            "vision_family_id": "gemma4-v1",
+            "melix.vlm.execution_mode": "multimodal",
+        },
+        "model": SimpleNamespace(config=SimpleNamespace(model_type="gemma4")),
+    }
+    prepared = PreparedVisionRequest(
+        prompt_text="Say hello.",
+        images=[],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=0,
+        preprocess_peak_memory_bytes=0,
+        prompt_hash_hex="1" * 64,
+        multimodal_hash_hex="2" * 64,
+    )
+
+    runtime._record_fast_path_probe(loaded_model, prepared)
+    receipt = runtime.last_probe_snapshot().position_metadata_receipt
+
+    assert receipt == {
+        "position_ids_present": False,
+        "position_ids_count": 0,
+        "rope_deltas_present": False,
+        "rope_deltas_count": 0,
+        "media_position_count": 0,
+        "cache_offset": 0,
+        "seq_len": 3,
+        "rebuild_count": 0,
+        "mismatch_fallback_count": 0,
+        "fallback_reason": "no_media",
+    }

--- a/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 import json
 from pathlib import Path
 from threading import Event
@@ -11,6 +11,7 @@ from packages.protocol.python.worker.v1 import cache_pb2, common_pb2
 from worker.runtime.deterministic_delay import sleep_if_configured
 from worker.runtime.mlx_text_runtime import RuntimeTokenEvent, RuntimeToolCallEvent
 from worker.runtime.multimodal_fast_paths import MultimodalFastPathController, fast_path_probe_signature
+from worker.runtime.multimodal_position_receipts import build_position_metadata_receipt
 from worker.runtime.multimodal_preprocessing import PreparedVisionRequest, prepare_vision_request
 from worker.runtime.temp_media_lifecycle import TempMediaSession
 from worker.runtime.token_counting import whitespace_token_count as _whitespace_token_count
@@ -41,6 +42,9 @@ class VisionProbeSnapshot:
     multi_image_scatter_mode: str = "none"
     quantized_load_mode: str = "fallback"
     quantized_load_fallback_reason: str = "not_reported"
+    position_metadata_receipt: dict[str, object] = field(
+        default_factory=lambda: build_position_metadata_receipt()
+    )
     text_batch_generator_submitted_request_count: int = 0
     text_batch_generator_completed_request_count: int = 0
     text_batch_generator_step_count: int = 0
@@ -166,7 +170,11 @@ class DeterministicVLMRuntime:
             loaded_model=loaded_model,
             execution_ext=execution_ext,
         )
-        self._record_fast_path_probe(loaded_model, prompt.prepared_request)
+        self._record_fast_path_probe(
+            loaded_model,
+            prompt.prepared_request,
+            seq_len=prompt.prompt_tokens,
+        )
         self._last_probe = replace(
             self._last_probe,
             cache_identity=prompt.cache_identity,
@@ -200,7 +208,11 @@ class DeterministicVLMRuntime:
         prompt_tokens = prompt.prompt_tokens
         cache_identity = prompt.cache_identity
         scope_id = prompt.scope_id
-        self._ensure_fast_path_probe(loaded_model, prepared_request)
+        self._ensure_fast_path_probe(
+            loaded_model,
+            prepared_request,
+            seq_len=prompt_tokens,
+        )
         self._cache_lookups += 1
         cache_hit = cache_identity in self._cache_entries
         if cache_hit:
@@ -410,11 +422,18 @@ class DeterministicVLMRuntime:
         self,
         loaded_model,
         prepared_request: PreparedVisionRequest,
+        *,
+        seq_len: int | None = None,
     ) -> None:
         signature = fast_path_probe_signature(loaded_model, prepared_request)
         if self._last_fast_path_signature == signature:
             return
-        self._record_fast_path_probe(loaded_model, prepared_request, signature=signature)
+        self._record_fast_path_probe(
+            loaded_model,
+            prepared_request,
+            signature=signature,
+            seq_len=seq_len,
+        )
 
     def _record_fast_path_probe(
         self,
@@ -422,6 +441,7 @@ class DeterministicVLMRuntime:
         prepared_request: PreparedVisionRequest,
         *,
         signature: tuple[str, ...] | None = None,
+        seq_len: int | None = None,
     ) -> None:
         fast_path = self._fast_path_controller.plan(loaded_model, prepared_request)
         self._last_fast_path_signature = signature or fast_path_probe_signature(
@@ -447,6 +467,28 @@ class DeterministicVLMRuntime:
             multi_image_scatter_mode=fast_path.multi_image_scatter_mode,
             quantized_load_mode=fast_path.quantized_load_mode,
             quantized_load_fallback_reason=fast_path.quantized_load_fallback_reason,
+            position_metadata_receipt=self._position_metadata_receipt(
+                loaded_model=loaded_model,
+                prepared_request=prepared_request,
+                fallback_reason=fast_path.multimodal_fallback_reason,
+                seq_len=seq_len,
+            ),
+        )
+
+    def _position_metadata_receipt(
+        self,
+        *,
+        loaded_model,
+        prepared_request: PreparedVisionRequest,
+        fallback_reason: str,
+        seq_len: int | None = None,
+    ) -> dict[str, object]:
+        if seq_len is None:
+            seq_len = self.prompt_token_count(prepared_request, loaded_model=loaded_model)
+        return build_position_metadata_receipt(
+            prepared_request=prepared_request,
+            seq_len=seq_len,
+            fallback_reason=fallback_reason,
         )
 
     def cache_stats_response(self) -> cache_pb2.GetCacheStatsResponse:

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -25,6 +25,7 @@ from worker.runtime.mlx_text_runtime import (
     _int_tuple,
 )
 from worker.runtime.multimodal_fast_paths import MultimodalFastPathController, fast_path_probe_signature
+from worker.runtime.multimodal_position_receipts import build_position_metadata_receipt
 from worker.runtime.multimodal_preprocessing import PreparedVisionRequest, prepare_vision_request, rebuild_multimodal_hash
 from worker.runtime.runtime_utils import (
     callable_accepts_kwarg as _callable_accepts_kwarg,
@@ -2238,6 +2239,7 @@ class MLXVLMRuntime:
         prepared_request: PreparedVisionRequest,
         *,
         signature: tuple[str, ...] | None = None,
+        seq_len: int | None = None,
     ) -> None:
         signature = signature or fast_path_probe_signature(
             loaded_model,
@@ -2266,6 +2268,28 @@ class MLXVLMRuntime:
             multi_image_scatter_mode=fast_path.multi_image_scatter_mode,
             quantized_load_mode=fast_path.quantized_load_mode,
             quantized_load_fallback_reason=fast_path.quantized_load_fallback_reason,
+            position_metadata_receipt=self._position_metadata_receipt(
+                loaded_model=loaded_model,
+                prepared_request=prepared_request,
+                fallback_reason=fast_path.multimodal_fallback_reason,
+                seq_len=seq_len,
+            ),
+        )
+
+    def _position_metadata_receipt(
+        self,
+        *,
+        loaded_model,
+        prepared_request: PreparedVisionRequest,
+        fallback_reason: str,
+        seq_len: int | None = None,
+    ) -> dict[str, object]:
+        if seq_len is None:
+            seq_len = self.prompt_token_count(prepared_request, loaded_model=loaded_model)
+        return build_position_metadata_receipt(
+            prepared_request=prepared_request,
+            seq_len=seq_len,
+            fallback_reason=fallback_reason,
         )
 
     @staticmethod

--- a/services/mlx-worker-python/worker/runtime/multimodal_position_receipts.py
+++ b/services/mlx-worker-python/worker/runtime/multimodal_position_receipts.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from functools import reduce
+from operator import mul
+from typing import Any
+
+
+def build_position_metadata_receipt(
+    *,
+    prepared_request: Any | None = None,
+    seq_len: int = 0,
+    cache_offset: int = 0,
+    position_ids: Any | None = None,
+    rope_deltas: Any | None = None,
+    fallback_reason: str = "",
+) -> dict[str, object]:
+    position_ids_count = _value_count(position_ids)
+    rope_deltas_count = _value_count(rope_deltas)
+    media_position_count = _media_position_count(prepared_request)
+    normalized_fallback_reason = str(fallback_reason or "")
+    return {
+        "position_ids_present": position_ids is not None,
+        "position_ids_count": position_ids_count,
+        "rope_deltas_present": rope_deltas is not None,
+        "rope_deltas_count": rope_deltas_count,
+        "media_position_count": media_position_count,
+        "cache_offset": max(0, int(cache_offset or 0)),
+        "seq_len": max(0, int(seq_len or 0)),
+        "rebuild_count": 1 if media_position_count else 0,
+        "mismatch_fallback_count": (
+            1 if media_position_count and normalized_fallback_reason not in {"", "no_media"} else 0
+        ),
+        "fallback_reason": normalized_fallback_reason,
+    }
+
+
+def _media_position_count(prepared_request: Any | None) -> int:
+    if prepared_request is None:
+        return 0
+    images = getattr(prepared_request, "images", ()) or ()
+    image_count = len(images)
+    video_frame_count = int(getattr(prepared_request, "effective_video_frame_count", 0) or 0)
+    videos = getattr(prepared_request, "videos", ()) or ()
+    if videos and video_frame_count <= 0:
+        video_frame_count = len(videos)
+    return max(0, image_count + video_frame_count)
+
+
+def _value_count(value: Any | None) -> int:
+    if value is None:
+        return 0
+    shape = getattr(value, "shape", None)
+    if isinstance(shape, (tuple, list)) and shape:
+        return int(reduce(mul, (max(0, int(part)) for part in shape), 1))
+    if isinstance(value, dict):
+        return len(value)
+    if isinstance(value, (list, tuple)):
+        return len(value)
+    return 1


### PR DESCRIPTION
## Summary
- Add worker-local VLM position metadata receipts for Issue 42 U2.1.1.
- Record shape-only `position_ids`, `rope_deltas`, media position counts, cache offset, sequence length, rebuild count, mismatch fallback count, and fallback reason on `VisionProbeSnapshot`.
- Cover deterministic and MLX VLM baseline, media, and fallback paths without changing public HTTP, protobuf, CLI, or chat payload shapes.

Closes #1447.

## Plan or Spec
- `docs/plans/2026-05-24-issue-42-u2-1-1-position-metadata-receipts.md`
- Governing roadmap: `docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md`

## Commands Run
```text
PYTHONPATH=.:services/mlx-worker-python uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_multimodal_position_receipts.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_streams_backend_tokens_and_records_probe services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_caches_family_config_across_prompt_render_and_token_count services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_uses_generate_step_for_mtp_when_available services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_completion_token_count_scans_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_vlm_response_from_file_image_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_prefill_reuses_prompt_metadata_without_recomputing_helpers
# post-merge result: 14 passed in 0.20s

PYTHONPATH=.:services/mlx-worker-python COVERAGE_FILE=.runtime/coverage/issue42-u211-postmerge.coverage uv run --project services/mlx-worker-python coverage run --source=services/mlx-worker-python/worker/runtime -m pytest -q services/mlx-worker-python/tests/test_multimodal_position_receipts.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_streams_backend_tokens_and_records_probe services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_caches_family_config_across_prompt_render_and_token_count services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_uses_generate_step_for_mtp_when_available services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_completion_token_count_scans_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_vlm_response_from_file_image_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_prefill_reuses_prompt_metadata_without_recomputing_helpers
# post-merge result: 14 passed in 0.32s

PYTHONPATH=.:services/mlx-worker-python COVERAGE_FILE=.runtime/coverage/issue42-u211-postmerge.coverage uv run --project services/mlx-worker-python coverage json -o .runtime/coverage/issue42-u211-postmerge.coverage.json
# result: Wrote JSON report to .runtime/coverage/issue42-u211-postmerge.coverage.json

uv run --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/issue42-u211-postmerge.coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/multimodal_position_receipts.py services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py services/mlx-worker-python/tests/test_multimodal_position_receipts.py
# result: TOTAL 100.00% 46/46

git diff --check origin/main...HEAD
# result: pass

git commit -m "feat: add vlm position metadata receipts"
# pre-commit result:
# make swift-test: pass, elapsed 462.4s
# make py-test: pass, 3039 passed, 14 skipped, 2 warnings in 143.45s
# make integration-test: pass, 114 passed, 1 skipped in 614.25s
# performance report: status ok, changed files 5, selected probes 3, regressions 0, verification failures 0
```

## Coverage and Metrics
- Changed-line coverage after merging current `origin/main`: `100.00% (46/46)`.
- Commit hook performance report: `.runtime/pre-commit-performance/20260524-001208-b78ca003/report/report.md`
- PR-scoped performance probes:
  - MLX-VLM family-config cache: pass, coverage 100.0%, elapsed neutral (-0.09%).
  - MLX-VLM Gemma4 weight-presence single-pass scan: pass, coverage 100.0%, elapsed neutral (-1.13%), peak bytes neutral.
  - Deterministic VLM completion token scan: pass, coverage 100.0%, elapsed neutral (+0.20%), peak bytes neutral (+0.46%).
- Observability mode: minimal worker-local probe snapshot receipt.
- Probe overhead: constant-time scalar receipt construction plus media item counting already present on `PreparedVisionRequest`; no tensor payload tracing and no public payload expansion.

## Known Gaps
- Public projection of these receipts remains out of scope for U2.1.1 and should be handled after the route/load receipt surfaces land.
- Follow-up U2.1.2/U2.1.3 guard fixtures remain open.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
