### PR TITLE
perf: streamline tool registry OpenAI payload copies

### DIFF
--- a/docs/plans/2026-05-24-tool-registry-openai-template-loop.md
+++ b/docs/plans/2026-05-24-tool-registry-openai-template-loop.md
@@ -1,0 +1,49 @@
+# Tool Registry OpenAI Template Loop
+
+Date: 2026-05-24
+
+## Scope
+
+This Python-only performance slice is limited to `ToolRegistry.as_openai_tools()`
+in `services/mlx-worker-python/worker/runtime/tool_registry.py`.
+
+## Problem
+
+The OpenAI tool payload hot path is already backed by cached descriptor
+metadata, but each call still builds the per-tool `properties` dictionary through
+an inner dictionary comprehension. The registered probe repeatedly materializes
+OpenAI tool payloads and mutates the returned `required` list to prove call-level
+isolation. On that small, repeated payload shape, the comprehension creates extra
+frame overhead while the registry already has the cached property tuple needed
+for a direct copy loop.
+
+## Plan
+
+- Keep the existing cached `_openai_tool_templates` source of truth.
+- Replace only the inner `properties` dictionary comprehension with an explicit
+  copy loop inside `ToolRegistry.as_openai_tools()`.
+- Preserve returned payload equality and mutation isolation for schema property
+  dictionaries and `required` lists.
+- Use the existing registered PR-scoped probe
+  `tool-registry-openai-tools-template-cache` for test, coverage, and metrics.
+
+## Registered Probe
+
+Registered PR-scoped probe: `tool-registry-openai-tools-template-cache` in
+`infra/perf/pr_scoped_probes.json`.
+
+Focused commands:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_openai_tools_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
+```
+
+## Acceptance Criteria
+
+- Focused behavior tests pass locally on Linux.
+- Changed-scope coverage is at least 95% for the touched scope.
+- The registered probe reports lower `elapsed_ms_mean` for repeated OpenAI tool
+  materialization compared with `origin/main`.
+- CI PR-scoped performance completes successfully before merge.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -294,34 +294,36 @@ class ToolRegistry:
     def as_openai_tools(self) -> list[dict[str, Any]]:
         copy_dict = _COPY_DICT
         copy_list = _COPY_LIST
-        return [
-            {
-                "type": "function",
-                "function": {
-                    "name": name,
-                    "description": description,
-                    "parameters": {
-                        "type": "object",
-                        "additionalProperties": False,
-                        "properties": {
-                            argument_name: copy_dict(schema)
-                            for argument_name, schema in schema_properties
+        tools: list[dict[str, Any]] = []
+        for (
+            name,
+            description,
+            tool_kind,
+            observation_kind,
+            schema_properties,
+            required_arguments,
+        ) in self._openai_tool_templates:
+            properties: dict[str, Any] = {}
+            for argument_name, schema in schema_properties:
+                properties[argument_name] = copy_dict(schema)
+            tools.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "description": description,
+                        "parameters": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": properties,
+                            "required": copy_list(required_arguments),
                         },
-                        "required": copy_list(required_arguments),
                     },
-                },
-                "x-melix-tool-kind": tool_kind,
-                "x-melix-observation-kind": observation_kind,
-            }
-            for (
-                name,
-                description,
-                tool_kind,
-                observation_kind,
-                schema_properties,
-                required_arguments,
-            ) in self._openai_tool_templates
-        ]
+                    "x-melix-tool-kind": tool_kind,
+                    "x-melix-observation-kind": observation_kind,
+                }
+            )
+        return tools
 
     def as_worker_tool_config(self) -> common_pb2.ToolConfig:
         if self._worker_tool_config_bytes:


### PR DESCRIPTION
## Summary
- Streamline `ToolRegistry.as_openai_tools()` by replacing the inner `properties` dictionary comprehension with an explicit cached-template copy loop.
- Preserve OpenAI tool payload equality and per-call mutation isolation for nested schema properties and `required` lists.

## Plan or Spec
- `docs/plans/2026-05-24-tool-registry-openai-template-loop.md`
- Registered PR-scoped probe: `tool-registry-openai-tools-template-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Registry/probe preflight
python3 - <<'PY'
import json
probes=json.load(open('infra/perf/pr_scoped_probes.json'))
probe=next(p for p in probes if p['id']=='tool-registry-openai-tools-template-cache')
print(probe['id'])
print(probe['watch_globs'])
print('test_command=', probe['test_command'])
print('coverage_command=', probe['coverage_command'])
print('probe_command=', probe['probe_command'])
PY
# exit 0; probe has focused test_command, coverage_command, and probe_command

git diff --check
# exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 53 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 53 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_openai_tools_probe.py
# exit 0; TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
# exit 0; head elapsed_ms_mean=437.0126221328974

# Base/head repeated registered probe comparison (default probe settings, 3 runs each):
# base elapsed_ms_mean: 449.52372051775455, 489.66275695711374, 457.2014453820884
# head elapsed_ms_mean: 467.9859804920852, 444.9731661006808, 458.2921767607331

# Higher-iteration comparison:
MELIX_TOOL_REGISTRY_OPENAI_TOOLS_ITERATIONS=200000 MELIX_TOOL_REGISTRY_OPENAI_TOOLS_SAMPLES=3 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
# base exit 0; elapsed_ms_mean=1885.754256664465
# head exit 0; elapsed_ms_mean=1805.7033396326005
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 7 0 100%`).
- Registered local probe (`tool-registry-openai-tools-template-cache`) default single head run: `elapsed_ms_mean=437.0126221328974`, `descriptor_as_openai_tool_calls_mean=0.0`, `isolated_payload_calls_mean=50000.0`.
- Default 3-run comparison: base mean `(449.52372051775455 + 489.66275695711374 + 457.2014453820884) / 3 = 465.4626409523189 ms`; head mean `(467.9859804920852 + 444.9731661006808 + 458.2921767607331) / 3 = 457.0837744511664 ms`; delta `-8.3788665011525 ms` (`~1.80%` faster).
- Higher-iteration comparison: base `1885.754256664465 ms`, head `1805.7033396326005 ms`; delta `-80.0509170318644 ms` (`~4.25%` faster).
- CI PR-scoped performance is required before merge.

## Known Gaps
- Local verification is Linux/Python-only; no Swift runtime behavior is changed.
- The default local probe is somewhat noisy, so the PR relies on the registered CI probe as the merge validation source.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing registered PR-scoped performance probe; probe overhead unchanged by this PR.
- [x] Deferred work and known gaps are stated explicitly.
