### PR TITLE
perf: bind embedding core registry locally

### DIFF
--- a/docs/plans/2026-05-24-embedding-core-local-bindings.md
+++ b/docs/plans/2026-05-24-embedding-core-local-bindings.md
@@ -1,0 +1,30 @@
+# Embedding core local binding slice
+
+## Scope
+
+This Python-only performance slice is limited to `EmbeddingCore.embed()` in
+`services/mlx-worker-python/worker/engine/embedding_core.py`.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped performance probe
+`embedding-core-inputs-view` in `infra/perf/pr_scoped_probes.json`. The probe
+already includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for `embedding_core.py`, the embedding runtime tests,
+the PR-scoped probe tests, and `scripts/embedding_core_inputs_probe.py`.
+
+## Optimization hypothesis
+
+`EmbeddingCore.embed()` touches `self._registry`, `request.inputs`, and the
+loaded runtime model on every request. This slice keeps behavior unchanged while
+binding those values to local variables before the hot runtime call and response
+materialization loop. The goal is to remove repeated attribute lookups in the
+probe path without materializing the protobuf repeated input container as a
+list.
+
+## Verification
+
+Run the registered focused pytest command, changed-scope coverage command, and
+`embedding-core-inputs-view` probe locally on Linux. Compare the local probe
+against the synced `origin/main` baseline before pushing. CI remains the merge
+gate for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/worker/engine/embedding_core.py
+++ b/services/mlx-worker-python/worker/engine/embedding_core.py
@@ -10,7 +10,8 @@ class EmbeddingCore:
         self._registry = registry
 
     def embed(self, request: inference_pb2.EmbedRequest) -> inference_pb2.EmbedResponse:
-        loaded_model = self._registry.get_loaded_model(request.model_handle)
+        registry = self._registry
+        loaded_model = registry.get_loaded_model(request.model_handle)
         if loaded_model is None:
             return inference_pb2.EmbedResponse(
                 error=common_pb2.ErrorStatus(code="not_found", message="Unknown model handle.")
@@ -25,7 +26,7 @@ class EmbeddingCore:
             )
 
         try:
-            vectors = self._registry.embedding_runtime.embed_inputs(
+            vectors = registry.embedding_runtime.embed_inputs(
                 loaded_model.runtime_model,
                 request.inputs,
             )


### PR DESCRIPTION
## Summary
- Bind `EmbeddingCore.embed()` registry access to a local variable before the runtime call.
- Keep the protobuf repeated input container passed through directly; no list materialization is introduced.
- Add a focused plan note for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-05-24-embedding-core-local-bindings.md`
- Registered probe: `embedding-core-inputs-view` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- Baseline local probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_CORE_INPUTS_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/embedding_core_inputs_probe.py`
- Focused tests: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_passes_request_inputs_without_list_materialization services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_returns_stable_vectors_for_loaded_embedding_models services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_runtime_reuses_duplicate_inputs_within_one_request services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_core_inputs_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_embedding_core_inputs_probe_script_emits_metrics`
- Changed-scope coverage: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/embedding_core.py services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/embedding_core_inputs_probe.py`
- Registered local probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_CORE_INPUTS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/embedding_core_inputs_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 7 passed.
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Baseline local probe (`origin/main`, 7 samples): `elapsed_ms_mean=5641.303069`, `peak_bytes_mean=794351.428571`, `runtime_input_is_view=1.0`.
- Candidate local probe (7 samples): `elapsed_ms_mean=5565.946356`, `peak_bytes_mean=794351.428571`, `runtime_input_is_view=1.0`.
- Registered local probe command (5 samples): `elapsed_ms_mean=5552.918575`, `peak_bytes_mean=794351.2`, `runtime_input_is_view=1.0`.
- Local 7-sample delta: `-75.356713 ms` (`~1.34%` faster), peak allocation unchanged.
- CI PR-scoped performance must complete the registered `embedding-core-inputs-view` report before merge.

## Known Gaps
- Linux local validation covers this Python path only.
- The registered CI PR-scoped performance report is the merge gate for repository-standard probe evidence.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% for touched lines.
- [x] Local registered probe shows a directionally positive delta.
- [ ] GitHub Actions and PR-scoped performance report are green.
