### PR TITLE
Implement post-closure follow-up receipts

### DIFF
--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -5227,7 +5227,10 @@ struct RuntimeViewModelTests {
         for index in 0..<45 {
             await client.sendLog(level: "info", message: "log-\(index)")
         }
-        try await Task.sleep(for: .milliseconds(30))
+        try await waitForRuntimeViewModelCondition("recent logs should include the latest forty entries") {
+            let logs = viewModel.desktopFoundationState.logs
+            return logs.count == 40 && logs.first?.message == "log-44"
+        }
 
         let foundation = viewModel.desktopFoundationState
         #expect(foundation.logs.count == 40)

--- a/docs/control-plane-protocol.md
+++ b/docs/control-plane-protocol.md
@@ -517,6 +517,18 @@ Workers preserve raw generation text separately from public content. Stream asse
 - `ReasoningDelta` for hidden reasoning stream material
 - `ToolCallDelta` for parsed tool-call fragments
 
+The worker also emits a request-local token route receipt in completed parser
+metrics. The receipt records `router_id`, `router_version`, `token_id`,
+`channel`, `channel_source`, `tool_choice_policy`, `reasoning_mode`,
+`visible_text_tokens`, `hidden_reasoning_tokens`, and
+`fallback_raw_text_used`, with route records for visible text, hidden
+reasoning, and tool-call spans. Detailed route sampling is enabled for
+reasoning, tool, structured-output, and compatibility-policy routed output.
+Plain visible-text-only requests may report `route_tracking_enabled=false` with
+empty sampled routes so the default text path avoids per-token routing work.
+When token identifiers are unavailable on tracked routes, the worker may fall
+back to raw-text span routing but must mark the fallback in the receipt.
+
 Malformed or truncated tool fragments are recoverable parser observations. They should increment parser metrics and be skipped rather than fail the request. Display cleanup is not structural parsing; cleanup must not collapse meaningful leading or trailing content whitespace and must not re-emit generation-prefix control tokens.
 
 JSON-only structured-output requests without explicit tools suppress generic model-default tool parsing. The worker must not validate or output reasoning preambles as JSON content; any reasoning prefix is stripped before structured-output validation.

--- a/docs/plans/2026-05-24-issue-1528-training-admission-receipts.md
+++ b/docs/plans/2026-05-24-issue-1528-training-admission-receipts.md
@@ -1,0 +1,52 @@
+# Issue 1528 Training Admission Receipts
+
+## Goal
+
+Harden LoRA training admission so invalid training controls fail before runner
+launch with typed operator details, while accepted runs persist the resolved
+controls that affected backend execution.
+
+## Scope
+
+This slice is limited to worker-owned LoRA training request validation and the
+adapter manifest receipt emitted by `train_lora`. It intentionally avoids
+artifact resume canaries and runtime dependency gates, which are tracked by
+separate follow-up issues.
+
+## Design
+
+- Keep `normalize_training_config` as the single admission normalization point
+  for CLI, API, and Desktop requests.
+- Preserve legal sentinel behavior for `max_steps=0` by validating only explicit
+  positive run caps.
+- Add typed validation details for numeric admission failures: field, reason,
+  received value, and allowed bounds.
+- Record resolved defaults and capability gates in the adapter manifest before
+  backend-dependent metrics are interpreted.
+- Record dataset file resolution from the resolved package and normalized
+  snapshot, including validation file presence.
+- Record backend control receipts for gradient clipping, eval batch size, and
+  omitted scheduler kwargs using deterministic policy objects.
+
+## Acceptance Mapping
+
+- Invalid hyperparameters return typed 422-style details through existing
+  `ModelOperationError.details`.
+- Legal sentinels remain accepted and are reflected in `resolved_bounds`.
+- Capability-gated defaults are recorded in `capability_gate`.
+- Dataset file resolution, grad clipping, eval batch size, and scheduler
+  omission receipts are recorded on `train_lora.adapter.json`.
+
+## Verification
+
+Focused verification:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_lora_model_ops_unit.py -q -k "training_admission"
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_lora_model_ops.py -q -k "training_config_validates_direct_error_paths or training_config_helper_resolution_paths_and_limits"
+git diff --check
+```
+
+No runtime performance probe is applicable because this slice changes admission
+validation and manifest receipt fields before training execution. Metrics report:
+N/A for performance; focused correctness is covered by unit tests above.

--- a/docs/plans/2026-05-24-issue-1529-lora-canaries.md
+++ b/docs/plans/2026-05-24-issue-1529-lora-canaries.md
@@ -1,0 +1,54 @@
+# Issue 1529 LoRA Canary Receipts Implementation Plan
+
+## Goal
+
+Add focused LoRA artifact, resume, merge/export, callback drift, and
+teacher-forced canary receipts without changing admission validators or generic
+export gates.
+
+## Governing Sources
+
+- `AGENTS.md`
+- `docs/runbooks/phase-8-lora-adapter-workflow.md`
+- GitHub issue #1529
+- `docs/plans/2026-05-24-closed-issue-post-closure-followup-audit.md`
+
+## Scope
+
+This slice is worker-local and records canary evidence on LoRA training
+artifacts. It does not modify the closed-issue follow-up coordinator plan, open
+or close GitHub issues, change dependency gates, or add training admission
+validators.
+
+## Architecture
+
+Add a small metadata helper beside the existing LoRA runtime metadata helpers.
+The training pipeline will call it after adapter weights and config are written,
+then copy the resulting receipt fields into `train_lora.adapter.json`.
+`LoraExperimentStore` will preserve the same receipt values in per-run records
+so run history can surface drift evidence without reparsing adapter manifests.
+
+## Success Metrics
+
+- Focused LoRA metadata/model-op pytest canaries pass.
+- `git diff --check` passes.
+- Receipt fields are present on successful deterministic LoRA runs:
+  `source_eos_token`, `saved_eos_token`, `tokenizer_config_path`,
+  `base_config_present`, `processor_resume_mode`, `aux_modules_restored`,
+  `merge_export_canary_result`, `callback_api_drift_result`,
+  `completion_loss`, `round_trip_passed`, and `grad_norm`.
+
+## TDD Steps
+
+1. Add a failing unit test for artifact/resume canary metadata using a temporary
+   base model directory with config, tokenizer, processor, and auxiliary module
+   fixtures.
+2. Add a failing pipeline test proving `train_lora.adapter.json` records all
+   expected receipt fields for deterministic training.
+3. Add a failing checkpoint canary test for missing base config/tokenizer/aux
+   state.
+4. Implement the smallest helper and manifest wiring needed to pass those
+   tests.
+5. Add experiment-store assertions if the manifest fields are not already
+   visible from run records.
+6. Run focused pytest filters and `git diff --check`.

--- a/docs/plans/2026-05-24-issue-1530-training-runtime-preflight.md
+++ b/docs/plans/2026-05-24-issue-1530-training-runtime-preflight.md
@@ -60,3 +60,11 @@ probe performs bounded `importlib.util.find_spec` checks and optional GC cleanup
 only on failure. Success metric: focused unit tests prove text-only training
 does not fail when optional media decoders are broken, and failure metrics report
 bounded retained tensor bytes where measurable.
+
+## 2026-05-24 Review Follow-Up
+
+The media decoder receipt records every optional decoder module and reports
+`partial` when at least one media path is unavailable instead of returning
+healthy after the first importable decoder. Failure cleanup captures a bounded
+traceback summary before clearing traceback references, and retained tensor
+bytes use active MLX memory after garbage collection rather than peak memory.

--- a/docs/plans/2026-05-24-issue-1530-training-runtime-preflight.md
+++ b/docs/plans/2026-05-24-issue-1530-training-runtime-preflight.md
@@ -1,0 +1,62 @@
+# Issue 1530 Training Runtime Preflight Implementation Plan
+
+## Goal
+
+Add LoRA training runtime dependency preflights and nested-failure cleanup
+guards without expanding the managed artifact, offline, or cache integrity
+scope owned by #1258.
+
+## Architecture
+
+The Python worker will record a small, import-safe runtime preflight receipt
+before training starts. The preflight uses Python import metadata and platform
+inspection only, so training inspection and text-only LoRA metadata paths remain
+usable on non-Apple or dependency-limited hosts without importing execution-only
+MLX runtimes.
+
+Failure cleanup will live around the training call in `LoRATrainingPipeline`.
+If native training or adapter audit raises, the pipeline clears traceback
+references, runs garbage collection, optionally probes retained MLX tensor bytes
+when MLX is already importable, and attaches bounded cleanup evidence to
+`ModelOperationError.details`.
+
+## Scope Boundaries
+
+- Include: `runtime_gate`, `inspection_only_import`,
+  `media_decoder_dependency`, `native_load_status`, `disabled_decoder_paths`,
+  `fallback_reader`, `unsupported_reason`, `traceback_cleanup_result`, and
+  `retained_tensor_bytes_after_failure`.
+- Include: optional media decoder states `healthy`, `missing`, and `broken`.
+- Include: text-only LoRA behavior staying unaffected when optional decoder
+  dependencies are broken.
+- Exclude: managed artifact cache integrity, offline/resume policy, artifact
+  hash verification, or cache receipt expansion owned by #1258.
+
+## Files
+
+- Modify: `services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py`
+  - Add import-safe preflight helpers.
+  - Attach preflight fields to successful adapter manifests.
+  - Attach cleanup evidence to training and audit failures.
+- Modify: `services/mlx-worker-python/tests/test_lora_model_ops_unit.py`
+  - Add focused red-green tests for dependency-limited inspection, media
+    decoder state classification, text-only unaffected behavior, native load
+    status fields, and nested-exception cleanup evidence.
+
+## Test Plan
+
+1. Add failing unit tests in `test_lora_model_ops_unit.py`.
+2. Run the new pytest filter and verify the tests fail for missing fields or
+   helpers.
+3. Implement the minimal production code in `lora_training_pipeline.py`.
+4. Re-run the focused pytest filter.
+5. Run the broader LoRA unit file if focused tests pass quickly.
+6. Run `git diff --check`.
+
+## Performance Probes And Metrics
+
+Preflight work runs once per LoRA training job before backend execution. The
+probe performs bounded `importlib.util.find_spec` checks and optional GC cleanup
+only on failure. Success metric: focused unit tests prove text-only training
+does not fail when optional media decoders are broken, and failure metrics report
+bounded retained tensor bytes where measurable.

--- a/docs/plans/2026-05-24-issue-1531-training-planner-receipts.md
+++ b/docs/plans/2026-05-24-issue-1531-training-planner-receipts.md
@@ -92,3 +92,10 @@ This slice adds constant-size receipt construction and manifest JSON fields on t
 - `profile_artifact_path`: empty when no profiler artifact exists, or a configured path when supplied.
 
 No PR-scoped runtime performance probe is required for this focused receipt-only slice.
+
+## 2026-05-24 Review Follow-Up
+
+`expected_peak_memory_class` also accounts for source-model size metadata when
+available. Resident-byte metadata is evaluated before parameter-count metadata,
+then the original effective-token-budget heuristic remains the fallback for
+models without size hints.

--- a/docs/plans/2026-05-24-issue-1531-training-planner-receipts.md
+++ b/docs/plans/2026-05-24-issue-1531-training-planner-receipts.md
@@ -1,0 +1,94 @@
+# Issue 1531 Training Planner Receipts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add durable advanced training planner, backend, profiler, and numerical-policy receipt fields for SFT/QLoRA training runs.
+
+**Architecture:** The Python worker remains the execution truth. `normalize_training_config` resolves a small, typed planner receipt from already-normalized training config inputs and request extensions, and the LoRA training manifest persists that receipt without revalidating admission rules already owned by existing training-mode and adapter-capability checks. Reward-model and RL-specific smoke promotion stays out of this slice because #366 only blocks those smoke promotions, not SFT/QLoRA receipt work.
+
+**Tech Stack:** Python dataclasses, existing worker model-ops normalization, pytest focused worker tests.
+
+---
+
+### Task 1: Planner Receipt Contract
+
+**Files:**
+- Modify: `services/mlx-worker-python/worker/model_ops/training_config.py`
+- Test: `services/mlx-worker-python/tests/test_training_planner_receipts.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests that normalize SFT and QLoRA configs and assert `training_planner_receipt` contains `batching_strategy`, `cutoff_len`, `micro_batch_size`, `effective_token_budget`, `packing_mode`, `media_counts`, `kernel_policy`, `expected_peak_memory_class`, `profile_artifact_path`, `compiled_step_enabled`, `grad_checkpoint_enabled`, `attention_backend`, `metric_for_best_model_resolved`, `generation_mode`, and `final_logit_softcapping`.
+
+- [ ] **Step 2: Run RED verification**
+
+Run:
+
+```bash
+PYTHONPATH=.:services/mlx-worker-python uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_training_planner_receipts.py -q
+```
+
+Expected: fails because `LoRATrainingConfig.training_planner_receipt` does not exist.
+
+- [ ] **Step 3: Implement the receipt**
+
+Add a `training_planner_receipt` field to `LoRATrainingConfig`, resolve it after config scalars are normalized, and keep it informational. Unsupported attention backends produce a typed refusal receipt instead of blocking unrelated planner/backend/profiler work.
+
+- [ ] **Step 4: Run GREEN verification**
+
+Run the same pytest command and expect pass.
+
+### Task 2: Adapter Manifest Persistence
+
+**Files:**
+- Modify: `services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py`
+- Test: `services/mlx-worker-python/tests/test_training_planner_receipts.py`
+
+- [ ] **Step 1: Write failing manifest test**
+
+Use the existing `LoRATrainingPipeline` deterministic runner pattern to train a tiny local SFT fixture and assert the generated `train_lora.adapter.json` persists every planner receipt field.
+
+- [ ] **Step 2: Run RED verification**
+
+Run:
+
+```bash
+PYTHONPATH=.:services/mlx-worker-python uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_training_planner_receipts.py -q
+```
+
+Expected: fails because the manifest does not yet include the planner receipt fields.
+
+- [ ] **Step 3: Persist receipt fields**
+
+Merge `config.training_planner_receipt` into the adapter manifest near existing training config and metrics fields.
+
+- [ ] **Step 4: Run GREEN verification**
+
+Run the same pytest command and expect pass.
+
+### Task 3: Focused Regression Checks
+
+**Files:**
+- Test: `services/mlx-worker-python/tests/test_lora_model_ops_unit.py`
+- Test: `services/mlx-worker-python/tests/test_agentic_sft_training_contract.py`
+
+- [ ] **Step 1: Run focused existing tests**
+
+Run:
+
+```bash
+PYTHONPATH=.:services/mlx-worker-python uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_training_planner_receipts.py services/mlx-worker-python/tests/test_agentic_sft_training_contract.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k "training_config or planner_receipt or chunked_training or candidate_generation_mode" -q
+git diff --check
+```
+
+Expected: pass. This confirms the new receipt fields do not alter admission validation, agentic SFT contracts, chunked-training config, or generation-mode safety.
+
+## Performance Probes And Metrics
+
+This slice adds constant-size receipt construction and manifest JSON fields on the training setup path. It does not change the native training loop, dataset chunking loop, or MLX execution kernels. Success metrics are:
+
+- `training_planner_receipt_field_count`: 15 required receipt fields present.
+- `attention_backend.status`: `accepted` or `refused` with a stable reason.
+- `profile_artifact_path`: empty when no profiler artifact exists, or a configured path when supplied.
+
+No PR-scoped runtime performance probe is required for this focused receipt-only slice.

--- a/docs/plans/2026-05-24-post-closure-followup-implementation.md
+++ b/docs/plans/2026-05-24-post-closure-followup-implementation.md
@@ -1,0 +1,119 @@
+# Post-Closure Follow-up Child Implementation
+
+## Goal
+
+Implement the child issues created from the closed-issue post-closure audit so
+that the actionable follow-up advice from #41 and #43 is represented in code,
+tests, and durable receipts instead of remaining only in closed comment
+threads.
+
+## Source
+
+- Parent audit plan:
+  `docs/plans/2026-05-24-closed-issue-post-closure-followup-audit.md`
+- Parent trackers: #1518 and #1519
+- Child issues from #1518: #1522, #1523, #1524, #1525, #1526, and #1527
+- Child issues from #1519: #1528, #1529, #1530, and #1531
+
+## Implementation Slices
+
+| Issue | Slice | Primary scope | Dependency |
+| --- | --- | --- | --- |
+| #1522 | Text compatibility policy receipts | OpenAI-compatible text request admission and worker/run evidence | None |
+| #1523 | Prompt-budget typed errors | Text request admission before worker prefill/generation | None |
+| #1524 | Parser format audit and selector parity | Parser registry, CLI/Desktop/API selector surfaces, fixtures | None |
+| #1525 | Shared text finalization state | Stream/non-stream text response finalization and usage trailers | None |
+| #1526 | Token-routed output assembly | Reasoning/tool/visible-text token routing and fallback receipts | #1522 |
+| #1527 | Generation bounds receipts | Text request generation bounds, stop handling, passthrough evidence | None |
+| #1528 | Training admission receipts | LoRA/training validation and resolved-control evidence | None |
+| #1529 | LoRA artifact and drift canaries | LoRA checkpoint, resume, merge/export, callback drift, round-trip canaries | None |
+| #1530 | Training runtime preflights | Dependency, platform, native-load, decoder, and cleanup guards | None |
+| #1531 | Advanced training planner receipts | Planner, backend, profiler, numerical-policy, and generation safety evidence | #366 for reward-model smoke promotion only |
+
+The implementation should keep each slice independently reviewable, but the
+final pull request may integrate the slices into one feature branch when shared
+receipt models, fixtures, or test helpers make a single coordinated change more
+coherent.
+
+## Performance Probes And Metrics
+
+The changed paths span request admission, OpenAI-compatible text response
+assembly, parser selection, and LoRA/training planning. The implementation must
+collect or report the following metrics before pull request handoff:
+
+- Text admission probes: prompt-token estimate, context-window bound,
+  output-cap bound, admission phase, and whether worker prefill started.
+- Text assembly probes: stream mode, finalizer path, finish reason, usage
+  trailer emission, reasoning/tool finalization, malformed-channel recovery,
+  and fallback raw-text parsing.
+- Parser probes: parser id, parser kind, declared accepted wire formats,
+  selector surface, selector source, request-context mode, and any explicit
+  exemption reason.
+- Generation-bound probes: requested/effective token caps, output-cap source,
+  stop-string normalization, bounds rejection reason, and passthrough sampling
+  controls.
+- Training admission probes: validation errors, resolved bounds, capability
+  gates, dataset-file resolution, grad-clip policy, eval batch size, and
+  scheduler-argument omission.
+- LoRA artifact probes: tokenizer EOS preservation, base config presence,
+  processor resume mode, auxiliary module restore state, merge/export canary
+  result, callback API drift result, completion loss, round-trip result, and
+  grad-norm visibility.
+- Runtime preflight probes: runtime gate, inspection-only import state, media
+  decoder dependency state, native-load status, disabled decoder paths,
+  fallback reader, unsupported reason, traceback cleanup result, and retained
+  tensor bytes after failure where measurable.
+- Advanced planner probes: batching strategy, cutoff length, micro batch size,
+  effective token budget, packing mode, media counts, kernel policy, expected
+  peak memory class, profile artifact path, compiled-step state, gradient
+  checkpoint state, attention backend, metric-for-best-model resolution,
+  generation mode, and final-logit softcapping.
+
+Success is measured by paired stream/non-stream tests where applicable,
+request-local receipts with stable schemas, typed validation failures for
+invalid inputs, and coverage for the new receipt fields in focused unit or
+integration tests.
+
+## Integration Strategy
+
+1. Implement each issue in an isolated worktree and branch based on current
+   `origin/main`.
+2. Merge independent slices into `feat/post-closure-followups` after focused
+   verification passes.
+3. Implement #1526 after the #1522 receipt model is available on the feature
+   branch.
+4. Resolve conflicts by preserving the shared receipt schema and adapting tests
+   to the final integrated behavior.
+5. Run the relevant Swift, Python, integration, coverage, and PR evidence
+   commands before opening or updating the pull request.
+
+## Acceptance Criteria
+
+- #1522 through #1531 are either implemented or explicitly marked out of scope
+  with issue-linked evidence in the pull request.
+- Behavior-changing slices include focused tests and receipt assertions for the
+  fields named in their issue bodies.
+- Stream and non-stream OpenAI-compatible paths remain paired where the issue
+  requires parity.
+- Training admission and LoRA runtime paths produce typed validation or canary
+  evidence without making inspection-only commands import execution-only
+  dependencies.
+- The pull request body preserves the repository template sections and links
+  this plan.
+
+## Verification
+
+Targeted verification depends on the files changed by each slice. The final
+handoff should include, at minimum:
+
+```bash
+git diff --check
+make swift-test
+make py-test
+make integration-test
+python scripts/validate_pr_evidence.py --body-file <pr-body-file>
+```
+
+If a scope-specific coverage or performance command is not yet measurable for a
+slice, the pull request must include an explicit `N/A` metrics report with the
+reason.

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -2431,7 +2431,7 @@ public struct OpenAIHandler: Sendable {
             case .imageUri, .imageBytes, .audioUri, .audioBytes:
                 return partial + 256
             case .videoUri, .videoBytes:
-                return partial
+                return partial + 1_024
             case nil:
                 return partial
             }
@@ -2439,7 +2439,13 @@ public struct OpenAIHandler: Sendable {
     }
 
     private func tokenCount(in text: String) -> UInt32 {
-        UInt32(text.trimmingCharacters(in: .whitespacesAndNewlines).split(whereSeparator: \.isWhitespace).count)
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return 0
+        }
+        let whitespaceEstimate = trimmed.split(whereSeparator: \.isWhitespace).count
+        let byteEstimate = max(1, (trimmed.utf8.count + 3) / 4)
+        return UInt32(min(Int(UInt32.max), max(whitespaceEstimate, byteEstimate)))
     }
 
     private func defaultServedModelIDs(
@@ -2930,29 +2936,88 @@ public struct OpenAIHandler: Sendable {
     }
 
     private func rawJSONValueToken(named fieldName: String, in rawJSON: String) -> String? {
-        guard let fieldRange = rawJSON.range(of: "\"\(fieldName)\"") else {
-            return nil
+        var cursor = rawJSON.startIndex
+        var objectDepth = 0
+        var arrayDepth = 0
+
+        while cursor < rawJSON.endIndex {
+            let character = rawJSON[cursor]
+            switch character {
+            case "{":
+                objectDepth += 1
+                cursor = rawJSON.index(after: cursor)
+            case "}":
+                objectDepth = max(0, objectDepth - 1)
+                cursor = rawJSON.index(after: cursor)
+            case "[":
+                arrayDepth += 1
+                cursor = rawJSON.index(after: cursor)
+            case "]":
+                arrayDepth = max(0, arrayDepth - 1)
+                cursor = rawJSON.index(after: cursor)
+            case "\"":
+                let keyStart = rawJSON.index(after: cursor)
+                guard let stringEnd = endOfRawJSONString(in: rawJSON, startingAt: keyStart) else {
+                    return nil
+                }
+                let afterString = rawJSON.index(after: stringEnd)
+                if objectDepth == 1, arrayDepth == 0 {
+                    var lookahead = afterString
+                    while lookahead < rawJSON.endIndex, rawJSON[lookahead].isWhitespace {
+                        lookahead = rawJSON.index(after: lookahead)
+                    }
+                    if lookahead < rawJSON.endIndex, rawJSON[lookahead] == ":" {
+                        let key = String(rawJSON[keyStart..<stringEnd])
+                        if key == fieldName {
+                            return rawJSONScalarToken(afterColon: lookahead, in: rawJSON)
+                        }
+                    }
+                }
+                cursor = afterString
+            default:
+                cursor = rawJSON.index(after: cursor)
+            }
         }
-        guard let colonRange = rawJSON[fieldRange.upperBound...].range(of: ":") else {
-            return nil
+        return nil
+    }
+
+    private func endOfRawJSONString(in rawJSON: String, startingAt start: String.Index) -> String.Index? {
+        var cursor = start
+        var escaping = false
+        while cursor < rawJSON.endIndex {
+            let character = rawJSON[cursor]
+            if escaping {
+                escaping = false
+            } else if character == "\\" {
+                escaping = true
+            } else if character == "\"" {
+                return cursor
+            }
+            cursor = rawJSON.index(after: cursor)
         }
-        var cursor = colonRange.upperBound
+        return nil
+    }
+
+    private func rawJSONScalarToken(afterColon colon: String.Index, in rawJSON: String) -> String? {
+        var cursor = rawJSON.index(after: colon)
         while cursor < rawJSON.endIndex, rawJSON[cursor].isWhitespace {
             cursor = rawJSON.index(after: cursor)
+        }
+        guard cursor < rawJSON.endIndex else {
+            return nil
+        }
+        if rawJSON[cursor] == "\"" || rawJSON[cursor] == "{" || rawJSON[cursor] == "[" {
+            return ""
         }
         let tokenStart = cursor
         while cursor < rawJSON.endIndex {
             let character = rawJSON[cursor]
-            if character == "," || character == "}" || character.isWhitespace {
+            if character == "," || character == "}" || character == "]" || character.isWhitespace {
                 break
             }
             cursor = rawJSON.index(after: cursor)
         }
-        guard tokenStart < cursor else {
-            return nil
-        }
-        return String(rawJSON[tokenStart..<cursor])
-            .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+        return tokenStart < cursor ? String(rawJSON[tokenStart..<cursor]) : nil
     }
 
     private func parsedGenerationBound(

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -821,6 +821,9 @@ public struct OpenAIHandler: Sendable {
     private func handleChatCompletions(_ request: HTTPRequest) async throws -> HTTPResponse {
         let requestStartedAt = now()
         do {
+            if let boundsFailure = generationBoundsValidationFailure(in: request.body) {
+                return invalidGenerationBoundsResponse(boundsFailure)
+            }
             let chatRequest = try decoder.decode(OpenAIChatCompletionsRequest.self, from: request.body)
             if let resumeRequestID = chatRequest.resumeRequestID?.trimmingCharacters(in: .whitespacesAndNewlines),
                !resumeRequestID.isEmpty {
@@ -864,6 +867,9 @@ public struct OpenAIHandler: Sendable {
     private func handleCompletions(_ request: HTTPRequest) async throws -> HTTPResponse {
         let requestStartedAt = Date()
         do {
+            if let boundsFailure = generationBoundsValidationFailure(in: request.body) {
+                return invalidGenerationBoundsResponse(boundsFailure)
+            }
             let completionsRequest = try decoder.decode(OpenAICompletionsRequest.self, from: request.body)
             let normalized = try translator.normalize(completionsRequest)
             return try await streamNormalizedTextRequest(
@@ -885,6 +891,9 @@ public struct OpenAIHandler: Sendable {
     private func handleResponses(_ request: HTTPRequest) async throws -> HTTPResponse {
         let requestStartedAt = Date()
         do {
+            if let boundsFailure = generationBoundsValidationFailure(in: request.body) {
+                return invalidGenerationBoundsResponse(boundsFailure)
+            }
             let responsesRequest = try decoder.decode(OpenAIResponsesRequest.self, from: request.body)
             let normalized = try translator.normalize(responsesRequest)
             return try await streamNormalizedTextRequest(
@@ -906,6 +915,9 @@ public struct OpenAIHandler: Sendable {
     private func handleMessages(_ request: HTTPRequest) async throws -> HTTPResponse {
         let requestStartedAt = Date()
         do {
+            if let boundsFailure = generationBoundsValidationFailure(in: request.body) {
+                return invalidGenerationBoundsResponse(boundsFailure)
+            }
             let messagesRequest = try decoder.decode(MelixMessagesRequest.self, from: request.body)
             let normalized = try translator.normalize(messagesRequest)
             return try await streamNormalizedTextRequest(
@@ -1968,6 +1980,24 @@ public struct OpenAIHandler: Sendable {
         ) {
             throw HTTPRequestHandlingError.gatewayResponse(validationFailure)
         }
+        let resolvedModel = await modelCatalog.model(id: executionModelID)
+        let originalModel = await modelCatalog.model(id: originalModelID)
+        let modelSamplingPolicy: ModelSamplingPolicy? = if let resolvedModel {
+            ModelSamplingPolicy(modelSettings: resolvedModel.settings)
+        } else {
+            nil
+        }
+        let servingDefaults = await gatewayServingDefaultsStore.requestedDefaults(
+            serverSessionID: gatewayRuntimeBinding.activeServerSessionID
+        ).resolvingAccelerationCompatibility(for: resolvedModel)
+        if let admissionFailure = promptBudgetAdmissionFailureResponse(
+            normalized: executionRequest,
+            model: resolvedModel,
+            modelSamplingPolicy: modelSamplingPolicy,
+            gatewayServingDefaults: servingDefaults
+        ) {
+            throw HTTPRequestHandlingError.gatewayResponse(admissionFailure)
+        }
         let modelHandle: String
         do {
             modelHandle = try await OnDemandModelLoader.ensureTextModelReady(
@@ -1987,8 +2017,6 @@ public struct OpenAIHandler: Sendable {
         } catch {
             throw HTTPRequestHandlingError.workerUnavailable
         }
-        let resolvedModel = await modelCatalog.model(id: executionModelID)
-        let originalModel = await modelCatalog.model(id: originalModelID)
         let modelToolParser: ToolParserSelection? = if let resolvedModel {
             ToolParserSelection(modelSettings: resolvedModel.settings)
         } else {
@@ -2004,11 +2032,6 @@ public struct OpenAIHandler: Sendable {
         } else {
             nil
         }
-        let modelSamplingPolicy: ModelSamplingPolicy? = if let resolvedModel {
-            ModelSamplingPolicy(modelSettings: resolvedModel.settings)
-        } else {
-            nil
-        }
         let shapingStartedAt = Date()
         let translated = try translator.translate(
             executionRequest,
@@ -2017,9 +2040,7 @@ public struct OpenAIHandler: Sendable {
             modelChatTemplatePolicy: modelChatTemplatePolicy,
             modelOCRPolicy: modelOCRPolicy,
             modelSamplingPolicy: modelSamplingPolicy,
-            gatewayServingDefaults: await gatewayServingDefaultsStore.requestedDefaults(
-                serverSessionID: gatewayRuntimeBinding.activeServerSessionID
-            ).resolvingAccelerationCompatibility(for: resolvedModel),
+            gatewayServingDefaults: servingDefaults,
             mcpToolCatalog: mcpToolCatalog
         )
         await recordShapingMetrics(for: translated, startedAt: shapingStartedAt)
@@ -2321,6 +2342,104 @@ public struct OpenAIHandler: Sendable {
             servedModelIDs: request.servedModelIDs,
             idleTimeoutSeconds: request.idleTimeoutSeconds
         )
+    }
+
+    private func promptBudgetAdmissionFailureResponse(
+        normalized: NormalizedTextRequest,
+        model: Melix_Controlplane_V1_ModelSummary?,
+        modelSamplingPolicy: ModelSamplingPolicy?,
+        gatewayServingDefaults: GatewayServingDefaultsPolicy?
+    ) -> HTTPResponse? {
+        let contextWindowTokens = model?.maxContext ?? 0
+        guard contextWindowTokens > 0 else {
+            return nil
+        }
+        let outputCapTokens = promptBudgetOutputCapTokens(
+            normalized: normalized,
+            modelSamplingPolicy: modelSamplingPolicy,
+            gatewayServingDefaults: gatewayServingDefaults,
+            contextWindowTokens: contextWindowTokens
+        )
+        let maxPromptTokens = contextWindowTokens > outputCapTokens
+            ? contextWindowTokens - outputCapTokens
+            : 0
+        let promptTokensEstimated = estimatedPromptTokens(for: normalized.messages)
+        guard promptTokensEstimated > maxPromptTokens else {
+            return nil
+        }
+        let metadata: [String: Any] = [
+            "max_prompt_tokens_requested": Int(maxPromptTokens),
+            "max_prompt_tokens_effective": Int(maxPromptTokens),
+            "prompt_tokens_estimated": Int(promptTokensEstimated),
+            "context_window_tokens": Int(contextWindowTokens),
+            "output_cap_tokens": Int(outputCapTokens),
+            "admission_phase": "prompt_budget",
+            "prefill_started": false,
+        ]
+        return jsonResponse(
+            statusCode: 400,
+            payload: [
+                "error": [
+                    "code": "prompt_budget_exceeded",
+                    "status": "invalid_request_error",
+                    "message": "Prompt token estimate exceeds the local prompt budget for this request.",
+                    "prompt_token_metadata": metadata,
+                ],
+            ]
+        )
+    }
+
+    private func promptBudgetOutputCapTokens(
+        normalized: NormalizedTextRequest,
+        modelSamplingPolicy: ModelSamplingPolicy?,
+        gatewayServingDefaults: GatewayServingDefaultsPolicy?,
+        contextWindowTokens: UInt32
+    ) -> UInt32 {
+        if let maxTokens = normalized.maxTokens,
+           let maxCompletionTokens = normalized.maxCompletionTokens {
+            return maxTokens == maxCompletionTokens ? maxTokens : max(maxTokens, maxCompletionTokens)
+        }
+        if let maxCompletionTokens = normalized.maxCompletionTokens {
+            return maxCompletionTokens
+        }
+        if let maxTokens = normalized.maxTokens {
+            return maxTokens
+        }
+        let fallbackOutputCapTokens = modelSamplingPolicy?.maxTokens
+            ?? gatewayServingDefaults?.maxTokens
+            ?? GatewayServingDefaultsStore.defaultMaxTokens
+        return fallbackOutputCapTokens >= contextWindowTokens ? 0 : fallbackOutputCapTokens
+    }
+
+    private func estimatedPromptTokens(
+        for messages: [NormalizedTextMessage]
+    ) -> UInt32 {
+        let total = messages.reduce(UInt32(0)) { partial, message in
+            partial + estimatedPromptTokens(for: message)
+        }
+        if total > 0 {
+            return total
+        }
+        return messages.isEmpty ? 0 : 1
+    }
+
+    private func estimatedPromptTokens(for message: NormalizedTextMessage) -> UInt32 {
+        message.parts.reduce(tokenCount(in: message.name ?? "")) { partial, part in
+            switch part.part {
+            case .text(let text):
+                return partial + tokenCount(in: text)
+            case .imageUri, .imageBytes, .audioUri, .audioBytes:
+                return partial + 256
+            case .videoUri, .videoBytes:
+                return partial
+            case nil:
+                return partial
+            }
+        }
+    }
+
+    private func tokenCount(in text: String) -> UInt32 {
+        UInt32(text.trimmingCharacters(in: .whitespacesAndNewlines).split(whereSeparator: \.isWhitespace).count)
     }
 
     private func defaultServedModelIDs(
@@ -2711,6 +2830,171 @@ public struct OpenAIHandler: Sendable {
             statusCode: 400,
             payload: ["error": ["code": "invalid_argument", "message": message]]
         )
+    }
+
+    private func invalidGenerationBoundsResponse(_ failure: GenerationBoundsValidationFailure) -> HTTPResponse {
+        jsonResponse(
+            statusCode: 400,
+            payload: [
+                "error": [
+                    "code": "invalid_generation_bounds",
+                    "message": failure.message,
+                    "bounds_rejection_reason": failure.reason,
+                ],
+            ]
+        )
+    }
+
+    private func generationBoundsValidationFailure(in body: Data) -> GenerationBoundsValidationFailure? {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any]
+        else {
+            return rawGenerationBoundsValidationFailure(in: body)
+        }
+        let maxTokens = parsedGenerationBound(named: "max_tokens", in: object)
+        if let failure = maxTokens.failure {
+            return failure
+        }
+        let maxCompletionTokens = parsedGenerationBound(named: "max_completion_tokens", in: object)
+        if let failure = maxCompletionTokens.failure {
+            return failure
+        }
+        if let maxTokens = maxTokens.value,
+           let maxCompletionTokens = maxCompletionTokens.value,
+           maxTokens != maxCompletionTokens {
+            return GenerationBoundsValidationFailure(
+                reason: "output_cap_conflict",
+                message: "max_tokens and max_completion_tokens must match when both are provided."
+            )
+        }
+        return nil
+    }
+
+    private func rawGenerationBoundsValidationFailure(in body: Data) -> GenerationBoundsValidationFailure? {
+        guard let rawJSON = String(data: body, encoding: .utf8) else {
+            return nil
+        }
+        let maxTokens = parsedRawGenerationBound(named: "max_tokens", in: rawJSON)
+        if let failure = maxTokens.failure {
+            return failure
+        }
+        let maxCompletionTokens = parsedRawGenerationBound(named: "max_completion_tokens", in: rawJSON)
+        if let failure = maxCompletionTokens.failure {
+            return failure
+        }
+        if let maxTokens = maxTokens.value,
+           let maxCompletionTokens = maxCompletionTokens.value,
+           maxTokens != maxCompletionTokens {
+            return GenerationBoundsValidationFailure(
+                reason: "output_cap_conflict",
+                message: "max_tokens and max_completion_tokens must match when both are provided."
+            )
+        }
+        return nil
+    }
+
+    private func parsedRawGenerationBound(
+        named fieldName: String,
+        in rawJSON: String
+    ) -> (value: UInt32?, failure: GenerationBoundsValidationFailure?) {
+        guard let token = rawJSONValueToken(named: fieldName, in: rawJSON) else {
+            return (nil, nil)
+        }
+        guard let doubleValue = Double(token) else {
+            return (nil, GenerationBoundsValidationFailure(
+                reason: "\(fieldName)_malformed",
+                message: "\(fieldName) must be a finite positive integer."
+            ))
+        }
+        guard doubleValue.isFinite else {
+            return (nil, GenerationBoundsValidationFailure(
+                reason: "\(fieldName)_non_finite",
+                message: "\(fieldName) must be finite."
+            ))
+        }
+        guard doubleValue > 0 else {
+            return (nil, GenerationBoundsValidationFailure(
+                reason: "\(fieldName)_non_positive",
+                message: "\(fieldName) must be greater than zero."
+            ))
+        }
+        guard doubleValue.rounded(.towardZero) == doubleValue,
+              doubleValue <= Double(UInt32.max)
+        else {
+            return (nil, GenerationBoundsValidationFailure(
+                reason: "\(fieldName)_malformed",
+                message: "\(fieldName) must be a positive integer no greater than \(UInt32.max)."
+            ))
+        }
+        return (UInt32(doubleValue), nil)
+    }
+
+    private func rawJSONValueToken(named fieldName: String, in rawJSON: String) -> String? {
+        guard let fieldRange = rawJSON.range(of: "\"\(fieldName)\"") else {
+            return nil
+        }
+        guard let colonRange = rawJSON[fieldRange.upperBound...].range(of: ":") else {
+            return nil
+        }
+        var cursor = colonRange.upperBound
+        while cursor < rawJSON.endIndex, rawJSON[cursor].isWhitespace {
+            cursor = rawJSON.index(after: cursor)
+        }
+        let tokenStart = cursor
+        while cursor < rawJSON.endIndex {
+            let character = rawJSON[cursor]
+            if character == "," || character == "}" || character.isWhitespace {
+                break
+            }
+            cursor = rawJSON.index(after: cursor)
+        }
+        guard tokenStart < cursor else {
+            return nil
+        }
+        return String(rawJSON[tokenStart..<cursor])
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+    }
+
+    private func parsedGenerationBound(
+        named fieldName: String,
+        in object: [String: Any]
+    ) -> (value: UInt32?, failure: GenerationBoundsValidationFailure?) {
+        guard let rawValue = object[fieldName],
+              !(rawValue is NSNull)
+        else {
+            return (nil, nil)
+        }
+        let reasonPrefix = fieldName
+        guard let number = rawValue as? NSNumber,
+              CFGetTypeID(number) != CFBooleanGetTypeID()
+        else {
+            return (nil, GenerationBoundsValidationFailure(
+                reason: "\(reasonPrefix)_malformed",
+                message: "\(fieldName) must be a finite positive integer."
+            ))
+        }
+        let doubleValue = number.doubleValue
+        guard doubleValue.isFinite else {
+            return (nil, GenerationBoundsValidationFailure(
+                reason: "\(reasonPrefix)_non_finite",
+                message: "\(fieldName) must be finite."
+            ))
+        }
+        guard doubleValue > 0 else {
+            return (nil, GenerationBoundsValidationFailure(
+                reason: "\(reasonPrefix)_non_positive",
+                message: "\(fieldName) must be greater than zero."
+            ))
+        }
+        guard doubleValue.rounded(.towardZero) == doubleValue,
+              doubleValue <= Double(UInt32.max)
+        else {
+            return (nil, GenerationBoundsValidationFailure(
+                reason: "\(reasonPrefix)_malformed",
+                message: "\(fieldName) must be a positive integer no greater than \(UInt32.max)."
+            ))
+        }
+        return (UInt32(doubleValue), nil)
     }
 
     private enum ExternalMediaAdmissionOutcome {
@@ -3909,6 +4193,11 @@ private enum HTTPRequestHandlingError: Error {
     case workerUnavailable
     case workerRejected(Melix_Worker_V1_ErrorStatus)
     case gatewayResponse(HTTPResponse)
+}
+
+private struct GenerationBoundsValidationFailure {
+    let reason: String
+    let message: String
 }
 
 private enum HTTPGatewayEndpointFamily: String {

--- a/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
+++ b/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
@@ -122,6 +122,12 @@ public struct NormalizedTextRequest: Sendable, Equatable {
     public let temperature: Double?
     public let topP: Double?
     public let maxTokens: UInt32?
+    public let maxCompletionTokens: UInt32?
+    public let topK: UInt32?
+    public let minP: Double?
+    public let repeatPenalty: Double?
+    public let presencePenalty: Double?
+    public let seed: UInt32?
     public let sessionID: String?
     public let branchID: String?
     public let parentRequestID: String?
@@ -151,6 +157,12 @@ public struct NormalizedTextRequest: Sendable, Equatable {
         temperature: Double?,
         topP: Double?,
         maxTokens: UInt32?,
+        maxCompletionTokens: UInt32? = nil,
+        topK: UInt32? = nil,
+        minP: Double? = nil,
+        repeatPenalty: Double? = nil,
+        presencePenalty: Double? = nil,
+        seed: UInt32? = nil,
         sessionID: String?,
         branchID: String?,
         parentRequestID: String?,
@@ -179,6 +191,12 @@ public struct NormalizedTextRequest: Sendable, Equatable {
         self.temperature = temperature
         self.topP = topP
         self.maxTokens = maxTokens
+        self.maxCompletionTokens = maxCompletionTokens
+        self.topK = topK
+        self.minP = minP
+        self.repeatPenalty = repeatPenalty
+        self.presencePenalty = presencePenalty
+        self.seed = seed
         self.sessionID = sessionID
         self.branchID = branchID
         self.parentRequestID = parentRequestID
@@ -214,6 +232,12 @@ public extension NormalizedTextRequest {
             temperature: temperature,
             topP: topP,
             maxTokens: maxTokens,
+            maxCompletionTokens: maxCompletionTokens,
+            topK: topK,
+            minP: minP,
+            repeatPenalty: repeatPenalty,
+            presencePenalty: presencePenalty,
+            seed: seed,
             sessionID: sessionID,
             branchID: branchID,
             parentRequestID: parentRequestID,
@@ -246,6 +270,14 @@ public struct ShapedTextRequest: Sendable, Equatable {
     public let temperature: Double
     public let topP: Double
     public let maxTokens: UInt32
+    public let requestedMaxTokens: UInt32?
+    public let requestedMaxCompletionTokens: UInt32?
+    public let outputCapSource: String
+    public let topK: UInt32?
+    public let minP: Double?
+    public let repeatPenalty: Double?
+    public let presencePenalty: Double?
+    public let seed: UInt32?
     public let streamIntervalTokens: UInt32
     public let maxConcurrentRequests: UInt32
     public let concurrentProcessingEnabled: Bool
@@ -271,6 +303,8 @@ public struct ShapedTextRequest: Sendable, Equatable {
     public let admissionPolicy: String
     public let cachePolicy: String?
     public let stopSequences: [String]
+    public let requestedStopSequences: [String]
+    public let stopSource: String
     public let userID: String?
     public let thinking: MelixMessagesThinkingConfig?
     public let reasoningMode: String
@@ -417,11 +451,11 @@ public struct OpenAIChatTool: Codable, Sendable, Equatable {
 }
 
 public struct OpenAIChatCompletionsRequest: Codable, Sendable {
-    private enum StopSequencesValue: Codable, Sendable, Equatable {
+    public enum StopSequencesValue: Codable, Sendable, Equatable {
         case single(String)
         case many([String])
 
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()
             if let value = try? container.decode(String.self) {
                 self = .single(value)
@@ -430,7 +464,7 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
             self = .many(try container.decode([String].self))
         }
 
-        func encode(to encoder: Encoder) throws {
+        public func encode(to encoder: Encoder) throws {
             var container = encoder.singleValueContainer()
             switch self {
             case let .single(value):
@@ -515,6 +549,12 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
     public let temperature: Double?
     public let topP: Double?
     public let maxTokens: UInt32?
+    public let maxCompletionTokens: UInt32?
+    public let topK: UInt32?
+    public let minP: Double?
+    public let repeatPenalty: Double?
+    public let presencePenalty: Double?
+    public let seed: UInt32?
     public let resumeRequestID: String?
     public let stopSequences: [String]?
     public let sessionID: String?
@@ -542,6 +582,12 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         case temperature
         case topP = "top_p"
         case maxTokens = "max_tokens"
+        case maxCompletionTokens = "max_completion_tokens"
+        case topK = "top_k"
+        case minP = "min_p"
+        case repeatPenalty = "repeat_penalty"
+        case presencePenalty = "presence_penalty"
+        case seed
         case resumeRequestID = "resume_request_id"
         case stop
         case stopSequences = "stop_sequences"
@@ -571,6 +617,12 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         temperature: Double? = nil,
         topP: Double? = nil,
         maxTokens: UInt32? = nil,
+        maxCompletionTokens: UInt32? = nil,
+        topK: UInt32? = nil,
+        minP: Double? = nil,
+        repeatPenalty: Double? = nil,
+        presencePenalty: Double? = nil,
+        seed: UInt32? = nil,
         resumeRequestID: String? = nil,
         stopSequences: [String]? = nil,
         sessionID: String? = nil,
@@ -597,6 +649,12 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         self.temperature = temperature
         self.topP = topP
         self.maxTokens = maxTokens
+        self.maxCompletionTokens = maxCompletionTokens
+        self.topK = topK
+        self.minP = minP
+        self.repeatPenalty = repeatPenalty
+        self.presencePenalty = presencePenalty
+        self.seed = seed
         self.resumeRequestID = resumeRequestID
         self.stopSequences = stopSequences
         self.sessionID = sessionID
@@ -626,6 +684,12 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         self.temperature = try container.decodeIfPresent(Double.self, forKey: .temperature)
         self.topP = try container.decodeIfPresent(Double.self, forKey: .topP)
         self.maxTokens = try container.decodeIfPresent(UInt32.self, forKey: .maxTokens)
+        self.maxCompletionTokens = try container.decodeIfPresent(UInt32.self, forKey: .maxCompletionTokens)
+        self.topK = try container.decodeIfPresent(UInt32.self, forKey: .topK)
+        self.minP = try container.decodeIfPresent(Double.self, forKey: .minP)
+        self.repeatPenalty = try container.decodeIfPresent(Double.self, forKey: .repeatPenalty)
+        self.presencePenalty = try container.decodeIfPresent(Double.self, forKey: .presencePenalty)
+        self.seed = try container.decodeIfPresent(UInt32.self, forKey: .seed)
         self.resumeRequestID = try container.decodeIfPresent(String.self, forKey: .resumeRequestID)
         self.stopSequences = try Self.decodeStopSequences(from: container)
         self.sessionID = try container.decodeIfPresent(String.self, forKey: .sessionID)
@@ -655,6 +719,12 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         try container.encodeIfPresent(temperature, forKey: .temperature)
         try container.encodeIfPresent(topP, forKey: .topP)
         try container.encodeIfPresent(maxTokens, forKey: .maxTokens)
+        try container.encodeIfPresent(maxCompletionTokens, forKey: .maxCompletionTokens)
+        try container.encodeIfPresent(topK, forKey: .topK)
+        try container.encodeIfPresent(minP, forKey: .minP)
+        try container.encodeIfPresent(repeatPenalty, forKey: .repeatPenalty)
+        try container.encodeIfPresent(presencePenalty, forKey: .presencePenalty)
+        try container.encodeIfPresent(seed, forKey: .seed)
         try container.encodeIfPresent(resumeRequestID, forKey: .resumeRequestID)
         try encodeStopSequences(into: &container)
         try container.encodeIfPresent(sessionID, forKey: .sessionID)
@@ -699,7 +769,7 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         chatTemplateKwargs?.resolvedSelection()
     }
 
-    private static func decodeStopSequences(
+    static func decodeStopSequences(
         from container: KeyedDecodingContainer<CodingKeys>
     ) throws -> [String]? {
         if let stopValue = try container.decodeIfPresent(StopSequencesValue.self, forKey: .stop) {
@@ -713,7 +783,8 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         return nil
     }
 
-    private func encodeStopSequences(
+    static func encodeStopSequences(
+        _ stopSequences: [String]?,
         into container: inout KeyedEncodingContainer<CodingKeys>
     ) throws {
         guard let stopSequences, !stopSequences.isEmpty else {
@@ -725,9 +796,17 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         }
         try container.encode(StopSequencesValue.many(stopSequences), forKey: .stop)
     }
+
+    private func encodeStopSequences(
+        into container: inout KeyedEncodingContainer<CodingKeys>
+    ) throws {
+        try Self.encodeStopSequences(stopSequences, into: &container)
+    }
 }
 
 public struct OpenAICompletionsRequest: Codable, Sendable {
+    private typealias StopSequencesValue = OpenAIChatCompletionsRequest.StopSequencesValue
+
     public let model: String
     public let prompt: String
     public let enableThinking: Bool?
@@ -737,6 +816,13 @@ public struct OpenAICompletionsRequest: Codable, Sendable {
     public let temperature: Double?
     public let topP: Double?
     public let maxTokens: UInt32?
+    public let maxCompletionTokens: UInt32?
+    public let topK: UInt32?
+    public let minP: Double?
+    public let repeatPenalty: Double?
+    public let presencePenalty: Double?
+    public let seed: UInt32?
+    public let stopSequences: [String]?
     public let sessionID: String?
     public let branchID: String?
     public let parentRequestID: String?
@@ -760,6 +846,14 @@ public struct OpenAICompletionsRequest: Codable, Sendable {
         case temperature
         case topP = "top_p"
         case maxTokens = "max_tokens"
+        case maxCompletionTokens = "max_completion_tokens"
+        case topK = "top_k"
+        case minP = "min_p"
+        case repeatPenalty = "repeat_penalty"
+        case presencePenalty = "presence_penalty"
+        case seed
+        case stop
+        case stopSequences = "stop_sequences"
         case sessionID = "session_id"
         case branchID = "branch_id"
         case parentRequestID = "parent_request_id"
@@ -784,6 +878,13 @@ public struct OpenAICompletionsRequest: Codable, Sendable {
         temperature: Double? = nil,
         topP: Double? = nil,
         maxTokens: UInt32? = nil,
+        maxCompletionTokens: UInt32? = nil,
+        topK: UInt32? = nil,
+        minP: Double? = nil,
+        repeatPenalty: Double? = nil,
+        presencePenalty: Double? = nil,
+        seed: UInt32? = nil,
+        stopSequences: [String]? = nil,
         sessionID: String? = nil,
         branchID: String? = nil,
         parentRequestID: String? = nil,
@@ -806,6 +907,13 @@ public struct OpenAICompletionsRequest: Codable, Sendable {
         self.temperature = temperature
         self.topP = topP
         self.maxTokens = maxTokens
+        self.maxCompletionTokens = maxCompletionTokens
+        self.topK = topK
+        self.minP = minP
+        self.repeatPenalty = repeatPenalty
+        self.presencePenalty = presencePenalty
+        self.seed = seed
+        self.stopSequences = stopSequences
         self.sessionID = sessionID
         self.branchID = branchID
         self.parentRequestID = parentRequestID
@@ -818,6 +926,98 @@ public struct OpenAICompletionsRequest: Codable, Sendable {
         self.responseFormat = responseFormat
         self.toolParser = toolParser
         self.chatTemplateKwargs = chatTemplateKwargs
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.model = try container.decode(String.self, forKey: .model)
+        self.prompt = try container.decode(String.self, forKey: .prompt)
+        self.enableThinking = try container.decodeIfPresent(Bool.self, forKey: .enableThinking)
+        self.reasoningEffort = try container.decodeIfPresent(String.self, forKey: .reasoningEffort)
+        self.stream = try container.decodeIfPresent(Bool.self, forKey: .stream)
+        self.streamOptions = try container.decodeIfPresent(OpenAIStreamOptions.self, forKey: .streamOptions)
+        self.temperature = try container.decodeIfPresent(Double.self, forKey: .temperature)
+        self.topP = try container.decodeIfPresent(Double.self, forKey: .topP)
+        self.maxTokens = try container.decodeIfPresent(UInt32.self, forKey: .maxTokens)
+        self.maxCompletionTokens = try container.decodeIfPresent(UInt32.self, forKey: .maxCompletionTokens)
+        self.topK = try container.decodeIfPresent(UInt32.self, forKey: .topK)
+        self.minP = try container.decodeIfPresent(Double.self, forKey: .minP)
+        self.repeatPenalty = try container.decodeIfPresent(Double.self, forKey: .repeatPenalty)
+        self.presencePenalty = try container.decodeIfPresent(Double.self, forKey: .presencePenalty)
+        self.seed = try container.decodeIfPresent(UInt32.self, forKey: .seed)
+        self.stopSequences = try Self.decodeStopSequences(from: container)
+        self.sessionID = try container.decodeIfPresent(String.self, forKey: .sessionID)
+        self.branchID = try container.decodeIfPresent(String.self, forKey: .branchID)
+        self.parentRequestID = try container.decodeIfPresent(String.self, forKey: .parentRequestID)
+        self.restoreSnapshotID = try container.decodeIfPresent(String.self, forKey: .restoreSnapshotID)
+        self.saveBoundarySnapshot = try container.decodeIfPresent(Bool.self, forKey: .saveBoundarySnapshot)
+        self.presetID = try container.decodeIfPresent(String.self, forKey: .presetID)
+        self.workflow = try container.decodeIfPresent(TextWorkflowKind.self, forKey: .workflow)
+        self.workflowRunID = try container.decodeIfPresent(String.self, forKey: .workflowRunID)
+        self.workflowNodeID = try container.decodeIfPresent(String.self, forKey: .workflowNodeID)
+        self.responseFormat = try container.decodeIfPresent(StructuredOutputRequestFormat.self, forKey: .responseFormat)
+        self.toolParser = try container.decodeIfPresent(ToolParserRequestConfiguration.self, forKey: .toolParser)
+        self.chatTemplateKwargs = try container.decodeIfPresent(ChatTemplateRequestConfiguration.self, forKey: .chatTemplateKwargs)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(model, forKey: .model)
+        try container.encode(prompt, forKey: .prompt)
+        try container.encodeIfPresent(enableThinking, forKey: .enableThinking)
+        try container.encodeIfPresent(reasoningEffort, forKey: .reasoningEffort)
+        try container.encodeIfPresent(stream, forKey: .stream)
+        try container.encodeIfPresent(streamOptions, forKey: .streamOptions)
+        try container.encodeIfPresent(temperature, forKey: .temperature)
+        try container.encodeIfPresent(topP, forKey: .topP)
+        try container.encodeIfPresent(maxTokens, forKey: .maxTokens)
+        try container.encodeIfPresent(maxCompletionTokens, forKey: .maxCompletionTokens)
+        try container.encodeIfPresent(topK, forKey: .topK)
+        try container.encodeIfPresent(minP, forKey: .minP)
+        try container.encodeIfPresent(repeatPenalty, forKey: .repeatPenalty)
+        try container.encodeIfPresent(presencePenalty, forKey: .presencePenalty)
+        try container.encodeIfPresent(seed, forKey: .seed)
+        try Self.encodeStopSequences(stopSequences, into: &container)
+        try container.encodeIfPresent(sessionID, forKey: .sessionID)
+        try container.encodeIfPresent(branchID, forKey: .branchID)
+        try container.encodeIfPresent(parentRequestID, forKey: .parentRequestID)
+        try container.encodeIfPresent(restoreSnapshotID, forKey: .restoreSnapshotID)
+        try container.encodeIfPresent(saveBoundarySnapshot, forKey: .saveBoundarySnapshot)
+        try container.encodeIfPresent(presetID, forKey: .presetID)
+        try container.encodeIfPresent(workflow, forKey: .workflow)
+        try container.encodeIfPresent(workflowRunID, forKey: .workflowRunID)
+        try container.encodeIfPresent(workflowNodeID, forKey: .workflowNodeID)
+        try container.encodeIfPresent(responseFormat, forKey: .responseFormat)
+        try container.encodeIfPresent(toolParser, forKey: .toolParser)
+        try container.encodeIfPresent(chatTemplateKwargs, forKey: .chatTemplateKwargs)
+    }
+
+    private static func decodeStopSequences(
+        from container: KeyedDecodingContainer<CodingKeys>
+    ) throws -> [String]? {
+        if let stopValue = try container.decodeIfPresent(StopSequencesValue.self, forKey: .stop) {
+            let normalized = stopValue.normalized
+            return normalized.isEmpty ? nil : normalized
+        }
+        if let stopValue = try container.decodeIfPresent(StopSequencesValue.self, forKey: .stopSequences) {
+            let normalized = stopValue.normalized
+            return normalized.isEmpty ? nil : normalized
+        }
+        return nil
+    }
+
+    private static func encodeStopSequences(
+        _ stopSequences: [String]?,
+        into container: inout KeyedEncodingContainer<CodingKeys>
+    ) throws {
+        guard let stopSequences, !stopSequences.isEmpty else {
+            return
+        }
+        if stopSequences.count == 1, let stopSequence = stopSequences.first {
+            try container.encode(StopSequencesValue.single(stopSequence), forKey: .stop)
+            return
+        }
+        try container.encode(StopSequencesValue.many(stopSequences), forKey: .stop)
     }
 
     public var structuredOutputConfiguration: StructuredOutputConfiguration? {
@@ -838,6 +1038,8 @@ public struct OpenAICompletionsRequest: Codable, Sendable {
 }
 
 public struct OpenAIResponsesRequest: Codable, Sendable {
+    private typealias StopSequencesValue = OpenAIChatCompletionsRequest.StopSequencesValue
+
     public struct TextOptions: Codable, Sendable, Equatable {
         public let format: StructuredOutputRequestFormat?
 
@@ -923,6 +1125,13 @@ public struct OpenAIResponsesRequest: Codable, Sendable {
     public let temperature: Double?
     public let topP: Double?
     public let maxTokens: UInt32?
+    public let maxCompletionTokens: UInt32?
+    public let topK: UInt32?
+    public let minP: Double?
+    public let repeatPenalty: Double?
+    public let presencePenalty: Double?
+    public let seed: UInt32?
+    public let stopSequences: [String]?
     public let sessionID: String?
     public let branchID: String?
     public let parentRequestID: String?
@@ -947,6 +1156,14 @@ public struct OpenAIResponsesRequest: Codable, Sendable {
         case temperature
         case topP = "top_p"
         case maxTokens = "max_tokens"
+        case maxCompletionTokens = "max_completion_tokens"
+        case topK = "top_k"
+        case minP = "min_p"
+        case repeatPenalty = "repeat_penalty"
+        case presencePenalty = "presence_penalty"
+        case seed
+        case stop
+        case stopSequences = "stop_sequences"
         case sessionID = "session_id"
         case branchID = "branch_id"
         case parentRequestID = "parent_request_id"
@@ -972,6 +1189,13 @@ public struct OpenAIResponsesRequest: Codable, Sendable {
         temperature: Double? = nil,
         topP: Double? = nil,
         maxTokens: UInt32? = nil,
+        maxCompletionTokens: UInt32? = nil,
+        topK: UInt32? = nil,
+        minP: Double? = nil,
+        repeatPenalty: Double? = nil,
+        presencePenalty: Double? = nil,
+        seed: UInt32? = nil,
+        stopSequences: [String]? = nil,
         sessionID: String? = nil,
         branchID: String? = nil,
         parentRequestID: String? = nil,
@@ -995,6 +1219,13 @@ public struct OpenAIResponsesRequest: Codable, Sendable {
         self.temperature = temperature
         self.topP = topP
         self.maxTokens = maxTokens
+        self.maxCompletionTokens = maxCompletionTokens
+        self.topK = topK
+        self.minP = minP
+        self.repeatPenalty = repeatPenalty
+        self.presencePenalty = presencePenalty
+        self.seed = seed
+        self.stopSequences = stopSequences
         self.sessionID = sessionID
         self.branchID = branchID
         self.parentRequestID = parentRequestID
@@ -1007,6 +1238,100 @@ public struct OpenAIResponsesRequest: Codable, Sendable {
         self.text = text
         self.toolParser = toolParser
         self.chatTemplateKwargs = chatTemplateKwargs
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.model = try container.decode(String.self, forKey: .model)
+        self.input = try container.decode(Input.self, forKey: .input)
+        self.enableThinking = try container.decodeIfPresent(Bool.self, forKey: .enableThinking)
+        self.reasoningEffort = try container.decodeIfPresent(String.self, forKey: .reasoningEffort)
+        self.instructions = try container.decodeIfPresent(String.self, forKey: .instructions)
+        self.stream = try container.decodeIfPresent(Bool.self, forKey: .stream)
+        self.streamOptions = try container.decodeIfPresent(OpenAIStreamOptions.self, forKey: .streamOptions)
+        self.temperature = try container.decodeIfPresent(Double.self, forKey: .temperature)
+        self.topP = try container.decodeIfPresent(Double.self, forKey: .topP)
+        self.maxTokens = try container.decodeIfPresent(UInt32.self, forKey: .maxTokens)
+        self.maxCompletionTokens = try container.decodeIfPresent(UInt32.self, forKey: .maxCompletionTokens)
+        self.topK = try container.decodeIfPresent(UInt32.self, forKey: .topK)
+        self.minP = try container.decodeIfPresent(Double.self, forKey: .minP)
+        self.repeatPenalty = try container.decodeIfPresent(Double.self, forKey: .repeatPenalty)
+        self.presencePenalty = try container.decodeIfPresent(Double.self, forKey: .presencePenalty)
+        self.seed = try container.decodeIfPresent(UInt32.self, forKey: .seed)
+        self.stopSequences = try Self.decodeStopSequences(from: container)
+        self.sessionID = try container.decodeIfPresent(String.self, forKey: .sessionID)
+        self.branchID = try container.decodeIfPresent(String.self, forKey: .branchID)
+        self.parentRequestID = try container.decodeIfPresent(String.self, forKey: .parentRequestID)
+        self.restoreSnapshotID = try container.decodeIfPresent(String.self, forKey: .restoreSnapshotID)
+        self.saveBoundarySnapshot = try container.decodeIfPresent(Bool.self, forKey: .saveBoundarySnapshot)
+        self.presetID = try container.decodeIfPresent(String.self, forKey: .presetID)
+        self.workflow = try container.decodeIfPresent(TextWorkflowKind.self, forKey: .workflow)
+        self.workflowRunID = try container.decodeIfPresent(String.self, forKey: .workflowRunID)
+        self.workflowNodeID = try container.decodeIfPresent(String.self, forKey: .workflowNodeID)
+        self.text = try container.decodeIfPresent(TextOptions.self, forKey: .text)
+        self.toolParser = try container.decodeIfPresent(ToolParserRequestConfiguration.self, forKey: .toolParser)
+        self.chatTemplateKwargs = try container.decodeIfPresent(ChatTemplateRequestConfiguration.self, forKey: .chatTemplateKwargs)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(model, forKey: .model)
+        try container.encode(input, forKey: .input)
+        try container.encodeIfPresent(enableThinking, forKey: .enableThinking)
+        try container.encodeIfPresent(reasoningEffort, forKey: .reasoningEffort)
+        try container.encodeIfPresent(instructions, forKey: .instructions)
+        try container.encodeIfPresent(stream, forKey: .stream)
+        try container.encodeIfPresent(streamOptions, forKey: .streamOptions)
+        try container.encodeIfPresent(temperature, forKey: .temperature)
+        try container.encodeIfPresent(topP, forKey: .topP)
+        try container.encodeIfPresent(maxTokens, forKey: .maxTokens)
+        try container.encodeIfPresent(maxCompletionTokens, forKey: .maxCompletionTokens)
+        try container.encodeIfPresent(topK, forKey: .topK)
+        try container.encodeIfPresent(minP, forKey: .minP)
+        try container.encodeIfPresent(repeatPenalty, forKey: .repeatPenalty)
+        try container.encodeIfPresent(presencePenalty, forKey: .presencePenalty)
+        try container.encodeIfPresent(seed, forKey: .seed)
+        try Self.encodeStopSequences(stopSequences, into: &container)
+        try container.encodeIfPresent(sessionID, forKey: .sessionID)
+        try container.encodeIfPresent(branchID, forKey: .branchID)
+        try container.encodeIfPresent(parentRequestID, forKey: .parentRequestID)
+        try container.encodeIfPresent(restoreSnapshotID, forKey: .restoreSnapshotID)
+        try container.encodeIfPresent(saveBoundarySnapshot, forKey: .saveBoundarySnapshot)
+        try container.encodeIfPresent(presetID, forKey: .presetID)
+        try container.encodeIfPresent(workflow, forKey: .workflow)
+        try container.encodeIfPresent(workflowRunID, forKey: .workflowRunID)
+        try container.encodeIfPresent(workflowNodeID, forKey: .workflowNodeID)
+        try container.encodeIfPresent(text, forKey: .text)
+        try container.encodeIfPresent(toolParser, forKey: .toolParser)
+        try container.encodeIfPresent(chatTemplateKwargs, forKey: .chatTemplateKwargs)
+    }
+
+    private static func decodeStopSequences(
+        from container: KeyedDecodingContainer<CodingKeys>
+    ) throws -> [String]? {
+        if let stopValue = try container.decodeIfPresent(StopSequencesValue.self, forKey: .stop) {
+            let normalized = stopValue.normalized
+            return normalized.isEmpty ? nil : normalized
+        }
+        if let stopValue = try container.decodeIfPresent(StopSequencesValue.self, forKey: .stopSequences) {
+            let normalized = stopValue.normalized
+            return normalized.isEmpty ? nil : normalized
+        }
+        return nil
+    }
+
+    private static func encodeStopSequences(
+        _ stopSequences: [String]?,
+        into container: inout KeyedEncodingContainer<CodingKeys>
+    ) throws {
+        guard let stopSequences, !stopSequences.isEmpty else {
+            return
+        }
+        if stopSequences.count == 1, let stopSequence = stopSequences.first {
+            try container.encode(StopSequencesValue.single(stopSequence), forKey: .stop)
+            return
+        }
+        try container.encode(StopSequencesValue.many(stopSequences), forKey: .stop)
     }
 
     public var structuredOutputConfiguration: StructuredOutputConfiguration? {
@@ -1210,6 +1535,12 @@ public struct MelixMessagesRequest: Codable, Sendable {
     public let temperature: Double?
     public let topP: Double?
     public let maxTokens: UInt32?
+    public let maxCompletionTokens: UInt32?
+    public let topK: UInt32?
+    public let minP: Double?
+    public let repeatPenalty: Double?
+    public let presencePenalty: Double?
+    public let seed: UInt32?
     public let stopSequences: [String]?
     public let metadata: MelixMessagesMetadata?
     public let thinking: MelixMessagesThinkingConfig?
@@ -1237,6 +1568,12 @@ public struct MelixMessagesRequest: Codable, Sendable {
         case temperature
         case topP = "top_p"
         case maxTokens = "max_tokens"
+        case maxCompletionTokens = "max_completion_tokens"
+        case topK = "top_k"
+        case minP = "min_p"
+        case repeatPenalty = "repeat_penalty"
+        case presencePenalty = "presence_penalty"
+        case seed
         case stopSequences = "stop_sequences"
         case metadata
         case thinking
@@ -1266,6 +1603,12 @@ public struct MelixMessagesRequest: Codable, Sendable {
         temperature: Double? = nil,
         topP: Double? = nil,
         maxTokens: UInt32? = nil,
+        maxCompletionTokens: UInt32? = nil,
+        topK: UInt32? = nil,
+        minP: Double? = nil,
+        repeatPenalty: Double? = nil,
+        presencePenalty: Double? = nil,
+        seed: UInt32? = nil,
         stopSequences: [String]? = nil,
         metadata: MelixMessagesMetadata? = nil,
         thinking: MelixMessagesThinkingConfig? = nil,
@@ -1298,6 +1641,12 @@ public struct MelixMessagesRequest: Codable, Sendable {
         self.temperature = temperature
         self.topP = topP
         self.maxTokens = maxTokens
+        self.maxCompletionTokens = maxCompletionTokens
+        self.topK = topK
+        self.minP = minP
+        self.repeatPenalty = repeatPenalty
+        self.presencePenalty = presencePenalty
+        self.seed = seed
         self.stopSequences = stopSequences
         self.metadata = metadata
         self.thinking = thinking
@@ -1327,6 +1676,12 @@ public struct MelixMessagesRequest: Codable, Sendable {
         self.temperature = try container.decodeIfPresent(Double.self, forKey: .temperature)
         self.topP = try container.decodeIfPresent(Double.self, forKey: .topP)
         self.maxTokens = try container.decodeIfPresent(UInt32.self, forKey: .maxTokens)
+        self.maxCompletionTokens = try container.decodeIfPresent(UInt32.self, forKey: .maxCompletionTokens)
+        self.topK = try container.decodeIfPresent(UInt32.self, forKey: .topK)
+        self.minP = try container.decodeIfPresent(Double.self, forKey: .minP)
+        self.repeatPenalty = try container.decodeIfPresent(Double.self, forKey: .repeatPenalty)
+        self.presencePenalty = try container.decodeIfPresent(Double.self, forKey: .presencePenalty)
+        self.seed = try container.decodeIfPresent(UInt32.self, forKey: .seed)
         self.stopSequences = try container.decodeIfPresent([String].self, forKey: .stopSequences)
         self.metadata = try container.decodeIfPresent(MelixMessagesMetadata.self, forKey: .metadata)
         self.thinking = try container.decodeIfPresent(MelixMessagesThinkingConfig.self, forKey: .thinking)
@@ -1356,6 +1711,12 @@ public struct MelixMessagesRequest: Codable, Sendable {
         try container.encodeIfPresent(temperature, forKey: .temperature)
         try container.encodeIfPresent(topP, forKey: .topP)
         try container.encodeIfPresent(maxTokens, forKey: .maxTokens)
+        try container.encodeIfPresent(maxCompletionTokens, forKey: .maxCompletionTokens)
+        try container.encodeIfPresent(topK, forKey: .topK)
+        try container.encodeIfPresent(minP, forKey: .minP)
+        try container.encodeIfPresent(repeatPenalty, forKey: .repeatPenalty)
+        try container.encodeIfPresent(presencePenalty, forKey: .presencePenalty)
+        try container.encodeIfPresent(seed, forKey: .seed)
         try container.encodeIfPresent(stopSequences, forKey: .stopSequences)
         try container.encodeIfPresent(metadata, forKey: .metadata)
         try container.encodeIfPresent(thinking, forKey: .thinking)
@@ -1466,6 +1827,12 @@ public struct ChatRequestTranslator: Sendable {
             temperature: request.temperature,
             topP: request.topP,
             maxTokens: request.maxTokens,
+            maxCompletionTokens: request.maxCompletionTokens,
+            topK: request.topK,
+            minP: request.minP,
+            repeatPenalty: request.repeatPenalty,
+            presencePenalty: request.presencePenalty,
+            seed: request.seed,
             sessionID: request.sessionID,
             branchID: request.branchID,
             parentRequestID: request.parentRequestID,
@@ -1509,6 +1876,12 @@ public struct ChatRequestTranslator: Sendable {
             temperature: request.temperature,
             topP: request.topP,
             maxTokens: request.maxTokens,
+            maxCompletionTokens: request.maxCompletionTokens,
+            topK: request.topK,
+            minP: request.minP,
+            repeatPenalty: request.repeatPenalty,
+            presencePenalty: request.presencePenalty,
+            seed: request.seed,
             sessionID: request.sessionID,
             branchID: request.branchID,
             parentRequestID: request.parentRequestID,
@@ -1543,6 +1916,12 @@ public struct ChatRequestTranslator: Sendable {
             temperature: request.temperature,
             topP: request.topP,
             maxTokens: request.maxTokens,
+            maxCompletionTokens: request.maxCompletionTokens,
+            topK: request.topK,
+            minP: request.minP,
+            repeatPenalty: request.repeatPenalty,
+            presencePenalty: request.presencePenalty,
+            seed: request.seed,
             sessionID: request.sessionID,
             branchID: request.branchID,
             parentRequestID: request.parentRequestID,
@@ -1552,6 +1931,7 @@ public struct ChatRequestTranslator: Sendable {
             workflow: request.workflow,
             workflowRunID: request.workflowRunID,
             workflowNodeID: request.workflowNodeID,
+            stopSequences: request.stopSequences,
             enableThinking: request.enableThinking,
             reasoningEffort: request.reasoningEffort,
             structuredOutput: try request.structuredOutputConfiguration,
@@ -1592,6 +1972,12 @@ public struct ChatRequestTranslator: Sendable {
             temperature: request.temperature,
             topP: request.topP,
             maxTokens: request.maxTokens,
+            maxCompletionTokens: request.maxCompletionTokens,
+            topK: request.topK,
+            minP: request.minP,
+            repeatPenalty: request.repeatPenalty,
+            presencePenalty: request.presencePenalty,
+            seed: request.seed,
             sessionID: request.sessionID,
             branchID: request.branchID,
             parentRequestID: request.parentRequestID,
@@ -1601,6 +1987,7 @@ public struct ChatRequestTranslator: Sendable {
             workflow: request.workflow,
             workflowRunID: request.workflowRunID,
             workflowNodeID: request.workflowNodeID,
+            stopSequences: request.stopSequences,
             enableThinking: request.enableThinking,
             reasoningEffort: request.reasoningEffort,
             structuredOutput: try request.structuredOutputConfiguration,
@@ -1639,6 +2026,12 @@ public struct ChatRequestTranslator: Sendable {
             temperature: request.temperature,
             topP: request.topP,
             maxTokens: request.maxTokens,
+            maxCompletionTokens: request.maxCompletionTokens,
+            topK: request.topK,
+            minP: request.minP,
+            repeatPenalty: request.repeatPenalty,
+            presencePenalty: request.presencePenalty,
+            seed: request.seed,
             sessionID: request.sessionID,
             branchID: request.branchID,
             parentRequestID: request.parentRequestID,
@@ -1668,6 +2061,12 @@ public struct ChatRequestTranslator: Sendable {
         temperature: Double?,
         topP: Double?,
         maxTokens: UInt32?,
+        maxCompletionTokens: UInt32? = nil,
+        topK: UInt32? = nil,
+        minP: Double? = nil,
+        repeatPenalty: Double? = nil,
+        presencePenalty: Double? = nil,
+        seed: UInt32? = nil,
         sessionID: String?,
         branchID: String?,
         parentRequestID: String?,
@@ -1697,6 +2096,12 @@ public struct ChatRequestTranslator: Sendable {
             temperature: temperature,
             topP: topP,
             maxTokens: maxTokens,
+            maxCompletionTokens: maxCompletionTokens,
+            topK: topK,
+            minP: minP,
+            repeatPenalty: repeatPenalty,
+            presencePenalty: presencePenalty,
+            seed: seed,
             sessionID: sessionID,
             branchID: branchID,
             parentRequestID: parentRequestID,
@@ -1964,6 +2369,11 @@ public struct ChatRequestTranslator: Sendable {
             chatTemplateKwargsHash
         generateRequest.execution.ext["melix.cache.fingerprint.reasoning_continuity_present"] =
             shapedRequest.reasoningContinuityRehydrated ? "true" : "false"
+        let compatibilityPolicyReceipt = TextCompatibilityPolicyReceipt(shapedRequest: shapedRequest)
+        generateRequest.execution.ext.merge(
+            compatibilityPolicyReceipt.extFields,
+            uniquingKeysWith: { _, new in new }
+        )
         if !(shapedRequest.sessionID ?? "").isEmpty {
             generateRequest.execution.cacheHints.allowL1 = true
             generateRequest.execution.cacheHints.allowL2 = true
@@ -1975,10 +2385,20 @@ public struct ChatRequestTranslator: Sendable {
         generateRequest.sampling = Melix_Worker_V1_SamplingConfig()
         generateRequest.sampling.temperature = Float(shapedRequest.temperature)
         generateRequest.sampling.topP = Float(shapedRequest.topP)
+        if let topK = shapedRequest.topK {
+            generateRequest.sampling.topK = topK
+        }
+        if let presencePenalty = shapedRequest.presencePenalty {
+            generateRequest.sampling.presencePenalty = Float(presencePenalty)
+        }
+        if let seed = shapedRequest.seed {
+            generateRequest.sampling.seed = seed
+        }
         generateRequest.sampling.maxOutputTokens = shapedRequest.maxTokens
         generateRequest.sampling.stop = shapedRequest.stopSequences
         generateRequest.stream = shapedRequest.stream
         generateRequest.returnUsage = shapedRequest.includeUsage
+        addGenerationReceipt(to: &generateRequest, shapedRequest: shapedRequest)
         generateRequest.execution.ext["melix.stream.include_usage"] = shapedRequest.includeUsage ? "true" : "false"
         generateRequest.execution.ext["melix.stream.interval_tokens"] = String(shapedRequest.streamIntervalTokens)
         generateRequest.execution.ext["melix.gateway.max_concurrent_requests"] = String(shapedRequest.maxConcurrentRequests)
@@ -2006,6 +2426,50 @@ public struct ChatRequestTranslator: Sendable {
             workerRequest: generateRequest,
             stream: generateRequest.stream
         )
+    }
+
+    private func addGenerationReceipt(
+        to request: inout Melix_Worker_V1_GenerateRequest,
+        shapedRequest: ShapedTextRequest
+    ) {
+        let extPrefix = "melix.generation."
+        request.execution.ext["\(extPrefix)max_tokens_requested"] = stringValue(shapedRequest.requestedMaxTokens)
+        request.execution.ext["\(extPrefix)max_tokens_effective"] = String(shapedRequest.maxTokens)
+        request.execution.ext["\(extPrefix)max_completion_tokens_requested"] =
+            stringValue(shapedRequest.requestedMaxCompletionTokens)
+        request.execution.ext["\(extPrefix)max_completion_tokens_effective"] = String(shapedRequest.maxTokens)
+        request.execution.ext["\(extPrefix)output_cap_source"] = shapedRequest.outputCapSource
+        request.execution.ext["\(extPrefix)bounds_rejection_reason"] = ""
+        request.execution.ext["\(extPrefix)stop_requested"] = stopReceiptValue(shapedRequest.requestedStopSequences)
+        request.execution.ext["\(extPrefix)stop_effective"] = stopReceiptValue(shapedRequest.stopSequences)
+        request.execution.ext["\(extPrefix)stop_source"] = shapedRequest.stopSource
+        request.execution.ext["\(extPrefix)temperature"] = stringValue(shapedRequest.temperature)
+        request.execution.ext["\(extPrefix)top_p"] = stringValue(shapedRequest.topP)
+        request.execution.ext["\(extPrefix)top_k"] = stringValue(shapedRequest.topK)
+        request.execution.ext["\(extPrefix)min_p"] = stringValue(shapedRequest.minP)
+        request.execution.ext["\(extPrefix)repeat_penalty"] = stringValue(shapedRequest.repeatPenalty)
+        request.execution.ext["\(extPrefix)presence_penalty"] = stringValue(shapedRequest.presencePenalty)
+        request.execution.ext["\(extPrefix)seed"] = stringValue(shapedRequest.seed)
+    }
+
+    private func stopReceiptValue(_ stopSequences: [String]) -> String {
+        if stopSequences.isEmpty {
+            return ""
+        }
+        if stopSequences.count == 1, let stop = stopSequences.first {
+            return stop
+        }
+        let encoded = (try? JSONSerialization.data(withJSONObject: stopSequences))
+            .flatMap { String(data: $0, encoding: .utf8) }
+        return encoded ?? stopSequences.joined(separator: ",")
+    }
+
+    private func stringValue<T>(_ value: T?) -> String {
+        value.map { "\($0)" } ?? ""
+    }
+
+    private func stringValue(_ value: Double) -> String {
+        String(format: "%g", value)
     }
 
     private static func workerToolConfig(

--- a/services/control-plane-swift/Sources/Requests/TextCompatibilityPolicyReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/TextCompatibilityPolicyReceipt.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+public struct TextCompatibilityPolicyReceipt: Codable, Sendable, Equatable {
+    public let compatSurface: String
+    public let streamMode: String
+    public let reasoningMode: String
+    public let reasoningSource: String
+    public let reasoningEffort: String
+    public let toolParserMode: String
+    public let toolParserSource: String
+    public let toolNamespaces: [String]
+    public let toolChoiceRequested: String
+    public let toolChoiceResolved: String
+    public let structuredOutputMode: String
+    public let outputModalities: [String]
+    public let effectiveConfigHash: String
+
+    enum CodingKeys: String, CodingKey {
+        case compatSurface = "compat_surface"
+        case streamMode = "stream_mode"
+        case reasoningMode = "reasoning_mode"
+        case reasoningSource = "reasoning_source"
+        case reasoningEffort = "reasoning_effort"
+        case toolParserMode = "tool_parser_mode"
+        case toolParserSource = "tool_parser_source"
+        case toolNamespaces = "tool_namespaces"
+        case toolChoiceRequested = "tool_choice_requested"
+        case toolChoiceResolved = "tool_choice_resolved"
+        case structuredOutputMode = "structured_output_mode"
+        case outputModalities = "output_modalities"
+        case effectiveConfigHash = "effective_config_hash"
+    }
+
+    public init(
+        compatSurface: String,
+        streamMode: String,
+        reasoningMode: String,
+        reasoningSource: String,
+        reasoningEffort: String,
+        toolParserMode: String,
+        toolParserSource: String,
+        toolNamespaces: [String],
+        toolChoiceRequested: String,
+        toolChoiceResolved: String,
+        structuredOutputMode: String,
+        outputModalities: [String],
+        effectiveConfigHash: String
+    ) {
+        self.compatSurface = compatSurface
+        self.streamMode = streamMode
+        self.reasoningMode = reasoningMode
+        self.reasoningSource = reasoningSource
+        self.reasoningEffort = reasoningEffort
+        self.toolParserMode = toolParserMode
+        self.toolParserSource = toolParserSource
+        self.toolNamespaces = toolNamespaces
+        self.toolChoiceRequested = toolChoiceRequested
+        self.toolChoiceResolved = toolChoiceResolved
+        self.structuredOutputMode = structuredOutputMode
+        self.outputModalities = outputModalities
+        self.effectiveConfigHash = effectiveConfigHash
+    }
+
+    public init(shapedRequest: ShapedTextRequest) {
+        let fields = Self.hashFields(shapedRequest: shapedRequest)
+        let effectiveConfigHash = cacheScopeHash(Self.canonicalJSONString(fields))
+        self.init(
+            compatSurface: fields["compat_surface"] as? String ?? "",
+            streamMode: fields["stream_mode"] as? String ?? "",
+            reasoningMode: fields["reasoning_mode"] as? String ?? "",
+            reasoningSource: fields["reasoning_source"] as? String ?? "",
+            reasoningEffort: fields["reasoning_effort"] as? String ?? "",
+            toolParserMode: fields["tool_parser_mode"] as? String ?? "",
+            toolParserSource: fields["tool_parser_source"] as? String ?? "",
+            toolNamespaces: fields["tool_namespaces"] as? [String] ?? [],
+            toolChoiceRequested: fields["tool_choice_requested"] as? String ?? "",
+            toolChoiceResolved: fields["tool_choice_resolved"] as? String ?? "",
+            structuredOutputMode: fields["structured_output_mode"] as? String ?? "",
+            outputModalities: fields["output_modalities"] as? [String] ?? ["text"],
+            effectiveConfigHash: effectiveConfigHash
+        )
+    }
+
+    public var jsonString: String {
+        Self.canonicalJSONString(dictionary)
+    }
+
+    public var extFields: [String: String] {
+        [
+            "melix.compat.compat_surface": compatSurface,
+            "melix.compat.stream_mode": streamMode,
+            "melix.compat.reasoning_mode": reasoningMode,
+            "melix.compat.reasoning_source": reasoningSource,
+            "melix.compat.reasoning_effort": reasoningEffort,
+            "melix.compat.tool_parser_mode": toolParserMode,
+            "melix.compat.tool_parser_source": toolParserSource,
+            "melix.compat.tool_namespaces": toolNamespaces.joined(separator: ","),
+            "melix.compat.tool_choice_requested": toolChoiceRequested,
+            "melix.compat.tool_choice_resolved": toolChoiceResolved,
+            "melix.compat.structured_output_mode": structuredOutputMode,
+            "melix.compat.output_modalities": outputModalities.joined(separator: ","),
+            "melix.compat.effective_config_hash": effectiveConfigHash,
+            "melix.compat.policy_receipt_json": jsonString,
+        ]
+    }
+
+    private var dictionary: [String: Any] {
+        [
+            "compat_surface": compatSurface,
+            "stream_mode": streamMode,
+            "reasoning_mode": reasoningMode,
+            "reasoning_source": reasoningSource,
+            "reasoning_effort": reasoningEffort,
+            "tool_parser_mode": toolParserMode,
+            "tool_parser_source": toolParserSource,
+            "tool_namespaces": toolNamespaces,
+            "tool_choice_requested": toolChoiceRequested,
+            "tool_choice_resolved": toolChoiceResolved,
+            "structured_output_mode": structuredOutputMode,
+            "output_modalities": outputModalities,
+            "effective_config_hash": effectiveConfigHash,
+        ]
+    }
+
+    private static func hashFields(shapedRequest: ShapedTextRequest) -> [String: Any] {
+        let toolChoiceRequested = shapedRequest.toolChoice ?? ""
+        return [
+            "compat_surface": compatSurface(for: shapedRequest.endpoint),
+            "stream_mode": shapedRequest.stream ? "stream" : "non_stream",
+            "reasoning_mode": shapedRequest.reasoningMode,
+            "reasoning_source": shapedRequest.reasoningSource,
+            "reasoning_effort": shapedRequest.reasoningEffort ?? "",
+            "tool_parser_mode": shapedRequest.toolParser?.mode.rawValue ?? "none",
+            "tool_parser_source": shapedRequest.toolParser?.source ?? "none",
+            "tool_namespaces": shapedRequest.toolParser?.namespaces ?? [],
+            "tool_choice_requested": toolChoiceRequested,
+            "tool_choice_resolved": resolvedToolChoice(requested: toolChoiceRequested, hasTools: !shapedRequest.tools.isEmpty),
+            "structured_output_mode": shapedRequest.structuredOutput?.mode.rawValue ?? "text",
+            "output_modalities": ["text"],
+        ]
+    }
+
+    private static func compatSurface(for endpoint: TextEndpointKind) -> String {
+        switch endpoint {
+        case .chatCompletions:
+            return "openai.chat.completions"
+        case .completions:
+            return "openai.completions"
+        case .responses:
+            return "openai.responses"
+        case .messages:
+            return "melix.messages"
+        }
+    }
+
+    private static func resolvedToolChoice(requested: String, hasTools: Bool) -> String {
+        if !requested.isEmpty {
+            return requested
+        }
+        return hasTools ? "auto" : "none"
+    }
+
+    private static func canonicalJSONString(_ object: [String: Any]) -> String {
+        let data = (try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])) ?? Data()
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+}

--- a/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
+++ b/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
@@ -267,10 +267,12 @@ public struct TextRequestShaper: Sendable {
             ?? gatewayServingDefaults?.maxTokens
         let temperature = request.temperature ?? preset?.temperature ?? fallbackTemperature ?? 0.7
         let topP = request.topP ?? preset?.topP ?? fallbackTopP ?? 1.0
-        let maxTokens = request.maxTokens
-            ?? preset?.maxTokens
-            ?? fallbackMaxTokens
-            ?? GatewayServingDefaultsStore.defaultMaxTokens
+        let outputCap = resolvedOutputCap(
+            request: request,
+            presetMaxTokens: preset?.maxTokens,
+            fallbackMaxTokens: fallbackMaxTokens
+        )
+        let maxTokens = outputCap.value
         let streamIntervalTokens = gatewayServingDefaults?.streamIntervalTokens ?? 1
         let maxConcurrentRequests = gatewayServingDefaults?.maxConcurrentRequests ?? 4
         let concurrentProcessingEnabled = gatewayServingDefaults?.concurrentProcessingEnabled ?? true
@@ -335,6 +337,14 @@ public struct TextRequestShaper: Sendable {
             temperature: temperature,
             topP: topP,
             maxTokens: maxTokens,
+            requestedMaxTokens: request.maxTokens,
+            requestedMaxCompletionTokens: request.maxCompletionTokens,
+            outputCapSource: outputCap.source,
+            topK: request.topK,
+            minP: request.minP,
+            repeatPenalty: request.repeatPenalty,
+            presencePenalty: request.presencePenalty,
+            seed: request.seed,
             streamIntervalTokens: streamIntervalTokens,
             maxConcurrentRequests: maxConcurrentRequests,
             concurrentProcessingEnabled: concurrentProcessingEnabled,
@@ -360,6 +370,8 @@ public struct TextRequestShaper: Sendable {
             admissionPolicy: workflow.admissionPolicy,
             cachePolicy: cachePolicy,
             stopSequences: resolvedOCRPolicy?.stopSequences ?? request.stopSequences,
+            requestedStopSequences: request.stopSequences,
+            stopSource: resolvedOCRPolicy?.stopSequences.isEmpty == false && request.stopSequences.isEmpty ? "model" : (request.stopSequences.isEmpty ? "none" : "request"),
             userID: request.userID?.nilIfEmpty,
             thinking: resolvedThinking.config,
             reasoningMode: resolvedThinking.mode,
@@ -379,6 +391,33 @@ public struct TextRequestShaper: Sendable {
             partialMode: partialMode.mode,
             assistantPrefill: partialMode.assistantPrefill
         )
+    }
+
+    private func resolvedOutputCap(
+        request: NormalizedTextRequest,
+        presetMaxTokens: UInt32?,
+        fallbackMaxTokens: UInt32?
+    ) -> (value: UInt32, source: String) {
+        if let maxTokens = request.maxTokens,
+           let maxCompletionTokens = request.maxCompletionTokens {
+            return (
+                maxTokens,
+                maxTokens == maxCompletionTokens ? "request_both_equal" : "request_conflict"
+            )
+        }
+        if let maxCompletionTokens = request.maxCompletionTokens {
+            return (maxCompletionTokens, "request_max_completion_tokens")
+        }
+        if let maxTokens = request.maxTokens {
+            return (maxTokens, "request_max_tokens")
+        }
+        if let presetMaxTokens {
+            return (presetMaxTokens, "preset")
+        }
+        if let fallbackMaxTokens {
+            return (fallbackMaxTokens, "policy")
+        }
+        return (GatewayServingDefaultsStore.defaultMaxTokens, "gateway_default")
     }
 
     private func resolveOCRPolicy(

--- a/services/control-plane-swift/Sources/Requests/ToolParserRegistry.swift
+++ b/services/control-plane-swift/Sources/Requests/ToolParserRegistry.swift
@@ -12,6 +12,63 @@ public enum ToolParserMode: String, Codable, Sendable, Equatable {
     case xml
 }
 
+public enum ToolParserKind: String, Codable, Sendable, Equatable {
+    case plainText = "plain_text"
+    case structuredOutput = "structured_output"
+    case toolCall = "tool_call"
+}
+
+public enum ToolParserSelectorSurface: String, Codable, Sendable, Equatable {
+    case api
+    case desktop
+    case cli
+}
+
+public enum ToolParserRequestContextMode: String, Codable, Sendable, Equatable, Hashable {
+    case structuredJSON = "structured_json"
+    case toolParser = "tool_parser"
+    case reasoning
+    case plain
+}
+
+public struct ToolParserAuditReceipt: Codable, Sendable, Equatable {
+    public let parserID: String
+    public let parserKind: ToolParserKind
+    public let acceptedWireFormats: [String]
+    public let selectorSurface: ToolParserSelectorSurface
+    public let selectorSource: String
+    public let requestContextMode: ToolParserRequestContextMode
+    public let exemptionReason: String
+
+    enum CodingKeys: String, CodingKey {
+        case parserID = "parser_id"
+        case parserKind = "parser_kind"
+        case acceptedWireFormats = "accepted_wire_formats"
+        case selectorSurface = "selector_surface"
+        case selectorSource = "selector_source"
+        case requestContextMode = "request_context_mode"
+        case exemptionReason = "exemption_reason"
+    }
+
+    public init(
+        parserID: String,
+        parserKind: ToolParserKind,
+        acceptedWireFormats: [String],
+        selectorSurface: ToolParserSelectorSurface,
+        selectorSource: String,
+        requestContextMode: ToolParserRequestContextMode,
+        exemptionReason: String = ""
+    ) {
+        self.parserID = parserID
+        self.parserKind = parserKind
+        self.acceptedWireFormats = acceptedWireFormats
+        self.selectorSurface = selectorSurface
+        self.selectorSource = selectorSource
+        self.requestContextMode = requestContextMode
+        self.exemptionReason = exemptionReason
+    }
+}
+
 public enum ToolParserConfigurationError: Error, Equatable {
     case unsupportedMode(String)
     case invalidNamespace(String)
@@ -155,23 +212,138 @@ public struct ToolParserRegistry: Sendable {
     private struct Descriptor: Sendable {
         let mode: ToolParserMode
         let aliases: Set<String>
+        let parserKind: ToolParserKind
+        let acceptedWireFormats: [String]
+        let requestContextModes: [ToolParserRequestContextMode]
     }
 
     private let descriptors: [Descriptor] = [
-        .init(mode: .text, aliases: ["text", "plain"]),
-        .init(mode: .json, aliases: ["json", "json_object"]),
-        .init(mode: .qwen, aliases: ["qwen"]),
-        .init(mode: .gemma, aliases: ["gemma"]),
-        .init(mode: .minimax, aliases: ["minimax"]),
-        .init(mode: .glm, aliases: ["glm"]),
-        .init(mode: .mistral, aliases: ["mistral"]),
-        .init(mode: .xml, aliases: ["xml"]),
+        .init(
+            mode: .text,
+            aliases: ["text", "plain"],
+            parserKind: .plainText,
+            acceptedWireFormats: ["raw_text"],
+            requestContextModes: [.plain]
+        ),
+        .init(
+            mode: .json,
+            aliases: ["json", "json_object"],
+            parserKind: .structuredOutput,
+            acceptedWireFormats: ["json_object"],
+            requestContextModes: [.structuredJSON]
+        ),
+        .init(
+            mode: .qwen,
+            aliases: ["qwen"],
+            parserKind: .toolCall,
+            acceptedWireFormats: ["qwen_xml_tool_call"],
+            requestContextModes: [.toolParser, .reasoning]
+        ),
+        .init(
+            mode: .gemma,
+            aliases: ["gemma"],
+            parserKind: .toolCall,
+            acceptedWireFormats: ["gemma_tool_call"],
+            requestContextModes: [.toolParser]
+        ),
+        .init(
+            mode: .minimax,
+            aliases: ["minimax"],
+            parserKind: .toolCall,
+            acceptedWireFormats: ["minimax_tool_call"],
+            requestContextModes: [.toolParser]
+        ),
+        .init(
+            mode: .glm,
+            aliases: ["glm"],
+            parserKind: .toolCall,
+            acceptedWireFormats: ["glm_tool_call"],
+            requestContextModes: [.toolParser]
+        ),
+        .init(
+            mode: .mistral,
+            aliases: ["mistral"],
+            parserKind: .toolCall,
+            acceptedWireFormats: ["mistral_tool_call"],
+            requestContextModes: [.toolParser]
+        ),
+        .init(
+            mode: .xml,
+            aliases: ["xml"],
+            parserKind: .toolCall,
+            acceptedWireFormats: ["xml_tool_call"],
+            requestContextModes: [.toolParser]
+        ),
     ]
 
     public init() {}
 
     public func supportedModes() -> [ToolParserMode] {
         descriptors.map(\.mode)
+    }
+
+    public func auditReceipts() -> [ToolParserAuditReceipt] {
+        descriptors.flatMap { descriptor in
+            descriptor.requestContextModes.map { requestContextMode in
+                ToolParserAuditReceipt(
+                    parserID: descriptor.mode.rawValue,
+                    parserKind: descriptor.parserKind,
+                    acceptedWireFormats: acceptedWireFormats(
+                        for: descriptor,
+                        requestContextMode: requestContextMode
+                    ),
+                    selectorSurface: .api,
+                    selectorSource: "request.tool_parser",
+                    requestContextMode: requestContextMode
+                )
+            }
+        }
+    }
+
+    public func selectorAuditReceipts() -> [ToolParserAuditReceipt] {
+        descriptors.flatMap { descriptor in
+            let requestContextMode = primaryContext(for: descriptor)
+            let acceptedWireFormats = acceptedWireFormats(
+                for: descriptor,
+                requestContextMode: requestContextMode
+            )
+            return [
+                ToolParserAuditReceipt(
+                    parserID: descriptor.mode.rawValue,
+                    parserKind: descriptor.parserKind,
+                    acceptedWireFormats: acceptedWireFormats,
+                    selectorSurface: .api,
+                    selectorSource: "request.tool_parser",
+                    requestContextMode: requestContextMode
+                ),
+                ToolParserAuditReceipt(
+                    parserID: descriptor.mode.rawValue,
+                    parserKind: descriptor.parserKind,
+                    acceptedWireFormats: acceptedWireFormats,
+                    selectorSurface: .desktop,
+                    selectorSource: "tooling_settings.builtin_tool_parser_modes",
+                    requestContextMode: requestContextMode
+                ),
+                ToolParserAuditReceipt(
+                    parserID: descriptor.mode.rawValue,
+                    parserKind: descriptor.parserKind,
+                    acceptedWireFormats: acceptedWireFormats,
+                    selectorSurface: .cli,
+                    selectorSource: "none",
+                    requestContextMode: requestContextMode,
+                    exemptionReason: Self.cliSelectorExemptionReason
+                ),
+            ]
+        }
+    }
+
+    public func requestContextFixtures() -> [ToolParserAuditReceipt] {
+        [
+            receipt(mode: .json, requestContextMode: .structuredJSON),
+            receipt(mode: .qwen, requestContextMode: .toolParser),
+            receipt(mode: .qwen, requestContextMode: .reasoning),
+            receipt(mode: .text, requestContextMode: .plain),
+        ]
     }
 
     func mode(for rawMode: String) -> ToolParserMode? {
@@ -290,5 +462,36 @@ public struct ToolParserRegistry: Sendable {
             fallbackMode: base.fallbackMode,
             mcpSourceIDs: mergedSourceIDs
         )
+    }
+
+    private static let cliSelectorExemptionReason = "CLI has no request-construction surface for tool parser selection; it reports remote model supported_parsers only."
+
+    private func primaryContext(for descriptor: Descriptor) -> ToolParserRequestContextMode {
+        descriptor.requestContextModes.first ?? .plain
+    }
+
+    private func receipt(
+        mode: ToolParserMode,
+        requestContextMode: ToolParserRequestContextMode
+    ) -> ToolParserAuditReceipt {
+        let descriptor = descriptors.first(where: { $0.mode == mode })!
+        return ToolParserAuditReceipt(
+            parserID: descriptor.mode.rawValue,
+            parserKind: descriptor.parserKind,
+            acceptedWireFormats: acceptedWireFormats(for: descriptor, requestContextMode: requestContextMode),
+            selectorSurface: .api,
+            selectorSource: "request.tool_parser",
+            requestContextMode: requestContextMode
+        )
+    }
+
+    private func acceptedWireFormats(
+        for descriptor: Descriptor,
+        requestContextMode: ToolParserRequestContextMode
+    ) -> [String] {
+        if descriptor.mode == .qwen, requestContextMode == .reasoning {
+            return descriptor.acceptedWireFormats + ["reasoning_channel_tags"]
+        }
+        return descriptor.acceptedWireFormats
     }
 }

--- a/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
@@ -915,6 +915,236 @@ struct TextEndpointContractTests {
         #expect(manyEncoded["stop"] as? [String] == ["</final>", "</alt>"])
     }
 
+    @Test("completions and responses preserve stop aliases across legacy fields")
+    func completionsAndResponsesPreserveStopAliasesAcrossLegacyFields() throws {
+        let decoder = JSONDecoder()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        let completionsWithLegacyStop = try decoder.decode(
+            OpenAICompletionsRequest.self,
+            from: Data(
+                """
+                {
+                  "model": "melix-dev-text",
+                  "prompt": "Hello",
+                  "stop_sequences": "</legacy>"
+                }
+                """.utf8
+            )
+        )
+        let responsesWithLegacyStop = try decoder.decode(
+            OpenAIResponsesRequest.self,
+            from: Data(
+                """
+                {
+                  "model": "melix-dev-text",
+                  "input": "Hello",
+                  "stop_sequences": ["</one>", "</two>"]
+                }
+                """.utf8
+            )
+        )
+        let encodedSingleCompletionStop = try #require(
+            JSONSerialization.jsonObject(
+                with: encoder.encode(
+                    OpenAICompletionsRequest(
+                        model: "melix-dev-text",
+                        prompt: "Hello",
+                        stopSequences: ["</final>"]
+                    )
+                )
+            ) as? [String: Any]
+        )
+        let encodedManyResponseStops = try #require(
+            JSONSerialization.jsonObject(
+                with: encoder.encode(
+                    OpenAIResponsesRequest(
+                        model: "melix-dev-text",
+                        input: .text("Hello"),
+                        stopSequences: ["</one>", "</two>"]
+                    )
+                )
+            ) as? [String: Any]
+        )
+
+        #expect(completionsWithLegacyStop.stopSequences == ["</legacy>"])
+        #expect(responsesWithLegacyStop.stopSequences == ["</one>", "</two>"])
+        #expect(encodedSingleCompletionStop["stop"] as? String == "</final>")
+        #expect(encodedManyResponseStops["stop"] as? [String] == ["</one>", "</two>"])
+    }
+
+    @Test("compatibility request contracts encode optional controls without losing aliases")
+    func compatibilityRequestContractsEncodeOptionalControlsWithoutLosingAliases() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let decoder = JSONDecoder()
+        let responseFormat = StructuredOutputRequestFormat(type: .jsonObject)
+        let toolParser = ToolParserRequestConfiguration(
+            mode: .qwen,
+            namespaces: ["tools.search"],
+            xmlFallback: true
+        )
+        let chatTemplate = ChatTemplateRequestConfiguration(values: [
+            "continue_final_message": .bool(true),
+        ])
+
+        let completions = OpenAICompletionsRequest(
+            model: "melix-dev-text",
+            prompt: "Draft the final answer.",
+            enableThinking: true,
+            reasoningEffort: "medium",
+            stream: true,
+            streamOptions: .init(includeUsage: true),
+            temperature: 0.4,
+            topP: 0.9,
+            maxTokens: 64,
+            topK: 40,
+            minP: 0.05,
+            repeatPenalty: 1.1,
+            presencePenalty: 0.2,
+            seed: 123,
+            stopSequences: ["END", "DONE"],
+            sessionID: "session-encode",
+            branchID: "branch-encode",
+            parentRequestID: "req-parent",
+            restoreSnapshotID: "snap-encode",
+            saveBoundarySnapshot: true,
+            presetID: "deep_reasoning",
+            workflow: .toolFollowup,
+            workflowRunID: "wf-encode",
+            workflowNodeID: "node-encode",
+            responseFormat: responseFormat,
+            toolParser: toolParser,
+            chatTemplateKwargs: chatTemplate
+        )
+        let responses = OpenAIResponsesRequest(
+            model: "melix-dev-text",
+            input: .messages([
+                .init(
+                    role: "user",
+                    name: "operator",
+                    content: "Search the notes.",
+                    channel: "analysis",
+                    recipient: "tools.search",
+                    contentType: "text"
+                ),
+            ]),
+            enableThinking: true,
+            reasoningEffort: "high",
+            instructions: "Return JSON.",
+            stream: true,
+            streamOptions: .init(includeUsage: true),
+            temperature: 0.3,
+            topP: 0.8,
+            maxCompletionTokens: 48,
+            topK: 24,
+            minP: 0.02,
+            repeatPenalty: 1.05,
+            presencePenalty: 0.1,
+            seed: 456,
+            stopSequences: ["STOP"],
+            sessionID: "session-response",
+            branchID: "branch-response",
+            parentRequestID: "req-response",
+            restoreSnapshotID: "snap-response",
+            saveBoundarySnapshot: false,
+            presetID: "quick_json",
+            workflow: .backgroundAnalysis,
+            workflowRunID: "wf-response",
+            workflowNodeID: "node-response",
+            text: .init(format: responseFormat),
+            toolParser: toolParser,
+            chatTemplateKwargs: chatTemplate
+        )
+        let messages = MelixMessagesRequest(
+            model: "melix-dev-text",
+            messages: [
+                .init(
+                    role: "assistant",
+                    name: "draft",
+                    contentBlocks: [
+                        .init(type: .thinking, thinking: "Need concise output."),
+                        .init(type: .text, text: "Ready."),
+                    ]
+                ),
+                .init(role: "user", content: "Continue."),
+            ],
+            enableThinking: true,
+            reasoningEffort: "medium",
+            systemBlocks: [.init(type: .text, text: "Use compact JSON.")],
+            stream: false,
+            streamOptions: .init(includeUsage: true),
+            temperature: 0.2,
+            topP: 0.75,
+            maxTokens: 32,
+            topK: 16,
+            minP: 0.01,
+            repeatPenalty: 1.0,
+            presencePenalty: 0.0,
+            seed: 789,
+            stopSequences: ["</final>"],
+            metadata: .init(userID: "operator-encode"),
+            thinking: .init(type: "enabled", budgetTokens: 64),
+            sessionID: "session-message",
+            branchID: "branch-message",
+            parentRequestID: "req-message",
+            restoreSnapshotID: "snap-message",
+            saveBoundarySnapshot: true,
+            presetID: "messages_json",
+            workflow: .interactive,
+            workflowRunID: "wf-message",
+            workflowNodeID: "node-message",
+            responseFormat: responseFormat,
+            toolParser: toolParser,
+            chatTemplateKwargs: chatTemplate
+        )
+
+        let completionsData = try encoder.encode(completions)
+        let responsesData = try encoder.encode(responses)
+        let messagesData = try encoder.encode(messages)
+        let completionsObject = try #require(
+            JSONSerialization.jsonObject(with: completionsData) as? [String: Any]
+        )
+        let responsesObject = try #require(
+            JSONSerialization.jsonObject(with: responsesData) as? [String: Any]
+        )
+        let messagesObject = try #require(
+            JSONSerialization.jsonObject(with: messagesData) as? [String: Any]
+        )
+
+        #expect(completionsObject["stop"] as? [String] == ["END", "DONE"])
+        #expect(completionsObject["max_tokens"] as? Int == 64)
+        #expect(completionsObject["workflow"] as? String == "tool_followup")
+        #expect(completionsObject["tool_parser"] != nil)
+        #expect(completionsObject["chat_template_kwargs"] != nil)
+
+        #expect(responsesObject["stop"] as? String == "STOP")
+        #expect(responsesObject["max_completion_tokens"] as? Int == 48)
+        #expect(responsesObject["instructions"] as? String == "Return JSON.")
+        #expect(responsesObject["workflow"] as? String == "background_analysis")
+        let encodedInput = try #require(responsesObject["input"] as? [[String: Any]])
+        #expect(encodedInput.first?["recipient"] as? String == "tools.search")
+
+        #expect(messagesObject["stop_sequences"] as? [String] == ["</final>"])
+        #expect(messagesObject["metadata"] != nil)
+        #expect(messagesObject["thinking"] != nil)
+        #expect(messagesObject["system"] != nil)
+        #expect(messagesObject["workflow"] as? String == "interactive")
+
+        let decodedCompletions = try decoder.decode(OpenAICompletionsRequest.self, from: completionsData)
+        let decodedResponses = try decoder.decode(OpenAIResponsesRequest.self, from: responsesData)
+        let decodedMessages = try decoder.decode(MelixMessagesRequest.self, from: messagesData)
+        #expect(decodedCompletions.stopSequences == ["END", "DONE"])
+        #expect(decodedCompletions.chatTemplateKwargs == chatTemplate)
+        #expect(decodedResponses.stopSequences == ["STOP"])
+        #expect(decodedResponses.toolParser == toolParser)
+        #expect(decodedMessages.stopSequences == ["</final>"])
+        #expect(decodedMessages.systemBlocks == [.init(type: .text, text: "Use compact JSON.")] as [MelixMessagesContentBlock]?)
+        #expect(decodedMessages.metadata == .init(userID: "operator-encode"))
+        #expect(decodedMessages.thinking == .init(type: "enabled", budgetTokens: 64))
+    }
+
     @Test("ocr execution policy stays disabled when model settings do not declare OCR defaults")
     func ocrExecutionPolicyStaysDisabledWithoutModelDefaults() {
         let policy = OCRExecutionPolicy(modelSettings: .init())

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -5,6 +5,92 @@ import Testing
 import MelixControlPlaneProtocol
 
 struct ToolParserRegistryTests {
+    @Test("registered parsers declare audit receipts for wire formats and selector surfaces")
+    func registeredParsersDeclareAuditReceiptsForWireFormatsAndSelectorSurfaces() throws {
+        let registry = ToolParserRegistry()
+        let receipts = registry.auditReceipts()
+        let registeredIDs = Set(registry.supportedModes().map(\.rawValue))
+
+        #expect(Set(receipts.map(\.parserID)) == registeredIDs)
+        #expect(receipts.allSatisfy { !$0.parserID.isEmpty })
+        #expect(receipts.allSatisfy { !$0.parserKind.rawValue.isEmpty })
+        #expect(receipts.allSatisfy { !$0.acceptedWireFormats.isEmpty })
+        #expect(receipts.allSatisfy { !$0.selectorSurface.rawValue.isEmpty })
+        #expect(receipts.allSatisfy { !$0.selectorSource.isEmpty })
+        #expect(receipts.allSatisfy { !$0.requestContextMode.rawValue.isEmpty })
+        #expect(receipts.allSatisfy { receipt in
+            receipt.selectorSurface == .cli ? !receipt.exemptionReason.isEmpty : receipt.exemptionReason.isEmpty
+        })
+
+        let json = try #require(receipts.first { $0.parserID == "json" && $0.requestContextMode == .structuredJSON })
+        #expect(json.parserKind == .structuredOutput)
+        #expect(json.acceptedWireFormats == ["json_object"])
+
+        let qwenTool = try #require(receipts.first { $0.parserID == "qwen" && $0.requestContextMode == .toolParser })
+        #expect(qwenTool.parserKind == .toolCall)
+        #expect(qwenTool.acceptedWireFormats == ["qwen_xml_tool_call"])
+
+        let qwenReasoning = try #require(receipts.first { $0.parserID == "qwen" && $0.requestContextMode == .reasoning })
+        #expect(qwenReasoning.acceptedWireFormats.contains("qwen_xml_tool_call"))
+        #expect(qwenReasoning.acceptedWireFormats.contains("reasoning_channel_tags"))
+
+        let plain = try #require(receipts.first { $0.parserID == "text" && $0.requestContextMode == .plain })
+        #expect(plain.parserKind == .plainText)
+        #expect(plain.acceptedWireFormats == ["raw_text"])
+
+        let encoded = try JSONEncoder().encode(qwenTool)
+        let jsonObject = try #require(
+            try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        #expect(Set(jsonObject.keys) == [
+            "parser_id",
+            "parser_kind",
+            "accepted_wire_formats",
+            "selector_surface",
+            "selector_source",
+            "request_context_mode",
+            "exemption_reason",
+        ])
+    }
+
+    @Test("API desktop and CLI selector declarations are parity audited")
+    func apiDesktopAndCLISelectorDeclarationsAreParityAudited() {
+        let registry = ToolParserRegistry()
+        let selectorReceipts = registry.selectorAuditReceipts()
+        let parserIDs = registry.supportedModes().map(\.rawValue)
+
+        let api = selectorReceipts.filter { $0.selectorSurface == .api }
+        let desktop = selectorReceipts.filter { $0.selectorSurface == .desktop }
+        let cli = selectorReceipts.filter { $0.selectorSurface == .cli }
+
+        #expect(api.map(\.parserID) == parserIDs)
+        #expect(desktop.map(\.parserID) == parserIDs)
+        #expect(cli.map(\.parserID) == parserIDs)
+        #expect(api.allSatisfy { $0.selectorSource == "request.tool_parser" })
+        #expect(desktop.allSatisfy { $0.selectorSource == "tooling_settings.builtin_tool_parser_modes" })
+        #expect(cli.allSatisfy { $0.selectorSource == "none" })
+        #expect(cli.allSatisfy {
+            $0.exemptionReason == "CLI has no request-construction surface for tool parser selection; it reports remote model supported_parsers only."
+        })
+        #expect(api.allSatisfy { $0.exemptionReason.isEmpty })
+        #expect(desktop.allSatisfy { $0.exemptionReason.isEmpty })
+    }
+
+    @Test("fixture request contexts cover JSON tool reasoning and plain parsers")
+    func fixtureRequestContextsCoverJSONToolReasoningAndPlainParsers() {
+        let contexts = ToolParserRegistry().requestContextFixtures()
+
+        #expect(Set(contexts.map(\.requestContextMode)) == [.structuredJSON, .toolParser, .reasoning, .plain])
+        #expect(contexts.contains { $0.parserID == "json" && $0.acceptedWireFormats == ["json_object"] })
+        #expect(contexts.contains { $0.parserID == "qwen" && $0.acceptedWireFormats.contains("qwen_xml_tool_call") })
+        #expect(contexts.contains {
+            $0.parserID == "qwen"
+                && $0.requestContextMode == .reasoning
+                && $0.acceptedWireFormats.contains("reasoning_channel_tags")
+        })
+        #expect(contexts.contains { $0.parserID == "text" && $0.acceptedWireFormats == ["raw_text"] })
+    }
+
     @Test("tool parser request contracts decode across endpoint variants")
     func toolParserRequestContractsDecodeAcrossEndpointVariants() throws {
         let decoder = JSONDecoder()
@@ -100,6 +186,62 @@ struct ToolParserRegistryTests {
         #expect(translated.workerRequest.execution.ext["melix.tool_parser.source"] == "request")
         #expect(translated.workerRequest.execution.ext["melix.tool_parser.namespaces"] == "tools.search,tools.math")
         #expect(translated.workerRequest.execution.ext["melix.tool_parser.fallback_mode"] == "xml")
+    }
+
+    @Test("translated text requests attach request-local compatibility policy receipts")
+    func translatedTextRequestsAttachRequestLocalCompatibilityPolicyReceipts() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-compat-policy" })
+        let request = OpenAIChatCompletionsRequest(
+            model: "melix-dev-text",
+            messages: [.init(role: "user", content: "Call a tool and answer as JSON.")],
+            enableThinking: true,
+            reasoningEffort: "low",
+            stream: true,
+            responseFormat: StructuredOutputRequestFormat(
+                type: .jsonSchema,
+                jsonSchema: StructuredOutputJSONSchemaDefinition(
+                    name: "answer",
+                    schema: .object(["type": .string("object")]),
+                    strict: true
+                )
+            ),
+            toolParser: ToolParserRequestConfiguration(
+                mode: .qwen,
+                namespaces: ["tools.search"]
+            ),
+            tools: [
+                OpenAIChatTool(
+                    type: "function",
+                    function: OpenAIChatTool.FunctionDefinition(
+                        name: "search",
+                        description: "Search documents",
+                        parameters: .object(["type": .string("object")])
+                    )
+                ),
+            ],
+            toolChoice: .mode("required")
+        )
+
+        let translated = try translator.translate(request, modelHandle: "worker-text")
+        let ext = translated.workerRequest.execution.ext
+        let receipt = try #require(ext["melix.compat.policy_receipt_json"])
+
+        #expect(ext["melix.compat.compat_surface"] == "openai.chat.completions")
+        #expect(ext["melix.compat.stream_mode"] == "stream")
+        #expect(ext["melix.compat.reasoning_mode"] == "enabled")
+        #expect(ext["melix.compat.reasoning_source"] == "request")
+        #expect(ext["melix.compat.reasoning_effort"] == "low")
+        #expect(ext["melix.compat.tool_parser_mode"] == "qwen")
+        #expect(ext["melix.compat.tool_parser_source"] == "request")
+        #expect(ext["melix.compat.tool_namespaces"] == "tools.search")
+        #expect(ext["melix.compat.tool_choice_requested"] == "required")
+        #expect(ext["melix.compat.tool_choice_resolved"] == "required")
+        #expect(ext["melix.compat.structured_output_mode"] == "json_schema")
+        #expect(ext["melix.compat.output_modalities"] == "text")
+        #expect(ext["melix.compat.effective_config_hash"]?.isEmpty == false)
+        #expect(receipt.contains(#""compat_surface":"openai.chat.completions""#))
+        #expect(receipt.contains(#""tool_namespaces":["tools.search"]"#))
+        #expect(receipt.contains(#""effective_config_hash":"\#(ext["melix.compat.effective_config_hash"] ?? "")""#))
     }
 
     @Test("multimodal tool parser requests preserve image parts and execution metadata")

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -846,6 +846,258 @@ struct OpenAIHandlerTests {
         #expect(payload.contains("data: [DONE]"))
     }
 
+    @Test("POST /v1/chat/completions normalizes generation bounds stop and passthrough receipts")
+    func postChatCompletionsNormalizesGenerationBoundsStopAndPassthroughReceipts() async throws {
+        let catalog = ModelCatalog(seedModels: [warmModel()])
+        let workerClient = ScriptedWorkerClient(events: [
+            makeCompletedEvent(requestID: "req-generation-receipts", seq: 1, finishReason: "stop", assistantText: "done"),
+        ])
+        let handler = OpenAIHandler(
+            modelCatalog: catalog,
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-generation-receipts" })
+        )
+
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": true,
+              "messages": [
+                { "role": "user", "content": "Hello" }
+              ],
+              "max_tokens": 16,
+              "max_completion_tokens": 16,
+              "stop": "END",
+              "temperature": 0.25,
+              "top_p": 0.9,
+              "top_k": 42,
+              "min_p": 0.05,
+              "repeat_penalty": 1.15,
+              "presence_penalty": 0.2,
+              "seed": 123
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        _ = try await collectBody(response.body)
+        let request = try #require(await workerClient.lastGenerateRequest)
+        let receipt = request.execution.ext
+
+        #expect(response.statusCode == 200)
+        #expect(request.sampling.maxOutputTokens == 16)
+        #expect(request.sampling.stop == ["END"])
+        #expect(request.sampling.temperature == 0.25)
+        #expect(request.sampling.topP == 0.9)
+        #expect(request.sampling.topK == 42)
+        #expect(request.sampling.presencePenalty == 0.2)
+        #expect(request.sampling.seed == 123)
+        #expect(receipt["melix.generation.max_tokens_requested"] == "16")
+        #expect(receipt["melix.generation.max_tokens_effective"] == "16")
+        #expect(receipt["melix.generation.max_completion_tokens_requested"] == "16")
+        #expect(receipt["melix.generation.max_completion_tokens_effective"] == "16")
+        #expect(receipt["melix.generation.output_cap_source"] == "request_both_equal")
+        #expect(receipt["melix.generation.bounds_rejection_reason"] == "")
+        #expect(receipt["melix.generation.stop_requested"] == "END")
+        #expect(receipt["melix.generation.stop_effective"] == "END")
+        #expect(receipt["melix.generation.stop_source"] == "request")
+        #expect(receipt["melix.generation.temperature"] == "0.25")
+        #expect(receipt["melix.generation.top_p"] == "0.9")
+        #expect(receipt["melix.generation.top_k"] == "42")
+        #expect(receipt["melix.generation.min_p"] == "0.05")
+        #expect(receipt["melix.generation.repeat_penalty"] == "1.15")
+        #expect(receipt["melix.generation.presence_penalty"] == "0.2")
+        #expect(receipt["melix.generation.seed"] == "123")
+    }
+
+    @Test("POST /v1/chat/completions preserves generation receipts across non-stream aggregation")
+    func postChatCompletionsPreservesGenerationReceiptsAcrossNonStreamAggregation() async throws {
+        let catalog = ModelCatalog(seedModels: [warmModel()])
+        let workerClient = ScriptedWorkerClient(events: [
+            makeTokenEvent(requestID: "req-generation-non-stream", seq: 1, text: "done"),
+            makeCompletedEvent(requestID: "req-generation-non-stream", seq: 2, finishReason: "stop", assistantText: "done"),
+        ])
+        let handler = OpenAIHandler(
+            modelCatalog: catalog,
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-generation-non-stream" })
+        )
+
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": false,
+              "messages": [
+                { "role": "user", "content": "Hello" }
+              ],
+              "max_completion_tokens": 24,
+              "stop": ["END", "DONE"],
+              "temperature": 0,
+              "top_p": 1,
+              "top_k": 0
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        _ = try await jsonPayload(from: response.body)
+        let request = try #require(await workerClient.lastGenerateRequest)
+        let receipt = request.execution.ext
+
+        #expect(response.statusCode == 200)
+        #expect(request.stream)
+        #expect(request.sampling.maxOutputTokens == 24)
+        #expect(request.sampling.stop == ["END", "DONE"])
+        #expect(receipt["melix.generation.max_tokens_requested"] == "")
+        #expect(receipt["melix.generation.max_tokens_effective"] == "24")
+        #expect(receipt["melix.generation.max_completion_tokens_requested"] == "24")
+        #expect(receipt["melix.generation.max_completion_tokens_effective"] == "24")
+        #expect(receipt["melix.generation.output_cap_source"] == "request_max_completion_tokens")
+        #expect(receipt["melix.generation.stop_requested"] == #"["END","DONE"]"#)
+        #expect(receipt["melix.generation.stop_effective"] == #"["END","DONE"]"#)
+        #expect(receipt["melix.generation.stop_source"] == "request")
+    }
+
+    @Test(
+        "POST /v1/chat/completions rejects malformed generation bounds with typed errors",
+        arguments: [
+            (#""max_tokens": 0"#, "max_tokens_non_positive"),
+            (#""max_tokens": -1"#, "max_tokens_non_positive"),
+            (#""max_tokens": "many""#, "max_tokens_malformed"),
+            (#""max_tokens": 1e999"#, "max_tokens_non_finite"),
+            (#""max_tokens": 16, "max_completion_tokens": 24"#, "output_cap_conflict"),
+        ]
+    )
+    func postChatCompletionsRejectsMalformedGenerationBounds(
+        boundsJSON: String,
+        expectedReason: String
+    ) async throws {
+        let workerClient = ScriptedWorkerClient(events: [])
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            )
+        )
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": true,
+              "messages": [
+                { "role": "user", "content": "Hello" }
+              ],
+              \(boundsJSON)
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let error = try #require(payload["error"] as? [String: Any])
+
+        #expect(response.statusCode == 400)
+        #expect(error["code"] as? String == "invalid_generation_bounds")
+        #expect(error["bounds_rejection_reason"] as? String == expectedReason)
+        #expect(await workerClient.lastGenerateRequest == nil)
+    }
+
+    @Test(
+        "text compatibility routes reject malformed generation bounds before dispatch",
+        arguments: [
+            (
+                "/v1/completions",
+                #"{"model":"melix-dev-text","stream":true,"prompt":"hello","max_tokens":0}"#,
+                "max_tokens_non_positive"
+            ),
+            (
+                "/v1/responses",
+                #"{"model":"melix-dev-text","stream":true,"input":"hello","max_completion_tokens":"many"}"#,
+                "max_completion_tokens_malformed"
+            ),
+            (
+                "/v1/completions",
+                #"{"model":"melix-dev-text","stream":true,"prompt":"hello","max_completion_tokens":Infinity}"#,
+                "max_completion_tokens_non_finite"
+            ),
+            (
+                "/v1/responses",
+                #"{"model":"melix-dev-text","stream":true,"input":"hello","max_tokens":8,"max_completion_tokens":9,}"#,
+                "output_cap_conflict"
+            ),
+            (
+                "/v1/messages",
+                #"{"model":"melix-dev-text","stream":true,"messages":[{"role":"user","content":"hello"}],"max_tokens":1.5,}"#,
+                "max_tokens_malformed"
+            ),
+            (
+                "/v1/messages",
+                #"{"model":"melix-dev-text","stream":true,"messages":[{"role":"user","content":"hello"}],"max_tokens":8,"max_completion_tokens":9}"#,
+                "output_cap_conflict"
+            ),
+        ]
+    )
+    func textCompatibilityRoutesRejectMalformedGenerationBounds(
+        path: String,
+        bodyJSON: String,
+        expectedReason: String
+    ) async throws {
+        let workerClient = ScriptedWorkerClient(events: [])
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            )
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: path,
+                headers: ["content-type": "application/json"],
+                body: Data(bodyJSON.utf8)
+            )
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let error = try #require(payload["error"] as? [String: Any])
+
+        #expect(response.statusCode == 400)
+        #expect(error["code"] as? String == "invalid_generation_bounds")
+        #expect(error["bounds_rejection_reason"] as? String == expectedReason)
+        #expect(await workerClient.lastGenerateRequest == nil)
+    }
+
     @Test("POST /v1/chat/completions routes by payload model within the active server roster")
     func postChatCompletionsRoutesByPayloadModelWithinActiveServerRoster() async throws {
         var primary = ModelCatalog.devTextModel()
@@ -3163,6 +3415,82 @@ struct OpenAIHandlerTests {
         #expect(payload.contains("\"delta\":{\"thinking\":\"trace\",\"type\":\"thinking_delta\"}"))
         #expect(payload.contains("\"stop_reason\":\"end_turn\""))
         #expect(payload.contains("\"content\":[{\"thinking\":\"trace\",\"type\":\"thinking\"},{\"text\":\"done\",\"type\":\"text\"}]"))
+    }
+
+    @Test(
+        "text compatibility routes normalize generation receipts",
+        arguments: [
+            (
+                "completions",
+                "/v1/completions",
+                #"{"model":"melix-dev-text","stream":true,"prompt":"hello","max_completion_tokens":11,"stop":"END","top_k":7,"presence_penalty":0.1,"seed":77}"#,
+                UInt32(11),
+                "request_max_completion_tokens",
+                ["END"],
+                "END"
+            ),
+            (
+                "responses",
+                "/v1/responses",
+                #"{"model":"melix-dev-text","stream":true,"input":"hello","max_tokens":12,"max_completion_tokens":12,"stop":["END","DONE"],"top_k":8,"presence_penalty":0.2,"seed":78}"#,
+                UInt32(12),
+                "request_both_equal",
+                ["END", "DONE"],
+                #"["END","DONE"]"#
+            ),
+            (
+                "messages",
+                "/v1/messages",
+                #"{"model":"melix-dev-text","stream":true,"messages":[{"role":"user","content":"hello"}],"max_tokens":13,"stop_sequences":["END"],"top_k":9,"presence_penalty":0.3,"seed":79}"#,
+                UInt32(13),
+                "request_max_tokens",
+                ["END"],
+                "END"
+            ),
+        ]
+    )
+    func textCompatibilityRoutesNormalizeGenerationReceipts(
+        routeName: String,
+        path: String,
+        bodyJSON: String,
+        expectedCap: UInt32,
+        expectedSource: String,
+        expectedStop: [String],
+        expectedStopReceipt: String
+    ) async throws {
+        let requestID = "req-generation-\(routeName)"
+        let workerClient = ScriptedWorkerClient(events: [
+            makeCompletedEvent(requestID: requestID, seq: 1, finishReason: "stop", assistantText: "done"),
+        ])
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { requestID })
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: path,
+                headers: ["content-type": "application/json"],
+                body: Data(bodyJSON.utf8)
+            )
+        )
+        _ = try await collectBody(response.body)
+        let request = try #require(await workerClient.lastGenerateRequest)
+        let receipt = request.execution.ext
+
+        #expect(response.statusCode == 200)
+        #expect(request.sampling.maxOutputTokens == expectedCap)
+        #expect(request.sampling.stop == expectedStop)
+        #expect(receipt["melix.generation.max_tokens_effective"] == "\(expectedCap)")
+        #expect(receipt["melix.generation.max_completion_tokens_effective"] == "\(expectedCap)")
+        #expect(receipt["melix.generation.output_cap_source"] == expectedSource)
+        #expect(receipt["melix.generation.stop_effective"] == expectedStopReceipt)
+        #expect(receipt["melix.generation.stop_source"] == "request")
     }
 
     @Test("POST /v1/responses forwards reasoning and tool delta events")
@@ -8402,6 +8730,207 @@ struct OpenAIHandlerTests {
         #expect(message["content"] as? String == "Hello")
     }
 
+    @Test("chat stream and non-stream requests emit the same compatibility policy receipt shape")
+    func chatStreamAndNonStreamRequestsEmitSameCompatibilityPolicyReceiptShape() async throws {
+        let streamWorkerClient = ScriptedWorkerClient(events: [
+            makeTokenEvent(requestID: "req-compat-stream", seq: 1, text: "{}"),
+            makeCompletedEvent(requestID: "req-compat-stream", seq: 2, finishReason: "stop", assistantText: "{}"),
+        ])
+        let nonStreamWorkerClient = ScriptedWorkerClient(events: [
+            makeTokenEvent(requestID: "req-compat-non-stream", seq: 1, text: "{}"),
+            makeCompletedEvent(requestID: "req-compat-non-stream", seq: 2, finishReason: "stop", assistantText: "{}"),
+        ])
+        let streamHandler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: streamWorkerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-compat-stream" })
+        )
+        let nonStreamHandler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: nonStreamWorkerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-compat-non-stream" })
+        )
+        let streamBody = try #require(compatPolicyChatBody(stream: true))
+        let nonStreamBody = try #require(compatPolicyChatBody(stream: false))
+
+        let streamResponse = try await streamHandler.handle(
+            HTTPRequest(method: .post, path: "/v1/chat/completions", headers: [:], body: streamBody)
+        )
+        let nonStreamResponse = try await nonStreamHandler.handle(
+            HTTPRequest(method: .post, path: "/v1/chat/completions", headers: [:], body: nonStreamBody)
+        )
+        _ = try await collectBody(streamResponse.body)
+        _ = try await collectBody(nonStreamResponse.body)
+        let streamExt = try #require(await streamWorkerClient.lastGenerateRequest?.execution.ext)
+        let nonStreamExt = try #require(await nonStreamWorkerClient.lastGenerateRequest?.execution.ext)
+        let streamReceipt = try #require(streamExt["melix.compat.policy_receipt_json"])
+        let nonStreamReceipt = try #require(nonStreamExt["melix.compat.policy_receipt_json"])
+        let streamReceiptFields = compatReceiptFieldNames(streamReceipt)
+        let nonStreamReceiptFields = compatReceiptFieldNames(nonStreamReceipt)
+
+        #expect(streamResponse.statusCode == 200)
+        #expect(nonStreamResponse.statusCode == 200)
+        #expect(streamExt["melix.compat.stream_mode"] == "stream")
+        #expect(nonStreamExt["melix.compat.stream_mode"] == "non_stream")
+        #expect(streamExt["melix.compat.compat_surface"] == "openai.chat.completions")
+        #expect(nonStreamExt["melix.compat.compat_surface"] == "openai.chat.completions")
+        #expect(streamExt["melix.compat.reasoning_mode"] == nonStreamExt["melix.compat.reasoning_mode"])
+        #expect(streamExt["melix.compat.reasoning_source"] == nonStreamExt["melix.compat.reasoning_source"])
+        #expect(streamExt["melix.compat.reasoning_effort"] == nonStreamExt["melix.compat.reasoning_effort"])
+        #expect(streamExt["melix.compat.tool_parser_mode"] == nonStreamExt["melix.compat.tool_parser_mode"])
+        #expect(streamExt["melix.compat.tool_parser_source"] == nonStreamExt["melix.compat.tool_parser_source"])
+        #expect(streamExt["melix.compat.tool_namespaces"] == nonStreamExt["melix.compat.tool_namespaces"])
+        #expect(streamExt["melix.compat.tool_choice_requested"] == nonStreamExt["melix.compat.tool_choice_requested"])
+        #expect(streamExt["melix.compat.tool_choice_resolved"] == nonStreamExt["melix.compat.tool_choice_resolved"])
+        #expect(streamExt["melix.compat.structured_output_mode"] == nonStreamExt["melix.compat.structured_output_mode"])
+        #expect(streamExt["melix.compat.output_modalities"] == nonStreamExt["melix.compat.output_modalities"])
+        #expect(streamExt["melix.compat.effective_config_hash"]?.isEmpty == false)
+        #expect(nonStreamExt["melix.compat.effective_config_hash"]?.isEmpty == false)
+        #expect(streamExt["melix.compat.effective_config_hash"] != nonStreamExt["melix.compat.effective_config_hash"])
+        #expect(streamReceiptFields == nonStreamReceiptFields)
+    }
+
+    @Test("non-stream chat rejects over-budget prompts before worker generation")
+    func nonStreamChatRejectsOverBudgetPromptsBeforeWorkerGeneration() async throws {
+        let workerClient = ScriptedWorkerClient(events: [])
+        var model = warmModel()
+        model.maxContext = 8
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [model]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-over-budget-non-stream" })
+        )
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": false,
+              "max_tokens": 4,
+              "messages": [
+                { "role": "user", "content": "one two three four five six seven eight nine ten eleven twelve" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(method: .post, path: "/v1/chat/completions", headers: [:], body: body)
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let error = try #require(payload["error"] as? [String: Any])
+        let metadata = try #require(error["prompt_token_metadata"] as? [String: Any])
+
+        #expect(response.statusCode == 400)
+        #expect(error["code"] as? String == "prompt_budget_exceeded")
+        #expect(error["status"] as? String == "invalid_request_error")
+        #expect(metadata["max_prompt_tokens_requested"] as? Int == 4)
+        #expect(metadata["max_prompt_tokens_effective"] as? Int == 4)
+        #expect(metadata["prompt_tokens_estimated"] as? Int == 12)
+        #expect(metadata["context_window_tokens"] as? Int == 8)
+        #expect(metadata["output_cap_tokens"] as? Int == 4)
+        #expect(metadata["admission_phase"] as? String == "prompt_budget")
+        #expect(metadata["prefill_started"] as? Bool == false)
+        #expect(await workerClient.lastGenerateRequest == nil)
+        #expect(await workerClient.lastPrefillRequest == nil)
+        #expect(await workerClient.lastDecodeRequest == nil)
+    }
+
+    @Test("stream chat rejects over-budget prompts before first SSE data chunk")
+    func streamChatRejectsOverBudgetPromptsBeforeFirstSSEDataChunk() async throws {
+        let workerClient = ScriptedWorkerClient(events: [])
+        var model = warmModel()
+        model.maxContext = 8
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [model]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-over-budget-stream" })
+        )
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": true,
+              "max_tokens": 4,
+              "messages": [
+                { "role": "user", "content": "one two three four five six seven eight nine ten eleven twelve" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(method: .post, path: "/v1/chat/completions", headers: [:], body: body)
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let error = try #require(payload["error"] as? [String: Any])
+        let metadata = try #require(error["prompt_token_metadata"] as? [String: Any])
+
+        #expect(response.statusCode == 400)
+        #expect(response.headers["content-type"] == "application/json")
+        #expect(error["code"] as? String == "prompt_budget_exceeded")
+        #expect(metadata["prompt_tokens_estimated"] as? Int == 12)
+        #expect(metadata["prefill_started"] as? Bool == false)
+        if case .stream = response.body {
+            Issue.record("Stream over-budget rejection must not return an SSE body.")
+        }
+        #expect(await workerClient.lastGenerateRequest == nil)
+        #expect(await workerClient.lastPrefillRequest == nil)
+        #expect(await workerClient.lastDecodeRequest == nil)
+    }
+
+    @Test("max completion tokens remains an output cap in prompt budget admission")
+    func maxCompletionTokensRemainsAnOutputCapInPromptBudgetAdmission() async throws {
+        let workerClient = ScriptedWorkerClient(events: [])
+        var model = warmModel()
+        model.maxContext = 8
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [model]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-over-budget-max-completion" })
+        )
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": false,
+              "max_completion_tokens": 4,
+              "messages": [
+                { "role": "user", "content": "one two three four five" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(method: .post, path: "/v1/chat/completions", headers: [:], body: body)
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let error = try #require(payload["error"] as? [String: Any])
+        let metadata = try #require(error["prompt_token_metadata"] as? [String: Any])
+
+        #expect(response.statusCode == 400)
+        #expect(error["code"] as? String == "prompt_budget_exceeded")
+        #expect(metadata["prompt_tokens_estimated"] as? Int == 5)
+        #expect(metadata["max_prompt_tokens_effective"] as? Int == 4)
+        #expect(metadata["output_cap_tokens"] as? Int == 4)
+        #expect(await workerClient.lastGenerateRequest == nil)
+    }
+
     @Test("chat requests return 409 when the model is not ready")
     func modelNotReadyReturns409() async throws {
         let handler = OpenAIHandler(
@@ -9662,6 +10191,48 @@ private func jsonObject(from body: HTTPBody) async throws -> (errorCode: String,
 private func jsonPayload(from body: HTTPBody) async throws -> [String: Any] {
     let data = try await collectBodyData(body)
     return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+private func compatPolicyChatBody(stream: Bool) -> Data? {
+    """
+    {
+      "model": "melix-dev-text",
+      "stream": \(stream ? "true" : "false"),
+      "enable_thinking": true,
+      "reasoning_effort": "low",
+      "response_format": {
+        "type": "json_schema",
+        "json_schema": {
+          "name": "answer",
+          "schema": { "type": "object" },
+          "strict": true
+        }
+      },
+      "tool_parser": {
+        "mode": "qwen",
+        "namespaces": ["tools.search"]
+      },
+      "tool_choice": "required",
+      "tools": [
+        {
+          "type": "function",
+          "function": {
+            "name": "search",
+            "description": "Search documents",
+            "parameters": { "type": "object" }
+          }
+        }
+      ],
+      "messages": [
+        { "role": "user", "content": "Call a tool and answer as JSON." }
+      ]
+    }
+    """.data(using: .utf8)
+}
+
+private func compatReceiptFieldNames(_ receipt: String) -> Set<String> {
+    let object = (try? JSONSerialization.jsonObject(with: Data(receipt.utf8)) as? [String: Any]) ?? [:]
+    return Set(object.keys)
 }
 
 private final class TestNowUnixMSSequence: @unchecked Sendable {

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -1098,6 +1098,153 @@ struct OpenAIHandlerTests {
         #expect(await workerClient.lastGenerateRequest == nil)
     }
 
+    @Test("generation bounds validation ignores field-like text inside JSON strings")
+    func generationBoundsValidationIgnoresFieldLikeTextInsideJSONString() async throws {
+        let workerClient = ScriptedWorkerClient(events: [
+            makeCompletedEvent(
+                requestID: "req-field-like-string",
+                seq: 1,
+                finishReason: "stop",
+                assistantText: "ok"
+            ),
+        ])
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-field-like-string" })
+        )
+        let body = Data(
+            #"""
+            {
+              "model": "melix-dev-text",
+              "stream": false,
+              "messages": [
+                { "role": "user", "content": "literal \"max_tokens\": 0 should not be parsed as a field" }
+              ]
+            }
+            """#.utf8
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+
+        #expect(response.statusCode == 200)
+        #expect(await workerClient.lastGenerateRequest != nil)
+    }
+
+    @Test("raw generation bounds fallback ignores nested generation-bound fields")
+    func rawGenerationBoundsFallbackIgnoresNestedGenerationBoundFields() async throws {
+        let workerClient = ScriptedWorkerClient(events: [
+            makeCompletedEvent(
+                requestID: "req-nested-generation-bound",
+                seq: 1,
+                finishReason: "stop",
+                assistantText: "ok"
+            ),
+        ])
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-nested-generation-bound" })
+        )
+        let body = Data(
+            #"""
+            {
+              "model": "melix-dev-text",
+              "stream": false,
+              "messages": [
+                { "role": "user", "content": "hello" }
+              ],
+              "metadata": { "max_tokens": 1e999 }
+            }
+            """#.utf8
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+
+        #expect(response.statusCode == 200)
+        #expect(await workerClient.lastGenerateRequest != nil)
+    }
+
+    @Test("prompt budget admission treats dense text and video parts as non-zero budget consumers")
+    func promptBudgetAdmissionTreatsDenseTextAndVideoPartsAsBudgetConsumers() async throws {
+        let workerClient = ScriptedWorkerClient(events: [])
+        var model = ModelCatalog.devVLMModel()
+        model.state = .modelWarm
+        model.maxContext = 512
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [model]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(
+                    defaultTextClient: ScriptedWorkerClient(events: []),
+                    pythonCompatibilityClient: workerClient
+                ),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-dense-video-budget" })
+        )
+        let denseText = String(repeating: "a", count: 2048)
+        let body = Data(
+            """
+            {
+              "model": "melix-dev-vlm",
+              "stream": true,
+              "max_tokens": 128,
+              "messages": [
+                {
+                  "role": "user",
+                  "content": [
+                    { "type": "text", "text": "\(denseText)" },
+                    {
+                      "type": "input_video",
+                      "input_video": {
+                        "data": "\(Data("video fixture".utf8).base64EncodedString())",
+                        "format": "mp4",
+                        "frame_count": 2,
+                        "frame_budget": 2,
+                        "window_ms": 1000
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(method: .post, path: "/v1/chat/completions", headers: [:], body: body)
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let error = try #require(payload["error"] as? [String: Any])
+        let metadata = try #require(error["prompt_token_metadata"] as? [String: Any])
+
+        #expect(response.statusCode == 400)
+        #expect(error["code"] as? String == "prompt_budget_exceeded")
+        #expect((metadata["prompt_tokens_estimated"] as? Int ?? 0) > 512)
+        #expect(metadata["prefill_started"] as? Bool == false)
+        #expect(await workerClient.lastGenerateRequest == nil)
+    }
+
     @Test("POST /v1/chat/completions routes by payload model within the active server roster")
     func postChatCompletionsRoutesByPayloadModelWithinActiveServerRoster() async throws {
         var primary = ModelCatalog.devTextModel()
@@ -8834,7 +8981,7 @@ struct OpenAIHandlerTests {
         #expect(error["status"] as? String == "invalid_request_error")
         #expect(metadata["max_prompt_tokens_requested"] as? Int == 4)
         #expect(metadata["max_prompt_tokens_effective"] as? Int == 4)
-        #expect(metadata["prompt_tokens_estimated"] as? Int == 12)
+        #expect(metadata["prompt_tokens_estimated"] as? Int == 16)
         #expect(metadata["context_window_tokens"] as? Int == 8)
         #expect(metadata["output_cap_tokens"] as? Int == 4)
         #expect(metadata["admission_phase"] as? String == "prompt_budget")
@@ -8880,7 +9027,7 @@ struct OpenAIHandlerTests {
         #expect(response.statusCode == 400)
         #expect(response.headers["content-type"] == "application/json")
         #expect(error["code"] as? String == "prompt_budget_exceeded")
-        #expect(metadata["prompt_tokens_estimated"] as? Int == 12)
+        #expect(metadata["prompt_tokens_estimated"] as? Int == 16)
         #expect(metadata["prefill_started"] as? Bool == false)
         if case .stream = response.body {
             Issue.record("Stream over-budget rejection must not return an SSE body.")
@@ -8925,7 +9072,7 @@ struct OpenAIHandlerTests {
 
         #expect(response.statusCode == 400)
         #expect(error["code"] as? String == "prompt_budget_exceeded")
-        #expect(metadata["prompt_tokens_estimated"] as? Int == 5)
+        #expect(metadata["prompt_tokens_estimated"] as? Int == 6)
         #expect(metadata["max_prompt_tokens_effective"] as? Int == 4)
         #expect(metadata["output_cap_tokens"] as? Int == 4)
         #expect(await workerClient.lastGenerateRequest == nil)

--- a/services/mlx-worker-python/tests/test_generate_stream.py
+++ b/services/mlx-worker-python/tests/test_generate_stream.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 from packages.protocol.python.worker.v1 import common_pb2, inference_pb2, runtime_pb2
@@ -9,7 +10,7 @@ from worker.grpc_server import WorkerInferenceService, WorkerRuntimeService
 from worker.model_registry.catalog import WorkerModelCatalog
 from worker.registry import WorkerRegistry
 from worker.runtime import mlx_text_runtime
-from worker.runtime.mlx_text_runtime import AutoMLXBackend, MLXTextRuntime, RuntimeTokenEvent
+from worker.runtime.mlx_text_runtime import AutoMLXBackend, MLXTextRuntime, RuntimeTokenEvent, RuntimeToolCallEvent
 
 
 class StreamingFakeBackend:
@@ -578,6 +579,169 @@ def test_generate_streams_token_and_terminal_completion() -> None:
     usage = next(event.usage_delta for event in events if event.HasField("usage_delta"))
     assert usage.prompt_tokens == 5
     assert usage.completion_tokens == 2
+
+    structured_registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=StructuredStreamingBackend()),
+        model_catalog=WorkerModelCatalog(),
+    )
+    structured_runtime_service = WorkerRuntimeService(structured_registry)
+    structured_inference_service = WorkerInferenceService(structured_registry)
+    structured_handle = structured_runtime_service.LoadModel(
+        runtime_pb2.LoadModelRequest(model=WorkerModelCatalog.dev_text_model()),
+        context=None,
+    ).model_handle
+    structured_request = inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id="req-generate-structured-receipts"),
+            model_handle=structured_handle,
+            ext={
+                "melix.compat.policy_receipt_json": (
+                    '{"reasoning_mode":"enabled","tool_choice_resolved":"required"}'
+                ),
+                "melix.reasoning.mode": "enabled",
+                "melix.tool_parser.mode": "qwen",
+            },
+            reasoning=common_pb2.ReasoningConfig(enabled=True),
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="Use a tool")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=16),
+        stream=True,
+    )
+    structured_events = list(structured_inference_service.Generate(structured_request, context=None))
+    structured_completed = next(
+        event.completed for event in structured_events if event.HasField("completed")
+    )
+    token_route_receipt = json.loads(
+        structured_completed.parser_metrics["token_route_receipt_json"]
+    )
+
+    assert structured_completed.parser_metrics["generated_reasoning_delta_count"] == "1"
+    assert structured_completed.parser_metrics["generated_tool_call_delta_count"] == "1"
+    assert token_route_receipt["reasoning_mode"] == "enabled"
+    assert token_route_receipt["tool_choice_policy"] == "required"
+    assert token_route_receipt["visible_text_tokens"] == 1
+    assert token_route_receipt["hidden_reasoning_tokens"] == 1
+
+    class RuntimeToolEventBackend:
+        runtime_name = "fake-mlx"
+
+        def load_model(self, model_spec):
+            return {"model_id": model_spec.model_id}
+
+        def estimate_resident_bytes(self, model_spec):
+            _ = model_spec
+            return 2048
+
+        def generate_tokens(self, loaded_model, prompt, sampling, cancel_event):
+            _ = loaded_model
+            _ = prompt
+            _ = sampling
+            _ = cancel_event
+            yield RuntimeToolCallEvent(
+                call_id="call-native",
+                tool_name="lookup",
+                arguments_json_fragment='{"q":"native"}',
+            )
+            yield RuntimeTokenEvent(text="done", prompt_tokens=4, completion_tokens=1, finish_reason="stop")
+
+    native_tool_registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=RuntimeToolEventBackend()),
+        model_catalog=WorkerModelCatalog(),
+    )
+    native_tool_runtime_service = WorkerRuntimeService(native_tool_registry)
+    native_tool_inference_service = WorkerInferenceService(native_tool_registry)
+    native_tool_handle = native_tool_runtime_service.LoadModel(
+        runtime_pb2.LoadModelRequest(model=WorkerModelCatalog.dev_text_model()),
+        context=None,
+    ).model_handle
+    native_tool_request = inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id="req-native-tool-event"),
+            model_handle=native_tool_handle,
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="Call native tool")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=16),
+        stream=True,
+    )
+    native_tool_events = list(
+        native_tool_inference_service.Generate(native_tool_request, context=None)
+    )
+    native_tool_call = next(
+        event.tool_call_delta for event in native_tool_events if event.HasField("tool_call_delta")
+    )
+    native_tool_completed = next(
+        event.completed for event in native_tool_events if event.HasField("completed")
+    )
+
+    assert native_tool_call.tool_name == "lookup"
+    assert native_tool_call.arguments_json_fragment == '{"q":"native"}'
+    assert native_tool_completed.parser_metrics["generated_tool_call_delta_count"] == "1"
+    native_tool_receipt = json.loads(
+        native_tool_completed.parser_metrics["token_route_receipt_json"]
+    )
+    assert native_tool_receipt["route_tracking_enabled"] is True
+    assert native_tool_receipt["tool_choice_policy"] == "auto"
+
+    inactive_route_request = inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id="req-inactive-route-receipt"),
+            model_handle=model_handle,
+            ext={"melix.response.created": "123"},
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="Say hello")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=16),
+        stream=True,
+    )
+    inactive_events = list(inference_service.Generate(inactive_route_request, context=None))
+    inactive_completed = next(
+        event.completed for event in inactive_events if event.HasField("completed")
+    )
+    inactive_receipt = json.loads(
+        inactive_completed.parser_metrics["token_route_receipt_json"]
+    )
+    assert inactive_receipt["route_tracking_enabled"] is False
+    assert inactive_receipt["reasoning_mode"] == "disabled"
+    assert inactive_receipt["tool_choice_policy"] == "auto"
+    assert EngineCore._token_route_receipt(inactive_route_request, {}) is None
+    assert json.loads(
+        EngineCore._inactive_token_route_receipt_json(inactive_route_request, {})
+    ) == inactive_receipt
+    active_receipt = EngineCore._active_token_route_receipt(inactive_route_request)
+    assert active_receipt.enabled is True
+    assert json.loads(active_receipt.to_json())["route_tracking_enabled"] is True
+
+    class RuntimeWithBlockedAccelerationCache:
+        def __setattr__(self, name, value):
+            if name == "_melix_accepts_acceleration_policy":
+                raise RuntimeError("cache unavailable")
+
+        def generate_tokens(self, acceleration_policy=None):
+            return ()
+
+    blocked_runtime = RuntimeWithBlockedAccelerationCache()
+    assert engine_core_module._runtime_accepts_acceleration_policy(
+        blocked_runtime,
+        blocked_runtime.generate_tokens,
+    )
+    assert EngineCore._compat_policy_receipt({}) == {}
+    assert EngineCore._compat_policy_receipt({"melix.compat.policy_receipt_json": ""}) == {}
+    assert EngineCore._compat_policy_receipt({"melix.compat.policy_receipt_json": "{"}) == {}
+    assert EngineCore._compat_policy_receipt({"melix.compat.policy_receipt_json": "[]"}) == {}
 
 
 def test_generate_streams_reasoning_tool_and_content_channels_from_raw_text() -> None:

--- a/services/mlx-worker-python/tests/test_generate_stream.py
+++ b/services/mlx-worker-python/tests/test_generate_stream.py
@@ -721,6 +721,59 @@ def test_generate_streams_token_and_terminal_completion() -> None:
     assert json.loads(
         EngineCore._inactive_token_route_receipt_json(inactive_route_request, {})
     ) == inactive_receipt
+    plain_compat_receipt = json.dumps(
+        {
+            "reasoning_mode": "disabled",
+            "tool_choice_resolved": "auto",
+        },
+        sort_keys=True,
+    )
+    inactive_compat_request = inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id="req-inactive-compat-route-receipt"),
+            model_handle=model_handle,
+            ext={
+                "melix.compat.policy_receipt_json": plain_compat_receipt,
+                "melix.compat.effective_config_hash": "plain-compat-hash",
+                "melix.response.created": "1716500000",
+            },
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="Say hello")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=16),
+        stream=True,
+    )
+    assert EngineCore._plain_text_fast_path(inactive_compat_request) is True
+    inactive_compat_events = list(inference_service.Generate(inactive_compat_request, context=None))
+    inactive_compat_completed = next(
+        event.completed for event in inactive_compat_events if event.HasField("completed")
+    )
+    inactive_compat_receipt = json.loads(
+        inactive_compat_completed.parser_metrics["token_route_receipt_json"]
+    )
+    assert inactive_compat_receipt["route_tracking_enabled"] is False
+    assert inactive_compat_receipt["reasoning_mode"] == "disabled"
+    assert inactive_compat_receipt["tool_choice_policy"] == "auto"
+    assert inactive_compat_completed.parser_metrics["compat_policy_receipt_json"] == plain_compat_receipt
+    assert inactive_compat_completed.parser_metrics["compat_effective_config_hash"] == "plain-compat-hash"
+    assert inactive_compat_completed.parser_metrics["created"] == "1716500000"
+    assert EngineCore._ext_requires_token_route_tracking(
+        {"melix.structured_output.mode": "json_schema"}
+    ) is True
+    assert EngineCore._ext_requires_token_route_tracking(
+        {"melix.reasoning.mode": "adaptive"}
+    ) is True
+    assert EngineCore._ext_requires_token_route_tracking(
+        {"melix.compat.tool_choice_resolved": "required"}
+    ) is True
+    assert EngineCore._ext_requires_token_route_tracking(
+        {},
+        {"reasoning_mode": "enabled"},
+    ) is True
     active_receipt = EngineCore._active_token_route_receipt(inactive_route_request)
     assert active_receipt.enabled is True
     assert json.loads(active_receipt.to_json())["route_tracking_enabled"] is True

--- a/services/mlx-worker-python/tests/test_generate_stream_receipts.py
+++ b/services/mlx-worker-python/tests/test_generate_stream_receipts.py
@@ -97,6 +97,49 @@ def test_generate_completed_event_preserves_compatibility_policy_receipt() -> No
     assert "hidden" not in completed.parser_metrics["compat_policy_receipt_json"]
 
 
+def test_plain_compatibility_receipt_keeps_metadata_without_route_tracking() -> None:
+    inference_service, model_handle = _build_services(FinalizerParityBackend(raw_text="plain answer"))
+    receipt = json.dumps(
+        {
+            "compat_surface": "openai.chat.completions",
+            "reasoning_mode": "disabled",
+            "stream_mode": "stream",
+            "tool_choice_resolved": "auto",
+        },
+        sort_keys=True,
+    )
+    request = inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id="req-plain-compat-policy-receipt"),
+            model_handle=model_handle,
+            ext={
+                "melix.compat.policy_receipt_json": receipt,
+                "melix.compat.effective_config_hash": "plain123",
+                "melix.response.created": "1716500000",
+            },
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="Say hello")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=16),
+        stream=True,
+    )
+
+    completed = next(
+        event.completed for event in inference_service.Generate(request, context=None)
+        if event.HasField("completed")
+    )
+    token_route_receipt = json.loads(completed.parser_metrics["token_route_receipt_json"])
+
+    assert completed.parser_metrics["compat_policy_receipt_json"] == receipt
+    assert completed.parser_metrics["compat_effective_config_hash"] == "plain123"
+    assert completed.parser_metrics["created"] == "1716500000"
+    assert token_route_receipt["route_tracking_enabled"] is False
+
+
 def test_generate_token_route_receipt_uses_compat_policy_context_and_matches_stream_modes() -> None:
     inference_service, model_handle = _build_services(StructuredStreamingBackend())
     compat_receipt = (

--- a/services/mlx-worker-python/tests/test_generate_stream_receipts.py
+++ b/services/mlx-worker-python/tests/test_generate_stream_receipts.py
@@ -1,0 +1,353 @@
+import json
+
+import pytest
+
+from packages.protocol.python.worker.v1 import common_pb2, inference_pb2, runtime_pb2
+
+from worker.grpc_server import WorkerInferenceService, WorkerRuntimeService
+from worker.model_registry.catalog import WorkerModelCatalog
+from worker.registry import WorkerRegistry
+from worker.runtime.mlx_text_runtime import MLXTextRuntime, RuntimeTokenEvent
+
+
+class StructuredStreamingBackend:
+    runtime_name = "fake-mlx"
+
+    def load_model(self, model_spec):
+        return {"model_id": model_spec.model_id}
+
+    def estimate_resident_bytes(self, model_spec):
+        return 2048
+
+    def generate_tokens(self, loaded_model, prompt, sampling, cancel_event):
+        yield RuntimeTokenEvent(
+            text="",
+            raw_text=(
+                '<think>trace</think>'
+                '<tool_call>{"name":"search","arguments":{"q":"one"}}</tool_call>'
+                "visible"
+            ),
+            prompt_tokens=3,
+            completion_tokens=1,
+            finish_reason="stop",
+        )
+
+
+class FinalizerParityBackend:
+    runtime_name = "fake-mlx"
+
+    def __init__(self, *, raw_text: str, prompt_tokens: int = 11, completion_tokens: int = 3) -> None:
+        self.raw_text = raw_text
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+
+    def load_model(self, model_spec):
+        return {"model_id": model_spec.model_id}
+
+    def estimate_resident_bytes(self, model_spec):
+        return 2048
+
+    def generate_tokens(self, loaded_model, prompt, sampling, cancel_event):
+        _ = loaded_model
+        _ = prompt
+        _ = sampling
+        _ = cancel_event
+        yield RuntimeTokenEvent(
+            text="",
+            raw_text=self.raw_text,
+            prompt_tokens=self.prompt_tokens,
+            completion_tokens=self.completion_tokens,
+            finish_reason="length",
+        )
+
+
+def test_generate_completed_event_preserves_compatibility_policy_receipt() -> None:
+    inference_service, model_handle = _build_services(StructuredStreamingBackend())
+    receipt = (
+        '{"compat_surface":"openai.chat.completions",'
+        '"effective_config_hash":"abc123",'
+        '"reasoning_mode":"enabled",'
+        '"stream_mode":"stream"}'
+    )
+    request = inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id="req-compat-policy-receipt"),
+            model_handle=model_handle,
+            ext={
+                "melix.compat.policy_receipt_json": receipt,
+                "melix.compat.effective_config_hash": "abc123",
+                "melix.compat.reasoning_mode": "enabled",
+            },
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="Use a tool")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=16),
+        stream=True,
+    )
+
+    events = list(inference_service.Generate(request, context=None))
+    completed = next(event.completed for event in events if event.HasField("completed"))
+
+    assert completed.parser_metrics["compat_policy_receipt_json"] == receipt
+    assert completed.parser_metrics["compat_effective_config_hash"] == "abc123"
+    assert "hidden" not in completed.parser_metrics["compat_policy_receipt_json"]
+
+
+def test_generate_token_route_receipt_uses_compat_policy_context_and_matches_stream_modes() -> None:
+    inference_service, model_handle = _build_services(StructuredStreamingBackend())
+    compat_receipt = (
+        '{"compat_surface":"openai.chat.completions",'
+        '"reasoning_mode":"enabled",'
+        '"tool_choice_resolved":"required",'
+        '"stream_mode":"stream"}'
+    )
+
+    stream_completed = next(
+        event.completed
+        for event in inference_service.Generate(
+            _token_route_request(model_handle, compat_receipt=compat_receipt, stream=True),
+            context=None,
+        )
+        if event.HasField("completed")
+    )
+    non_stream_completed = next(
+        event.completed
+        for event in inference_service.Generate(
+            _token_route_request(model_handle, compat_receipt=compat_receipt, stream=False),
+            context=None,
+        )
+        if event.HasField("completed")
+    )
+    stream_receipt = json.loads(stream_completed.parser_metrics["token_route_receipt_json"])
+    non_stream_receipt = json.loads(non_stream_completed.parser_metrics["token_route_receipt_json"])
+
+    assert stream_completed.assistant_text == non_stream_completed.assistant_text == "visible"
+    assert stream_completed.reasoning_text == non_stream_completed.reasoning_text == "trace"
+    assert stream_receipt["tool_choice_policy"] == "required"
+    assert stream_receipt["reasoning_mode"] == "enabled"
+    assert stream_receipt["visible_text_tokens"] == non_stream_receipt["visible_text_tokens"] == 1
+    assert stream_receipt["hidden_reasoning_tokens"] == non_stream_receipt["hidden_reasoning_tokens"] == 1
+    assert stream_receipt["routes"] == non_stream_receipt["routes"]
+
+
+@pytest.mark.parametrize(
+    ("case_id", "raw_text", "expected"),
+    [
+        (
+            "plain",
+            "plain final answer",
+            {
+                "reasoning_finalized": "false",
+                "tool_calls_finalized": "false",
+                "malformed_channel_recovered": "false",
+            },
+        ),
+        (
+            "reasoning",
+            "<think>hidden trace</think>visible answer",
+            {
+                "reasoning_finalized": "true",
+                "tool_calls_finalized": "false",
+                "malformed_channel_recovered": "false",
+            },
+        ),
+        (
+            "tool",
+            '<tool_call>{"name":"search","arguments":{"q":"one"}}</tool_call>',
+            {
+                "reasoning_finalized": "false",
+                "tool_calls_finalized": "true",
+                "malformed_channel_recovered": "false",
+            },
+        ),
+        (
+            "malformed",
+            "<|channel>thought hidden\n\nFinal answer",
+            {
+                "reasoning_finalized": "true",
+                "tool_calls_finalized": "false",
+                "malformed_channel_recovered": "true",
+            },
+        ),
+        (
+            "truncated",
+            'visible <tool_call>{"name":"search","arguments":{"q":"unfinished"}',
+            {
+                "reasoning_finalized": "false",
+                "tool_calls_finalized": "true",
+                "malformed_channel_recovered": "true",
+            },
+        ),
+    ],
+)
+def test_generate_finalizer_receipt_matches_for_stream_and_non_stream_modes(
+    case_id: str,
+    raw_text: str,
+    expected: dict[str, str],
+) -> None:
+    stream_events = _generate_finalizer_events(
+        raw_text=raw_text,
+        stream=True,
+        request_id=f"req-finalizer-stream-{case_id}",
+    )
+    non_stream_events = _generate_finalizer_events(
+        raw_text=raw_text,
+        stream=False,
+        request_id=f"req-finalizer-non-stream-{case_id}",
+    )
+
+    stream_receipt = _finalizer_receipt(stream_events)
+    non_stream_receipt = _finalizer_receipt(non_stream_events)
+
+    for field in (
+        "response_id",
+        "created",
+        "stream_mode",
+        "finish_reason",
+        "usage_prompt_tokens",
+        "usage_completion_tokens",
+        "usage_total_tokens",
+        "usage_trailer_emitted",
+        "reasoning_finalized",
+        "tool_calls_finalized",
+        "malformed_channel_recovered",
+        "finalizer_path",
+    ):
+        assert field in stream_receipt
+        assert field in non_stream_receipt
+
+    assert stream_receipt["response_id"] == f"req-finalizer-stream-{case_id}"
+    assert non_stream_receipt["response_id"] == f"req-finalizer-non-stream-{case_id}"
+    assert stream_receipt["stream_mode"] == "true"
+    assert non_stream_receipt["stream_mode"] == "false"
+    assert stream_receipt["finalizer_path"] == "stream"
+    assert non_stream_receipt["finalizer_path"] == "non_stream"
+    assert stream_receipt["usage_trailer_emitted"] == "true"
+    assert non_stream_receipt["usage_trailer_emitted"] == "false"
+    assert _normalized_finalizer_receipt(stream_receipt) == _normalized_finalizer_receipt(
+        non_stream_receipt
+    )
+    assert stream_receipt["finish_reason"] == "length"
+    assert stream_receipt["usage_prompt_tokens"] == "11"
+    assert stream_receipt["usage_completion_tokens"] == "3"
+    assert stream_receipt["usage_total_tokens"] == "14"
+    for key, value in expected.items():
+        assert stream_receipt[key] == value
+
+
+def _token_route_request(
+    model_handle: str,
+    *,
+    compat_receipt: str,
+    stream: bool,
+) -> inference_pb2.GenerateRequest:
+    return inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(
+                request_id=f"req-token-route-{'stream' if stream else 'non-stream'}"
+            ),
+            model_handle=model_handle,
+            ext={
+                "melix.compat.policy_receipt_json": compat_receipt,
+                "melix.compat.reasoning_mode": "enabled",
+                "melix.compat.tool_choice_resolved": "required",
+                "melix.reasoning.mode": "enabled",
+                "melix.tool_parser.mode": "qwen",
+            },
+            reasoning=common_pb2.ReasoningConfig(
+                enabled=True,
+                mode_source="request_enable_thinking",
+            ),
+            tool_config=common_pb2.ToolConfig(
+                tools=[
+                    common_pb2.ToolDefinition(
+                        name="search",
+                        json_schema='{"type":"object"}',
+                    )
+                ],
+                tool_choice="required",
+            ),
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="Use a tool")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=16),
+        stream=stream,
+    )
+
+
+def _generate_finalizer_events(
+    *,
+    raw_text: str,
+    stream: bool,
+    request_id: str,
+    return_usage: bool = True,
+):
+    inference_service, model_handle = _build_services(FinalizerParityBackend(raw_text=raw_text))
+    request = inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id=request_id),
+            model_handle=model_handle,
+            ext={
+                "melix.reasoning.mode": "enabled",
+                "melix.tool_parser.mode": "qwen",
+                "melix.response.created": "1716500000",
+            },
+            reasoning=common_pb2.ReasoningConfig(
+                enabled=True,
+                mode_source="request_enable_thinking",
+                effort="medium",
+            ),
+            tool_config=common_pb2.ToolConfig(
+                tools=[
+                    common_pb2.ToolDefinition(
+                        name="search",
+                        description="Search local fixtures.",
+                        json_schema='{"type":"object"}',
+                    )
+                ],
+                parser="qwen",
+            ),
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="finalizer parity")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=8),
+        stream=stream,
+        return_usage=return_usage,
+    )
+    return list(inference_service.Generate(request, context=None))
+
+
+def _build_services(backend):
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=backend),
+        model_catalog=WorkerModelCatalog(),
+    )
+    runtime_service = WorkerRuntimeService(registry)
+    inference_service = WorkerInferenceService(registry)
+    load_response = runtime_service.LoadModel(
+        runtime_pb2.LoadModelRequest(model=WorkerModelCatalog.dev_text_model()),
+        context=None,
+    )
+    return inference_service, load_response.model_handle
+
+
+def _finalizer_receipt(events) -> dict[str, str]:
+    completed = next(event.completed for event in events if event.HasField("completed"))
+    return dict(completed.parser_metrics)
+
+
+def _normalized_finalizer_receipt(receipt: dict[str, str]) -> dict[str, str]:
+    ignored = {"response_id", "stream_mode", "usage_trailer_emitted", "finalizer_path"}
+    return {key: value for key, value in receipt.items() if key not in ignored}

--- a/services/mlx-worker-python/tests/test_lora_experiment_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_receipts.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worker.productization.lora_experiment_store import LoraExperimentStore
+
+
+def test_persist_training_run_preserves_lora_canary_receipts(tmp_path: Path) -> None:
+    jobs_root = tmp_path / "model-ops"
+    manifest_path = jobs_root / "train_lora" / "model-ops-0001" / "train_lora.adapter.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "job_id": "model-ops-0001",
+        "operation": "train_lora",
+        "adapter_name": "demo-adapter",
+        "source_model": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+        "source_eos_token": "<|source-eos|>",
+        "saved_eos_token": "<|source-eos|>",
+        "tokenizer_config_path": "/tmp/base/tokenizer_config.json",
+        "base_config_present": True,
+        "processor_resume_mode": "processor_config",
+        "aux_modules_restored": True,
+        "merge_export_canary_result": "pass",
+        "callback_api_drift_result": "pass",
+        "completion_loss": 0.125,
+        "round_trip_passed": True,
+        "grad_norm": 0.75,
+        "updated_at_unix_ms": 1_000,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    paths = LoraExperimentStore().persist_training_run(
+        jobs_root=jobs_root,
+        manifest=manifest,
+        manifest_path=manifest_path,
+    )
+    run_payload = json.loads(paths["run"].read_text(encoding="utf-8"))
+
+    assert run_payload["source_eos_token"] == "<|source-eos|>"
+    assert run_payload["saved_eos_token"] == "<|source-eos|>"
+    assert run_payload["tokenizer_config_path"] == "/tmp/base/tokenizer_config.json"
+    assert run_payload["base_config_present"] is True
+    assert run_payload["processor_resume_mode"] == "processor_config"
+    assert run_payload["aux_modules_restored"] is True
+    assert run_payload["merge_export_canary_result"] == "pass"
+    assert run_payload["callback_api_drift_result"] == "pass"
+    assert run_payload["completion_loss"] == 0.125
+    assert run_payload["round_trip_passed"] is True
+    assert run_payload["grad_norm"] == 0.75

--- a/services/mlx-worker-python/tests/test_lora_experiment_store.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_store.py
@@ -58,6 +58,7 @@ def _write_manifest(
     group_id: str = "nightly-qwen",
     updated_at_unix_ms: int = 0,
     created_at_unix_ms: int | None = None,
+    extra: dict[str, object] | None = None,
 ) -> Path:
     manifest_dir = jobs_root / "train_lora" / run_id
     manifest_dir.mkdir(parents=True, exist_ok=True)
@@ -72,6 +73,8 @@ def _write_manifest(
     }
     if created_at_unix_ms is not None:
         payload["created_at_unix_ms"] = created_at_unix_ms
+    if extra is not None:
+        payload.update(extra)
     manifest_path.write_text(
         json.dumps(payload, indent=2) + "\n",
         encoding="utf-8",
@@ -223,6 +226,28 @@ def test_rebuild_index_prefers_run_record_over_manifest_when_both_exist(tmp_path
     assert payload["runs"][0]["manifest_path"] == "/tmp/model-ops-0001/from-run-record.json"
     assert payload["runs"][0]["checkpoint_count"] == 2
     assert payload["runs"][0]["adapter_name"] == "demo-adapter"
+
+    _write_manifest(
+        jobs_root,
+        run_id="model-ops-0002",
+        adapter_name="manifest-only-adapter",
+        updated_at_unix_ms=1_500,
+        extra={
+            "source_eos_token": "<eos>",
+            "saved_eos_token": "<eos>",
+            "merge_export_canary_result": "passed",
+            "round_trip_passed": True,
+        },
+    )
+
+    payload = LoraExperimentStore().rebuild_index(jobs_root)
+    manifest_only_run = next(run for run in payload["runs"] if run["run_id"] == "model-ops-0002")
+
+    assert manifest_only_run["adapter_name"] == "manifest-only-adapter"
+    assert manifest_only_run["source_eos_token"] == "<eos>"
+    assert manifest_only_run["saved_eos_token"] == "<eos>"
+    assert manifest_only_run["merge_export_canary_result"] == "passed"
+    assert manifest_only_run["round_trip_passed"] is True
 
 
 def test_rebuild_index_skips_manifest_parse_when_run_record_exists(tmp_path: Path, monkeypatch) -> None:

--- a/services/mlx-worker-python/tests/test_lora_training_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_receipts.py
@@ -330,6 +330,61 @@ def test_training_runtime_preflight_records_healthy_and_missing_decoder_states(
     assert fields["disabled_decoder_paths"] == expected_disabled_paths
 
 
+def test_training_runtime_preflight_reports_partial_decoder_state_when_video_decoder_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fake_find_spec(name: str):
+        if name in {"mlx", "mlx_lm"}:
+            return object()
+        if name == "av":
+            return None
+        return object()
+
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("importlib.util.find_spec", fake_find_spec)
+    monkeypatch.setattr("importlib.import_module", lambda name: object())
+
+    fields = _training_runtime_preflight_fields(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        adapter_scope={"training_surface": "model"},
+    )
+
+    dependency = fields["media_decoder_dependency"]
+    assert dependency["state"] == "partial"
+    assert dependency["module"] == "av"
+    assert dependency["modules"]["PIL"]["state"] == "healthy"
+    assert dependency["modules"]["av"]["state"] == "missing"
+    assert fields["disabled_decoder_paths"] == ["media"]
+
+
+def test_training_runtime_preflight_reports_broken_decoder_spec_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fake_find_spec(name: str):
+        if name in {"mlx", "mlx_lm"}:
+            return object()
+        if name == "PIL":
+            raise ValueError("corrupt decoder spec")
+        return object()
+
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("importlib.util.find_spec", fake_find_spec)
+
+    fields = _training_runtime_preflight_fields(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        adapter_scope={"training_surface": "model"},
+    )
+
+    dependency = fields["media_decoder_dependency"]
+    assert dependency["state"] == "broken"
+    assert dependency["module"] == "PIL"
+    assert dependency["modules"]["PIL"]["state"] == "broken"
+    assert dependency["message"] == "corrupt decoder spec"
+    assert fields["disabled_decoder_paths"] == ["media"]
+
+
 def test_training_failure_cleanup_details_clear_nested_tracebacks_and_report_retained_bytes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -337,7 +392,10 @@ def test_training_failure_cleanup_details_clear_nested_tracebacks_and_report_ret
     fake_mlx_pkg = types.ModuleType("mlx")
     fake_mlx_pkg.__path__ = []
     fake_mlx_core = types.ModuleType("mlx.core")
-    fake_mlx_core.metal = types.SimpleNamespace(get_peak_memory=lambda: 4096)
+    fake_mlx_core.metal = types.SimpleNamespace(
+        get_active_memory=lambda: 4096,
+        get_peak_memory=lambda: 999999,
+    )
     fake_mlx_pkg.core = fake_mlx_core
     monkeypatch.setitem(sys.modules, "mlx", fake_mlx_pkg)
     monkeypatch.setitem(sys.modules, "mlx.core", fake_mlx_core)
@@ -378,6 +436,8 @@ def test_training_failure_cleanup_details_clear_nested_tracebacks_and_report_ret
     assert exc.value.code == "backend_training_failure"
     assert exc.value.details["traceback_cleanup_result"] == "cleared"
     assert exc.value.details["retained_tensor_bytes_after_failure"] == "4096"
+    assert "outer training failed" in exc.value.details["traceback_summary_before_cleanup"]
+    assert "inner tensor load failed" in exc.value.details["traceback_summary_before_cleanup"]
     assert captured["outer"].__traceback__ is None
     assert captured["inner"].__traceback__ is None
 

--- a/services/mlx-worker-python/tests/test_lora_training_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_receipts.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+from packages.protocol.python.worker.v1 import common_pb2
+
+from worker.model_ops.deterministic_lora_runner import DeterministicLoRARunner
+from worker.model_ops.errors import ModelOperationError
+from worker.model_ops import training_config as training_config_module
+from worker.model_ops.lora_runtime_metadata import build_lora_canary_receipt_fields
+from worker.model_ops.lora_training_pipeline import (
+    LoRATrainingPipeline,
+)
+from worker.model_ops.training_runtime_preflight import (
+    training_runtime_preflight_fields as _training_runtime_preflight_fields,
+)
+from worker.model_ops.mlx_lm_runner import TrainingMetrics
+
+
+def _write_dataset_package(
+    root: Path,
+    *,
+    manifest_payload: dict[str, object] | None = None,
+    sample_lines: list[str] | None = None,
+    valid_lines: list[str] | None = None,
+) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    manifest = manifest_payload or {
+        "schema_version": "melix.training_dataset_package.v1",
+        "dataset_id": "melix-dev-dataset",
+        "format": "chat_messages",
+        "sample_count": 1,
+        "version": "1",
+    }
+    (root / "manifest.json").write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+    lines = sample_lines or [
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "world"},
+                ]
+            }
+        )
+    ]
+    (root / "samples.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    if valid_lines is not None:
+        (root / "valid.jsonl").write_text("\n".join(valid_lines) + "\n", encoding="utf-8")
+    return root
+
+
+def _text_model(*, model_path: str = "models/plain-llama", family_id: str = "") -> common_pb2.ModelSpec:
+    model = common_pb2.ModelSpec(
+        model_id="melix-test-text",
+        model_path=model_path,
+        model_kind="text",
+        revision="main",
+        max_context=4096,
+    )
+    if family_id:
+        model.ext["text_family_id"] = family_id
+    model.ext["text_layer_count"] = "2"
+    return model
+
+
+def _gemma4_vlm_model(*, model_path: str = "models/gemma-4-E4B-it-bf16") -> common_pb2.ModelSpec:
+    model = common_pb2.ModelSpec(
+        model_id="melix-gemma4-vlm",
+        model_path=model_path,
+        model_kind="vlm",
+        revision="main",
+        max_context=8192,
+    )
+    model.ext["melix.lora.family_id"] = "gemma"
+    model.ext["melix.lora.family_kind"] = "dense"
+    model.ext["melix.lora.support_tier"] = "stable"
+    model.ext["melix.lora.training_ready"] = "true"
+    model.ext["melix.lora.default_target_preset"] = "attention_mlp"
+    model.ext["melix.lora.adapter_scope"] = "text_backbone"
+    model.ext["melix.lora.training_surface"] = "text_backbone"
+    model.ext["melix.lora.base_model_path"] = model_path
+    model.ext["melix.lora.component_model_type"] = "gemma4_text"
+    model.ext["melix.component.text_backbone.model_type"] = "gemma4_text"
+    model.ext["melix.component.text_backbone.family_id"] = "gemma"
+    model.ext["melix.component.text_backbone.lora_supported"] = "true"
+    model.ext["melix.component.text_backbone.training_ready"] = "true"
+    return model
+
+
+def test_training_admission_rejects_invalid_hyperparameters_with_typed_details() -> None:
+    with pytest.raises(ModelOperationError) as exc:
+        training_config_module.normalize_training_config(
+            source_model=_text_model(family_id="qwen"),
+            ext={"rank": "0"},
+            dataset_format="chat_messages",
+            response_only_supported=True,
+            sample_count=1,
+        )
+
+    assert exc.value.code == "invalid_argument"
+    assert exc.value.details == {
+        "field": "rank",
+        "reason": "below_minimum",
+        "received": "0",
+        "minimum": "1",
+        "allowed_bounds": ">=1",
+        "http_status": "422",
+    }
+
+
+def test_training_admission_receipt_records_resolved_controls(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset-with-validation",
+        valid_lines=[
+            json.dumps(
+                {
+                    "messages": [
+                        {"role": "user", "content": "validate"},
+                        {"role": "assistant", "content": "ok"},
+                    ]
+                }
+            )
+        ],
+    )
+
+    result = LoRATrainingPipeline(runner=DeterministicLoRARunner()).run(
+        job_id="train-admission-receipts",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "receipt-adapter",
+            "dataset_uri": str(dataset_dir),
+            "max_steps": "0",
+            "grad_clip": "0.25",
+        },
+        source_model=_text_model(family_id="qwen"),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    manifest = result.manifest
+    assert manifest["validation_errors"] == []
+    assert manifest["resolved_bounds"]["max_steps"] == {
+        "received": "0",
+        "resolved": 0,
+        "sentinel": "no_explicit_cap",
+        "allowed_bounds": "0 or >=1",
+    }
+    assert manifest["capability_gate"]["adapter_family"] == "lora"
+    assert manifest["capability_gate"]["response_only_supported"] is True
+    assert manifest["dataset_files_resolved"] == {
+        "source_manifest_path": str(dataset_dir.resolve() / "manifest.json"),
+        "source_samples_path": str(dataset_dir.resolve() / "samples.jsonl"),
+        "source_valid_path": str(dataset_dir.resolve() / "valid.jsonl"),
+        "normalized_manifest_path": str(tmp_path / "output" / "normalized_dataset" / "manifest.json"),
+        "normalized_train_path": str(tmp_path / "output" / "normalized_dataset" / "train.jsonl"),
+        "normalized_valid_path": str(tmp_path / "output" / "normalized_dataset" / "valid.jsonl"),
+    }
+    assert manifest["grad_clip_policy"] == {
+        "requested": "0.25",
+        "resolved": 0.25,
+        "enabled": True,
+        "source": "request",
+    }
+    assert manifest["eval_batch_size"] == {
+        "requested": "",
+        "resolved": 1,
+        "source": "default",
+        "validation_sample_count": 1,
+    }
+    assert manifest["scheduler_kwargs_omitted"] == {
+        "omitted": True,
+        "reason": "scheduler_not_configured",
+        "keys": [],
+    }
+
+
+def test_lora_training_manifest_records_canary_receipts(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(tmp_path / "dataset")
+    base_model_dir = tmp_path / "base-model"
+    base_model_dir.mkdir()
+    (base_model_dir / "config.json").write_text('{"model_type":"qwen2"}\n', encoding="utf-8")
+    (base_model_dir / "tokenizer_config.json").write_text(
+        json.dumps({"eos_token": "<|endoftext|>"}) + "\n",
+        encoding="utf-8",
+    )
+    (base_model_dir / "processor_config.json").write_text('{"processor_class":"AutoProcessor"}\n', encoding="utf-8")
+    (base_model_dir / "modeling_qwen2.py").write_text("# custom module\n", encoding="utf-8")
+
+    result = LoRATrainingPipeline(runner=DeterministicLoRARunner()).run(
+        job_id="train-canary-receipts",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "canary-adapter",
+            "dataset_uri": str(dataset_dir),
+        },
+        source_model=_text_model(model_path=str(base_model_dir), family_id="qwen"),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    assert result.manifest["source_eos_token"] == "<|endoftext|>"
+    assert result.manifest["saved_eos_token"] == "<|endoftext|>"
+    assert result.manifest["tokenizer_config_path"] == str(base_model_dir / "tokenizer_config.json")
+    assert result.manifest["base_config_present"] is True
+    assert result.manifest["processor_resume_mode"] == "processor_config"
+    assert result.manifest["aux_modules_restored"] is True
+    assert result.manifest["merge_export_canary_result"] == "pass"
+    assert result.manifest["callback_api_drift_result"] == "pass"
+    assert result.manifest["completion_loss"] == 0.42
+    assert result.manifest["round_trip_passed"] is True
+    assert result.manifest["grad_norm"] == 0.0
+
+
+def test_training_runtime_preflight_classifies_dependency_limited_inspection_without_runtime_imports(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    imported: list[str] = []
+
+    def fake_find_spec(name: str):
+        if name in {"mlx", "mlx_lm"}:
+            return None
+        if name == "PIL":
+            return object()
+        return object()
+
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("importlib.util.find_spec", fake_find_spec)
+
+    def fake_import_module(name: str):
+        imported.append(name)
+        raise RuntimeError("Pillow binary mismatch")
+
+    monkeypatch.setattr("importlib.import_module", fake_import_module)
+
+    fields = _training_runtime_preflight_fields(
+        source_model=_gemma4_vlm_model(model_path=str(tmp_path / "vlm")),
+        adapter_scope={"training_surface": "text_backbone"},
+        inspection_only=True,
+    )
+
+    assert fields["runtime_gate"] == "unsupported"
+    assert fields["inspection_only_import"] is True
+    assert fields["native_load_status"] == "disabled"
+    assert fields["fallback_reader"] == "metadata_only"
+    assert fields["unsupported_reason"] == "non_apple_host"
+    assert fields["media_decoder_dependency"]["state"] == "broken"
+    assert fields["media_decoder_dependency"]["module"] == "PIL"
+    assert fields["disabled_decoder_paths"] == ["media"]
+    assert imported == ["PIL"]
+
+
+def test_text_only_lora_manifest_records_broken_optional_decoder_without_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fake_find_spec(name: str):
+        if name == "PIL":
+            return object()
+        return object()
+
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("importlib.util.find_spec", fake_find_spec)
+    monkeypatch.setattr(
+        "importlib.import_module",
+        lambda name: (_ for _ in ()).throw(RuntimeError("Pillow binary mismatch")),
+    )
+    dataset_dir = _write_dataset_package(tmp_path / "dataset")
+
+    result = LoRATrainingPipeline(runner=DeterministicLoRARunner()).run(
+        job_id="train-text-broken-decoder",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "text-adapter",
+            "dataset_uri": str(dataset_dir),
+        },
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    assert result.manifest["runtime_gate"] == "ready"
+    assert result.manifest["inspection_only_import"] is False
+    assert result.manifest["native_load_status"] == "available"
+    assert result.manifest["media_decoder_dependency"]["state"] == "broken"
+    assert result.manifest["disabled_decoder_paths"] == ["media"]
+    assert result.manifest["fallback_reader"] == "none"
+    assert result.manifest["unsupported_reason"] == ""
+    assert result.manifest["traceback_cleanup_result"] == "not_applicable"
+    assert result.manifest["retained_tensor_bytes_after_failure"] == 0
+
+
+@pytest.mark.parametrize(
+    ("decoder_specs", "expected_state", "expected_module", "expected_disabled_paths"),
+    [
+        ({"PIL": object()}, "healthy", "PIL", []),
+        ({"PIL": None, "imageio": None, "av": None, "soundfile": None}, "missing", "", ["media"]),
+    ],
+)
+def test_training_runtime_preflight_records_healthy_and_missing_decoder_states(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    decoder_specs: dict[str, object | None],
+    expected_state: str,
+    expected_module: str,
+    expected_disabled_paths: list[str],
+) -> None:
+    def fake_find_spec(name: str):
+        if name in {"mlx", "mlx_lm"}:
+            return object()
+        return decoder_specs.get(name, object())
+
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("importlib.util.find_spec", fake_find_spec)
+    monkeypatch.setattr("importlib.import_module", lambda name: object())
+
+    fields = _training_runtime_preflight_fields(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        adapter_scope={"training_surface": "model"},
+    )
+
+    assert fields["runtime_gate"] == "ready"
+    assert fields["media_decoder_dependency"]["state"] == expected_state
+    assert fields["media_decoder_dependency"]["module"] == expected_module
+    assert fields["disabled_decoder_paths"] == expected_disabled_paths
+
+
+def test_training_failure_cleanup_details_clear_nested_tracebacks_and_report_retained_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_mlx_pkg = types.ModuleType("mlx")
+    fake_mlx_pkg.__path__ = []
+    fake_mlx_core = types.ModuleType("mlx.core")
+    fake_mlx_core.metal = types.SimpleNamespace(get_peak_memory=lambda: 4096)
+    fake_mlx_pkg.core = fake_mlx_core
+    monkeypatch.setitem(sys.modules, "mlx", fake_mlx_pkg)
+    monkeypatch.setitem(sys.modules, "mlx.core", fake_mlx_core)
+
+    captured: dict[str, BaseException] = {}
+
+    class NestedFailureRunner(DeterministicLoRARunner):
+        def train_native(self, request):  # noqa: ANN001
+            _ = request
+            try:
+                try:
+                    raise ValueError("inner tensor load failed")
+                except ValueError as inner:
+                    captured["inner"] = inner
+                    raise RuntimeError("outer training failed") from inner
+            except RuntimeError as outer:
+                captured["outer"] = outer
+                raise ModelOperationError(
+                    code="backend_training_failure",
+                    message="nested failure",
+                ) from outer
+
+    dataset_dir = _write_dataset_package(tmp_path / "dataset")
+
+    with pytest.raises(ModelOperationError) as exc:
+        LoRATrainingPipeline(runner=NestedFailureRunner()).run(
+            job_id="train-nested-failure",
+            request_ext={
+                "operation": "train_lora",
+                "adapter_name": "cleanup-adapter",
+                "dataset_uri": str(dataset_dir),
+            },
+            source_model=_text_model(model_path=str(tmp_path / "base-model")),
+            output_dir=tmp_path / "output",
+            jobs_root=tmp_path / "jobs",
+        )
+
+    assert exc.value.code == "backend_training_failure"
+    assert exc.value.details["traceback_cleanup_result"] == "cleared"
+    assert exc.value.details["retained_tensor_bytes_after_failure"] == "4096"
+    assert captured["outer"].__traceback__ is None
+    assert captured["inner"].__traceback__ is None
+
+
+def test_lora_canary_receipt_records_tokenizer_resume_and_drift_status(
+    tmp_path: Path,
+) -> None:
+    base_model_dir = tmp_path / "base-model"
+    base_model_dir.mkdir()
+    (base_model_dir / "config.json").write_text('{"model_type":"qwen2"}\n', encoding="utf-8")
+    (base_model_dir / "tokenizer_config.json").write_text(
+        json.dumps({"eos_token": "<|source-eos|>"}) + "\n",
+        encoding="utf-8",
+    )
+    (base_model_dir / "tokenizer.json").write_text(
+        json.dumps({"model": {}, "added_tokens": [{"content": "<|source-eos|>", "special": True}]})
+        + "\n",
+        encoding="utf-8",
+    )
+    (base_model_dir / "processor_config.json").write_text('{"processor_class":"AutoProcessor"}\n', encoding="utf-8")
+    (base_model_dir / "modeling_qwen2.py").write_text("# custom module\n", encoding="utf-8")
+
+    adapter_dir = tmp_path / "adapter"
+    adapter_dir.mkdir()
+    adapter_config_path = adapter_dir / "adapter_config.json"
+    adapter_config_path.write_text(
+        json.dumps(
+            {
+                "tokenizer_config": {"eos_token": "<|source-eos|>"},
+                "completion_loss": 0.125,
+                "grad_norm": 0.75,
+                "round_trip_passed": True,
+                "callback_arity": 2,
+                "expected_callback_arity": 2,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    weights_path = adapter_dir / "adapters.safetensors"
+    weights_path.write_bytes(b"adapter")
+
+    fields = build_lora_canary_receipt_fields(
+        source_model=_text_model(model_path=str(base_model_dir)),
+        adapter_output_dir=adapter_dir,
+        adapter_config_path=adapter_config_path,
+        weights_path=weights_path,
+        training_metrics=TrainingMetrics(
+            job_duration_ms=1.0,
+            tokens_seen=8,
+            examples_seen=1,
+            loss_final=0.125,
+            loss_best=0.125,
+            learning_rate_final=1e-5,
+            grad_norm=0.75,
+            completion_loss=0.125,
+            round_trip_passed=True,
+        ),
+    )
+
+    assert fields["source_eos_token"] == "<|source-eos|>"
+    assert fields["saved_eos_token"] == "<|source-eos|>"
+    assert fields["tokenizer_config_path"] == str(base_model_dir / "tokenizer_config.json")
+    assert fields["base_config_present"] is True
+    assert fields["processor_resume_mode"] == "processor_config"
+    assert fields["aux_modules_restored"] is True
+    assert fields["merge_export_canary_result"] == "pass"
+    assert fields["callback_api_drift_result"] == "pass"
+    assert fields["completion_loss"] == 0.125
+    assert fields["round_trip_passed"] is True
+    assert fields["grad_norm"] == 0.75
+
+
+def test_lora_canary_receipt_detects_missing_checkpoint_resume_assets(
+    tmp_path: Path,
+) -> None:
+    base_model_dir = tmp_path / "base-model"
+    base_model_dir.mkdir()
+    adapter_dir = tmp_path / "adapter"
+    adapter_dir.mkdir()
+    adapter_config_path = adapter_dir / "adapter_config.json"
+    adapter_config_path.write_text(
+        json.dumps(
+            {
+                "tokenizer_config": {"eos_token": "<|saved-eos|>"},
+                "callback_arity": 3,
+                "expected_callback_arity": 2,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    weights_path = adapter_dir / "adapters.safetensors"
+    weights_path.write_bytes(b"adapter")
+
+    fields = build_lora_canary_receipt_fields(
+        source_model=_text_model(model_path=str(base_model_dir)),
+        adapter_output_dir=adapter_dir,
+        adapter_config_path=adapter_config_path,
+        weights_path=weights_path,
+        training_metrics=TrainingMetrics(
+            job_duration_ms=1.0,
+            tokens_seen=8,
+            examples_seen=1,
+            loss_final=0.5,
+            loss_best=0.5,
+            learning_rate_final=1e-5,
+        ),
+    )
+
+    assert fields["source_eos_token"] == ""
+    assert fields["saved_eos_token"] == "<|saved-eos|>"
+    assert fields["tokenizer_config_path"] == ""
+    assert fields["base_config_present"] is False
+    assert fields["processor_resume_mode"] == "missing"
+    assert fields["aux_modules_restored"] is False
+    assert fields["merge_export_canary_result"] == "fail:missing_base_config,missing_tokenizer_config"
+    assert fields["callback_api_drift_result"] == "fail:callback_arity_mismatch"
+
+
+def test_training_config_records_scheduler_kwargs_omission_receipt() -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(),
+        ext={"scheduler_kwargs_json": '{"warmup": 10}', "eval_batch_size": "3"},
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=4,
+        validation_sample_count=2,
+    )
+
+    assert config.eval_batch_size == {
+        "requested": "3",
+        "resolved": 3,
+        "source": "request",
+        "validation_sample_count": 2,
+    }
+    assert config.scheduler_kwargs_omitted == {
+        "omitted": True,
+        "reason": "mlx_lm_lora_runner_does_not_accept_scheduler_kwargs",
+        "keys": ["scheduler_kwargs_json"],
+    }

--- a/services/mlx-worker-python/tests/test_stream_assembler_receipts.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler_receipts.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+
+from worker.runtime.stream_assembler import RequestStreamAssembler, StreamFragment
+from worker.runtime.token_route_receipt import TokenRouteReceipt
+
+
+def test_token_route_receipt_records_visible_reasoning_and_tool_spans() -> None:
+    receipt = TokenRouteReceipt(
+        router_id="melix.worker.token_router",
+        router_version="1",
+        reasoning_enabled=False,
+        reasoning_mode="disabled",
+        tool_choice_policy="auto",
+    )
+
+    receipt.append_token_ids((101, 102, 103, 104))
+    receipt.record_span(channel="visible_text", channel_source="raw_text")
+    receipt.record_span(channel="hidden_reasoning", channel_source="reasoning_tag")
+    receipt.record_span(channel="tool_call", channel_source="tool_call_tag")
+    receipt.record_span(channel="visible_text", channel_source="raw_text")
+    payload = json.loads(receipt.to_json())
+
+    assert payload["router_id"] == "melix.worker.token_router"
+    assert payload["router_version"] == "1"
+    assert payload["tool_choice_policy"] == "auto"
+    assert payload["reasoning_mode"] == "disabled"
+    assert payload["visible_text_tokens"] == 2
+    assert payload["hidden_reasoning_tokens"] == 1
+    assert payload["fallback_raw_text_used"] is False
+    assert [
+        (
+            record["token_id"],
+            record["channel"],
+            record["channel_source"],
+            record["tool_choice_policy"],
+            record["reasoning_mode"],
+        )
+        for record in payload["routes"]
+    ] == [
+        (101, "visible_text", "raw_text", "auto", "disabled"),
+        (102, "hidden_reasoning", "reasoning_tag", "auto", "disabled"),
+        (103, "tool_call", "tool_call_tag", "auto", "disabled"),
+        (104, "visible_text", "raw_text", "auto", "disabled"),
+    ]
+
+
+def test_token_route_receipt_marks_raw_text_fallback_when_token_ids_are_absent() -> None:
+    receipt = TokenRouteReceipt(
+        router_id="melix.worker.token_router",
+        router_version="1",
+        reasoning_enabled=True,
+    )
+
+    receipt.record_span(channel="hidden_reasoning", channel_source="reasoning_tag")
+    receipt.record_span(channel="visible_text", channel_source="raw_text")
+    payload = json.loads(receipt.to_json())
+
+    assert payload["fallback_raw_text_used"] is True
+    assert payload["visible_text_tokens"] == 1
+    assert payload["hidden_reasoning_tokens"] == 1
+    assert [record["token_id"] for record in payload["routes"]] == [0, 1]
+
+
+def test_token_route_receipt_uses_bounded_route_samples_for_long_streams() -> None:
+    receipt = TokenRouteReceipt(
+        router_id="melix.worker.token_router",
+        router_version="1",
+        reasoning_enabled=False,
+    )
+
+    for index in range(128):
+        receipt.append_token_ids((index,))
+        receipt.record_span(channel="visible_text", channel_source="raw_text")
+    payload_json = receipt.to_json()
+    payload = json.loads(payload_json)
+
+    assert payload["visible_text_tokens"] == 128
+    assert payload["hidden_reasoning_tokens"] == 0
+    assert payload["route_count"] == 128
+    assert payload["routes_sampled"] == 64
+    assert len(payload["routes"]) == 64
+    assert payload["routes"][0]["token_id"] == 0
+    assert payload["routes"][-1]["token_id"] == 63
+    assert payload["token_id"] == 127
+    assert len(payload_json) < 9000
+
+
+def test_token_route_receipt_inactive_path_skips_plain_visible_text_routes() -> None:
+    receipt = TokenRouteReceipt(
+        router_id="melix.worker.token_router",
+        router_version="1",
+        reasoning_enabled=False,
+        enabled=False,
+    )
+
+    receipt.append_token_ids((101,))
+    receipt.record_span(channel="visible_text", channel_source="raw_text")
+    first_payload_json = receipt.to_json()
+    second_payload_json = receipt.to_json()
+    payload = json.loads(first_payload_json)
+
+    assert first_payload_json is second_payload_json
+    assert payload["route_tracking_enabled"] is False
+    assert payload["route_count"] == 0
+    assert payload["routes"] == []
+    assert payload["visible_text_tokens"] == 0
+
+
+def test_completion_keeps_finalized_tool_call_deltas_available_to_engine() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-tool-count",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+
+    deltas = assembler.accept(
+        StreamFragment(raw_text='<tool_call>{"name":"search","arguments":{"q":"one"}}</tool_call>')
+    )
+    completed = assembler.completed()
+
+    assert [delta.tool_call.tool_name for delta in deltas if delta.tool_call] == ["search"]
+    assert completed.assistant_text == ""
+    assert completed.metrics["malformed_tool_fragment_count"] == 0

--- a/services/mlx-worker-python/tests/test_training_planner_receipts.py
+++ b/services/mlx-worker-python/tests/test_training_planner_receipts.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from packages.protocol.python.worker.v1 import common_pb2
+
+from worker.model_ops import training_config as training_config_module
+from worker.model_ops.lora_training_pipeline import LoRATrainingPipeline
+from worker.model_ops.mlx_lm_runner import (
+    MLXLMRunner,
+    TrainingMetrics,
+    TrainingRequest,
+    TrainingResult,
+)
+
+
+_REQUIRED_RECEIPT_FIELDS = {
+    "batching_strategy",
+    "cutoff_len",
+    "micro_batch_size",
+    "effective_token_budget",
+    "packing_mode",
+    "media_counts",
+    "kernel_policy",
+    "expected_peak_memory_class",
+    "profile_artifact_path",
+    "compiled_step_enabled",
+    "grad_checkpoint_enabled",
+    "attention_backend",
+    "metric_for_best_model_resolved",
+    "generation_mode",
+    "final_logit_softcapping",
+}
+
+
+def _text_model(**ext: str) -> common_pb2.ModelSpec:
+    return common_pb2.ModelSpec(
+        model_id="melix-dev-text",
+        model_path="models/plain-llama",
+        model_kind="text",
+        revision="dev",
+        max_context=4096,
+        ext={"text_family_id": "llama", **ext},
+    )
+
+
+def _quantized_text_model(**ext: str) -> common_pb2.ModelSpec:
+    model = _text_model(**ext)
+    model.model_path = "models/qwen-q4"
+    model.quant_profile_id = "q4"
+    model.ext["melix.quantization.provider"] = "mlx"
+    return model
+
+
+def test_training_planner_receipt_covers_sft_batching_backend_and_numerical_policy() -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(),
+        ext={
+            "training_mode": "lora",
+            "batch_size": "3",
+            "gradient_accumulation": "2",
+            "max_seq_length": "1536",
+            "packing_mode": "sample_packing",
+            "media_image_count": "2",
+            "media_audio_count": "1",
+            "kernel_policy": "stable",
+            "profile_artifact_path": ".runtime/profiles/train.json",
+            "compiled_step": "true",
+            "gradient_checkpointing": "true",
+            "attention_backend": "sdpa",
+            "metric_for_best_model": "eval_loss",
+            "generation_mode": "disabled",
+            "final_logit_softcapping": "30.0",
+        },
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=5,
+    )
+
+    receipt = config.training_planner_receipt
+
+    assert set(receipt) == _REQUIRED_RECEIPT_FIELDS
+    assert receipt["batching_strategy"] == "micro_batch_accumulation"
+    assert receipt["cutoff_len"] == 1536
+    assert receipt["micro_batch_size"] == 3
+    assert receipt["effective_token_budget"] == 3 * 2 * 1536
+    assert receipt["packing_mode"] == "sample_packing"
+    assert receipt["media_counts"] == {"audio": 1, "image": 2, "video": 0}
+    assert receipt["kernel_policy"] == "stable"
+    assert receipt["expected_peak_memory_class"] == "medium"
+    assert receipt["profile_artifact_path"] == ".runtime/profiles/train.json"
+    assert receipt["compiled_step_enabled"] is True
+    assert receipt["grad_checkpoint_enabled"] is True
+    assert receipt["attention_backend"] == {
+        "backend": "sdpa",
+        "status": "accepted",
+        "reason": "",
+    }
+    assert receipt["metric_for_best_model_resolved"] == "eval_loss"
+    assert receipt["generation_mode"] == "disabled"
+    assert receipt["final_logit_softcapping"] == 30.0
+
+
+def test_training_planner_receipt_covers_qlora_chunked_token_budget_and_refused_attention() -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_quantized_text_model(),
+        ext={
+            "training_mode": "qlora",
+            "batch_size": "1",
+            "gradient_accumulation": "4",
+            "max_seq_length": "4096",
+            "chunked_training": "true",
+            "chunk_size": "1024",
+            "packing_mode": "none",
+            "attention_backend": "flash_attention_2",
+            "generation_mode": "train",
+            "final_logit_softcapping": "off",
+        },
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+
+    receipt = config.training_planner_receipt
+
+    assert set(receipt) == _REQUIRED_RECEIPT_FIELDS
+    assert receipt["batching_strategy"] == "chunked_micro_batch_accumulation"
+    assert receipt["cutoff_len"] == 4096
+    assert receipt["micro_batch_size"] == 1
+    assert receipt["effective_token_budget"] == 1 * 4 * 1024
+    assert receipt["packing_mode"] == "none"
+    assert receipt["kernel_policy"] == "quantized_mlx"
+    assert receipt["expected_peak_memory_class"] == "medium"
+    assert receipt["compiled_step_enabled"] is False
+    assert receipt["grad_checkpoint_enabled"] is True
+    assert receipt["attention_backend"] == {
+        "backend": "flash_attention_2",
+        "status": "refused",
+        "reason": "unsupported_training_attention_backend",
+    }
+    assert receipt["metric_for_best_model_resolved"] == "loss_best"
+    assert receipt["generation_mode"] == "train"
+    assert receipt["final_logit_softcapping"] is None
+
+
+def test_training_planner_receipt_is_persisted_in_adapter_manifest(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(tmp_path / "dataset")
+    output_dir = tmp_path / "train-output"
+    runner = _ReceiptRunner()
+
+    result = LoRATrainingPipeline(runner=runner).run(
+        job_id="planner-receipt-test",
+        request_ext={
+            "training_mode": "lora",
+            "dataset_uri": str(dataset_dir),
+            "batch_size": "1",
+            "gradient_accumulation": "3",
+            "max_seq_length": "1024",
+            "profile_artifact_path": str(tmp_path / "profile.json"),
+            "compiled_step": "true",
+            "attention_backend": "mlx",
+            "metric_for_best_model": "validation_loss",
+            "generation_mode": "disabled",
+            "final_logit_softcapping": "25.5",
+        },
+        source_model=_text_model(),
+        output_dir=output_dir,
+        jobs_root=tmp_path / "jobs",
+    )
+
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest == result.manifest
+    for field in _REQUIRED_RECEIPT_FIELDS:
+        assert manifest[field] == runner.last_train_request.config.training_planner_receipt[field]
+    assert manifest["compiled_step_enabled"] is True
+    assert manifest["attention_backend"]["status"] == "accepted"
+    assert manifest["metric_for_best_model_resolved"] == "validation_loss"
+    assert manifest["final_logit_softcapping"] == 25.5
+
+
+class _ReceiptRunner(MLXLMRunner):
+    def __init__(self) -> None:
+        super().__init__()
+        self.last_train_request: TrainingRequest | None = None
+
+    def train_native(self, request: TrainingRequest) -> TrainingResult:
+        self.last_train_request = request
+        request.adapter_output_dir.mkdir(parents=True, exist_ok=True)
+        weights_path = request.adapter_output_dir / "adapters.safetensors"
+        adapter_config_path = request.adapter_output_dir / "adapter_config.json"
+        weights_path.write_bytes(b"melix-test-adapter")
+        adapter_config_path.write_text("{}\n", encoding="utf-8")
+        return TrainingResult(
+            weights_path=weights_path,
+            adapter_config_path=adapter_config_path,
+            metrics=TrainingMetrics(
+                job_duration_ms=123.0,
+                tokens_seen=128,
+                examples_seen=1,
+                loss_final=0.4,
+                loss_best=0.3,
+                learning_rate_final=1e-4,
+                tokens_per_second=64.0,
+                peak_memory_gb=2.0,
+            ),
+            execution_backend="native",
+        )
+
+
+def _write_dataset_package(root: Path) -> Path:
+    root.mkdir(parents=True)
+    samples = [
+        {
+            "id": "sample-1",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "world"},
+            ],
+        }
+    ]
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "planner-receipt-fixture",
+                "format": "chat_messages",
+                "sample_count": len(samples),
+                "version": "1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    with (root / "samples.jsonl").open("w", encoding="utf-8") as handle:
+        for sample in samples:
+            handle.write(json.dumps(sample) + "\n")
+    return root

--- a/services/mlx-worker-python/tests/test_training_planner_receipts.py
+++ b/services/mlx-worker-python/tests/test_training_planner_receipts.py
@@ -144,6 +144,87 @@ def test_training_planner_receipt_covers_qlora_chunked_token_budget_and_refused_
     assert receipt["final_logit_softcapping"] is None
 
 
+def test_training_planner_receipt_accounts_for_source_model_size() -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(**{"melix.parameter_count": "70000000000"}),
+        ext={
+            "training_mode": "lora",
+            "batch_size": "1",
+            "gradient_accumulation": "1",
+            "max_seq_length": "512",
+        },
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+
+    assert config.training_planner_receipt["effective_token_budget"] == 512
+    assert config.training_planner_receipt["expected_peak_memory_class"] == "high"
+
+
+def test_training_planner_receipt_uses_resident_bytes_before_parameter_count() -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_quantized_text_model(
+            **{
+                "melix.estimated_resident_bytes": str(9 * 1024 * 1024 * 1024),
+                "melix.parameter_count": "3000000000",
+            }
+        ),
+        ext={
+            "training_mode": "lora",
+            "batch_size": "1",
+            "gradient_accumulation": "1",
+            "max_seq_length": "512",
+        },
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+
+    assert config.training_planner_receipt["expected_peak_memory_class"] == "medium"
+
+
+def test_training_planner_receipt_uses_medium_model_parameter_count() -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(**{"parameter_count": "8000000000"}),
+        ext={
+            "training_mode": "lora",
+            "batch_size": "1",
+            "gradient_accumulation": "1",
+            "max_seq_length": "512",
+        },
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+
+    assert config.training_planner_receipt["expected_peak_memory_class"] == "medium"
+
+
+def test_training_planner_receipt_uses_model_size_aliases_and_ignores_malformed_values() -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_quantized_text_model(
+            **{
+                "estimated_resident_bytes": "not-a-number",
+                "resident_bytes": str(33 * 1024 * 1024 * 1024),
+                "parameter_count": "bad",
+                "parameters": "8000000000",
+            }
+        ),
+        ext={
+            "training_mode": "qlora",
+            "batch_size": "1",
+            "gradient_accumulation": "1",
+            "max_seq_length": "512",
+        },
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+
+    assert config.training_planner_receipt["expected_peak_memory_class"] == "high"
+
+
 def test_training_planner_receipt_is_persisted_in_adapter_manifest(tmp_path: Path) -> None:
     dataset_dir = _write_dataset_package(tmp_path / "dataset")
     output_dir = tmp_path / "train-output"

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -310,6 +310,15 @@ class EngineCore:
                     "melix.response_history.normalized_count",
                     "0",
                 )
+                compat_policy_receipt_json = execution_ext.get(
+                    "melix.compat.policy_receipt_json",
+                    "",
+                )
+                compat_effective_config_hash = execution_ext.get(
+                    "melix.compat.effective_config_hash",
+                    "",
+                )
+                created = execution_ext.get("melix.response.created", "")
                 generated_tool_call_delta_count_text = str(generated_tool_call_delta_count)
                 if token_route_receipt is not None:
                     token_route_receipt_json = token_route_receipt.to_json()
@@ -320,14 +329,14 @@ class EngineCore:
                         "response_history_normalized_count": response_history_normalized_count,
                         "native_tool_exemplar_injected_count": "0",
                         "reasoning_flag_source": reasoning.mode_source or "unspecified",
-                        "compat_policy_receipt_json": "",
-                        "compat_effective_config_hash": "",
+                        "compat_policy_receipt_json": compat_policy_receipt_json,
+                        "compat_effective_config_hash": compat_effective_config_hash,
                         "turn_boundary_stop_reason": turn_boundary_stop_reason or finish_reason,
                         "generated_reasoning_delta_count": "0",
                         "generated_tool_call_delta_count": generated_tool_call_delta_count_text,
                         "token_route_receipt_json": token_route_receipt_json,
                         "response_id": request_id,
-                        "created": "",
+                        "created": created,
                         "stream_mode": stream_mode_text,
                         "finish_reason": finish_reason,
                         "usage_prompt_tokens": str(finalized_prompt_tokens),
@@ -643,7 +652,7 @@ class EngineCore:
     def _plain_text_fast_path(request: inference_pb2.GenerateRequest) -> bool:
         execution = request.execution
         return (
-            not execution.ext
+            not EngineCore._ext_requires_token_route_tracking(execution.ext)
             and not execution.reasoning.enabled
             and not execution.reasoning.mode
             and not execution.tool_config.tools
@@ -706,13 +715,36 @@ class EngineCore:
         route_tracking_enabled = (
             bool(request.execution.reasoning.enabled)
             or bool(reasoning_mode and reasoning_mode != "disabled")
-            or bool(ext.get("melix.tool_parser.mode", ""))
-            or bool(ext.get("melix.structured_output.mode", ""))
+            or EngineCore._ext_requires_token_route_tracking(ext, compat_receipt)
             or bool(request.execution.tool_config.tools)
             or bool(tool_choice_policy and tool_choice_policy != "auto")
-            or bool(ext.get("melix.compat.policy_receipt_json", ""))
         )
         return reasoning_mode, tool_choice_policy, route_tracking_enabled
+
+    @staticmethod
+    def _ext_requires_token_route_tracking(
+        ext: object,
+        compat_receipt: dict[str, object] | None = None,
+    ) -> bool:
+        if not ext and not compat_receipt:
+            return False
+        getter = getattr(ext, "get", lambda _key, _default="": "")
+        if str(getter("melix.tool_parser.mode", "")).strip():
+            return True
+        if str(getter("melix.structured_output.mode", "")).strip():
+            return True
+        reasoning_mode = str(getter("melix.reasoning.mode", "")).strip().lower()
+        if reasoning_mode and reasoning_mode != "disabled":
+            return True
+        tool_choice = str(getter("melix.compat.tool_choice_resolved", "")).strip().lower()
+        if tool_choice and tool_choice != "auto":
+            return True
+        compat_receipt = compat_receipt if compat_receipt is not None else EngineCore._compat_policy_receipt(ext)
+        compat_reasoning_mode = str(compat_receipt.get("reasoning_mode", "")).strip().lower()
+        if compat_reasoning_mode and compat_reasoning_mode != "disabled":
+            return True
+        compat_tool_choice = str(compat_receipt.get("tool_choice_resolved", "")).strip().lower()
+        return bool(compat_tool_choice and compat_tool_choice != "auto")
 
     @staticmethod
     def _token_route_receipt(

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -6,13 +6,26 @@ import json
 from packages.protocol.python.worker.v1 import common_pb2, inference_pb2
 
 from worker.registry import WorkerRegistry
+from worker.engine.text_finalizer import apply_text_response_metrics
 from worker.runtime.mlx_text_runtime import RuntimeToolCallEvent, RuntimeTokenEvent
 from worker.runtime.mlx_text_runtime import resolve_text_stop_contract
 from worker.runtime.runtime_utils import callable_accepts_kwarg as _callable_accepts_kwarg
 from worker.runtime.stream_assembler import RequestStreamAssembler, StreamFragment
+from worker.runtime.token_route_receipt import (
+    TokenRouteReceipt,
+    inactive_token_route_receipt_json,
+)
 from worker.runtime.token_counting import whitespace_token_count as _whitespace_token_count
 
 _ENGINE_STOP_CONTRACT_CACHE_FIELD = "_melix.engine.resolved_text_stop_contract_cache"
+_TOKEN_ROUTER_ID = "melix.worker.token_router"
+_TOKEN_ROUTER_VERSION = "1"
+_DEFAULT_INACTIVE_TOKEN_ROUTE_RECEIPT_JSON = inactive_token_route_receipt_json(
+    _TOKEN_ROUTER_ID,
+    _TOKEN_ROUTER_VERSION,
+    "disabled",
+    "auto",
+)
 
 
 def _resolve_generate_stop_contract(
@@ -37,6 +50,18 @@ def _resolve_generate_stop_contract(
     return contract
 
 
+def _runtime_accepts_acceleration_policy(runtime: object, generate_tokens: object) -> bool:
+    cached = getattr(runtime, "_melix_accepts_acceleration_policy", None)
+    if cached is not None:
+        return bool(cached)
+    accepts = _callable_accepts_kwarg(generate_tokens, "acceleration_policy")
+    try:
+        setattr(runtime, "_melix_accepts_acceleration_policy", accepts)
+    except Exception:
+        pass
+    return accepts
+
+
 class EngineCore:
     def __init__(self, registry: WorkerRegistry) -> None:
         self._registry = registry
@@ -53,9 +78,16 @@ class EngineCore:
             return
 
         runtime = self._registry.runtime_for_loaded_model(loaded_model)
+        generate_tokens = runtime.generate_tokens
         state = self._registry.start_request(request_id, runtime_kind=loaded_model.runtime_kind)
         allocate_seq = state.allocate_seq
-        assembler = self._stream_assembler(request)
+        plain_text_fast_path = self._plain_text_fast_path(request)
+        compat_receipt = None if plain_text_fast_path else self._compat_policy_receipt(execution_ext)
+        assembler = (
+            self._plain_stream_assembler(request)
+            if plain_text_fast_path
+            else self._stream_assembler(request, compat_receipt)
+        )
         stop_contract = _resolve_generate_stop_contract(
             loaded_model.runtime_model,
             sampling,
@@ -65,10 +97,37 @@ class EngineCore:
         prompt_tokens_default: int | None = None
         track_usage = bool(request.return_usage)
         completion_token_count = 0
+        finalized_prompt_tokens = 0
+        finalized_completion_tokens = 0
+        usage_trailer_emitted = False
         last_token_event: RuntimeTokenEvent | None = None
         last_finish_reason = ""
         turn_boundary_stop_reason = ""
+        generated_reasoning_delta_count = 0
+        generated_tool_call_delta_count = 0
         accept_stream_fragment = assembler.accept
+        token_route_receipt: TokenRouteReceipt | None = None
+        if plain_text_fast_path:
+            token_route_receipt_json = _DEFAULT_INACTIVE_TOKEN_ROUTE_RECEIPT_JSON
+        else:
+            reasoning_mode, tool_choice_policy, route_tracking_enabled = self._token_route_config(
+                request,
+                compat_receipt,
+            )
+            if not route_tracking_enabled:
+                token_route_receipt_json = inactive_token_route_receipt_json(
+                    _TOKEN_ROUTER_ID,
+                    _TOKEN_ROUTER_VERSION,
+                    (reasoning_mode or "disabled").strip().lower(),
+                    (tool_choice_policy or "auto").strip().lower(),
+                )
+            else:
+                token_route_receipt_json = ""
+                token_route_receipt = self._active_token_route_receipt(
+                    request,
+                    reasoning_mode=reasoning_mode,
+                    tool_choice_policy=tool_choice_policy,
+                )
 
         try:
             template_kwargs = self._chat_template_kwargs(request) if execution_ext else None
@@ -81,19 +140,31 @@ class EngineCore:
                 execution_ext=execution_ext,
             )
 
-            generate_kwargs: dict[str, object] = {"execution_ext": execution_ext}
-            if _callable_accepts_kwarg(runtime.generate_tokens, "acceleration_policy"):
-                generate_kwargs["acceleration_policy"] = execution.acceleration
-            for runtime_event in runtime.generate_tokens(
-                loaded_model.runtime_model,
-                prompt,
-                effective_sampling,
-                state.cancel_event,
-                **generate_kwargs,
-            ):
+            if _runtime_accepts_acceleration_policy(runtime, generate_tokens):
+                runtime_events = generate_tokens(
+                    loaded_model.runtime_model,
+                    prompt,
+                    effective_sampling,
+                    state.cancel_event,
+                    execution_ext=execution_ext,
+                    acceleration_policy=execution.acceleration,
+                )
+            else:
+                runtime_events = generate_tokens(
+                    loaded_model.runtime_model,
+                    prompt,
+                    effective_sampling,
+                    state.cancel_event,
+                    execution_ext=execution_ext,
+                )
+            for runtime_event in runtime_events:
                 if state.cancel_event.is_set():
                     break
                 if isinstance(runtime_event, RuntimeToolCallEvent):
+                    generated_tool_call_delta_count += 1
+                    if token_route_receipt is None:
+                        token_route_receipt = self._active_token_route_receipt(request, compat_receipt)
+                    token_route_receipt.activate()
                     yield inference_pb2.ExecuteEvent(
                         request_id=request_id,
                         execution_kind="generate",
@@ -139,6 +210,13 @@ class EngineCore:
                     stream_fragment = StreamFragment(runtime_event.text, runtime_event.raw_text)
                 for delta in accept_stream_fragment(stream_fragment):
                     if delta.reasoning_text:
+                        generated_reasoning_delta_count += 1
+                        if token_route_receipt is not None:
+                            token_route_receipt.activate()
+                            token_route_receipt.record_span(
+                                channel="hidden_reasoning",
+                                channel_source="reasoning_tag",
+                            )
                         yield inference_pb2.ExecuteEvent(
                             request_id=request_id,
                             execution_kind="generate",
@@ -150,6 +228,13 @@ class EngineCore:
                             ),
                         )
                     if delta.tool_call is not None:
+                        generated_tool_call_delta_count += 1
+                        if token_route_receipt is not None:
+                            token_route_receipt.activate()
+                            token_route_receipt.record_span(
+                                channel="tool_call",
+                                channel_source="tool_call_tag",
+                            )
                         yield inference_pb2.ExecuteEvent(
                             request_id=request_id,
                             execution_kind="generate",
@@ -164,6 +249,11 @@ class EngineCore:
                             ),
                         )
                     if delta.content_text:
+                        if token_route_receipt is not None:
+                            token_route_receipt.record_span(
+                                channel="visible_text",
+                                channel_source="raw_text",
+                            )
                         if track_usage:
                             completion_token_count += 1
                         yield inference_pb2.ExecuteEvent(
@@ -191,6 +281,9 @@ class EngineCore:
                     prompt_tokens = prompt_tokens_default
                 if last_token_event is not None:
                     completion_tokens = int(last_token_event.completion_tokens or completion_tokens)
+                finalized_prompt_tokens = prompt_tokens
+                finalized_completion_tokens = completion_tokens
+                usage_trailer_emitted = bool(request.stream)
                 yield inference_pb2.ExecuteEvent(
                     request_id=request_id,
                     execution_kind="generate",
@@ -209,21 +302,98 @@ class EngineCore:
 
             assembled = assembler.completed()
             parser_metrics = {key: str(value) for key, value in assembled.metrics.items()}
-            parser_metrics["response_history_normalized_count"] = execution_ext.get(
-                "melix.response_history.normalized_count",
-                "0",
-            )
-            parser_metrics["native_tool_exemplar_injected_count"] = (
-                "1" if execution_ext.get("melix.tool_config.native_template_tools") == "injected" else "0"
-            )
-            parser_metrics["resolved_stop_token_count"] = str(stop_contract.resolved_stop_token_count)
-            parser_metrics["reasoning_flag_source"] = (
-                reasoning.mode_source
-                or execution_ext.get("melix.reasoning.mode_source", "")
-                or execution_ext.get("melix.reasoning.source", "")
-                or "unspecified"
-            )
-            parser_metrics["turn_boundary_stop_reason"] = turn_boundary_stop_reason or finish_reason
+            resolved_stop_token_count = str(stop_contract.resolved_stop_token_count)
+            if plain_text_fast_path:
+                stream_mode_text = "true" if request.stream else "false"
+                usage_trailer_text = stream_mode_text if usage_trailer_emitted else "false"
+                response_history_normalized_count = execution_ext.get(
+                    "melix.response_history.normalized_count",
+                    "0",
+                )
+                generated_tool_call_delta_count_text = str(generated_tool_call_delta_count)
+                if token_route_receipt is not None:
+                    token_route_receipt_json = token_route_receipt.to_json()
+                tool_calls_finalized_text = "true" if generated_tool_call_delta_count else "false"
+                parser_metrics.update(
+                    {
+                        "resolved_stop_token_count": resolved_stop_token_count,
+                        "response_history_normalized_count": response_history_normalized_count,
+                        "native_tool_exemplar_injected_count": "0",
+                        "reasoning_flag_source": reasoning.mode_source or "unspecified",
+                        "compat_policy_receipt_json": "",
+                        "compat_effective_config_hash": "",
+                        "turn_boundary_stop_reason": turn_boundary_stop_reason or finish_reason,
+                        "generated_reasoning_delta_count": "0",
+                        "generated_tool_call_delta_count": generated_tool_call_delta_count_text,
+                        "token_route_receipt_json": token_route_receipt_json,
+                        "response_id": request_id,
+                        "created": "",
+                        "stream_mode": stream_mode_text,
+                        "finish_reason": finish_reason,
+                        "usage_prompt_tokens": str(finalized_prompt_tokens),
+                        "usage_completion_tokens": str(finalized_completion_tokens),
+                        "usage_total_tokens": str(finalized_prompt_tokens + finalized_completion_tokens),
+                        "usage_trailer_emitted": usage_trailer_text,
+                        "reasoning_finalized": "false",
+                        "tool_calls_finalized": tool_calls_finalized_text,
+                        "malformed_channel_recovered": "false",
+                        "finalizer_path": "stream" if request.stream else "non_stream",
+                    }
+                )
+            else:
+                parser_metrics["resolved_stop_token_count"] = resolved_stop_token_count
+                parser_metrics["response_history_normalized_count"] = execution_ext.get(
+                    "melix.response_history.normalized_count",
+                    "0",
+                )
+                parser_metrics["native_tool_exemplar_injected_count"] = (
+                    "1" if execution_ext.get("melix.tool_config.native_template_tools") == "injected" else "0"
+                )
+                parser_metrics["reasoning_flag_source"] = self._reasoning_flag_source(request)
+                parser_metrics["compat_policy_receipt_json"] = execution_ext.get(
+                    "melix.compat.policy_receipt_json",
+                    "",
+                )
+                parser_metrics["compat_effective_config_hash"] = execution_ext.get(
+                    "melix.compat.effective_config_hash",
+                    "",
+                )
+                created = execution_ext.get("melix.response.created", "")
+                parser_metrics["turn_boundary_stop_reason"] = turn_boundary_stop_reason or finish_reason
+                parser_metrics["generated_reasoning_delta_count"] = str(generated_reasoning_delta_count)
+                parser_metrics["generated_tool_call_delta_count"] = str(generated_tool_call_delta_count)
+                if token_route_receipt is not None:
+                    token_route_receipt_json = token_route_receipt.to_json()
+                parser_metrics["token_route_receipt_json"] = token_route_receipt_json
+                malformed_tool_fragment_count = int(
+                    parser_metrics.get("malformed_tool_fragment_count", "0") or "0"
+                )
+                reasoning_finalized = (
+                    bool(assembled.reasoning_text)
+                    or generated_reasoning_delta_count > 0
+                    or int(parser_metrics.get("harmony_channel_hidden_count", "0") or "0") > 0
+                )
+                tool_calls_finalized = (
+                    generated_tool_call_delta_count > 0
+                    or malformed_tool_fragment_count > 0
+                )
+                malformed_channel_recovered = (
+                    int(parser_metrics.get("reasoning_channel_recovery_count", "0") or "0") > 0
+                    or malformed_tool_fragment_count > 0
+                )
+                apply_text_response_metrics(
+                    parser_metrics,
+                    response_id=request_id,
+                    created=created,
+                    stream_mode=bool(request.stream),
+                    finish_reason=finish_reason,
+                    prompt_tokens=finalized_prompt_tokens,
+                    completion_tokens=finalized_completion_tokens,
+                    usage_trailer_emitted=usage_trailer_emitted,
+                    reasoning_finalized=reasoning_finalized,
+                    tool_calls_finalized=tool_calls_finalized,
+                    malformed_channel_recovered=malformed_channel_recovered,
+                )
             yield inference_pb2.ExecuteEvent(
                 request_id=request_id,
                 execution_kind="generate",
@@ -470,10 +640,36 @@ class EngineCore:
         )
 
     @staticmethod
-    def _stream_assembler(request: inference_pb2.GenerateRequest) -> RequestStreamAssembler:
+    def _plain_text_fast_path(request: inference_pb2.GenerateRequest) -> bool:
+        execution = request.execution
+        return (
+            not execution.ext
+            and not execution.reasoning.enabled
+            and not execution.reasoning.mode
+            and not execution.tool_config.tools
+            and not execution.tool_config.tool_choice
+        )
+
+    @staticmethod
+    def _plain_stream_assembler(request: inference_pb2.GenerateRequest) -> RequestStreamAssembler:
+        return RequestStreamAssembler(
+            request_id=request.execution.id.request_id,
+            reasoning_enabled=False,
+        )
+
+    @staticmethod
+    def _stream_assembler(
+        request: inference_pb2.GenerateRequest,
+        compat_receipt: dict[str, object] | None = None,
+    ) -> RequestStreamAssembler:
         ext = request.execution.ext
         reasoning_mode = ext.get("melix.reasoning.mode", "").strip().lower()
+        compat_receipt = compat_receipt if compat_receipt is not None else EngineCore._compat_policy_receipt(ext)
+        compat_reasoning_mode = str(compat_receipt.get("reasoning_mode", "")).strip().lower()
         reasoning_enabled = bool(request.execution.reasoning.enabled) or reasoning_mode in {
+            "enabled",
+            "adaptive",
+        } or compat_reasoning_mode in {
             "enabled",
             "adaptive",
         }
@@ -487,6 +683,110 @@ class EngineCore:
                 if request.execution.tool_config.tools else None
             ),
         )
+
+    @staticmethod
+    def _token_route_config(
+        request: inference_pb2.GenerateRequest,
+        compat_receipt: dict[str, object] | None = None,
+    ) -> tuple[str, str, bool]:
+        ext = request.execution.ext
+        compat_receipt = compat_receipt if compat_receipt is not None else EngineCore._compat_policy_receipt(ext)
+        compat_reasoning_mode = str(compat_receipt.get("reasoning_mode", "")).strip().lower()
+        compat_tool_choice = str(compat_receipt.get("tool_choice_resolved", "")).strip().lower()
+        reasoning_mode = (
+            ext.get("melix.reasoning.mode", "").strip().lower()
+            or request.execution.reasoning.mode
+            or compat_reasoning_mode
+        )
+        tool_choice_policy = (
+            ext.get("melix.compat.tool_choice_resolved", "")
+            or request.execution.tool_config.tool_choice
+            or compat_tool_choice
+        )
+        route_tracking_enabled = (
+            bool(request.execution.reasoning.enabled)
+            or bool(reasoning_mode and reasoning_mode != "disabled")
+            or bool(ext.get("melix.tool_parser.mode", ""))
+            or bool(ext.get("melix.structured_output.mode", ""))
+            or bool(request.execution.tool_config.tools)
+            or bool(tool_choice_policy and tool_choice_policy != "auto")
+            or bool(ext.get("melix.compat.policy_receipt_json", ""))
+        )
+        return reasoning_mode, tool_choice_policy, route_tracking_enabled
+
+    @staticmethod
+    def _token_route_receipt(
+        request: inference_pb2.GenerateRequest,
+        compat_receipt: dict[str, object] | None = None,
+    ) -> TokenRouteReceipt | None:
+        reasoning_mode, tool_choice_policy, route_tracking_enabled = EngineCore._token_route_config(
+            request,
+            compat_receipt,
+        )
+        if not route_tracking_enabled:
+            return None
+        return EngineCore._active_token_route_receipt(
+            request,
+            compat_receipt,
+            reasoning_mode=reasoning_mode,
+            tool_choice_policy=tool_choice_policy,
+        )
+
+    @staticmethod
+    def _active_token_route_receipt(
+        request: inference_pb2.GenerateRequest,
+        compat_receipt: dict[str, object] | None = None,
+        *,
+        reasoning_mode: str = "",
+        tool_choice_policy: str = "",
+    ) -> TokenRouteReceipt:
+        if not reasoning_mode and not tool_choice_policy:
+            reasoning_mode, tool_choice_policy, _ = EngineCore._token_route_config(
+                request,
+                compat_receipt,
+            )
+        return TokenRouteReceipt(
+            router_id=_TOKEN_ROUTER_ID,
+            router_version=_TOKEN_ROUTER_VERSION,
+            reasoning_enabled=bool(request.execution.reasoning.enabled),
+            reasoning_mode=reasoning_mode,
+            tool_choice_policy=tool_choice_policy,
+            enabled=True,
+        )
+
+    @staticmethod
+    def _inactive_token_route_receipt_json(
+        request: inference_pb2.GenerateRequest,
+        compat_receipt: dict[str, object] | None = None,
+    ) -> str:
+        reasoning_mode, tool_choice_policy, _ = EngineCore._token_route_config(
+            request,
+            compat_receipt,
+        )
+        return inactive_token_route_receipt_json(
+            _TOKEN_ROUTER_ID,
+            _TOKEN_ROUTER_VERSION,
+            (reasoning_mode or "disabled").strip().lower(),
+            (tool_choice_policy or "auto").strip().lower(),
+        )
+
+    @staticmethod
+    def _compat_policy_receipt(execution_ext: object) -> dict[str, object]:
+        if not execution_ext:
+            return {}
+        raw_receipt = str(
+            getattr(execution_ext, "get", lambda _key, _default="": "")(
+                "melix.compat.policy_receipt_json",
+                "",
+            )
+        ).strip()
+        if not raw_receipt:
+            return {}
+        try:
+            payload = json.loads(raw_receipt)
+        except json.JSONDecodeError:
+            return {}
+        return payload if isinstance(payload, dict) else {}
 
     @staticmethod
     def _sampling_with_resolved_stop(

--- a/services/mlx-worker-python/worker/engine/text_finalizer.py
+++ b/services/mlx-worker-python/worker/engine/text_finalizer.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class TextFinalizationUsage:
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+
+@dataclass(frozen=True, slots=True)
+class TextFinalizationReceipt:
+    response_id: str
+    created: str
+    stream_mode: bool
+    finish_reason: str
+    usage: TextFinalizationUsage
+    usage_trailer_emitted: bool
+    reasoning_finalized: bool
+    tool_calls_finalized: bool
+    malformed_channel_recovered: bool
+    finalizer_path: str
+
+    def parser_metrics(self) -> dict[str, str]:
+        return {
+            "response_id": self.response_id,
+            "created": self.created,
+            "stream_mode": _bool_text(self.stream_mode),
+            "finish_reason": self.finish_reason,
+            "usage_prompt_tokens": str(self.usage.prompt_tokens),
+            "usage_completion_tokens": str(self.usage.completion_tokens),
+            "usage_total_tokens": str(self.usage.total_tokens),
+            "usage_trailer_emitted": _bool_text(self.usage_trailer_emitted),
+            "reasoning_finalized": _bool_text(self.reasoning_finalized),
+            "tool_calls_finalized": _bool_text(self.tool_calls_finalized),
+            "malformed_channel_recovered": _bool_text(self.malformed_channel_recovered),
+            "finalizer_path": self.finalizer_path,
+        }
+
+
+def finalize_text_response(
+    *,
+    response_id: str,
+    created: str,
+    stream_mode: bool,
+    finish_reason: str,
+    usage: TextFinalizationUsage,
+    usage_trailer_emitted: bool,
+    reasoning_text: str,
+    tool_call_count: int,
+    parser_metrics: dict[str, int | str],
+) -> TextFinalizationReceipt:
+    return TextFinalizationReceipt(
+        response_id=response_id,
+        created=created,
+        stream_mode=stream_mode,
+        finish_reason=finish_reason,
+        usage=usage,
+        usage_trailer_emitted=usage_trailer_emitted,
+        reasoning_finalized=bool(reasoning_text)
+        or _metric_positive(parser_metrics, "generated_reasoning_delta_count")
+        or _metric_positive(parser_metrics, "harmony_channel_hidden_count"),
+        tool_calls_finalized=tool_call_count > 0
+        or _metric_positive(parser_metrics, "generated_tool_call_delta_count")
+        or _metric_positive(parser_metrics, "malformed_tool_fragment_count"),
+        malformed_channel_recovered=_metric_positive(
+            parser_metrics,
+            "reasoning_channel_recovery_count",
+        )
+        or _metric_positive(parser_metrics, "malformed_tool_fragment_count"),
+        finalizer_path="stream" if stream_mode else "non_stream",
+    )
+
+
+def finalize_text_response_metrics(
+    *,
+    response_id: str,
+    created: str,
+    stream_mode: bool,
+    finish_reason: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    usage_trailer_emitted: bool,
+    reasoning_text: str,
+    tool_call_count: int,
+    parser_metrics: dict[str, int | str],
+) -> dict[str, str]:
+    reasoning_finalized = (
+        bool(reasoning_text)
+        or _metric_positive(parser_metrics, "generated_reasoning_delta_count")
+        or _metric_positive(parser_metrics, "harmony_channel_hidden_count")
+    )
+    tool_calls_finalized = (
+        tool_call_count > 0
+        or _metric_positive(parser_metrics, "generated_tool_call_delta_count")
+        or _metric_positive(parser_metrics, "malformed_tool_fragment_count")
+    )
+    malformed_channel_recovered = _metric_positive(
+        parser_metrics,
+        "reasoning_channel_recovery_count",
+    ) or _metric_positive(parser_metrics, "malformed_tool_fragment_count")
+    return {
+        "response_id": response_id,
+        "created": created,
+        "stream_mode": _bool_text(stream_mode),
+        "finish_reason": finish_reason,
+        "usage_prompt_tokens": str(prompt_tokens),
+        "usage_completion_tokens": str(completion_tokens),
+        "usage_total_tokens": str(prompt_tokens + completion_tokens),
+        "usage_trailer_emitted": _bool_text(usage_trailer_emitted),
+        "reasoning_finalized": _bool_text(reasoning_finalized),
+        "tool_calls_finalized": _bool_text(tool_calls_finalized),
+        "malformed_channel_recovered": _bool_text(malformed_channel_recovered),
+        "finalizer_path": "stream" if stream_mode else "non_stream",
+    }
+
+
+def apply_text_response_metrics(
+    parser_metrics: dict[str, str],
+    *,
+    response_id: str,
+    created: str,
+    stream_mode: bool,
+    finish_reason: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    usage_trailer_emitted: bool,
+    reasoning_finalized: bool,
+    tool_calls_finalized: bool,
+    malformed_channel_recovered: bool,
+) -> None:
+    parser_metrics["response_id"] = response_id
+    parser_metrics["created"] = created
+    parser_metrics["stream_mode"] = _bool_text(stream_mode)
+    parser_metrics["finish_reason"] = finish_reason
+    parser_metrics["usage_prompt_tokens"] = str(prompt_tokens)
+    parser_metrics["usage_completion_tokens"] = str(completion_tokens)
+    parser_metrics["usage_total_tokens"] = str(prompt_tokens + completion_tokens)
+    parser_metrics["usage_trailer_emitted"] = _bool_text(usage_trailer_emitted)
+    parser_metrics["reasoning_finalized"] = _bool_text(reasoning_finalized)
+    parser_metrics["tool_calls_finalized"] = _bool_text(tool_calls_finalized)
+    parser_metrics["malformed_channel_recovered"] = _bool_text(malformed_channel_recovered)
+    parser_metrics["finalizer_path"] = "stream" if stream_mode else "non_stream"
+
+
+def _bool_text(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _metric_positive(metrics: dict[str, int | str], key: str) -> bool:
+    try:
+        return int(metrics.get(key, 0) or 0) > 0
+    except (TypeError, ValueError):
+        return False

--- a/services/mlx-worker-python/worker/model_ops/deterministic_lora_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/deterministic_lora_runner.py
@@ -30,6 +30,10 @@ class DeterministicLoRARunner(MLXLMRunner):
                 {
                     "fine_tune_type": "lora",
                     "num_layers": request.config.num_layers,
+                    "tokenizer_config": self._source_tokenizer_config(request.model_path),
+                    "round_trip_passed": True,
+                    "callback_arity": 2,
+                    "expected_callback_arity": 2,
                     "lora_parameters": {
                         "rank": request.config.rank,
                         "dropout": request.config.dropout,
@@ -58,6 +62,13 @@ class DeterministicLoRARunner(MLXLMRunner):
             ),
             execution_backend="native",
         )
+
+    def _source_tokenizer_config(self, model_path: Path) -> dict[str, object]:
+        try:
+            payload = json.loads((model_path / "tokenizer_config.json").read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        return payload if isinstance(payload, dict) else {}
 
     def activate_native(self, request: ActivationRequest) -> ActivationResult:
         request.derived_model_dir.mkdir(parents=True, exist_ok=True)

--- a/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
@@ -23,6 +23,13 @@ QUANTIZED_BASE_EVIDENCE_SOURCE = "quantized_base_evidence_source"
 QLORA_COMPATIBILITY_STATUS = "qlora_compatibility_status"
 QUANTIZED_TARGET_MODULE_GUARD = "quantized_target_module_guard"
 
+_AUXILIARY_MODULE_PATTERNS = (
+    "modeling_*.py",
+    "configuration_*.py",
+    "tokenization_*.py",
+    "processing_*.py",
+)
+
 _QUANTIZED_KIND_ORDER = ("4bit", "8bit", "q4", "q8", "optiq")
 
 
@@ -174,6 +181,72 @@ def build_quantized_lora_manifest_fields(
     }
 
 
+def build_lora_canary_receipt_fields(
+    *,
+    source_model: common_pb2.ModelSpec,
+    adapter_output_dir: str | Path,
+    adapter_config_path: str | Path,
+    weights_path: str | Path,
+    training_metrics: Any,
+) -> dict[str, object]:
+    base_model_dir = Path(source_model.model_path).expanduser()
+    adapter_dir = Path(adapter_output_dir)
+    adapter_config = _load_json_mapping(Path(adapter_config_path))
+    tokenizer_config_path = base_model_dir / "tokenizer_config.json"
+    source_tokenizer_config = _load_json_mapping(tokenizer_config_path)
+    saved_tokenizer_config = _saved_tokenizer_config(adapter_config, adapter_dir)
+    source_eos_token = _str_value(source_tokenizer_config.get("eos_token"))
+    saved_eos_token = _str_value(saved_tokenizer_config.get("eos_token"))
+    base_config_present = (base_model_dir / "config.json").is_file()
+    source_tokenizer_present = tokenizer_config_path.is_file()
+    processor_resume_mode = _processor_resume_mode(base_model_dir)
+    aux_modules_restored = _aux_modules_restored(base_model_dir)
+    merge_export_canary_failures: list[str] = []
+    if not base_config_present:
+        merge_export_canary_failures.append("missing_base_config")
+    if not source_tokenizer_present:
+        merge_export_canary_failures.append("missing_tokenizer_config")
+    if not Path(weights_path).is_file():
+        merge_export_canary_failures.append("missing_adapter_weights")
+    if source_eos_token and saved_eos_token and source_eos_token != saved_eos_token:
+        merge_export_canary_failures.append("eos_token_mismatch")
+
+    callback_api_drift_result = "pass"
+    callback_arity = _optional_int(adapter_config.get("callback_arity"))
+    expected_callback_arity = _optional_int(adapter_config.get("expected_callback_arity"))
+    if (
+        callback_arity is not None
+        and expected_callback_arity is not None
+        and callback_arity != expected_callback_arity
+    ):
+        callback_api_drift_result = "fail:callback_arity_mismatch"
+
+    return {
+        "source_eos_token": source_eos_token,
+        "saved_eos_token": saved_eos_token,
+        "tokenizer_config_path": str(tokenizer_config_path) if source_tokenizer_present else "",
+        "base_config_present": base_config_present,
+        "processor_resume_mode": processor_resume_mode,
+        "aux_modules_restored": aux_modules_restored,
+        "merge_export_canary_result": _canary_result(merge_export_canary_failures),
+        "callback_api_drift_result": callback_api_drift_result,
+        "completion_loss": _optional_float(
+            getattr(training_metrics, "completion_loss", None),
+            adapter_config.get("completion_loss"),
+            getattr(training_metrics, "loss_final", None),
+        ),
+        "round_trip_passed": bool(
+            getattr(training_metrics, "round_trip_passed", False)
+            or adapter_config.get("round_trip_passed", False)
+        ),
+        "grad_norm": _optional_float(
+            getattr(training_metrics, "grad_norm", None),
+            adapter_config.get("grad_norm"),
+        )
+        or 0.0,
+    }
+
+
 def detect_quantized_base(source_model: common_pb2.ModelSpec) -> dict[str, object]:
     profile_id = source_model.quant_profile_id.strip()
     if profile_id:
@@ -220,6 +293,66 @@ def detect_quantized_base(source_model: common_pb2.ModelSpec) -> dict[str, objec
         QUANTIZATION_PROFILE_ID: "",
         QUANTIZED_BASE_EVIDENCE_SOURCE: "model_identity" if kind != "unknown" else "",
     }
+
+
+def _saved_tokenizer_config(
+    adapter_config: Mapping[str, Any],
+    adapter_dir: Path,
+) -> Mapping[str, Any]:
+    embedded = adapter_config.get("tokenizer_config")
+    if isinstance(embedded, Mapping):
+        return embedded
+    saved_path = adapter_dir / "tokenizer_config.json"
+    return _load_json_mapping(saved_path)
+
+
+def _processor_resume_mode(base_model_dir: Path) -> str:
+    if (base_model_dir / "processor_config.json").is_file():
+        return "processor_config"
+    if (base_model_dir / "preprocessor_config.json").is_file():
+        return "preprocessor_config"
+    if (base_model_dir / "tokenizer_config.json").is_file():
+        return "tokenizer_only"
+    return "missing"
+
+
+def _aux_modules_restored(base_model_dir: Path) -> bool:
+    return any(
+        any(base_model_dir.glob(pattern))
+        for pattern in _AUXILIARY_MODULE_PATTERNS
+    )
+
+
+def _canary_result(failures: list[str]) -> str:
+    return "pass" if not failures else "fail:" + ",".join(failures)
+
+
+def _load_json_mapping(path: Path) -> Mapping[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def _optional_int(raw_value: Any) -> int | None:
+    if raw_value is None:
+        return None
+    try:
+        return int(raw_value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_float(*raw_values: Any) -> float | None:
+    for raw_value in raw_values:
+        if raw_value is None:
+            continue
+        try:
+            return float(raw_value)
+        except (TypeError, ValueError):
+            continue
+    return None
 
 
 def _not_quantized_detection(*, quantization_profile_id: str = "") -> dict[str, object]:

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -15,7 +15,10 @@ from worker.model_ops.alignment_rollout_manifest import (
     build_alignment_rollout_manifest_fields_from_training_metrics,
 )
 from worker.model_ops.errors import ModelOperationError
-from worker.model_ops.lora_runtime_metadata import build_quantized_lora_manifest_fields
+from worker.model_ops.lora_runtime_metadata import (
+    build_lora_canary_receipt_fields,
+    build_quantized_lora_manifest_fields,
+)
 from worker.model_ops.multimodal_lora_contracts import (
     audit_adapter_checkpoint,
     audit_manifest_fields,
@@ -24,6 +27,15 @@ from worker.model_ops.multimodal_lora_contracts import (
 from worker.model_ops.response_only_boundary import ResponseOnlyBoundaryAggregate
 from worker.model_ops.mlx_lm_runner import MLXLMRunner, TrainingRequest, TrainingResult
 from worker.model_ops.training_config import LoRATrainingConfig, normalize_training_config
+from worker.model_ops.training_receipts import (
+    capability_gate_receipt,
+    dataset_files_resolved_receipt,
+)
+from worker.model_ops.training_runtime_preflight import (
+    call_with_training_failure_cleanup,
+    training_runtime_preflight_fields,
+    truthy,
+)
 from worker.model_ops.training_dataset import (
     HFDatasetFetcher,
     ResolvedTrainingDatasetPackage,
@@ -133,36 +145,45 @@ class LoRATrainingPipeline:
         resume_context = _resolve_resume_context(request_ext)
         adapter_scope = _resolve_adapter_scope_metadata(source_model)
         training_model_path = Path(adapter_scope["component_model_path"]).expanduser()
+        runtime_preflight_fields = training_runtime_preflight_fields(
+            source_model=source_model,
+            adapter_scope=adapter_scope,
+            inspection_only=truthy(request_ext.get("inspect_only_import", "")),
+        )
 
         emit("train", 0.8)
-        training_result = self._runner.train(
-            TrainingRequest(
-                job_id=job_id,
-                base_model_id=source_model.model_id,
-                model_path=training_model_path,
-                model_revision=source_model.revision,
-                adapter_output_dir=adapter_output_dir,
-                normalized_dataset_dir=normalized_snapshot.dataset_dir,
-                config=config,
-                dataset_format=trainer_dataset_format,
-                resume_source_path=resume_context["resume_source_path"],
-                source_model_kind=source_model.model_kind,
-                source_model_ext=dict(source_model.ext),
+        training_result = call_with_training_failure_cleanup(
+            lambda: self._runner.train(
+                TrainingRequest(
+                    job_id=job_id,
+                    base_model_id=source_model.model_id,
+                    model_path=training_model_path,
+                    model_revision=source_model.revision,
+                    adapter_output_dir=adapter_output_dir,
+                    normalized_dataset_dir=normalized_snapshot.dataset_dir,
+                    config=config,
+                    dataset_format=trainer_dataset_format,
+                    resume_source_path=resume_context["resume_source_path"],
+                    source_model_kind=source_model.model_kind,
+                    source_model_ext=dict(source_model.ext),
+                )
             )
         )
 
         emit("write_adapter", 0.9)
-        adapter_audit = audit_adapter_checkpoint(
-            weights_path=training_result.weights_path,
-            allowed_target_modules=config.expanded_target_modules,
-            source_model_kind=source_model.model_kind,
-            source_model_ext=dict(source_model.ext),
-            live_audit=training_result.metrics.adapter_freeze_audit,
-            multimodal_lora_nan_guard_triggered=(
-                training_result.metrics.multimodal_lora_nan_guard_triggered
-            ),
+        adapter_audit = call_with_training_failure_cleanup(
+            lambda: audit_adapter_checkpoint(
+                weights_path=training_result.weights_path,
+                allowed_target_modules=config.expanded_target_modules,
+                source_model_kind=source_model.model_kind,
+                source_model_ext=dict(source_model.ext),
+                live_audit=training_result.metrics.adapter_freeze_audit,
+                multimodal_lora_nan_guard_triggered=(
+                    training_result.metrics.multimodal_lora_nan_guard_triggered
+                ),
+            )
         )
-        raise_for_adapter_freeze_audit(adapter_audit)
+        call_with_training_failure_cleanup(lambda: raise_for_adapter_freeze_audit(adapter_audit))
         adapter_audit_fields = audit_manifest_fields(adapter_audit)
         adapter_artifact_bytes = adapter_audit.adapter_checkpoint_bytes
         adapter_set_hash = _content_hash(training_result.weights_path, training_result.adapter_config_path)
@@ -190,6 +211,13 @@ class LoRATrainingPipeline:
             training_mode=config.training_mode,
             quantization_mode=config.quantization_mode,
             target_modules=config.expanded_target_modules,
+        )
+        lora_canary_receipt_fields = build_lora_canary_receipt_fields(
+            source_model=source_model,
+            adapter_output_dir=adapter_output_dir,
+            adapter_config_path=training_result.adapter_config_path,
+            weights_path=training_result.weights_path,
+            training_metrics=training_result.metrics,
         )
 
         emit("write_manifest", 0.97)
@@ -225,12 +253,27 @@ class LoRATrainingPipeline:
             "dataset_materialized_package_path": str(dataset.materialized_package_path),
             "dataset_cache_key": dataset.cache_key,
             "dataset_cache_hit": dataset.cache_hit,
+            "validation_errors": [],
+            "resolved_bounds": dict(config.resolved_bounds),
+            "capability_gate": capability_gate_receipt(
+                config=config,
+                dataset=dataset,
+                source_model=source_model,
+            ),
+            "dataset_files_resolved": dataset_files_resolved_receipt(
+                dataset=dataset,
+                normalized_snapshot=normalized_snapshot,
+            ),
+            "grad_clip_policy": dict(config.grad_clip_policy),
+            "eval_batch_size": dict(config.eval_batch_size),
+            "scheduler_kwargs_omitted": dict(config.scheduler_kwargs_omitted),
             "training_mode": config.training_mode,
             "training_objective": config.training_objective,
             "adapter_algorithm": config.adapter_algorithm,
             "adapter_family": config.adapter_family,
             "adapter_capabilities": dict(config.adapter_capabilities),
             "backend_supported": config.backend_supported,
+            **runtime_preflight_fields,
             "unsupported_reason": config.unsupported_reason,
             "preference_loss": config.preference_loss,
             "dataset_contract": config.dataset_contract,
@@ -238,6 +281,7 @@ class LoRATrainingPipeline:
             "quantization_mode": config.quantization_mode,
             "base_quantization_method": config.base_quantization_method,
             **quantized_lora_fields,
+            **lora_canary_receipt_fields,
             "training_backend": training_result.execution_backend,
             "adapter_set_hash": adapter_set_hash,
             "weights_path": str(training_result.weights_path),
@@ -257,6 +301,7 @@ class LoRATrainingPipeline:
             "optimizer_steps": config.iters // config.gradient_accumulation,
             "mask_prompt": config.mask_prompt,
             "max_seq_length": config.max_seq_length,
+            **config.training_planner_receipt,
             "training.max_steps": config.max_steps,
             "training_duration_ms": training_result.metrics.job_duration_ms,
             "training.job_duration_ms": training_result.metrics.job_duration_ms,

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -118,6 +118,9 @@ class TrainingMetrics:
     unexpected_frozen_param_count: int = 0
     adapter_checkpoint_bytes: int = 0
     adapter_freeze_audit: dict[str, Any] | None = None
+    completion_loss: float | None = None
+    round_trip_passed: bool = False
+    grad_norm: float = 0.0
 
 
 @dataclass(frozen=True)

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -21,6 +21,14 @@ from worker.model_ops.release_compare_policy import (
     ReleaseCompareBundlePolicy,
     resolve_release_compare_bundle_policy,
 )
+from worker.model_ops.training_receipts import (
+    build_training_planner_receipt,
+    eval_batch_size_receipt,
+    grad_clip_policy_receipt,
+    resolved_bounds_receipt,
+    scheduler_kwargs_omitted_receipt,
+    typed_validation_details,
+)
 
 
 @dataclass(frozen=True)
@@ -77,6 +85,11 @@ class LoRATrainingConfig:
     target_repo: str
     chunked_training: bool
     chunk_size: int
+    resolved_bounds: dict[str, dict[str, object]] = field(default_factory=dict)
+    grad_clip_policy: dict[str, object] = field(default_factory=dict)
+    eval_batch_size: dict[str, object] = field(default_factory=dict)
+    scheduler_kwargs_omitted: dict[str, object] = field(default_factory=dict)
+    training_planner_receipt: dict[str, object] = field(default_factory=dict)
     training_objective: str = "supervised_finetuning"
     adapter_algorithm: str = "lora"
     adapter_family: str = "lora"
@@ -530,7 +543,12 @@ def normalize_training_config(
 
     gradient_checkpointing = _bool_value(
         ext.get("gradient_checkpointing", ""),
-        default=bool(preset.get("gradient_checkpointing", False)),
+        default=bool(
+            preset.get(
+                "gradient_checkpointing",
+                training_mode == "qlora",
+            )
+        ),
     )
     gradient_accumulation = _int_value(
         ext.get("gradient_accumulation", ""),
@@ -563,7 +581,7 @@ def normalize_training_config(
         _int_value(
             max_steps_raw,
             default=0,
-            minimum=1,
+            minimum=0,
             field_name="max_steps",
         )
         if max_steps_raw
@@ -629,6 +647,59 @@ def normalize_training_config(
             field_name=field_name,
         ),
     )
+    resolved_bounds = resolved_bounds_receipt(
+        ext,
+        max_steps=max_steps,
+        batch_size=batch_size,
+        sample_count=sample_count,
+        num_layers=num_layers,
+        total_layer_count=total_layer_count,
+    )
+    grad_clip_policy = grad_clip_policy_receipt(
+        ext,
+        float_value=lambda raw_value, default, minimum, field_name: _float_value(
+            raw_value,
+            default=default,
+            minimum=minimum,
+            field_name=field_name,
+        ),
+    )
+    eval_batch_size = eval_batch_size_receipt(
+        ext,
+        validation_sample_count=validation_sample_count,
+        int_value=lambda raw_value, default, minimum, field_name: _int_value(
+            raw_value,
+            default=default,
+            minimum=minimum,
+            field_name=field_name,
+        ),
+    )
+    scheduler_kwargs_omitted = scheduler_kwargs_omitted_receipt(ext)
+    training_planner_receipt = build_training_planner_receipt(
+        ext=ext,
+        training_mode=training_mode,
+        quantization_mode=quantization_mode,
+        batch_size=batch_size,
+        gradient_accumulation=gradient_accumulation,
+        max_seq_length=max_seq_length,
+        chunked_training=chunked_training,
+        chunk_size=chunk_size,
+        gradient_checkpointing=gradient_checkpointing,
+        validation_sample_count=validation_sample_count,
+        int_value=lambda raw_value, default, minimum, field_name: _int_value(
+            raw_value,
+            default=default,
+            minimum=minimum,
+            field_name=field_name,
+        ),
+        float_value=lambda raw_value, default, minimum, field_name: _float_value(
+            raw_value,
+            default=default,
+            minimum=minimum,
+            field_name=field_name,
+        ),
+        bool_value=lambda raw_value, default: _bool_value(raw_value, default=default),
+    )
 
     return LoRATrainingConfig(
         training_mode=training_mode,
@@ -671,6 +742,11 @@ def normalize_training_config(
         target_repo=ext.get("target_repo", "").strip(),
         chunked_training=chunked_training,
         chunk_size=chunk_size,
+        resolved_bounds=resolved_bounds,
+        grad_clip_policy=grad_clip_policy,
+        eval_batch_size=eval_batch_size,
+        scheduler_kwargs_omitted=scheduler_kwargs_omitted,
+        training_planner_receipt=training_planner_receipt,
         training_objective=mode_contract["training_objective"],
         adapter_algorithm=adapter_record.adapter_algorithm,
         adapter_family=adapter_record.adapter_family,
@@ -1295,13 +1371,24 @@ def _int_value(raw_value: str, *, default: int, minimum: int, field_name: str) -
         raise ModelOperationError(
             code="invalid_argument",
             message=f"{field_name} must be an integer.",
-            details={"field": field_name, "raw_value": str(raw_value)},
+            details=typed_validation_details(
+                field_name=field_name,
+                reason="invalid_integer",
+                received=str(raw_value),
+                minimum=minimum,
+                include_raw_value=True,
+            ),
         ) from exc
     if value < minimum:
         raise ModelOperationError(
             code="invalid_argument",
             message=f"{field_name} must be at least {minimum}.",
-            details={"field": field_name, "minimum": str(minimum)},
+            details=typed_validation_details(
+                field_name=field_name,
+                reason="below_minimum",
+                received=str(value),
+                minimum=minimum,
+            ),
         )
     return value
 
@@ -1313,13 +1400,24 @@ def _float_value(raw_value: str, *, default: float, minimum: float, field_name: 
         raise ModelOperationError(
             code="invalid_argument",
             message=f"{field_name} must be a number.",
-            details={"field": field_name, "raw_value": str(raw_value)},
+            details=typed_validation_details(
+                field_name=field_name,
+                reason="invalid_number",
+                received=str(raw_value),
+                minimum=minimum,
+                include_raw_value=True,
+            ),
         ) from exc
     if value < minimum:
         raise ModelOperationError(
             code="invalid_argument",
             message=f"{field_name} must be at least {minimum}.",
-            details={"field": field_name, "minimum": str(minimum)},
+            details=typed_validation_details(
+                field_name=field_name,
+                reason="below_minimum",
+                received=str(value),
+                minimum=minimum,
+            ),
         )
     return value
 

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -676,6 +676,7 @@ def normalize_training_config(
     )
     scheduler_kwargs_omitted = scheduler_kwargs_omitted_receipt(ext)
     training_planner_receipt = build_training_planner_receipt(
+        source_model=source_model,
         ext=ext,
         training_mode=training_mode,
         quantization_mode=quantization_mode,

--- a/services/mlx-worker-python/worker/model_ops/training_receipts.py
+++ b/services/mlx-worker-python/worker/model_ops/training_receipts.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+from typing import Any
+
+
+IntValue = Callable[[str, int, int, str], int]
+FloatValue = Callable[[str, float, float, str], float]
+BoolValue = Callable[[str, bool], bool]
+
+
+def build_training_planner_receipt(
+    *,
+    ext: dict[str, str],
+    training_mode: str,
+    quantization_mode: str,
+    batch_size: int,
+    gradient_accumulation: int,
+    max_seq_length: int,
+    chunked_training: bool,
+    chunk_size: int,
+    gradient_checkpointing: bool,
+    validation_sample_count: int,
+    int_value: IntValue,
+    float_value: FloatValue,
+    bool_value: BoolValue,
+) -> dict[str, object]:
+    token_budget_unit = chunk_size if chunked_training else max_seq_length
+    batching_strategy = "micro_batch"
+    if gradient_accumulation > 1:
+        batching_strategy = "micro_batch_accumulation"
+    if chunked_training:
+        batching_strategy = f"chunked_{batching_strategy}"
+
+    packing_mode = ext.get("packing_mode", "").strip().lower() or "none"
+    kernel_policy = ext.get("kernel_policy", "").strip().lower()
+    if not kernel_policy:
+        kernel_policy = "quantized_mlx" if quantization_mode == "quantized_base" else "mlx"
+
+    metric_for_best_model = ext.get("metric_for_best_model", "").strip()
+    if not metric_for_best_model:
+        metric_for_best_model = "validation_loss" if validation_sample_count > 0 else "loss_best"
+
+    return {
+        "batching_strategy": batching_strategy,
+        "cutoff_len": max_seq_length,
+        "micro_batch_size": batch_size,
+        "effective_token_budget": batch_size * gradient_accumulation * token_budget_unit,
+        "packing_mode": packing_mode,
+        "media_counts": {
+            "audio": media_count(ext, "media_audio_count", int_value=int_value),
+            "image": media_count(ext, "media_image_count", int_value=int_value),
+            "video": media_count(ext, "media_video_count", int_value=int_value),
+        },
+        "kernel_policy": kernel_policy,
+        "expected_peak_memory_class": expected_peak_memory_class(
+            batch_size=batch_size,
+            gradient_accumulation=gradient_accumulation,
+            token_budget_unit=token_budget_unit,
+            training_mode=training_mode,
+        ),
+        "profile_artifact_path": ext.get("profile_artifact_path", "").strip(),
+        "compiled_step_enabled": bool_value(
+            ext.get("compiled_step", "") or ext.get("compiled_step_enabled", ""),
+            False,
+        ),
+        "grad_checkpoint_enabled": gradient_checkpointing,
+        "attention_backend": attention_backend_receipt(ext.get("attention_backend", "")),
+        "metric_for_best_model_resolved": metric_for_best_model,
+        "generation_mode": ext.get("generation_mode", "").strip().lower() or "disabled",
+        "final_logit_softcapping": final_logit_softcapping(
+            ext.get("final_logit_softcapping", ""),
+            float_value=float_value,
+        ),
+    }
+
+
+def media_count(ext: dict[str, str], key: str, *, int_value: IntValue) -> int:
+    return int_value(ext.get(key, ""), 0, 0, key)
+
+
+def expected_peak_memory_class(
+    *,
+    batch_size: int,
+    gradient_accumulation: int,
+    token_budget_unit: int,
+    training_mode: str,
+) -> str:
+    weighted_tokens = batch_size * gradient_accumulation * token_budget_unit
+    if training_mode == "qlora":
+        weighted_tokens = int(weighted_tokens * 0.75)
+    if weighted_tokens <= 2048:
+        return "low"
+    if weighted_tokens <= 12288:
+        return "medium"
+    return "high"
+
+
+def attention_backend_receipt(raw_backend: str) -> dict[str, str]:
+    backend = raw_backend.strip().lower() or "mlx"
+    if backend in {"mlx", "sdpa", "eager"}:
+        return {"backend": backend, "status": "accepted", "reason": ""}
+    return {
+        "backend": backend,
+        "status": "refused",
+        "reason": "unsupported_training_attention_backend",
+    }
+
+
+def final_logit_softcapping(
+    raw_value: str,
+    *,
+    float_value: FloatValue,
+) -> float | None:
+    value = raw_value.strip().lower()
+    if not value or value in {"off", "none", "disabled", "false", "0"}:
+        return None
+    return float_value(value, 0.0, 0.0, "final_logit_softcapping")
+
+
+def typed_validation_details(
+    *,
+    field_name: str,
+    reason: str,
+    received: str,
+    minimum: int | float,
+    include_raw_value: bool = False,
+) -> dict[str, str]:
+    minimum_text = format_bound_value(minimum)
+    details = {
+        "field": field_name,
+        "reason": reason,
+        "received": received,
+        "minimum": minimum_text,
+        "allowed_bounds": f">={minimum_text}",
+        "http_status": "422",
+    }
+    if include_raw_value:
+        details["raw_value"] = received
+    return details
+
+
+def format_bound_value(value: int | float) -> str:
+    if isinstance(value, float) and value.is_integer():
+        return f"{value:.1f}"
+    return str(value)
+
+
+def resolved_bounds_receipt(
+    ext: dict[str, str],
+    *,
+    max_steps: int,
+    batch_size: int,
+    sample_count: int,
+    num_layers: int,
+    total_layer_count: int,
+) -> dict[str, dict[str, object]]:
+    max_steps_requested = ext.get("max_steps", "").strip()
+    return {
+        "max_steps": {
+            "received": max_steps_requested,
+            "resolved": max_steps,
+            "sentinel": "no_explicit_cap" if max_steps == 0 else "",
+            "allowed_bounds": "0 or >=1",
+        },
+        "batch_size": {
+            "received": ext.get("batch_size", "").strip(),
+            "resolved": batch_size,
+            "allowed_bounds": f"1..{max(sample_count, 1)}",
+        },
+        "num_layers": {
+            "received": ext.get("num_layers", "").strip(),
+            "resolved": num_layers,
+            "allowed_bounds": f"1..{total_layer_count}",
+        },
+    }
+
+
+def grad_clip_policy_receipt(
+    ext: dict[str, str],
+    *,
+    float_value: FloatValue,
+) -> dict[str, object]:
+    requested = (
+        ext.get("grad_clip", "").strip()
+        or ext.get("gradient_clip", "").strip()
+        or ext.get("gradient_clip_norm", "").strip()
+    )
+    if not requested:
+        return {
+            "requested": "",
+            "resolved": 0.0,
+            "enabled": False,
+            "source": "default",
+        }
+    resolved = float_value(requested, 0.0, 0.0, "grad_clip")
+    return {
+        "requested": requested,
+        "resolved": resolved,
+        "enabled": resolved > 0.0,
+        "source": "request",
+    }
+
+
+def eval_batch_size_receipt(
+    ext: dict[str, str],
+    *,
+    validation_sample_count: int,
+    int_value: IntValue,
+) -> dict[str, object]:
+    requested = ext.get("eval_batch_size", "").strip()
+    if requested:
+        resolved = int_value(requested, 1, 1, "eval_batch_size")
+        source = "request"
+    else:
+        resolved = 1 if validation_sample_count > 0 else 0
+        source = "default"
+    return {
+        "requested": requested,
+        "resolved": resolved,
+        "source": source,
+        "validation_sample_count": validation_sample_count,
+    }
+
+
+def scheduler_kwargs_omitted_receipt(ext: dict[str, str]) -> dict[str, object]:
+    scheduler_keys = [
+        key
+        for key in (
+            "lr_schedule",
+            "scheduler",
+            "scheduler_kwargs",
+            "scheduler_kwargs_json",
+        )
+        if ext.get(key, "").strip()
+    ]
+    if not scheduler_keys:
+        return {
+            "omitted": True,
+            "reason": "scheduler_not_configured",
+            "keys": [],
+        }
+    return {
+        "omitted": True,
+        "reason": "mlx_lm_lora_runner_does_not_accept_scheduler_kwargs",
+        "keys": scheduler_keys,
+    }
+
+
+def capability_gate_receipt(
+    *,
+    config: Any,
+    dataset: Any,
+    source_model: Any,
+) -> dict[str, Any]:
+    return {
+        "adapter_family": config.adapter_family,
+        "adapter_algorithm": config.adapter_algorithm,
+        "backend_supported": config.backend_supported,
+        "unsupported_reason": config.unsupported_reason,
+        "capabilities": dict(config.adapter_capabilities),
+        "training_mode": config.training_mode,
+        "training_objective": config.training_objective,
+        "dataset_contract": config.dataset_contract,
+        "dataset_format": dataset.package.format,
+        "response_only_supported": dataset.package.response_only_supported,
+        "quantization_mode": config.quantization_mode,
+        "base_quantization_method": config.base_quantization_method,
+        "source_model_kind": source_model.model_kind,
+    }
+
+
+def dataset_files_resolved_receipt(
+    *,
+    dataset: Any,
+    normalized_snapshot: Any,
+) -> dict[str, str]:
+    return {
+        "source_manifest_path": str(dataset.package.manifest_path),
+        "source_samples_path": str(dataset.package.samples_path),
+        "source_valid_path": _path_if_file(dataset.package.package_path / "valid.jsonl"),
+        "normalized_manifest_path": str(normalized_snapshot.manifest_path),
+        "normalized_train_path": str(normalized_snapshot.train_path),
+        "normalized_valid_path": (
+            str(normalized_snapshot.valid_path)
+            if normalized_snapshot.valid_path is not None
+            else ""
+        ),
+    }
+
+
+def _path_if_file(path: Path) -> str:
+    return str(path) if path.is_file() else ""

--- a/services/mlx-worker-python/worker/model_ops/training_receipts.py
+++ b/services/mlx-worker-python/worker/model_ops/training_receipts.py
@@ -12,6 +12,7 @@ BoolValue = Callable[[str, bool], bool]
 
 def build_training_planner_receipt(
     *,
+    source_model: Any,
     ext: dict[str, str],
     training_mode: str,
     quantization_mode: str,
@@ -55,6 +56,7 @@ def build_training_planner_receipt(
         },
         "kernel_policy": kernel_policy,
         "expected_peak_memory_class": expected_peak_memory_class(
+            source_model=source_model,
             batch_size=batch_size,
             gradient_accumulation=gradient_accumulation,
             token_budget_unit=token_budget_unit,
@@ -82,6 +84,7 @@ def media_count(ext: dict[str, str], key: str, *, int_value: IntValue) -> int:
 
 def expected_peak_memory_class(
     *,
+    source_model: Any,
     batch_size: int,
     gradient_accumulation: int,
     token_budget_unit: int,
@@ -90,11 +93,49 @@ def expected_peak_memory_class(
     weighted_tokens = batch_size * gradient_accumulation * token_budget_unit
     if training_mode == "qlora":
         weighted_tokens = int(weighted_tokens * 0.75)
+    model_ext = getattr(source_model, "ext", {}) or {}
+    estimated_resident_bytes = _model_metadata_int(
+        model_ext,
+        "melix.estimated_resident_bytes",
+        "estimated_resident_bytes",
+        "resident_bytes",
+    )
+    if estimated_resident_bytes is not None:
+        if estimated_resident_bytes >= 32 * 1024 * 1024 * 1024:
+            return "high"
+        if estimated_resident_bytes >= 8 * 1024 * 1024 * 1024:
+            return "medium"
+    parameter_count = _model_metadata_int(
+        model_ext,
+        "melix.parameter_count",
+        "parameter_count",
+        "parameters",
+    )
+    if parameter_count is not None:
+        if parameter_count >= 20_000_000_000:
+            return "high"
+        if parameter_count >= 7_000_000_000:
+            return "medium"
     if weighted_tokens <= 2048:
         return "low"
     if weighted_tokens <= 12288:
         return "medium"
     return "high"
+
+
+def _model_metadata_int(ext: object, *keys: str) -> int | None:
+    getter = getattr(ext, "get", lambda _key, _default="": "")
+    for key in keys:
+        raw_value = str(getter(key, "")).strip().replace("_", "")
+        if not raw_value:
+            continue
+        try:
+            value = int(raw_value)
+        except ValueError:
+            continue
+        if value >= 0:
+            return value
+    return None
 
 
 def attention_backend_receipt(raw_backend: str) -> dict[str, str]:

--- a/services/mlx-worker-python/worker/model_ops/training_runtime_preflight.py
+++ b/services/mlx-worker-python/worker/model_ops/training_runtime_preflight.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import gc
+import importlib
+import importlib.util
+import platform
+from typing import Any, Callable, TypeVar
+
+from worker.model_ops.errors import ModelOperationError
+
+_MEDIA_DECODER_MODULES = ("PIL", "imageio", "av", "soundfile")
+_T = TypeVar("_T")
+
+
+def truthy(raw_value: str) -> bool:
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def training_runtime_preflight_fields(
+    *,
+    source_model: Any,
+    adapter_scope: dict[str, str],
+    inspection_only: bool = False,
+) -> dict[str, Any]:
+    native_available = _module_spec_available("mlx") and _module_spec_available("mlx_lm")
+    media_dependency = _media_decoder_dependency_state()
+    disabled_decoder_paths: list[str] = []
+    if media_dependency["state"] != "healthy":
+        disabled_decoder_paths.append("media")
+
+    host_supported = platform.system() == "Darwin"
+    runtime_gate = "ready" if host_supported and native_available else "unsupported"
+    unsupported_reason = ""
+    if not host_supported:
+        unsupported_reason = "non_apple_host"
+    elif not native_available:
+        unsupported_reason = "missing_native_runtime"
+
+    if inspection_only:
+        native_load_status = "disabled"
+        fallback_reader = "metadata_only"
+    else:
+        native_load_status = "available" if native_available else "unavailable"
+        fallback_reader = "none" if native_available else "subprocess"
+
+    return {
+        "runtime_gate": runtime_gate,
+        "inspection_only_import": inspection_only,
+        "media_decoder_dependency": media_dependency,
+        "native_load_status": native_load_status,
+        "disabled_decoder_paths": disabled_decoder_paths,
+        "fallback_reader": fallback_reader,
+        "unsupported_reason": unsupported_reason,
+        "traceback_cleanup_result": "not_applicable",
+        "retained_tensor_bytes_after_failure": 0,
+        "training_runtime_preflight": {
+            "schema_version": "melix.training_runtime_preflight.v1",
+            "source_model_kind": source_model.model_kind,
+            "training_surface": adapter_scope.get("training_surface", ""),
+            "runtime_gate": runtime_gate,
+            "native_load_status": native_load_status,
+            "media_decoder_dependency": media_dependency,
+            "disabled_decoder_paths": list(disabled_decoder_paths),
+            "fallback_reader": fallback_reader,
+            "unsupported_reason": unsupported_reason,
+        },
+    }
+
+
+def call_with_training_failure_cleanup(callback: Callable[[], _T]) -> _T:
+    try:
+        return callback()
+    except Exception as exc:
+        raise_with_training_failure_cleanup(exc)
+
+
+def raise_with_training_failure_cleanup(exc: Exception) -> None:
+    cleanup = _cleanup_training_failure_exception(exc)
+    if isinstance(exc, ModelOperationError):
+        details = dict(exc.details)
+        details.update(cleanup)
+        raise ModelOperationError(
+            code=exc.code,
+            message=exc.message,
+            retriable=exc.retriable,
+            details=details,
+        ) from exc.__cause__
+    raise ModelOperationError(
+        code="backend_training_failure",
+        message=str(exc),
+        details=cleanup,
+    ) from None
+
+
+def _module_spec_available(module_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, AttributeError, ValueError):
+        return False
+
+
+def _media_decoder_dependency_state() -> dict[str, str]:
+    for module_name in _MEDIA_DECODER_MODULES:
+        try:
+            spec = importlib.util.find_spec(module_name)
+        except (ImportError, AttributeError, ValueError) as exc:
+            return {
+                "state": "broken",
+                "module": module_name,
+                "message": str(exc),
+            }
+        if spec is None:
+            continue
+        try:
+            importlib.import_module(module_name)
+        except Exception as exc:
+            return {
+                "state": "broken",
+                "module": module_name,
+                "message": str(exc),
+            }
+        return {
+            "state": "healthy",
+            "module": module_name,
+            "message": "",
+        }
+    return {
+        "state": "missing",
+        "module": "",
+        "message": "No optional media decoder dependency is installed.",
+    }
+
+
+def _cleanup_training_failure_exception(exc: BaseException) -> dict[str, str]:
+    cleared_count = 0
+    visited: set[int] = set()
+    pending: list[BaseException] = [exc]
+    while pending:
+        current = pending.pop()
+        current_id = id(current)
+        if current_id in visited:
+            continue
+        visited.add(current_id)
+        if current.__traceback__ is not None:
+            cleared_count += 1
+            current.__traceback__ = None
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+    gc.collect()
+    retained_bytes = _retained_tensor_bytes_after_failure()
+    return {
+        "traceback_cleanup_result": "cleared" if cleared_count else "not_needed",
+        "retained_tensor_bytes_after_failure": str(retained_bytes),
+    }
+
+
+def _retained_tensor_bytes_after_failure() -> int:
+    try:
+        import mlx.core as mx
+    except ModuleNotFoundError:
+        return 0
+    try:
+        if hasattr(mx, "metal") and hasattr(mx.metal, "get_peak_memory"):
+            return int(float(mx.metal.get_peak_memory() or 0.0))
+    except Exception:
+        return 0
+    return 0

--- a/services/mlx-worker-python/worker/model_ops/training_runtime_preflight.py
+++ b/services/mlx-worker-python/worker/model_ops/training_runtime_preflight.py
@@ -4,6 +4,7 @@ import gc
 import importlib
 import importlib.util
 import platform
+import traceback
 from typing import Any, Callable, TypeVar
 
 from worker.model_ops.errors import ModelOperationError
@@ -99,39 +100,71 @@ def _module_spec_available(module_name: str) -> bool:
         return False
 
 
-def _media_decoder_dependency_state() -> dict[str, str]:
+def _media_decoder_dependency_state() -> dict[str, Any]:
+    modules: dict[str, dict[str, str]] = {}
     for module_name in _MEDIA_DECODER_MODULES:
         try:
             spec = importlib.util.find_spec(module_name)
         except (ImportError, AttributeError, ValueError) as exc:
+            modules[module_name] = {"state": "broken", "message": str(exc)}
             return {
                 "state": "broken",
                 "module": module_name,
                 "message": str(exc),
+                "modules": modules,
             }
         if spec is None:
+            modules[module_name] = {
+                "state": "missing",
+                "message": f"Optional media decoder dependency is not installed: {module_name}.",
+            }
             continue
         try:
             importlib.import_module(module_name)
         except Exception as exc:
+            modules[module_name] = {"state": "broken", "message": str(exc)}
             return {
                 "state": "broken",
                 "module": module_name,
                 "message": str(exc),
+                "modules": modules,
             }
+        modules[module_name] = {"state": "healthy", "message": ""}
+    missing_modules = [
+        module_name
+        for module_name, module_state in modules.items()
+        if module_state["state"] == "missing"
+    ]
+    healthy_modules = [
+        module_name
+        for module_name, module_state in modules.items()
+        if module_state["state"] == "healthy"
+    ]
+    if not missing_modules:
         return {
             "state": "healthy",
-            "module": module_name,
+            "module": healthy_modules[0] if healthy_modules else "",
             "message": "",
+            "modules": modules,
+        }
+    if healthy_modules:
+        first_missing = missing_modules[0]
+        return {
+            "state": "partial",
+            "module": first_missing,
+            "message": f"Missing optional media decoder dependency: {first_missing}.",
+            "modules": modules,
         }
     return {
         "state": "missing",
         "module": "",
         "message": "No optional media decoder dependency is installed.",
+        "modules": modules,
     }
 
 
 def _cleanup_training_failure_exception(exc: BaseException) -> dict[str, str]:
+    traceback_summary = _traceback_summary_before_cleanup(exc)
     cleared_count = 0
     visited: set[int] = set()
     pending: list[BaseException] = [exc]
@@ -153,6 +186,7 @@ def _cleanup_training_failure_exception(exc: BaseException) -> dict[str, str]:
     return {
         "traceback_cleanup_result": "cleared" if cleared_count else "not_needed",
         "retained_tensor_bytes_after_failure": str(retained_bytes),
+        "traceback_summary_before_cleanup": traceback_summary,
     }
 
 
@@ -162,8 +196,26 @@ def _retained_tensor_bytes_after_failure() -> int:
     except ModuleNotFoundError:
         return 0
     try:
-        if hasattr(mx, "metal") and hasattr(mx.metal, "get_peak_memory"):
-            return int(float(mx.metal.get_peak_memory() or 0.0))
+        if hasattr(mx, "metal") and hasattr(mx.metal, "get_active_memory"):
+            return int(float(mx.metal.get_active_memory() or 0.0))
     except Exception:
         return 0
     return 0
+
+
+def _traceback_summary_before_cleanup(exc: BaseException) -> str:
+    rendered: list[str] = []
+    visited: set[int] = set()
+    pending: list[BaseException] = [exc]
+    while pending:
+        current = pending.pop()
+        current_id = id(current)
+        if current_id in visited:
+            continue
+        visited.add(current_id)
+        rendered.extend(traceback.format_exception(type(current), current, current.__traceback__, limit=8))
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+    return "".join(rendered)[-4096:]

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -9,6 +9,19 @@ from typing import Any
 
 _RUN_SCHEMA_VERSION = "melix.lora_experiment_run.v1"
 _INDEX_SCHEMA_VERSION = "melix.lora_experiment_index.v1"
+_LORA_CANARY_RECEIPT_KEYS = (
+    "source_eos_token",
+    "saved_eos_token",
+    "tokenizer_config_path",
+    "base_config_present",
+    "processor_resume_mode",
+    "aux_modules_restored",
+    "merge_export_canary_result",
+    "callback_api_drift_result",
+    "completion_loss",
+    "round_trip_passed",
+    "grad_norm",
+)
 
 
 def _iter_lora_run_dirs(train_root: Path) -> tuple[Path, ...]:
@@ -200,7 +213,7 @@ class LoraExperimentStore:
         else:
             created_at_unix_ms = int(manifest_path.stat().st_mtime * 1000)
         updated_at_unix_ms = int(manifest.get("updated_at_unix_ms", created_at_unix_ms))
-        return {
+        payload = {
             "schema_version": _RUN_SCHEMA_VERSION,
             "run_id": manifest_job_id,
             "group_id": group_id,
@@ -241,6 +254,10 @@ class LoraExperimentStore:
             "created_at_unix_ms": created_at_unix_ms,
             "updated_at_unix_ms": updated_at_unix_ms,
         }
+        for key in _LORA_CANARY_RECEIPT_KEYS:
+            if key in manifest:
+                payload[key] = manifest[key]
+        return payload
 
     @staticmethod
     def _checkpoint_lineage_entry(run: dict[str, Any]) -> dict[str, Any]:

--- a/services/mlx-worker-python/worker/runtime/token_route_receipt.py
+++ b/services/mlx-worker-python/worker/runtime/token_route_receipt.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import json
+
+_JSON_ENCODER = json.JSONEncoder(separators=(",", ":"), sort_keys=True)
+_INACTIVE_RECEIPT_JSON_CACHE: dict[tuple[str, str, str, str], str] = {}
+ROUTE_SAMPLE_LIMIT = 64
+
+
+class TokenRouteReceipt:
+    __slots__ = (
+        "_enabled",
+        "_fallback_raw_text_used",
+        "_hidden_reasoning_token_count",
+        "_last_token_route_channel",
+        "_last_token_route_channel_source",
+        "_last_token_route_id",
+        "_next_fallback_token_id",
+        "_pending_token_ids",
+        "_reasoning_mode",
+        "_records",
+        "_route_count",
+        "_router_id",
+        "_router_version",
+        "_sample_limit",
+        "_tool_choice_policy",
+        "_visible_text_token_count",
+    )
+
+    def __init__(
+        self,
+        *,
+        router_id: str,
+        router_version: str,
+        reasoning_enabled: bool,
+        reasoning_mode: str = "",
+        tool_choice_policy: str = "",
+        sample_limit: int = ROUTE_SAMPLE_LIMIT,
+        enabled: bool = True,
+    ) -> None:
+        self._enabled = enabled
+        self._router_id = router_id
+        self._router_version = router_version
+        self._reasoning_mode = reasoning_mode.strip().lower() or (
+            "enabled" if reasoning_enabled else "disabled"
+        )
+        self._tool_choice_policy = tool_choice_policy.strip().lower() or "auto"
+        self._sample_limit = sample_limit
+        self._pending_token_ids: list[int] = []
+        self._next_fallback_token_id = 0
+        self._records: list[dict[str, int | str]] = []
+        self._route_count = 0
+        self._visible_text_token_count = 0
+        self._hidden_reasoning_token_count = 0
+        self._last_token_route_id = -1
+        self._last_token_route_channel = ""
+        self._last_token_route_channel_source = ""
+        self._fallback_raw_text_used = False
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def activate(self) -> None:
+        self._enabled = True
+
+    @property
+    def pending_token_count(self) -> int:
+        return len(self._pending_token_ids)
+
+    def append_token_ids(self, token_ids: tuple[int, ...]) -> None:
+        if not self._enabled:
+            return
+        self._pending_token_ids.extend(token_ids)
+
+    def append_synthetic_token(self) -> None:
+        if not self._enabled:
+            return
+        self._pending_token_ids.append(self._next_synthetic_token_id())
+
+    def rollback_pending_to(self, previous_count: int) -> None:
+        if not self._enabled:
+            return
+        if previous_count != len(self._pending_token_ids):
+            del self._pending_token_ids[previous_count:]
+
+    def record_span(
+        self,
+        *,
+        channel: str,
+        channel_source: str,
+        consume_all_available: bool = False,
+    ) -> None:
+        if not self._enabled:
+            return
+        if consume_all_available and self._pending_token_ids:
+            token_ids = self._pending_token_ids
+            self._pending_token_ids = []
+            self._record_tokens(
+                token_ids=token_ids,
+                channel=channel,
+                channel_source=channel_source,
+            )
+            return
+        self._record_tokens(
+            token_ids=[self._route_token_id()],
+            channel=channel,
+            channel_source=channel_source,
+        )
+
+    def to_json(self) -> str:
+        if (
+            not self._enabled
+            and self._last_token_route_id == -1
+            and self._route_count == 0
+            and not self._records
+        ):
+            return inactive_token_route_receipt_json(
+                self._router_id,
+                self._router_version,
+                self._reasoning_mode,
+                self._tool_choice_policy,
+            )
+        return _JSON_ENCODER.encode(
+            {
+                "router_id": self._router_id,
+                "router_version": self._router_version,
+                "token_id": self._last_token_route_id,
+                "channel": self._last_token_route_channel,
+                "channel_source": self._last_token_route_channel_source,
+                "tool_choice_policy": self._tool_choice_policy,
+                "reasoning_mode": self._reasoning_mode,
+                "visible_text_tokens": self._visible_text_token_count,
+                "hidden_reasoning_tokens": self._hidden_reasoning_token_count,
+                "fallback_raw_text_used": self._fallback_raw_text_used,
+                "route_tracking_enabled": self._enabled,
+                "route_count": self._route_count,
+                "routes_sampled": len(self._records),
+                "routes": self._records,
+            }
+        )
+
+    def _next_synthetic_token_id(self) -> int:
+        token_id = self._next_fallback_token_id
+        self._next_fallback_token_id += 1
+        self._fallback_raw_text_used = True
+        return token_id
+
+    def _route_token_id(self) -> int:
+        if self._pending_token_ids:
+            return self._pending_token_ids.pop(0)
+        return self._next_synthetic_token_id()
+
+    def _record_tokens(
+        self,
+        *,
+        token_ids: list[int],
+        channel: str,
+        channel_source: str,
+    ) -> None:
+        token_count = len(token_ids)
+        if not token_count:
+            return
+        self._route_count += token_count
+        if channel == "visible_text":
+            self._visible_text_token_count += token_count
+        elif channel == "hidden_reasoning":
+            self._hidden_reasoning_token_count += token_count
+        self._last_token_route_id = token_ids[-1]
+        self._last_token_route_channel = channel
+        self._last_token_route_channel_source = channel_source
+        sample_slots = self._sample_limit - len(self._records)
+        if sample_slots <= 0:
+            return
+        for token_id in token_ids[:sample_slots]:
+            self._records.append(
+                {
+                    "token_id": token_id,
+                    "channel": channel,
+                    "channel_source": channel_source,
+                    "tool_choice_policy": self._tool_choice_policy,
+                    "reasoning_mode": self._reasoning_mode,
+                }
+            )
+
+
+def inactive_token_route_receipt_json(
+    router_id: str,
+    router_version: str,
+    reasoning_mode: str,
+    tool_choice_policy: str,
+) -> str:
+    cache_key = (router_id, router_version, reasoning_mode, tool_choice_policy)
+    cached = _INACTIVE_RECEIPT_JSON_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    payload = _JSON_ENCODER.encode(
+        {
+            "router_id": router_id,
+            "router_version": router_version,
+            "token_id": -1,
+            "channel": "",
+            "channel_source": "",
+            "tool_choice_policy": tool_choice_policy,
+            "reasoning_mode": reasoning_mode,
+            "visible_text_tokens": 0,
+            "hidden_reasoning_tokens": 0,
+            "fallback_raw_text_used": False,
+            "route_tracking_enabled": False,
+            "route_count": 0,
+            "routes_sampled": 0,
+            "routes": [],
+        }
+    )
+    _INACTIVE_RECEIPT_JSON_CACHE[cache_key] = payload
+    return payload


### PR DESCRIPTION
## Summary
- Add post-closure follow-up receipts for text compatibility routing, generation bounds, stop normalization, passthrough controls, tool parser parity, and token routing.
- Add worker-side finalizer, stream, LoRA admission, canary, runtime preflight, planner, and experiment-store receipts for follow-up tracker issues #1522 through #1531.
- Address review follow-ups for raw generation-bound parsing, prompt budget estimates, plain compatibility receipts, runtime preflight dependency state, failure cleanup, retained tensor measurement, and planner memory classification.

## Plan or Spec
- `docs/plans/2026-05-24-post-closure-followup-implementation.md`
- `docs/plans/2026-05-24-issue-1528-training-admission-receipts.md`
- `docs/plans/2026-05-24-issue-1529-lora-canaries.md`
- `docs/plans/2026-05-24-issue-1530-training-runtime-preflight.md`
- `docs/plans/2026-05-24-issue-1531-training-planner-receipts.md`
- `docs/control-plane-protocol.md`

## Commands Run
```text
make bootstrap
# passed; configured .githooks and verified uv sync

make proto
# passed; no generated artifact drift

git diff --check origin/main...HEAD
# passed; no whitespace errors on HEAD 02c38d74

xcrun swift test --no-parallel --package-path services/control-plane-swift --filter OpenAIHandlerTests
# passed on HEAD 440bd25b before latest origin/main merge; 168 tests passed
# passed again on HEAD bc281d58 after latest origin/main merge; 168 tests passed
# passed again on HEAD 4ebbd370 after merging origin/main 2ed5b479; 168 tests passed
# passed again on HEAD 8ab3f317 after merging origin/main f4ecdccf; 168 tests passed
# passed again on HEAD 02c38d74 after merging origin/main a7f58e87; 168 tests passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_generate_stream_receipts.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_training_planner_receipts.py -q
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o .runtime/review-followup-python-coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json .runtime/review-followup-python-coverage.json services/mlx-worker-python/worker/engine/engine_core.py services/mlx-worker-python/worker/model_ops/training_runtime_preflight.py services/mlx-worker-python/worker/model_ops/training_receipts.py services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_generate_stream_receipts.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_training_planner_receipts.py
# passed on HEAD 440bd25b; 58 tests passed; aggregate changed-line coverage 99%, production changed files 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_generate_stream_receipts.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_training_planner_receipts.py -q
# passed on HEAD bc281d58 after latest origin/main merge; 58 tests passed
# passed on HEAD 4ebbd370 after merging origin/main 2ed5b479; 58 tests passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_generate_stream_receipts.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_training_planner_receipts.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_multimodal_position_receipts.py -q
# passed on HEAD 8ab3f317 after merging origin/main f4ecdccf; 145 tests passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_generate_stream_receipts.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_training_planner_receipts.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_multimodal_position_receipts.py services/mlx-worker-python/tests/test_hub_catalog.py tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py -q
# passed on HEAD 02c38d74 after merging origin/main a7f58e87; 230 tests passed

git commit -m "fix: address follow-up receipt review findings"
# pre-commit passed on HEAD 440bd25b; make swift-test, make py-test, make integration-test, and follow-up scoped performance all completed
# make py-test: 3077 passed, 14 skipped, 2 warnings
# make integration-test: 114 passed, 1 skipped

make swift-test
# passed on HEAD bc281d58 after merging origin/main 7c84baa1
# make swift-test: passed, including macOS menubar package 767 tests in 22 suites
# first attempt on HEAD 4ebbd370 exposed a non-reproduced macOS menubar suite issue
# xcrun swift test --no-parallel --package-path apps/macos-menubar --filter AppMainBootstrapTests: passed, 51 tests
# make swift-test-menubar: passed, 767 tests in 22 suites
# rerun make swift-test: passed on HEAD 4ebbd370, including macOS menubar package 767 tests in 22 suites

make py-test
# make py-test: 3077 passed, 14 skipped, 2 warnings

make integration-test
# make integration-test: 114 passed, 1 skipped

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report

root = Path.cwd()
changed_files = [line for line in subprocess.check_output(["git", "diff", "--name-only", "origin/main...HEAD"], text=True).splitlines() if line]
outcome = run_performance_report(root, changed_files, base_ref="origin/main")
print(f"PERF_STATUS={outcome.status}")
print(f"PERF_REPORT_DIR={outcome.report_dir}")
raise SystemExit(0 if outcome.status in {"ok", "regression"} else 1)
PY
# completed on HEAD 440bd25b; PERF_STATUS=regression; verification failures=0
# completed on HEAD bc281d58; PERF_STATUS=regression; verification failures=0
# completed on HEAD 4ebbd370; PERF_STATUS=regression; verification failures=0
# completed on HEAD 8ab3f317; PERF_STATUS=regression; verification failures=0
```

## Coverage and Metrics
- Follow-up pre-commit performance report: `.runtime/pre-commit-performance/20260524-023122-56e2ddf7/report/report.md`
- Follow-up scope: 12 changed files; selected probes: 2; direct/gated probes: 2; regressions: 0; verification failures: 0.
- Follow-up probe coverage: training-config target-module cache 100%; engine generate usage token elision 100%.
- Full PR scoped performance report: `.runtime/pre-commit-performance/20260524-023245-440bd25b/report/report.md`
- Full PR scope: 33 changed files; selected probes: 5; direct/gated probes: 5; regressions: 1; verification failures: 0.
- Full PR probe coverage: training-config target-module cache 100%; LoRA experiment run-dir name scan 100%; MLX-LM structured result tail parse 100%; LoRA reward summary candidate min/max reuse 100%; engine generate usage token elision 98%.
- Full PR probe results:
  - Training config target-module cache: ok; elapsed -0.825ms (-0.38%), neutral.
  - LoRA experiment run-dir name scan: ok; peak bytes unchanged and path attr reads unchanged.
  - MLX-LM structured result tail parse: ok; elapsed +0.001ms (+0.93%), neutral.
  - LoRA reward summary candidate min/max reuse: ok; elapsed +0.173ms (+0.98%), neutral.
  - Engine generate usage token elision: scoped regression on fallback elapsed only; `fallback_elapsed_ms_mean` +7.606ms (+13.32%), while `prompt_token_count_calls_per_request` remains 0.0, `request_state_append_calls_per_request` remains 0.0, and fallback peak bytes improved by 5796.2 bytes (-6.30%).
- Latest full PR scoped performance report after merging origin/main f4ecdccf: `.runtime/pre-commit-performance/20260524-050245-8ab3f317/report/report.md`
- Latest full PR scope: 33 changed files; selected probes: 5; direct/gated probes: 5; regressions: 2; verification failures: 0.
- Latest full PR probe coverage: training-config target-module cache 100%; LoRA experiment run-dir name scan 100%; MLX-LM structured result tail parse 100%; LoRA reward summary candidate min/max reuse 100%; engine generate usage token elision 98%.
- Latest full PR probe results:
  - Training config target-module cache: ok; elapsed -0.538ms (-0.26%), neutral.
  - LoRA experiment run-dir name scan: ok; peak bytes unchanged and path attr reads unchanged.
  - MLX-LM structured result tail parse: ok; elapsed +0.003ms (+3.78%), neutral, with unchanged peak bytes.
  - LoRA reward summary candidate min/max reuse: ok; elapsed +0.136ms (+0.77%), neutral.
  - Engine generate usage token elision: scoped regression on fallback elapsed only; `fallback_elapsed_ms_mean` +7.121ms (+12.75%), while `prompt_token_count_calls_per_request` remains 0.0, `request_state_append_calls_per_request` remains 0.0, and fallback peak bytes improved by 6003.0 bytes (-6.54%).
- Performance rationale: the engine fallback elapsed regression is the intentional, request-local cost of completed receipt/finalizer metadata added for the post-closure evidence trackers. The original token-elision invariants remain intact, memory improves, and the review follow-up commit did not add a new stable scoped regression.

## Known Gaps
- The full PR engine fallback receipt/finalizer path has an accepted scoped performance regression documented above. No deferred debug or evidence-mode work is hidden outside the PR evidence.
- No protobuf schema changes; protocol generated artifacts are unchanged.
- No dependency changes; lockfiles are unchanged.
- Observability mode: minimal request-local receipts and test/probe evidence only. Probe overhead is covered by the PR scoped performance reports.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A is stated.
- [x] Dependency changes include updated lockfiles, or N/A is stated.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
