### PR TITLE
perf: fast-path video uri format inference

### DIFF
--- a/docs/plans/2026-05-24-video-preprocessing-uri-format-fastpath.md
+++ b/docs/plans/2026-05-24-video-preprocessing-uri-format-fastpath.md
@@ -1,0 +1,22 @@
+# Video preprocessing URI format fast path
+
+## Scope
+
+This Python-only performance slice is limited to URI-backed video preprocessing in `services/mlx-worker-python/worker/runtime/video_preprocessing.py`.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped performance probe `video-preprocessing-uri-byte-length-reuse` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` fields and watches:
+
+- `services/mlx-worker-python/worker/runtime/video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/video_preprocessing_uri_probe.py`
+
+## Optimization plan
+
+For URI video inputs with no explicit `format`, `mime_type`, or `filename`, reuse the already parsed URI suffix directly when it is one of the supported video formats. This keeps validation and output behavior unchanged while avoiding an extra `_resolve_video_format` call and varargs tuple construction in the hot path exercised by the registered probe.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and local registered probe on Linux. GitHub Actions PR-scoped performance remains the merge gate for base-vs-head validation.

--- a/services/mlx-worker-python/tests/test_video_preprocessing.py
+++ b/services/mlx-worker-python/tests/test_video_preprocessing.py
@@ -185,6 +185,7 @@ def test_prepare_video_input_reuses_parsed_uri_when_filename_is_absent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     parse_calls = 0
+    resolve_format_calls = 0
     original_parse = video_preprocessing._parse_video_reference
 
     def counting_parse(reference: str):
@@ -197,8 +198,14 @@ def test_prepare_video_input_reuses_parsed_uri_when_filename_is_absent(
             f"prepare_video_input should reuse parsed path metadata: {reference}"
         )
 
+    def counting_resolve_format(*args: object) -> str:  # pragma: no cover - regression only
+        nonlocal resolve_format_calls
+        resolve_format_calls += 1
+        return "mov"
+
     monkeypatch.setattr(video_preprocessing, "_parse_video_reference", counting_parse)
     monkeypatch.setattr(video_preprocessing, "_filename_from_reference", fail_filename_lookup)
+    monkeypatch.setattr(video_preprocessing, "_resolve_video_format", counting_resolve_format)
     part = common_pb2.MessagePart(
         video_uri="https://example.com/media/demo.mov",
         media=common_pb2.MediaMetadata(
@@ -212,6 +219,7 @@ def test_prepare_video_input_reuses_parsed_uri_when_filename_is_absent(
     assert prepared.format == "mov"
     assert prepared.filename == "demo.mov"
     assert parse_calls == 1
+    assert resolve_format_calls == 0
 
 
 def test_prepare_video_input_infers_format_from_plain_local_path() -> None:

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -89,7 +89,11 @@ def prepare_video_input(part) -> PreparedVideoInput:
         )
         resolved_filename = filename
     else:
-        resolved_format = _resolve_video_format(format_name, mime_type, parsed_reference)
+        inferred_suffix = parsed_reference.path_suffix
+        if not format_name and not mime_type and inferred_suffix in SUPPORTED_VIDEO_FORMATS:
+            resolved_format = inferred_suffix
+        else:
+            resolved_format = _resolve_video_format(format_name, mime_type, parsed_reference)
         resolved_filename = parsed_reference.path_name or f"remote-video.{resolved_format}"
     byte_length = int(getattr(media, "byte_length", 0) or 0)
     return PreparedVideoInput(


### PR DESCRIPTION
## Summary
- Fast-path URI-backed video preprocessing when the parsed URI suffix is already a supported video format and no explicit format, MIME type, or filename override is provided.
- Extend the regression test to prove the suffix-only hot path reuses parsed metadata without calling the generic format resolver.

## Plan or Spec
- `docs/plans/2026-05-24-video-preprocessing-uri-format-fastpath.md`
- Registered probe: `video-preprocessing-uri-byte-length-reuse` in `infra/perf/pr_scoped_probes.json` (has focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py::test_validate_video_uri_accepts_parsed_and_string_remote_references services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics
# 35 passed in 3.63s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py::test_validate_video_uri_accepts_parsed_and_string_remote_references services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/video_preprocessing_uri_probe.py
# 35 passed; TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/video_preprocessing_uri_probe.py
# {"byte_length_getattrs_per_call": 1.0, "elapsed_ms_mean": 586.0612398944795, "iterations_per_sample": 50000.0, "parse_calls_per_call": 1.0, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id video-preprocessing-uri-byte-length-reuse --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/video_preprocessing_uri_probe_compare.json
# base elapsed_ms_mean=562.7368716523051; head=569.303713645786; delta=+6.566841993480921 ms (+1.17%)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id video-preprocessing-uri-byte-length-reuse --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/video_preprocessing_uri_probe_compare_2.json
# base elapsed_ms_mean=611.6958385333419; head=565.1342961005867; delta=-46.56154243275523 ms (-7.61%)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id video-preprocessing-uri-byte-length-reuse --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/video_preprocessing_uri_probe_compare_3.json
# base elapsed_ms_mean=585.1525604724884; head=579.1252672672272; delta=-6.0272932052612305 ms (-1.03%)

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Local registered probe repeated runs:
  - Run 1: base `562.737 ms`, head `569.304 ms`, delta `+6.567 ms` (`+1.17%`).
  - Run 2: base `611.696 ms`, head `565.134 ms`, delta `-46.562 ms` (`-7.61%`).
  - Run 3: base `585.153 ms`, head `579.125 ms`, delta `-6.027 ms` (`-1.03%`).
  - Mean across registered runs: base `586.528 ms`, head `571.188 ms`, delta `-15.341 ms` (`-2.62%`).
- Structural metrics stayed unchanged: `byte_length_getattrs_per_call=1.0`, `parse_calls_per_call=1.0`.
- CI PR-scoped performance remains the required registered probe merge gate.

## Known Gaps
- Local Linux probe timing was noisy across repeated runs; the averaged registered runs point positive, but merge should wait for GitHub Actions PR-scoped performance validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
