### PR TITLE
perf: scan lora auxiliary modules once

### DIFF
--- a/docs/plans/2026-05-24-lora-aux-modules-scandir.md
+++ b/docs/plans/2026-05-24-lora-aux-modules-scandir.md
@@ -1,0 +1,42 @@
+# LoRA Auxiliary Module Scandir Slice
+
+## Goal
+
+Reduce filesystem iterator overhead in LoRA canary receipt generation when checking
+whether a base model directory restored auxiliary Python modules (`modeling_*.py`,
+`configuration_*.py`, `tokenization_*.py`, or `processing_*.py`).
+
+## Scope
+
+- Path: `services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py`
+- Replace the current four `Path.glob(...)` probes with one direct
+  `os.scandir(...)` pass over the base model directory.
+- Preserve the existing direct-child filename contract for auxiliary module
+  detection.
+- Register a PR-scoped probe for this path so CI and local verification can
+  compare the changed hot path.
+
+## Probe
+
+Registered probe: `lora-aux-modules-scandir`
+
+Metrics:
+
+- `elapsed_ms_mean` (lower is better)
+- `peak_bytes_mean` (lower is better)
+- `scandir_calls_mean` (lower is better; expected `1.0` per sample)
+- `noise_file_count` (input scale)
+
+## Verification Plan
+
+1. Focused regression tests for complete and missing LoRA canary resume assets.
+2. New regression test proving auxiliary module detection uses one `os.scandir`
+   pass and does not call `Path.glob`.
+3. Changed-scope coverage command from the registered probe.
+4. Registered probe locally on Linux before opening the PR.
+5. PR-scoped performance workflow in GitHub Actions before merge.
+
+## Linux Boundary
+
+This slice changes Python worker metadata code and is locally verifiable on
+Linux. No Swift/macOS-only runtime effect is claimed for this slice.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4177,5 +4177,47 @@
         "direction": "informational"
       }
     ]
+  },
+  {
+    "id": "lora-aux-modules-scandir",
+    "name": "LoRA auxiliary module scandir",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py",
+      "services/mlx-worker-python/tests/test_lora_training_receipts.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/lora_aux_modules_scandir_probe.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_aux_modules_scandir_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/lora_aux_modules_scandir_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "scandir_calls_mean",
+        "unit": "count",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "noise_file_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      }
+    ]
   }
 ]

--- a/scripts/lora_aux_modules_scandir_probe.py
+++ b/scripts/lora_aux_modules_scandir_probe.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.model_ops import lora_runtime_metadata as metadata_module  # noqa: E402
+
+
+def _int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name, "")
+    return int(raw_value) if raw_value else default
+
+
+def _seed_base_model(root: Path, *, noise_count: int, aux_index: int) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    for index in range(noise_count):
+        (root / f"noise-{index:05d}.txt").write_text("noise\n", encoding="utf-8")
+    (root / f"tokenization_custom_{aux_index:05d}.py").write_text(
+        "# auxiliary tokenizer module\n", encoding="utf-8"
+    )
+
+
+def _measure(*, noise_count: int, sample_count: int) -> dict[str, float]:
+    elapsed_ms: list[float] = []
+    peak_bytes: list[float] = []
+    scandir_calls: list[float] = []
+
+    with tempfile.TemporaryDirectory(prefix="melix-lora-aux-probe-") as temp_dir:
+        base_model_dir = Path(temp_dir) / "base-model"
+        _seed_base_model(base_model_dir, noise_count=noise_count, aux_index=noise_count)
+
+        original_scandir = metadata_module.os.scandir
+        for _ in range(sample_count):
+            call_count = 0
+
+            def counting_scandir(path: str | Path):
+                nonlocal call_count
+                call_count += 1
+                return original_scandir(path)
+
+            metadata_module.os.scandir = counting_scandir
+            tracemalloc.start()
+            started = time.perf_counter()
+            try:
+                restored = metadata_module._aux_modules_restored(base_model_dir)
+            finally:
+                elapsed = (time.perf_counter() - started) * 1000.0
+                _, peak = tracemalloc.get_traced_memory()
+                tracemalloc.stop()
+                metadata_module.os.scandir = original_scandir
+            if not restored:
+                raise RuntimeError("expected auxiliary module detection to return true")
+            elapsed_ms.append(elapsed)
+            peak_bytes.append(float(peak))
+            scandir_calls.append(float(call_count))
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_ms),
+        "elapsed_ms_min": min(elapsed_ms),
+        "peak_bytes_mean": statistics.fmean(peak_bytes),
+        "scandir_calls_mean": statistics.fmean(scandir_calls),
+        "noise_file_count": float(noise_count),
+        "sample_count": float(sample_count),
+    }
+
+
+def main() -> int:
+    noise_count = _int_env("MELIX_LORA_AUX_MODULES_PROBE_NOISE_FILES", 4000)
+    sample_count = _int_env("MELIX_LORA_AUX_MODULES_PROBE_SAMPLES", 7)
+    print(json.dumps(_measure(noise_count=noise_count, sample_count=sample_count), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_lora_training_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_receipts.py
@@ -12,6 +12,7 @@ from packages.protocol.python.worker.v1 import common_pb2
 from worker.model_ops.deterministic_lora_runner import DeterministicLoRARunner
 from worker.model_ops.errors import ModelOperationError
 from worker.model_ops import training_config as training_config_module
+from worker.model_ops import lora_runtime_metadata as lora_runtime_metadata_module
 from worker.model_ops.lora_runtime_metadata import build_lora_canary_receipt_fields
 from worker.model_ops.lora_training_pipeline import (
     LoRATrainingPipeline,
@@ -509,6 +510,48 @@ def test_lora_canary_receipt_records_tokenizer_resume_and_drift_status(
     assert fields["completion_loss"] == 0.125
     assert fields["round_trip_passed"] is True
     assert fields["grad_norm"] == 0.75
+
+
+def test_lora_canary_aux_module_detection_uses_single_scandir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    base_model_dir = tmp_path / "base-model"
+    base_model_dir.mkdir()
+    (base_model_dir / "tokenization_qwen2.py").write_text(
+        "# custom tokenizer\n", encoding="utf-8"
+    )
+    (base_model_dir / "modeling_notes.txt").write_text("ignored\n", encoding="utf-8")
+
+    def fail_glob(self: Path, pattern: str):
+        raise AssertionError("auxiliary module detection should use os.scandir")  # pragma: no cover
+
+    original_scandir = lora_runtime_metadata_module.os.scandir
+    scanned_paths: list[str] = []
+
+    def counting_scandir(path: str | Path):
+        scanned_paths.append(str(path))
+        return original_scandir(path)
+
+    monkeypatch.setattr(Path, "glob", fail_glob)
+    monkeypatch.setattr(lora_runtime_metadata_module.os, "scandir", counting_scandir)
+
+    assert lora_runtime_metadata_module._aux_modules_restored(base_model_dir) is True
+    assert scanned_paths == [str(base_model_dir)]
+
+
+def test_lora_canary_aux_module_detection_returns_false_when_scandir_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    base_model_dir = tmp_path / "base-model"
+
+    def fail_scandir(path: str | Path):
+        raise OSError("base model unavailable")
+
+    monkeypatch.setattr(lora_runtime_metadata_module.os, "scandir", fail_scandir)
+
+    assert lora_runtime_metadata_module._aux_modules_restored(base_model_dir) is False
 
 
 def test_lora_canary_receipt_detects_missing_checkpoint_resume_assets(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -210,6 +210,31 @@ def test_scope_report_selects_dataset_version_listing_probe() -> None:
     assert "dataset-version-listing-scandir" in _selected_probe_ids(scope)
 
 
+def test_scope_report_selects_lora_aux_modules_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py"],
+    )
+
+    assert _selected_probe_ids(scope) == ["lora-aux-modules-scandir"]
+
+
+def test_lora_aux_modules_scandir_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_LORA_AUX_MODULES_PROBE_NOISE_FILES", "5")
+    monkeypatch.setenv("MELIX_LORA_AUX_MODULES_PROBE_SAMPLES", "1")
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/lora_aux_modules_scandir_probe.py"))
+
+    assert probe_script["main"]() == 0
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] >= 0.0
+    assert metrics["noise_file_count"] == 5.0
+    assert metrics["scandir_calls_mean"] == 1.0
+
+
 def test_dataset_version_listing_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -2641,6 +2666,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "embedding-core-inputs-view",
         "job-registry-derived-model-single-pass",
         "job-registry-restore-sort-elision",
+        "lora-aux-modules-scandir",
         "lora-experiment-run-dir-name-scan",
         "lora-reward-summary-candidate-minmax",
         "mlx-lm-structured-result-tail-parse",

--- a/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from pathlib import Path
 import re
 from typing import Any, Mapping
@@ -28,6 +29,9 @@ _AUXILIARY_MODULE_PATTERNS = (
     "configuration_*.py",
     "tokenization_*.py",
     "processing_*.py",
+)
+_AUXILIARY_MODULE_PREFIXES = tuple(
+    pattern.removesuffix("*.py") for pattern in _AUXILIARY_MODULE_PATTERNS
 )
 
 _QUANTIZED_KIND_ORDER = ("4bit", "8bit", "q4", "q8", "optiq")
@@ -317,10 +321,15 @@ def _processor_resume_mode(base_model_dir: Path) -> str:
 
 
 def _aux_modules_restored(base_model_dir: Path) -> bool:
-    return any(
-        any(base_model_dir.glob(pattern))
-        for pattern in _AUXILIARY_MODULE_PATTERNS
-    )
+    try:
+        with os.scandir(base_model_dir) as entries:
+            for entry in entries:
+                name = entry.name
+                if name.endswith(".py") and name.startswith(_AUXILIARY_MODULE_PREFIXES):
+                    return True
+    except OSError:
+        return False
+    return False
 
 
 def _canary_result(failures: list[str]) -> str:


### PR DESCRIPTION
## Summary
- Replace LoRA canary auxiliary-module detection with one `os.scandir` pass instead of four `Path.glob` iterators.
- Add the `lora-aux-modules-scandir` PR-scoped performance probe with focused tests, coverage, and probe commands.
- Document the slice plan and Linux verification boundary.

## Plan or Spec
- `docs/plans/2026-05-24-lora-aux-modules-scandir.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...same focused tests...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_aux_modules_scandir_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/lora_aux_modules_scandir_probe.py`
- `python3 /tmp/compare_lora_aux_modules.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 7 passed.
- Changed-scope coverage: `TOTAL 45 0 100%`.
- Local registered probe: `elapsed_ms_mean=1.346052624285221`, `elapsed_ms_min=1.2254919856786728`, `peak_bytes_mean=815.0`, `scandir_calls_mean=1.0`, `noise_file_count=4000.0`, `sample_count=7.0`.
- Local old/new comparison on 4,000 noise files plus one auxiliary module: `old_mean=36.13505805177348ms`, `new_mean=3.601892718247005ms`, `delta_ms=-32.53316533352647`, `speedup=10.032241623609474x`, old peak bytes `1004543.1428571428`, new peak bytes `828.0`.

## Known Gaps
- Python worker slice only; no Swift/macOS runtime effect is claimed.
- Registered probe validation must complete in GitHub Actions before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests pass locally on Linux.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe runs locally on Linux.
- [ ] PR-scoped performance CI completes successfully.
