### PR TITLE
perf: build embedding responses in place

### DIFF
--- a/docs/plans/2026-05-24-embedding-core-response-build.md
+++ b/docs/plans/2026-05-24-embedding-core-response-build.md
@@ -1,0 +1,30 @@
+# Embedding Core Response Build Performance Slice
+
+## Scope
+
+Optimize the Python embedding response build path in `services/mlx-worker-python/worker/engine/embedding_core.py`.
+
+This slice is intentionally limited to replacing the intermediate Python list of `Embedding` messages with direct protobuf repeated-field appends. The runtime input forwarding behavior stays unchanged: `request.inputs` is still passed through to the embedding runtime without list materialization.
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped performance probe `embedding-core-inputs-view` in `infra/perf/pr_scoped_probes.json`.
+
+The probe already includes:
+
+- `test_command` for focused embedding core behavior and probe registry selection tests.
+- `coverage_command` for the same changed scope.
+- `probe_command` via `scripts/embedding_core_inputs_probe.py` reporting `elapsed_ms_mean` and `peak_bytes_mean`.
+
+## Local Verification Plan
+
+Run on Linux before PR creation:
+
+1. Focused test command from the registered probe.
+2. Focused coverage command from the registered probe.
+3. Registered probe command locally.
+4. Head-vs-`origin/main` comparison using the same probe workload.
+
+## Expected Effect
+
+Directly appending protobuf repeated messages should reduce temporary Python allocation and elapsed time for large embedding responses while preserving response contents and error behavior.

--- a/services/mlx-worker-python/worker/engine/embedding_core.py
+++ b/services/mlx-worker-python/worker/engine/embedding_core.py
@@ -34,9 +34,8 @@ class EmbeddingCore:
                 error=common_pb2.ErrorStatus(code="runtime_error", message=str(exc))
             )
 
-        return inference_pb2.EmbedResponse(
-            embeddings=[
-                inference_pb2.Embedding(values=values)
-                for values in vectors
-            ]
-        )
+        response = inference_pb2.EmbedResponse()
+        for values in vectors:
+            embedding = response.embeddings.add()
+            embedding.values.extend(values)
+        return response


### PR DESCRIPTION
## Summary
- Build `EmbedResponse` messages by appending directly to the protobuf repeated field.
- Avoid the intermediate Python list of `Embedding` messages while preserving runtime input pass-through and response contents.

## Plan or Spec
- `docs/plans/2026-05-24-embedding-core-response-build.md`
- Registered PR-scoped probe: `embedding-core-inputs-view` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# focused registered tests, before commit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_passes_request_inputs_without_list_materialization services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_returns_stable_vectors_for_loaded_embedding_models services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_runtime_reuses_duplicate_inputs_within_one_request services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_core_inputs_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_embedding_core_inputs_probe_script_emits_metrics
# result: 7 passed in 0.53s

# changed-scope coverage, before commit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_passes_request_inputs_without_list_materialization services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_returns_stable_vectors_for_loaded_embedding_models services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_runtime_reuses_duplicate_inputs_within_one_request services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_core_inputs_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_embedding_core_inputs_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/embedding_core.py services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/embedding_core_inputs_probe.py
# result: 7 passed; changed lines in embedding_core.py: 5/5 covered; TOTAL 5 0 100%

# registered probe on origin/main baseline worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_CORE_INPUTS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/embedding_core_inputs_probe.py
# result: elapsed_ms_mean=7606.645506, peak_bytes_mean=1253455.8

# registered probe on PR head after rebase
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_CORE_INPUTS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/embedding_core_inputs_probe.py
# result: elapsed_ms_mean=6474.04634, peak_bytes_mean=794263.2

# focused tests after rebase onto origin/main
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_passes_request_inputs_without_list_materialization services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_returns_stable_vectors_for_loaded_embedding_models services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_runtime_reuses_duplicate_inputs_within_one_request services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_core_inputs_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_embedding_core_inputs_probe_script_emits_metrics
# result: 7 passed in 0.51s
```

## Coverage and Metrics
- Changed-scope coverage before commit: `TOTAL 5 0 100%` for the modified `embedding_core.py` lines.
- Registered local probe (`embedding-core-inputs-view`):
  - baseline `origin/main`: `elapsed_ms_mean=7606.645506`, `peak_bytes_mean=1253455.8`
  - PR head: `elapsed_ms_mean=6474.04634`, `peak_bytes_mean=794263.2`
  - delta: `-1132.599166 ms` (`14.89%` faster), peak memory `-459192.6 bytes` (`36.64%` lower)
- CI PR-scoped performance workflow is required for the registered probe validation before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime behavior is changed in this slice.
- The registered CI probe report must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
