### PR TITLE
perf: parse changed-scope diffs with splitlines

### DIFF
--- a/docs/plans/2026-05-25-changed-scope-diff-splitlines.md
+++ b/docs/plans/2026-05-25-changed-scope-diff-splitlines.md
@@ -1,0 +1,16 @@
+# Changed-scope diff parser splitlines
+
+## Scope
+
+This performance slice targets `scripts/changed_scope_coverage.py` and the registered PR-scoped probe `changed-scope-coverage-diff-parser`.
+
+## Plan
+
+- Keep the existing prefix-dispatch parser semantics for git diff output.
+- Replace the explicit `split("\n")` line materialization with `splitlines()` in `_parse_changed_lines` so the hot parser loop avoids producing a synthetic trailing empty record for normal newline-terminated diff output.
+- Preserve line-number accounting for blank context lines, additions, deletions, malformed hunks, and no-newline markers.
+
+## Validation
+
+- Focused parser regression coverage keeps multiple-file/multiple-hunk parsing stable and now asserts equivalent output for newline-terminated diff text.
+- Registered probe: `scripts/changed_scope_coverage_parse_probe.py` reports parser elapsed time for a synthetic multi-file diff under the `changed-scope-coverage-diff-parser` PR-scoped probe.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -63,7 +63,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     header_separator_len = len(header_separator)
     add_changed_line = None
     new_line: int | None = None
-    for line in diff_text.split("\n"):
+    for line in diff_text.splitlines():
         if not line:
             if add_changed_line is not None and new_line is not None:
                 new_line += 1

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -68,6 +68,7 @@ def test_parse_changed_lines_handles_multiple_files_and_hunks() -> None:
         "foo.py": {3, 4, 12},
         "bar.py": {6, 7},
     }
+    assert changed_scope_coverage._parse_changed_lines(diff_text + "\n") == changed
 
 
 def test_parse_hunk_new_start_uses_delimiters_for_counted_and_single_line_ranges() -> None:


### PR DESCRIPTION
## Summary
- Parse changed-scope diff text with `splitlines()` instead of `split("\n")` in the hot parser loop.
- Add a regression assertion that newline-terminated diff text produces the same changed-line map.
- Document the slice under `docs/plans/2026-05-25-changed-scope-diff-splitlines.md`.

## Plan or Spec
- `docs/plans/2026-05-25-changed-scope-diff-splitlines.md`
- Registered probe: `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `python3 scripts/changed_scope_coverage_parse_probe.py` on `origin/main` baseline: `elapsed_ms_mean=3.6219404622291527`, `elapsed_ms_min=3.212638199329376`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `python3 scripts/changed_scope_coverage_parse_probe.py` on this branch: `elapsed_ms_mean=3.488698275759816`, `elapsed_ms_min=3.2282480970025063`
- `python3 /tmp/compare_changed_scope_splitlines.py`: `base_mean=3.8762369100004435`, `head_mean=3.8326682057231665`, `delta_ms=-0.04356870427727699`, `speedup=1.0113677213728591`, `samples=50`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 31 passed.
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Local registered probe metric: baseline `elapsed_ms_mean=3.6219404622291527`; branch `elapsed_ms_mean=3.488698275759816`; local delta `-0.13324218646933652 ms` (~1.04x faster).
- Interleaved comparison: `base_mean=3.8762369100004435`, `head_mean=3.8326682057231665`, `speedup=1.0113677213728591`.
- CI PR-scoped performance report is required for merge validation.

## Known Gaps
- This is a small Python parser-loop slice; the local gain is intentionally modest and should be confirmed by the registered CI probe.
- No Swift runtime behavior is touched.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is >= 95%.
- [x] Local registered probe was run on Linux.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
