### PR TITLE
perf: fast-path hub catalog byte-width tags

### DIFF
--- a/docs/plans/2026-05-25-hub-catalog-quant-tag-membership.md
+++ b/docs/plans/2026-05-25-hub-catalog-quant-tag-membership.md
@@ -1,0 +1,26 @@
+# Hub Catalog Quantization Tag Membership Fast Path
+
+## Goal
+
+Reduce repeated Hub catalog summary-record overhead for common exact quantization byte-width tags without changing quantization priority or summary text.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `hub-catalog-tag-normalization-single-pass` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_tag_normalization_probe.py`
+
+## Slice
+
+This Python-only Linux-verifiable slice narrows byte-width detection in `hub_catalog.py`:
+
+- Keep exact lowercase byte-width tags on direct set-membership checks before scanning tag substrings.
+- Preserve substring fallback for non-standard byte-width aliases.
+- Preserve bytes-per-parameter priority (`2-bit`, `3-bit`, `4-bit`, `8-bit`, `fp32`).
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and local registered probe against an `origin/main` baseline worktree and this branch. CI PR-scoped performance remains the merge gate before squash merge.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -86,6 +86,7 @@ def test_quantization_summary_preserves_alias_order_from_lowered_tags() -> None:
 
 
 def test_bytes_per_parameter_preserves_quantization_priority_without_joining_tags() -> None:
+    assert _bytes_per_parameter([], lowered_tags={"family", "2bit", "float32"}) == 0.25
     assert _bytes_per_parameter([], lowered_tags={"family", "float32", "4-bit"}) == 0.5
     assert _bytes_per_parameter([], lowered_tags={"family", "8bit"}) == 1.0
     assert _bytes_per_parameter([], lowered_tags={"family", "3-bit", "8bit"}) == 0.375

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -803,6 +803,20 @@ def _kv_cache_bytes_per_element(config: dict[str, Any]) -> int:
 
 def _bytes_per_parameter(tags: list[str], *, lowered_tags: set[str] | None = None) -> float:
     lowered = _normalized_lowered_tags(tags, lowered_tags)
+    if "2bit" in lowered or "2-bit" in lowered:
+        return 0.25
+    if "3bit" in lowered or "3-bit" in lowered:
+        return 0.375
+    if "4bit" in lowered or "4-bit" in lowered:
+        return 0.5
+    if "8bit" in lowered or "8-bit" in lowered:
+        return 1.0
+    if "fp32" in lowered or "float32" in lowered or "f32" in lowered:
+        return 4.0
+    return _bytes_per_parameter_from_tag_substrings(lowered)
+
+
+def _bytes_per_parameter_from_tag_substrings(lowered: set[str]) -> float:
     has_3bit = False
     has_4bit = False
     has_8bit = False


### PR DESCRIPTION
## Summary
- Add a direct set-membership fast path for exact Hub catalog byte-width tags before falling back to substring scanning.
- Preserve bytes-per-parameter priority and existing quantization summary behavior.
- Add a focused regression assertion for exact `2bit` priority.

## Plan or Spec
- Added `docs/plans/2026-05-25-hub-catalog-quant-tag-membership.md`.
- Registered probe coverage: `hub-catalog-tag-normalization-single-pass` in `infra/perf/pr_scoped_probes.json` already covers the affected Hub catalog path with `test_command`, `coverage_command`, and `probe_command`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-tag-normalization-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-hub-catalog-quant-tag-membership-base --head-repo "$PWD" --output /tmp/hub_catalog_quant_tag_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `60 passed`.
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Local registered probe (`hub-catalog-tag-normalization-single-pass`, Linux):
  - `base_elapsed_ms_mean=235.2719129063189`
  - `head_elapsed_ms_mean=228.86058371514082`
  - `delta_ms=-6.411329191178083`
  - `speedup_pct=2.7250720717057972`
  - `tag_normalization_calls_mean=5000.0 -> 5000.0`

## Known Gaps
- This is a Python-only slice validated locally on Linux. CI PR-scoped performance is still required as the merge gate.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Registered PR-scoped probe exists with focused test, coverage, and probe commands.
- [x] Focused tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe improved the target elapsed metric.
- [ ] GitHub Actions PR-scoped performance completed successfully.
