### PR TITLE
perf: elide weight stat size normalization

### DIFF
--- a/docs/plans/2026-05-24-runtime-weight-stat-size-fastpath.md
+++ b/docs/plans/2026-05-24-runtime-weight-stat-size-fastpath.md
@@ -1,0 +1,22 @@
+# Runtime weight stat size fast path
+
+## Scope
+
+This Python-only performance slice is limited to model weight resident-byte estimation in `services/mlx-worker-python/worker/runtime/runtime_utils.py`.
+
+The affected path is already covered by the registered PR-scoped performance probe `runtime-utils-top-level-weight-streaming` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for the runtime utility, focused tests, PR-scoped performance selection tests, and `scripts/runtime_utils_top_level_weights_probe.py`.
+
+## Optimization
+
+For top-level weight files and direct weight-file paths, use the integer `st_size` returned by `stat()` directly after file checks. Local filesystem `stat().st_size` is already a non-negative integer for regular files, so this removes redundant `int()` and `max()` work inside the hot weight-size scan while preserving existing file/suffix/error handling.
+
+## Verification Plan
+
+Run the registered focused pytest command, changed-scope coverage command, and registered probe locally on Linux before opening the PR. GitHub Actions PR-scoped performance remains the final base-vs-head validation source before merge.
+
+## Acceptance Criteria
+
+- Existing runtime utility behavior tests pass.
+- Changed-scope coverage for the touched runtime utility/test/probe scope remains at least 95%.
+- Local registered probe shows lower `elapsed_ms_mean` without changing checksum or expected bytes.
+- PR-scoped performance CI selects and completes `runtime-utils-top-level-weight-streaming` successfully before merge.

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -201,7 +201,7 @@ def _weight_dir_entry_file_size(entry: os.DirEntry[str]) -> int:
     try:
         if not entry.is_file():
             return 0
-        return max(int(entry.stat().st_size), 0)
+        return entry.stat().st_size
     except OSError:
         return 0
 
@@ -212,6 +212,6 @@ def _weight_file_size(path: Path) -> int:
     try:
         if not path.is_file():
             return 0
-        return max(int(path.stat().st_size), 0)
+        return path.stat().st_size
     except OSError:
         return 0


### PR DESCRIPTION
## Summary
- Elides redundant `int()` and `max()` normalization around filesystem `stat().st_size` in model weight resident-byte estimation.
- Keeps the existing file/suffix/error handling unchanged for direct files and top-level weight scans.

## Plan or Spec
- `docs/plans/2026-05-24-runtime-weight-stat-size-fastpath.md`
- Registered PR-scoped probe: `runtime-utils-top-level-weight-streaming`

## Commands Run
```text
# Base/head local probe comparison (3 runs each, same worktree; base restored via git checkout, candidate re-applied via git apply)
BASE runtime_utils_top_level_weights_probe.py:
  elapsed_ms_mean=198.39236997067928, 177.97359321266413, 212.72696731612086
CANDIDATE runtime_utils_top_level_weights_probe.py:
  elapsed_ms_mean=189.90874364972115, 178.1265060417354, 175.37447893992066

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards \
  services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights \
  services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries \
  services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors \
  services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory \
  services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics
# 9 passed in 0.84s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused test list>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/runtime/runtime_utils.py \
  services/mlx-worker-python/tests/test_runtime_utils.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/runtime_utils_top_level_weights_probe.py
# TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py
# {"checksum": 107840.0, "elapsed_ms_mean": 163.68554485961795, "expected_bytes": 13480.0, "file_count": 3000.0, "iterations": 8.0, "peak_bytes_mean": 2040.8}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Local registered probe base mean: `(198.39236997067928 + 177.97359321266413 + 212.72696731612086) / 3 = 196.36431016648808 ms`.
- Local registered probe candidate mean: `(189.90874364972115 + 178.1265060417354 + 175.37447893992066) / 3 = 181.13657621045908 ms`.
- Local delta: `-15.227733956029 ms` (`~7.76%` lower elapsed mean). Checksums and expected bytes stayed unchanged (`checksum=107840.0`, `expected_bytes=13480.0`).
- CI is required for the registered PR-scoped performance base-vs-head report before merge.

## Known Gaps
- Swift runtime effects: N/A, Python-only runtime utility slice.
- CI PR-scoped performance report is pending and remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
