### PR TITLE
perf: scan dataset ingest sources with scandir

### DIFF
--- a/docs/plans/2026-05-24-dataset-source-records-scandir.md
+++ b/docs/plans/2026-05-24-dataset-source-records-scandir.md
@@ -1,0 +1,43 @@
+# Dataset Source Records scandir Slice
+
+## Scope
+
+This Python performance slice is limited to dataset ingest source-file discovery in
+`services/mlx-worker-python/worker/productization/dataset_preparation.py`. It does
+not change dataset record parsing, cleaning controls, segmentation behavior,
+protobuf schemas, or dependencies.
+
+## Optimization Hypothesis
+
+Dataset ingest currently materializes source files with `Path.rglob("*")` and then
+filters files. For large raw-input trees this walks through `Path` glob machinery
+and allocates `Path` objects for non-file entries before ingest can classify each
+source. Replacing that discovery step with an explicit `os.scandir(...)` stack,
+while returning the same sorted `Path` list, should reduce source discovery
+latency without changing deterministic source ordering or operator-failure
+behavior.
+
+## Registered Probe
+
+This slice registers `dataset-source-records-scandir` in
+`infra/perf/pr_scoped_probes.json`. The probe builds a deterministic synthetic raw
+input tree, calls the source discovery helper repeatedly, validates the file count
+and ordering, and reports:
+
+- `elapsed_ms_mean` / `elapsed_ms_min` / `elapsed_ms_p95` for source discovery;
+- `file_count_mean` as an informational workload-size guard.
+
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries. This is a Python-only slice and is locally verifiable on
+Linux; GitHub Actions PR-scoped performance remains the merge gate for the
+registered probe report.
+
+## Validation Plan
+
+1. Run the registered focused test command locally on Linux.
+2. Run the registered changed-scope coverage command and require at least 95%
+   coverage for the touched scope.
+3. Run the registered probe locally against `origin/main` and this branch, then
+   compare `elapsed_ms_mean`.
+4. Push only if behavior tests pass and the local probe is neutral-to-improved;
+   rely on CI for final registered probe validation before merging.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4179,6 +4179,46 @@
     ]
   },
   {
+    "id": "dataset-source-records-scandir",
+    "name": "Dataset source records scandir",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/dataset_preparation.py",
+      "services/mlx-worker-python/tests/test_dataset_preparation_ingest.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/dataset_source_records_probe.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/dataset_source_records_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT=\"$PWD\" python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better"
+      },
+      {
+        "key": "elapsed_ms_p95",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "file_count_mean",
+        "unit": "items",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "lora-aux-modules-scandir",
     "name": "LoRA auxiliary module scandir",
     "runner": "ubuntu-latest",

--- a/scripts/dataset_source_records_probe.py
+++ b/scripts/dataset_source_records_probe.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(os.environ.get("MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT", Path.cwd()))
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.productization import dataset_preparation  # noqa: E402
+
+
+def _build_tree(root: Path, *, directory_count: int, files_per_directory: int) -> int:
+    total = 0
+    for directory_index in range(directory_count):
+        directory = root / f"group-{directory_index:04d}"
+        directory.mkdir(parents=True, exist_ok=True)
+        for file_index in range(files_per_directory):
+            (directory / f"sample-{file_index:04d}.txt").write_text("Melix source row\n", encoding="utf-8")
+            total += 1
+    return total
+
+
+def _iter_source_file_paths(input_path: Path) -> list[Path]:
+    helper = getattr(dataset_preparation, "_iter_source_file_paths", None)
+    if helper is None:
+        return sorted(path for path in input_path.rglob("*") if path.is_file())
+    return helper(input_path)
+
+
+def measure(*, directory_count: int, files_per_directory: int, samples: int) -> dict[str, float]:
+    elapsed_ms: list[float] = []
+    file_counts: list[float] = []
+    with tempfile.TemporaryDirectory(prefix="melix-dataset-source-records-probe-") as tmp:
+        root = Path(tmp) / "raw-inputs"
+        expected_count = _build_tree(root, directory_count=directory_count, files_per_directory=files_per_directory)
+        expected_first = root / "group-0000" / "sample-0000.txt"
+        expected_last = root / f"group-{directory_count - 1:04d}" / f"sample-{files_per_directory - 1:04d}.txt"
+        for _ in range(samples):
+            started = time.perf_counter()
+            paths = _iter_source_file_paths(root)
+            elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+            file_counts.append(float(len(paths)))
+            if len(paths) != expected_count:
+                raise RuntimeError(f"unexpected source file count: {len(paths)} != {expected_count}")
+            if paths[0] != expected_first or paths[-1] != expected_last:
+                raise RuntimeError("source file ordering changed")
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_ms),
+        "elapsed_ms_min": min(elapsed_ms),
+        "elapsed_ms_p95": sorted(elapsed_ms)[int((len(elapsed_ms) - 1) * 0.95)],
+        "directory_count": float(directory_count),
+        "files_per_directory": float(files_per_directory),
+        "file_count_mean": statistics.fmean(file_counts),
+        "sample_count": float(samples),
+    }
+
+
+def main() -> int:
+    directory_count = int(os.environ.get("MELIX_DATASET_SOURCE_RECORDS_PROBE_DIRS", "250"))
+    files_per_directory = int(os.environ.get("MELIX_DATASET_SOURCE_RECORDS_PROBE_FILES_PER_DIR", "24"))
+    samples = int(os.environ.get("MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES", "7"))
+    print(json.dumps(measure(directory_count=directory_count, files_per_directory=files_per_directory, samples=samples), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import sys
 
+import pytest
+
 from worker.productization.dataset_preparation import (
     DatasetIngestRequest,
+    _iter_source_file_paths,
     prepare_dataset_ingest,
 )
 
@@ -18,6 +22,85 @@ WORKSPACE_FIXTURE = (
     Path(__file__).resolve().parents[1]
     / "fixtures/workspace/m-courtyard-smoke.dev.v1/workspace-manifest.json"
 )
+
+
+def test_dataset_ingest_source_file_paths_use_scandir_without_rglob(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_root = tmp_path / "raw-inputs"
+    (input_root / "b").mkdir(parents=True)
+    (input_root / "a").mkdir()
+    (input_root / "z.txt").write_text("root\n", encoding="utf-8")
+    (input_root / "b" / "b.txt").write_text("b\n", encoding="utf-8")
+    (input_root / "a" / "a.txt").write_text("a\n", encoding="utf-8")
+
+    def fail_rglob(self: Path, pattern: str):  # pragma: no cover - failure path only
+        raise AssertionError(f"_iter_source_file_paths() should not call Path.rglob({pattern!r})")
+
+    monkeypatch.setattr(Path, "rglob", fail_rglob)
+
+    assert [path.relative_to(input_root).as_posix() for path in _iter_source_file_paths(input_root)] == [
+        "a/a.txt",
+        "b/b.txt",
+        "z.txt",
+    ]
+
+
+def test_dataset_ingest_source_file_paths_skips_scandir_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_root = tmp_path / "raw-inputs"
+    input_root.mkdir()
+    child_dir = input_root / "child"
+    file_path = input_root / "ok.txt"
+
+    class _ScandirResult:
+        def __init__(self, entries: list[object]) -> None:
+            self._entries = entries
+
+        def __enter__(self) -> list[object]:
+            return self._entries
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+            return False
+
+    class _BadEntry:
+        path = os.fspath(input_root / "bad.txt")
+
+        def is_dir(self, *, follow_symlinks: bool) -> bool:
+            raise OSError("bad entry")
+
+        def is_file(self, *, follow_symlinks: bool) -> bool:
+            raise OSError("bad entry")
+
+    class _ChildDirEntry:
+        path = os.fspath(child_dir)
+
+        def is_dir(self, *, follow_symlinks: bool) -> bool:
+            return True
+
+        def is_file(self, *, follow_symlinks: bool) -> bool:
+            return False
+
+    class _FileEntry:
+        path = os.fspath(file_path)
+
+        def is_dir(self, *, follow_symlinks: bool) -> bool:
+            return False
+
+        def is_file(self, *, follow_symlinks: bool) -> bool:
+            return True
+
+    def fake_scandir(path: object) -> _ScandirResult:
+        if os.fspath(path) == os.fspath(input_root):
+            return _ScandirResult([_BadEntry(), _ChildDirEntry(), _FileEntry()])
+        raise OSError("missing child")
+
+    monkeypatch.setattr("worker.productization.dataset_preparation.os.scandir", fake_scandir)
+
+    assert _iter_source_file_paths(input_root) == [file_path]
 
 
 def test_dataset_ingest_receipt_reports_independent_cleaning_controls(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -207,7 +207,9 @@ def test_scope_report_selects_dataset_version_listing_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/productization/dataset_preparation.py"],
     )
 
-    assert "dataset-version-listing-scandir" in _selected_probe_ids(scope)
+    selected_ids = _selected_probe_ids(scope)
+    assert "dataset-version-listing-scandir" in selected_ids
+    assert "dataset-source-records-scandir" in selected_ids
 
 
 def test_scope_report_selects_lora_aux_modules_probe() -> None:
@@ -250,6 +252,26 @@ def test_dataset_version_listing_probe_script_emits_metrics(
     assert metrics["elapsed_ms_p95"] >= 0.0
     assert metrics["sample_count"] == 1.0
     assert metrics["version_count"] == 5.0
+
+
+def test_dataset_source_records_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_DATASET_SOURCE_RECORDS_PROBE_DIRS", "3")
+    monkeypatch.setenv("MELIX_DATASET_SOURCE_RECORDS_PROBE_FILES_PER_DIR", "4")
+    monkeypatch.setenv("MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES", "1")
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/dataset_source_records_probe.py"))
+
+    assert probe_script["main"]() == 0
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] >= 0.0
+    assert metrics["elapsed_ms_p95"] >= 0.0
+    assert metrics["sample_count"] == 1.0
+    assert metrics["directory_count"] == 3.0
+    assert metrics["files_per_directory"] == 4.0
+    assert metrics["file_count_mean"] == 12.0
 
 
 def test_scope_report_selects_tool_registry_schema_bytes_probe() -> None:
@@ -2694,6 +2716,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "training-dataset-chunker-top-level-base-copy",
         "dataset-registry-preview-limit-short-circuit",
         "dataset-version-listing-scandir",
+        "dataset-source-records-scandir",
         "maintenance-bench-report-readback",
         "maintenance-percentile-vector-reuse",
         "maintenance-prompt-shape-vector-repeat",

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -499,7 +499,7 @@ def _iter_source_records(
     input_path: Path,
     operator_failures: list[dict[str, Any]],
 ) -> Iterable[dict[str, Any]]:
-    paths = [input_path] if input_path.is_file() else sorted(path for path in input_path.rglob("*") if path.is_file())
+    paths = [input_path] if input_path.is_file() else _iter_source_file_paths(input_path)
     for path in paths:
         source_kind = _source_kind(path)
         if source_kind is None:
@@ -534,6 +534,27 @@ def _iter_source_records(
                 text=_normalize_line_endings(text),
                 metadata=_metadata_for_path(path, source_kind),
             )
+
+
+def _iter_source_file_paths(input_path: Path) -> list[Path]:
+    file_paths: list[str] = []
+    stack = [os.fspath(input_path)]
+    while stack:
+        directory = stack.pop()
+        try:
+            with os.scandir(directory) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append(entry.path)
+                        elif entry.is_file(follow_symlinks=False):
+                            file_paths.append(entry.path)
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+    file_paths.sort()
+    return [Path(path) for path in file_paths]
 
 
 def _source_kind(path: Path) -> str | None:


### PR DESCRIPTION
## Summary
- Replaces dataset ingest source discovery `Path.rglob("*")` with an explicit `os.scandir` stack that keeps the existing sorted file ordering.
- Adds focused regression coverage for deterministic ordering and skipped `scandir`/entry errors.
- Registers the `dataset-source-records-scandir` PR-scoped performance probe with focused test, coverage, and probe commands.

## Plan or Spec
- `docs/plans/2026-05-24-dataset-source-records-scandir.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 8 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# 8 passed; TOTAL 83 2 98%

MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$BASE" PYTHONPATH="$BASE:$BASE/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 "$HEAD/scripts/dataset_source_records_probe.py"
# baseline elapsed_ms_mean=64.26759476640395, elapsed_ms_p95=67.91693903505802

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# head elapsed_ms_mean=11.687132263822216, elapsed_ms_p95=11.890637688338757

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 83 2 98%`.
- Local Linux registered probe equivalent: old_mean=64.26759476640395 ms, new_mean=11.687132263822216 ms, delta=-52.58046250258173 ms, speedup=5.499004658768666x.
- Workload guard: directory_count=250, files_per_directory=24, file_count_mean=6000.
- CI PR-scoped performance is required as the final registered-probe validation before merge.

## Known Gaps
- None for Python local validation. CI remains the merge gate for the registered PR-scoped probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
