### PR TITLE
perf: bind LoRA run-dir append hot path

### DIFF
--- a/docs/plans/2026-05-24-lora-run-dir-name-append-binding.md
+++ b/docs/plans/2026-05-24-lora-run-dir-name-append-binding.md
@@ -1,0 +1,34 @@
+# LoRA Run Directory Name Append Binding Slice
+
+## Scope
+
+This Python-only performance slice is limited to `_iter_lora_run_dirs()` in
+`services/mlx-worker-python/worker/productization/lora_experiment_store.py`.
+It keeps LoRA experiment run-directory discovery behavior unchanged while
+binding the `run_dir_names.append` method once before the `os.scandir()` loop.
+The hot path already avoids `DirEntry.path`; this slice removes one repeated
+list method lookup per accepted run directory.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`lora-experiment-run-dir-name-scan` in `infra/perf/pr_scoped_probes.json`.
+The registry already has focused `test_command`, `coverage_command`, and
+`probe_command` entries. The existing probe command also emits `elapsed_ms_mean`
+for local and CI inspection, while the registered counters continue to gate
+path-read and peak-memory behavior without broadening the probe selection scope.
+
+## Acceptance Criteria
+
+- Focused LoRA experiment store tests pass locally on Linux.
+- Changed-scope coverage for the touched Python and probe-registry paths remains
+  at or above 95%.
+- The registered probe reports no behavior drift (`path_attr_reads_mean == 0`,
+  stable `run_dir_count`) and lower or neutral `elapsed_ms_mean` for the head
+  branch compared with the baseline worktree.
+- PR-scoped performance CI completes successfully before merge.
+
+## Non-Goals
+
+- No LoRA experiment index schema changes.
+- No generated protocol, Swift, or lockfile changes.

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -28,6 +28,7 @@ def _iter_lora_run_dirs(train_root: Path) -> tuple[Path, ...]:
     try:
         with os.scandir(train_root) as entries:
             run_dir_names = []
+            append_run_dir_name = run_dir_names.append
             for entry in entries:
                 if not entry.name.startswith("model-ops-"):
                     continue
@@ -36,7 +37,7 @@ def _iter_lora_run_dirs(train_root: Path) -> tuple[Path, ...]:
                         continue
                 except OSError:
                     continue
-                run_dir_names.append(entry.name)
+                append_run_dir_name(entry.name)
     except OSError:
         return ()
 


### PR DESCRIPTION
## Summary
- Bind `run_dir_names.append` once in `_iter_lora_run_dirs()` before the `os.scandir()` loop.
- Keep LoRA run-directory discovery behavior unchanged: only `model-ops-*` directories are accepted, names remain sorted, and the path-read guard still reports zero `DirEntry.path` reads.
- Add a focused plan note for the slice under `docs/plans/`.

## Plan or Spec
- Plan: `docs/plans/2026-05-24-lora-run-dir-name-append-binding.md`
- Existing registered PR-scoped probe: `lora-experiment-run-dir-name-scan`
- The affected path is already covered by the registered probe's `watch_globs`, focused `test_command`, `coverage_command`, and `probe_command`. This PR does not broaden the probe registry; the probe command already emits `elapsed_ms_mean` for inspection while registered gates continue covering path reads, peak memory, and run-dir count.

## Commands Run
- `git diff --check origin/main...HEAD`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py::test_iter_lora_run_dirs_sorts_names_without_reading_entry_paths services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_prefers_run_record_over_manifest_when_both_exist services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_experiment_run_dir_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_experiment_run_dir_scan_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py::test_iter_lora_run_dirs_sorts_names_without_reading_entry_paths services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_prefers_run_record_over_manifest_when_both_exist services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_experiment_run_dir_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_experiment_run_dir_scan_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/lora_experiment_store.py services/mlx-worker-python/tests/test_lora_experiment_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_experiment_run_dir_scan_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id lora-experiment-run-dir-name-scan --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/lora_run_dir_probe_after_revert.json`

## Coverage and Metrics
- Focused pytest: `5 passed in 7.50s`.
- Changed-scope coverage before commit: `TOTAL 2 0 100%` with measurable changed lines `[31, 40]` in `lora_experiment_store.py` covered.
- Registered probe rerun after final amend: `lora-experiment-run-dir-name-scan` completed successfully for base and head.
- Local Linux probe metrics after final amend:
  - Base: `elapsed_ms_mean=1096.9407245516777`, `peak_bytes_mean=3027840.0`, `path_attr_reads_mean=0.0`, `run_dir_count=8000`.
  - Head: `elapsed_ms_mean=1056.7797884345055`, `peak_bytes_mean=3027912.0`, `path_attr_reads_mean=0.0`, `run_dir_count=8000`.
  - Delta: elapsed `-40.16093611717224 ms` (~`3.66%` lower), peak memory `+72 bytes` (~`0.0024%`), path reads unchanged at `0.0`.

## Known Gaps
- This is a Python-only slice validated locally on Linux. Swift runtime effects are out of scope.
- The timing delta is intentionally treated as supporting evidence for a tiny hot-path cleanup; the registered gates remain focused on path-read safety, peak memory, and run-dir count.
- CI must still complete the PR-scoped performance workflow for the registered probe before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused behavior tests pass locally.
- [x] Changed-scope coverage meets the 95% threshold for the measurable changed lines.
- [x] Registered local probe completed for base and head.
- [ ] GitHub Actions PR checks are green.
- [ ] PR-scoped performance workflow completed successfully in CI.
