### PR TITLE
Guard VLM vision metadata receipts

### DIFF
--- a/docs/plans/2026-05-24-issue-42-u2-1-2-vision-metadata-shape-guards.md
+++ b/docs/plans/2026-05-24-issue-42-u2-1-2-vision-metadata-shape-guards.md
@@ -1,0 +1,67 @@
+# Issue 42 Unit 2.1.2 Vision Metadata Shape Guards
+
+## Source
+
+- Parent issue: <https://github.com/Keith-CY/melix/issues/1448>
+- Governing roadmap: `docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md`
+- Prior unit: `docs/plans/2026-05-24-issue-42-u2-1-1-position-metadata-receipts.md`
+
+## Scope
+
+Add worker-local guard receipts for VLM requests whose vision-position metadata
+is absent, stale, or unsafe to reuse. This unit keeps the public HTTP,
+protobuf, chat, CLI, health, and diagnostics payload shapes unchanged.
+
+The current Python worker does not expose a literal `visual_pos_masks` field.
+The equivalent runtime boundary is the shape-only position receipt introduced
+in U2.1.1: `position_ids`, `rope_deltas`, media position counts, `cache_offset`,
+and `seq_len`. U2.1.2 records when those shapes are safe, absent, or stale
+instead of slicing or reusing missing multimodal metadata implicitly.
+
+## Design
+
+- Extend the position metadata receipt with null-safe guard fields:
+  `vision_metadata_guard`, `vision_metadata_reuse_allowed`,
+  `stale_metadata_fallback_count`, and `companion_rederive_skip_reason`.
+- Treat prompt-only and image-free prefills as normal baseline requests:
+  no media position state is required, no mismatch is counted, and reuse remains
+  allowed for text-only state.
+- Replace any previous media-bearing probe receipt when a text-only follow-up
+  reaches the VLM runtime, even if a test or legacy caller presents the same
+  probe signature. Text-only receipts must not inherit stale media position
+  counts or companion skip reasons.
+- Treat media-bearing requests without aligned `position_ids` or `rope_deltas`
+  as conservative fallback receipts before reuse:
+  `vision_metadata_guard=missing_position_metadata`,
+  `vision_metadata_reuse_allowed=false`, and
+  `stale_metadata_fallback_count=1`.
+- Treat media-bearing companion-state rederive as skipped in this worker-local
+  unit by recording `companion_rederive_skip_reason=
+  multimodal_companion_rederive_skipped_has_media`.
+
+## Performance And Metrics
+
+The guard is receipt-only and runs in constant time over scalar metadata plus
+the existing media count. It introduces no tensor tracing, public metrics, or
+runtime scheduling work in this unit.
+
+Success metrics:
+
+- Existing VLM fast-path probe tests stay green.
+- Image-free / prompt-only VLM tests do not create media sessions or mismatch
+  fallback receipts.
+- Media-bearing requests with missing position metadata emit a conservative
+  worker-local receipt.
+- Changed-line coverage for touched Python worker files is at least 95 percent.
+
+## Verification
+
+Run focused Python tests for:
+
+- `services/mlx-worker-python/tests/test_multimodal_position_receipts.py`
+- `services/mlx-worker-python/tests/test_mlx_vlm_runtime.py`
+- `services/mlx-worker-python/tests/test_vision_runtime.py`
+
+Before PR handoff, run `git diff --check`, changed-line coverage for touched
+files, and a metrics report. The repository pre-commit hook provides the full
+local gate and PR-scoped performance report on the macOS 128 GiB host.

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -191,6 +191,64 @@ def imported_gemma4_vlm_model() -> common_pb2.ModelSpec:
     )
 
 
+def _assert_text_only_follow_up_replaces_media_probe_when_signature_repeats() -> None:
+    runtime = MLXVLMRuntime()
+    loaded_model = {
+        "metadata": {
+            "vision_family_id": "gemma4-v1",
+            "melix.vlm.execution_mode": "multimodal",
+        },
+        "model": SimpleNamespace(config=SimpleNamespace(model_type="gemma4")),
+    }
+    media_request = PreparedVisionRequest(
+        prompt_text="Describe.",
+        images=[
+            PreparedImageInput(
+                bytes_data=b"image",
+                source_kind="inline",
+                reference="inline:image",
+                mime_type="image/jpeg",
+                format="jpg",
+                filename="image.jpg",
+                sha256_hex="deadbeef",
+            )
+        ],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=len(b"image"),
+        preprocess_peak_memory_bytes=len(b"image"),
+        prompt_hash_hex="1" * 64,
+        multimodal_hash_hex="shared-probe-signature",
+    )
+    prompt_only_request = PreparedVisionRequest(
+        prompt_text="Now answer in text.",
+        images=[],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=len(b"Now answer in text."),
+        preprocess_peak_memory_bytes=0,
+        prompt_hash_hex="2" * 64,
+        multimodal_hash_hex="shared-probe-signature",
+    )
+
+    runtime._record_fast_path_probe(loaded_model, media_request)
+    runtime._record_fast_path_probe(loaded_model, prompt_only_request)
+    text_probe = runtime.last_probe_snapshot()
+    receipt = text_probe.position_metadata_receipt
+
+    assert receipt["media_position_count"] == 0
+    assert receipt["vision_metadata_guard"] == "no_media"
+    assert receipt["vision_metadata_reuse_allowed"] is True
+    assert receipt["stale_metadata_fallback_count"] == 0
+    assert receipt["companion_rederive_skip_reason"] == ""
+
+    runtime._record_fast_path_probe(loaded_model, prompt_only_request)
+
+    assert runtime.last_probe_snapshot() is text_probe
+
+
 def test_registry_routes_imported_vlm_models_to_mlx_vlm_runtime() -> None:
     fake_runtime = object()
     registry = WorkerRegistry(mlx_vlm_runtime=fake_runtime)  # type: ignore[arg-type]
@@ -701,6 +759,7 @@ def _run_text_only_step_with_buffered_detokenizer(
 def test_mlx_vlm_runtime_text_only_step_flushes_buffer_before_stop_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _assert_text_only_follow_up_replaces_media_probe_when_signature_repeats()
     events = _run_text_only_step_with_buffered_detokenizer(monkeypatch, [101, 102, 106])
 
     assert [event.text for event in events] == ["Hello!"]

--- a/services/mlx-worker-python/tests/test_multimodal_position_receipts.py
+++ b/services/mlx-worker-python/tests/test_multimodal_position_receipts.py
@@ -107,6 +107,10 @@ def test_position_metadata_receipt_counts_tensor_shapes_and_media_positions() ->
         "rebuild_count": 1,
         "mismatch_fallback_count": 1,
         "fallback_reason": "shape_mismatch",
+        "vision_metadata_guard": "aligned",
+        "vision_metadata_reuse_allowed": True,
+        "stale_metadata_fallback_count": 0,
+        "companion_rederive_skip_reason": "multimodal_companion_rederive_skipped_has_media",
     }
 
 
@@ -122,6 +126,10 @@ def test_position_metadata_receipt_defaults_to_shape_only_baseline() -> None:
         "rebuild_count": 0,
         "mismatch_fallback_count": 0,
         "fallback_reason": "",
+        "vision_metadata_guard": "no_media",
+        "vision_metadata_reuse_allowed": True,
+        "stale_metadata_fallback_count": 0,
+        "companion_rederive_skip_reason": "",
     }
 
 
@@ -134,6 +142,175 @@ def test_position_metadata_receipt_counts_flat_metadata_values() -> None:
 
     assert receipt["position_ids_count"] == 4
     assert receipt["rope_deltas_count"] == 2
+
+
+def test_position_metadata_receipt_blocks_media_reuse_when_position_metadata_is_missing() -> None:
+    request = PreparedVisionRequest(
+        prompt_text="Describe the image.",
+        images=[
+            PreparedImageInput(
+                bytes_data=b"image",
+                source_kind="inline",
+                reference="inline:image",
+                mime_type="image/jpeg",
+                format="jpg",
+                filename="image.jpg",
+                sha256_hex="abc123",
+            )
+        ],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=5,
+        preprocess_peak_memory_bytes=5,
+    )
+
+    receipt = build_position_metadata_receipt(
+        prepared_request=request,
+        seq_len=12,
+        fallback_reason="",
+    )
+
+    assert receipt["vision_metadata_guard"] == "missing_position_metadata"
+    assert receipt["vision_metadata_reuse_allowed"] is False
+    assert receipt["stale_metadata_fallback_count"] == 1
+    assert receipt["companion_rederive_skip_reason"] == (
+        "multimodal_companion_rederive_skipped_has_media"
+    )
+
+
+def test_position_metadata_receipt_allows_media_reuse_when_position_metadata_is_aligned() -> None:
+    request = PreparedVisionRequest(
+        prompt_text="Describe the image.",
+        images=[
+            PreparedImageInput(
+                bytes_data=b"image",
+                source_kind="inline",
+                reference="inline:image",
+                mime_type="image/jpeg",
+                format="jpg",
+                filename="image.jpg",
+                sha256_hex="abc123",
+            )
+        ],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=5,
+        preprocess_peak_memory_bytes=5,
+    )
+
+    receipt = build_position_metadata_receipt(
+        prepared_request=request,
+        seq_len=12,
+        position_ids=SimpleNamespace(shape=(1, 12)),
+        rope_deltas=SimpleNamespace(shape=(1, 3)),
+    )
+
+    assert receipt["vision_metadata_guard"] == "aligned"
+    assert receipt["vision_metadata_reuse_allowed"] is True
+    assert receipt["stale_metadata_fallback_count"] == 0
+    assert receipt["companion_rederive_skip_reason"] == (
+        "multimodal_companion_rederive_skipped_has_media"
+    )
+
+
+def test_position_metadata_receipt_blocks_stale_position_metadata_shapes() -> None:
+    request = PreparedVisionRequest(
+        prompt_text="Describe the image.",
+        images=[
+            PreparedImageInput(
+                bytes_data=b"image",
+                source_kind="inline",
+                reference="inline:image",
+                mime_type="image/jpeg",
+                format="jpg",
+                filename="image.jpg",
+                sha256_hex="abc123",
+            )
+        ],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=5,
+        preprocess_peak_memory_bytes=5,
+    )
+
+    receipt = build_position_metadata_receipt(
+        prepared_request=request,
+        seq_len=12,
+        position_ids=SimpleNamespace(shape=(1, 8)),
+        rope_deltas=SimpleNamespace(shape=(1, 3)),
+    )
+
+    assert receipt["vision_metadata_guard"] == "stale_position_metadata"
+    assert receipt["vision_metadata_reuse_allowed"] is False
+    assert receipt["stale_metadata_fallback_count"] == 1
+
+
+def test_position_metadata_receipt_allows_flat_media_metadata_without_shape() -> None:
+    request = PreparedVisionRequest(
+        prompt_text="Describe the image.",
+        images=[
+            PreparedImageInput(
+                bytes_data=b"image",
+                source_kind="inline",
+                reference="inline:image",
+                mime_type="image/jpeg",
+                format="jpg",
+                filename="image.jpg",
+                sha256_hex="abc123",
+            )
+        ],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=5,
+        preprocess_peak_memory_bytes=5,
+    )
+
+    receipt = build_position_metadata_receipt(
+        prepared_request=request,
+        seq_len=4,
+        position_ids=[0, 1, 2, 3],
+        rope_deltas={"row0": 0},
+    )
+
+    assert receipt["vision_metadata_guard"] == "aligned"
+    assert receipt["vision_metadata_reuse_allowed"] is True
+    assert receipt["stale_metadata_fallback_count"] == 0
+
+
+def test_position_metadata_receipt_allows_unknown_extent_when_seq_len_is_zero() -> None:
+    request = PreparedVisionRequest(
+        prompt_text="Describe the image.",
+        images=[
+            PreparedImageInput(
+                bytes_data=b"image",
+                source_kind="inline",
+                reference="inline:image",
+                mime_type="image/jpeg",
+                format="jpg",
+                filename="image.jpg",
+                sha256_hex="abc123",
+            )
+        ],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=5,
+        preprocess_peak_memory_bytes=5,
+    )
+
+    receipt = build_position_metadata_receipt(
+        prepared_request=request,
+        seq_len=0,
+        position_ids=object(),
+        rope_deltas={"row0": 0},
+    )
+
+    assert receipt["vision_metadata_guard"] == "aligned"
+    assert receipt["vision_metadata_reuse_allowed"] is True
 
 
 def test_position_metadata_receipt_counts_video_without_expanded_frame_policy() -> None:
@@ -170,6 +347,8 @@ def test_position_metadata_receipt_counts_video_without_expanded_frame_policy() 
 
     assert receipt["position_ids_count"] == 1
     assert receipt["media_position_count"] == 1
+    assert receipt["vision_metadata_guard"] == "missing_rope_metadata"
+    assert receipt["vision_metadata_reuse_allowed"] is False
 
 
 def test_deterministic_vlm_runtime_records_position_metadata_receipt() -> None:
@@ -205,7 +384,13 @@ def test_deterministic_vlm_runtime_records_position_metadata_receipt() -> None:
     assert receipt["media_position_count"] == 1
     assert receipt["seq_len"] > 1
     assert receipt["rebuild_count"] == 1
-    assert receipt["mismatch_fallback_count"] == 0
+    assert receipt["mismatch_fallback_count"] == 1
+    assert receipt["vision_metadata_guard"] == "missing_position_metadata"
+    assert receipt["vision_metadata_reuse_allowed"] is False
+    assert receipt["stale_metadata_fallback_count"] == 1
+    assert receipt["companion_rederive_skip_reason"] == (
+        "multimodal_companion_rederive_skipped_has_media"
+    )
 
 
 def test_mlx_vlm_runtime_records_position_metadata_receipt_for_media_requests() -> None:
@@ -283,8 +468,12 @@ def test_mlx_vlm_runtime_records_position_metadata_receipt_for_media_requests() 
         "cache_offset": 0,
         "seq_len": 5,
         "rebuild_count": 1,
-        "mismatch_fallback_count": 0,
+        "mismatch_fallback_count": 1,
         "fallback_reason": "",
+        "vision_metadata_guard": "missing_position_metadata",
+        "vision_metadata_reuse_allowed": False,
+        "stale_metadata_fallback_count": 1,
+        "companion_rederive_skip_reason": "multimodal_companion_rederive_skipped_has_media",
     }
 
 
@@ -326,6 +515,9 @@ def test_mlx_vlm_runtime_position_receipt_records_fallback_reason_for_text_backe
     assert receipt["seq_len"] == 3
     assert receipt["mismatch_fallback_count"] == 1
     assert receipt["fallback_reason"] == "text_backed_no_vision_weights"
+    assert receipt["vision_metadata_guard"] == "missing_position_metadata"
+    assert receipt["vision_metadata_reuse_allowed"] is False
+    assert receipt["stale_metadata_fallback_count"] == 1
 
 
 def test_mlx_vlm_runtime_position_receipt_records_baseline_for_prompt_only_turns() -> None:
@@ -363,4 +555,8 @@ def test_mlx_vlm_runtime_position_receipt_records_baseline_for_prompt_only_turns
         "rebuild_count": 0,
         "mismatch_fallback_count": 0,
         "fallback_reason": "no_media",
+        "vision_metadata_guard": "no_media",
+        "vision_metadata_reuse_allowed": True,
+        "stale_metadata_fallback_count": 0,
+        "companion_rederive_skip_reason": "",
     }

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -2246,7 +2246,9 @@ class MLXVLMRuntime:
             prepared_request,
         )
         if self._last_fast_path_signature == signature and not prepared_request.images and not prepared_request.videos:
-            return
+            receipt = self._last_probe.position_metadata_receipt or {}
+            if int(receipt.get("media_position_count", 0) or 0) == 0:
+                return
         fast_path = self._fast_path_controller.plan(loaded_model, prepared_request)
         self._last_fast_path_signature = signature
         self._last_probe = VisionProbeSnapshot(

--- a/services/mlx-worker-python/worker/runtime/multimodal_position_receipts.py
+++ b/services/mlx-worker-python/worker/runtime/multimodal_position_receipts.py
@@ -17,20 +17,43 @@ def build_position_metadata_receipt(
     position_ids_count = _value_count(position_ids)
     rope_deltas_count = _value_count(rope_deltas)
     media_position_count = _media_position_count(prepared_request)
+    normalized_cache_offset = max(0, int(cache_offset or 0))
+    normalized_seq_len = max(0, int(seq_len or 0))
     normalized_fallback_reason = str(fallback_reason or "")
+    guard = _vision_metadata_guard(
+        media_position_count=media_position_count,
+        position_ids=position_ids,
+        rope_deltas=rope_deltas,
+        seq_len=normalized_seq_len,
+    )
+    reuse_allowed = guard in {"no_media", "aligned"}
+    stale_metadata_fallback_count = 0 if reuse_allowed else 1
+    companion_rederive_skip_reason = (
+        "multimodal_companion_rederive_skipped_has_media" if media_position_count else ""
+    )
     return {
         "position_ids_present": position_ids is not None,
         "position_ids_count": position_ids_count,
         "rope_deltas_present": rope_deltas is not None,
         "rope_deltas_count": rope_deltas_count,
         "media_position_count": media_position_count,
-        "cache_offset": max(0, int(cache_offset or 0)),
-        "seq_len": max(0, int(seq_len or 0)),
+        "cache_offset": normalized_cache_offset,
+        "seq_len": normalized_seq_len,
         "rebuild_count": 1 if media_position_count else 0,
         "mismatch_fallback_count": (
-            1 if media_position_count and normalized_fallback_reason not in {"", "no_media"} else 0
+            1
+            if media_position_count
+            and (
+                normalized_fallback_reason not in {"", "no_media"}
+                or stale_metadata_fallback_count
+            )
+            else 0
         ),
         "fallback_reason": normalized_fallback_reason,
+        "vision_metadata_guard": guard,
+        "vision_metadata_reuse_allowed": reuse_allowed,
+        "stale_metadata_fallback_count": stale_metadata_fallback_count,
+        "companion_rederive_skip_reason": companion_rederive_skip_reason,
     }
 
 
@@ -57,3 +80,41 @@ def _value_count(value: Any | None) -> int:
     if isinstance(value, (list, tuple)):
         return len(value)
     return 1
+
+
+def _vision_metadata_guard(
+    *,
+    media_position_count: int,
+    position_ids: Any | None,
+    rope_deltas: Any | None,
+    seq_len: int,
+) -> str:
+    if media_position_count <= 0:
+        return "no_media"
+    if position_ids is None:
+        return "missing_position_metadata"
+    if rope_deltas is None:
+        return "missing_rope_metadata"
+    if not _position_metadata_covers_sequence(position_ids, seq_len):
+        return "stale_position_metadata"
+    return "aligned"
+
+
+def _position_metadata_covers_sequence(position_ids: Any, seq_len: int) -> bool:
+    if seq_len <= 0:
+        return _value_count(position_ids) > 0
+
+    shape_extent = _last_shape_extent(position_ids)
+    if shape_extent is not None:
+        return shape_extent >= seq_len
+
+    if isinstance(position_ids, (list, tuple)):
+        return len(position_ids) >= seq_len
+    return _value_count(position_ids) >= seq_len
+
+
+def _last_shape_extent(value: Any) -> int | None:
+    shape = getattr(value, "shape", None)
+    if not isinstance(shape, (tuple, list)) or not shape:
+        return None
+    return max(0, int(shape[-1]))


### PR DESCRIPTION
## Summary
- Add worker-local VLM position metadata receipt guards for no-media, missing metadata, stale metadata, and aligned multimodal metadata states.
- Prevent a text-only follow-up from reusing a prior media-bearing fast-path probe receipt when the synthetic fast-path signature repeats.
- Document the U2.1.2 guard slice and keep the change inside the Python worker/probe surface with no protocol or public API change.

Closes #1448.

## Plan or Spec
- `docs/plans/2026-05-24-issue-42-u2-1-2-vision-metadata-shape-guards.md`

## Commands Run
```text
# Focused Python VLM regression suite before commit
PYTHONPATH=.:services/mlx-worker-python uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_multimodal_position_receipts.py services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_text_only_step_flushes_buffer_before_stop_token services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_supports_prompt_only_generation_for_multimodal_models services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_text_only_step_uses_isolated_detokenizer services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_text_only_batch_generator_requires_opt_in
Result: 39 passed in 0.09s

# Focused Swift route regression
swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests/postChatCompletionsKeepsGemma4VLMMediaRequestsOnPythonVLMRoute
Result: passed, 1 test in 0.006s

# Pre-commit full local gate on 256 GiB macOS host
make swift-test
Result: passed, including macOS menubar 767 tests

make py-test
Result: 3048 passed, 14 skipped, 2 warnings in 146.07s

make integration-test
Result: 114 passed, 1 skipped in 688.34s

# Whitespace checks after merge from origin/main
git diff --check
Result: passed

git diff --cached --check
Result: passed
```

## Coverage and Metrics
- Changed-line coverage: 100.0% for the VLM runtime probe paths selected by the PR-scoped performance gate.
- Pre-commit performance report: `.runtime/pre-commit-performance/20260524-034640-314b41e5/report/report.md`
- Report status: `ok`; selected probes: 2; regressions: 0; verification failures: 0.
- `mlx-vlm-family-config-cache`: elapsed_ms_mean base=1.886 head=1.666, improvement; resolve_calls_mean unchanged at 1.000.
- `mlx-vlm-gemma4-weight-presence-single-pass`: elapsed_ms_mean base=56.793 head=56.844 (+0.09%, neutral); peak_bytes_mean and visited_names_mean unchanged.
- Observability mode: minimal worker-local receipt fields surfaced through existing probe snapshots; no new production request-path probe, background sampler, or public diagnostics surface.
- Probe overhead: existing PR-scoped probes only; no additional runtime loop or request-path instrumentation.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
