### PR TITLE
perf: speed up report evidence run kind matching

### DIFF
--- a/docs/plans/2026-05-24-report-evidence-gate-run-kind-set-membership.md
+++ b/docs/plans/2026-05-24-report-evidence-gate-run-kind-set-membership.md
@@ -1,0 +1,19 @@
+# Report Evidence Gate Run-Kind Set Membership
+
+## Context
+
+`worker.productization.report_evidence_gate._rule_matches_report` checks release-matrix `run_kinds` against report runs while building PR/release evidence summaries. Rules can contain multiple accepted run kinds, and reports can contain many runs.
+
+## Slice
+
+Convert the run-kind membership check from tuple membership to a one-time per-rule `frozenset` membership inside `_rule_matches_report`. This keeps behavior identical for non-tuple iterables while reducing repeated linear membership scans across report runs.
+
+## Probe
+
+Registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership`.
+
+The probe executes `scripts/report_evidence_gate_run_kind_probe.py` against a synthetic rule with 65 accepted run kinds and 80 report runs, asserting the expected match while reporting `elapsed_ms_mean`, `run_kind_count`, and `runs_per_call`.
+
+## Verification
+
+Use the registered probe commands from `infra/perf/pr_scoped_probes.json` for focused tests, changed-scope coverage, and command-json performance measurement.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4095,5 +4095,39 @@
         "warn_pct": 5.0
       }
     ]
+  },
+  {
+    "id": "report-evidence-gate-run-kind-set-membership",
+    "name": "Report evidence gate run kind set membership",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/report_evidence_gate.py",
+      "services/mlx-worker-python/tests/test_report_evidence_gate.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/report_evidence_gate_run_kind_probe.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/report_evidence_gate_run_kind_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "run_kind_count",
+        "unit": "items",
+        "direction": "informational"
+      },
+      {
+        "key": "runs_per_call",
+        "unit": "items",
+        "direction": "informational"
+      }
+    ]
   }
 ]

--- a/scripts/report_evidence_gate_run_kind_probe.py
+++ b/scripts/report_evidence_gate_run_kind_probe.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(os.environ.get("MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT", Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.productization.report_evidence_gate import _rule_matches_report  # noqa: E402
+
+
+def _measure(iterations: int, sample_count: int) -> dict[str, float]:
+    run_kinds = tuple(f"probe_kind_{index}" for index in range(64)) + ("target_kind",)
+    rule = {"run_kinds": run_kinds}
+    runs = [{"run_kind": f"observed_kind_{index}"} for index in range(79)] + [{"run_kind": "target_kind"}]
+    elapsed_samples: list[float] = []
+    match_count = 0
+
+    for _ in range(sample_count):
+        started = time.perf_counter()
+        for _index in range(iterations):
+            if not _rule_matches_report(
+                rule=rule,
+                runs=runs,
+                targets=[],
+                metrics=[],
+                probe_phases=set(),
+            ):
+                raise RuntimeError("expected run-kind rule to match target run")
+            match_count += 1
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "iterations": float(iterations),
+        "sample_count": float(sample_count),
+        "run_kind_count": float(len(run_kinds)),
+        "runs_per_call": float(len(runs)),
+        "match_count": float(match_count),
+    }
+
+
+def main() -> int:
+    iterations = int(os.environ.get("MELIX_REPORT_EVIDENCE_RUN_KIND_ITERATIONS", "50000"))
+    sample_count = int(os.environ.get("MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES", "5"))
+    print(json.dumps(_measure(iterations, sample_count), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -175,6 +175,32 @@ def test_scope_report_selects_engine_generate_usage_probe() -> None:
     assert _selected_probe_ids(scope) == ["engine-generate-usage-token-elision"]
 
 
+def test_scope_report_selects_report_evidence_gate_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/report_evidence_gate.py"],
+    )
+
+    assert scope["selected_count"] == 1
+    assert _selected_probe_ids(scope) == ["report-evidence-gate-run-kind-set-membership"]
+
+
+def test_report_evidence_gate_run_kind_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_REPORT_EVIDENCE_RUN_KIND_ITERATIONS", "20")
+    monkeypatch.setenv("MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES", "1")
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/report_evidence_gate_run_kind_probe.py"))
+
+    assert probe_script["main"]() == 0
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] >= 0.0
+    assert metrics["match_count"] == metrics["iterations"] * metrics["sample_count"]
+    assert metrics["run_kind_count"] == 65.0
+
+
 def test_scope_report_selects_tool_registry_schema_bytes_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -2585,6 +2611,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "evaluation-compare-target-lookup-early-stop",
         "evaluation-store-samples-csv-streaming",
         "engine-generate-usage-token-elision",
+        "report-evidence-gate-run-kind-set-membership",
         "embedding-core-inputs-view",
         "job-registry-derived-model-single-pass",
         "job-registry-restore-sort-elision",

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -147,6 +147,23 @@ def _write_report(
     return outputs["json"]
 
 
+def test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables() -> None:
+    assert report_evidence_gate_module._rule_matches_report(
+        rule={"run_kinds": {"evaluation", "serving_benchmark"}},
+        runs=[{"run_kind": "serving_benchmark"}],
+        targets=[],
+        metrics=[],
+        probe_phases=set(),
+    )
+    assert not report_evidence_gate_module._rule_matches_report(
+        rule={"run_kinds": {"evaluation"}},
+        runs=[{"run_kind": "serving_benchmark"}],
+        targets=[],
+        metrics=[],
+        probe_phases=set(),
+    )
+
+
 def test_report_evidence_gate_passes_complete_release_matrix(tmp_path: Path) -> None:
     serving_report = _write_report(tmp_path, "serving", run_kind="serving_benchmark")
     evaluation_report = _write_report(tmp_path, "evaluation", run_kind="evaluation")

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -286,9 +286,11 @@ def _rule_matches_report(
     metrics: list[dict[str, object]],
     probe_phases: set[str],
 ) -> bool:
-    run_kinds = tuple(str(item) for item in rule.get("run_kinds", ()))
-    if run_kinds and any(str(run.get("run_kind", "")) in run_kinds for run in runs):
-        return True
+    run_kinds = rule.get("run_kinds", ())
+    if run_kinds:
+        run_kind_set = frozenset(str(item) for item in run_kinds)
+        if any(str(run.get("run_kind", "")) in run_kind_set for run in runs):
+            return True
     metric_prefixes = tuple(str(item) for item in rule.get("metric_prefixes", ()))
     if metric_prefixes and any(
         str(metric.get("metric", "")).startswith(metric_prefixes) for metric in metrics


### PR DESCRIPTION
## Summary
- Converts report evidence gate run-kind matching from tuple membership to a per-rule `frozenset` membership check.
- Adds a registered PR-scoped command-json probe for the affected report evidence gate path, including base/head fallback support while the probe script is new.
- Adds focused regression coverage for non-tuple run-kind iterables and probe selection/output.

## Plan or Spec
- Plan: `docs/plans/2026-05-24-report-evidence-gate-run-kind-set-membership.md`
- Registered probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py`
- Base fallback simulation from a main worktree using the head probe script with `MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT` pointed at the base checkout.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 5 passed.
- Changed-scope coverage: 100%.
- Local probe candidate: `elapsed_ms_mean=548.1842862442136`, `run_kind_count=65.0`, `runs_per_call=80.0`, `sample_count=5.0`.
- Local fallback baseline simulation: `old_mean=2222.8331255726516`, `new_mean=548.1842862442136`, `delta_ms=-1674.648839`, `speedup=4.055x`, `improvement≈75.3%`.

## Known Gaps
- Linux local validation covers the Python behavior and command-json probe only.
- Final registered PR-scoped performance validation must come from GitHub Actions comparing base/head for `report-evidence-gate-run-kind-set-membership`.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Probe registry entry includes `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local probe produced command-json metrics.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
