### PR TITLE
Fix Swift baseline decode throughput

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ PROTOCOL_SWIFT_HOME := $(SWIFT_HOME)/protocol
 TEXT_WORKER_SWIFT_HOME := $(SWIFT_HOME)/mlx-text-worker-swift
 CONTROL_PLANE_SWIFT_HOME := $(SWIFT_HOME)/control-plane-swift
 MENUBAR_SWIFT_HOME := $(SWIFT_HOME)/macos-menubar
-MENUBAR_SWIFT_TEST_FLAGS := -Xswiftc -gnone
+# AppKit-backed menubar tests share NSApplication/status-bar process state.
+MENUBAR_SWIFT_TEST_FLAGS := --no-parallel -Xswiftc -gnone
 
 PROTOCOL_MODULE_CACHE_PATH := $(CLANG_MODULE_CACHE_PATH)/protocol
 TEXT_WORKER_MODULE_CACHE_PATH := $(CLANG_MODULE_CACHE_PATH)/mlx-text-worker-swift

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -145,7 +145,7 @@ struct DesktopFoundationViewTests {
             makefile.slice(from: "swift-coverage:", to: "py-coverage:")
         )
 
-        #expect(makefile.contains("MENUBAR_SWIFT_TEST_FLAGS := -Xswiftc -gnone"))
+        #expect(makefile.contains("MENUBAR_SWIFT_TEST_FLAGS := --no-parallel -Xswiftc -gnone"))
         #expect(menubarTestTarget.contains("$(MENUBAR_SWIFT_TEST_FLAGS)"))
         #expect(menubarCoverageCommand.contains("$(MENUBAR_SWIFT_TEST_FLAGS)"))
     }

--- a/docs/plans/2026-05-23-three-way-gemma4-31b-128k-serving-comparison.md
+++ b/docs/plans/2026-05-23-three-way-gemma4-31b-128k-serving-comparison.md
@@ -213,3 +213,99 @@ SwiftLM TTFT advantage was mostly measurement-profile and token-accounting
 contamination. Melix still has a small warm-path gap, but the next runtime
 optimization should be justified with longer decode or long-context scenarios,
 not with the old cold-loaded short smoke.
+
+## 2026-05-24 Decode Throughput Fix Slice
+
+The latest same-host warm smoke after the Melix performance update was exported
+to `~/Downloads/latest-main-release-three-way-warm-1024x16-20260524-073858`.
+It used the same `1024` prompt target, `16` output tokens, concurrency `1`, one
+warmup request per endpoint, `--include-usage`, and measurement profile `warm`.
+
+| Endpoint | TTFT ms | Total ms | Decode tok/s | Aggregate tok/s |
+|---|---:|---:|---:|---:|
+| Melix | 2798.09 | 3695.93 | 16.24 | 4.33 |
+| OMLX | 3206.34 | 4024.23 | 19.56 | 3.98 |
+| SwiftLM | 2841.83 | 3682.82 | 19.03 | 4.34 |
+
+The request payload is not the source of this gap. The benchmark sends
+`temperature: 0.0`, `max_tokens`, `stream: true`, and optional usage accounting;
+it does not send Melix-specific sampling knobs. The Melix control-plane and
+worker metrics also showed baseline decode, with active-KV metrics at zero.
+
+The likely hot-path issue is the custom phase-aware Swift decode loop. Upstream
+`MLXLMCommon.TokenIterator` keeps the MLX lazy graph pipeline full by scheduling
+the next token with `asyncEval(...)` before returning the current token to the
+streaming caller. Melix's custom `makePreparedDecodeEvents(...)` loop emitted
+the current chunk before constructing the next model output, which serialized
+part of next-token model work behind stream emission and made short warm decode
+throughput fall behind OMLX and SwiftLM.
+
+This slice should preserve stream order, terminal-token behavior, active-KV
+route reporting, and the existing max-output guard while scheduling the next
+baseline decode logits before yielding the current chunk. Verification must
+include focused Swift tests for preserved behavior plus a release-built warm
+Gemma 4 31B 8-bit smoke comparison against the previous artifact.
+
+### Post-Fix Verification
+
+The retained code change updates the baseline Swift decode loop to keep a
+pending sampled token, schedule the next sampled token with `asyncEval(...)`
+before yielding the current text chunk, and synchronize the MLX stream before
+finishing the generation stream. This mirrors the upstream `TokenIterator`
+pipeline while keeping the existing max-token guard so the worker still skips the
+terminal extra model call at the output limit. The fix also removes the
+decode-loop KV quantization maintenance branch because active-KV decode
+quantization is already decided and applied before the first sampled decode
+token; leaving the second branch in the pipelined loop would preserve unreachable
+work around the hot path.
+
+Release-built Melix-only verification:
+
+- Export: `~/Downloads/melix-decode-fix-warm-1024x16-20260524-085131`
+- Staged artifact:
+  `.runtime/three-way-gemma31b128k/melix-decode-fix-warm-1024x16-20260524-085131`
+- Scenario: `1024` prompt target, `16` output tokens, concurrency `1`,
+  five measured repeats, one warmup per endpoint, `--include-usage`,
+  measurement profile `warm`.
+- Result: Melix median decode improved from the pre-fix `16.24 tok/s` artifact
+  to `19.65 tok/s` with zero request errors.
+
+Release-built three-way verification:
+
+- Export: `~/Downloads/decode-fix-three-way-warm-1024x16-20260524-085627`
+- Staged artifact:
+  `.runtime/three-way-gemma31b128k/decode-fix-three-way-warm-1024x16-20260524-085627`
+- Same scenario and measurement profile as above, with OMLX at commit
+  `2f2f508` and SwiftLM at commit `d5a9d11`.
+
+| Endpoint | TTFT ms | Total ms | Decode tok/s | Aggregate tok/s |
+|---|---:|---:|---:|---:|
+| Melix | 2786.60 | 3606.11 | 19.33 | 4.44 |
+| OMLX | 3131.58 | 3976.92 | 19.10 | 4.02 |
+| SwiftLM | 2703.73 | 3536.08 | 19.36 | 4.52 |
+
+The fix removes the decode-throughput regression: Melix is now effectively tied
+with SwiftLM for decode throughput on this short warm smoke and slightly ahead
+of OMLX. SwiftLM still wins TTFT and aggregate output throughput by a small
+margin in this scenario, so the next optimization target should be short-context
+prefill/TTFT rather than baseline decode.
+
+Verification commands:
+
+- `git diff --check` -> passed.
+- Focused Swift tests around the live decode bridge, active-KV probe helpers,
+  opt-in model-eval sync probe, lazy quantized-cache prefill, TurboQuant route,
+  and the live max-output decode guard passed.
+- Changed-line coverage for the touched Swift executable and test files:
+  `TOTAL 99.19% (123/124)`.
+- The macOS menubar Swift test shard now runs with `--no-parallel` because the
+  AppKit-backed tests share `NSApplication` and status-bar process state; this
+  keeps the required pre-commit Swift gate deterministic while leaving runtime
+  behavior unchanged. The menubar repository-policy test was updated to keep
+  asserting both `--no-parallel` and `-Xswiftc -gnone` are present.
+- `xcrun swift build --package-path services/mlx-text-worker-swift --product melix-text-worker-swift -c release --disable-automatic-resolution`
+  -> passed.
+- `xcrun swift build --package-path services/control-plane-swift --product melix-control-plane -c release --disable-automatic-resolution`
+  -> passed.
+- Temporary Melix, OMLX, and SwiftLM services were stopped after the benchmark;
+  ports `12465`, `18061`, and `18062` had no listeners afterward.

--- a/services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift
@@ -1891,7 +1891,7 @@ private func makePreparedDecodeEvents(
             var decodeStreamYieldCallCount = 0
             var turboQuantCandidateTotalMicros = 0
             var turboQuantCandidateCallCount = 0
-            var decodeQuantizeTotalMicros = 0
+            let decodeQuantizeTotalMicros = 0
             var prefillQuantizeMicros = decodeState.prefillQuantizeMicros
             let shouldRecordActiveKVDecodeProbe =
                 normalizedAccelerationPolicy(acceleration).mode == .activeKvQuantized
@@ -1925,25 +1925,13 @@ private func makePreparedDecodeEvents(
                 acceleration: acceleration,
                 candidateProbeEnabled: turboQuantCandidateProbeEnabled
             )
-            var shouldMaintainQuantizedDecodeCache = shouldAttemptActiveKVDecodeQuantization(
-                cache: cache,
-                kvBits: parameters.kvBits,
-                quantizedKVStart: parameters.quantizedKVStart,
-                acceleration: acceleration
-            )
             let shouldForceModelEvalProbe =
                 ProcessInfo.processInfo.environment["MELIX_SWIFT_ACTIVE_KV_FORCE_MODEL_EVAL_PROBE"] == "1"
                 && normalizedAccelerationPolicy(acceleration).mode == .activeKvQuantized
             let startedAt = Date.timeIntervalSinceReferenceDate
 
-            while parameters.maxTokens.map({ generatedTokenCount < $0 }) ?? true {
-                if Task.isCancelled {
-                    break
-                }
-
-                let tokenEvalStartedAt = shouldRecordActiveKVDecodeProbe
-                    ? Date.timeIntervalSinceReferenceDate
-                    : 0
+            var pendingToken: MLXArray?
+            if parameters.maxTokens.map({ $0 > 0 }) ?? true {
                 let sampleStartedAt = shouldRecordActiveKVDecodeProbe
                     ? Date.timeIntervalSinceReferenceDate
                     : 0
@@ -1956,7 +1944,20 @@ private func makePreparedDecodeEvents(
                     decodeSampleCallCount += 1
                     decodeSampleTotalMicros += elapsedMicros(since: sampleStartedAt)
                 }
+                asyncEval(token)
+                pendingToken = token
+            }
 
+            while let token = pendingToken,
+                  parameters.maxTokens.map({ generatedTokenCount < $0 }) ?? true
+            {
+                if Task.isCancelled {
+                    break
+                }
+
+                let tokenEvalStartedAt = shouldRecordActiveKVDecodeProbe
+                    ? Date.timeIntervalSinceReferenceDate
+                    : 0
                 let tokenIDStartedAt = shouldRecordActiveKVDecodeProbe
                     ? Date.timeIntervalSinceReferenceDate
                     : 0
@@ -1976,6 +1977,60 @@ private func makePreparedDecodeEvents(
                 }
 
                 generatedTokenCount += 1
+                var nextToken: MLXArray?
+                if parameters.maxTokens.map({ generatedTokenCount < $0 }) ?? true {
+                    let nextInput = LMInput.Text(tokens: token)
+                    if shouldEvaluateTurboQuantFusedAttentionCandidate && !didDispatchTurboQuantFusedAttention {
+                        turboQuantCandidateEligibilityCheckCount += 1
+                        let candidateStartedAt = shouldRecordActiveKVDecodeProbe
+                            ? Date.timeIntervalSinceReferenceDate
+                            : 0
+                        didDispatchTurboQuantFusedAttention = dispatchTurboQuantFusedAttentionCandidateIfNeeded(
+                            cache: cache,
+                            acceleration: acceleration,
+                            candidateProbeEnabled: turboQuantCandidateProbeEnabled
+                        )
+                        if shouldRecordActiveKVDecodeProbe {
+                            turboQuantCandidateCallCount += 1
+                            turboQuantCandidateTotalMicros += elapsedMicros(since: candidateStartedAt)
+                        }
+                    }
+                    let modelStartedAt = shouldRecordActiveKVDecodeProbe
+                        ? Date.timeIntervalSinceReferenceDate
+                        : 0
+                    let nextOutput = context.model(
+                        nextInput[text: .newAxis],
+                        cache: cache.isEmpty ? nil : cache,
+                        state: output.state
+                    )
+                    if shouldRecordActiveKVDecodeProbe {
+                        decodeModelCallCount += 1
+                        decodeModelTotalMicros += elapsedMicros(since: modelStartedAt)
+                    }
+                    if let modelEvalSyncMicros = activeKVModelEvalSyncMicrosIfNeeded(
+                        enabled: shouldForceModelEvalProbe,
+                        logits: nextOutput.logits
+                    ) {
+                        decodeModelEvalSyncCallCount += 1
+                        decodeModelEvalSyncTotalMicros += modelEvalSyncMicros
+                    }
+                    output = nextOutput
+                    let sampleStartedAt = shouldRecordActiveKVDecodeProbe
+                        ? Date.timeIntervalSinceReferenceDate
+                        : 0
+                    let sampledNextToken = sampleNextToken(
+                        logits: output.logits,
+                        processor: &processor,
+                        sampler: sampler
+                    )
+                    if shouldRecordActiveKVDecodeProbe {
+                        decodeSampleCallCount += 1
+                        decodeSampleTotalMicros += elapsedMicros(since: sampleStartedAt)
+                    }
+                    asyncEval(sampledNextToken)
+                    nextToken = sampledNextToken
+                }
+
                 let detokenizeStartedAt = shouldRecordActiveKVDecodeProbe
                     ? Date.timeIntervalSinceReferenceDate
                     : 0
@@ -1996,64 +2051,18 @@ private func makePreparedDecodeEvents(
                     }
                 }
 
-                if let maxTokens = parameters.maxTokens, generatedTokenCount >= maxTokens {
+                if let nextToken {
+                    pendingToken = nextToken
+                } else {
                     break
-                }
-
-                let nextInput = LMInput.Text(tokens: token)
-                if shouldEvaluateTurboQuantFusedAttentionCandidate && !didDispatchTurboQuantFusedAttention {
-                    turboQuantCandidateEligibilityCheckCount += 1
-                    let candidateStartedAt = shouldRecordActiveKVDecodeProbe
-                        ? Date.timeIntervalSinceReferenceDate
-                        : 0
-                    didDispatchTurboQuantFusedAttention = dispatchTurboQuantFusedAttentionCandidateIfNeeded(
-                        cache: cache,
-                        acceleration: acceleration,
-                        candidateProbeEnabled: turboQuantCandidateProbeEnabled
-                    )
-                    if shouldRecordActiveKVDecodeProbe {
-                        turboQuantCandidateCallCount += 1
-                        turboQuantCandidateTotalMicros += elapsedMicros(since: candidateStartedAt)
-                    }
-                }
-                let modelStartedAt = shouldRecordActiveKVDecodeProbe
-                    ? Date.timeIntervalSinceReferenceDate
-                    : 0
-                output = context.model(
-                    nextInput[text: .newAxis],
-                    cache: cache.isEmpty ? nil : cache,
-                    state: output.state
-                )
-                if shouldRecordActiveKVDecodeProbe {
-                    decodeModelCallCount += 1
-                    decodeModelTotalMicros += elapsedMicros(since: modelStartedAt)
-                }
-                if let modelEvalSyncMicros = activeKVModelEvalSyncMicrosIfNeeded(
-                    enabled: shouldForceModelEvalProbe,
-                    logits: output.logits
-                ) {
-                    decodeModelEvalSyncCallCount += 1
-                    decodeModelEvalSyncTotalMicros += modelEvalSyncMicros
-                }
-                if shouldMaintainQuantizedDecodeCache {
-                    let quantizeStartedAt = Date.timeIntervalSinceReferenceDate
-                    maybeQuantizeKVCache(
-                        cache: &cache,
-                        kvBits: parameters.kvBits,
-                        kvGroupSize: parameters.kvGroupSize,
-                        quantizedKVStart: parameters.quantizedKVStart
-                    )
-                    decodeQuantizeTotalMicros += elapsedMicros(since: quantizeStartedAt)
-                    shouldMaintainQuantizedDecodeCache = shouldAttemptActiveKVDecodeQuantization(
-                        cache: cache,
-                        kvBits: parameters.kvBits,
-                        quantizedKVStart: parameters.quantizedKVStart,
-                        acceleration: acceleration
-                    )
                 }
             }
 
             let decodeLoopTotalMicros = elapsedMicros(since: startedAt)
+            // `asyncEval` keeps the next-token graph in flight while the current
+            // chunk is streamed; synchronize before finishing so canceled or
+            // terminal streams do not leave MLX work running past stream teardown.
+            Stream().synchronize()
             let elapsed = max(Double(decodeLoopTotalMicros) / 1_000_000, 0.000_001)
             let summaryStartedAt = shouldRecordActiveKVDecodeProbe
                 ? Date.timeIntervalSinceReferenceDate

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -1563,6 +1563,54 @@ final class WorkerScaffoldTests: XCTestCase {
         XCTAssertGreaterThan(activeKVProbe.estimatedQuantizedBytes, 0)
         XCTAssertEqual(activeKVProbe.estimatedMemorySavingsPercent, 75)
     }
+
+    func testAutoSwiftMLXBackendDecodeRecordsOptInModelEvalSyncProbe() async throws {
+        let backend = AutoSwiftMLXBackend()
+        let promptTokens = [1, 2, 3, 4, 5]
+        var sampling = Melix_Worker_V1_SamplingConfig()
+        sampling.temperature = 0
+        sampling.topP = 1
+        sampling.maxOutputTokens = 2
+
+        var acceleration = Melix_Worker_V1_AccelerationPolicy()
+        acceleration.mode = .activeKvQuantized
+        acceleration.activeKvQuantProfile = "q4"
+
+        setenv("MELIX_SWIFT_ACTIVE_KV_FORCE_MODEL_EVAL_PROBE", "1", 1)
+        defer { unsetenv("MELIX_SWIFT_ACTIVE_KV_FORCE_MODEL_EVAL_PROBE") }
+
+        let events = try await withTemporaryDefaultMetallib {
+            try await Device.withDefaultDevice(.cpu) {
+                let model = LoadedTextModel(
+                    storage: makeQuantizableLiveSwiftMLXModelContainer(promptTokens: promptTokens)
+                )
+                let prefill = try await backend.prefill(
+                    model: model,
+                    messages: [makeSystemMessage("system"), makeUserMessage("bridge active kv eval probe")],
+                    prefillStepSize: 32,
+                    resumeHint: "live-active-kv-eval-probe",
+                    acceleration: Melix_Worker_V1_AccelerationPolicy(),
+                    shouldAbort: { false }
+                )
+                let stream = try await backend.decodeEvents(
+                    model: model,
+                    context: prefill.context,
+                    sampling: sampling,
+                    maxOutputTokens: 2,
+                    decodeStepSize: 1,
+                    prefillToken: "",
+                    acceleration: acceleration,
+                    shouldAbort: { false }
+                )
+                return try await collectTextGenerationEvents(from: stream)
+            }
+        }
+
+        let summary = try XCTUnwrap(renderedSummary(from: events))
+        let activeKVProbe = try XCTUnwrap(summary.activeKVProbe)
+        XCTAssertEqual(activeKVProbe.decodeModelEvalSyncCallCount, 1)
+        XCTAssertGreaterThanOrEqual(activeKVProbe.decodeModelEvalSyncTotalMicros, 0)
+    }
     #endif
 
     func testChatMessageConversionFlattensTextAndRejectsUnsupportedParts() throws {


### PR DESCRIPTION
## Summary
- Pipeline the Swift MLX baseline decode loop by scheduling the next sampled token with `asyncEval(...)` before yielding the current streamed chunk.
- Synchronize the MLX stream before final summaries and remove the unreachable decode-loop KV quantization maintenance branch from the hot path.
- Add a focused opt-in model-eval sync probe test, document the Gemma 4 31B decode evidence, and serialize the AppKit-backed menubar Swift shard to stabilize the required local gate.

## Plan or Spec
- `docs/plans/2026-05-23-three-way-gemma4-31b-128k-serving-comparison.md`

## Commands Run
```text
git diff --check
-> passed

HOME="$PWD/.swift-home/test-worker" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/test-worker" xcrun swift test --package-path services/mlx-text-worker-swift --filter 'WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeUsesLiveModelContainerBridge|WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeSkipsTerminalModelCallAtMaxOutputTokens|WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeCanLazilyQuantizeBaselinePrefillCache|WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeReportsTurboQuantFusedRuntimeRoute|WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeRecordsOptInModelEvalSyncProbe|WorkerScaffoldTests/testActiveKVProbeSummaryAveragesReturnZeroWithoutDecodeTokens|WorkerScaffoldTests/testActiveKVDecodeQuantizationGuardSkipsWhenCacheIsAlreadyQuantized'
-> passed, 7 tests

HOME="$PWD/.swift-home/test-worker-coverage" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/test-worker-coverage" xcrun swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeUsesLiveModelContainerBridge|WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeSkipsTerminalModelCallAtMaxOutputTokens|WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeCanLazilyQuantizeBaselinePrefillCache|WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeReportsTurboQuantFusedRuntimeRoute|WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeRecordsOptInModelEvalSyncProbe|WorkerScaffoldTests/testActiveKVProbeSummaryAveragesReturnZeroWithoutDecodeTokens|WorkerScaffoldTests/testActiveKVDecodeQuantizationGuardSkipsWhenCacheIsAlreadyQuantized'
-> passed

uv run --project services/mlx-worker-python python scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
-> TOTAL 99.19% (123/124)

HOME="$PWD/.swift-home/mlx-text-worker-release" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/mlx-text-worker-release" xcrun swift build --package-path services/mlx-text-worker-swift --product melix-text-worker-swift -c release --disable-automatic-resolution
-> passed

HOME="$PWD/.swift-home/control-plane-release" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/control-plane-release" xcrun swift build --package-path services/control-plane-swift --product melix-control-plane -c release --disable-automatic-resolution
-> passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/three_way_serving_compare.py --endpoint melix=http://127.0.0.1:12465/v1::melix-dev-text --endpoint melix_same=http://127.0.0.1:12465/v1::melix-dev-text --target-endpoint melix --prompt-token-targets 1024 --max-tokens 16 --repeats 5 --concurrency 1 --warmup-requests 1 --warmup-prompt-token-target 1024 --warmup-max-tokens 16 --include-usage --timeout-seconds 300 --preflight-timeout-seconds 10 --preflight-wait-seconds 0 --melix-control-plane-metrics .runtime/sidecars/gemma31b-decode-fix/control-plane-metrics.json --melix-swift-text-worker-metrics .runtime/sidecars/gemma31b-decode-fix/swift-text-worker-metrics.json --measurement-profile warm --run-id melix-decode-fix-warm-1024x16-20260524-085131 --staging-root .runtime/three-way-gemma31b128k --export-dir "$HOME/Downloads" --json
-> passed, export ~/Downloads/melix-decode-fix-warm-1024x16-20260524-085131

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/three_way_serving_compare.py --endpoint melix=http://127.0.0.1:12465/v1::melix-dev-text --endpoint omlx=http://127.0.0.1:18061/v1::gemma-4-31b-it-8bit --endpoint swiftlm=http://127.0.0.1:18062/v1::mlx-community/gemma-4-31b-it-8bit --target-endpoint melix --prompt-token-targets 1024 --max-tokens 16 --repeats 5 --concurrency 1 --warmup-requests 1 --warmup-prompt-token-target 1024 --warmup-max-tokens 16 --include-usage --timeout-seconds 300 --preflight-timeout-seconds 10 --preflight-wait-seconds 0 --melix-control-plane-metrics .runtime/sidecars/gemma31b-decode-fix/control-plane-metrics.json --melix-swift-text-worker-metrics .runtime/sidecars/gemma31b-decode-fix/swift-text-worker-metrics.json --measurement-profile warm --run-id decode-fix-three-way-warm-1024x16-20260524-085627 --staging-root .runtime/three-way-gemma31b128k --export-dir "$HOME/Downloads" --json
-> passed, export ~/Downloads/decode-fix-three-way-warm-1024x16-20260524-085627

make swift-test-menubar
-> passed, 777 tests

git commit -m "perf: pipeline Swift baseline decode"
-> pre-commit full gate passed:
   make swift-test rc=0
   make py-test rc=0, 3180 passed, 14 skipped
   make integration-test rc=0, 115 passed, 1 skipped
   performance report status ok, regressions 0

git merge --no-edit origin/main
-> passed, merged aebb3d8b Guard mixed-length VLM batch geometry (#1559)

git diff --check origin/main...HEAD
-> passed

HOME="$PWD/.swift-home/test-worker-post-merge" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/test-worker-post-merge" xcrun swift test --package-path services/mlx-text-worker-swift --filter 'WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeUsesLiveModelContainerBridge|WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeSkipsTerminalModelCallAtMaxOutputTokens|WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeCanLazilyQuantizeBaselinePrefillCache|WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeReportsTurboQuantFusedRuntimeRoute|WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeRecordsOptInModelEvalSyncProbe|WorkerScaffoldTests/testActiveKVProbeSummaryAveragesReturnZeroWithoutDecodeTokens|WorkerScaffoldTests/testActiveKVDecodeQuantizationGuardSkipsWhenCacheIsAlreadyQuantized'
-> passed, 7 tests

make swift-test-menubar
-> passed, 777 tests
```

## Coverage and Metrics
- Changed-line coverage for the touched Swift executable/test files: `99.19%` (`123/124`).
- Pre-fix warm three-way artifact: `~/Downloads/latest-main-release-three-way-warm-1024x16-20260524-073858`.
  - Melix decode: `16.24 tok/s`
  - OMLX decode: `19.56 tok/s`
  - SwiftLM decode: `19.03 tok/s`
- Post-fix Melix-only artifact: `~/Downloads/melix-decode-fix-warm-1024x16-20260524-085131`.
  - Melix median decode: `19.65 tok/s`
  - Request errors: `0`
- Post-fix three-way artifact: `~/Downloads/decode-fix-three-way-warm-1024x16-20260524-085627`.
  - Melix: TTFT `2786.60 ms`, total `3606.11 ms`, decode `19.33 tok/s`, aggregate `4.44 tok/s`
  - OMLX: TTFT `3131.58 ms`, total `3976.92 ms`, decode `19.10 tok/s`, aggregate `4.02 tok/s`
  - SwiftLM: TTFT `2703.73 ms`, total `3536.08 ms`, decode `19.36 tok/s`, aggregate `4.52 tok/s`
- Pre-commit performance report: `.runtime/pre-commit-performance/20260524-103651-5c1e039d/report/report.md`
  - Status: `ok`
  - Selected probes: `0`
  - Regressions: `0`
- Observability mode: evidence, using the benchmark artifacts above plus the existing worker decode metrics.
- Probe overhead: N/A, no production-request debug probe was added; the new model-eval sync probe remains opt-in behind `MELIX_SWIFT_ACTIVE_KV_FORCE_MODEL_EVAL_PROBE`.

## Known Gaps
- Full `make py-test` and `make integration-test` ran in the pre-commit gate before merging the latest `origin/main`; after the upstream-only VLM merge, I reran the touched Swift worker focus set plus the menubar shard on the final HEAD.
- This PR does not rerun the full 128k matrix; the live benchmark evidence targets the short warm `1024x16` decode regression that motivated the fix.
- SwiftLM remains slightly ahead on TTFT and aggregate throughput in the short warm smoke, so the next optimization target is prefill/TTFT rather than baseline decode.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
