### PR TITLE
perf: avoid embedding cycle copy materialization

### DIFF
--- a/docs/plans/2026-05-24-deterministic-embedding-cycle-copy-elision.md
+++ b/docs/plans/2026-05-24-deterministic-embedding-cycle-copy-elision.md
@@ -1,0 +1,40 @@
+# Deterministic Embedding Cycle Copy Elision
+
+## Scope
+
+This Python-only performance slice is limited to the repeated-cycle fast path in
+`worker.runtime.deterministic_embedding_runtime.DeterministicEmbeddingRuntime.embed_inputs()`.
+The runtime already detects repeated input cycles and computes one cycle of vectors before
+copying those vectors into the repeated output. This slice avoids materializing a temporary
+list of all repeated vector copies before extending the output list.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe
+`deterministic-embedding-duplicate-input-cache` in `infra/perf/pr_scoped_probes.json`.
+That probe includes focused `test_command`, `coverage_command`, and `probe_command`
+entries for:
+
+- `services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py`
+- `services/mlx-worker-python/tests/test_embedding_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/deterministic_embedding_duplicate_probe.py`
+
+The probe script now also emits `peak_bytes_mean` as local diagnostic evidence so the
+copy-elision effect is visible during Linux validation. The registered CI comparison
+continues to gate on the existing declared metrics.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and registered
+probe locally on Linux. Compare the registered probe against `origin/main` and the branch
+before pushing. GitHub Actions PR-scoped performance remains the merge gate.
+
+## Acceptance criteria
+
+- Focused tests pass.
+- Changed-scope coverage for the touched Python scope is at least 95%.
+- The registered probe reports unchanged `embed_text_calls_mean` and a non-regressing or
+  improved `elapsed_ms_mean`; the additional local `peak_bytes_mean` diagnostic should move
+  down or remain stable.
+- PR-scoped performance CI selects and completes the registered probe successfully.

--- a/scripts/deterministic_embedding_duplicate_probe.py
+++ b/scripts/deterministic_embedding_duplicate_probe.py
@@ -4,6 +4,7 @@ import json
 import statistics
 import sys
 import time
+import tracemalloc
 from pathlib import Path
 
 repo_root = Path.cwd()
@@ -87,6 +88,7 @@ def run_probe() -> dict[str, float]:
     sample_count = 5
     elapsed_samples: list[float] = []
     call_samples: list[float] = []
+    peak_samples: list[float] = []
     checksum = 0.0
 
     for _ in range(sample_count):
@@ -98,9 +100,13 @@ def run_probe() -> dict[str, float]:
             "embedding_backend": backend,
             "embedding_family_adapter": CountingEmbeddingFamilyAdapter(),
         }
+        tracemalloc.start()
         started = time.perf_counter()
         vectors = runtime.embed_inputs(loaded_model, inputs)
         elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_samples.append(float(peak))
         call_samples.append(float(backend.calls))
         checksum = sum(vector[0] for vector in vectors)
 
@@ -109,6 +115,7 @@ def run_probe() -> dict[str, float]:
     assert vectors[0] is not vectors[len(unique_inputs)]
     return {
         "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+        "peak_bytes_mean": round(statistics.fmean(peak_samples), 6),
         "embed_text_calls_mean": round(statistics.fmean(call_samples), 6),
         "input_count": float(len(inputs)),
         "unique_input_count": float(expected_unique_count),

--- a/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
@@ -65,14 +65,14 @@ class DeterministicEmbeddingRuntime:
         embed_text = family.embed_text
         cycle_length = _repeated_input_cycle_length(inputs)
         if cycle_length:
-            for text in inputs[:cycle_length]:
-                vector = embed_text(backend, text, dimensions)
+            for index in range(cycle_length):
+                vector = embed_text(backend, inputs[index], dimensions)
                 append_vector(vector)
             cycle_vectors = tuple(vectors)
             repeat_count = len(inputs) // cycle_length - 1
-            vectors.extend(
-                [vector.copy() for _ in range(repeat_count) for vector in cycle_vectors]
-            )
+            for _ in range(repeat_count):
+                for vector in cycle_vectors:
+                    append_vector(vector.copy())
             return vectors
 
         vector_cache: dict[str, list[float]] = {}


### PR DESCRIPTION
## Summary
- Avoid materializing a temporary list of all repeated-cycle embedding vector copies before extending the output list.
- Keep the deterministic embedding duplicate-input behavior unchanged while making the cycle copy path stream copies into the output list.
- Extend the local duplicate-input probe output with `peak_bytes_mean` diagnostic evidence for this copy-elision slice.

## Plan or Spec
- `docs/plans/2026-05-24-deterministic-embedding-cycle-copy-elision.md`
- Registered PR-scoped probe: `deterministic-embedding-duplicate-input-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline/head diagnostic probe using the branch probe script against origin/main and this branch
origin/main: PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 <branch>/scripts/deterministic_embedding_duplicate_probe.py
  exit 0; {"elapsed_ms_mean": 28.196006, "embed_text_calls_mean": 512.0, "peak_bytes_mean": 3081828.0, ...}
branch: PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_duplicate_probe.py
  exit 0; {"elapsed_ms_mean": 25.109724, "embed_text_calls_mean": 512.0, "peak_bytes_mean": 3016367.2, ...}

# Registered focused test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics
  exit 0; 17 passed in 1.68s

# Registered changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_duplicate_probe.py
  exit 0; 17 passed; TOTAL 11 0 100%

# Registered probe command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/deterministic_embedding_duplicate_probe.py ]; then python3 scripts/deterministic_embedding_duplicate_probe.py; else ...; fi'
  exit 0; {"elapsed_ms_mean": 23.813108, "embed_text_calls_mean": 512.0, "peak_bytes_mean": 3016367.2, ...}

git diff --check
  exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Local diagnostic baseline vs branch probe: `elapsed_ms_mean` 28.196006 ms -> 25.109724 ms (delta -3.086282 ms, ~10.94% faster); `peak_bytes_mean` 3,081,828.0 -> 3,016,367.2 bytes (delta -65,460.8 bytes, ~2.12% lower); `embed_text_calls_mean` unchanged at 512.0.
- Registered branch probe after coverage: `elapsed_ms_mean=23.813108`, `peak_bytes_mean=3016367.2`, `embed_text_calls_mean=512.0`.
- CI PR-scoped performance is required for the registered probe validation before merge.

## Known Gaps
- None for the Python slice. Linux local validation covers the touched Python path; CI remains the required registered PR-scoped performance gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
