### PR TITLE
perf: inline report evidence run-kind scan

### DIFF
--- a/docs/plans/2026-05-24-report-evidence-run-kind-cache.md
+++ b/docs/plans/2026-05-24-report-evidence-run-kind-cache.md
@@ -5,7 +5,10 @@
 This Python-only performance slice is limited to report evidence gate run-kind
 rule matching in `services/mlx-worker-python/worker/productization/report_evidence_gate.py`.
 It keeps release evidence matrix behavior unchanged while avoiding repeated
-`frozenset` construction for immutable tuple-backed `run_kinds` rules.
+`frozenset` construction for immutable tuple-backed `run_kinds` rules. This
+follow-up slice keeps the same cached tuple-backed rule set and replaces the
+hot-path `any(...)` generator with an explicit loop so a matching run can return
+without per-call generator frame overhead.
 
 ## Registered Probe
 

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -290,8 +290,9 @@ def _rule_matches_report(
     run_kinds = rule.get("run_kinds", ())
     if run_kinds:
         run_kind_set = _string_frozenset(run_kinds)
-        if any(str(run.get("run_kind", "")) in run_kind_set for run in runs):
-            return True
+        for run in runs:
+            if str(run.get("run_kind", "")) in run_kind_set:
+                return True
     metric_prefixes = tuple(str(item) for item in rule.get("metric_prefixes", ()))
     if metric_prefixes and any(
         str(metric.get("metric", "")).startswith(metric_prefixes) for metric in metrics


### PR DESCRIPTION
## Summary
- Replace the report evidence gate run-kind `any(...)` generator with an explicit loop that returns on the first matching run.
- Keep the existing tuple-backed run-kind set cache and release evidence behavior unchanged.
- Update the governing performance slice plan with this follow-up optimization.

## Plan or Spec
- `docs/plans/2026-05-24-report-evidence-run-kind-cache.md`

## Commands Run
```text
uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# 7 passed in 0.75s

uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
# 7 passed; changed-scope coverage TOTAL 3 0 100%

MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# {"elapsed_ms_mean": 263.200623029843, "iterations": 50000.0, "match_count": 250000.0, "run_kind_count": 65.0, "runs_per_call": 80.0, "sample_count": 5.0}

uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id report-evidence-gate-run-kind-set-membership --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-report-evidence-run-kind-local-contains-20260524-base --head-repo "$PWD" --output /tmp/report_evidence_run_kind_probe_compare.json
# base elapsed_ms_mean=363.2586624007672; head elapsed_ms_mean=273.98584415204823
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` for `services/mlx-worker-python/worker/productization/report_evidence_gate.py` changed lines.
- Registered local probe: `report-evidence-gate-run-kind-set-membership`.
- Local base-vs-head metric: `elapsed_ms_mean` improved from `363.2586624007672 ms` to `273.98584415204823 ms` (`-89.27281824871898 ms`, about `-24.57%`).
- Guard metrics unchanged: `run_kind_count=65`, `runs_per_call=80`, `match_count=250000`.
- CI PR-scoped performance is still required as the merge gate.

## Known Gaps
- None. Local validation is Linux/Python-only; the registered PR-scoped performance workflow remains the final validation source.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
