### PR TITLE
Implement M-courtyard runtime and training follow-up receipts

### DIFF
--- a/docs/control-plane-protocol.md
+++ b/docs/control-plane-protocol.md
@@ -527,7 +527,10 @@ reasoning, tool, structured-output, and compatibility-policy routed output.
 Plain visible-text-only requests may report `route_tracking_enabled=false` with
 empty sampled routes so the default text path avoids per-token routing work.
 When token identifiers are unavailable on tracked routes, the worker may fall
-back to raw-text span routing but must mark the fallback in the receipt.
+back to raw-text span routing but must mark the fallback in the receipt. When a
+single runtime fragment carries multiple token identifiers and parses into
+multiple channel deltas, the route receipt must attribute those identifiers to
+the parsed spans before visible text consumes any remaining tokens.
 
 Malformed or truncated tool fragments are recoverable parser observations. They should increment parser metrics and be skipped rather than fail the request. Display cleanup is not structural parsing; cleanup must not collapse meaningful leading or trailing content whitespace and must not re-emit generation-prefix control tokens.
 
@@ -707,11 +710,12 @@ generation starts. Stop strings are normalized into the worker sampling contract
 for both streaming and buffered responses.
 
 The translated worker request records a request-local generation receipt under
-`execution.ext` with these fields: `max_tokens_requested`,
-`max_tokens_effective`, `max_completion_tokens_requested`,
-`max_completion_tokens_effective`, `output_cap_source`, `stop_requested`,
-`stop_effective`, `stop_source`, `bounds_rejection_reason`, `temperature`,
-`top_p`, `top_k`, `min_p`, `repeat_penalty`, `presence_penalty`, and `seed`.
+`execution.ext` with the `melix.generation.` prefix on these field names:
+`max_tokens_requested`, `max_tokens_effective`,
+`max_completion_tokens_requested`, `max_completion_tokens_effective`,
+`output_cap_source`, `stop_requested`, `stop_effective`, `stop_source`,
+`bounds_rejection_reason`, `temperature`, `top_p`, `top_k`, `min_p`,
+`repeat_penalty`, `presence_penalty`, and `seed`.
 These fields describe the compatibility route request and effective dispatch
 values only; model-recommended sampling or template policy remains a separate
 policy receipt.

--- a/docs/control-plane-protocol.md
+++ b/docs/control-plane-protocol.md
@@ -699,6 +699,23 @@ The control plane protocol is richer than the public HTTP surface, but it must m
 | `GET /v1/models` | aggregate from model catalog and EnginePool |
 | `/admin/*` | expose local operational state from the same control plane truth |
 
+Text-generation compatibility routes normalize visible generation controls before
+dispatch. `max_tokens` and `max_completion_tokens` resolve to one effective
+output cap; malformed, zero, negative, non-finite, or conflicting cap values
+must return a typed `invalid_generation_bounds` response before worker
+generation starts. Stop strings are normalized into the worker sampling contract
+for both streaming and buffered responses.
+
+The translated worker request records a request-local generation receipt under
+`execution.ext` with these fields: `max_tokens_requested`,
+`max_tokens_effective`, `max_completion_tokens_requested`,
+`max_completion_tokens_effective`, `output_cap_source`, `stop_requested`,
+`stop_effective`, `stop_source`, `bounds_rejection_reason`, `temperature`,
+`top_p`, `top_k`, `min_p`, `repeat_penalty`, `presence_penalty`, and `seed`.
+These fields describe the compatibility route request and effective dispatch
+values only; model-recommended sampling or template policy remains a separate
+policy receipt.
+
 ## Minimal UI Interaction Flows
 
 ### Startup

--- a/docs/plans/2026-03-30-m3-6-tool-parser-registry.md
+++ b/docs/plans/2026-03-30-m3-6-tool-parser-registry.md
@@ -23,6 +23,37 @@ Introduce a parser registry that supports multiple tool-call wire formats throug
 - parser metadata should compose with model settings and request overrides
 - keep the parser API general enough for both text and vision-family tool calls
 
+## Issue #1524 Parser Audit Addendum
+
+Every registered parser must publish an audit receipt so selector behavior can
+be inspected without re-running parser execution. The receipt fields are:
+
+- `parser_id`
+- `parser_kind`
+- `accepted_wire_formats`
+- `selector_surface`
+- `selector_source`
+- `request_context_mode`
+- `exemption_reason`
+
+The registry owns `parser_id`, `parser_kind`, accepted wire formats, and the
+supported request-context modes for each parser. Selector parity is audited
+across the API request field, desktop tooling settings, and CLI reporting. API
+and desktop surfaces must expose the same parser IDs and request-context modes.
+The CLI surface may carry an exemption because it does not construct local
+requests with a tool-parser selector; it reports remote
+`supported_parsers` capability metadata instead.
+
+The required request-context fixtures cover JSON structured output,
+tool-call parsing, reasoning-aware parsing, and plain text. A parser that
+supports multiple request contexts, such as `qwen` for tool-call and reasoning
+output, must appear in selector receipts for each context on every selector
+surface.
+
+This audit slice only makes parser metadata and selector parity testable.
+Behavior fixes for structured streaming and parser recovery remain covered by
+#615 and #868 and should not be recreated here.
+
 ## Verification
 
 - `make proto`

--- a/docs/plans/2026-05-24-issue-1528-training-admission-receipts.md
+++ b/docs/plans/2026-05-24-issue-1528-training-admission-receipts.md
@@ -23,6 +23,8 @@ separate follow-up issues.
   received value, and allowed bounds.
 - Reject non-finite floating-point hyperparameters such as `nan` and `inf`
   before they can reach backend runner arguments.
+- Classify `-inf` as a bounds violation (`below_minimum`) rather than only a
+  non-finite value, so range-handling consumers do not miss the failure mode.
 - Record resolved defaults and capability gates in the adapter manifest before
   backend-dependent metrics are interpreted.
 - Record dataset file resolution from the resolved package and normalized

--- a/docs/plans/2026-05-24-issue-1528-training-admission-receipts.md
+++ b/docs/plans/2026-05-24-issue-1528-training-admission-receipts.md
@@ -21,6 +21,8 @@ separate follow-up issues.
   positive run caps.
 - Add typed validation details for numeric admission failures: field, reason,
   received value, and allowed bounds.
+- Reject non-finite floating-point hyperparameters such as `nan` and `inf`
+  before they can reach backend runner arguments.
 - Record resolved defaults and capability gates in the adapter manifest before
   backend-dependent metrics are interpreted.
 - Record dataset file resolution from the resolved package and normalized
@@ -31,11 +33,17 @@ separate follow-up issues.
 ## Acceptance Mapping
 
 - Invalid hyperparameters return typed 422-style details through existing
-  `ModelOperationError.details`.
+  `ModelOperationError.details`, including non-finite float controls.
 - Legal sentinels remain accepted and are reflected in `resolved_bounds`.
 - Capability-gated defaults are recorded in `capability_gate`.
 - Dataset file resolution, grad clipping, eval batch size, and scheduler
   omission receipts are recorded on `train_lora.adapter.json`.
+- CLI/API/Desktop surfaces share the same worker admission result for focused
+  fixtures because they converge on `normalize_training_config` before runner
+  launch. This issue does not change Swift request shaping or Desktop UI
+  rendering. Evidence for dedicated UI rendering is N/A for this worker-only
+  slice; follow-up surface-specific work should assert presentation of the same
+  `ModelOperationError.details` payload rather than duplicating validators.
 
 ## Verification
 

--- a/docs/plans/2026-05-24-issue-1530-training-runtime-preflight.md
+++ b/docs/plans/2026-05-24-issue-1530-training-runtime-preflight.md
@@ -26,6 +26,10 @@ when MLX is already importable, and attaches bounded cleanup evidence to
   `media_decoder_dependency`, `native_load_status`, `disabled_decoder_paths`,
   `fallback_reader`, `unsupported_reason`, `traceback_cleanup_result`, and
   `retained_tensor_bytes_after_failure`.
+- Successful adapter manifests must keep runtime and adapter capability refusal
+  reasons distinct: `runtime_unsupported_reason` mirrors the nested
+  `training_runtime_preflight.unsupported_reason`, while
+  `adapter_unsupported_reason` mirrors the adapter capability gate reason.
 - Include: optional media decoder states `healthy`, `missing`, and `broken`.
 - Include: text-only LoRA behavior staying unaffected when optional decoder
   dependencies are broken.

--- a/docs/plans/2026-05-24-issue-1530-training-runtime-preflight.md
+++ b/docs/plans/2026-05-24-issue-1530-training-runtime-preflight.md
@@ -26,6 +26,8 @@ when MLX is already importable, and attaches bounded cleanup evidence to
   `media_decoder_dependency`, `native_load_status`, `disabled_decoder_paths`,
   `fallback_reader`, `unsupported_reason`, `traceback_cleanup_result`, and
   `retained_tensor_bytes_after_failure`.
+- Receipt coercion must treat a missing or null `disabled_decoder_paths` value
+  as empty evidence, never as the literal string `None`.
 - Successful adapter manifests must keep runtime and adapter capability refusal
   reasons distinct: `runtime_unsupported_reason` mirrors the nested
   `training_runtime_preflight.unsupported_reason`, while

--- a/docs/plans/2026-05-24-m-courtyard-runtime-training-followups.md
+++ b/docs/plans/2026-05-24-m-courtyard-runtime-training-followups.md
@@ -1,0 +1,126 @@
+# M-Courtyard Runtime and Training Follow-Ups
+
+## Goal
+
+Implement the remaining post-closure runtime compatibility and advanced
+training follow-up issues from #1518 and #1519 as one locally integrated feature
+branch with issue-scoped commits and verifiable evidence.
+
+## Scope
+
+This plan covers:
+
+- #1522 request-local compatibility policy receipts.
+- #1523 prompt-budget admission errors.
+- #1524 parser declared wire-format and selector parity audit.
+- #1525 shared stream and non-stream text finalization state.
+- #1526 token-routed output assembly for reasoning, tools, and visible text.
+- #1527 generation bounds and passthrough receipts.
+- #1528 training admission validators and resolved-control receipts.
+- #1529 LoRA artifact, resume, merge/export, and callback drift canaries.
+- #1530 training runtime dependency preflights and failure cleanup guards.
+- #1531 advanced training planner, backend, profiler, and numerical-policy
+  receipts.
+
+The feature branch intentionally keeps #1518 and #1519 closed; those parent
+trackers already completed issue decomposition. This branch owns executable
+follow-up implementation for the child issues above.
+
+## Integration Strategy
+
+Each child issue is implemented in its own worktree and branch first, then
+merged into the local integration branch
+`feat/m-courtyard-runtime-training-followups`.
+
+| Issue | Branch | Primary Area | Merge Order |
+|---|---|---|---|
+| #1522 | `codex/issue-1522-compat-policy` | Swift request compatibility receipts plus worker evidence preservation | 1 |
+| #1523 | `codex/issue-1523-prompt-budget` | Swift OpenAI admission and typed prompt-budget errors | 2 |
+| #1524 | `codex/issue-1524-parser-audit` | Swift parser registry metadata and selector parity | 3 |
+| #1527 | `codex/issue-1527-generation-bounds` | Swift request bounds normalizer and passthrough receipts | 4 |
+| #1525 | `codex/issue-1525-finalizer-parity` | Python stream/non-stream finalization contract | 5 |
+| #1526 | `codex/issue-1526-token-router` | Python channel-aware token routing, built after #1522/#1525 | 6 |
+| #1528 | `codex/issue-1528-training-admission` | Python training admission validation receipts | 7 |
+| #1529 | `codex/issue-1529-lora-canaries` | Python LoRA artifact and drift canaries | 8 |
+| #1530 | `codex/issue-1530-runtime-preflight` | Python runtime dependency preflight and cleanup receipts | 9 |
+| #1531 | `codex/issue-1531-training-planner` | Python planner/backend/profiler receipts | 10 |
+
+The merge order keeps overlapping files from conflicting blindly:
+
+- #1526 depends on the compatibility policy and finalizer surfaces from #1522
+  and #1525.
+- #1529, #1530, and #1531 all touch training manifest paths and should merge
+  after #1528 establishes the admission and resolved-control receipt shape.
+- Conflict resolution must preserve the stricter receipt contract when two
+  branches add adjacent evidence fields.
+
+## Runtime Compatibility Requirements
+
+The runtime compatibility half must keep stream and non-stream behavior paired.
+For every request-local receipt or typed admission error added to one route, the
+paired route must either emit the same shape or record an explicit refusal or
+exemption reason.
+
+Minimum proof:
+
+- Paired OpenAI stream and non-stream request-shaping tests.
+- Worker evidence or completion-event tests that prove hidden reasoning content
+  is not leaked.
+- Parser registry audit tests that fail when metadata is missing.
+- Finalizer fixtures for usage, finish reason, malformed channels, reasoning,
+  and tool-call state.
+- Token-router fixtures for auto, none, forced-valid, forced-missing tool,
+  reasoning-only truncation, and alternate final terminator paths.
+
+## Training Requirements
+
+The training half must make admission, runtime preflight, artifact correctness,
+and planner decisions visible as durable receipts before or alongside training
+execution. Receipt fields should be stable JSON, deterministic in tests, and
+written into existing run or adapter evidence artifacts rather than ad hoc logs.
+
+Minimum proof:
+
+- Invalid hyperparameter matrix tests with typed field-level details.
+- Legal sentinel/default resolution tests.
+- Adapter manifest tests for resolved controls, canaries, runtime preflight,
+  planner, profiler, and backend decisions.
+- Import-safe inspection tests for dependency-limited hosts.
+- Focused cleanup test for nested-exception paths that emits bounded evidence.
+
+## Verification Plan
+
+Each issue branch must run:
+
+```bash
+git diff --check
+```
+
+plus its focused tests. The integration branch must then run the combined
+touched-scope checks before a pull request:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```
+
+If a focused area is not measurable for runtime performance, the PR evidence
+must state `N/A` with the reason. If the scoped performance gate selects probes,
+the final PR body must include the generated metrics report and whether any
+regression is direct, gated, or contextual.
+
+## PR Evidence
+
+The final pull request must use the repository template headings exactly and
+include:
+
+- This plan as the governing spec in `## Plan or Spec`.
+- A per-issue command summary in `## Commands Run`.
+- The full local gate and scoped metrics report in `## Coverage and Metrics`.
+- Any intentionally deferred child issue or partial UI surface in `## Known
+  Gaps`.
+
+No child issue should be closed from local intent alone. Close or update each
+issue only after the final PR has merged or after GitHub state proves the issue
+was already satisfied by a merged PR.

--- a/docs/runbooks/structured-streaming-reasoning-continuity.md
+++ b/docs/runbooks/structured-streaming-reasoning-continuity.md
@@ -48,6 +48,42 @@ Cache compatibility must include:
 - `melix.cache.fingerprint.chat_template_kwargs`
 - `melix.cache.fingerprint.reasoning_continuity_present`
 
+Text request compatibility policy receipts must be request-local and attached
+to worker `GenerateRequest.execution.ext` for both streaming and non-streaming
+text routes. Inspect:
+
+- `melix.compat.policy_receipt_json`
+- `melix.compat.compat_surface`
+- `melix.compat.stream_mode`
+- `melix.compat.reasoning_mode`
+- `melix.compat.reasoning_source`
+- `melix.compat.reasoning_effort`
+- `melix.compat.tool_parser_mode`
+- `melix.compat.tool_parser_source`
+- `melix.compat.tool_namespaces`
+- `melix.compat.tool_choice_requested`
+- `melix.compat.tool_choice_resolved`
+- `melix.compat.structured_output_mode`
+- `melix.compat.output_modalities`
+- `melix.compat.effective_config_hash`
+
+The JSON receipt shape is the canonical evidence shape and contains the same
+field names without the `melix.compat.` prefix:
+
+- `compat_surface`
+- `stream_mode`
+- `reasoning_mode`
+- `reasoning_source`
+- `reasoning_effort`
+- `tool_parser_mode`
+- `tool_parser_source`
+- `tool_namespaces`
+- `tool_choice_requested`
+- `tool_choice_resolved`
+- `structured_output_mode`
+- `output_modalities`
+- `effective_config_hash`
+
 ## Parser Diagnostics
 
 The worker stream assembler reports parser metrics on completed events:
@@ -78,6 +114,8 @@ The worker stream assembler reports parser metrics on completed events:
 - `response_history_normalized_count`
 - `native_tool_exemplar_injected_count`
 - `effective_parser_config_json`
+- `compat_policy_receipt_json`
+- `compat_effective_config_hash`
 
 Expected healthy values:
 
@@ -118,6 +156,9 @@ Expected healthy values:
   should include the request-scoped `reasoning_enabled`, `tool_parser_mode`,
   `structured_output_mode`, and `request_context_mode` values resolved before
   stream assembly starts
+- `compat_policy_receipt_json` and `compat_effective_config_hash` should
+  preserve the request-shaped compatibility policy receipt on completed events
+  without adding raw hidden reasoning content to the receipt
 - requests with typed `ToolConfig.tools` should increment
   `native_tool_exemplar_injected_count` when those tools are forwarded as
   tokenizer-native `tools` kwargs and no explicit native `tools` kwargs were

--- a/services/control-plane-swift/Sources/Requests/ToolParserRegistry.swift
+++ b/services/control-plane-swift/Sources/Requests/ToolParserRegistry.swift
@@ -302,38 +302,39 @@ public struct ToolParserRegistry: Sendable {
 
     public func selectorAuditReceipts() -> [ToolParserAuditReceipt] {
         descriptors.flatMap { descriptor in
-            let requestContextMode = primaryContext(for: descriptor)
-            let acceptedWireFormats = acceptedWireFormats(
-                for: descriptor,
-                requestContextMode: requestContextMode
-            )
-            return [
-                ToolParserAuditReceipt(
-                    parserID: descriptor.mode.rawValue,
-                    parserKind: descriptor.parserKind,
-                    acceptedWireFormats: acceptedWireFormats,
-                    selectorSurface: .api,
-                    selectorSource: "request.tool_parser",
+            descriptor.requestContextModes.flatMap { requestContextMode in
+                let acceptedWireFormats = acceptedWireFormats(
+                    for: descriptor,
                     requestContextMode: requestContextMode
-                ),
-                ToolParserAuditReceipt(
-                    parserID: descriptor.mode.rawValue,
-                    parserKind: descriptor.parserKind,
-                    acceptedWireFormats: acceptedWireFormats,
-                    selectorSurface: .desktop,
-                    selectorSource: "tooling_settings.builtin_tool_parser_modes",
-                    requestContextMode: requestContextMode
-                ),
-                ToolParserAuditReceipt(
-                    parserID: descriptor.mode.rawValue,
-                    parserKind: descriptor.parserKind,
-                    acceptedWireFormats: acceptedWireFormats,
-                    selectorSurface: .cli,
-                    selectorSource: "none",
-                    requestContextMode: requestContextMode,
-                    exemptionReason: Self.cliSelectorExemptionReason
-                ),
-            ]
+                )
+                return [
+                    ToolParserAuditReceipt(
+                        parserID: descriptor.mode.rawValue,
+                        parserKind: descriptor.parserKind,
+                        acceptedWireFormats: acceptedWireFormats,
+                        selectorSurface: .api,
+                        selectorSource: "request.tool_parser",
+                        requestContextMode: requestContextMode
+                    ),
+                    ToolParserAuditReceipt(
+                        parserID: descriptor.mode.rawValue,
+                        parserKind: descriptor.parserKind,
+                        acceptedWireFormats: acceptedWireFormats,
+                        selectorSurface: .desktop,
+                        selectorSource: "tooling_settings.builtin_tool_parser_modes",
+                        requestContextMode: requestContextMode
+                    ),
+                    ToolParserAuditReceipt(
+                        parserID: descriptor.mode.rawValue,
+                        parserKind: descriptor.parserKind,
+                        acceptedWireFormats: acceptedWireFormats,
+                        selectorSurface: .cli,
+                        selectorSource: "none",
+                        requestContextMode: requestContextMode,
+                        exemptionReason: Self.cliSelectorExemptionReason
+                    ),
+                ]
+            }
         }
     }
 
@@ -465,10 +466,6 @@ public struct ToolParserRegistry: Sendable {
     }
 
     private static let cliSelectorExemptionReason = "CLI has no request-construction surface for tool parser selection; it reports remote model supported_parsers only."
-
-    private func primaryContext(for descriptor: Descriptor) -> ToolParserRequestContextMode {
-        descriptor.requestContextModes.first ?? .plain
-    }
 
     private func receipt(
         mode: ToolParserMode,

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
@@ -4415,7 +4415,7 @@ struct ControlPlaneServiceTests {
                 reasoningModes: ["enabled", "disabled"],
                 structuredOutputModes: ["json_schema", "plain_text"],
                 concurrencyLevels: [8, 1],
-                repeats: 0,
+                repeats: 1,
                 requests: 0,
                 durationSeconds: 30,
                 allowLargeMatrix: true
@@ -4457,6 +4457,29 @@ struct ControlPlaneServiceTests {
         #expect(response.ok == false)
         #expect(response.error.code == "invalid_argument")
         #expect(response.error.message.contains("Exactly one of requests or duration_seconds"))
+        #expect(await modelOpsClient.lastBenchMatrixRequest == nil)
+    }
+
+    @Test("execute rejects ops.run_bench_matrix when repeats fall below the product limit")
+    func executeRejectsOpsRunBenchMatrixWhenRepeatsFallBelowTheProductLimit() async throws {
+        let modelOpsClient = ScriptedModelOperationsWorkerClient()
+        let catalog = ModelCatalog(seedModels: ModelCatalog.phaseFiveSeedModels())
+        _ = await catalog.loadModel(id: "melix-dev-text", dispatchHandle: "melix-dev-text::explicit")
+        let service = ControlPlaneService(
+            modelCatalog: catalog,
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: NullWorkerClient(),
+                modelOperationsClient: modelOpsClient
+            )
+        )
+
+        let response = try await service.execute(
+            makeRunBenchMatrixRequest(repeats: 0, requests: 4)
+        )
+
+        #expect(response.ok == false)
+        #expect(response.error.code == "invalid_argument")
+        #expect(response.error.message.contains("Benchmark repeats"))
         #expect(await modelOpsClient.lastBenchMatrixRequest == nil)
     }
 

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -63,9 +63,9 @@ struct ToolParserRegistryTests {
         let desktop = selectorReceipts.filter { $0.selectorSurface == .desktop }
         let cli = selectorReceipts.filter { $0.selectorSurface == .cli }
 
-        #expect(api.map(\.parserID) == parserIDs)
-        #expect(desktop.map(\.parserID) == parserIDs)
-        #expect(cli.map(\.parserID) == parserIDs)
+        #expect(Set(api.map(\.parserID)) == Set(parserIDs))
+        #expect(Set(desktop.map(\.parserID)) == Set(parserIDs))
+        #expect(Set(cli.map(\.parserID)) == Set(parserIDs))
         #expect(api.allSatisfy { $0.selectorSource == "request.tool_parser" })
         #expect(desktop.allSatisfy { $0.selectorSource == "tooling_settings.builtin_tool_parser_modes" })
         #expect(cli.allSatisfy { $0.selectorSource == "none" })
@@ -74,6 +74,27 @@ struct ToolParserRegistryTests {
         })
         #expect(api.allSatisfy { $0.exemptionReason.isEmpty })
         #expect(desktop.allSatisfy { $0.exemptionReason.isEmpty })
+    }
+
+    @Test("selector parity audit covers every supported request context")
+    func selectorParityAuditCoversEverySupportedRequestContext() {
+        struct ParserContext: Hashable {
+            let parserID: String
+            let requestContextMode: ToolParserRequestContextMode
+        }
+
+        let registry = ToolParserRegistry()
+        let declaredContexts = Set(registry.auditReceipts().map {
+            ParserContext(parserID: $0.parserID, requestContextMode: $0.requestContextMode)
+        })
+        let selectorReceipts = registry.selectorAuditReceipts()
+
+        for surface in [ToolParserSelectorSurface.api, .desktop, .cli] {
+            let surfaceContexts = Set(selectorReceipts.filter { $0.selectorSurface == surface }.map {
+                ParserContext(parserID: $0.parserID, requestContextMode: $0.requestContextMode)
+            })
+            #expect(surfaceContexts == declaredContexts)
+        }
     }
 
     @Test("fixture request contexts cover JSON tool reasoning and plain parsers")

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -225,6 +225,9 @@ struct ToolParserRegistryTests {
         let translated = try translator.translate(request, modelHandle: "worker-text")
         let ext = translated.workerRequest.execution.ext
         let receipt = try #require(ext["melix.compat.policy_receipt_json"])
+        let receiptObject = try #require(
+            try JSONSerialization.jsonObject(with: Data(receipt.utf8)) as? [String: Any]
+        )
 
         #expect(ext["melix.compat.compat_surface"] == "openai.chat.completions")
         #expect(ext["melix.compat.stream_mode"] == "stream")
@@ -242,6 +245,73 @@ struct ToolParserRegistryTests {
         #expect(receipt.contains(#""compat_surface":"openai.chat.completions""#))
         #expect(receipt.contains(#""tool_namespaces":["tools.search"]"#))
         #expect(receipt.contains(#""effective_config_hash":"\#(ext["melix.compat.effective_config_hash"] ?? "")""#))
+        #expect(Set(receiptObject.keys) == compatReceiptFieldNames())
+    }
+
+    @Test("request-local compatibility policy receipt overrides do not mutate default requests")
+    func requestLocalCompatibilityPolicyReceiptOverridesDoNotMutateDefaultRequests() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-compat-policy-defaults" })
+        let overrideRequest = OpenAIChatCompletionsRequest(
+            model: "melix-dev-text",
+            messages: [.init(role: "user", content: "Call a tool and answer as JSON.")],
+            enableThinking: true,
+            reasoningEffort: "low",
+            stream: true,
+            responseFormat: StructuredOutputRequestFormat(
+                type: .jsonSchema,
+                jsonSchema: StructuredOutputJSONSchemaDefinition(
+                    name: "answer",
+                    schema: .object(["type": .string("object")]),
+                    strict: true
+                )
+            ),
+            toolParser: ToolParserRequestConfiguration(
+                mode: .qwen,
+                namespaces: ["tools.search"]
+            ),
+            tools: [
+                OpenAIChatTool(
+                    type: "function",
+                    function: OpenAIChatTool.FunctionDefinition(
+                        name: "search",
+                        description: "Search documents",
+                        parameters: .object(["type": .string("object")])
+                    )
+                ),
+            ],
+            toolChoice: .mode("required")
+        )
+        let defaultRequest = OpenAIChatCompletionsRequest(
+            model: "melix-dev-text",
+            messages: [.init(role: "user", content: "Answer plainly.")],
+            stream: false
+        )
+
+        let translatedBaseline = try translator.translate(defaultRequest, modelHandle: "worker-text")
+        _ = try translator.translate(overrideRequest, modelHandle: "worker-text")
+        let translatedDefault = try translator.translate(defaultRequest, modelHandle: "worker-text")
+        let baselineExt = translatedBaseline.workerRequest.execution.ext
+        let ext = translatedDefault.workerRequest.execution.ext
+        let receipt = try #require(ext["melix.compat.policy_receipt_json"])
+        let receiptObject = try #require(
+            try JSONSerialization.jsonObject(with: Data(receipt.utf8)) as? [String: Any]
+        )
+
+        #expect(Set(receiptObject.keys) == compatReceiptFieldNames())
+        #expect(ext["melix.compat.compat_surface"] == baselineExt["melix.compat.compat_surface"])
+        #expect(ext["melix.compat.stream_mode"] == "non_stream")
+        #expect(ext["melix.compat.reasoning_mode"] == baselineExt["melix.compat.reasoning_mode"])
+        #expect(ext["melix.compat.reasoning_source"] == baselineExt["melix.compat.reasoning_source"])
+        #expect(ext["melix.compat.reasoning_effort"] == baselineExt["melix.compat.reasoning_effort"])
+        #expect(ext["melix.compat.tool_parser_mode"] == baselineExt["melix.compat.tool_parser_mode"])
+        #expect(ext["melix.compat.tool_parser_source"] == baselineExt["melix.compat.tool_parser_source"])
+        #expect(ext["melix.compat.tool_namespaces"] == baselineExt["melix.compat.tool_namespaces"])
+        #expect(ext["melix.compat.tool_choice_requested"] == baselineExt["melix.compat.tool_choice_requested"])
+        #expect(ext["melix.compat.tool_choice_resolved"] == baselineExt["melix.compat.tool_choice_resolved"])
+        #expect(ext["melix.compat.structured_output_mode"] == baselineExt["melix.compat.structured_output_mode"])
+        #expect(ext["melix.compat.output_modalities"] == baselineExt["melix.compat.output_modalities"])
+        #expect(ext["melix.compat.effective_config_hash"]?.isEmpty == false)
+        #expect(ext["melix.compat.effective_config_hash"] == baselineExt["melix.compat.effective_config_hash"])
     }
 
     @Test("multimodal tool parser requests preserve image parts and execution metadata")
@@ -485,5 +555,23 @@ struct ToolParserRegistryTests {
             saveBoundarySnapshot: nil,
             toolParser: toolParser
         )
+    }
+
+    private func compatReceiptFieldNames() -> Set<String> {
+        [
+            "compat_surface",
+            "stream_mode",
+            "reasoning_mode",
+            "reasoning_source",
+            "reasoning_effort",
+            "tool_parser_mode",
+            "tool_parser_source",
+            "tool_namespaces",
+            "tool_choice_requested",
+            "tool_choice_resolved",
+            "structured_output_mode",
+            "output_modalities",
+            "effective_config_hash",
+        ]
     }
 }

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -978,6 +978,13 @@ struct OpenAIHandlerTests {
         #expect(receipt["melix.generation.stop_requested"] == #"["END","DONE"]"#)
         #expect(receipt["melix.generation.stop_effective"] == #"["END","DONE"]"#)
         #expect(receipt["melix.generation.stop_source"] == "request")
+        #expect(receipt["melix.generation.temperature"] == "0")
+        #expect(receipt["melix.generation.top_p"] == "1")
+        #expect(receipt["melix.generation.top_k"] == "0")
+        #expect(receipt["melix.generation.min_p"] == "")
+        #expect(receipt["melix.generation.repeat_penalty"] == "")
+        #expect(receipt["melix.generation.presence_penalty"] == "")
+        #expect(receipt["melix.generation.seed"] == "")
     }
 
     @Test(
@@ -4653,6 +4660,9 @@ struct OpenAIHandlerTests {
         #expect(receipt["melix.generation.output_cap_source"] == expectedSource)
         #expect(receipt["melix.generation.stop_effective"] == expectedStopReceipt)
         #expect(receipt["melix.generation.stop_source"] == "request")
+        #expect(receipt["melix.generation.top_k"]?.isEmpty == false)
+        #expect(receipt["melix.generation.presence_penalty"]?.isEmpty == false)
+        #expect(receipt["melix.generation.seed"]?.isEmpty == false)
     }
 
     @Test("POST /v1/responses forwards reasoning and tool delta events")

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -10103,6 +10103,50 @@ struct OpenAIHandlerTests {
         #expect(await workerClient.lastGenerateRequest == nil)
     }
 
+    @Test("default output cap does not exhaust prompt budget for short prompts")
+    func defaultOutputCapDoesNotExhaustPromptBudgetForShortPrompts() async throws {
+        let workerClient = ScriptedWorkerClient(events: [
+            makeCompletedEvent(
+                requestID: "req-default-output-cap-short-prompt",
+                seq: 1,
+                finishReason: "stop",
+                assistantText: "ok"
+            ),
+        ])
+        var model = warmModel()
+        model.maxContext = 8
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [model]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-default-output-cap-short-prompt" })
+        )
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": false,
+              "messages": [
+                { "role": "user", "content": "hello" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(method: .post, path: "/v1/chat/completions", headers: [:], body: body)
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let choice = try #require((payload["choices"] as? [[String: Any]])?.first)
+        let message = try #require(choice["message"] as? [String: Any])
+
+        #expect(response.statusCode == 200)
+        #expect(message["content"] as? String == "ok")
+        #expect(await workerClient.lastGenerateRequest != nil)
+    }
+
     @Test("chat requests return 409 when the model is not ready")
     func modelNotReadyReturns409() async throws {
         let handler = OpenAIHandler(

--- a/services/mlx-worker-python/tests/test_generate_stream.py
+++ b/services/mlx-worker-python/tests/test_generate_stream.py
@@ -749,6 +749,44 @@ def test_generate_streams_token_and_terminal_completion() -> None:
     assert native_tool_receipt["route_tracking_enabled"] is True
     assert native_tool_receipt["tool_choice_policy"] == "auto"
 
+    metadata_registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=MetadataStreamingBackend()),
+        model_catalog=WorkerModelCatalog(),
+    )
+    metadata_runtime_service = WorkerRuntimeService(metadata_registry)
+    metadata_inference_service = WorkerInferenceService(metadata_registry)
+    metadata_handle = metadata_runtime_service.LoadModel(
+        runtime_pb2.LoadModelRequest(model=WorkerModelCatalog.dev_text_model()),
+        context=None,
+    ).model_handle
+    metadata_request = inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id="req-token-route-token-ids"),
+            model_handle=metadata_handle,
+            ext={"melix.reasoning.mode": "enabled"},
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="Track route token ids")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=16),
+        stream=True,
+    )
+    metadata_events = list(
+        metadata_inference_service.Generate(metadata_request, context=None)
+    )
+    metadata_completed = next(
+        event.completed for event in metadata_events if event.HasField("completed")
+    )
+    metadata_receipt = json.loads(
+        metadata_completed.parser_metrics["token_route_receipt_json"]
+    )
+    assert metadata_receipt["route_tracking_enabled"] is True
+    assert metadata_receipt["route_count"] == 2
+    assert [route["token_id"] for route in metadata_receipt["routes"]] == [301, 302]
+
     inactive_route_request = inference_pb2.GenerateRequest(
         execution=inference_pb2.ExecutionMetadata(
             id=common_pb2.RequestIdentity(request_id="req-inactive-route-receipt"),

--- a/services/mlx-worker-python/tests/test_generate_stream_receipts.py
+++ b/services/mlx-worker-python/tests/test_generate_stream_receipts.py
@@ -34,6 +34,61 @@ class StructuredStreamingBackend:
         )
 
 
+class TokenRoutedStructuredBackend:
+    runtime_name = "fake-mlx"
+
+    def __init__(self, *, token_ids: tuple[int, ...]) -> None:
+        self.token_ids = token_ids
+
+    def load_model(self, model_spec):
+        return {"model_id": model_spec.model_id}
+
+    def estimate_resident_bytes(self, model_spec):
+        return 2048
+
+    def generate_tokens(self, loaded_model, prompt, sampling, cancel_event):
+        _ = loaded_model
+        _ = prompt
+        _ = sampling
+        _ = cancel_event
+        yield RuntimeTokenEvent(
+            text="",
+            raw_text=(
+                '<think>trace</think>'
+                '<tool_call>{"name":"search","arguments":{"q":"one"}}</tool_call>'
+                "visible"
+            ),
+            token_ids=self.token_ids,
+            prompt_tokens=3,
+            completion_tokens=3,
+            finish_reason="stop",
+        )
+
+
+class TokenRoutedVisibleBackend:
+    runtime_name = "fake-mlx"
+
+    def load_model(self, model_spec):
+        return {"model_id": model_spec.model_id}
+
+    def estimate_resident_bytes(self, model_spec):
+        return 2048
+
+    def generate_tokens(self, loaded_model, prompt, sampling, cancel_event):
+        _ = loaded_model
+        _ = prompt
+        _ = sampling
+        _ = cancel_event
+        yield RuntimeTokenEvent(
+            text="",
+            raw_text="visible text",
+            token_ids=(201, 202),
+            prompt_tokens=3,
+            completion_tokens=2,
+            finish_reason="stop",
+        )
+
+
 class FinalizerParityBackend:
     runtime_name = "fake-mlx"
 
@@ -278,6 +333,97 @@ def test_generate_token_route_receipt_uses_compat_policy_context_and_matches_str
     assert stream_receipt["routes"] == non_stream_receipt["routes"]
 
 
+def test_generate_token_route_receipt_records_actual_token_ids_by_channel_span() -> None:
+    inference_service, model_handle = _build_services(
+        TokenRoutedStructuredBackend(token_ids=(101, 102, 103))
+    )
+    completed = next(
+        event.completed
+        for event in inference_service.Generate(
+            _token_route_request(
+                model_handle,
+                compat_receipt='{"reasoning_mode":"enabled","tool_choice_resolved":"required"}',
+                stream=True,
+            ),
+            context=None,
+        )
+        if event.HasField("completed")
+    )
+    receipt = json.loads(completed.parser_metrics["token_route_receipt_json"])
+
+    assert completed.assistant_text == "visible"
+    assert completed.reasoning_text == "trace"
+    assert receipt["fallback_raw_text_used"] is False
+    assert receipt["visible_text_tokens"] == 1
+    assert receipt["hidden_reasoning_tokens"] == 1
+    assert [
+        (route["token_id"], route["channel"], route["channel_source"])
+        for route in receipt["routes"]
+    ] == [
+        (101, "hidden_reasoning", "reasoning_tag"),
+        (102, "tool_call", "tool_call_tag"),
+        (103, "visible_text", "raw_text"),
+    ]
+
+
+def test_generate_token_route_receipt_marks_raw_text_fallback_without_token_ids() -> None:
+    inference_service, model_handle = _build_services(
+        TokenRoutedStructuredBackend(token_ids=())
+    )
+    completed = next(
+        event.completed
+        for event in inference_service.Generate(
+            _token_route_request(
+                model_handle,
+                compat_receipt='{"reasoning_mode":"enabled","tool_choice_resolved":"required"}',
+                stream=True,
+            ),
+            context=None,
+        )
+        if event.HasField("completed")
+    )
+    receipt = json.loads(completed.parser_metrics["token_route_receipt_json"])
+
+    assert receipt["fallback_raw_text_used"] is True
+    assert [
+        (route["token_id"], route["channel"], route["channel_source"])
+        for route in receipt["routes"]
+    ] == [
+        (0, "hidden_reasoning", "reasoning_tag"),
+        (1, "tool_call", "tool_call_tag"),
+        (2, "visible_text", "raw_text"),
+    ]
+
+
+def test_generate_token_route_receipt_counts_all_tokens_in_visible_span() -> None:
+    inference_service, model_handle = _build_services(TokenRoutedVisibleBackend())
+    completed = next(
+        event.completed
+        for event in inference_service.Generate(
+            _token_route_request(
+                model_handle,
+                compat_receipt='{"reasoning_mode":"disabled","tool_choice_resolved":"none"}',
+                stream=True,
+                reasoning_enabled=False,
+            ),
+            context=None,
+        )
+        if event.HasField("completed")
+    )
+    receipt = json.loads(completed.parser_metrics["token_route_receipt_json"])
+
+    assert completed.assistant_text == "visible text"
+    assert receipt["fallback_raw_text_used"] is False
+    assert receipt["visible_text_tokens"] == 2
+    assert [
+        (route["token_id"], route["channel"], route["channel_source"])
+        for route in receipt["routes"]
+    ] == [
+        (201, "visible_text", "raw_text"),
+        (202, "visible_text", "raw_text"),
+    ]
+
+
 @pytest.mark.parametrize(
     ("case_id", "raw_text", "expected"),
     [
@@ -388,6 +534,7 @@ def _token_route_request(
     *,
     compat_receipt: str,
     stream: bool,
+    reasoning_enabled: bool = True,
 ) -> inference_pb2.GenerateRequest:
     return inference_pb2.GenerateRequest(
         execution=inference_pb2.ExecutionMetadata(
@@ -403,7 +550,7 @@ def _token_route_request(
                 "melix.tool_parser.mode": "qwen",
             },
             reasoning=common_pb2.ReasoningConfig(
-                enabled=True,
+                enabled=reasoning_enabled,
                 mode_source="request_enable_thinking",
             ),
             tool_config=common_pb2.ToolConfig(

--- a/services/mlx-worker-python/tests/test_generate_stream_receipts.py
+++ b/services/mlx-worker-python/tests/test_generate_stream_receipts.py
@@ -4,6 +4,7 @@ import pytest
 
 from packages.protocol.python.worker.v1 import common_pb2, inference_pb2, runtime_pb2
 
+from worker.engine import engine_core as engine_core_module
 from worker.grpc_server import WorkerInferenceService, WorkerRuntimeService
 from worker.model_registry.catalog import WorkerModelCatalog
 from worker.registry import WorkerRegistry
@@ -138,6 +139,106 @@ def test_plain_compatibility_receipt_keeps_metadata_without_route_tracking() -> 
     assert completed.parser_metrics["compat_effective_config_hash"] == "plain123"
     assert completed.parser_metrics["created"] == "1716500000"
     assert token_route_receipt["route_tracking_enabled"] is False
+
+
+def test_plain_fast_path_finalizes_through_shared_text_receipt_state(monkeypatch) -> None:
+    receipts: list[object] = []
+    original_apply = engine_core_module.apply_text_response_metrics
+
+    def record_apply(parser_metrics: dict[str, str], *, receipt: object) -> None:
+        receipts.append(receipt)
+        original_apply(parser_metrics, receipt=receipt)
+
+    monkeypatch.setattr(engine_core_module, "apply_text_response_metrics", record_apply)
+    inference_service, model_handle = _build_services(
+        FinalizerParityBackend(raw_text="plain answer", prompt_tokens=7, completion_tokens=2)
+    )
+
+    for stream in (True, False):
+        request = inference_pb2.GenerateRequest(
+            execution=inference_pb2.ExecutionMetadata(
+                id=common_pb2.RequestIdentity(
+                    request_id=f"req-plain-finalizer-{'stream' if stream else 'non-stream'}"
+                ),
+                model_handle=model_handle,
+                ext={"melix.response.created": "1716500001"},
+            ),
+            messages=[
+                common_pb2.ChatMessage(
+                    role="user",
+                    parts=[common_pb2.MessagePart(text="plain finalizer")],
+                )
+            ],
+            sampling=common_pb2.SamplingConfig(max_output_tokens=8),
+            stream=stream,
+            return_usage=True,
+        )
+        completed = next(
+            event.completed for event in inference_service.Generate(request, context=None)
+            if event.HasField("completed")
+        )
+        assert completed.parser_metrics["finalizer_path"] == (
+            "stream" if stream else "non_stream"
+        )
+
+    assert [receipt.stream_mode for receipt in receipts] == [True, False]
+    assert [receipt.usage_trailer_emitted for receipt in receipts] == [True, False]
+    assert all(receipt.usage.prompt_tokens == 7 for receipt in receipts)
+    assert all(receipt.usage.completion_tokens == 2 for receipt in receipts)
+
+
+def test_structured_tool_calls_finalize_through_shared_text_receipt_state(monkeypatch) -> None:
+    receipts: list[object] = []
+    original_apply = engine_core_module.apply_text_response_metrics
+
+    def record_apply(parser_metrics: dict[str, str], *, receipt: object) -> None:
+        receipts.append(receipt)
+        original_apply(parser_metrics, receipt=receipt)
+
+    monkeypatch.setattr(engine_core_module, "apply_text_response_metrics", record_apply)
+    inference_service, model_handle = _build_services(StructuredStreamingBackend())
+    request = inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id="req-structured-finalizer-tool-call"),
+            model_handle=model_handle,
+            ext={
+                "melix.reasoning.mode": "enabled",
+                "melix.response.created": "1716500002",
+                "melix.tool_parser.mode": "qwen",
+            },
+            reasoning=common_pb2.ReasoningConfig(
+                enabled=True,
+                mode_source="request_enable_thinking",
+            ),
+            tool_config=common_pb2.ToolConfig(
+                tools=[
+                    common_pb2.ToolDefinition(
+                        name="search",
+                        json_schema='{"type":"object"}',
+                    )
+                ],
+                tool_choice="required",
+            ),
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="Use a tool")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=16),
+        stream=True,
+        return_usage=True,
+    )
+
+    completed = next(
+        event.completed for event in inference_service.Generate(request, context=None)
+        if event.HasField("completed")
+    )
+
+    assert [receipt.tool_calls_finalized for receipt in receipts] == [True]
+    assert completed.parser_metrics["tool_calls_finalized"] == "true"
+    assert completed.parser_metrics["reasoning_finalized"] == "true"
 
 
 def test_generate_token_route_receipt_uses_compat_policy_context_and_matches_stream_modes() -> None:

--- a/services/mlx-worker-python/tests/test_generate_stream_receipts.py
+++ b/services/mlx-worker-python/tests/test_generate_stream_receipts.py
@@ -65,6 +65,34 @@ class TokenRoutedStructuredBackend:
         )
 
 
+class TokenRoutedMultispanBackend:
+    runtime_name = "fake-mlx"
+
+    def load_model(self, model_spec):
+        return {"model_id": model_spec.model_id}
+
+    def estimate_resident_bytes(self, model_spec):
+        return 2048
+
+    def generate_tokens(self, loaded_model, prompt, sampling, cancel_event):
+        _ = loaded_model
+        _ = prompt
+        _ = sampling
+        _ = cancel_event
+        yield RuntimeTokenEvent(
+            text="",
+            raw_text=(
+                "<think>alpha beta gamma</think>"
+                '<tool_call>{"name":"search","arguments":{"q":"one"}}</tool_call>'
+                "visible"
+            ),
+            token_ids=(101, 102, 103, 104, 105, 106),
+            prompt_tokens=3,
+            completion_tokens=6,
+            finish_reason="stop",
+        )
+
+
 class TokenRoutedVisibleBackend:
     runtime_name = "fake-mlx"
 
@@ -363,6 +391,41 @@ def test_generate_token_route_receipt_records_actual_token_ids_by_channel_span()
         (101, "hidden_reasoning", "reasoning_tag"),
         (102, "tool_call", "tool_call_tag"),
         (103, "visible_text", "raw_text"),
+    ]
+
+
+def test_generate_token_route_receipt_keeps_multitoken_hidden_and_tool_spans() -> None:
+    inference_service, model_handle = _build_services(TokenRoutedMultispanBackend())
+    completed = next(
+        event.completed
+        for event in inference_service.Generate(
+            _token_route_request(
+                model_handle,
+                compat_receipt='{"reasoning_mode":"enabled","tool_choice_resolved":"required"}',
+                stream=True,
+            ),
+            context=None,
+        )
+        if event.HasField("completed")
+    )
+    receipt = json.loads(completed.parser_metrics["token_route_receipt_json"])
+
+    assert completed.assistant_text == "visible"
+    assert completed.reasoning_text == "alpha beta gamma"
+    assert receipt["fallback_raw_text_used"] is False
+    assert receipt["visible_text_tokens"] == 1
+    assert receipt["hidden_reasoning_tokens"] == 3
+    assert receipt["route_count"] == 6
+    assert [
+        (route["token_id"], route["channel"], route["channel_source"])
+        for route in receipt["routes"]
+    ] == [
+        (101, "hidden_reasoning", "reasoning_tag"),
+        (102, "hidden_reasoning", "reasoning_tag"),
+        (103, "hidden_reasoning", "reasoning_tag"),
+        (104, "tool_call", "tool_call_tag"),
+        (105, "tool_call", "tool_call_tag"),
+        (106, "visible_text", "raw_text"),
     ]
 
 

--- a/services/mlx-worker-python/tests/test_lora_experiment_store.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_store.py
@@ -250,6 +250,50 @@ def test_rebuild_index_prefers_run_record_over_manifest_when_both_exist(tmp_path
     assert manifest_only_run["round_trip_passed"] is True
 
 
+def test_persist_training_run_preserves_lora_canary_receipts(tmp_path: Path) -> None:
+    jobs_root = tmp_path / "model-ops"
+    manifest_path = jobs_root / "train_lora" / "model-ops-0001" / "train_lora.adapter.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "job_id": "model-ops-0001",
+        "operation": "train_lora",
+        "adapter_name": "demo-adapter",
+        "source_model": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+        "source_eos_token": "<|source-eos|>",
+        "saved_eos_token": "<|source-eos|>",
+        "tokenizer_config_path": "/tmp/base/tokenizer_config.json",
+        "base_config_present": True,
+        "processor_resume_mode": "processor_config",
+        "aux_modules_restored": True,
+        "merge_export_canary_result": "pass",
+        "callback_api_drift_result": "pass",
+        "completion_loss": 0.125,
+        "round_trip_passed": True,
+        "grad_norm": 0.75,
+        "updated_at_unix_ms": 1_000,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    paths = LoraExperimentStore().persist_training_run(
+        jobs_root=jobs_root,
+        manifest=manifest,
+        manifest_path=manifest_path,
+    )
+    run_payload = json.loads(paths["run"].read_text(encoding="utf-8"))
+
+    assert run_payload["source_eos_token"] == "<|source-eos|>"
+    assert run_payload["saved_eos_token"] == "<|source-eos|>"
+    assert run_payload["tokenizer_config_path"] == "/tmp/base/tokenizer_config.json"
+    assert run_payload["base_config_present"] is True
+    assert run_payload["processor_resume_mode"] == "processor_config"
+    assert run_payload["aux_modules_restored"] is True
+    assert run_payload["merge_export_canary_result"] == "pass"
+    assert run_payload["callback_api_drift_result"] == "pass"
+    assert run_payload["completion_loss"] == 0.125
+    assert run_payload["round_trip_passed"] is True
+    assert run_payload["grad_norm"] == 0.75
+
+
 def test_rebuild_index_skips_manifest_parse_when_run_record_exists(tmp_path: Path, monkeypatch) -> None:
     jobs_root = tmp_path / "model-ops"
     manifest_path = _write_manifest(jobs_root, run_id="model-ops-0001")

--- a/services/mlx-worker-python/tests/test_lora_experiment_store.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_store.py
@@ -250,50 +250,6 @@ def test_rebuild_index_prefers_run_record_over_manifest_when_both_exist(tmp_path
     assert manifest_only_run["round_trip_passed"] is True
 
 
-def test_persist_training_run_preserves_lora_canary_receipts(tmp_path: Path) -> None:
-    jobs_root = tmp_path / "model-ops"
-    manifest_path = jobs_root / "train_lora" / "model-ops-0001" / "train_lora.adapter.json"
-    manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest = {
-        "job_id": "model-ops-0001",
-        "operation": "train_lora",
-        "adapter_name": "demo-adapter",
-        "source_model": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
-        "source_eos_token": "<|source-eos|>",
-        "saved_eos_token": "<|source-eos|>",
-        "tokenizer_config_path": "/tmp/base/tokenizer_config.json",
-        "base_config_present": True,
-        "processor_resume_mode": "processor_config",
-        "aux_modules_restored": True,
-        "merge_export_canary_result": "pass",
-        "callback_api_drift_result": "pass",
-        "completion_loss": 0.125,
-        "round_trip_passed": True,
-        "grad_norm": 0.75,
-        "updated_at_unix_ms": 1_000,
-    }
-    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
-
-    paths = LoraExperimentStore().persist_training_run(
-        jobs_root=jobs_root,
-        manifest=manifest,
-        manifest_path=manifest_path,
-    )
-    run_payload = json.loads(paths["run"].read_text(encoding="utf-8"))
-
-    assert run_payload["source_eos_token"] == "<|source-eos|>"
-    assert run_payload["saved_eos_token"] == "<|source-eos|>"
-    assert run_payload["tokenizer_config_path"] == "/tmp/base/tokenizer_config.json"
-    assert run_payload["base_config_present"] is True
-    assert run_payload["processor_resume_mode"] == "processor_config"
-    assert run_payload["aux_modules_restored"] is True
-    assert run_payload["merge_export_canary_result"] == "pass"
-    assert run_payload["callback_api_drift_result"] == "pass"
-    assert run_payload["completion_loss"] == 0.125
-    assert run_payload["round_trip_passed"] is True
-    assert run_payload["grad_norm"] == 0.75
-
-
 def test_rebuild_index_skips_manifest_parse_when_run_record_exists(tmp_path: Path, monkeypatch) -> None:
     jobs_root = tmp_path / "model-ops"
     manifest_path = _write_manifest(jobs_root, run_id="model-ops-0001")

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -319,6 +319,47 @@ class SuccessfulRunner(MLXLMRunner):
         return self.activate_native(request)
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _lora_manifest_reason_receipt_probe(tmp_path_factory: pytest.TempPathFactory) -> None:
+    tmp_path = tmp_path_factory.mktemp("lora-runtime-reason-receipt")
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset",
+        samples=[
+            {
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "world"},
+                ]
+            }
+        ],
+    )
+    result = LoRATrainingPipeline(runner=SuccessfulRunner()).run(
+        job_id="train-runtime-reason-receipt",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "text-adapter",
+            "dataset_uri": str(dataset_dir),
+        },
+        source_model=common_pb2.ModelSpec(
+            model_id="melix-runtime-reason-text",
+            model_path=str(tmp_path / "qwen-base"),
+            model_kind="text",
+            revision="dev",
+            max_context=2048,
+            ext={"text_family_id": "qwen", "text_layer_count": "2"},
+        ),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    manifest = result.manifest
+    assert manifest["runtime_unsupported_reason"] == (
+        manifest["training_runtime_preflight"]["unsupported_reason"]
+    )
+    assert manifest["adapter_unsupported_reason"] == manifest["capability_gate"]["unsupported_reason"]
+    assert manifest["unsupported_reason"] == manifest["adapter_unsupported_reason"]
+
+
 class NativeUnavailableRunner(SuccessfulRunner):
     def train_native(self, request: TrainingRequest) -> TrainingResult:
         self.native_train_calls += 1
@@ -833,7 +874,6 @@ def test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alia
         "train",
         "validation",
     ]
-
 
 def test_train_lora_supports_dora_mode_contract_and_manifest(tmp_path: Path) -> None:
     dataset_dir = _write_dataset_package(

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -31,7 +31,6 @@ from worker.model_ops.lora_training_pipeline import (
     _validated_resume_path,
 )
 from worker.model_ops.lora_runtime_metadata import build_adapter_runtime_manifest_fields
-from worker.model_ops.lora_runtime_metadata import build_lora_canary_receipt_fields
 from worker.model_ops.lora_runtime_metadata import build_quantized_lora_manifest_fields
 from worker.model_ops.multimodal_lora_contracts import (
     _adapter_parameter_matches_fragment,
@@ -199,43 +198,6 @@ def test_lora_training_manifest_records_quantized_qlora_compatibility_for_gemma8
     assert freeze_audit["adapter_checkpoint_size_within_target"] is True
 
 
-def test_lora_training_manifest_records_canary_receipts(tmp_path: Path) -> None:
-    dataset_dir = _write_dataset_package(tmp_path / "dataset")
-    base_model_dir = tmp_path / "base-model"
-    base_model_dir.mkdir()
-    (base_model_dir / "config.json").write_text('{"model_type":"qwen2"}\n', encoding="utf-8")
-    (base_model_dir / "tokenizer_config.json").write_text(
-        json.dumps({"eos_token": "<|endoftext|>"}) + "\n",
-        encoding="utf-8",
-    )
-    (base_model_dir / "processor_config.json").write_text('{"processor_class":"AutoProcessor"}\n', encoding="utf-8")
-    (base_model_dir / "modeling_qwen2.py").write_text("# custom module\n", encoding="utf-8")
-
-    result = LoRATrainingPipeline(runner=DeterministicLoRARunner()).run(
-        job_id="train-canary-receipts",
-        request_ext={
-            "operation": "train_lora",
-            "adapter_name": "canary-adapter",
-            "dataset_uri": str(dataset_dir),
-        },
-        source_model=_text_model(model_path=str(base_model_dir), family_id="qwen"),
-        output_dir=tmp_path / "output",
-        jobs_root=tmp_path / "jobs",
-    )
-
-    assert result.manifest["source_eos_token"] == "<|endoftext|>"
-    assert result.manifest["saved_eos_token"] == "<|endoftext|>"
-    assert result.manifest["tokenizer_config_path"] == str(base_model_dir / "tokenizer_config.json")
-    assert result.manifest["base_config_present"] is True
-    assert result.manifest["processor_resume_mode"] == "processor_config"
-    assert result.manifest["aux_modules_restored"] is True
-    assert result.manifest["merge_export_canary_result"] == "pass"
-    assert result.manifest["callback_api_drift_result"] == "pass"
-    assert result.manifest["completion_loss"] == 0.42
-    assert result.manifest["round_trip_passed"] is True
-    assert result.manifest["grad_norm"] == 0.0
-
-
 def test_quantized_lora_metadata_does_not_treat_fp_profile_as_quantized() -> None:
     source_model = _text_model(
         model_path="mlx-community/plain-gemma-bf16",
@@ -256,127 +218,6 @@ def test_quantized_lora_metadata_does_not_treat_fp_profile_as_quantized() -> Non
     assert fields["quantized_base_evidence_source"] == ""
     assert fields["qlora_compatibility_status"] == "not_applicable"
     assert fields["quantized_target_module_guard"] == "not_required"
-
-
-def test_lora_canary_receipt_records_tokenizer_resume_and_drift_status(
-    tmp_path: Path,
-) -> None:
-    base_model_dir = tmp_path / "base-model"
-    base_model_dir.mkdir()
-    (base_model_dir / "config.json").write_text('{"model_type":"qwen2"}\n', encoding="utf-8")
-    (base_model_dir / "tokenizer_config.json").write_text(
-        json.dumps({"eos_token": "<|source-eos|>"}) + "\n",
-        encoding="utf-8",
-    )
-    (base_model_dir / "tokenizer.json").write_text(
-        json.dumps({"model": {}, "added_tokens": [{"content": "<|source-eos|>", "special": True}]})
-        + "\n",
-        encoding="utf-8",
-    )
-    (base_model_dir / "processor_config.json").write_text('{"processor_class":"AutoProcessor"}\n', encoding="utf-8")
-    (base_model_dir / "modeling_qwen2.py").write_text("# custom module\n", encoding="utf-8")
-
-    adapter_dir = tmp_path / "adapter"
-    adapter_dir.mkdir()
-    adapter_config_path = adapter_dir / "adapter_config.json"
-    adapter_config_path.write_text(
-        json.dumps(
-            {
-                "tokenizer_config": {"eos_token": "<|source-eos|>"},
-                "completion_loss": 0.125,
-                "grad_norm": 0.75,
-                "round_trip_passed": True,
-                "callback_arity": 2,
-                "expected_callback_arity": 2,
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    weights_path = adapter_dir / "adapters.safetensors"
-    weights_path.write_bytes(b"adapter")
-
-    fields = build_lora_canary_receipt_fields(
-        source_model=_text_model(model_path=str(base_model_dir)),
-        adapter_output_dir=adapter_dir,
-        adapter_config_path=adapter_config_path,
-        weights_path=weights_path,
-        training_metrics=TrainingMetrics(
-            job_duration_ms=1.0,
-            tokens_seen=8,
-            examples_seen=1,
-            loss_final=0.125,
-            loss_best=0.125,
-            learning_rate_final=1e-5,
-            grad_norm=0.75,
-            completion_loss=0.125,
-            round_trip_passed=True,
-        ),
-    )
-
-    assert fields["source_eos_token"] == "<|source-eos|>"
-    assert fields["saved_eos_token"] == "<|source-eos|>"
-    assert fields["tokenizer_config_path"] == str(base_model_dir / "tokenizer_config.json")
-    assert fields["base_config_present"] is True
-    assert fields["processor_resume_mode"] == "processor_config"
-    assert fields["aux_modules_restored"] is True
-    assert fields["merge_export_canary_result"] == "pass"
-    assert fields["callback_api_drift_result"] == "pass"
-    assert fields["completion_loss"] == 0.125
-    assert fields["round_trip_passed"] is True
-    assert fields["grad_norm"] == 0.75
-
-
-def test_lora_canary_receipt_detects_missing_checkpoint_resume_assets(
-    tmp_path: Path,
-) -> None:
-    base_model_dir = tmp_path / "base-model"
-    base_model_dir.mkdir()
-    (base_model_dir / "config.json").write_text('{"model_type":"qwen2"}\n', encoding="utf-8")
-    (base_model_dir / "tokenizer_config.json").write_text(
-        json.dumps({"model_max_length": 8192}) + "\n",
-        encoding="utf-8",
-    )
-    adapter_dir = tmp_path / "adapter"
-    adapter_dir.mkdir()
-    adapter_config_path = adapter_dir / "adapter_config.json"
-    adapter_config_path.write_text(
-        json.dumps(
-            {
-                "tokenizer_config": {"eos_token": "<|saved-eos|>"},
-                "callback_arity": 3,
-                "expected_callback_arity": 2,
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    weights_path = adapter_dir / "adapters.safetensors"
-    weights_path.write_bytes(b"adapter")
-
-    fields = build_lora_canary_receipt_fields(
-        source_model=_text_model(model_path=str(base_model_dir)),
-        adapter_output_dir=adapter_dir,
-        adapter_config_path=adapter_config_path,
-        weights_path=weights_path,
-        training_metrics=TrainingMetrics(
-            job_duration_ms=1.0,
-            tokens_seen=8,
-            examples_seen=1,
-            loss_final=0.5,
-            loss_best=0.5,
-            learning_rate_final=1e-5,
-        ),
-    )
-
-    assert fields["source_eos_token"] == ""
-    assert fields["saved_eos_token"] == "<|saved-eos|>"
-    assert fields["tokenizer_config_path"] == str(base_model_dir / "tokenizer_config.json")
-    assert fields["base_config_present"] is True
-    assert fields["processor_resume_mode"] == "tokenizer_only"
-    assert fields["aux_modules_restored"] is False
-    assert fields["merge_export_canary_result"] == "fail:missing_source_eos_token,missing_auxiliary_modules"
-    assert fields["callback_api_drift_result"] == "fail:callback_arity_mismatch"
 
 
 def test_normalize_training_config_rejects_qlora_for_non_quantized_profile() -> None:

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -2759,14 +2759,28 @@ def test_extract_structured_result_payload_accepts_carriage_return_line_end() ->
         f"{mlx_lm_runner_module._RESULT_PREFIX}{json.dumps(payload)}\r\n"
         "tail noise"
     )
+    carriage_only_stdout = (
+        "leading noise\r"
+        f"{mlx_lm_runner_module._RESULT_PREFIX}{json.dumps(payload)}\r"
+        "tail noise"
+    )
 
     assert mlx_lm_runner_module._extract_structured_result_payload(stdout) == payload
-
+    assert mlx_lm_runner_module._extract_structured_result_payload(carriage_only_stdout) == payload
 
 
 def test_extract_structured_result_payload_skips_embedded_prefix_and_finds_prior_line() -> None:
     payload = {"value": 7}
-    stdout = (
+
+    class NoCarriageFindStr(str):
+        def find(self, sub: str, *args: object) -> int:  # type: ignore[override]
+            if sub == "\r":
+                raise AssertionError(  # pragma: no cover - assertion path must stay unreachable.
+                    "newline-terminated result should not scan for carriage returns"
+                )
+            return super().find(sub, *args)
+
+    stdout = NoCarriageFindStr(
         f"{mlx_lm_runner_module._RESULT_PREFIX}{json.dumps(payload)}\n"
         "trailing log __MELIX_MLX_RESULT__=not-a-result-line"
     )

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -31,6 +31,7 @@ from worker.model_ops.lora_training_pipeline import (
     _validated_resume_path,
 )
 from worker.model_ops.lora_runtime_metadata import build_adapter_runtime_manifest_fields
+from worker.model_ops.lora_runtime_metadata import build_lora_canary_receipt_fields
 from worker.model_ops.lora_runtime_metadata import build_quantized_lora_manifest_fields
 from worker.model_ops.multimodal_lora_contracts import (
     _adapter_parameter_matches_fragment,
@@ -198,6 +199,43 @@ def test_lora_training_manifest_records_quantized_qlora_compatibility_for_gemma8
     assert freeze_audit["adapter_checkpoint_size_within_target"] is True
 
 
+def test_lora_training_manifest_records_canary_receipts(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(tmp_path / "dataset")
+    base_model_dir = tmp_path / "base-model"
+    base_model_dir.mkdir()
+    (base_model_dir / "config.json").write_text('{"model_type":"qwen2"}\n', encoding="utf-8")
+    (base_model_dir / "tokenizer_config.json").write_text(
+        json.dumps({"eos_token": "<|endoftext|>"}) + "\n",
+        encoding="utf-8",
+    )
+    (base_model_dir / "processor_config.json").write_text('{"processor_class":"AutoProcessor"}\n', encoding="utf-8")
+    (base_model_dir / "modeling_qwen2.py").write_text("# custom module\n", encoding="utf-8")
+
+    result = LoRATrainingPipeline(runner=DeterministicLoRARunner()).run(
+        job_id="train-canary-receipts",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "canary-adapter",
+            "dataset_uri": str(dataset_dir),
+        },
+        source_model=_text_model(model_path=str(base_model_dir), family_id="qwen"),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    assert result.manifest["source_eos_token"] == "<|endoftext|>"
+    assert result.manifest["saved_eos_token"] == "<|endoftext|>"
+    assert result.manifest["tokenizer_config_path"] == str(base_model_dir / "tokenizer_config.json")
+    assert result.manifest["base_config_present"] is True
+    assert result.manifest["processor_resume_mode"] == "processor_config"
+    assert result.manifest["aux_modules_restored"] is True
+    assert result.manifest["merge_export_canary_result"] == "pass"
+    assert result.manifest["callback_api_drift_result"] == "pass"
+    assert result.manifest["completion_loss"] == 0.42
+    assert result.manifest["round_trip_passed"] is True
+    assert result.manifest["grad_norm"] == 0.0
+
+
 def test_quantized_lora_metadata_does_not_treat_fp_profile_as_quantized() -> None:
     source_model = _text_model(
         model_path="mlx-community/plain-gemma-bf16",
@@ -218,6 +256,127 @@ def test_quantized_lora_metadata_does_not_treat_fp_profile_as_quantized() -> Non
     assert fields["quantized_base_evidence_source"] == ""
     assert fields["qlora_compatibility_status"] == "not_applicable"
     assert fields["quantized_target_module_guard"] == "not_required"
+
+
+def test_lora_canary_receipt_records_tokenizer_resume_and_drift_status(
+    tmp_path: Path,
+) -> None:
+    base_model_dir = tmp_path / "base-model"
+    base_model_dir.mkdir()
+    (base_model_dir / "config.json").write_text('{"model_type":"qwen2"}\n', encoding="utf-8")
+    (base_model_dir / "tokenizer_config.json").write_text(
+        json.dumps({"eos_token": "<|source-eos|>"}) + "\n",
+        encoding="utf-8",
+    )
+    (base_model_dir / "tokenizer.json").write_text(
+        json.dumps({"model": {}, "added_tokens": [{"content": "<|source-eos|>", "special": True}]})
+        + "\n",
+        encoding="utf-8",
+    )
+    (base_model_dir / "processor_config.json").write_text('{"processor_class":"AutoProcessor"}\n', encoding="utf-8")
+    (base_model_dir / "modeling_qwen2.py").write_text("# custom module\n", encoding="utf-8")
+
+    adapter_dir = tmp_path / "adapter"
+    adapter_dir.mkdir()
+    adapter_config_path = adapter_dir / "adapter_config.json"
+    adapter_config_path.write_text(
+        json.dumps(
+            {
+                "tokenizer_config": {"eos_token": "<|source-eos|>"},
+                "completion_loss": 0.125,
+                "grad_norm": 0.75,
+                "round_trip_passed": True,
+                "callback_arity": 2,
+                "expected_callback_arity": 2,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    weights_path = adapter_dir / "adapters.safetensors"
+    weights_path.write_bytes(b"adapter")
+
+    fields = build_lora_canary_receipt_fields(
+        source_model=_text_model(model_path=str(base_model_dir)),
+        adapter_output_dir=adapter_dir,
+        adapter_config_path=adapter_config_path,
+        weights_path=weights_path,
+        training_metrics=TrainingMetrics(
+            job_duration_ms=1.0,
+            tokens_seen=8,
+            examples_seen=1,
+            loss_final=0.125,
+            loss_best=0.125,
+            learning_rate_final=1e-5,
+            grad_norm=0.75,
+            completion_loss=0.125,
+            round_trip_passed=True,
+        ),
+    )
+
+    assert fields["source_eos_token"] == "<|source-eos|>"
+    assert fields["saved_eos_token"] == "<|source-eos|>"
+    assert fields["tokenizer_config_path"] == str(base_model_dir / "tokenizer_config.json")
+    assert fields["base_config_present"] is True
+    assert fields["processor_resume_mode"] == "processor_config"
+    assert fields["aux_modules_restored"] is True
+    assert fields["merge_export_canary_result"] == "pass"
+    assert fields["callback_api_drift_result"] == "pass"
+    assert fields["completion_loss"] == 0.125
+    assert fields["round_trip_passed"] is True
+    assert fields["grad_norm"] == 0.75
+
+
+def test_lora_canary_receipt_detects_missing_checkpoint_resume_assets(
+    tmp_path: Path,
+) -> None:
+    base_model_dir = tmp_path / "base-model"
+    base_model_dir.mkdir()
+    (base_model_dir / "config.json").write_text('{"model_type":"qwen2"}\n', encoding="utf-8")
+    (base_model_dir / "tokenizer_config.json").write_text(
+        json.dumps({"model_max_length": 8192}) + "\n",
+        encoding="utf-8",
+    )
+    adapter_dir = tmp_path / "adapter"
+    adapter_dir.mkdir()
+    adapter_config_path = adapter_dir / "adapter_config.json"
+    adapter_config_path.write_text(
+        json.dumps(
+            {
+                "tokenizer_config": {"eos_token": "<|saved-eos|>"},
+                "callback_arity": 3,
+                "expected_callback_arity": 2,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    weights_path = adapter_dir / "adapters.safetensors"
+    weights_path.write_bytes(b"adapter")
+
+    fields = build_lora_canary_receipt_fields(
+        source_model=_text_model(model_path=str(base_model_dir)),
+        adapter_output_dir=adapter_dir,
+        adapter_config_path=adapter_config_path,
+        weights_path=weights_path,
+        training_metrics=TrainingMetrics(
+            job_duration_ms=1.0,
+            tokens_seen=8,
+            examples_seen=1,
+            loss_final=0.5,
+            loss_best=0.5,
+            learning_rate_final=1e-5,
+        ),
+    )
+
+    assert fields["source_eos_token"] == ""
+    assert fields["saved_eos_token"] == "<|saved-eos|>"
+    assert fields["tokenizer_config_path"] == str(base_model_dir / "tokenizer_config.json")
+    assert fields["base_config_present"] is True
+    assert fields["processor_resume_mode"] == "tokenizer_only"
+    assert fields["aux_modules_restored"] is False
+    assert fields["merge_export_canary_result"] == "fail:missing_source_eos_token,missing_auxiliary_modules"
+    assert fields["callback_api_drift_result"] == "fail:callback_arity_mismatch"
 
 
 def test_normalize_training_config_rejects_qlora_for_non_quantized_profile() -> None:

--- a/services/mlx-worker-python/tests/test_lora_training_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_receipts.py
@@ -18,6 +18,7 @@ from worker.model_ops.lora_training_pipeline import (
     LoRATrainingPipeline,
 )
 from worker.model_ops.training_runtime_preflight import (
+    runtime_preflight_failure_details,
     training_runtime_preflight_fields as _training_runtime_preflight_fields,
 )
 from worker.model_ops.mlx_lm_runner import TrainingMetrics
@@ -441,6 +442,77 @@ def test_training_failure_cleanup_details_clear_nested_tracebacks_and_report_ret
     assert "inner tensor load failed" in exc.value.details["traceback_summary_before_cleanup"]
     assert captured["outer"].__traceback__ is None
     assert captured["inner"].__traceback__ is None
+
+
+def test_training_failure_cleanup_preserves_runtime_preflight_details(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fake_find_spec(name: str):
+        if name in {"mlx", "mlx_lm"}:
+            return object()
+        if name == "PIL":
+            raise ValueError("corrupt decoder spec")
+        return object()
+
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("importlib.util.find_spec", fake_find_spec)
+
+    class FailingRunner(DeterministicLoRARunner):
+        def train_native(self, request):  # noqa: ANN001
+            _ = request
+            raise RuntimeError("native trainer crashed before adapter output")
+
+    dataset_dir = _write_dataset_package(tmp_path / "dataset")
+
+    with pytest.raises(ModelOperationError) as exc:
+        LoRATrainingPipeline(runner=FailingRunner()).run(
+            job_id="train-runtime-preflight-failure",
+            request_ext={
+                "operation": "train_lora",
+                "adapter_name": "runtime-preflight-adapter",
+                "dataset_uri": str(dataset_dir),
+            },
+            source_model=_text_model(model_path=str(tmp_path / "base-model")),
+            output_dir=tmp_path / "output",
+            jobs_root=tmp_path / "jobs",
+        )
+
+    assert exc.value.code == "backend_training_failure"
+    assert exc.value.details["runtime_gate"] == "ready"
+    assert exc.value.details["native_load_status"] == "available"
+    assert exc.value.details["disabled_decoder_paths"] == "media"
+    assert exc.value.details["media_decoder_dependency_state"] == "broken"
+    assert exc.value.details["media_decoder_dependency_module"] == "PIL"
+    assert exc.value.details["unsupported_reason"] == ""
+    assert exc.value.details["traceback_cleanup_result"] == "cleared"
+    retained_bytes = int(exc.value.details["retained_tensor_bytes_after_failure"])
+    assert 0 <= retained_bytes < 1024 * 1024
+
+
+def test_runtime_preflight_failure_details_coerces_unexpected_receipt_shapes() -> None:
+    details = runtime_preflight_failure_details(
+        {
+            "runtime_gate": "unsupported",
+            "inspection_only_import": True,
+            "native_load_status": "disabled",
+            "disabled_decoder_paths": "media",
+            "fallback_reader": "metadata_only",
+            "unsupported_reason": "non_apple_host",
+            "media_decoder_dependency": "not-a-dict",
+        }
+    )
+
+    assert details == {
+        "runtime_gate": "unsupported",
+        "inspection_only_import": "true",
+        "native_load_status": "disabled",
+        "disabled_decoder_paths": "media",
+        "fallback_reader": "metadata_only",
+        "unsupported_reason": "non_apple_host",
+        "media_decoder_dependency_state": "",
+        "media_decoder_dependency_module": "",
+    }
 
 
 def test_lora_canary_receipt_records_tokenizer_resume_and_drift_status(

--- a/services/mlx-worker-python/tests/test_lora_training_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_receipts.py
@@ -690,7 +690,9 @@ def test_lora_canary_receipt_detects_missing_checkpoint_resume_assets(
     assert fields["base_config_present"] is False
     assert fields["processor_resume_mode"] == "missing"
     assert fields["aux_modules_restored"] is False
-    assert fields["merge_export_canary_result"] == "fail:missing_base_config,missing_tokenizer_config"
+    assert fields["merge_export_canary_result"] == (
+        "fail:missing_base_config,missing_tokenizer_config,missing_auxiliary_modules"
+    )
     assert fields["callback_api_drift_result"] == "fail:callback_arity_mismatch"
 
 

--- a/services/mlx-worker-python/tests/test_lora_training_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_receipts.py
@@ -604,6 +604,32 @@ def test_lora_canary_receipt_records_tokenizer_resume_and_drift_status(
     assert fields["round_trip_passed"] is True
     assert fields["grad_norm"] == 0.75
 
+    with pytest.raises(ModelOperationError) as exc:
+        training_config_module.normalize_training_config(
+            source_model=_text_model(family_id="qwen"),
+            ext={"learning_rate": "-inf"},
+            dataset_format="chat_messages",
+            response_only_supported=True,
+            sample_count=1,
+        )
+    assert exc.value.code == "invalid_argument"
+    assert exc.value.details == {
+        "field": "learning_rate",
+        "reason": "below_minimum",
+        "received": "-inf",
+        "minimum": "0.0",
+        "allowed_bounds": "finite >=0.0",
+        "http_status": "422",
+    }
+
+    details = runtime_preflight_failure_details(
+        {
+            "runtime_gate": "ready",
+            "disabled_decoder_paths": None,
+        }
+    )
+    assert details["disabled_decoder_paths"] == ""
+
 
 def test_lora_canary_aux_module_detection_uses_single_scandir(
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/tests/test_lora_training_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_receipts.py
@@ -602,6 +602,44 @@ def test_lora_canary_receipt_detects_missing_checkpoint_resume_assets(
     )
     assert fields["callback_api_drift_result"] == "fail:callback_arity_mismatch"
 
+    missing_eos_base_dir = tmp_path / "base-model-missing-eos"
+    missing_eos_base_dir.mkdir()
+    (missing_eos_base_dir / "config.json").write_text('{"model_type":"qwen2"}\n', encoding="utf-8")
+    (missing_eos_base_dir / "tokenizer_config.json").write_text(
+        json.dumps({"tokenizer_class": "Qwen2Tokenizer"}) + "\n",
+        encoding="utf-8",
+    )
+    missing_eos_adapter_dir = tmp_path / "adapter-missing-eos"
+    missing_eos_adapter_dir.mkdir()
+    missing_eos_adapter_config_path = missing_eos_adapter_dir / "adapter_config.json"
+    missing_eos_adapter_config_path.write_text(
+        json.dumps({"tokenizer_config": {"tokenizer_class": "Qwen2Tokenizer"}}) + "\n",
+        encoding="utf-8",
+    )
+    missing_eos_weights_path = missing_eos_adapter_dir / "adapters.safetensors"
+    missing_eos_weights_path.write_bytes(b"adapter")
+
+    missing_eos_fields = build_lora_canary_receipt_fields(
+        source_model=_text_model(model_path=str(missing_eos_base_dir)),
+        adapter_output_dir=missing_eos_adapter_dir,
+        adapter_config_path=missing_eos_adapter_config_path,
+        weights_path=missing_eos_weights_path,
+        training_metrics=TrainingMetrics(
+            job_duration_ms=1.0,
+            tokens_seen=8,
+            examples_seen=1,
+            loss_final=0.5,
+            loss_best=0.5,
+            learning_rate_final=1e-5,
+        ),
+    )
+
+    assert missing_eos_fields["source_eos_token"] == ""
+    assert missing_eos_fields["saved_eos_token"] == ""
+    assert missing_eos_fields["merge_export_canary_result"] == (
+        "fail:missing_source_eos_token,missing_saved_eos_token,missing_auxiliary_modules"
+    )
+
 
 def test_training_config_records_scheduler_kwargs_omission_receipt() -> None:
     config = training_config_module.normalize_training_config(

--- a/services/mlx-worker-python/tests/test_lora_training_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_receipts.py
@@ -18,7 +18,6 @@ from worker.model_ops.lora_training_pipeline import (
     LoRATrainingPipeline,
 )
 from worker.model_ops.training_runtime_preflight import (
-    runtime_preflight_failure_details,
     training_runtime_preflight_fields as _training_runtime_preflight_fields,
 )
 from worker.model_ops.mlx_lm_runner import TrainingMetrics
@@ -111,27 +110,6 @@ def test_training_admission_rejects_invalid_hyperparameters_with_typed_details()
         "received": "0",
         "minimum": "1",
         "allowed_bounds": ">=1",
-        "http_status": "422",
-    }
-
-
-def test_training_admission_rejects_non_finite_float_hyperparameters() -> None:
-    with pytest.raises(ModelOperationError) as exc:
-        training_config_module.normalize_training_config(
-            source_model=_text_model(family_id="qwen"),
-            ext={"learning_rate": "nan"},
-            dataset_format="chat_messages",
-            response_only_supported=True,
-            sample_count=1,
-        )
-
-    assert exc.value.code == "invalid_argument"
-    assert exc.value.details == {
-        "field": "learning_rate",
-        "reason": "not_finite",
-        "received": "nan",
-        "minimum": "0.0",
-        "allowed_bounds": "finite >=0.0",
         "http_status": "422",
     }
 
@@ -465,77 +443,6 @@ def test_training_failure_cleanup_details_clear_nested_tracebacks_and_report_ret
     assert captured["inner"].__traceback__ is None
 
 
-def test_training_failure_cleanup_preserves_runtime_preflight_details(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    def fake_find_spec(name: str):
-        if name in {"mlx", "mlx_lm"}:
-            return object()
-        if name == "PIL":
-            raise ValueError("corrupt decoder spec")
-        return object()
-
-    monkeypatch.setattr("platform.system", lambda: "Darwin")
-    monkeypatch.setattr("importlib.util.find_spec", fake_find_spec)
-
-    class FailingRunner(DeterministicLoRARunner):
-        def train_native(self, request):  # noqa: ANN001
-            _ = request
-            raise RuntimeError("native trainer crashed before adapter output")
-
-    dataset_dir = _write_dataset_package(tmp_path / "dataset")
-
-    with pytest.raises(ModelOperationError) as exc:
-        LoRATrainingPipeline(runner=FailingRunner()).run(
-            job_id="train-runtime-preflight-failure",
-            request_ext={
-                "operation": "train_lora",
-                "adapter_name": "runtime-preflight-adapter",
-                "dataset_uri": str(dataset_dir),
-            },
-            source_model=_text_model(model_path=str(tmp_path / "base-model")),
-            output_dir=tmp_path / "output",
-            jobs_root=tmp_path / "jobs",
-        )
-
-    assert exc.value.code == "backend_training_failure"
-    assert exc.value.details["runtime_gate"] == "ready"
-    assert exc.value.details["native_load_status"] == "available"
-    assert exc.value.details["disabled_decoder_paths"] == "media"
-    assert exc.value.details["media_decoder_dependency_state"] == "broken"
-    assert exc.value.details["media_decoder_dependency_module"] == "PIL"
-    assert exc.value.details["unsupported_reason"] == ""
-    assert exc.value.details["traceback_cleanup_result"] == "cleared"
-    retained_bytes = int(exc.value.details["retained_tensor_bytes_after_failure"])
-    assert 0 <= retained_bytes < 1024 * 1024
-
-
-def test_runtime_preflight_failure_details_coerces_unexpected_receipt_shapes() -> None:
-    details = runtime_preflight_failure_details(
-        {
-            "runtime_gate": "unsupported",
-            "inspection_only_import": True,
-            "native_load_status": "disabled",
-            "disabled_decoder_paths": "media",
-            "fallback_reader": "metadata_only",
-            "unsupported_reason": "non_apple_host",
-            "media_decoder_dependency": "not-a-dict",
-        }
-    )
-
-    assert details == {
-        "runtime_gate": "unsupported",
-        "inspection_only_import": "true",
-        "native_load_status": "disabled",
-        "disabled_decoder_paths": "media",
-        "fallback_reader": "metadata_only",
-        "unsupported_reason": "non_apple_host",
-        "media_decoder_dependency_state": "",
-        "media_decoder_dependency_module": "",
-    }
-
-
 def test_lora_canary_receipt_records_tokenizer_resume_and_drift_status(
     tmp_path: Path,
 ) -> None:
@@ -603,32 +510,6 @@ def test_lora_canary_receipt_records_tokenizer_resume_and_drift_status(
     assert fields["completion_loss"] == 0.125
     assert fields["round_trip_passed"] is True
     assert fields["grad_norm"] == 0.75
-
-    with pytest.raises(ModelOperationError) as exc:
-        training_config_module.normalize_training_config(
-            source_model=_text_model(family_id="qwen"),
-            ext={"learning_rate": "-inf"},
-            dataset_format="chat_messages",
-            response_only_supported=True,
-            sample_count=1,
-        )
-    assert exc.value.code == "invalid_argument"
-    assert exc.value.details == {
-        "field": "learning_rate",
-        "reason": "below_minimum",
-        "received": "-inf",
-        "minimum": "0.0",
-        "allowed_bounds": "finite >=0.0",
-        "http_status": "422",
-    }
-
-    details = runtime_preflight_failure_details(
-        {
-            "runtime_gate": "ready",
-            "disabled_decoder_paths": None,
-        }
-    )
-    assert details["disabled_decoder_paths"] == ""
 
 
 def test_lora_canary_aux_module_detection_uses_single_scandir(

--- a/services/mlx-worker-python/tests/test_lora_training_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_receipts.py
@@ -115,6 +115,27 @@ def test_training_admission_rejects_invalid_hyperparameters_with_typed_details()
     }
 
 
+def test_training_admission_rejects_non_finite_float_hyperparameters() -> None:
+    with pytest.raises(ModelOperationError) as exc:
+        training_config_module.normalize_training_config(
+            source_model=_text_model(family_id="qwen"),
+            ext={"learning_rate": "nan"},
+            dataset_format="chat_messages",
+            response_only_supported=True,
+            sample_count=1,
+        )
+
+    assert exc.value.code == "invalid_argument"
+    assert exc.value.details == {
+        "field": "learning_rate",
+        "reason": "not_finite",
+        "received": "nan",
+        "minimum": "0.0",
+        "allowed_bounds": "finite >=0.0",
+        "http_status": "422",
+    }
+
+
 def test_training_admission_receipt_records_resolved_controls(tmp_path: Path) -> None:
     dataset_dir = _write_dataset_package(
         tmp_path / "dataset-with-validation",

--- a/services/mlx-worker-python/tests/test_lora_training_runtime_preflight_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_runtime_preflight_receipts.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from packages.protocol.python.worker.v1 import common_pb2
+
+from worker.model_ops import training_config as training_config_module
+from worker.model_ops.deterministic_lora_runner import DeterministicLoRARunner
+from worker.model_ops.errors import ModelOperationError
+from worker.model_ops.lora_training_pipeline import LoRATrainingPipeline
+from worker.model_ops.training_runtime_preflight import runtime_preflight_failure_details
+
+
+def _write_dataset_package(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "melix-dev-dataset",
+                "format": "chat_messages",
+                "sample_count": 1,
+                "version": "1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "samples.jsonl").write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "world"},
+                ]
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def _text_model(*, model_path: str = "models/plain-llama", family_id: str = "") -> common_pb2.ModelSpec:
+    model = common_pb2.ModelSpec(
+        model_id="melix-test-text",
+        model_path=model_path,
+        model_kind="text",
+        revision="main",
+        max_context=4096,
+    )
+    if family_id:
+        model.ext["text_family_id"] = family_id
+    model.ext["text_layer_count"] = "2"
+    return model
+
+
+@pytest.mark.parametrize(
+    ("received", "reason"),
+    [
+        ("nan", "not_finite"),
+        ("-inf", "below_minimum"),
+    ],
+)
+def test_training_admission_rejects_non_finite_float_hyperparameters(
+    received: str,
+    reason: str,
+) -> None:
+    with pytest.raises(ModelOperationError) as exc:
+        training_config_module.normalize_training_config(
+            source_model=_text_model(family_id="qwen"),
+            ext={"learning_rate": received},
+            dataset_format="chat_messages",
+            response_only_supported=True,
+            sample_count=1,
+        )
+
+    assert exc.value.code == "invalid_argument"
+    assert exc.value.details == {
+        "field": "learning_rate",
+        "reason": reason,
+        "received": received,
+        "minimum": "0.0",
+        "allowed_bounds": "finite >=0.0",
+        "http_status": "422",
+    }
+
+
+def test_training_failure_cleanup_preserves_runtime_preflight_details(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fake_find_spec(name: str):
+        if name in {"mlx", "mlx_lm"}:
+            return object()
+        if name == "PIL":
+            raise ValueError("corrupt decoder spec")
+        return object()
+
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("importlib.util.find_spec", fake_find_spec)
+
+    class FailingRunner(DeterministicLoRARunner):
+        def train_native(self, request):  # noqa: ANN001
+            _ = request
+            raise RuntimeError("native trainer crashed before adapter output")
+
+    dataset_dir = _write_dataset_package(tmp_path / "dataset")
+
+    with pytest.raises(ModelOperationError) as exc:
+        LoRATrainingPipeline(runner=FailingRunner()).run(
+            job_id="train-runtime-preflight-failure",
+            request_ext={
+                "operation": "train_lora",
+                "adapter_name": "runtime-preflight-adapter",
+                "dataset_uri": str(dataset_dir),
+            },
+            source_model=_text_model(model_path=str(tmp_path / "base-model")),
+            output_dir=tmp_path / "output",
+            jobs_root=tmp_path / "jobs",
+        )
+
+    assert exc.value.code == "backend_training_failure"
+    assert exc.value.details["runtime_gate"] == "ready"
+    assert exc.value.details["native_load_status"] == "available"
+    assert exc.value.details["disabled_decoder_paths"] == "media"
+    assert exc.value.details["media_decoder_dependency_state"] == "broken"
+    assert exc.value.details["media_decoder_dependency_module"] == "PIL"
+    assert exc.value.details["unsupported_reason"] == ""
+    assert exc.value.details["traceback_cleanup_result"] == "cleared"
+    retained_bytes = int(exc.value.details["retained_tensor_bytes_after_failure"])
+    assert 0 <= retained_bytes < 1024 * 1024
+
+
+def test_runtime_preflight_failure_details_coerces_unexpected_receipt_shapes() -> None:
+    details = runtime_preflight_failure_details(
+        {
+            "runtime_gate": "unsupported",
+            "inspection_only_import": True,
+            "native_load_status": "disabled",
+            "disabled_decoder_paths": "media",
+            "fallback_reader": "metadata_only",
+            "unsupported_reason": "non_apple_host",
+            "media_decoder_dependency": "not-a-dict",
+        }
+    )
+
+    assert details == {
+        "runtime_gate": "unsupported",
+        "inspection_only_import": "true",
+        "native_load_status": "disabled",
+        "disabled_decoder_paths": "media",
+        "fallback_reader": "metadata_only",
+        "unsupported_reason": "non_apple_host",
+        "media_decoder_dependency_state": "",
+        "media_decoder_dependency_module": "",
+    }
+
+    empty_paths_details = runtime_preflight_failure_details(
+        {
+            "runtime_gate": "ready",
+            "disabled_decoder_paths": None,
+        }
+    )
+    assert empty_paths_details["disabled_decoder_paths"] == ""

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -3,8 +3,158 @@ from __future__ import annotations
 import json
 import logging
 
+import pytest
+
 from worker.runtime import stream_assembler
-from worker.runtime.stream_assembler import RequestStreamAssembler, StreamFragment
+from worker.runtime.stream_assembler import (
+    AssembledToolCall,
+    AssemblyDelta,
+    RequestStreamAssembler,
+    StreamFragment,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _token_count_routing_probe() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-token-count-spans",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+    deltas = assembler.accept(
+        StreamFragment(
+            raw_text=(
+                "<think>alpha beta gamma</think>"
+                '<tool_call>{"name":"search","arguments":{"q":"one"}}</tool_call>'
+                "visible"
+            ),
+            token_ids=(101, 102, 103, 104, 105, 106),
+        )
+    )
+    plain_assembler = RequestStreamAssembler(
+        request_id="req-plain-token-count",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+    plain_deltas = plain_assembler.accept(
+        StreamFragment(raw_text="visible plain", token_ids=(201, 202))
+    )
+    default_plain_assembler = RequestStreamAssembler(
+        request_id="req-plain-default-token-count",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+    default_plain_deltas = default_plain_assembler.accept(
+        StreamFragment(raw_text="visible default")
+    )
+    observed_assembler = RequestStreamAssembler(
+        request_id="req-observed-default-token-count",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+    observed_deltas = observed_assembler.accept(
+        StreamFragment(raw_text="observed visible", parser_observation="flush_tokens=0")
+    )
+    empty_annotated = assembler._annotate_token_counts([], 2)
+    single_annotated = assembler._annotate_token_counts(
+        [AssemblyDelta(content_text="visible")],
+        2,
+    )
+    compressed = assembler._annotate_token_counts(
+        [
+            AssemblyDelta(reasoning_text="alpha beta"),
+            AssemblyDelta(tool_call=AssembledToolCall("call-1", "search", "{}", 1, "qwen")),
+            AssemblyDelta(content_text="visible"),
+        ],
+        2,
+    )
+    compressed_with_extra = assembler._annotate_token_counts(
+        [
+            AssemblyDelta(reasoning_text="alpha beta gamma"),
+            AssemblyDelta(tool_call=AssembledToolCall("call-2", "search", "{}", 1, "qwen")),
+            AssemblyDelta(content_text="visible"),
+        ],
+        4,
+    )
+    compressed_after_sparse_extra = assembler._annotate_token_counts(
+        [
+            AssemblyDelta(content_text="visible"),
+            AssemblyDelta(reasoning_text="alpha beta gamma"),
+            AssemblyDelta(tool_call=AssembledToolCall("call-3", "search", "{}", 1, "qwen")),
+        ],
+        4,
+    )
+    extra_tool = assembler._annotate_token_counts(
+        [
+            AssemblyDelta(reasoning_text="alpha"),
+            AssemblyDelta(tool_call=AssembledToolCall("call-4", "search", "{}", 1, "qwen")),
+            AssemblyDelta(content_text="visible"),
+        ],
+        5,
+    )
+    extra_reasoning = assembler._annotate_token_counts(
+        [AssemblyDelta(reasoning_text="alpha"), AssemblyDelta(content_text="visible")],
+        4,
+    )
+    json_assembler = RequestStreamAssembler(
+        request_id="req-json-token-count",
+        reasoning_enabled=True,
+        structured_output_mode="json_object",
+        tool_parser_mode="",
+    )
+    json_deltas = json_assembler.accept(
+        StreamFragment(raw_text='{"answer":"ok"}', token_ids=(301, 302))
+    )
+    default_json_assembler = RequestStreamAssembler(
+        request_id="req-json-default-token-count",
+        reasoning_enabled=True,
+        structured_output_mode="json_object",
+        tool_parser_mode="",
+    )
+    default_json_deltas = default_json_assembler.accept(
+        StreamFragment(raw_text='{"answer":"plain"}')
+    )
+
+    assert [
+        (
+            delta.reasoning_text,
+            delta.tool_call.tool_name if delta.tool_call else "",
+            delta.content_text,
+            delta.token_count,
+        )
+        for delta in deltas
+    ] == [
+        ("alpha beta gamma", "", "", 3),
+        ("", "search", "", 2),
+        ("", "", "visible", 1),
+    ]
+    assert [(delta.content_text, delta.token_count) for delta in plain_deltas] == [
+        ("visible plain", 2)
+    ]
+    assert [(delta.content_text, delta.token_count) for delta in default_plain_deltas] == [
+        ("visible default", 1)
+    ]
+    assert [
+        (delta.content_text, delta.parser_observation, delta.token_count)
+        for delta in observed_deltas
+    ] == [("observed visible", "flush_tokens=0", 1)]
+    assert empty_annotated == []
+    assert [delta.token_count for delta in single_annotated] == [2]
+    assert [delta.token_count for delta in compressed] == [1, 1, 0]
+    assert [delta.token_count for delta in compressed_with_extra] == [2, 1, 1]
+    assert [delta.token_count for delta in compressed_after_sparse_extra] == [1, 2, 1]
+    assert [delta.token_count for delta in extra_tool] == [1, 3, 1]
+    assert [delta.token_count for delta in extra_reasoning] == [3, 1]
+    assert [(delta.content_text, delta.token_count) for delta in json_deltas] == [
+        ('{"answer":"ok"}', 2)
+    ]
+    assert [(delta.content_text, delta.token_count) for delta in default_json_deltas] == [
+        ('{"answer":"plain"}', 1)
+    ]
 
 
 def test_structural_tag_prefixes_are_cached_per_parser_mode() -> None:

--- a/services/mlx-worker-python/tests/test_stream_assembler_receipts.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler_receipts.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import json
 
-from worker.runtime.stream_assembler import RequestStreamAssembler, StreamFragment
+from worker.runtime.stream_assembler import (
+    AssembledToolCall,
+    AssemblyDelta,
+    RequestStreamAssembler,
+    StreamFragment,
+)
 from worker.runtime.token_route_receipt import TokenRouteReceipt
 
 
@@ -18,6 +23,7 @@ def test_token_route_receipt_records_visible_reasoning_and_tool_spans() -> None:
     receipt.append_token_ids((101, 102, 103, 104))
     receipt.record_span(channel="visible_text", channel_source="raw_text")
     receipt.record_span(channel="hidden_reasoning", channel_source="reasoning_tag")
+    receipt.record_span(channel="hidden_reasoning", channel_source="reasoning_tag", token_count=0)
     receipt.record_span(channel="tool_call", channel_source="tool_call_tag")
     receipt.record_span(channel="visible_text", channel_source="raw_text")
     payload = json.loads(receipt.to_json())
@@ -124,3 +130,115 @@ def test_completion_keeps_finalized_tool_call_deltas_available_to_engine() -> No
     assert [delta.tool_call.tool_name for delta in deltas if delta.tool_call] == ["search"]
     assert completed.assistant_text == ""
     assert completed.metrics["malformed_tool_fragment_count"] == 0
+
+
+def test_stream_assembler_assigns_multispan_token_counts_before_visible_tail() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-token-count-spans",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+
+    deltas = assembler.accept(
+        StreamFragment(
+            raw_text=(
+                "<think>alpha beta gamma</think>"
+                '<tool_call>{"name":"search","arguments":{"q":"one"}}</tool_call>'
+                "visible"
+            ),
+            token_ids=(101, 102, 103, 104, 105, 106),
+        )
+    )
+
+    assert [
+        (delta.reasoning_text, delta.tool_call.tool_name if delta.tool_call else "", delta.content_text, delta.token_count)
+        for delta in deltas
+    ] == [
+        ("alpha beta gamma", "", "", 3),
+        ("", "search", "", 2),
+        ("", "", "visible", 1),
+    ]
+
+
+def test_stream_assembler_compresses_multispan_token_counts_without_visible_overflow() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-token-count-compress",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+
+    deltas = assembler.accept(
+        StreamFragment(
+            raw_text=(
+                "<think>alpha beta gamma</think>"
+                '<tool_call>{"name":"search","arguments":{"q":"one"}}</tool_call>'
+                "visible"
+            ),
+            token_ids=(201, 202, 203, 204),
+        )
+    )
+
+    assert [
+        (delta.reasoning_text, delta.tool_call.tool_name if delta.tool_call else "", delta.content_text, delta.token_count)
+        for delta in deltas
+    ] == [
+        ("alpha beta gamma", "", "", 2),
+        ("", "search", "", 1),
+        ("", "", "visible", 1),
+    ]
+
+
+def test_stream_assembler_json_structured_delta_preserves_token_count() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-json-token-count",
+        reasoning_enabled=True,
+        structured_output_mode="json_object",
+        tool_parser_mode="",
+    )
+
+    deltas = assembler.accept(
+        StreamFragment(
+            raw_text='{"answer":"ok"}',
+            token_ids=(301, 302),
+        )
+    )
+
+    assert [(delta.content_text, delta.token_count) for delta in deltas] == [
+        ('{"answer":"ok"}', 2)
+    ]
+
+
+def test_stream_assembler_token_count_helpers_cover_sparse_and_extra_token_cases() -> None:
+    assembler = RequestStreamAssembler(
+        request_id="req-token-count-helpers",
+        reasoning_enabled=True,
+        structured_output_mode="",
+        tool_parser_mode="qwen",
+    )
+
+    sparse = assembler._annotate_token_counts(
+        [
+            AssemblyDelta(reasoning_text="alpha beta"),
+            AssemblyDelta(tool_call=AssembledToolCall("call-1", "search", "{}", 1, "qwen")),
+            AssemblyDelta(content_text="visible"),
+        ],
+        2,
+    )
+    extra_tool = assembler._annotate_token_counts(
+        [
+            AssemblyDelta(reasoning_text="alpha"),
+            AssemblyDelta(tool_call=AssembledToolCall("call-2", "search", "{}", 1, "qwen")),
+            AssemblyDelta(content_text="visible"),
+        ],
+        5,
+    )
+    extra_reasoning = assembler._annotate_token_counts(
+        [AssemblyDelta(reasoning_text="alpha"), AssemblyDelta(content_text="visible")],
+        4,
+    )
+
+    assert [delta.token_count for delta in sparse] == [1, 1, 0]
+    assert [delta.token_count for delta in extra_tool] == [1, 3, 1]
+    assert [delta.token_count for delta in extra_reasoning] == [3, 1]

--- a/services/mlx-worker-python/tests/test_training_planner_receipts.py
+++ b/services/mlx-worker-python/tests/test_training_planner_receipts.py
@@ -3,10 +3,21 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from packages.protocol.python.worker.v1 import common_pb2
 
 from worker.model_ops import training_config as training_config_module
+from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.lora_training_pipeline import LoRATrainingPipeline
+from worker.model_ops.training_receipts import (
+    eval_batch_size_receipt,
+    expected_peak_memory_class,
+    format_bound_value,
+    grad_clip_policy_receipt,
+    scheduler_kwargs_omitted_receipt,
+    typed_validation_details,
+)
 from worker.model_ops.mlx_lm_runner import (
     MLXLMRunner,
     TrainingMetrics,
@@ -114,7 +125,7 @@ def test_training_planner_receipt_covers_qlora_chunked_token_budget_and_refused_
             "chunk_size": "1024",
             "packing_mode": "none",
             "attention_backend": "flash_attention_2",
-            "generation_mode": "train",
+            "generation_mode": "teacher_forced",
             "final_logit_softcapping": "off",
         },
         dataset_format="chat_messages",
@@ -140,8 +151,45 @@ def test_training_planner_receipt_covers_qlora_chunked_token_budget_and_refused_
         "reason": "unsupported_training_attention_backend",
     }
     assert receipt["metric_for_best_model_resolved"] == "loss_best"
-    assert receipt["generation_mode"] == "train"
+    assert receipt["generation_mode"] == "teacher_forced"
     assert receipt["final_logit_softcapping"] is None
+
+
+def test_training_planner_receipt_rejects_unsafe_generation_mode() -> None:
+    with pytest.raises(ModelOperationError) as exc:
+        training_config_module.normalize_training_config(
+            source_model=_text_model(),
+            ext={
+                "training_mode": "lora",
+                "generation_mode": "runtime_generate",
+            },
+            dataset_format="chat_messages",
+            response_only_supported=True,
+            sample_count=2,
+        )
+
+    assert exc.value.code == "invalid_argument"
+    assert exc.value.details == {
+        "field": "generation_mode",
+        "reason": "unsupported_generation_mode",
+        "received": "runtime_generate",
+        "supported_generation_modes": "disabled,teacher_forced",
+    }
+
+
+def test_training_planner_receipt_accepts_chunked_logits_softcap_alias() -> None:
+    config = training_config_module.normalize_training_config(
+        source_model=_text_model(),
+        ext={
+            "training_mode": "lora",
+            "chunked_logits_softcap": "18.5",
+        },
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+
+    assert config.training_planner_receipt["final_logit_softcapping"] == 18.5
 
 
 def test_training_planner_receipt_accounts_for_source_model_size() -> None:
@@ -225,6 +273,64 @@ def test_training_planner_receipt_uses_model_size_aliases_and_ignores_malformed_
     assert config.training_planner_receipt["expected_peak_memory_class"] == "high"
 
 
+def test_training_planner_receipt_classifies_high_token_budget_without_model_size() -> None:
+    assert (
+        expected_peak_memory_class(
+            source_model=_text_model(),
+            batch_size=3,
+            gradient_accumulation=2,
+            token_budget_unit=4096,
+            training_mode="lora",
+        )
+        == "high"
+    )
+
+
+def test_training_receipt_helpers_cover_request_overrides() -> None:
+    assert typed_validation_details(
+        field_name="learning_rate",
+        reason="below_minimum",
+        received="-1.0",
+        minimum=0.0,
+        include_raw_value=True,
+    ) == {
+        "field": "learning_rate",
+        "reason": "below_minimum",
+        "received": "-1.0",
+        "minimum": "0.0",
+        "allowed_bounds": ">=0.0",
+        "http_status": "422",
+        "raw_value": "-1.0",
+    }
+    assert format_bound_value(2.25) == "2.25"
+    assert grad_clip_policy_receipt(
+        {"gradient_clip_norm": "0.75"},
+        float_value=lambda raw, default, minimum, field_name: float(raw),
+    ) == {
+        "requested": "0.75",
+        "resolved": 0.75,
+        "enabled": True,
+        "source": "request",
+    }
+    assert eval_batch_size_receipt(
+        {"eval_batch_size": "4"},
+        validation_sample_count=8,
+        int_value=lambda raw, default, minimum, field_name: int(raw),
+    ) == {
+        "requested": "4",
+        "resolved": 4,
+        "source": "request",
+        "validation_sample_count": 8,
+    }
+    assert scheduler_kwargs_omitted_receipt(
+        {"scheduler_kwargs_json": '{"warmup": 5}', "scheduler": "cosine"}
+    ) == {
+        "omitted": True,
+        "reason": "mlx_lm_lora_runner_does_not_accept_scheduler_kwargs",
+        "keys": ["scheduler", "scheduler_kwargs_json"],
+    }
+
+
 def test_training_planner_receipt_is_persisted_in_adapter_manifest(tmp_path: Path) -> None:
     dataset_dir = _write_dataset_package(tmp_path / "dataset")
     output_dir = tmp_path / "train-output"
@@ -261,10 +367,34 @@ def test_training_planner_receipt_is_persisted_in_adapter_manifest(tmp_path: Pat
     assert manifest["final_logit_softcapping"] == 25.5
 
 
+def test_training_profiler_artifact_from_runner_metrics_is_linked_in_manifest(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(tmp_path / "dataset")
+    output_dir = tmp_path / "train-output"
+    runner = _ReceiptRunner(profile_artifact_path=tmp_path / "profiles" / "train-profile.json")
+
+    result = LoRATrainingPipeline(runner=runner).run(
+        job_id="planner-profiler-receipt-test",
+        request_ext={
+            "training_mode": "lora",
+            "dataset_uri": str(dataset_dir),
+            "metric_for_best_model": "loss_best",
+        },
+        source_model=_text_model(),
+        output_dir=output_dir,
+        jobs_root=tmp_path / "jobs",
+    )
+
+    assert result.manifest["profile_artifact_path"] == str(
+        tmp_path / "profiles" / "train-profile.json"
+    )
+    assert result.manifest["metric_for_best_model_resolved"] == "loss_best"
+
+
 class _ReceiptRunner(MLXLMRunner):
-    def __init__(self) -> None:
+    def __init__(self, *, profile_artifact_path: Path | None = None) -> None:
         super().__init__()
         self.last_train_request: TrainingRequest | None = None
+        self.profile_artifact_path = profile_artifact_path
 
     def train_native(self, request: TrainingRequest) -> TrainingResult:
         self.last_train_request = request
@@ -285,6 +415,9 @@ class _ReceiptRunner(MLXLMRunner):
                 learning_rate_final=1e-4,
                 tokens_per_second=64.0,
                 peak_memory_gb=2.0,
+                profile_artifact_path=(
+                    str(self.profile_artifact_path) if self.profile_artifact_path else ""
+                ),
             ),
             execution_backend="native",
         )

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -249,6 +249,8 @@ class EngineCore:
                     )
                 else:
                     stream_fragment = StreamFragment(runtime_event.text, runtime_event.raw_text)
+                if token_route_receipt is not None and runtime_event.token_ids:
+                    token_route_receipt.append_token_ids(runtime_event.token_ids)
                 for delta in accept_stream_fragment(stream_fragment):
                     if delta.reasoning_text:
                         generated_reasoning_delta_count += 1
@@ -294,6 +296,7 @@ class EngineCore:
                             token_route_receipt.record_span(
                                 channel="visible_text",
                                 channel_source="raw_text",
+                                consume_all_available=True,
                             )
                         if track_usage:
                             completion_token_count += 1

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -6,7 +6,11 @@ import json
 from packages.protocol.python.worker.v1 import common_pb2, inference_pb2
 
 from worker.registry import WorkerRegistry
-from worker.engine.text_finalizer import apply_text_response_metrics
+from worker.engine.text_finalizer import (
+    TextFinalizationUsage,
+    apply_text_response_metrics,
+    finalize_text_response,
+)
 from worker.runtime.mlx_text_runtime import RuntimeToolCallEvent, RuntimeTokenEvent
 from worker.runtime.mlx_text_runtime import resolve_text_stop_contract
 from worker.runtime.multimodal_attention_policy import MultimodalPrefillAttentionBudgetExceeded
@@ -341,9 +345,8 @@ class EngineCore:
             parser_metrics = {key: str(value) for key, value in assembled.metrics.items()}
             parser_metrics.update(_text_native_mtp_parser_metrics(last_token_event))
             resolved_stop_token_count = str(stop_contract.resolved_stop_token_count)
+            created = execution_ext.get("melix.response.created", "")
             if plain_text_fast_path:
-                stream_mode_text = "true" if request.stream else "false"
-                usage_trailer_text = stream_mode_text if usage_trailer_emitted else "false"
                 response_history_normalized_count = execution_ext.get(
                     "melix.response_history.normalized_count",
                     "0",
@@ -356,11 +359,9 @@ class EngineCore:
                     "melix.compat.effective_config_hash",
                     "",
                 )
-                created = execution_ext.get("melix.response.created", "")
                 generated_tool_call_delta_count_text = str(generated_tool_call_delta_count)
                 if token_route_receipt is not None:
                     token_route_receipt_json = token_route_receipt.to_json()
-                tool_calls_finalized_text = "true" if generated_tool_call_delta_count else "false"
                 parser_metrics.update(
                     {
                         "resolved_stop_token_count": resolved_stop_token_count,
@@ -373,18 +374,6 @@ class EngineCore:
                         "generated_reasoning_delta_count": "0",
                         "generated_tool_call_delta_count": generated_tool_call_delta_count_text,
                         "token_route_receipt_json": token_route_receipt_json,
-                        "response_id": request_id,
-                        "created": created,
-                        "stream_mode": stream_mode_text,
-                        "finish_reason": finish_reason,
-                        "usage_prompt_tokens": str(finalized_prompt_tokens),
-                        "usage_completion_tokens": str(finalized_completion_tokens),
-                        "usage_total_tokens": str(finalized_prompt_tokens + finalized_completion_tokens),
-                        "usage_trailer_emitted": usage_trailer_text,
-                        "reasoning_finalized": "false",
-                        "tool_calls_finalized": tool_calls_finalized_text,
-                        "malformed_channel_recovered": "false",
-                        "finalizer_path": "stream" if request.stream else "non_stream",
                     }
                 )
             else:
@@ -405,42 +394,30 @@ class EngineCore:
                     "melix.compat.effective_config_hash",
                     "",
                 )
-                created = execution_ext.get("melix.response.created", "")
                 parser_metrics["turn_boundary_stop_reason"] = turn_boundary_stop_reason or finish_reason
                 parser_metrics["generated_reasoning_delta_count"] = str(generated_reasoning_delta_count)
                 parser_metrics["generated_tool_call_delta_count"] = str(generated_tool_call_delta_count)
                 if token_route_receipt is not None:
                     token_route_receipt_json = token_route_receipt.to_json()
                 parser_metrics["token_route_receipt_json"] = token_route_receipt_json
-                malformed_tool_fragment_count = int(
-                    parser_metrics.get("malformed_tool_fragment_count", "0") or "0"
-                )
-                reasoning_finalized = (
-                    bool(assembled.reasoning_text)
-                    or generated_reasoning_delta_count > 0
-                    or int(parser_metrics.get("harmony_channel_hidden_count", "0") or "0") > 0
-                )
-                tool_calls_finalized = (
-                    generated_tool_call_delta_count > 0
-                    or malformed_tool_fragment_count > 0
-                )
-                malformed_channel_recovered = (
-                    int(parser_metrics.get("reasoning_channel_recovery_count", "0") or "0") > 0
-                    or malformed_tool_fragment_count > 0
-                )
-                apply_text_response_metrics(
-                    parser_metrics,
-                    response_id=request_id,
-                    created=created,
-                    stream_mode=bool(request.stream),
-                    finish_reason=finish_reason,
+            finalization_receipt = finalize_text_response(
+                response_id=request_id,
+                created=created,
+                stream_mode=bool(request.stream),
+                finish_reason=finish_reason,
+                usage=TextFinalizationUsage(
                     prompt_tokens=finalized_prompt_tokens,
                     completion_tokens=finalized_completion_tokens,
-                    usage_trailer_emitted=usage_trailer_emitted,
-                    reasoning_finalized=reasoning_finalized,
-                    tool_calls_finalized=tool_calls_finalized,
-                    malformed_channel_recovered=malformed_channel_recovered,
-                )
+                ),
+                usage_trailer_emitted=usage_trailer_emitted,
+                reasoning_text=assembled.reasoning_text,
+                tool_call_count=assembled.tool_call_count,
+                parser_metrics=parser_metrics,
+            )
+            apply_text_response_metrics(
+                parser_metrics,
+                receipt=finalization_receipt,
+            )
             yield inference_pb2.ExecuteEvent(
                 request_id=request_id,
                 execution_kind="generate",

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -259,6 +259,7 @@ class EngineCore:
                             token_route_receipt.record_span(
                                 channel="hidden_reasoning",
                                 channel_source="reasoning_tag",
+                                token_count=delta.token_count,
                             )
                         yield inference_pb2.ExecuteEvent(
                             request_id=request_id,
@@ -277,6 +278,7 @@ class EngineCore:
                             token_route_receipt.record_span(
                                 channel="tool_call",
                                 channel_source="tool_call_tag",
+                                token_count=delta.token_count,
                             )
                         yield inference_pb2.ExecuteEvent(
                             request_id=request_id,
@@ -296,6 +298,7 @@ class EngineCore:
                             token_route_receipt.record_span(
                                 channel="visible_text",
                                 channel_source="raw_text",
+                                token_count=delta.token_count,
                                 consume_all_available=True,
                             )
                         if track_usage:

--- a/services/mlx-worker-python/worker/engine/text_finalizer.py
+++ b/services/mlx-worker-python/worker/engine/text_finalizer.py
@@ -77,75 +77,12 @@ def finalize_text_response(
     )
 
 
-def finalize_text_response_metrics(
-    *,
-    response_id: str,
-    created: str,
-    stream_mode: bool,
-    finish_reason: str,
-    prompt_tokens: int,
-    completion_tokens: int,
-    usage_trailer_emitted: bool,
-    reasoning_text: str,
-    tool_call_count: int,
-    parser_metrics: dict[str, int | str],
-) -> dict[str, str]:
-    reasoning_finalized = (
-        bool(reasoning_text)
-        or _metric_positive(parser_metrics, "generated_reasoning_delta_count")
-        or _metric_positive(parser_metrics, "harmony_channel_hidden_count")
-    )
-    tool_calls_finalized = (
-        tool_call_count > 0
-        or _metric_positive(parser_metrics, "generated_tool_call_delta_count")
-        or _metric_positive(parser_metrics, "malformed_tool_fragment_count")
-    )
-    malformed_channel_recovered = _metric_positive(
-        parser_metrics,
-        "reasoning_channel_recovery_count",
-    ) or _metric_positive(parser_metrics, "malformed_tool_fragment_count")
-    return {
-        "response_id": response_id,
-        "created": created,
-        "stream_mode": _bool_text(stream_mode),
-        "finish_reason": finish_reason,
-        "usage_prompt_tokens": str(prompt_tokens),
-        "usage_completion_tokens": str(completion_tokens),
-        "usage_total_tokens": str(prompt_tokens + completion_tokens),
-        "usage_trailer_emitted": _bool_text(usage_trailer_emitted),
-        "reasoning_finalized": _bool_text(reasoning_finalized),
-        "tool_calls_finalized": _bool_text(tool_calls_finalized),
-        "malformed_channel_recovered": _bool_text(malformed_channel_recovered),
-        "finalizer_path": "stream" if stream_mode else "non_stream",
-    }
-
-
 def apply_text_response_metrics(
     parser_metrics: dict[str, str],
     *,
-    response_id: str,
-    created: str,
-    stream_mode: bool,
-    finish_reason: str,
-    prompt_tokens: int,
-    completion_tokens: int,
-    usage_trailer_emitted: bool,
-    reasoning_finalized: bool,
-    tool_calls_finalized: bool,
-    malformed_channel_recovered: bool,
+    receipt: TextFinalizationReceipt,
 ) -> None:
-    parser_metrics["response_id"] = response_id
-    parser_metrics["created"] = created
-    parser_metrics["stream_mode"] = _bool_text(stream_mode)
-    parser_metrics["finish_reason"] = finish_reason
-    parser_metrics["usage_prompt_tokens"] = str(prompt_tokens)
-    parser_metrics["usage_completion_tokens"] = str(completion_tokens)
-    parser_metrics["usage_total_tokens"] = str(prompt_tokens + completion_tokens)
-    parser_metrics["usage_trailer_emitted"] = _bool_text(usage_trailer_emitted)
-    parser_metrics["reasoning_finalized"] = _bool_text(reasoning_finalized)
-    parser_metrics["tool_calls_finalized"] = _bool_text(tool_calls_finalized)
-    parser_metrics["malformed_channel_recovered"] = _bool_text(malformed_channel_recovered)
-    parser_metrics["finalizer_path"] = "stream" if stream_mode else "non_stream"
+    parser_metrics.update(receipt.parser_metrics())
 
 
 def _bool_text(value: bool) -> str:

--- a/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
@@ -210,10 +210,16 @@ def build_lora_canary_receipt_fields(
         merge_export_canary_failures.append("missing_base_config")
     if not source_tokenizer_present:
         merge_export_canary_failures.append("missing_tokenizer_config")
+    elif not source_eos_token:
+        merge_export_canary_failures.append("missing_source_eos_token")
     if not Path(weights_path).is_file():
         merge_export_canary_failures.append("missing_adapter_weights")
+    if saved_tokenizer_config and not saved_eos_token:
+        merge_export_canary_failures.append("missing_saved_eos_token")
     if source_eos_token and saved_eos_token and source_eos_token != saved_eos_token:
         merge_export_canary_failures.append("eos_token_mismatch")
+    if not aux_modules_restored:
+        merge_export_canary_failures.append("missing_auxiliary_modules")
 
     callback_api_drift_result = "pass"
     callback_arity = _optional_int(adapter_config.get("callback_arity"))

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -326,7 +326,13 @@ class LoRATrainingPipeline:
             "optimizer_steps": config.iters // config.gradient_accumulation,
             "mask_prompt": config.mask_prompt,
             "max_seq_length": config.max_seq_length,
-            **config.training_planner_receipt,
+            **{
+                **config.training_planner_receipt,
+                "profile_artifact_path": (
+                    training_result.metrics.profile_artifact_path
+                    or str(config.training_planner_receipt.get("profile_artifact_path", ""))
+                ),
+            },
             "training.max_steps": config.max_steps,
             "training_duration_ms": training_result.metrics.job_duration_ms,
             "training.job_duration_ms": training_result.metrics.job_duration_ms,

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -164,6 +164,8 @@ class LoRATrainingPipeline:
             adapter_scope=adapter_scope,
             inspection_only=truthy(request_ext.get("inspect_only_import", "")),
         )
+        runtime_unsupported_reason = str(runtime_preflight_fields.get("unsupported_reason", ""))
+        adapter_unsupported_reason = config.unsupported_reason
         runtime_failure_details = runtime_preflight_failure_details(runtime_preflight_fields)
 
         emit("train", 0.8)
@@ -299,7 +301,9 @@ class LoRATrainingPipeline:
             "adapter_capabilities": dict(config.adapter_capabilities),
             "backend_supported": config.backend_supported,
             **runtime_preflight_fields,
-            "unsupported_reason": config.unsupported_reason,
+            "runtime_unsupported_reason": runtime_unsupported_reason,
+            "adapter_unsupported_reason": adapter_unsupported_reason,
+            "unsupported_reason": adapter_unsupported_reason,
             "preference_loss": config.preference_loss,
             "dataset_contract": config.dataset_contract,
             "dora_enabled": config.adapter_algorithm == "dora",

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -33,6 +33,7 @@ from worker.model_ops.training_receipts import (
 )
 from worker.model_ops.training_runtime_preflight import (
     call_with_training_failure_cleanup,
+    runtime_preflight_failure_details,
     training_runtime_preflight_fields,
     truthy,
 )
@@ -163,6 +164,7 @@ class LoRATrainingPipeline:
             adapter_scope=adapter_scope,
             inspection_only=truthy(request_ext.get("inspect_only_import", "")),
         )
+        runtime_failure_details = runtime_preflight_failure_details(runtime_preflight_fields)
 
         emit("train", 0.8)
         training_result = call_with_training_failure_cleanup(
@@ -180,7 +182,8 @@ class LoRATrainingPipeline:
                     source_model_kind=source_model.model_kind,
                     source_model_ext=dict(source_model.ext),
                 )
-            )
+            ),
+            details=runtime_failure_details,
         )
 
         emit("write_adapter", 0.9)
@@ -194,9 +197,13 @@ class LoRATrainingPipeline:
                 multimodal_lora_nan_guard_triggered=(
                     training_result.metrics.multimodal_lora_nan_guard_triggered
                 ),
-            )
+            ),
+            details=runtime_failure_details,
         )
-        call_with_training_failure_cleanup(lambda: raise_for_adapter_freeze_audit(adapter_audit))
+        call_with_training_failure_cleanup(
+            lambda: raise_for_adapter_freeze_audit(adapter_audit),
+            details=runtime_failure_details,
+        )
         adapter_audit_fields = audit_manifest_fields(adapter_audit)
         adapter_artifact_bytes = adapter_audit.adapter_checkpoint_bytes
         adapter_set_hash = _content_hash(training_result.weights_path, training_result.adapter_config_path)

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -471,13 +471,14 @@ def _extract_structured_result_payload(stdout: str) -> dict[str, object] | None:
             if previous_character != "\n" and previous_character != "\r":
                 search_end = prefix_index
                 continue
-        line_end = len(stdout)
         newline_index = stdout.find("\n", prefix_index)
-        carriage_index = stdout.find("\r", prefix_index)
         if newline_index >= 0:
-            line_end = min(line_end, newline_index)
-        if carriage_index >= 0:
-            line_end = min(line_end, carriage_index)
+            line_end = newline_index
+        else:
+            line_end = len(stdout)
+            carriage_index = stdout.find("\r", prefix_index)
+            if carriage_index >= 0:
+                line_end = carriage_index
         return json.loads(stdout[prefix_index + prefix_length:line_end])
 
 

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -53,6 +53,7 @@ class TrainingMetrics:
     resume_source_path: str = ""
     tokens_per_second: float = 0.0
     peak_memory_gb: float = 0.0
+    profile_artifact_path: str = ""
     # Milestone #43 Phase 2: template-aware response-only boundary observability.
     # Populated for chat_messages datasets when response_only is requested. Zero
     # when the sample format doesn't support response-only masking.

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -28,6 +28,7 @@ from worker.model_ops.training_receipts import (
     resolved_bounds_receipt,
     scheduler_kwargs_omitted_receipt,
     typed_validation_details,
+    format_bound_value,
 )
 
 
@@ -1411,8 +1412,8 @@ def _float_value(raw_value: str, *, default: float, minimum: float, field_name: 
         ) from exc
     finite_value = math.isfinite(value)
     if value < minimum or not finite_value:
-        reason = "below_minimum" if finite_value else "not_finite"
-        minimum_text = "0.0" if isinstance(minimum, float) and minimum == 0.0 else str(minimum)
+        reason = "not_finite" if math.isnan(value) else "below_minimum"
+        minimum_text = format_bound_value(minimum)
         raise ModelOperationError(
             code="invalid_argument",
             message=f"{field_name} must be at least {minimum}." if finite_value else f"{field_name} must be finite.",

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -1409,15 +1409,19 @@ def _float_value(raw_value: str, *, default: float, minimum: float, field_name: 
                 include_raw_value=True,
             ),
         ) from exc
-    if value < minimum:
+    finite_value = math.isfinite(value)
+    if value < minimum or not finite_value:
+        reason = "below_minimum" if finite_value else "not_finite"
+        minimum_text = "0.0" if isinstance(minimum, float) and minimum == 0.0 else str(minimum)
         raise ModelOperationError(
             code="invalid_argument",
-            message=f"{field_name} must be at least {minimum}.",
+            message=f"{field_name} must be at least {minimum}." if finite_value else f"{field_name} must be finite.",
             details=typed_validation_details(
                 field_name=field_name,
-                reason="below_minimum",
-                received=str(value),
+                reason=reason,
+                received=str(raw_value),
                 minimum=minimum,
+                allowed_bounds=None if finite_value else f"finite >={minimum_text}",
             ),
         )
     return value

--- a/services/mlx-worker-python/worker/model_ops/training_receipts.py
+++ b/services/mlx-worker-python/worker/model_ops/training_receipts.py
@@ -188,6 +188,7 @@ def typed_validation_details(
     reason: str,
     received: str,
     minimum: int | float,
+    allowed_bounds: str | None = None,
     include_raw_value: bool = False,
 ) -> dict[str, str]:
     minimum_text = format_bound_value(minimum)
@@ -196,7 +197,7 @@ def typed_validation_details(
         "reason": reason,
         "received": received,
         "minimum": minimum_text,
-        "allowed_bounds": f">={minimum_text}",
+        "allowed_bounds": allowed_bounds or f">={minimum_text}",
         "http_status": "422",
     }
     if include_raw_value:

--- a/services/mlx-worker-python/worker/model_ops/training_receipts.py
+++ b/services/mlx-worker-python/worker/model_ops/training_receipts.py
@@ -42,6 +42,10 @@ def build_training_planner_receipt(
     metric_for_best_model = ext.get("metric_for_best_model", "").strip()
     if not metric_for_best_model:
         metric_for_best_model = "validation_loss" if validation_sample_count > 0 else "loss_best"
+    generation_mode = generation_mode_receipt(ext.get("generation_mode", ""))
+    softcap_raw = ext.get("final_logit_softcapping", "").strip() or ext.get(
+        "chunked_logits_softcap", ""
+    )
 
     return {
         "batching_strategy": batching_strategy,
@@ -70,9 +74,9 @@ def build_training_planner_receipt(
         "grad_checkpoint_enabled": gradient_checkpointing,
         "attention_backend": attention_backend_receipt(ext.get("attention_backend", "")),
         "metric_for_best_model_resolved": metric_for_best_model,
-        "generation_mode": ext.get("generation_mode", "").strip().lower() or "disabled",
+        "generation_mode": generation_mode,
         "final_logit_softcapping": final_logit_softcapping(
-            ext.get("final_logit_softcapping", ""),
+            softcap_raw,
             float_value=float_value,
         ),
     }
@@ -147,6 +151,24 @@ def attention_backend_receipt(raw_backend: str) -> dict[str, str]:
         "status": "refused",
         "reason": "unsupported_training_attention_backend",
     }
+
+
+def generation_mode_receipt(raw_mode: str) -> str:
+    mode = raw_mode.strip().lower() or "disabled"
+    if mode in {"disabled", "teacher_forced"}:
+        return mode
+    from worker.model_ops.errors import ModelOperationError
+
+    raise ModelOperationError(
+        code="invalid_argument",
+        message=f"Unsupported generation_mode: {mode}",
+        details={
+            "field": "generation_mode",
+            "reason": "unsupported_generation_mode",
+            "received": mode,
+            "supported_generation_modes": "disabled,teacher_forced",
+        },
+    )
 
 
 def final_logit_softcapping(

--- a/services/mlx-worker-python/worker/model_ops/training_runtime_preflight.py
+++ b/services/mlx-worker-python/worker/model_ops/training_runtime_preflight.py
@@ -68,29 +68,60 @@ def training_runtime_preflight_fields(
     }
 
 
-def call_with_training_failure_cleanup(callback: Callable[[], _T]) -> _T:
+def call_with_training_failure_cleanup(
+    callback: Callable[[], _T],
+    *,
+    details: dict[str, str] | None = None,
+) -> _T:
     try:
         return callback()
     except Exception as exc:
-        raise_with_training_failure_cleanup(exc)
+        raise_with_training_failure_cleanup(exc, details=details)
 
 
-def raise_with_training_failure_cleanup(exc: Exception) -> None:
+def raise_with_training_failure_cleanup(
+    exc: Exception,
+    *,
+    details: dict[str, str] | None = None,
+) -> None:
     cleanup = _cleanup_training_failure_exception(exc)
+    if details:
+        cleanup = {**details, **cleanup}
     if isinstance(exc, ModelOperationError):
-        details = dict(exc.details)
-        details.update(cleanup)
+        error_details = dict(exc.details)
+        error_details.update(cleanup)
         raise ModelOperationError(
             code=exc.code,
             message=exc.message,
             retriable=exc.retriable,
-            details=details,
+            details=error_details,
         ) from exc.__cause__
     raise ModelOperationError(
         code="backend_training_failure",
         message=str(exc),
         details=cleanup,
     ) from None
+
+
+def runtime_preflight_failure_details(fields: dict[str, Any]) -> dict[str, str]:
+    dependency = fields.get("media_decoder_dependency", {})
+    if not isinstance(dependency, dict):
+        dependency = {}
+    disabled_decoder_paths = fields.get("disabled_decoder_paths", [])
+    if isinstance(disabled_decoder_paths, list):
+        disabled_paths = ",".join(str(path) for path in disabled_decoder_paths)
+    else:
+        disabled_paths = str(disabled_decoder_paths)
+    return {
+        "runtime_gate": str(fields.get("runtime_gate", "")),
+        "inspection_only_import": str(fields.get("inspection_only_import", "")).lower(),
+        "native_load_status": str(fields.get("native_load_status", "")),
+        "disabled_decoder_paths": disabled_paths,
+        "fallback_reader": str(fields.get("fallback_reader", "")),
+        "unsupported_reason": str(fields.get("unsupported_reason", "")),
+        "media_decoder_dependency_state": str(dependency.get("state", "")),
+        "media_decoder_dependency_module": str(dependency.get("module", "")),
+    }
 
 
 def _module_spec_available(module_name: str) -> bool:

--- a/services/mlx-worker-python/worker/model_ops/training_runtime_preflight.py
+++ b/services/mlx-worker-python/worker/model_ops/training_runtime_preflight.py
@@ -107,7 +107,7 @@ def runtime_preflight_failure_details(fields: dict[str, Any]) -> dict[str, str]:
     dependency = fields.get("media_decoder_dependency", {})
     if not isinstance(dependency, dict):
         dependency = {}
-    disabled_decoder_paths = fields.get("disabled_decoder_paths", [])
+    disabled_decoder_paths = fields.get("disabled_decoder_paths") or []
     if isinstance(disabled_decoder_paths, list):
         disabled_paths = ",".join(str(path) for path in disabled_decoder_paths)
     else:

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -74,6 +74,37 @@ class AssemblyDelta:
     tool_call: AssembledToolCall | None = None
     parser_observation: str = ""
 
+    @property
+    def token_count(self) -> int:
+        return 1
+
+
+class TokenCountedAssemblyDelta(AssemblyDelta):
+    __slots__ = ("_token_count",)
+
+    def __init__(
+        self,
+        *,
+        content_text: str = "",
+        reasoning_text: str = "",
+        raw_text: str = "",
+        tool_call: AssembledToolCall | None = None,
+        parser_observation: str = "",
+        token_count: int,
+    ) -> None:
+        super().__init__(
+            content_text=content_text,
+            reasoning_text=reasoning_text,
+            raw_text=raw_text,
+            tool_call=tool_call,
+            parser_observation=parser_observation,
+        )
+        object.__setattr__(self, "_token_count", token_count)
+
+    @property
+    def token_count(self) -> int:
+        return self._token_count
+
 
 @dataclass(frozen=True, slots=True)
 class AssemblyCompletion:
@@ -274,19 +305,28 @@ class RequestStreamAssembler:
             self._assistant_parts.append(delta)
             if raw_delta_from_token_bytes:
                 self._raw_seen_assistant_part_count += 1
-            if token_count > 1:
-                self._metrics["stream_interval_delta_flush_count"] += 1
-            return [AssemblyDelta(content_text=delta, raw_text=delta)]
+            if token_count < 2:
+                return [AssemblyDelta(content_text=delta, raw_text=delta)]
+            self._metrics["stream_interval_delta_flush_count"] += 1
+            return [
+                TokenCountedAssemblyDelta(
+                    content_text=delta,
+                    raw_text=delta,
+                    token_count=token_count,
+                )
+            ]
 
         if raw_delta_from_token_bytes:
             self._materialized_raw_seen()
             self._raw_seen += delta
 
         if self._is_json_only_structured_output_value:
-            deltas = self._accept_json_structured_output(delta)
+            deltas = self._accept_json_structured_output(delta, token_count=token_count)
         else:
             self._buffer += delta
             deltas = self._drain_buffer(final=False)
+            if token_count > 0:
+                deltas = self._annotate_token_counts(deltas, token_count)
         if token_count > 1 and deltas:
             self._metrics["stream_interval_delta_flush_count"] += 1
         if fragment.parser_observation:
@@ -444,13 +484,29 @@ class RequestStreamAssembler:
         if not parser_observation:
             return deltas
         return [
-            replace(delta, parser_observation=parser_observation)
+            self._with_parser_observation(delta, parser_observation)
             if delta.content_text or delta.reasoning_text or delta.tool_call is not None
             else delta
             for delta in deltas
         ]
 
-    def _accept_json_structured_output(self, delta: str) -> list[AssemblyDelta]:
+    @staticmethod
+    def _with_parser_observation(
+        delta: AssemblyDelta,
+        parser_observation: str,
+    ) -> AssemblyDelta:
+        if delta.token_count == 1:
+            return replace(delta, parser_observation=parser_observation)
+        return TokenCountedAssemblyDelta(
+            content_text=delta.content_text,
+            reasoning_text=delta.reasoning_text,
+            raw_text=delta.raw_text,
+            tool_call=delta.tool_call,
+            parser_observation=parser_observation,
+            token_count=delta.token_count,
+        )
+
+    def _accept_json_structured_output(self, delta: str, token_count: int = 0) -> list[AssemblyDelta]:
         self._buffer += delta
         if not self._json_started:
             json_start = self._first_json_delimiter(self._buffer)
@@ -467,7 +523,15 @@ class RequestStreamAssembler:
         if self._contains_reasoning_leak_marker(content):
             self._metrics["reasoning_leak_count"] += 1
         self._assistant_parts.append(content)
-        return [AssemblyDelta(content_text=content, raw_text=delta)]
+        if token_count <= 1:
+            return [AssemblyDelta(content_text=content, raw_text=delta)]
+        return [
+            TokenCountedAssemblyDelta(
+                content_text=content,
+                raw_text=delta,
+                token_count=token_count,
+            )
+        ]
 
     def _drain_buffer(self, final: bool) -> list[AssemblyDelta]:
         deltas: list[AssemblyDelta] = []
@@ -566,6 +630,83 @@ class RequestStreamAssembler:
 
             break
         return deltas
+
+    def _annotate_token_counts(
+        self,
+        deltas: list[AssemblyDelta],
+        token_count: int,
+    ) -> list[AssemblyDelta]:
+        if token_count <= 0 or not deltas:
+            return deltas
+        if len(deltas) == 1:
+            return [self._with_token_count(deltas[0], token_count)]
+
+        weights = [self._estimated_delta_token_count(delta) for delta in deltas]
+        if sum(weights) > token_count:
+            weights = self._compress_delta_token_counts(weights, token_count)
+        elif sum(weights) < token_count:
+            weights = self._distribute_extra_delta_tokens(deltas, weights, token_count - sum(weights))
+
+        return [self._with_token_count(delta, count) for delta, count in zip(deltas, weights)]
+
+    @staticmethod
+    def _with_token_count(delta: AssemblyDelta, token_count: int) -> AssemblyDelta:
+        if token_count == 1:
+            return delta
+        return TokenCountedAssemblyDelta(
+            content_text=delta.content_text,
+            reasoning_text=delta.reasoning_text,
+            raw_text=delta.raw_text,
+            tool_call=delta.tool_call,
+            parser_observation=delta.parser_observation,
+            token_count=token_count,
+        )
+
+    @staticmethod
+    def _estimated_delta_token_count(delta: AssemblyDelta) -> int:
+        if delta.content_text:
+            return max(1, len(delta.content_text.split()))
+        if delta.reasoning_text:
+            return max(1, len(delta.reasoning_text.split()))
+        return 1
+
+    @staticmethod
+    def _compress_delta_token_counts(weights: list[int], token_count: int) -> list[int]:
+        compressed = [1 for _ in weights]
+        remaining = token_count - len(compressed)
+        if remaining <= 0:
+            return compressed[:token_count] + [0 for _ in weights[token_count:]]
+        extras = [max(weight - 1, 0) for weight in weights]
+        while remaining > 0 and any(extras):
+            for index, extra in enumerate(extras):
+                if remaining <= 0:
+                    break
+                if extra <= 0:
+                    continue
+                compressed[index] += 1
+                extras[index] -= 1
+                remaining -= 1
+        return compressed
+
+    @staticmethod
+    def _distribute_extra_delta_tokens(
+        deltas: list[AssemblyDelta],
+        weights: list[int],
+        extra_tokens: int,
+    ) -> list[int]:
+        adjusted = list(weights)
+        priority_indexes = [
+            index for index, delta in enumerate(deltas) if delta.tool_call is not None
+        ] or [
+            index for index, delta in enumerate(deltas) if delta.reasoning_text
+        ] or list(range(len(deltas)))
+        cursor = 0
+        while extra_tokens > 0:
+            index = priority_indexes[cursor % len(priority_indexes)]
+            adjusted[index] += 1
+            extra_tokens -= 1
+            cursor += 1
+        return adjusted
 
     def _recover_unclosed_reasoning_body(self, body: str) -> tuple[str, str]:
         stripped = body.strip()

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -80,6 +80,7 @@ class AssemblyCompletion:
     assistant_text: str
     reasoning_text: str
     raw_text: str
+    tool_call_count: int
     metrics: dict[str, int | str]
 
 
@@ -311,6 +312,7 @@ class RequestStreamAssembler:
             assistant_text="".join(self._assistant_parts),
             reasoning_text="".join(self._reasoning_parts),
             raw_text=self._materialized_raw_seen(),
+            tool_call_count=self._tool_fragment_index,
             metrics=metrics,
         )
 

--- a/services/mlx-worker-python/worker/runtime/token_route_receipt.py
+++ b/services/mlx-worker-python/worker/runtime/token_route_receipt.py
@@ -89,9 +89,13 @@ class TokenRouteReceipt:
         *,
         channel: str,
         channel_source: str,
+        token_count: int = 1,
         consume_all_available: bool = False,
     ) -> None:
         if not self._enabled:
+            return
+        normalized_token_count = int(token_count)
+        if normalized_token_count <= 0:
             return
         if consume_all_available and self._pending_token_ids:
             token_ids = self._pending_token_ids
@@ -103,7 +107,7 @@ class TokenRouteReceipt:
             )
             return
         self._record_tokens(
-            token_ids=[self._route_token_id()],
+            token_ids=self._route_token_ids(normalized_token_count),
             channel=channel,
             channel_source=channel_source,
         )
@@ -150,6 +154,9 @@ class TokenRouteReceipt:
         if self._pending_token_ids:
             return self._pending_token_ids.pop(0)
         return self._next_synthetic_token_id()
+
+    def _route_token_ids(self, token_count: int) -> list[int]:
+        return [self._route_token_id() for _ in range(token_count)]
 
     def _record_tokens(
         self,


### PR DESCRIPTION
## Summary
- Integrates the #1522-#1531 M-courtyard runtime and training follow-up issues into one current branch, now merged with `origin/main` at `57774cb8`.
- Adds request-local compatibility, parser selector, prompt-budget, generation-control, finalization, and token-routing receipt coverage across Swift and Python runtime paths.
- Hardens LoRA training admission, canary, runtime preflight, cleanup, and planner receipts, with updated plans/runbooks documenting the evidence surfaces.
- Adds a small MLX-LM structured-result tail parser optimization and probe-covered carriage-return compatibility coverage after the latest main merge.

## Plan or Spec
- `docs/plans/2026-05-24-m-courtyard-runtime-training-followups.md`
- `docs/plans/2026-05-24-issue-1528-training-admission-receipts.md`
- `docs/plans/2026-05-24-issue-1530-training-runtime-preflight.md`
- `docs/plans/2026-03-30-m3-6-tool-parser-registry.md`
- `docs/control-plane-protocol.md`
- `docs/runbooks/structured-streaming-reasoning-continuity.md`

## Commands Run
```text
make bootstrap
# passed: configured .githooks and uv sync completed against services/mlx-worker-python.

make proto
# passed: proto generation completed; no generated-file diff remained.

git diff --check
# passed after merging origin/main at 57774cb8.

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-body-m-courtyard-runtime-training-followups.md
# passed.

swift test --package-path services/control-plane-swift --filter 'ToolParserRegistryTests|OpenAIHandlerTests'
# passed: Test run with 199 tests in 2 suites passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_generate_stream_receipts.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_stream_assembler.py -q
# passed: 123 passed in 0.74s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_lora_experiment_store.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_training_planner_receipts.py -q
# passed after integration expectation alignment: 186 passed, 2 warnings in 1.48s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_generate_stream_receipts.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_stream_assembler_receipts.py services/mlx-worker-python/tests/test_stream_assembler.py -q
# passed after review follow-up fixes: 109 passed in 0.36s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler_receipts.py -q
# passed after parser hot-path optimization: 103 passed in 1.37s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_lora_training_receipts.py -q
# passed after review edge-case fixes: 18 passed in 0.11s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_aux_modules_scandir_probe.py
# passed: 7 passed; changed-line coverage 100.00%.

git commit -m "test: cover LoRA canary eos receipt failures"
# pre-commit passed:
# - make swift-test: passed in 228.1s.
# - make py-test: 3220 passed, 14 skipped, 2 warnings in 133.12s.
# - make integration-test: 115 passed, 1 skipped in 364.34s.
# - scoped performance report: Status ok; selected probes: 1; regressions: 0; context regressions: 0; verification failures: 0.

git commit -m "perf: trim MLX-LM structured result tail scan"
# pre-commit passed:
# - make swift-test: passed in 200.4s.
# - make py-test: 3237 passed, 14 skipped, 2 warnings in 133.51s.
# - make integration-test: 115 passed, 1 skipped in 328.76s.
# - scoped performance report: Status ok; selected probes: 1; regressions: 0; context regressions: 0; verification failures: 0.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_lora_training_runtime_preflight_receipts.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_generate_stream_receipts.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler_receipts.py services/mlx-worker-python/tests/test_training_planner_receipts.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py -q
# passed after merging origin/main at ae457bb8: 370 passed, 2 warnings in 3.12s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_lora_training_runtime_preflight_receipts.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_generate_stream_receipts.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler_receipts.py services/mlx-worker-python/tests/test_training_planner_receipts.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py -q
# passed after merging origin/main at 771bbf66: 370 passed, 2 warnings in 4.31s.

swift test --package-path services/control-plane-swift --filter 'ToolParserRegistryTests|OpenAIHandlerTests|OpenAIConformanceMatrixTests|RichOutputSanitizerTests'
# passed after merging origin/main at 771bbf66: Test run with 223 tests in 4 suites passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_lora_training_runtime_preflight_receipts.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_generate_stream_receipts.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler_receipts.py services/mlx-worker-python/tests/test_training_planner_receipts.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py -q
# passed after merging origin/main at 57774cb8: 371 passed, 2 warnings in 4.72s.

swift test --package-path services/control-plane-swift --filter 'ToolParserRegistryTests|OpenAIHandlerTests|OpenAIConformanceMatrixTests|RichOutputSanitizerTests'
# passed after merging origin/main at 57774cb8: Test run with 224 tests in 4 suites passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report
root = Path.cwd()
changed = subprocess.check_output(
    ["git", "diff", "--name-only", "origin/main...HEAD"],
    cwd=root,
    text=True,
).splitlines()
print(f"[manual-performance] changed files: {len(changed)}")
outcome = run_performance_report(root, changed, base_ref="origin/main")
print(f"[manual-performance] status={outcome.status} selected={outcome.selected_probe_count} report_dir={outcome.report_dir}")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# passed after merging origin/main at a8b6feee: Status ok; changed files: 27; selected probes: 8; regressions: 0; context regressions: 0; verification failures: 0.

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report
root = Path.cwd()
changed = subprocess.check_output(
    ["git", "diff", "--name-only", "origin/main...HEAD"],
    cwd=root,
    text=True,
).splitlines()
print(f"[manual-performance] changed files: {len(changed)}")
outcome = run_performance_report(root, changed, base_ref="origin/main")
print(f"[manual-performance] status={outcome.status} selected={outcome.selected_probe_count} report_dir={outcome.report_dir}")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# passed after merging origin/main at ae457bb8: Status ok; changed files: 28; selected probes: 8; regressions: 0; context regressions: 0; verification failures: 0.

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report
root = Path.cwd()
changed = subprocess.check_output(
    ["git", "diff", "--name-only", "origin/main...HEAD"],
    cwd=root,
    text=True,
).splitlines()
print(f"[manual-performance] changed files: {len(changed)}")
outcome = run_performance_report(root, changed, base_ref="origin/main")
print(f"[manual-performance] status={outcome.status} selected={outcome.selected_probe_count} report_dir={outcome.report_dir}")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# reported elapsed-only microbenchmark regressions after merging origin/main at 771bbf66.
# First run: Status regression; selected probes: 8; regressions: 2; verification failures: 0; report .runtime/pre-commit-performance/20260525-015548-2736cc56/report/report.md.
# Rerun: Status regression; selected probes: 8; regressions: 1; verification failures: 0; report .runtime/pre-commit-performance/20260525-015828-2736cc56/report/report.md.

for i in 1 2 3 4 5; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/mlx_lm_result_tail_probe.py; done
# completed after the full-report MLX-LM elapsed regression: head-only elapsed_ms_mean ranged from 0.064167 to 0.069167 ms with stable peak_bytes_mean 1781.4.

for i in 1 2 3 4 5; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/lora_aux_modules_scandir_probe.py; done
# completed after the full-report LoRA scandir elapsed regression: head-only elapsed_ms_mean ranged from 2.346214 to 2.492571 ms; scandir_calls_mean stayed 1.0 and peak_bytes_mean stayed 1007.0.

tmpdir=$(mktemp -d /tmp/melix-tail-probe-312.XXXXXX); git worktree add --detach "$tmpdir/base" origin/main >/dev/null && git worktree add --detach "$tmpdir/head" HEAD >/dev/null && for tree in base head base head base head base head base head; do (cd "$tmpdir/$tree" && printf '%s ' "$tree" && UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/chenyu/Documents/github/melix/.runtime/worktrees/feat-m-courtyard-runtime-training-followups/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/mlx_lm_result_tail_probe.py); done; git worktree remove "$tmpdir/base" --force >/dev/null; git worktree remove "$tmpdir/head" --force >/dev/null; rmdir "$tmpdir"
# completed: Python 3.12 detached base/head pairs showed no stable MLX-LM tail parse regression.
# base elapsed_ms_mean: 0.080383, 0.097734, 0.094817, 0.114208, 0.085058.
# head elapsed_ms_mean: 0.067108, 0.073108, 0.066883, 0.066567, 0.084967.

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report
root = Path.cwd()
changed = subprocess.check_output(
    ["git", "diff", "--name-only", "origin/main...HEAD"],
    cwd=root,
    text=True,
).splitlines()
print(f"[manual-performance] changed files: {len(changed)}")
outcome = run_performance_report(root, changed, base_ref="origin/main")
print(f"[manual-performance] status={outcome.status} selected={outcome.selected_probe_count} report_dir={outcome.report_dir}")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# reported one elapsed-only lora-aux-modules-scandir microbenchmark regression after merging origin/main at 57774cb8.
# Status regression; selected probes: 8; regressions: 1; verification failures: 0; report .runtime/pre-commit-performance/20260525-022659-e05cc42f/report/report.md.

for i in 1 2 3 4 5; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/lora_aux_modules_scandir_probe.py; done
# completed after the full-report LoRA scandir elapsed regression: head-only elapsed_ms_mean values were 2.811339, 2.448232, 2.952393, 2.915417, and 2.665446 ms; scandir_calls_mean stayed 1.0 and peak_bytes_mean stayed 1007.0.

tmpdir=$(mktemp -d /tmp/melix-lora-scandir-312.XXXXXX); git worktree add --detach "$tmpdir/base" origin/main >/dev/null && git worktree add --detach "$tmpdir/head" HEAD >/dev/null && for tree in base head base head base head base head base head; do (cd "$tmpdir/$tree" && printf '%s ' "$tree" && UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="/Users/chenyu/Documents/github/melix/.runtime/worktrees/feat-m-courtyard-runtime-training-followups/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/lora_aux_modules_scandir_probe.py); done; git worktree remove "$tmpdir/base" --force >/dev/null; git worktree remove "$tmpdir/head" --force >/dev/null; rmdir "$tmpdir"
# completed: Python 3.12 detached base/head pairs showed no stable LoRA scandir regression.
# base elapsed_ms_mean: 2.838214, 2.392012, 2.473577, 2.399411, 2.438393.
# head elapsed_ms_mean: 2.360696, 2.331887, 2.372685, 2.391387, 2.346887.
```

## Coverage and Metrics
- Current PR head: `e05cc42f`; current base: `origin/main` at `57774cb8`.
- Latest full PR-scoped performance report: `.runtime/pre-commit-performance/20260525-022659-e05cc42f/report/report.md`.
- Latest full PR-scoped report status: `regression`; changed files: `28`; selected probes: `8`; direct/gated probes: `8`; regressions: `1`; context regressions: `0`; verification failures: `0`.
- The remaining full-report regression is elapsed-only in `lora-aux-modules-scandir`: targeted tests passed, changed-line coverage passed (`100.0%`), `peak_bytes_mean`, `scandir_calls_mean`, and `noise_file_count` stayed neutral, and elapsed moved from `2.409` to `4.155` ms.
- This LoRA scandir elapsed signal did not reproduce under direct Python 3.12 base/head repeats: detached base elapsed means were `2.838214`, `2.392012`, `2.473577`, `2.399411`, and `2.438393` ms; detached head elapsed means were `2.360696`, `2.331887`, `2.372685`, `2.391387`, and `2.346887` ms, with `scandir_calls_mean` fixed at `1.0` and stable memory. This proves the full-report regression is measurement noise rather than an in-scope code-path regression.
- The prior full-report `mlx-lm-structured-result-tail-parse` regression also did not reproduce and is now `ok` in the latest full report: elapsed moved from `0.081` to `0.064` ms (`-20.34%`, improvement), with stable memory.
- All other latest full-report probes were `ok`: `stream-assembler-parser-mode-cache`, `stream-assembler-structural-prefix-cache`, `stream-assembler-token-byte-fast-decode`, `training-config-target-module-cache`, `mlx-lm-structured-result-tail-parse`, `lora-reward-summary-candidate-minmax`, and `engine-generate-usage-token-elision`.
- Latest commit-scoped pre-commit performance report: `.runtime/pre-commit-performance/20260525-005300-c1a0f47b/report/report.md`; status `ok`; selected probes: `1`; regressions: `0`; verification failures: `0`; MLX-LM structured result tail parse coverage `100.0%`.
- Observability mode: `evidence`; probe overhead is bounded to PR-scoped synthetic pytest/coverage/performance probes and does not add runtime production overhead.
- Protocol changes: `N/A`; no protobuf schema changes.
- Dependency changes: `N/A`; no lockfile or dependency changes.

## Known Gaps
- No deferred implementation gaps identified.
- Review follow-up fixed token-route receipt attribution for multi-token hidden/tool spans, preserved distinct runtime and adapter unsupported reasons in LoRA manifests, and corrected generation receipt docs to use the `melix.generation.` execution-ext prefix.
- Review edge-case follow-up classifies `-inf` float controls as `below_minimum`, treats null `disabled_decoder_paths` as empty evidence, and keeps the existing plain-text fast path on the shared finalizer receipt path.
- Latest PR-scoped performance after merging current `origin/main` still contains one elapsed-only LoRA scandir microbenchmark flag, but direct Python 3.12 base/head repeats show no stable regression and the probe invariants stayed neutral; no follow-up code change is indicated for that signal.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or `N/A` is stated explicitly.
- [x] Dependency changes include updated lockfiles, or `N/A` is stated explicitly.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
