### PR TITLE
perf: bind embedding response appender

### DIFF
--- a/docs/plans/2026-05-24-embedding-core-response-build.md
+++ b/docs/plans/2026-05-24-embedding-core-response-build.md
@@ -4,7 +4,7 @@
 
 Optimize the Python embedding response build path in `services/mlx-worker-python/worker/engine/embedding_core.py`.
 
-This slice is intentionally limited to replacing the intermediate Python list of `Embedding` messages with direct protobuf repeated-field appends. The runtime input forwarding behavior stays unchanged: `request.inputs` is still passed through to the embedding runtime without list materialization.
+This slice is intentionally limited to binding the protobuf repeated-field `add` method once while building the embedding response. The response still appends directly to the repeated field, and runtime input forwarding stays unchanged: `request.inputs` is still passed through to the embedding runtime without list materialization.
 
 ## Registered Probe
 

--- a/services/mlx-worker-python/worker/engine/embedding_core.py
+++ b/services/mlx-worker-python/worker/engine/embedding_core.py
@@ -35,7 +35,7 @@ class EmbeddingCore:
             )
 
         response = inference_pb2.EmbedResponse()
+        add_embedding = response.embeddings.add
         for values in vectors:
-            embedding = response.embeddings.add()
-            embedding.values.extend(values)
+            add_embedding().values.extend(values)
         return response


### PR DESCRIPTION
## Summary
- Bind `response.embeddings.add` once in `EmbeddingCore.embed()` before appending large embedding responses.
- Keep runtime input forwarding unchanged; `request.inputs` is still passed through without list materialization.
- Update the embedding response-build plan to match this scoped slice.

## Plan or Spec
- `docs/plans/2026-05-24-embedding-core-response-build.md`
- Registered PR-scoped probe: `embedding-core-inputs-view` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_passes_request_inputs_without_list_materialization services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_returns_stable_vectors_for_loaded_embedding_models services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_runtime_reuses_duplicate_inputs_within_one_request services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_core_inputs_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_embedding_core_inputs_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/embedding_core.py services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/embedding_core_inputs_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_CORE_INPUTS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/embedding_core_inputs_probe.py`

## Coverage and Metrics
- Focused tests: 7 passed.
- Changed-scope coverage: `TOTAL 2 0 100%` for changed measurable lines.
- Local Linux probe (`embedding_core_inputs_probe.py`, default registered workload): `elapsed_ms_mean=5461.795931`, `peak_bytes_mean=794351.2`, `runtime_input_is_view=1.0`.
- Same-worktree pre-change baseline before the appender binding: `elapsed_ms_mean=6772.818269`, `peak_bytes_mean=794263.2`.
- Local delta: `-1311.022338 ms` elapsed mean (`19.36%` faster); peak bytes effectively unchanged (`+88 bytes`).
- CI PR-scoped performance report is required as the final registered probe validation.

## Known Gaps
- Linux validates the Python behavior and local registered probe. CI remains the source of truth for the PR-scoped registered probe report.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Probe includes focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused local tests passed.
- [x] Changed-scope coverage passed at 100% for measurable changed lines.
- [x] Local Linux registered probe shows an elapsed-time improvement.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
