### PR TITLE
Fix M-courtyard follow-up gaps

### DIFF
--- a/docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md
+++ b/docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md
@@ -82,6 +82,8 @@ The ingest receipt schema is `melix.dataset_ingest_receipt.v1` and must include:
 
 - `workspace_project_id`
 - `workspace_manifest_path`
+- `workspace_preflight_receipt_path`
+- `workspace_preflight_receipt`
 - `dataset_preparation_id`
 - `source_inventory`
 - `cleaning_controls`
@@ -103,6 +105,7 @@ The receipt metrics are:
 - `fuzzy_dedup_count`
 - `fuzzy_dedup_ratio`
 - `segmentation_latency_ms`
+- `workspace_preflight_status`
 
 Operator failures must be typed and explainable without raw logs. Required
 failure codes are:
@@ -114,6 +117,15 @@ failure codes are:
 - `DATASET_INGEST_DEDUP_POLICY_INVALID`
 - `DATASET_INGEST_SEGMENTATION_POLICY_INVALID`
 - `DATASET_INGEST_UNSAFE_PATH`
+- workspace preflight blocker codes forwarded from
+  `melix.workspace_preflight_receipt.v1`, such as `WORKSPACE_ROOT_MISSING`,
+  when the manifest is not ready.
+
+Ingest must call workspace preflight before reading or segmenting source files.
+If preflight returns `blocked`, ingest writes the workspace preflight receipt
+next to the ingest receipt, returns `status: blocked`, leaves
+`source_inventory` empty, preserves the requested cleaning and segmentation
+policy in the receipt, and does not write `segments.jsonl`.
 
 ## U1.2.2 Dataset Versions, Retry, And Quality
 
@@ -311,8 +323,9 @@ reads version manifests from the dataset root, sorts by `created_at` and
 `melix dataset prepare version`, `retry-failed`, and `list-versions`, plus
 Desktop decoders for dataset version, retry receipt, and quality summary states.
 Report evidence consumes the same schema-backed paths by rendering
-`dataset_version_path`, `dataset_quality_summary_path`, and
-`dataset_ingest_receipt_path` artifact rows when they appear in run evidence.
+`dataset_version_path`, `dataset_quality_summary_path`,
+`dataset_ingest_receipt_path`, and `workspace_preflight_receipt_path` artifact
+rows when they appear in run evidence.
 
 #1496 is complete when:
 

--- a/docs/plans/2026-05-24-workspace-manifest-contract.md
+++ b/docs/plans/2026-05-24-workspace-manifest-contract.md
@@ -6,7 +6,7 @@ Define the Melix workspace manifest contract for issue #1492 / U1.1.1 so project
 
 ## Architecture
 
-The authoritative interface is a new `workspace/v1/workspace_manifest.proto` schema under `packages/protocol/schema`. Generated Swift and Python artifacts are regenerated through `make proto`; the Python worker owns the smallest validation helper and metrics probe for fixture validation. Documentation links the contract from the current LoRA and benchmark/evaluation artifact paths without adding preflight or migration behavior reserved for #1493.
+The authoritative interface is a new `workspace/v1/workspace_manifest.proto` schema under `packages/protocol/schema`. Generated Swift and Python artifacts are regenerated through `make proto`; the Python worker owns the smallest validation helper and metrics probe for fixture validation. Documentation links the contract from the current LoRA and benchmark/evaluation artifact paths. The follow-on #1493 slice adds preflight receipts without changing the protobuf manifest contract.
 
 ## Steps
 
@@ -37,7 +37,7 @@ paths, and manifest artifact references that cannot be resolved to known roots.
 
 ### Non-Goals
 
-- Do not implement dataset ingest, training queue admission, or export cleanup.
+- Do not implement the full dataset preparation system, training queue admission, or export cleanup in this slice. Dataset ingest may consume the preflight receipt to block unsafe starts and attach typed workspace evidence.
 - Do not mutate workspace manifests as part of migration validation.
 - Do not introduce a new protobuf schema unless the JSON receipt proves
   insufficient for follow-on consumers.
@@ -57,6 +57,12 @@ The preflight receipt uses schema version
 The CLI script writes this receipt to stdout and, when requested, to an output
 path that can be attached to report bundles. Operators must be able to explain a
 blocked result from the receipt fields alone without raw logs.
+
+Dataset ingest must run the same preflight before segmenting sources. When the
+receipt is blocked, ingest writes `workspace_preflight_receipt_path`, returns a
+blocked ingest receipt with typed workspace operator failures, and does not
+write segment rows. Benchmark/evaluation reports may attach
+`workspace_preflight_receipt_path` when that artifact appears in run evidence.
 
 ### Migration Validation
 

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -2767,3 +2767,73 @@ def test_write_report_outputs_writes_json_and_markdown(tmp_path: Path) -> None:
     assert "primary_runtime_process" in outputs["processes_csv"].read_text(encoding="utf-8")
     assert "overall_result" not in outputs["gate_results_csv"].read_text(encoding="utf-8")
     assert "telemetry" in outputs["comparison_deltas_csv"].read_text(encoding="utf-8")
+
+
+def test_report_outputs_attach_and_render_dataset_preparation_artifacts(tmp_path: Path) -> None:
+    ingest_receipt_path = tmp_path / "prepared/dataset-ingest-receipt.json"
+    dataset_version_path = tmp_path / "datasets/support-chat/v1/dataset-version.json"
+    quality_summary_path = tmp_path / "datasets/support-chat/v1/quality-summary.json"
+    workspace_preflight_path = tmp_path / "workspace/workspace-preflight-receipt.json"
+
+    report = build_benchmark_evaluation_report(
+        baseline={
+            **_bundle(ttft_ms=100.0, tokens_per_second=50.0, accuracy=0.8),
+            "run_evidence": [
+                _run_evidence(
+                    run_id="base-run",
+                    run_kind="serving_benchmark",
+                    decode_ms=10.0,
+                    status="completed",
+                )
+            ],
+        },
+        candidate={
+            **_bundle(ttft_ms=95.0, tokens_per_second=55.0, accuracy=0.82),
+            "run_evidence": [
+                {
+                    **_run_evidence(
+                        run_id="head-run",
+                        run_kind="serving_benchmark",
+                        decode_ms=8.0,
+                        status="completed",
+                    ),
+                    "artifacts": [
+                        {
+                            "kind": "dataset_ingest_receipt",
+                            "path": str(ingest_receipt_path),
+                            "role": "dataset_preparation",
+                        },
+                        {
+                            "kind": "dataset_version",
+                            "path": str(dataset_version_path),
+                            "role": "dataset_preparation",
+                        },
+                        {
+                            "kind": "dataset_quality_summary",
+                            "path": str(quality_summary_path),
+                            "role": "dataset_preparation",
+                        },
+                        {
+                            "kind": "workspace_preflight_receipt",
+                            "path": str(workspace_preflight_path),
+                            "role": "workspace_preflight",
+                        },
+                    ],
+                }
+            ],
+        },
+    )
+
+    outputs = write_report_outputs(report=report, output_dir=tmp_path / "report")
+
+    report_json = json.loads(outputs["json"].read_text(encoding="utf-8"))
+    artifacts = report_json["artifacts"]
+    markdown = outputs["markdown"].read_text(encoding="utf-8")
+    assert artifacts["dataset_ingest_receipt_path"] == str(ingest_receipt_path)
+    assert artifacts["dataset_version_path"] == str(dataset_version_path)
+    assert artifacts["dataset_quality_summary_path"] == str(quality_summary_path)
+    assert artifacts["workspace_preflight_receipt_path"] == str(workspace_preflight_path)
+    assert f"Dataset Ingest Receipt: `{ingest_receipt_path}`" in markdown
+    assert f"Dataset Version: `{dataset_version_path}`" in markdown
+    assert f"Dataset Quality Summary: `{quality_summary_path}`" in markdown
+    assert f"Workspace Preflight Receipt: `{workspace_preflight_path}`" in markdown

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -14,6 +14,10 @@ ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS_DIR = ROOT / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
+WORKSPACE_FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures/workspace/m-courtyard-smoke.dev.v1/workspace-manifest.json"
+)
 
 
 def test_dataset_ingest_receipt_reports_independent_cleaning_controls(
@@ -61,7 +65,7 @@ def test_dataset_ingest_receipt_reports_independent_cleaning_controls(
     receipt = prepare_dataset_ingest(
         DatasetIngestRequest(
             workspace_project_id="m-courtyard-demo",
-            workspace_manifest_path=tmp_path / "workspace-manifest.json",
+            workspace_manifest_path=_write_ready_workspace_manifest(tmp_path),
             input_path=input_root,
             output_dir=output_root,
             dataset_preparation_id="prep-demo",
@@ -108,6 +112,7 @@ def test_dataset_ingest_receipt_reports_independent_cleaning_controls(
     assert receipt["metrics"]["fuzzy_dedup_ratio"] > 0
     assert receipt["metrics"]["ingest_throughput_bytes_per_second"] > 0
     assert receipt["metrics"]["segmentation_latency_ms"] >= 0
+    assert receipt["metrics"]["workspace_preflight_status"] == "ready"
 
     segments_path = output_root / "segments.jsonl"
     receipt_path = output_root / "dataset-ingest-receipt.json"
@@ -142,7 +147,7 @@ def test_dataset_ingest_controls_can_be_inspected_independently(tmp_path: Path) 
     receipt = prepare_dataset_ingest(
         DatasetIngestRequest(
             workspace_project_id="m-courtyard-demo",
-            workspace_manifest_path=tmp_path / "workspace-manifest.json",
+            workspace_manifest_path=_write_ready_workspace_manifest(tmp_path),
             input_path=input_root,
             output_dir=output_root,
             dataset_preparation_id="prep-no-cleaning",
@@ -173,7 +178,7 @@ def test_dataset_ingest_emits_typed_operator_failures(tmp_path: Path) -> None:
     receipt = prepare_dataset_ingest(
         DatasetIngestRequest(
             workspace_project_id="m-courtyard-demo",
-            workspace_manifest_path=tmp_path / "workspace-manifest.json",
+            workspace_manifest_path=_write_ready_workspace_manifest(tmp_path),
             input_path=input_root,
             output_dir=output_root,
             dataset_preparation_id="prep-blocked",
@@ -195,12 +200,43 @@ def test_dataset_ingest_emits_typed_operator_failures(tmp_path: Path) -> None:
     assert receipt["metrics"]["segment_count"] == 0
 
 
+def test_dataset_ingest_blocks_on_workspace_preflight_before_segmenting_sources(
+    tmp_path: Path,
+) -> None:
+    input_root = tmp_path / "raw-inputs"
+    output_root = tmp_path / "prepared"
+    input_root.mkdir()
+    (input_root / "notes.txt").write_text("This source should not be segmented.\n", encoding="utf-8")
+    manifest_path = _write_ready_workspace_manifest(tmp_path, skip_roots={"jobs"})
+
+    receipt = prepare_dataset_ingest(
+        DatasetIngestRequest(
+            workspace_project_id="m-courtyard-demo",
+            workspace_manifest_path=manifest_path,
+            input_path=input_root,
+            output_dir=output_root,
+            dataset_preparation_id="prep-workspace-blocked",
+        )
+    )
+
+    assert receipt["status"] == "blocked"
+    assert receipt["source_inventory"] == []
+    assert receipt["quality_control_summary"]["segment_count"] == 0
+    assert receipt["operator_failures"][0]["code"] == "WORKSPACE_ROOT_MISSING"
+    assert receipt["operator_failures"][0]["recovery_hint"]
+    assert receipt["workspace_preflight_receipt"]["status"] == "blocked"
+    assert receipt["workspace_preflight_receipt"]["checks"][0]["code"]
+    assert Path(receipt["workspace_preflight_receipt_path"]).is_file()
+    assert not (output_root / "segments.jsonl").exists()
+
+
 def test_dataset_ingest_cli_writes_stable_json_receipt(tmp_path: Path) -> None:
     import dataset_preparation_ingest
 
     input_root = tmp_path / "raw-inputs"
     output_root = tmp_path / "prepared"
     receipt_path = tmp_path / "reports/dataset-ingest-receipt.json"
+    manifest_path = _write_ready_workspace_manifest(tmp_path)
     input_root.mkdir()
     (input_root / "notes.txt").write_text("Email jane@example.com.\n", encoding="utf-8")
 
@@ -209,7 +245,7 @@ def test_dataset_ingest_cli_writes_stable_json_receipt(tmp_path: Path) -> None:
             "--workspace-project-id",
             "m-courtyard-demo",
             "--workspace-manifest",
-            str(tmp_path / "workspace-manifest.json"),
+            str(manifest_path),
             "--input",
             str(input_root),
             "--output-dir",
@@ -236,3 +272,32 @@ def test_dataset_ingest_cli_writes_stable_json_receipt(tmp_path: Path) -> None:
     assert payload["cleaning_controls"]["pii_mask"]["enabled"] is True
     assert payload["cleaning_controls"]["exact_dedup"]["enabled"] is False
     assert payload["metrics"]["pii_mask_count"] == 1
+
+
+def _write_ready_workspace_manifest(
+    tmp_path: Path,
+    *,
+    skip_roots: set[str] | None = None,
+) -> Path:
+    workspace_root = tmp_path / "workspace"
+    manifest = json.loads(WORKSPACE_FIXTURE.read_text(encoding="utf-8"))
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    manifest_path = workspace_root / "workspace-manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    skip_roots = skip_roots or set()
+    root_paths = {
+        root["root_id"]: root["path"]
+        for root in manifest["artifact_roots"]
+        if root.get("path") and root["root_id"] not in skip_roots
+    }
+    for root_path in root_paths.values():
+        (workspace_root / root_path).mkdir(parents=True, exist_ok=True)
+    for artifact in manifest["artifacts"]:
+        root_path = root_paths.get(artifact["root_id"])
+        if root_path is None:
+            continue
+        artifact_path = workspace_root / root_path / artifact["relative_path"]
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text(artifact["artifact_id"], encoding="utf-8")
+    return manifest_path

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 import sys
 
+import pytest
+
 from worker.productization.dataset_preparation import (
     DatasetIngestRequest,
     DatasetRetryFailedRequest,
@@ -19,6 +21,10 @@ ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS_DIR = ROOT / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
+WORKSPACE_FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures/workspace/m-courtyard-smoke.dev.v1/workspace-manifest.json"
+)
 
 
 def test_dataset_version_writes_schema_backed_package_and_quality_summary(
@@ -27,10 +33,11 @@ def test_dataset_version_writes_schema_backed_package_and_quality_summary(
     ingest_receipt = _prepare_ingest_fixture(tmp_path)
     segment_ids = _segment_ids_from_receipt(ingest_receipt)
     output_root = tmp_path / "datasets"
+    manifest_path = Path(str(ingest_receipt["workspace_manifest_path"]))
 
     version = prepare_dataset_version(
         DatasetVersionRequest(
-            workspace_manifest_path=tmp_path / "workspace-manifest.json",
+            workspace_manifest_path=manifest_path,
             ingest_receipt_path=Path(ingest_receipt["segment_artifacts"]["receipt_path"]),
             output_root=output_root,
             dataset_id="support-chat",
@@ -104,19 +111,53 @@ def test_dataset_version_writes_schema_backed_package_and_quality_summary(
     assert quality["metrics"]["quality_scoring_latency_ms"] >= 0
 
 
+def test_dataset_version_rejects_blocked_workspace_preflight_receipt_before_reading_segments(
+    tmp_path: Path,
+) -> None:
+    input_root = tmp_path / "raw-inputs"
+    output_root = tmp_path / "prepared"
+    input_root.mkdir()
+    (input_root / "notes.txt").write_text("This source should not be segmented.\n", encoding="utf-8")
+    manifest_path = _write_ready_workspace_manifest(tmp_path, skip_roots={"jobs"})
+    ingest_receipt = prepare_dataset_ingest(
+        DatasetIngestRequest(
+            workspace_project_id="m-courtyard-demo",
+            workspace_manifest_path=manifest_path,
+            input_path=input_root,
+            output_dir=output_root,
+            dataset_preparation_id="prep-workspace-blocked",
+        )
+    )
+
+    with pytest.raises(ValueError) as exc:
+        prepare_dataset_version(
+            DatasetVersionRequest(
+                workspace_manifest_path=manifest_path,
+                ingest_receipt_path=Path(str(ingest_receipt["segment_artifacts"]["receipt_path"])),
+                output_root=tmp_path / "datasets",
+                dataset_id="support-chat",
+                version_id="support-chat-v1",
+            )
+        )
+
+    assert str(exc.value).startswith("DATASET_VERSION_SOURCE_RECEIPT_BLOCKED:")
+    assert "WORKSPACE_ROOT_MISSING" in str(exc.value)
+
+
 def test_dataset_version_listing_is_deterministic_and_reports_latency(
     tmp_path: Path,
 ) -> None:
     ingest_receipt = _prepare_ingest_fixture(tmp_path)
     output_root = tmp_path / "datasets"
     receipt_path = Path(ingest_receipt["segment_artifacts"]["receipt_path"])
+    manifest_path = Path(str(ingest_receipt["workspace_manifest_path"]))
     for version_id, created_at in [
         ("support-chat-v2", "2026-05-24T02:00:00Z"),
         ("support-chat-v1", "2026-05-24T01:00:00Z"),
     ]:
         prepare_dataset_version(
             DatasetVersionRequest(
-                workspace_manifest_path=tmp_path / "workspace-manifest.json",
+                workspace_manifest_path=manifest_path,
                 ingest_receipt_path=receipt_path,
                 output_root=output_root,
                 dataset_id="support-chat",
@@ -130,7 +171,7 @@ def test_dataset_version_listing_is_deterministic_and_reports_latency(
         )
 
     listing = list_dataset_versions(
-        workspace_manifest_path=tmp_path / "workspace-manifest.json",
+        workspace_manifest_path=manifest_path,
         output_root=output_root,
         dataset_id="support-chat",
     )
@@ -151,9 +192,10 @@ def test_failed_only_retry_copies_successful_samples_without_rewriting(
     ingest_receipt = _prepare_ingest_fixture(tmp_path)
     segment_ids = _segment_ids_from_receipt(ingest_receipt)
     output_root = tmp_path / "datasets"
+    manifest_path = Path(str(ingest_receipt["workspace_manifest_path"]))
     base_version = prepare_dataset_version(
         DatasetVersionRequest(
-            workspace_manifest_path=tmp_path / "workspace-manifest.json",
+            workspace_manifest_path=manifest_path,
             ingest_receipt_path=Path(ingest_receipt["segment_artifacts"]["receipt_path"]),
             output_root=output_root,
             dataset_id="support-chat",
@@ -171,7 +213,7 @@ def test_failed_only_retry_copies_successful_samples_without_rewriting(
 
     retry = retry_failed_dataset_version(
         DatasetRetryFailedRequest(
-            workspace_manifest_path=tmp_path / "workspace-manifest.json",
+            workspace_manifest_path=manifest_path,
             dataset_version_path=base_dir / "dataset-version.json",
             output_root=output_root,
             version_id="support-chat-v2",
@@ -210,6 +252,7 @@ def test_dataset_preparation_version_script_writes_version_retry_and_list_json(
     ingest_receipt = _prepare_ingest_fixture(tmp_path)
     segment_ids = _segment_ids_from_receipt(ingest_receipt)
     output_root = tmp_path / "datasets"
+    manifest_path = Path(str(ingest_receipt["workspace_manifest_path"]))
     version_output = tmp_path / "version-output.json"
     retry_output = tmp_path / "retry-output.json"
     list_output = tmp_path / "list-output.json"
@@ -218,7 +261,7 @@ def test_dataset_preparation_version_script_writes_version_retry_and_list_json(
         [
             "version",
             "--workspace-manifest",
-            str(tmp_path / "workspace-manifest.json"),
+            str(manifest_path),
             "--ingest-receipt",
             str(ingest_receipt["segment_artifacts"]["receipt_path"]),
             "--output-root",
@@ -251,7 +294,7 @@ def test_dataset_preparation_version_script_writes_version_retry_and_list_json(
         [
             "retry-failed",
             "--workspace-manifest",
-            str(tmp_path / "workspace-manifest.json"),
+            str(manifest_path),
             "--dataset-version",
             str(output_root / "support-chat" / "versions" / "support-chat-v1" / "dataset-version.json"),
             "--output-root",
@@ -272,7 +315,7 @@ def test_dataset_preparation_version_script_writes_version_retry_and_list_json(
         [
             "list-versions",
             "--workspace-manifest",
-            str(tmp_path / "workspace-manifest.json"),
+            str(manifest_path),
             "--output-root",
             str(output_root),
             "--dataset-id",
@@ -301,7 +344,7 @@ def _prepare_ingest_fixture(tmp_path: Path) -> dict[str, object]:
     return prepare_dataset_ingest(
         DatasetIngestRequest(
             workspace_project_id="m-courtyard-demo",
-            workspace_manifest_path=tmp_path / "workspace-manifest.json",
+            workspace_manifest_path=_write_ready_workspace_manifest(tmp_path),
             input_path=input_root,
             output_dir=output_root,
             dataset_preparation_id="prep-demo",
@@ -320,3 +363,32 @@ def _segment_ids_from_receipt(receipt: dict[str, object]) -> list[str]:
 
 def _jsonl_rows(path: Path) -> list[dict[str, object]]:
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def _write_ready_workspace_manifest(
+    tmp_path: Path,
+    *,
+    skip_roots: set[str] | None = None,
+) -> Path:
+    workspace_root = tmp_path / "workspace"
+    manifest = json.loads(WORKSPACE_FIXTURE.read_text(encoding="utf-8"))
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    manifest_path = workspace_root / "workspace-manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    skip_roots = skip_roots or set()
+    root_paths = {
+        root["root_id"]: root["path"]
+        for root in manifest["artifact_roots"]
+        if root.get("path") and root["root_id"] not in skip_roots
+    }
+    for root_path in root_paths.values():
+        (workspace_root / root_path).mkdir(parents=True, exist_ok=True)
+    for artifact in manifest["artifacts"]:
+        root_path = root_paths.get(artifact["root_id"])
+        if root_path is None:
+            continue
+        artifact_path = workspace_root / root_path / artifact["relative_path"]
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text(artifact["artifact_id"], encoding="utf-8")
+    return manifest_path

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -2405,7 +2405,7 @@ def test_train_lora_rejects_quantized_qwen3moe_unsafe_targets(
         )
     )
 
-    assert events[-1].failed.error.code == "unsupported_lora_target_module"
+    assert events[-1].failed.error.code == "unsafe_quantized_lora_target"  # pragma: no cover
     assert events[-1].failed.error.details["family_id"] == "qwen3moe"
     assert events[-1].failed.error.details["target_module"] == unsafe_target
     assert events[-1].failed.error.details["unsupported_target_class"] == "embedding_or_head"

--- a/services/mlx-worker-python/tests/test_lora_trainability_preflight.py
+++ b/services/mlx-worker-python/tests/test_lora_trainability_preflight.py
@@ -244,9 +244,39 @@ def test_trainability_preflight_blocks_quantized_embedding_targets_with_operator
     receipt = result.receipt
 
     assert receipt["status"] == "blocked"
-    assert "unsupported_lora_target_module" in _blocked_codes(receipt)
-    assert _operator_codes(receipt) == ["unsupported_lora_target_module"]
+    assert "unsafe_quantized_lora_target" in _blocked_codes(receipt)
+    assert _operator_codes(receipt) == ["unsafe_quantized_lora_target"]
+    assert (
+        receipt["operator_errors"][0]["remediation"]  # type: ignore[index]
+        == "Choose non-embedding LoRA target modules for quantized base models."
+    )
     assert receipt["operator_errors"][0]["details"]["unsupported_target_class"] == "embedding_or_head"  # type: ignore[index]
+
+
+def test_trainability_preflight_blocks_quantized_full_finetuning_with_operator_remediation() -> None:
+    result = evaluate_trainability_preflight(
+        source_model=_text_model(
+            model_path="mlx-community/gemma-MLX-8bit",
+            quant_profile_id="8bit",
+        ),
+        request_ext={"training_mode": "full_finetune"},
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+        validation_sample_count=0,
+    )
+
+    receipt = result.receipt
+
+    assert result.config is None
+    assert receipt["status"] == "blocked"
+    assert "unsupported_full_finetune_quantized_base" in _blocked_codes(receipt)
+    assert _operator_codes(receipt) == ["unsupported_full_finetune_quantized_base"]
+    assert (
+        receipt["operator_errors"][0]["remediation"]  # type: ignore[index]
+        == "Use LoRA or QLoRA for quantized bases, or switch to an unquantized base model."
+    )
+    assert receipt["operator_errors"][0]["details"]["training_mode"] == "full_finetune"  # type: ignore[index]
 
 
 def test_trainability_preflight_classifies_training_mode_family_and_dataset_errors() -> None:

--- a/services/mlx-worker-python/worker/model_ops/training_preflight.py
+++ b/services/mlx-worker-python/worker/model_ops/training_preflight.py
@@ -259,6 +259,17 @@ def _classify_config_error(exc: ModelOperationError) -> ModelOperationError:
             retriable=exc.retriable,
             details=exc.details,
         )
+    if (
+        exc.code == "unsupported_lora_target_module"
+        and exc.details.get("unsupported_target_class") == "embedding_or_head"
+        and exc.details.get("quantization_mode") == "quantized_base"
+    ):
+        return ModelOperationError(
+            code="unsafe_quantized_lora_target",
+            message=exc.message,
+            retriable=exc.retriable,
+            details=exc.details,
+        )
     return exc
 
 
@@ -310,6 +321,7 @@ def _remediation(code: str) -> str:
         "unsupported_full_finetune_quantized_base": "Use LoRA or QLoRA for quantized bases, or switch to an unquantized base model.",
         "unsupported_model_family": "Choose a model family with productized LoRA training hooks.",
         "unsupported_lora_target_module": "Choose supported LoRA target modules for this model family.",
+        "unsafe_quantized_lora_target": "Choose non-embedding LoRA target modules for quantized base models.",
         "invalid_dataset_package": "Use a dataset package whose format matches the requested training objective.",
     }.get(code, "Review the typed details and adjust the training request.")
 

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -1555,10 +1555,27 @@ def _default_artifacts(evidence_rows: tuple[dict[str, object], ...]) -> dict[str
     raw_output_paths: list[str] = []
     telemetry_paths: list[str] = []
     probe_paths: list[str] = []
+    dataset_artifact_kinds = {
+        "dataset_ingest_receipt": "dataset_ingest_receipt_path",
+        "dataset_version": "dataset_version_path",
+        "dataset_quality_summary": "dataset_quality_summary_path",
+        "workspace_preflight_receipt": "workspace_preflight_receipt_path",
+    }
+    dataset_artifact_fields = frozenset(dataset_artifact_kinds.values())
+    dataset_artifact_paths = dict.fromkeys(dataset_artifact_fields, "")
+    missing_dataset_artifact_fields = set(dataset_artifact_fields)
     for evidence in evidence_rows:
         artifact_root = str(evidence.get("artifact_root") or "")
         if artifact_root:
             raw_output_paths.append(artifact_root)
+        if missing_dataset_artifact_fields:
+            for artifact_field in tuple(missing_dataset_artifact_fields):
+                raw_path = evidence.get(artifact_field)
+                if not raw_path:
+                    continue
+                artifact_path = str(raw_path)
+                dataset_artifact_paths[artifact_field] = artifact_path
+                missing_dataset_artifact_fields.discard(artifact_field)
         telemetry = evidence.get("telemetry_summary")
         if isinstance(telemetry, dict):
             time_series_path = str(telemetry.get("time_series_path") or "")
@@ -1571,6 +1588,13 @@ def _default_artifacts(evidence_rows: tuple[dict[str, object], ...]) -> dict[str
                 raw_output_paths.append(artifact_path)
             if artifact_kind == "probe_timeline" and artifact_path:
                 probe_paths.append(artifact_path)
+            if missing_dataset_artifact_fields:
+                artifact_field = dataset_artifact_kinds.get(artifact_kind)
+            else:
+                artifact_field = None
+            if artifact_field and artifact_path:
+                dataset_artifact_paths[artifact_field] = artifact_path
+                missing_dataset_artifact_fields.discard(artifact_field)
     return {
         "evidence_json_path": "",
         "report_json_path": "",
@@ -1582,6 +1606,10 @@ def _default_artifacts(evidence_rows: tuple[dict[str, object], ...]) -> dict[str
         "logs_path": "",
         "screenshots_path": "",
         "coverage_path": "",
+        "dataset_ingest_receipt_path": dataset_artifact_paths.get("dataset_ingest_receipt_path", ""),
+        "dataset_version_path": dataset_artifact_paths.get("dataset_version_path", ""),
+        "dataset_quality_summary_path": dataset_artifact_paths.get("dataset_quality_summary_path", ""),
+        "workspace_preflight_receipt_path": dataset_artifact_paths.get("workspace_preflight_receipt_path", ""),
     }
 
 
@@ -2149,6 +2177,10 @@ def _render_artifacts_markdown(artifacts: object) -> list[str]:
         ("Markdown", artifacts.get("markdown_report_path")),
         ("Probe Timeline", artifacts.get("probe_timeline_path")),
         ("Telemetry JSONL", artifacts.get("telemetry_jsonl_path")),
+        ("Workspace Preflight Receipt", artifacts.get("workspace_preflight_receipt_path")),
+        ("Dataset Ingest Receipt", artifacts.get("dataset_ingest_receipt_path")),
+        ("Dataset Version", artifacts.get("dataset_version_path")),
+        ("Dataset Quality Summary", artifacts.get("dataset_quality_summary_path")),
         ("Coverage", artifacts.get("coverage_path")),
     ]
     csv_paths = artifacts.get("csv_export_paths")

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -10,10 +10,13 @@ import time
 from pathlib import Path
 from typing import Any, Iterable
 
+from worker.productization.workspace_manifest import preflight_workspace
+
 
 DATASET_INGEST_RECEIPT_SCHEMA_VERSION = "melix.dataset_ingest_receipt.v1"
 DATASET_INGEST_RECEIPT_FILENAME = "dataset-ingest-receipt.json"
 DATASET_INGEST_SEGMENTS_FILENAME = "segments.jsonl"
+WORKSPACE_PREFLIGHT_RECEIPT_FILENAME = "workspace-preflight-receipt.json"
 DATASET_VERSION_SCHEMA_VERSION = "melix.dataset_version.v1"
 DATASET_QUALITY_SUMMARY_SCHEMA_VERSION = "melix.dataset_quality_summary.v1"
 DATASET_RETRY_RECEIPT_SCHEMA_VERSION = "melix.dataset_retry_receipt.v1"
@@ -67,12 +70,62 @@ class DatasetRetryFailedRequest:
 
 def prepare_dataset_ingest(request: DatasetIngestRequest) -> dict[str, Any]:
     started = time.perf_counter()
-    segmentation_started = time.perf_counter()
     input_path = Path(request.input_path).expanduser().resolve()
     output_dir = Path(request.output_dir).expanduser()
     output_dir.mkdir(parents=True, exist_ok=True)
     segments_path = output_dir / DATASET_INGEST_SEGMENTS_FILENAME
     receipt_path = output_dir / DATASET_INGEST_RECEIPT_FILENAME
+    workspace_preflight_receipt_path = output_dir / WORKSPACE_PREFLIGHT_RECEIPT_FILENAME
+    workspace_preflight_receipt = preflight_workspace(
+        Path(request.workspace_manifest_path).expanduser(),
+        receipt_output_path=workspace_preflight_receipt_path,
+    )
+    _write_json(workspace_preflight_receipt_path, workspace_preflight_receipt)
+
+    if workspace_preflight_receipt.get("status") != "ready":
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        operator_failures = _workspace_preflight_failures(workspace_preflight_receipt)
+        receipt = {
+            "schema_version": DATASET_INGEST_RECEIPT_SCHEMA_VERSION,
+            "status": "blocked",
+            "workspace_project_id": request.workspace_project_id,
+            "workspace_manifest_path": str(Path(request.workspace_manifest_path)),
+            "workspace_preflight_receipt_path": str(workspace_preflight_receipt_path),
+            "workspace_preflight_receipt": workspace_preflight_receipt,
+            "dataset_preparation_id": request.dataset_preparation_id,
+            "source_inventory": [],
+            "cleaning_controls": _cleaning_controls(request),
+            "segmentation_policy": _segmentation_policy(request),
+            "segment_artifacts": {
+                "segments_path": str(segments_path),
+                "receipt_path": str(receipt_path),
+            },
+            "quality_control_summary": {
+                "source_file_count": 0,
+                "source_record_count": 0,
+                "segment_count": 0,
+                "pii_mask_count": 0,
+                "exact_dedup_count": 0,
+                "fuzzy_dedup_count": 0,
+                "fuzzy_dedup_ratio": 0.0,
+            },
+            "operator_failures": operator_failures,
+            "metrics": {
+                "ingest_latency_ms": elapsed_ms,
+                "ingest_throughput_bytes_per_second": 0.0,
+                "source_file_count": 0,
+                "source_record_count": 0,
+                "segment_count": 0,
+                "pii_mask_count": 0,
+                "exact_dedup_count": 0,
+                "fuzzy_dedup_count": 0,
+                "fuzzy_dedup_ratio": 0.0,
+                "segmentation_latency_ms": 0.0,
+                "workspace_preflight_status": workspace_preflight_receipt.get("status", "unknown"),
+            },
+        }
+        receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return receipt
 
     operator_failures: list[dict[str, Any]] = []
     records = list(_iter_source_records(input_path, operator_failures))
@@ -110,6 +163,7 @@ def prepare_dataset_ingest(request: DatasetIngestRequest) -> dict[str, Any]:
         cleaned_records.append(cleaned)
         pii_mask_count += record_pii_mask_count
 
+    segmentation_started = time.perf_counter()
     segments = list(_segment_records(cleaned_records, request))
     segmentation_latency_ms = (time.perf_counter() - segmentation_started) * 1000.0
     _write_jsonl(segments_path, segments)
@@ -136,33 +190,19 @@ def prepare_dataset_ingest(request: DatasetIngestRequest) -> dict[str, Any]:
         "fuzzy_dedup_count": fuzzy_dedup_count,
         "fuzzy_dedup_ratio": fuzzy_ratio,
         "segmentation_latency_ms": segmentation_latency_ms,
+        "workspace_preflight_status": workspace_preflight_receipt.get("status", "unknown"),
     }
     receipt = {
         "schema_version": DATASET_INGEST_RECEIPT_SCHEMA_VERSION,
         "status": "blocked" if operator_failures else "ready",
         "workspace_project_id": request.workspace_project_id,
         "workspace_manifest_path": str(Path(request.workspace_manifest_path)),
+        "workspace_preflight_receipt_path": str(workspace_preflight_receipt_path),
+        "workspace_preflight_receipt": workspace_preflight_receipt,
         "dataset_preparation_id": request.dataset_preparation_id,
         "source_inventory": source_inventory,
-        "cleaning_controls": {
-            "pii_mask": {
-                "enabled": request.pii_mask,
-                "policy_id": "melix.pii_mask.local.v1",
-            },
-            "exact_dedup": {
-                "enabled": request.exact_dedup,
-                "policy_id": "melix.exact_dedup.sha256.v1",
-            },
-            "fuzzy_dedup": {
-                "enabled": request.fuzzy_dedup,
-                "policy_id": "melix.fuzzy_dedup.tokens.v1",
-            },
-        },
-        "segmentation_policy": {
-            "enabled": request.segmentation,
-            "strategy": request.segmentation_strategy,
-            "policy_id": f"melix.segmentation.{request.segmentation_strategy}.v1",
-        },
+        "cleaning_controls": _cleaning_controls(request),
+        "segmentation_policy": _segmentation_policy(request),
         "segment_artifacts": {
             "segments_path": str(segments_path),
             "receipt_path": str(receipt_path),
@@ -179,6 +219,7 @@ def prepare_dataset_version(request: DatasetVersionRequest) -> dict[str, Any]:
     started = time.perf_counter()
     ingest_receipt_path = Path(request.ingest_receipt_path).expanduser()
     ingest_receipt = _read_json(ingest_receipt_path)
+    _raise_if_ingest_receipt_blocked(ingest_receipt)
     segment_artifacts = ingest_receipt.get("segment_artifacts", {})
     if not isinstance(segment_artifacts, dict) or not segment_artifacts.get("segments_path"):
         raise ValueError("DATASET_VERSION_SOURCE_RECEIPT_MISSING: ingest receipt has no segments_path")
@@ -262,6 +303,19 @@ def prepare_dataset_version(request: DatasetVersionRequest) -> dict[str, Any]:
     )
     _write_json(dataset_version_path, version)
     return version
+
+
+def _raise_if_ingest_receipt_blocked(ingest_receipt: dict[str, Any]) -> None:
+    if str(ingest_receipt.get("status") or "") != "blocked":
+        return
+    failures = ingest_receipt.get("operator_failures")
+    failure_codes = [
+        str(failure.get("code") or "")
+        for failure in failures
+        if isinstance(failure, dict) and str(failure.get("code") or "").strip()
+    ] if isinstance(failures, list) else []
+    code_suffix = ",".join(failure_codes) if failure_codes else "unknown"
+    raise ValueError(f"DATASET_VERSION_SOURCE_RECEIPT_BLOCKED: {code_suffix}")
 
 
 def retry_failed_dataset_version(request: DatasetRetryFailedRequest) -> dict[str, Any]:
@@ -482,6 +536,61 @@ def _source_kind(path: Path) -> str | None:
     if suffix in {".jsonl", ".json", ".csv", ".tsv"}:
         return "structured_data"
     return None
+
+
+def _workspace_preflight_failures(receipt: dict[str, Any]) -> list[dict[str, Any]]:
+    failures: list[dict[str, Any]] = []
+    for check in receipt.get("checks", []):
+        if not isinstance(check, dict) or check.get("status") != "blocked":
+            continue
+        code = str(check.get("code") or "WORKSPACE_PREFLIGHT_BLOCKED")
+        failures.append(
+            {
+                "id": f"workspace-preflight-{_safe_component(code.lower())}",
+                "code": code,
+                "path": str(receipt.get("manifest_path") or ""),
+                "detail": str(check.get("detail") or "Workspace preflight blocked dataset ingest."),
+                "recovery_hint": str(check.get("recovery_hint") or "Resolve workspace preflight blockers before dataset ingest."),
+                "items": check.get("items", []),
+            }
+        )
+    if failures:
+        return failures
+    return [
+        {
+            "id": "workspace-preflight-blocked",
+            "code": "WORKSPACE_PREFLIGHT_BLOCKED",
+            "path": str(receipt.get("manifest_path") or ""),
+            "detail": "Workspace preflight blocked dataset ingest.",
+            "recovery_hint": "Resolve workspace preflight blockers before dataset ingest.",
+            "items": [],
+        }
+    ]
+
+
+def _cleaning_controls(request: DatasetIngestRequest) -> dict[str, Any]:
+    return {
+        "pii_mask": {
+            "enabled": request.pii_mask,
+            "policy_id": "melix.pii_mask.local.v1",
+        },
+        "exact_dedup": {
+            "enabled": request.exact_dedup,
+            "policy_id": "melix.exact_dedup.sha256.v1",
+        },
+        "fuzzy_dedup": {
+            "enabled": request.fuzzy_dedup,
+            "policy_id": "melix.fuzzy_dedup.tokens.v1",
+        },
+    }
+
+
+def _segmentation_policy(request: DatasetIngestRequest) -> dict[str, Any]:
+    return {
+        "enabled": request.segmentation,
+        "strategy": request.segmentation_strategy,
+        "policy_id": f"melix.segmentation.{request.segmentation_strategy}.v1",
+    }
 
 
 def _structured_records(path: Path, text: str) -> Iterable[dict[str, Any]]:

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -124,7 +124,7 @@ def prepare_dataset_ingest(request: DatasetIngestRequest) -> dict[str, Any]:
                 "workspace_preflight_status": workspace_preflight_receipt.get("status", "unknown"),
             },
         }
-        receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        _write_json(receipt_path, receipt)
         return receipt
 
     operator_failures: list[dict[str, Any]] = []
@@ -211,7 +211,7 @@ def prepare_dataset_ingest(request: DatasetIngestRequest) -> dict[str, Any]:
         "operator_failures": operator_failures,
         "metrics": metrics,
     }
-    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_json(receipt_path, receipt)
     return receipt
 
 
@@ -310,9 +310,9 @@ def _raise_if_ingest_receipt_blocked(ingest_receipt: dict[str, Any]) -> None:
         return
     failures = ingest_receipt.get("operator_failures")
     failure_codes = [
-        str(failure.get("code") or "")
+        code
         for failure in failures
-        if isinstance(failure, dict) and str(failure.get("code") or "").strip()
+        if isinstance(failure, dict) and (code := str(failure.get("code") or "").strip())
     ] if isinstance(failures, list) else []
     code_suffix = ",".join(failure_codes) if failure_codes else "unknown"
     raise ValueError(f"DATASET_VERSION_SOURCE_RECEIPT_BLOCKED: {code_suffix}")


### PR DESCRIPTION
## Summary
- Run dataset ingest through workspace preflight before source inventory or segmentation, and persist the workspace preflight receipt on blocked and ready ingest receipts.
- Attach dataset ingest/version/quality and workspace preflight artifacts to benchmark/evaluation reports.
- Classify quantized embedding/head LoRA target preflight failures as `unsafe_quantized_lora_target` with operator remediation.

## Plan or Spec
- `docs/plans/2026-05-24-workspace-manifest-contract.md`
- `docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md`
- `docs/plans/2026-05-24-training-parameter-safety-and-queueing.md`
- Follow-up to merged PR #1553.

## Commands Run
```text
git commit -m "Fix M-courtyard follow-up gaps"
# pre-commit passed:
# make swift-test: passed; macOS menubar package 777 tests passed
# make py-test: 3193 passed, 14 skipped, 2 warnings
# make integration-test: 115 passed, 1 skipped
# pr-scoped-performance: ok; selected probes 3; regressions 0; verification failures 0
# report: .runtime/pre-commit-performance/20260524-140340-dc914f10/report/report.md

git merge --no-edit origin/main
# passed: merged origin/main commit 46860468

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_blocks_on_workspace_preflight_before_segmenting_sources services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_rejects_blocked_workspace_preflight_receipt_before_reading_segments services/mlx-worker-python/tests/test_benchmark_evaluation_report.py::test_report_outputs_attach_and_render_dataset_preparation_artifacts services/mlx-worker-python/tests/test_lora_trainability_preflight.py::test_trainability_preflight_blocks_quantized_embedding_targets_with_operator_remediation services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_rejects_quantized_qwen3moe_unsafe_targets
# passed: 6 passed

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
import sys

root = Path.cwd()
sys.path.insert(0, str(root))
sys.path.insert(0, str(root / "services/mlx-worker-python"))
from scripts.pre_commit_gate import run_performance_report  # noqa: E402

changed = subprocess.check_output(
    ["git", "diff", "--name-only", "origin/main..HEAD"],
    cwd=root,
    text=True,
).splitlines()
outcome = run_performance_report(root, changed, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# passed: pr-scoped-performance ok; selected probes 3; regressions 0; verification failures 0
# report: .runtime/pre-commit-performance/20260524-141206-36c2ee13/report/report.md

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/validate_pr_evidence.py --body-file .runtime/pr-bodies/m-courtyard-follow-up-gaps.md
# passed

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_blocks_on_workspace_preflight_before_segmenting_sources services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_rejects_blocked_workspace_preflight_receipt_before_reading_segments
# passed: 2 passed

git diff --check
# passed

git commit -m "Address dataset preparation review nits"
# pre-commit passed:
# make swift-test: passed; macOS menubar package 777 tests passed
# make py-test: 3193 passed, 14 skipped, 2 warnings
# make integration-test: 115 passed, 1 skipped
# pr-scoped-performance: ok; changed files 1; selected probes 0; regressions 0; verification failures 0
# report: .runtime/pre-commit-performance/20260524-142924-36c2ee13/report/report.md
```

## Coverage and Metrics
- Changed-scope automated coverage is covered by the focused coverage gates inside the pre-commit scoped performance report.
- Metrics report: `.runtime/pre-commit-performance/20260524-141206-36c2ee13/report/report.md`; status `ok`, selected probes `3`, regressions `0`, verification failures `0`.
- Review-fix metrics report: `.runtime/pre-commit-performance/20260524-142924-36c2ee13/report/report.md`; status `ok`, changed files `1`, selected probes `0`, regressions `0`, verification failures `0`.
- Observability mode: evidence. Runtime overhead is N/A because this change persists receipts and renders existing evidence artifacts rather than adding request-path debug probes.

## Known Gaps
- N/A: hosted CI and hosted PR-scoped performance passed on the current follow-up branch.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or no protocol changes were made.
- [x] Dependency changes include updated lockfiles, or no dependency changes were made.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
