### PR TITLE
perf: reuse tool registry missing sentinel

### DIFF
--- a/docs/plans/2026-05-24-tool-registry-select-sentinel-performance.md
+++ b/docs/plans/2026-05-24-tool-registry-select-sentinel-performance.md
@@ -1,0 +1,37 @@
+# Tool registry select sentinel performance slice
+
+## Scope
+
+This Python-only performance slice keeps `ToolRegistry.select()` behavior unchanged while removing a per-call sentinel allocation from the requested-name lookup loop.
+
+Affected files:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `docs/plans/2026-05-24-tool-registry-select-sentinel-performance.md`
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`. The registry entry already includes focused `test_command`, `coverage_command`, and `probe_command` commands for the tool-registry selection path.
+
+## Implementation plan
+
+1. Run the registered probe on `origin/main` to capture the local Linux baseline.
+2. Promote the missing-tool sentinel used by `ToolRegistry.select()` from a fresh `object()` per normalized selection to a module-level singleton.
+3. Run the focused tool-registry tests, changed-scope coverage, and registered probe locally on Linux.
+4. Use the PR-scoped performance workflow as the merge gate after push.
+
+## Expected behavior
+
+- Unknown selected tool names still raise `ToolRegistryError` with the same missing-name list.
+- Selected registries, raw tuple aliases, cache bounds, and full-list fast paths are unchanged.
+- The registered probe should show a neutral-to-improved `elapsed_ms_mean` for repeated selection calls.
+
+## Validation commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
+```

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -13,6 +13,7 @@ _TOOL_CONFIG_FROM_BYTES = _TOOL_CONFIG.FromString
 _COMPACT_SORTED_JSON_ENCODER = json.JSONEncoder(separators=(",", ":"), sort_keys=True)
 _COPY_DICT = dict.copy
 _COPY_LIST = list.copy
+_MISSING_TOOL = object()
 
 
 def _copy_tool_config(template: common_pb2.ToolConfig) -> common_pb2.ToolConfig:
@@ -264,12 +265,11 @@ class ToolRegistry:
         if cached_selection is not None:
             return cached_selection
         tool_by_name = self._tool_by_name
-        missing_sentinel = object()
         selected: list[ToolDescriptor] = []
         missing_names: list[str] = []
         for name in requested_names:
-            tool = tool_by_name.get(name, missing_sentinel)
-            if tool is missing_sentinel:
+            tool = tool_by_name.get(name, _MISSING_TOOL)
+            if tool is _MISSING_TOOL:
                 missing_names.append(name)
             else:
                 selected.append(tool)


### PR DESCRIPTION
## Summary
- Reuse a module-level missing-tool sentinel in `ToolRegistry.select()` instead of allocating a fresh `object()` for every normalized selection lookup.
- Add a focused plan for the tool-registry select sentinel performance slice.

## Plan or Spec
- `docs/plans/2026-05-24-tool-registry-select-sentinel-performance.md`
- Registered PR-scoped probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` (baseline on `origin/main`)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- `MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=240000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=9 PYTHONPATH="$dir:$dir/services/mlx-worker-python" uv run --project "$dir/services/mlx-worker-python" python3 "$dir/scripts/tool_registry_select_probe.py"` for `origin/main` and this branch
- `git diff --check`

## Coverage and Metrics
- Focused tests: `53 passed in 0.84s`.
- Changed-scope coverage: `TOTAL 3 0 100%` for changed measurable lines.
- Default registered probe baseline on `origin/main`: `elapsed_ms_mean=23.366499`, `full_config_template_elapsed_ms_mean=25.650556`.
- Default registered probe after change: `elapsed_ms_mean=23.930735`, `full_config_template_elapsed_ms_mean=25.891979` (small default-run noise/regression; extended comparison below was used for acceptance).
- Extended local comparison (`iterations=240000`, `samples=9`): old `elapsed_ms_mean=65.589189`, new `elapsed_ms_mean=63.541793`, delta `-2.047396 ms` (`3.12%` faster). Old `full_config_template_elapsed_ms_mean=68.266308`, new `65.777068`, delta `-2.489241 ms` (`3.65%` faster).
- CI PR-scoped performance must run the registered `tool-registry-select-name-index-cache` probe before merge.

## Known Gaps
- Python-only slice locally verified on Linux. No Swift runtime effect is claimed.
- The default local registered probe was noisy; the higher-iteration repeated comparison showed the accepted improvement. CI remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Fresh worktree created from current `origin/main`.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage measured at or above 95%.
- [x] Registered probe run locally on Linux.
- [x] PR-scoped performance CI required before merge.
