### PR TITLE
perf: reduce embedding digest projection setup

### DIFF
--- a/docs/plans/2026-05-24-embedding-project-digest-fixed-scale.md
+++ b/docs/plans/2026-05-24-embedding-project-digest-fixed-scale.md
@@ -1,0 +1,22 @@
+# Embedding project digest fixed-scale performance slice
+
+## Scope
+
+This Python-only performance slice targets `DeterministicEmbeddingBackend._project_digest` in `services/mlx-worker-python/worker/runtime/embedding_backends.py`.
+
+The affected path is covered by the registered PR-scoped performance probe `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json`. The registry entry already includes focused `test_command`, `coverage_command`, and `probe_command` entries for the implementation, embedding runtime tests, PR-scoped performance tests, and `scripts/deterministic_embedding_project_digest_probe.py`.
+
+## Optimization
+
+The digest projection always unpacks a SHA-256 digest into exactly eight little-endian `uint32` values. This slice keeps the projection semantics unchanged while switching the eight-value normalization setup to a fixed-scale list comprehension. The change avoids the per-value append loop and repeated division in the digest hot path, then reuses the same normalized base tiling behavior for arbitrary embedding dimensions.
+
+## Verification plan
+
+1. Run the registered focused test command for `deterministic-embedding-project-digest-allocation` locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run the registered probe locally against `origin/main` and this branch with `scripts/pr_scoped_performance_run.py --probe-id deterministic-embedding-project-digest-allocation`.
+4. Use the PR-scoped performance workflow as the merge gate for the registered CI probe report.
+
+## Metrics
+
+Primary metric: `elapsed_ms_mean` from `deterministic-embedding-project-digest-allocation` (lower is better). Secondary metric: `peak_bytes_mean` should not regress materially because output vector materialization is unchanged.

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -7,6 +7,7 @@ import struct
 import unicodedata
 
 _UNPACK_DIGEST_UINT32 = struct.Struct("<8I").unpack
+_DIGEST_UINT32_SCALE = 2.0 / 0xFFFFFFFF
 
 
 @dataclass(frozen=True)
@@ -44,16 +45,12 @@ class DeterministicEmbeddingBackend:
         raise NotImplementedError
 
     def _project_digest(self, seed_text: str, dimensions: int) -> list[float]:
-        digest = hashlib.sha256(seed_text.encode("utf-8")).digest()
-        base_values: list[float] = []
-        base_squared_sum = 0.0
-        for raw in _UNPACK_DIGEST_UINT32(digest):
-            value = (raw / 0xFFFFFFFF) * 2.0 - 1.0
-            base_values.append(value)
-            base_squared_sum += value * value
-        base_count = len(base_values)
-        full_repeats, remainder = divmod(dimensions, base_count)
-        squared_sum = base_squared_sum * full_repeats
+        base_values = [
+            raw * _DIGEST_UINT32_SCALE - 1.0
+            for raw in _UNPACK_DIGEST_UINT32(hashlib.sha256(seed_text.encode("utf-8")).digest())
+        ]
+        full_repeats, remainder = divmod(dimensions, 8)
+        squared_sum = sum(value * value for value in base_values) * full_repeats
         for value in base_values[:remainder]:
             squared_sum += value * value
 


### PR DESCRIPTION
## Summary
- Reduce deterministic embedding digest projection setup by using a fixed uint32 scale and list comprehension for the eight SHA-256 chunks.
- Keep embedding projection values unchanged; the existing legacy parity test covers dimensions including 0, 1, 8, 9, 17, 384, 1536, and 4096.

## Plan or Spec
- `docs/plans/2026-05-24-embedding-project-digest-fixed-scale.md`
- Registered probe: `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
18 passed in 14.30s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
18 passed in 45.21s; TOTAL 4 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-project-digest-allocation --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-tool-registry-select-sentinel-20260524022605 --head-repo "$PWD" --output /tmp/embedding_project_digest_probe_fixed_scale_20260524025815.json
head verification ok; base/head probes ok
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Local registered probe (`deterministic-embedding-project-digest-allocation`):
  - `elapsed_ms_mean`: base `17.807051` ms, head `17.634473` ms, delta `-0.172578` ms (`-0.97%`).
  - `peak_bytes_mean`: base `66771.666667` bytes, head `66650.666667` bytes, delta `-121` bytes (`-0.18%`).
- CI PR-scoped performance is required as the final registered probe validation source before merge.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this is a narrow Python hot-path slice verified with the registered focused tests, coverage, and probe on Linux.
- No Swift runtime validation is involved in this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
