### PR TITLE
Surface LoRA preflight and queue evidence

### DIFF
--- a/Sources/MelixCLICore/LocalTrainingQueueStore.swift
+++ b/Sources/MelixCLICore/LocalTrainingQueueStore.swift
@@ -336,7 +336,12 @@ public final class LocalTrainingQueueStore: @unchecked Sendable {
             document.metrics.cancellationLatencyMS = 0
             recomputeMetrics(&document)
             try writeCancellationRequest(updated)
-            try saveDocumentUnlocked(document)
+            do {
+                try saveDocumentUnlocked(document)
+            } catch {
+                removeCancellationRequest(updated)
+                throw error
+            }
             return updated
         }
     }
@@ -441,6 +446,14 @@ public final class LocalTrainingQueueStore: @unchecked Sendable {
                 message: "Failed to persist cancellation request for \(job.jobID): \(error.localizedDescription)"
             )
         }
+    }
+
+    private func removeCancellationRequest(_ job: LocalTrainingQueueJob) {
+        let url = URL(fileURLWithPath: job.cancellationRequestPath)
+        guard fileManager.fileExists(atPath: url.path) else {
+            return
+        }
+        try? fileManager.removeItem(at: url)
     }
 
     private func normalizedRunDirectory(_ value: String, jobID: String) -> String {

--- a/Sources/MelixCLICore/LocalTrainingQueueStore.swift
+++ b/Sources/MelixCLICore/LocalTrainingQueueStore.swift
@@ -26,11 +26,30 @@ public struct LocalTrainingQueueOperatorError: Codable, Equatable, Sendable {
     public var code: String
     public var message: String
     public var retriable: Bool
+    public var remediation: String
 
-    public init(code: String, message: String, retriable: Bool = false) {
+    public init(code: String, message: String, retriable: Bool = false, remediation: String = "") {
         self.code = code
         self.message = message
         self.retriable = retriable
+        self.remediation = remediation
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case code
+        case message
+        case retriable
+        case remediation
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            code: try container.decodeIfPresent(String.self, forKey: .code) ?? "",
+            message: try container.decodeIfPresent(String.self, forKey: .message) ?? "",
+            retriable: try container.decodeIfPresent(Bool.self, forKey: .retriable) ?? false,
+            remediation: try container.decodeIfPresent(String.self, forKey: .remediation) ?? ""
+        )
     }
 }
 
@@ -273,12 +292,21 @@ public final class LocalTrainingQueueStore: @unchecked Sendable {
         jobID: String,
         code: String,
         message: String,
-        retriable: Bool = false
+        retriable: Bool = false,
+        remediation: String = ""
     ) throws -> LocalTrainingQueueJob {
-        try update(
+        let resolvedRemediation = remediation.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? Self.defaultRemediation(for: code)
+            : remediation
+        return try update(
             jobID: jobID,
             status: .failed,
-            operatorError: LocalTrainingQueueOperatorError(code: code, message: message, retriable: retriable)
+            operatorError: LocalTrainingQueueOperatorError(
+                code: code,
+                message: message,
+                retriable: retriable,
+                remediation: resolvedRemediation
+            )
         )
     }
 
@@ -432,6 +460,29 @@ public final class LocalTrainingQueueStore: @unchecked Sendable {
             || normalized == "exclusive_local_training"
             || normalized == "local_apple_silicon_training"
             || normalized == "local_training"
+    }
+
+    private static func defaultRemediation(for code: String) -> String {
+        switch code.trimmingCharacters(in: .whitespacesAndNewlines) {
+        case "insufficient_training_samples":
+            return "Add more accepted training samples before starting training."
+        case "sequence_length_exceeds_model_context":
+            return "Lower max_seq_length or choose a model with a larger context window."
+        case "training_memory_fit_failed":
+            return "Choose a smaller model, reduce sequence length or batch size, or pass allow_memory_risk after review."
+        case "unsupported_full_finetune_quantized_base":
+            return "Use LoRA or QLoRA for quantized bases, or switch to an unquantized base model."
+        case "unsupported_lora_target_module":
+            return "Choose supported LoRA target modules for this model family."
+        case "unsafe_quantized_lora_target":
+            return "Choose non-embedding LoRA target modules for quantized base models."
+        case "unsupported_model_family":
+            return "Choose a model family with productized LoRA training hooks."
+        case "invalid_dataset_package":
+            return "Use a dataset package whose format matches the requested training objective."
+        default:
+            return ""
+        }
     }
 
     private func recomputeMetrics(_ document: inout LocalTrainingQueueDocument) {

--- a/Sources/MelixCLICore/MelixJobs.swift
+++ b/Sources/MelixCLICore/MelixJobs.swift
@@ -390,6 +390,9 @@ final class MelixJobStatusStore {
             "dataset_version_id": job.datasetVersionID,
             "preflight_receipt_path": job.preflightReceiptPath,
         ]
+        if let trainabilityPreflight = localTrainingQueueTrainabilityPreflightPayload(job) {
+            payload["trainability_preflight"] = trainabilityPreflight
+        }
         return payload
     }
 
@@ -640,10 +643,30 @@ final class MelixJobStatusStore {
         guard let first = job.operatorErrors.first else {
             return NSNull()
         }
-        return [
+        var payload: [String: Any] = [
             "code": first.code,
             "message": first.message,
+            "retriable": first.retriable,
         ]
+        if !first.remediation.isEmpty {
+            payload["remediation"] = first.remediation
+        }
+        return payload
+    }
+
+    private func localTrainingQueueTrainabilityPreflightPayload(_ job: LocalTrainingQueueJob) -> [String: Any]? {
+        let trimmedPath = job.preflightReceiptPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPath.isEmpty else {
+            return nil
+        }
+        let url = URL(fileURLWithPath: (trimmedPath as NSString).expandingTildeInPath)
+        guard var payload = loadJSONPayload(at: url),
+              stringField(payload, "schema_version") == "melix.trainability_preflight.v1"
+        else {
+            return nil
+        }
+        payload["receipt_path"] = url.path
+        return payload
     }
 
     private func modelOpsThroughputMetrics(_ record: MelixModelOpsJobRecord) -> [[String: Any]] {
@@ -852,6 +875,10 @@ final class MelixJobStatusStore {
     }
 
     private func loadCancelRequest(at url: URL) -> [String: Any]? {
+        loadJSONPayload(at: url)
+    }
+
+    private func loadJSONPayload(at url: URL) -> [String: Any]? {
         guard let data = try? Data(contentsOf: url),
               let object = try? JSONSerialization.jsonObject(with: data),
               let payload = object as? [String: Any]
@@ -1125,6 +1152,47 @@ func renderJobStatus(_ payload: [String: Any]) -> String {
         "Started: \(stringField(payload, "started_at_unix_ms"))",
         "Record: \(stringField(payload, "record_path"))",
     ]
+    if let error = payload["error"] as? [String: Any] {
+        let code = stringField(error, "code")
+        let message = stringField(error, "message")
+        let errorText = [code, message].filter { !$0.isEmpty }.joined(separator: ": ")
+        if !errorText.isEmpty {
+            lines.append("Error: \(errorText)")
+        }
+        let remediation = stringField(error, "remediation")
+        if !remediation.isEmpty {
+            lines.append("Remediation: \(remediation)")
+        }
+    }
+    if let trainingQueue = payload["training_queue"] as? [String: Any] {
+        let recoveryPolicy = stringField(trainingQueue, "recovery_policy")
+        if !recoveryPolicy.isEmpty {
+            lines.append("Recovery: \(recoveryPolicy)")
+        }
+        let preflightReceiptPath = stringField(trainingQueue, "preflight_receipt_path")
+        if !preflightReceiptPath.isEmpty {
+            lines.append("Preflight: \(preflightReceiptPath)")
+        }
+    }
+    if let preflight = payload["trainability_preflight"] as? [String: Any],
+       let checks = preflight["checks"] as? [[String: Any]] {
+        for check in checks {
+            let status = stringField(check, "status").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard status == "blocked" else {
+                continue
+            }
+            let code = stringField(check, "code")
+            let message = stringField(check, "operator_message")
+            let checkText = [code, message].filter { !$0.isEmpty }.joined(separator: ": ")
+            if !checkText.isEmpty {
+                lines.append("Preflight Check: \(checkText)")
+            }
+            let remediation = stringField(check, "remediation")
+            if !remediation.isEmpty {
+                lines.append("Preflight Remediation: \(remediation)")
+            }
+        }
+    }
     if let logs = payload["logs"] as? [String: Any],
        !stringField(logs, "path").isEmpty {
         lines.append("Logs: \(stringField(logs, "path"))")

--- a/Sources/MelixCLICore/MelixJobs.swift
+++ b/Sources/MelixCLICore/MelixJobs.swift
@@ -1178,7 +1178,7 @@ func renderJobStatus(_ payload: [String: Any]) -> String {
        let checks = preflight["checks"] as? [[String: Any]] {
         for check in checks {
             let status = stringField(check, "status").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            guard status == "blocked" else {
+            guard status == "blocked" || status == "error" else {
                 continue
             }
             let code = stringField(check, "code")

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -5099,6 +5099,8 @@ struct DesktopJobsToolSectionView: View {
             ]
         })
         return values
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.isEmpty == false }
     }
 
     private func retriableText(_ retriable: Bool) -> String {

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -4934,7 +4934,35 @@ struct DesktopJobsToolSectionView: View {
                     }
 
                     if let error = detail.error {
-                        DesktopJobDetailBlock(title: "Error", values: [error.code, error.message])
+                        DesktopJobDetailBlock(
+                            title: "Error",
+                            values: [
+                                error.code,
+                                error.message,
+                                retriableText(error.retriable),
+                                error.remediation,
+                            ]
+                        )
+                    }
+
+                    if let trainingQueue = detail.trainingQueue {
+                        DesktopJobDetailBlock(
+                            title: "Training Queue",
+                            values: [
+                                trainingQueue.recoveryPolicy,
+                                trainingQueue.resourceClass,
+                                trainingQueue.datasetVersionID,
+                                trainingQueue.preflightReceiptPath,
+                                trainingQueue.queuePath,
+                            ]
+                        )
+                    }
+
+                    if let preflight = detail.trainabilityPreflight {
+                        DesktopJobDetailBlock(
+                            title: "Trainability Preflight",
+                            values: trainabilityPreflightValues(preflight)
+                        )
                     }
 
                     DesktopJobDetailBlock(
@@ -5046,6 +5074,35 @@ struct DesktopJobsToolSectionView: View {
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { $0.isEmpty == false }
             .joined(separator: " • ")
+    }
+
+    private func trainabilityPreflightValues(_ preflight: RuntimeJobTrainabilityPreflightState) -> [String] {
+        var values = [
+            preflight.status,
+            preflight.modelID,
+            preflight.trainingMode,
+            preflight.receiptPath,
+        ]
+        values.append(contentsOf: preflight.blockingChecks.flatMap { check in
+            [
+                check.code,
+                check.operatorMessage,
+                check.remediation,
+            ]
+        })
+        values.append(contentsOf: preflight.operatorErrors.flatMap { error in
+            [
+                error.code,
+                error.operatorMessage,
+                retriableText(error.retriable),
+                error.remediation,
+            ]
+        })
+        return values
+    }
+
+    private func retriableText(_ retriable: Bool) -> String {
+        retriable ? "retriable" : "not retriable"
     }
 
     private func statusColor(for job: RuntimeJobSummaryState) -> Color {

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeJobsState.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeJobsState.swift
@@ -122,6 +122,8 @@ public struct RuntimeJobDetailState: Decodable, Equatable, Sendable {
     public let logs: RuntimeJobLogReferenceState
     public let artifacts: [RuntimeJobArtifactState]
     public let cancellation: RuntimeJobCancellationState
+    public let trainingQueue: RuntimeJobTrainingQueueState?
+    public let trainabilityPreflight: RuntimeJobTrainabilityPreflightState?
 
     public init(from decoder: Decoder) throws {
         summary = try RuntimeJobSummaryState(from: decoder)
@@ -142,6 +144,11 @@ public struct RuntimeJobDetailState: Decodable, Equatable, Sendable {
         artifacts = (try? container.decode([RuntimeJobArtifactState].self, forKey: .artifacts)) ?? []
         cancellation = (try? container.decode(RuntimeJobCancellationState.self, forKey: .cancellation))
             ?? RuntimeJobCancellationState(cancelable: summary.cancelable, requested: summary.cancellationRequested)
+        trainingQueue = try? container.decodeIfPresent(RuntimeJobTrainingQueueState.self, forKey: .trainingQueue)
+        trainabilityPreflight = try? container.decodeIfPresent(
+            RuntimeJobTrainabilityPreflightState.self,
+            forKey: .trainabilityPreflight
+        )
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -153,6 +160,8 @@ public struct RuntimeJobDetailState: Decodable, Equatable, Sendable {
         case logs
         case artifacts
         case cancellation
+        case trainingQueue = "training_queue"
+        case trainabilityPreflight = "trainability_preflight"
     }
 }
 
@@ -234,16 +243,166 @@ public struct RuntimeJobMetricState: Decodable, Equatable, Sendable {
 public struct RuntimeJobErrorState: Decodable, Equatable, Sendable {
     public let code: String
     public let message: String
+    public let retriable: Bool
+    public let remediation: String
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         code = container.decodeFlexibleString(forKey: .code)
         message = container.decodeFlexibleString(forKey: .message)
+        retriable = container.decodeFlexibleBool(forKey: .retriable)
+        remediation = container.decodeFlexibleString(forKey: .remediation)
     }
 
     private enum CodingKeys: String, CodingKey {
         case code
         case message
+        case retriable
+        case remediation
+    }
+}
+
+public struct RuntimeJobTrainingQueueState: Decodable, Equatable, Sendable {
+    public let schemaVersion: String
+    public let resourceClass: String
+    public let recoveryPolicy: String
+    public let queuePath: String
+    public let workspaceManifestPath: String
+    public let datasetVersionID: String
+    public let preflightReceiptPath: String
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = container.decodeFlexibleString(forKey: .schemaVersion)
+        resourceClass = container.decodeFlexibleString(forKey: .resourceClass)
+        recoveryPolicy = container.decodeFlexibleString(forKey: .recoveryPolicy)
+        queuePath = container.decodeFlexibleString(forKey: .queuePath)
+        workspaceManifestPath = container.decodeFlexibleString(forKey: .workspaceManifestPath)
+        datasetVersionID = container.decodeFlexibleString(forKey: .datasetVersionID)
+        preflightReceiptPath = container.decodeFlexibleString(forKey: .preflightReceiptPath)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case resourceClass = "resource_class"
+        case recoveryPolicy = "recovery_policy"
+        case queuePath = "queue_path"
+        case workspaceManifestPath = "workspace_manifest_path"
+        case datasetVersionID = "dataset_version_id"
+        case preflightReceiptPath = "preflight_receipt_path"
+    }
+}
+
+public struct RuntimeJobTrainabilityPreflightState: Decodable, Equatable, Sendable {
+    public let schemaVersion: String
+    public let status: String
+    public let receiptPath: String
+    public let modelID: String
+    public let modelFamily: String
+    public let datasetFormat: String
+    public let trainingMode: String
+    public let sampleCount: Int64
+    public let validationSampleCount: Int64
+    public let checks: [RuntimeJobTrainabilityCheckState]
+    public let operatorErrors: [RuntimeJobTrainabilityOperatorErrorState]
+
+    public var blockingChecks: [RuntimeJobTrainabilityCheckState] {
+        checks.filter(\.isBlocking)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = container.decodeFlexibleString(forKey: .schemaVersion)
+        status = container.decodeFlexibleString(forKey: .status)
+        receiptPath = container.decodeFlexibleString(forKey: .receiptPath)
+        modelID = container.decodeFlexibleString(forKey: .modelID)
+        modelFamily = container.decodeFlexibleString(forKey: .modelFamily)
+        datasetFormat = container.decodeFlexibleString(forKey: .datasetFormat)
+        trainingMode = container.decodeFlexibleString(forKey: .trainingMode)
+        sampleCount = container.decodeFlexibleInt64(forKey: .sampleCount)
+        validationSampleCount = container.decodeFlexibleInt64(forKey: .validationSampleCount)
+        checks = (try? container.decode([RuntimeJobTrainabilityCheckState].self, forKey: .checks)) ?? []
+        operatorErrors = (try? container.decode(
+            [RuntimeJobTrainabilityOperatorErrorState].self,
+            forKey: .operatorErrors
+        )) ?? []
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case status
+        case receiptPath = "receipt_path"
+        case modelID = "model_id"
+        case modelFamily = "model_family"
+        case datasetFormat = "dataset_format"
+        case trainingMode = "training_mode"
+        case sampleCount = "sample_count"
+        case validationSampleCount = "validation_sample_count"
+        case checks
+        case operatorErrors = "operator_errors"
+    }
+}
+
+public struct RuntimeJobTrainabilityCheckState: Decodable, Equatable, Identifiable, Sendable {
+    public let code: String
+    public let status: String
+    public let severity: String
+    public let operatorMessage: String
+    public let remediation: String
+
+    public var id: String {
+        code
+    }
+
+    public var isBlocking: Bool {
+        let normalized = status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized == "blocked" || normalized == "error"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        code = container.decodeFlexibleString(forKey: .code)
+        status = container.decodeFlexibleString(forKey: .status)
+        severity = container.decodeFlexibleString(forKey: .severity)
+        operatorMessage = container.decodeFlexibleString(forKey: .operatorMessage)
+        remediation = container.decodeFlexibleString(forKey: .remediation)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case code
+        case status
+        case severity
+        case operatorMessage = "operator_message"
+        case remediation
+    }
+}
+
+public struct RuntimeJobTrainabilityOperatorErrorState: Decodable, Equatable, Identifiable, Sendable {
+    public let code: String
+    public let severity: String
+    public let operatorMessage: String
+    public let retriable: Bool
+    public let remediation: String
+
+    public var id: String {
+        code
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        code = container.decodeFlexibleString(forKey: .code)
+        severity = container.decodeFlexibleString(forKey: .severity)
+        operatorMessage = container.decodeFlexibleString(forKey: .operatorMessage)
+        retriable = container.decodeFlexibleBool(forKey: .retriable)
+        remediation = container.decodeFlexibleString(forKey: .remediation)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case code
+        case severity
+        case operatorMessage = "operator_message"
+        case retriable
+        case remediation
     }
 }
 

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -3331,6 +3331,13 @@ struct DesktopFoundationViewTests {
                 "operator_message": "LoRA training requires at least one training sample.",
                 "retriable": false,
                 "remediation": "Add more accepted training samples before starting training."
+              },
+              {
+                "code": "workspace_manifest_unreadable",
+                "severity": "error",
+                "operator_message": "",
+                "retriable": true,
+                "remediation": "   "
               }
             ]
           },
@@ -3366,6 +3373,9 @@ struct DesktopFoundationViewTests {
         #expect(values.contains("LoRA training requires at least one training sample."))
         #expect(values.contains("not retriable"))
         #expect(values.contains("Add more accepted training samples before starting training."))
+        #expect(values.contains("workspace_manifest_unreadable"))
+        #expect(values.contains("retriable"))
+        #expect(values.allSatisfy { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false })
         #expect(values.contains("fix_preflight_and_retry"))
         #expect(values.contains("exclusive_local_training"))
         #expect(values.contains("support-chat-v2"))

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -3273,14 +3273,17 @@ struct DesktopFoundationViewTests {
         viewModel.selectToolSection(.jobs)
         let detail = try RuntimeJobsPayloadDecoder.decodeDetail(Data("""
         {
-          "job_id": "bench-20260516-1120",
-          "run_kind": "benchmark",
-          "operation": "bench run",
+          "job_id": "training-queue-0001",
+          "run_kind": "training",
+          "operation": "train_lora",
           "status": "failed",
-          "phase": "export",
-          "model_id": "mlx-community/Qwen3-8B",
-          "task_kind": "text-generation",
-          "artifact_root": "/tmp/melix/jobs/bench-20260516-1120",
+          "phase": "preflight",
+          "model_id": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+          "task_kind": "train_lora",
+          "dataset_id": "support-chat",
+          "artifact_root": "/tmp/melix/jobs/training-queue-0001",
+          "record_path": "/tmp/melix/state/local-training-queue.json",
+          "cancelable": false,
           "timestamps": {
             "started_at_unix_ms": 1778911200000,
             "updated_at_unix_ms": 1778911210000,
@@ -3288,18 +3291,58 @@ struct DesktopFoundationViewTests {
             "duration_ms": 15000
           },
           "error": {
-            "code": "E_MLX",
-            "message": "out of memory"
+            "code": "insufficient_training_samples",
+            "message": "LoRA training requires at least one training sample.",
+            "retriable": false,
+            "remediation": "Add more accepted training samples before starting training."
+          },
+          "training_queue": {
+            "schema_version": "melix.local_training_queue.v1",
+            "resource_class": "exclusive_local_training",
+            "recovery_policy": "fix_preflight_and_retry",
+            "queue_path": "/tmp/melix/state/local-training-queue.json",
+            "workspace_manifest_path": "/tmp/workspace/workspace-manifest.json",
+            "dataset_version_id": "support-chat-v2",
+            "preflight_receipt_path": "/tmp/melix/jobs/training-queue-0001/trainability-preflight.json"
+          },
+          "trainability_preflight": {
+            "schema_version": "melix.trainability_preflight.v1",
+            "status": "blocked",
+            "receipt_path": "/tmp/melix/jobs/training-queue-0001/trainability-preflight.json",
+            "model_id": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+            "model_family": "qwen3",
+            "dataset_format": "chat_messages",
+            "training_mode": "qlora",
+            "sample_count": 0,
+            "validation_sample_count": 0,
+            "checks": [
+              {
+                "code": "insufficient_training_samples",
+                "status": "blocked",
+                "severity": "error",
+                "operator_message": "LoRA training requires at least one training sample.",
+                "remediation": "Add more accepted training samples before starting training."
+              }
+            ],
+            "operator_errors": [
+              {
+                "code": "insufficient_training_samples",
+                "severity": "error",
+                "operator_message": "LoRA training requires at least one training sample.",
+                "retriable": false,
+                "remediation": "Add more accepted training samples before starting training."
+              }
+            ]
           },
           "logs": {
             "available": true,
-            "path": "/tmp/melix/jobs/bench-20260516-1120/job.log",
-            "command": "melix jobs logs bench-20260516-1120"
+            "path": "/tmp/melix/jobs/training-queue-0001/job.log",
+            "command": "melix jobs logs training-queue-0001"
           },
           "artifacts": [
             {
               "kind": "manifest",
-              "path": "/tmp/melix/jobs/bench-20260516-1120/manifest.json",
+              "path": "/tmp/melix/jobs/training-queue-0001/manifest.json",
               "relative_path": "manifest.json",
               "exists": true
             }
@@ -3311,20 +3354,29 @@ struct DesktopFoundationViewTests {
         let view = hostView(DesktopJobsToolSectionView(viewModel: viewModel))
         let values = renderedTextValues(in: view)
 
-        #expect(values.contains("bench-20260516-1120"))
+        #expect(values.contains("training-queue-0001"))
         #expect(values.contains("failed"))
-        #expect(values.contains("export"))
+        #expect(values.contains("preflight"))
         #expect(values.contains(expectedDesktopJobTimestampText(1_778_911_200_000)))
         #expect(values.contains("raw 1778911200000 ms"))
         #expect(values.contains(expectedDesktopJobTimestampText(1_778_911_215_000)))
         #expect(values.contains("raw 1778911215000 ms"))
         #expect(values.contains("15000 ms"))
-        #expect(values.contains("E_MLX"))
-        #expect(values.contains("out of memory"))
-        #expect(values.contains("/tmp/melix/jobs/bench-20260516-1120/job.log"))
-        #expect(values.contains("melix jobs logs bench-20260516-1120"))
+        #expect(values.contains("insufficient_training_samples"))
+        #expect(values.contains("LoRA training requires at least one training sample."))
+        #expect(values.contains("not retriable"))
+        #expect(values.contains("Add more accepted training samples before starting training."))
+        #expect(values.contains("fix_preflight_and_retry"))
+        #expect(values.contains("exclusive_local_training"))
+        #expect(values.contains("support-chat-v2"))
+        #expect(values.contains("/tmp/melix/state/local-training-queue.json"))
+        #expect(values.contains("/tmp/melix/jobs/training-queue-0001/trainability-preflight.json"))
+        #expect(values.contains("blocked"))
+        #expect(values.contains("qlora"))
+        #expect(values.contains("/tmp/melix/jobs/training-queue-0001/job.log"))
+        #expect(values.contains("melix jobs logs training-queue-0001"))
         #expect(values.contains("manifest"))
-        #expect(values.contains("/tmp/melix/jobs/bench-20260516-1120/manifest.json"))
+        #expect(values.contains("/tmp/melix/jobs/training-queue-0001/manifest.json"))
     }
 
     @Test("jobs tool section renders CLI operation controls")

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeJobsStateTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeJobsStateTests.swift
@@ -399,6 +399,95 @@ struct RuntimeJobsStateTests {
         #expect(viewModel.selectedRuntimeJobDetail?.summary.id == "bench-20260516-1120")
     }
 
+    @Test("job detail decodes local training queue and trainability preflight state")
+    @MainActor
+    func jobDetailDecodesLocalTrainingQueueAndTrainabilityPreflightState() throws {
+        let viewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        let detail = try RuntimeJobsPayloadDecoder.decodeDetail(Data("""
+        {
+          "schema_version": "melix.job_status.v1",
+          "job_id": "training-queue-0001",
+          "run_kind": "training",
+          "operation": "train_lora",
+          "status": "failed",
+          "phase": "failed",
+          "started_at_unix_ms": 1778911200000,
+          "updated_at_unix_ms": 1778911210000,
+          "duration_ms": 10000,
+          "model_id": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+          "task_kind": "train_lora",
+          "dataset_id": "support-chat",
+          "artifact_root": "/tmp/melix/jobs/training-queue-0001",
+          "record_path": "/tmp/melix/state/local-training-queue.json",
+          "cancelable": false,
+          "error": {
+            "code": "insufficient_training_samples",
+            "message": "LoRA training requires at least one training sample.",
+            "retriable": false,
+            "remediation": "Add more accepted training samples before starting training."
+          },
+          "training_queue": {
+            "schema_version": "melix.local_training_queue.v1",
+            "resource_class": "exclusive_local_training",
+            "recovery_policy": "fix_preflight_and_retry",
+            "queue_path": "/tmp/melix/state/local-training-queue.json",
+            "workspace_manifest_path": "/tmp/workspace/workspace-manifest.json",
+            "dataset_version_id": "support-chat-v2",
+            "preflight_receipt_path": "/tmp/melix/jobs/training-queue-0001/trainability-preflight.json"
+          },
+          "trainability_preflight": {
+            "schema_version": "melix.trainability_preflight.v1",
+            "status": "blocked",
+            "model_id": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+            "model_family": "qwen3",
+            "dataset_format": "chat_messages",
+            "training_mode": "qlora",
+            "sample_count": 0,
+            "validation_sample_count": 0,
+            "checks": [
+              {
+                "code": "insufficient_training_samples",
+                "status": "blocked",
+                "severity": "error",
+                "operator_message": "LoRA training requires at least one training sample.",
+                "remediation": "Add more accepted training samples before starting training.",
+                "details": {
+                  "sample_count": "0",
+                  "minimum_sample_count": "1"
+                }
+              }
+            ],
+            "operator_errors": [
+              {
+                "code": "insufficient_training_samples",
+                "severity": "error",
+                "operator_message": "LoRA training requires at least one training sample.",
+                "retriable": false,
+                "remediation": "Add more accepted training samples before starting training.",
+                "details": {
+                  "sample_count": "0",
+                  "minimum_sample_count": "1"
+                }
+              }
+            ],
+            "metrics": {
+              "unsupported_configuration_count": 1
+            }
+          }
+        }
+        """.utf8))
+
+        viewModel.applyRuntimeJobDetail(detail)
+
+        #expect(viewModel.selectedRuntimeJobDetail?.trainingQueue?.recoveryPolicy == "fix_preflight_and_retry")
+        #expect(viewModel.selectedRuntimeJobDetail?.trainingQueue?.datasetVersionID == "support-chat-v2")
+        #expect(viewModel.selectedRuntimeJobDetail?.error?.remediation == "Add more accepted training samples before starting training.")
+        let preflight = try #require(viewModel.selectedRuntimeJobDetail?.trainabilityPreflight)
+        #expect(preflight.status == "blocked")
+        #expect(preflight.blockingChecks.map(\.code) == ["insufficient_training_samples"])
+        #expect(preflight.operatorErrors.first?.remediation == "Add more accepted training samples before starting training.")
+    }
+
     @Test("runtime view model refreshes jobs through CLI workflow runner")
     @MainActor
     func runtimeViewModelRefreshesJobsThroughCLIWorkflowRunner() async throws {

--- a/apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
@@ -13,8 +13,7 @@ enum MenuBarTestEnvironment {
     }
 
     static var bootstrapConditionTimeout: Duration {
-        let environment = ProcessInfo.processInfo.environment
-        return environment["GITHUB_ACTIONS"] == "true" ? .seconds(10) : .seconds(5)
+        .seconds(10)
     }
 }
 

--- a/docs/plans/2026-05-24-training-parameter-safety-and-queueing.md
+++ b/docs/plans/2026-05-24-training-parameter-safety-and-queueing.md
@@ -65,7 +65,7 @@ receipt must include:
 Each check row must include:
 
 - `code`
-- `status`: `passed`, `blocked`, or `warning`
+- `status`: `passed`, `blocked`, `error`, or `warning`
 - `severity`
 - `operator_message`
 - `remediation`

--- a/docs/plans/2026-05-24-training-parameter-safety-and-queueing.md
+++ b/docs/plans/2026-05-24-training-parameter-safety-and-queueing.md
@@ -94,6 +94,13 @@ reading the trainability receipt. When a guardrail is attached to a training
 attempt, the run evidence must include a redacted path to the receipt and the
 typed operator errors.
 
+For local queue-backed training attempts, `melix jobs show --json` must attach
+the trainability receipt as `trainability_preflight` when
+`preflight_receipt_path` points to a `melix.trainability_preflight.v1` receipt.
+The text renderer and Desktop job detail surface must show the receipt path,
+blocking check code/message, and remediation so the operator does not need to
+open raw logs to understand why a run is blocked.
+
 Metrics:
 
 - `preflight_latency_ms`
@@ -145,11 +152,18 @@ Each job row must include:
 - `preflight_receipt_path`
 - `run_directory`
 - `operator_errors`
+- `recovery_policy`
 
 Queue admission must be durable before any worker launch. Local Apple Silicon
 training remains exclusive unless a later scheduler explicitly marks a resource
 class as shareable. Cancellation and recovery transitions must also persist
 before the CLI or Desktop reports them.
+
+Queue operator errors may include `remediation`. Older queue documents without
+that field must continue to decode with an empty remediation string. When a
+known trainability guardrail is marked failed without an explicit remediation,
+the store may fill the default guardrail remediation so CLI and Desktop expose a
+single operator-facing recovery path.
 
 Required queue error codes are:
 
@@ -174,8 +188,9 @@ Verification:
 - Swift store tests for queue round-trip, restore, exclusive admission,
   cancellation persistence, and malformed document handling.
 - CLI parser/runner tests for queue status and admission surfaces.
-- Desktop state tests proving queued and running jobs survive app
-  reconstruction from the same `MELIX_HOME`.
+- Desktop state and detail rendering tests proving queued and running jobs
+  survive app reconstruction from the same `MELIX_HOME` and expose recovery
+  policy, trainability preflight, and remediation fields.
 - Python pipeline test proving queue admission failure prevents worker launch
   when the CLI attaches a queue token to the run.
 
@@ -189,6 +204,9 @@ Implementation slice:
 - Project queue rows into the existing `melix jobs list/show/cancel` surfaces
   without changing the public `melix.job_summary.v1`,
   `melix.job_status.v1`, or `melix.job_cancel_result.v1` schemas.
+- Project queue recovery policy, failure remediation, and attached
+  trainability preflight receipts into CLI text/JSON and Desktop job detail
+  views.
 - Mark admitted rows `running` before worker launch and transition them to
   `succeeded` or `failed` after the synchronous operation returns.
 

--- a/docs/plans/2026-05-24-training-parameter-safety-and-queueing.md
+++ b/docs/plans/2026-05-24-training-parameter-safety-and-queueing.md
@@ -158,6 +158,10 @@ Queue admission must be durable before any worker launch. Local Apple Silicon
 training remains exclusive unless a later scheduler explicitly marks a resource
 class as shareable. Cancellation and recovery transitions must also persist
 before the CLI or Desktop reports them.
+If a cancellation request file is written but the queue document cannot be
+persisted, the cancellation request must be removed before the error is
+reported so the worker and operator surfaces do not observe a stale cancel
+intent for a still-running queue row.
 
 Queue operator errors may include `remediation`. Older queue documents without
 that field must continue to decode with an empty remediation string. When a

--- a/tests/MelixCLITests/LoraTrainingJobStoreTests.swift
+++ b/tests/MelixCLITests/LoraTrainingJobStoreTests.swift
@@ -313,7 +313,8 @@ struct LoraTrainingJobStoreTests {
             jobID: first.jobID,
             code: "worker_failed",
             message: "worker crashed",
-            retriable: true
+            retriable: true,
+            remediation: "Rerun after freeing memory."
         )
 
         #expect(first.id == first.jobID)
@@ -324,7 +325,26 @@ struct LoraTrainingJobStoreTests {
         #expect(second.jobID == "training-queue-0002")
         #expect(failed.status == .failed)
         #expect(failed.operatorErrors == [
-            LocalTrainingQueueOperatorError(code: "worker_failed", message: "worker crashed", retriable: true),
+            LocalTrainingQueueOperatorError(
+                code: "worker_failed",
+                message: "worker crashed",
+                retriable: true,
+                remediation: "Rerun after freeing memory."
+            ),
+        ])
+
+        let guardrailFailed = try store.markFailed(
+            jobID: second.jobID,
+            code: "insufficient_training_samples",
+            message: "LoRA training requires at least one training sample."
+        )
+        #expect(guardrailFailed.operatorErrors == [
+            LocalTrainingQueueOperatorError(
+                code: "insufficient_training_samples",
+                message: "LoRA training requires at least one training sample.",
+                retriable: false,
+                remediation: "Add more accepted training samples before starting training."
+            ),
         ])
 
         #expect(throws: MelixCLIError.requestFailed(
@@ -351,6 +371,51 @@ struct LoraTrainingJobStoreTests {
         )) {
             _ = try store.requestCancel(jobID: first.jobID)
         }
+    }
+
+    @Test("local training queue restores legacy operator errors without remediation")
+    func localTrainingQueueRestoresLegacyOperatorErrorsWithoutRemediation() throws {
+        let home = temporaryMelixHome()
+        defer { try? FileManager.default.removeItem(at: home.rootURL) }
+        try FileManager.default.createDirectory(at: home.stateDirectoryURL, withIntermediateDirectories: true)
+
+        try """
+        {
+          "schema_version": "melix.local_training_queue.v1",
+          "queue_id": "local-training",
+          "updated_at_unix_ms": 1234,
+          "jobs": [
+            {
+              "schema_version": "melix.local_training_queue_job.v1",
+              "job_id": "training-queue-0001",
+              "model_id": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+              "adapter_name": "legacy-adapter",
+              "status": "failed",
+              "created_at_unix_ms": 1000,
+              "updated_at_unix_ms": 1234,
+              "operator_errors": [
+                {
+                  "code": "worker_failed",
+                  "message": "worker crashed",
+                  "retriable": true
+                }
+              ]
+            }
+          ]
+        }
+        """
+        .write(to: home.localTrainingQueueFileURL, atomically: true, encoding: .utf8)
+
+        let restored = try #require(try LocalTrainingQueueStore(melixHome: home).get(jobID: "training-queue-0001"))
+
+        #expect(restored.operatorErrors == [
+            LocalTrainingQueueOperatorError(
+                code: "worker_failed",
+                message: "worker crashed",
+                retriable: true,
+                remediation: ""
+            ),
+        ])
     }
 
     @Test("local training queue keeps status unchanged when cancel request cannot be written")
@@ -383,6 +448,43 @@ struct LoraTrainingJobStoreTests {
             #expect(message.contains("Failed to persist cancellation request for \(admitted.jobID):"))
         }
 
+        let restored = try store.get(jobID: admitted.jobID)
+
+        #expect(restored?.status == .running)
+        #expect(!FileManager.default.fileExists(atPath: admitted.cancellationRequestPath))
+    }
+
+    @Test("local training queue removes cancellation request when queue save fails")
+    func localTrainingQueueRemovesCancellationRequestWhenQueueSaveFails() throws {
+        let home = temporaryMelixHome()
+        defer { try? FileManager.default.removeItem(at: home.rootURL) }
+        let store = LocalTrainingQueueStore(melixHome: home)
+        let admitted = try store.admit(
+            LocalTrainingQueueAdmissionRequest(
+                modelID: "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                datasetURI: "/tmp/datasets/alpaca.jsonl",
+                adapterName: "rollback-adapter"
+            )
+        )
+        _ = try store.markRunning(jobID: admitted.jobID)
+        try FileManager.default.setAttributes([.immutable: true], ofItemAtPath: home.localTrainingQueueFileURL.path)
+        defer {
+            try? FileManager.default.setAttributes([.immutable: false], ofItemAtPath: home.localTrainingQueueFileURL.path)
+        }
+
+        do {
+            _ = try store.requestCancel(jobID: admitted.jobID)
+            Issue.record("Expected cancellation to roll back when queue save fails.")
+        } catch let error as MelixCLIError {
+            guard case .requestFailed(let code, let message) = error else {
+                Issue.record("Unexpected cancellation error: \(error).")
+                return
+            }
+            #expect(code == "training_queue_admission_failed")
+            #expect(message.contains("Failed to persist local training queue:"))
+        }
+
+        try FileManager.default.setAttributes([.immutable: false], ofItemAtPath: home.localTrainingQueueFileURL.path)
         let restored = try store.get(jobID: admitted.jobID)
 
         #expect(restored?.status == .running)

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -11945,6 +11945,12 @@ struct MelixCLIRunnerTests {
                         "operator_message": "LoRA training requires at least one training sample.",
                         "remediation": "Add accepted samples before retrying.",
                     ],
+                    [
+                        "code": "workspace_manifest_unreadable",
+                        "status": "error",
+                        "operator_message": "Workspace manifest could not be decoded.",
+                        "remediation": "Repair the workspace manifest before retrying.",
+                    ],
                 ],
             ],
         ])
@@ -11953,6 +11959,8 @@ struct MelixCLIRunnerTests {
         #expect(renderedQueueStatus.contains("Preflight: /tmp/melix/jobs/training-queue-0001/trainability-preflight.json"))
         #expect(renderedQueueStatus.contains("Preflight Check: insufficient_training_samples: LoRA training requires at least one training sample."))
         #expect(renderedQueueStatus.contains("Preflight Remediation: Add accepted samples before retrying."))
+        #expect(renderedQueueStatus.contains("Preflight Check: workspace_manifest_unreadable: Workspace manifest could not be decoded."))
+        #expect(renderedQueueStatus.contains("Preflight Remediation: Repair the workspace manifest before retrying."))
 
         #expect(renderJobArtifacts(["job_id": "empty", "artifacts": []]) == "No artifacts found for empty.\n")
         let renderedFallbacks = renderJobList([

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -11922,6 +11922,38 @@ struct MelixCLIRunnerTests {
             #expect(error == .runtime("No job was found for missing."))
         }
 
+        let renderedQueueStatus = renderJobStatus([
+            "job_id": "training-queue-0001",
+            "status": "failed",
+            "phase": "failed",
+            "started_at_unix_ms": 1,
+            "record_path": "/tmp/melix/state/local-training-queue.json",
+            "error": [
+                "code": "insufficient_training_samples",
+                "message": "LoRA training requires at least one training sample.",
+                "remediation": "Add more accepted training samples before starting training.",
+            ],
+            "training_queue": [
+                "recovery_policy": "fix_preflight_and_retry",
+                "preflight_receipt_path": "/tmp/melix/jobs/training-queue-0001/trainability-preflight.json",
+            ],
+            "trainability_preflight": [
+                "checks": [
+                    [
+                        "code": "insufficient_training_samples",
+                        "status": "blocked",
+                        "operator_message": "LoRA training requires at least one training sample.",
+                        "remediation": "Add accepted samples before retrying.",
+                    ],
+                ],
+            ],
+        ])
+        #expect(renderedQueueStatus.contains("Recovery: fix_preflight_and_retry"))
+        #expect(renderedQueueStatus.contains("Remediation: Add more accepted training samples before starting training."))
+        #expect(renderedQueueStatus.contains("Preflight: /tmp/melix/jobs/training-queue-0001/trainability-preflight.json"))
+        #expect(renderedQueueStatus.contains("Preflight Check: insufficient_training_samples: LoRA training requires at least one training sample."))
+        #expect(renderedQueueStatus.contains("Preflight Remediation: Add accepted samples before retrying."))
+
         #expect(renderJobArtifacts(["job_id": "empty", "artifacts": []]) == "No artifacts found for empty.\n")
         let renderedFallbacks = renderJobList([
             [
@@ -11953,8 +11985,52 @@ struct MelixCLIRunnerTests {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("melix-jobs-training-queue-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         let home = MelixHome(environment: ["MELIX_HOME": root.path])
         let queue = LocalTrainingQueueStore(melixHome: home)
+        let preflightReceiptPath = root.appendingPathComponent("trainability-preflight.json")
+        try """
+        {
+          "schema_version": "melix.trainability_preflight.v1",
+          "status": "blocked",
+          "model_id": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+          "model_family": "qwen3",
+          "dataset_format": "chat_messages",
+          "training_mode": "qlora",
+          "sample_count": 0,
+          "validation_sample_count": 0,
+          "checks": [
+            {
+              "code": "insufficient_training_samples",
+              "status": "blocked",
+              "severity": "error",
+              "operator_message": "LoRA training requires at least one training sample.",
+              "remediation": "Add more accepted training samples before starting training.",
+              "details": {
+                "sample_count": "0",
+                "minimum_sample_count": "1"
+              }
+            }
+          ],
+          "operator_errors": [
+            {
+              "code": "insufficient_training_samples",
+              "severity": "error",
+              "operator_message": "LoRA training requires at least one training sample.",
+              "retriable": false,
+              "remediation": "Add more accepted training samples before starting training.",
+              "details": {
+                "sample_count": "0",
+                "minimum_sample_count": "1"
+              }
+            }
+          ],
+          "metrics": {
+            "unsupported_configuration_count": 1
+          }
+        }
+        """
+        .write(to: preflightReceiptPath, atomically: true, encoding: .utf8)
         let admitted = try queue.admit(
             LocalTrainingQueueAdmissionRequest(
                 modelID: "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
@@ -11964,10 +12040,18 @@ struct MelixCLIRunnerTests {
                 parameters: [
                     "dataset_version_id": "dataset-v2",
                     "workspace_manifest_path": "/tmp/workspace/manifest.json",
+                    "preflight_receipt_path": preflightReceiptPath.path,
+                    "recovery_policy": "fix_preflight_and_retry",
                 ]
             )
         )
-        _ = try queue.markRunning(jobID: admitted.jobID)
+        _ = try queue.markFailed(
+            jobID: admitted.jobID,
+            code: "insufficient_training_samples",
+            message: "LoRA training requires at least one training sample.",
+            retriable: false,
+            remediation: "Add more accepted training samples before starting training."
+        )
 
         let runner = MelixCLIRunner(
             client: StubControlPlaneXPCClient(),
@@ -11978,17 +12062,26 @@ struct MelixCLIRunnerTests {
             try await runner.run(.jobsList(.init(json: true)))
         ) as? [[String: Any]])
         let summary = try #require(listJSON.first { $0["job_id"] as? String == admitted.jobID })
-        #expect(summary["status"] as? String == "running")
+        #expect(summary["status"] as? String == "failed")
         #expect(summary["record_path"] as? String == home.localTrainingQueueFileURL.path)
 
         let showJSON = try #require(parseJSONObject(
             try await runner.run(.jobsShow(.init(jobID: admitted.jobID, json: true)))
         ))
         let trainingQueue = try #require(showJSON["training_queue"] as? [String: Any])
+        let error = try #require(showJSON["error"] as? [String: Any])
+        let trainabilityPreflight = try #require(showJSON["trainability_preflight"] as? [String: Any])
+        let operatorErrors = try #require(trainabilityPreflight["operator_errors"] as? [[String: Any]])
         #expect(showJSON["schema_version"] as? String == "melix.job_status.v1")
-        #expect(showJSON["phase"] as? String == "running")
+        #expect(showJSON["phase"] as? String == "failed")
         #expect(trainingQueue["schema_version"] as? String == "melix.local_training_queue.v1")
         #expect(trainingQueue["dataset_version_id"] as? String == "dataset-v2")
+        #expect(trainingQueue["recovery_policy"] as? String == "fix_preflight_and_retry")
+        #expect(trainingQueue["preflight_receipt_path"] as? String == preflightReceiptPath.path)
+        #expect(error["code"] as? String == "insufficient_training_samples")
+        #expect(error["remediation"] as? String == "Add more accepted training samples before starting training.")
+        #expect(trainabilityPreflight["status"] as? String == "blocked")
+        #expect(operatorErrors.first?["remediation"] as? String == "Add more accepted training samples before starting training.")
 
         let artifactsJSON = try #require(parseJSONObject(
             try await runner.run(.jobsArtifacts(.init(jobID: admitted.jobID, json: true)))
@@ -12005,27 +12098,11 @@ struct MelixCLIRunnerTests {
             #expect(error == .runtime("No logs were found for \(admitted.jobID)."))
         }
 
-        let cancelJSON = try #require(parseJSONObject(
-            try await runner.run(.jobsCancel(.init(jobID: admitted.jobID, json: true)))
-        ))
-        let requestPath = try #require(cancelJSON["request_path"] as? String)
-        let request = try #require(try parseJSONFile(requestPath))
-        let cancelledShow = try #require(parseJSONObject(
-            try await runner.run(.jobsShow(.init(jobID: admitted.jobID, json: true)))
-        ))
-        let cancellation = try #require(cancelledShow["cancellation"] as? [String: Any])
-
-        #expect(cancelJSON["cancel_requested"] as? Bool == true)
-        #expect(cancelJSON["status"] as? String == "cancel_requested")
-        #expect(request["source_queue_path"] as? String == home.localTrainingQueueFileURL.path)
-        #expect(cancellation["requested"] as? Bool == true)
-
-        _ = try queue.markSucceeded(jobID: admitted.jobID)
         let terminalCancelJSON = try #require(parseJSONObject(
             try await runner.run(.jobsCancel(.init(jobID: admitted.jobID, json: true)))
         ))
         #expect(terminalCancelJSON["cancel_requested"] as? Bool == false)
-        #expect(terminalCancelJSON["status"] as? String == "succeeded")
+        #expect(terminalCancelJSON["status"] as? String == "failed")
         #expect(terminalCancelJSON["reason"] as? String == "job_terminal_or_not_active")
     }
 


### PR DESCRIPTION
## Summary
- Adds durable local training queue cancellation evidence: active cancellations create a request file, terminal cancellations stay guard-railed, worker failures carry remediation, and failed queue persistence rolls back stale cancellation requests.
- Surfaces local training queue and trainability preflight evidence through `melix jobs show` and the macOS desktop Jobs detail view, including blocking checks, operator messages, remediation, queue recovery path, and receipt paths.
- Stabilizes the macOS menu bar bootstrap test wait budget under full-suite load.

## Plan or Spec
- `docs/plans/2026-05-24-training-parameter-safety-and-queueing.md`

## Commands Run
```text
git diff --check
# passed

swift test --filter 'LoraTrainingJobStoreTests/localTrainingQueueRemovesCancellationRequestWhenQueueSaveFails'
# red before rollback fix: failed because stale cancellation request file remained after queue save failure
# green after rollback fix: 1 test passed

swift test --filter 'LoraTrainingJobStoreTests|MelixCLIRunnerTests/jobsCLIRestoresLocalTrainingQueueRowsAndPersistsCancellation|MelixCLIRunnerTests/loraTrain'
# 27 tests passed

xcrun swift test --package-path apps/macos-menubar -Xswiftc -gnone --filter 'RuntimeJobsStateTests|DesktopFoundationViewTests/jobsToolSectionRendersSelectedJobDetailSummary|AppMainBootstrapTests/launchLiveUsesSharedLauncherPath'
# 19 tests passed

git fetch origin main && git merge origin/main
# merged ba22af2b Fix M-courtyard follow-up gaps (#1566) without conflicts

swift test --filter 'LoraTrainingJobStoreTests|MelixCLIRunnerTests/jobsCLIRestoresLocalTrainingQueueRowsAndPersistsCancellation|MelixCLIRunnerTests/loraTrain'
# after latest main merge: 27 tests passed

xcrun swift test --package-path apps/macos-menubar -Xswiftc -gnone --filter 'RuntimeJobsStateTests|DesktopFoundationViewTests/jobsToolSectionRendersSelectedJobDetailSummary|AppMainBootstrapTests/launchLiveUsesSharedLauncherPath'
# after latest main merge: 19 tests passed

swift test --filter 'MelixCLIRunnerTests/jobsCLIRestoresLocalTrainingQueueRowsAndPersistsCancellation|MelixCLIRunnerTests/loraTrain'
# review-fix focused CLI coverage: 10 tests passed

xcrun swift test --package-path apps/macos-menubar -Xswiftc -gnone --filter 'DesktopFoundationViewTests/jobsToolSectionRendersSelectedJobDetailSummary'
# review-fix focused desktop coverage: 1 test passed

git fetch origin main && git merge origin/main
# merged 60e2232e perf: scan lora auxiliary modules once (#1569) without conflicts

swift test --filter 'LoraTrainingJobStoreTests|MelixCLIRunnerTests/jobsCLIRestoresLocalTrainingQueueRowsAndPersistsCancellation|MelixCLIRunnerTests/loraTrain'
# after latest main merge: 27 tests passed

xcrun swift test --package-path apps/macos-menubar -Xswiftc -gnone --filter 'RuntimeJobsStateTests|DesktopFoundationViewTests/jobsToolSectionRendersSelectedJobDetailSummary|AppMainBootstrapTests/launchLiveUsesSharedLauncherPath'
# after latest main merge: 19 tests passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py -q
# after latest main merge: 268 tests passed

git fetch origin main && git merge origin/main
# merged ed0f985a Fix Swift baseline decode throughput (#1560) without conflicts

swift test --filter 'LoraTrainingJobStoreTests|MelixCLIRunnerTests/jobsCLIRestoresLocalTrainingQueueRowsAndPersistsCancellation|MelixCLIRunnerTests/loraTrain'
# after latest main merge: 27 tests passed

xcrun swift test --package-path apps/macos-menubar -Xswiftc -gnone --filter 'RuntimeJobsStateTests|DesktopFoundationViewTests/jobsToolSectionRendersSelectedJobDetailSummary|AppMainBootstrapTests/launchLiveUsesSharedLauncherPath'
# after latest main merge: 19 tests passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py -q
# after latest main merge: 268 tests passed

git fetch origin main && git merge origin/main
# merged 3e134f5a perf: bind report evidence run-kind hot names (#1575) without conflicts

git diff --check origin/main...HEAD
# passed

swift test --filter 'LoraTrainingJobStoreTests|MelixCLIRunnerTests/jobsCLIRestoresLocalTrainingQueueRowsAndPersistsCancellation|MelixCLIRunnerTests/loraTrain'
# after latest main merge: 27 tests passed

xcrun swift test --package-path apps/macos-menubar -Xswiftc -gnone --filter 'RuntimeJobsStateTests|DesktopFoundationViewTests/jobsToolSectionRendersSelectedJobDetailSummary|AppMainBootstrapTests/launchLiveUsesSharedLauncherPath'
# after latest main merge: 19 tests passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py -q
# after latest main merge: 268 tests passed

make swift-test
# passed in each commit pre-commit gate; latest manual pre-commit-equivalent full gate on HEAD 5c15d27d completed rc=0 elapsed=377.7s

make py-test
# latest manual pre-commit-equivalent full gate on HEAD 5c15d27d: 3201 passed, 14 skipped, 2 warnings in 161.37s

make integration-test
# latest manual pre-commit-equivalent full gate on HEAD 5c15d27d: 115 passed, 1 skipped in 662.70s

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-bodies/m-courtyard-follow-up-gaps.md
# PR evidence looks valid.
```

## Coverage and Metrics
- Changed-scope automated coverage target: covered by focused Swift tests above plus full repository Swift/Python/integration pre-commit gate.
- Latest PR scoped performance report: `.runtime/pre-commit-performance/20260524-172032-5c15d27d/report/report.md`
  - Status: `ok`
  - Changed files: `10`
  - Selected probes: `1`
  - Direct/gated probes: `1`
  - Regressions: `0`
  - Context regressions: `0`
  - Verification failures: `0`
  - Probe: `swift-cli-json-envelope-encoding`; elapsed mean improved from `98049.811ms` to `14764.595ms`.
- Earlier slice performance reports were also generated by the pre-commit hook and passed:
  - `.runtime/pre-commit-performance/20260524-131924-dc914f10/report/report.md`
  - `.runtime/pre-commit-performance/20260524-135332-78711d5d/report/report.md`
  - `.runtime/pre-commit-performance/20260524-141715-8bececd3/report/report.md`
  - `.runtime/pre-commit-performance/20260524-143915-6467a2d8/report/report.md`

## Known Gaps
- This PR does not change dataset artifact lifecycle behavior. Dataset preparation outputs inside unmanaged workspace roots or artifact roots still need to be written outside unmanaged roots or promoted into manifest-managed artifacts; existing preflight blocks unmanaged artifacts.
- No protocol or dependency changes; `make proto` and lockfile regeneration were not required.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence; probe overhead: one direct Swift CLI JSON envelope encoding performance probe selected by the pre-commit gate.
- [x] Deferred work and known gaps are stated explicitly.
