### PR TITLE
perf: scan dataset version manifests once

### DIFF
--- a/docs/plans/2026-05-24-dataset-version-listing-scandir.md
+++ b/docs/plans/2026-05-24-dataset-version-listing-scandir.md
@@ -1,0 +1,33 @@
+# Dataset version listing scandir slice
+
+This Python-only performance slice keeps dataset-version listing behavior unchanged while replacing the one-level `Path.glob("*/dataset-version.json")` scan with an explicit `os.scandir()` pass.
+
+## Scope
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_versioning.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_version_listing_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Registered probe
+
+This slice registers `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and runs on `ubuntu-latest`.
+
+Metrics:
+
+- `elapsed_ms_mean` / `elapsed_ms_p95`: lower is better for listing a synthetic dataset with many versions.
+- `version_count`: informational workload size.
+
+## Behavior
+
+The listing still:
+
+- returns only child directories that contain `dataset-version.json`;
+- ignores files and empty directories under the versions root;
+- returns an empty list when the versions root is absent or unreadable;
+- sorts the final list by `(created_at, version_id)` exactly as before.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and registered probe locally on Linux before opening the PR. GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4137,5 +4137,45 @@
         "direction": "informational"
       }
     ]
+  },
+  {
+    "id": "dataset-version-listing-scandir",
+    "name": "Dataset version listing scandir",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/dataset_preparation.py",
+      "services/mlx-worker-python/tests/test_dataset_preparation_versioning.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/dataset_version_listing_probe.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/dataset_version_listing_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better"
+      },
+      {
+        "key": "elapsed_ms_p95",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "version_count",
+        "unit": "items",
+        "direction": "informational"
+      }
+    ]
   }
 ]

--- a/scripts/dataset_version_listing_probe.py
+++ b/scripts/dataset_version_listing_probe.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "services/mlx-worker-python"))
+
+from worker.productization.dataset_preparation import list_dataset_versions  # noqa: E402
+
+
+def _write_version_manifest(path: Path, *, version_id: str, created_at: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "dataset_id": "support-chat",
+                "version_id": version_id,
+                "created_at": created_at,
+                "status": "ready",
+                "train_count": 2,
+                "validation_count": 1,
+                "failed_count": 0,
+                "quality_summary_path": str(path.parent / "quality-summary.json"),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    version_count = int(os.environ.get("MELIX_DATASET_VERSION_LISTING_PROBE_COUNT", "2500"))
+    sample_count = int(os.environ.get("MELIX_DATASET_VERSION_LISTING_PROBE_SAMPLES", "7"))
+    elapsed_samples: list[float] = []
+
+    with tempfile.TemporaryDirectory(prefix="melix-dataset-version-listing-probe-") as temp_dir:
+        temp_root = Path(temp_dir)
+        output_root = temp_root / "datasets"
+        versions_root = output_root / "support-chat" / "versions"
+        for index in range(version_count):
+            version_id = f"support-chat-v{index:05d}"
+            _write_version_manifest(
+                versions_root / version_id / "dataset-version.json",
+                version_id=version_id,
+                created_at=f"2026-05-24T00:{index % 60:02d}:{index // 60 % 60:02d}Z",
+            )
+        # Noise entries should not be counted.
+        (versions_root / "not-a-version.txt").write_text("ignored", encoding="utf-8")
+        (versions_root / "empty-dir").mkdir(parents=True, exist_ok=True)
+
+        listing = None
+        for _ in range(sample_count):
+            started = time.perf_counter()
+            listing = list_dataset_versions(
+                workspace_manifest_path=temp_root / "workspace-manifest.json",
+                output_root=output_root,
+                dataset_id="support-chat",
+            )
+            elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+
+    if listing is None:
+        raise AssertionError("listing was not measured")
+    if listing["metrics"]["dataset_version_count"] != version_count:
+        raise AssertionError(
+            f"expected {version_count} versions, got {listing['metrics']['dataset_version_count']}"
+        )
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+                "elapsed_ms_min": round(min(elapsed_samples), 6),
+                "elapsed_ms_p95": round(sorted(elapsed_samples)[int(0.95 * (len(elapsed_samples) - 1))], 6),
+                "sample_count": float(sample_count),
+                "version_count": float(version_count),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -186,6 +186,54 @@ def test_dataset_version_listing_is_deterministic_and_reports_latency(
     assert listing["metrics"]["dataset_version_count"] == 2
 
 
+def test_dataset_version_listing_uses_scandir_without_path_glob(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    ingest_receipt = _prepare_ingest_fixture(tmp_path)
+    output_root = tmp_path / "datasets"
+    receipt_path = Path(ingest_receipt["segment_artifacts"]["receipt_path"])
+    prepare_dataset_version(
+        DatasetVersionRequest(
+            workspace_manifest_path=tmp_path / "workspace-manifest.json",
+            ingest_receipt_path=receipt_path,
+            output_root=output_root,
+            dataset_id="support-chat",
+            version_id="support-chat-v1",
+            created_at="2026-05-24T01:00:00Z",
+            mode="chat",
+            generator_model="melix.local.dataset-versioner.v1",
+            output_kind="training",
+            output_format="prompt_completion",
+        )
+    )
+
+    def fail_glob(self: Path, pattern: str):  # pragma: no cover - exercised only on regression
+        raise AssertionError(f"list_dataset_versions() should not allocate Path.glob({pattern!r})")
+
+    monkeypatch.setattr(Path, "glob", fail_glob)
+
+    listing = list_dataset_versions(
+        workspace_manifest_path=tmp_path / "workspace-manifest.json",
+        output_root=output_root,
+        dataset_id="support-chat",
+    )
+
+    assert [item["version_id"] for item in listing["versions"]] == ["support-chat-v1"]
+    assert listing["metrics"]["dataset_version_count"] == 1
+
+
+def test_dataset_version_listing_handles_missing_versions_root(tmp_path: Path) -> None:
+    listing = list_dataset_versions(
+        workspace_manifest_path=tmp_path / "workspace-manifest.json",
+        output_root=tmp_path / "datasets",
+        dataset_id="missing-dataset",
+    )
+
+    assert listing["versions"] == []
+    assert listing["metrics"]["dataset_version_count"] == 0
+
+
 def test_failed_only_retry_copies_successful_samples_without_rewriting(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -201,6 +201,32 @@ def test_report_evidence_gate_run_kind_probe_script_emits_metrics(
     assert metrics["run_kind_count"] == 65.0
 
 
+def test_scope_report_selects_dataset_version_listing_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/productization/dataset_preparation.py"],
+    )
+
+    assert "dataset-version-listing-scandir" in _selected_probe_ids(scope)
+
+
+def test_dataset_version_listing_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_DATASET_VERSION_LISTING_PROBE_COUNT", "5")
+    monkeypatch.setenv("MELIX_DATASET_VERSION_LISTING_PROBE_SAMPLES", "1")
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/dataset_version_listing_probe.py"))
+
+    assert probe_script["main"]() == 0
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] >= 0.0
+    assert metrics["elapsed_ms_p95"] >= 0.0
+    assert metrics["sample_count"] == 1.0
+    assert metrics["version_count"] == 5.0
+
+
 def test_scope_report_selects_tool_registry_schema_bytes_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -2641,6 +2667,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "training-dataset-validation-sample-limit",
         "training-dataset-chunker-top-level-base-copy",
         "dataset-registry-preview-limit-short-circuit",
+        "dataset-version-listing-scandir",
         "maintenance-bench-report-readback",
         "maintenance-percentile-vector-reuse",
         "maintenance-prompt-shape-vector-repeat",

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -5,6 +5,7 @@ import csv
 from datetime import datetime, timezone
 import hashlib
 import json
+import os
 import re
 import time
 from pathlib import Path
@@ -451,7 +452,7 @@ def list_dataset_versions(
     started = time.perf_counter()
     versions_root = Path(output_root).expanduser() / dataset_id / "versions"
     versions: list[dict[str, Any]] = []
-    for manifest_path in sorted(versions_root.glob("*/dataset-version.json")):
+    for manifest_path in _iter_dataset_version_manifest_paths(versions_root):
         version = _read_json(manifest_path)
         versions.append(
             {
@@ -477,6 +478,21 @@ def list_dataset_versions(
             "dataset_version_count": len(versions),
         },
     }
+
+
+def _iter_dataset_version_manifest_paths(versions_root: Path) -> list[Path]:
+    manifest_paths: list[Path] = []
+    try:
+        with os.scandir(versions_root) as entries:
+            for entry in entries:
+                if not entry.is_dir(follow_symlinks=False):
+                    continue
+                manifest_path = os.path.join(entry.path, "dataset-version.json")
+                if os.path.isfile(manifest_path):
+                    manifest_paths.append(Path(manifest_path))
+    except OSError:
+        return []
+    return manifest_paths
 
 
 def _iter_source_records(


### PR DESCRIPTION
## Summary
- Register a PR-scoped performance probe for dataset version listing.
- Replace the one-level `Path.glob("*/dataset-version.json")` listing pass with `os.scandir()` while preserving filtering and final `(created_at, version_id)` ordering.
- Add focused regression coverage for deterministic listing, missing roots, and avoiding `Path.glob` allocations.

## Plan or Spec
- `docs/plans/2026-05-24-dataset-version-listing-scandir.md`
- Probe: `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` → 7 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json ...` → 100% changed-scope coverage before commit (41/41 changed measurable lines covered); rerun after commit produced no uncommitted changed lines, as expected.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py` → success
- `git diff --check` → success

## Coverage and Metrics
- Local focused tests: 7 passed.
- Changed-scope coverage: 100% before commit (41 measurable changed lines, 0 missed).
- Registered local probe (new implementation): `elapsed_ms_mean=88.624354`, `elapsed_ms_min=77.776441`, `elapsed_ms_p95=96.320252`, `version_count=2500`, `sample_count=7`.
- Local baseline comparison against `origin/main` with the same synthetic workload:
  - old run 1: mean `87.926524` ms, p95 `91.762628` ms
  - new run 1: mean `84.695283` ms, p95 `89.412576` ms
  - old run 2: mean `86.85645` ms, p95 `89.045327` ms
  - new run 2: mean `82.033327` ms, p95 `84.692846` ms
  - approximate mean delta: `-4.027182` ms (`~4.6%` faster across the paired runs)
- GitHub Actions PR-scoped performance is still required as the registered probe validation/merge gate.

## Known Gaps
- This is a Python-only slice validated locally on Linux; no Swift runtime effect is claimed.
- Microbenchmark variance exists on shared Linux runners, so the PR-scoped performance report is the authoritative registered probe result.

## Evidence Checklist
- [x] Synced/rebased onto `origin/main` before PR creation.
- [x] Registered PR-scoped probe has focused `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused local tests passed.
- [x] Changed-scope coverage measured at or above 95% before commit.
- [x] Local registered probe command ran successfully.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
- [ ] All PR checks green before merge.
