### PR TITLE
perf: select PR scope probes by matched indexes

### DIFF
--- a/docs/plans/2026-05-24-pr-scope-selected-indexes.md
+++ b/docs/plans/2026-05-24-pr-scope-selected-indexes.md
@@ -1,0 +1,21 @@
+# PR-scoped Selected Probe Index Iteration
+
+## Scope
+
+This Python-only performance slice is limited to the PR-scoped performance scope-selection hot path in `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`.
+
+The affected path is already covered by registered PR-scoped probe `pr-scoped-performance-scope-matcher` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for the scope matcher, coverage path selection, and command-summary behavior.
+
+## Optimization
+
+For non-force-all scope reports, `_scope_selection_uncached()` already computes the matched probe indexes. The current implementation still walks every registered probe to emit selected probe dictionaries and matched probe IDs. This slice will reuse the matched indexes directly, preserving registry order via sorted indexes while skipping the extra full registry scans for the common small-selection case.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and local registered probe on Linux before opening the PR. The PR-scoped performance GitHub Actions workflow remains the merge gate for the registered probe result in CI.
+
+## Expected Metrics
+
+- `build_scope_report_ms_mean`: lower is better; expected to improve for small changed-file sets that select a subset of probes.
+- `selected_probe_count_mean`: unchanged.
+- `force_all_selected_mean`: unchanged.

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -2439,16 +2439,13 @@ def _scope_selection_uncached(
         changed_paths=changed_path_set,
         probes=probes,
     )
-    selected_probes = tuple(
-        _probe_scope_dict(probe)
-        for index, probe in enumerate(probes)
-        if force_all or index in matched_probe_indexes
-    )
-    matched_probe_ids = tuple(
-        probe.probe_id
-        for index, probe in enumerate(probes)
-        if index in matched_probe_indexes
-    )
+    matched_probe_index_tuple = tuple(sorted(matched_probe_indexes))
+    matched_probe_entries = tuple(probes[index] for index in matched_probe_index_tuple)
+    if force_all:
+        selected_probes = tuple(_probe_scope_dict(probe) for probe in probes)
+    else:
+        selected_probes = tuple(_probe_scope_dict(probe) for probe in matched_probe_entries)
+    matched_probe_ids = tuple(probe.probe_id for probe in matched_probe_entries)
     return force_all, matched_probe_ids, selected_probes
 
 


### PR DESCRIPTION
## Summary
- Reuse the matched probe index set when building non-force-all PR-scoped performance scope reports.
- Preserve registry ordering by sorting matched indexes and avoid walking every registered probe for the selected-probe and matched-ID outputs.
- Add a focused plan for this Python performance slice.

## Plan or Spec
- `docs/plans/2026-05-24-pr-scope-selected-indexes.md`
- Registered probe: `pr-scoped-performance-scope-matcher` in `infra/perf/pr_scoped_probes.json` already defines focused `test_command`, `coverage_command`, and `probe_command` entries for this path.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_exact_force_all_skips_wildcard_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_pr_scope_script_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_changed_paths_force_all_wildcards_handles_empty_matchers services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_empty_direct_paths_skips_probe_matching services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_exact_only_intersects_changed_paths services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_reuses_cached_frozenset_without_copying services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_matching_preserves_prefix_short_circuit services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_json_probe_rejects_missing_command_and_non_numeric_metrics
# 16 passed in 16.20s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 16 passed in 49.56s; changed-scope coverage TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id pr-scoped-performance-scope-matcher --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/pr_scope_selected_indexes_probe.json
# completed rc=0; head verification test_ok=True coverage_ok=True; base/head probes ok=True

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`5/5` measurable changed lines covered).
- Local registered probe `pr-scoped-performance-scope-matcher`:
  - `build_scope_report_ms_mean`: base `1.890732 ms`, head `1.404601 ms`, delta `-0.486131 ms` (`-25.71%`).
  - `command_summary_ms_mean`: base `16.389808 ms`, head `16.471741 ms`, delta `+0.081933 ms` (`+0.50%`, below the registered 5% warning threshold and not the optimized path).
  - `selected_probe_count_mean`: `7.0 -> 7.0`.
  - `force_all_selected_mean`: `0.0 -> 0.0`.
- CI PR-scoped performance remains the merge gate for the registered probe report.

## Known Gaps
- None. This is a Linux-verifiable Python tooling slice; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
