### PR TITLE
perf: bind rerank core registry locally

### DIFF
--- a/docs/plans/2026-05-24-rerank-core-registry-binding.md
+++ b/docs/plans/2026-05-24-rerank-core-registry-binding.md
@@ -1,0 +1,40 @@
+# Rerank Core Registry Binding Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to `RerankCore.rerank()` in
+`services/mlx-worker-python/worker/engine/rerank_core.py`.
+
+The hot path repeatedly touches `self._registry` while servicing rerank requests.
+This slice binds the registry to a local variable once per request and reuses that
+local for loaded-model lookup and rerank runtime dispatch. Ranking behavior,
+request document passthrough, and response construction stay unchanged.
+
+## Registered Probe
+
+Reuse registered PR-scoped probe `rerank-core-top-k-heap-selection` in
+`infra/perf/pr_scoped_probes.json`. The probe already has focused
+`test_command`, `coverage_command`, and `probe_command` entries for the affected
+rerank core path.
+
+This slice also registers the probe's existing `request_elapsed_ms` output as a
+lower-is-better metric so CI can validate the request dispatch path touched by
+this local-binding change, not only the bounded top-k ranker loop.
+
+## Verification Plan
+
+1. Run the focused rerank tests and probe-selection tests from the registered
+   probe command.
+2. Run changed-scope coverage for `rerank_core.py`, `test_rerank_runtime.py`,
+   `test_pr_scoped_performance.py`, and `scripts/rerank_top_k_probe.py`.
+3. Run the registered probe locally on Linux before and after the slice and
+   compare `request_elapsed_ms` plus the existing top-k metrics.
+4. Use the PR-scoped performance workflow as the merge gate for the registered
+   probe report.
+
+## Acceptance
+
+Accept only if behavior tests pass, changed-scope coverage remains at or above
+95%, and the registered probe shows non-regressing or improved
+`request_elapsed_ms` while preserving ranker metrics and document passthrough
+counters.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1925,6 +1925,13 @@
         "unit": "bytes",
         "direction": "lower_is_better",
         "warn_pct": 10.0
+      },
+      {
+        "key": "request_elapsed_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0,
+        "warn_abs": 1.0
       }
     ]
   },

--- a/services/mlx-worker-python/worker/engine/rerank_core.py
+++ b/services/mlx-worker-python/worker/engine/rerank_core.py
@@ -12,7 +12,8 @@ class RerankCore:
         self._registry = registry
 
     def rerank(self, request: inference_pb2.RerankRequest) -> inference_pb2.RerankResponse:
-        loaded_model = self._registry.get_loaded_model(request.model_handle)
+        registry = self._registry
+        loaded_model = registry.get_loaded_model(request.model_handle)
         if loaded_model is None:
             return inference_pb2.RerankResponse(
                 error=common_pb2.ErrorStatus(code="not_found", message="Unknown model handle.")
@@ -27,7 +28,7 @@ class RerankCore:
             )
 
         try:
-            scores = self._registry.rerank_runtime.score_documents(
+            scores = registry.rerank_runtime.score_documents(
                 loaded_model.runtime_model,
                 request.query,
                 request.documents,


### PR DESCRIPTION
## Summary
- Bind `RerankCore.rerank()`'s registry reference to a local variable before loaded-model lookup and rerank runtime dispatch.
- Register the existing rerank probe's `request_elapsed_ms` output as a PR-scoped lower-is-better metric for this dispatch path.
- Add a focused plan for the rerank core registry-binding slice.

## Plan or Spec
- `docs/plans/2026-05-24-rerank-core-registry-binding.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_core_passes_request_documents_without_copying services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_rerank_top_k_probe_script_emits_top_k_one_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_preserves_sort_contract_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_uses_single_scan_for_top_k_one services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_uses_heap_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_keeps_full_sort_when_unbounded services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_returns_sorted_scores_and_honors_top_k services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_rerank_core_top_k_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_rerank_top_k_probe_script_emits_top_k_one_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/rerank_core.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/rerank_top_k_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/rerank_top_k_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `8 passed in 0.44s`.
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Local registered probe baseline (`origin/main`, 7 samples): `elapsed_ms_mean=2479.440402`, `peak_bytes_mean=710.857143`, `request_elapsed_ms=593.469863`.
- Local registered probe head (7 samples): `elapsed_ms_mean=2471.665772`, `peak_bytes_mean=710.857143`, `request_elapsed_ms=585.593384`.
- Local deltas: `elapsed_ms_mean=-7.77463 ms` (`0.31%` faster), `request_elapsed_ms=-7.876479 ms` (`1.33%` faster), `peak_bytes_mean=0`.
- Registered PR-scoped performance CI is required as the merge gate for the selected `rerank-core-top-k-heap-selection` probe.

## Known Gaps
- Linux local validation covers the Python rerank path only. No Swift runtime effect is claimed.
- The local improvement is intentionally small; CI registered probe output is the merge decision source.

## Evidence Checklist
- [x] Registered PR-scoped probe exists for the affected path.
- [x] Probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally with base-vs-head evidence.
- [ ] PR-scoped performance workflow completed successfully in CI.
