### PR TITLE
perf: scan native MTP safetensors once

### DIFF
--- a/docs/plans/2026-05-25-native-mtp-loader-safetensor-scandir.md
+++ b/docs/plans/2026-05-25-native-mtp-loader-safetensor-scandir.md
@@ -1,0 +1,34 @@
+# Native MTP loader safetensor scandir slice
+
+## Scope
+
+Replace the native-MTP loader's top-level `model*.safetensors` glob with a
+single `os.scandir()` pass. This path is exercised only when sidecar MTP shards
+are present and the loader falls back to the custom `mlx-lm` model-load path.
+
+## Probe
+
+Registered PR-scoped probe: `native-mtp-loader-safetensor-scandir` in
+`infra/perf/pr_scoped_probes.json`.
+
+The probe builds a synthetic model directory containing base model shard files,
+MTP sidecar shard files, and distractor entries, then compares:
+
+- old behavior: `glob.glob(str(model_dir / "model*.safetensors"))` plus file filtering
+- new behavior: `_model_safetensor_files(model_dir)` backed by `os.scandir()`
+
+Metrics:
+
+- `old_mean_ms`
+- `new_mean_ms`
+- `delta_ms`
+- `speedup`
+- `old_peak_bytes_mean`
+- `new_peak_bytes_mean`
+- `result_count`
+
+## Verification
+
+Run the registered focused `test_command`, `coverage_command`, and
+`probe_command` locally on Linux. The runtime effect is Python-only and locally
+measurable; no Swift runtime validation is required for this slice.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4313,5 +4313,66 @@
         "warn_pct": 0.0
       }
     ]
+  },
+  {
+    "id": "native-mtp-loader-safetensor-scandir",
+    "name": "Native MTP loader safetensor scandir",
+    "description": "List native-MTP base model safetensor shards with os.scandir instead of glob during sidecar shard attachment.",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py",
+      "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/native_mtp_loader_safetensor_scandir_probe.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_NATIVE_MTP_LOADER_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/native_mtp_loader_safetensor_scandir_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "old_mean_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "new_mean_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "delta_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "speedup",
+        "unit": "x",
+        "direction": "higher_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "old_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "new_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "result_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      }
+    ]
   }
 ]

--- a/scripts/native_mtp_loader_safetensor_scandir_probe.py
+++ b/scripts/native_mtp_loader_safetensor_scandir_probe.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import glob
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+
+repo_root_env = os.environ.get("MELIX_NATIVE_MTP_LOADER_REPO_ROOT")
+repo_root = Path(repo_root_env) if repo_root_env else Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
+
+try:
+    from worker.runtime.native_mtp.mlx_lm_loader import _model_safetensor_files
+except ImportError:  # Base revisions before this slice do not expose the helper.
+    _model_safetensor_files = None
+
+
+def _populate_model_dir(model_dir: Path, *, model_files: int, distractor_files: int) -> None:
+    model_dir.mkdir(parents=True, exist_ok=True)
+    for index in range(model_files):
+        (model_dir / f"model-{index:05d}-of-{model_files:05d}.safetensors").write_bytes(b"0")
+    (model_dir / "model.safetensors").write_bytes(b"0")
+    for index in range(distractor_files):
+        (model_dir / f"mtp-{index:05d}.safetensors").write_bytes(b"0")
+        (model_dir / f"model-{index:05d}.bin").write_bytes(b"0")
+    (model_dir / "model-nested.safetensors").mkdir()
+
+
+def _glob_model_safetensors(model_dir: Path) -> list[str]:
+    files = glob.glob(str(model_dir / "model*.safetensors"))
+    files.sort()
+    return files
+
+
+def _measure(callback, model_dir: Path, *, samples: int) -> tuple[list[float], list[float], int]:
+    elapsed_ms: list[float] = []
+    peaks: list[float] = []
+    result_count = 0
+    for _ in range(samples):
+        tracemalloc.start()
+        start = time.perf_counter()
+        try:
+            result = callback(model_dir)
+        finally:
+            _, peak = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+        elapsed_ms.append((time.perf_counter() - start) * 1000.0)
+        peaks.append(float(peak))
+        result_count = len(result)
+    return elapsed_ms, peaks, result_count
+
+
+def run_probe() -> dict[str, float | int | str]:
+    model_files = int(os.environ.get("MELIX_NATIVE_MTP_LOADER_MODEL_FILES", "1500"))
+    distractor_files = int(os.environ.get("MELIX_NATIVE_MTP_LOADER_DISTRACTOR_FILES", "1500"))
+    samples = int(os.environ.get("MELIX_NATIVE_MTP_LOADER_SAMPLES", "5"))
+    with tempfile.TemporaryDirectory() as tmp:
+        model_dir = Path(tmp) / "model"
+        _populate_model_dir(
+            model_dir,
+            model_files=model_files,
+            distractor_files=distractor_files,
+        )
+        baseline = _glob_model_safetensors(model_dir)
+        candidate_callback = _model_safetensor_files or _glob_model_safetensors
+        candidate = candidate_callback(model_dir)
+        if baseline != candidate:
+            raise SystemExit("candidate safetensor listing differs from glob baseline")
+        old_ms, old_peaks, result_count = _measure(_glob_model_safetensors, model_dir, samples=samples)
+        new_ms, new_peaks, _ = _measure(candidate_callback, model_dir, samples=samples)
+    old_mean = statistics.mean(old_ms)
+    new_mean = statistics.mean(new_ms)
+    return {
+        "result_count": result_count,
+        "model_files": model_files,
+        "distractor_files": distractor_files,
+        "samples": samples,
+        "old_mean_ms": old_mean,
+        "new_mean_ms": new_mean,
+        "delta_ms": new_mean - old_mean,
+        "speedup": old_mean / new_mean if new_mean else 0.0,
+        "old_peak_bytes_mean": statistics.mean(old_peaks),
+        "new_peak_bytes_mean": statistics.mean(new_peaks),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(run_probe(), sort_keys=True))

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -44,6 +44,7 @@ from worker.runtime.mlx_vlm_runtime import (
     _patch_gemma4_scaled_linear_quantization,
 )
 from worker.runtime.mlx_executor import MLXRuntimeExecutor
+from worker.runtime.native_mtp.mlx_lm_loader import _model_safetensor_files
 from worker.runtime.temp_media_lifecycle import TempMediaSession
 
 
@@ -1492,6 +1493,108 @@ def test_mlx_vlm_runtime_applies_native_mtp_preload_patch_before_load(
     assert loaded["metadata"]["melix.native_mtp.patch_applied"] == "true"
     assert loaded["metadata"]["melix.native_mtp.active"] == "true"
     assert loaded["metadata"][_TEXT_ONLY_BATCH_GENERATOR_EXT_KEY] == "true"
+
+
+def test_native_mtp_model_safetensor_listing_uses_scandir_without_glob(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    expected_files = [
+        model_dir / "model-00002-of-00002.safetensors",
+        model_dir / "model-00001-of-00002.safetensors",
+        model_dir / "model.safetensors",
+    ]
+    for path in expected_files:
+        path.write_bytes(b"weights")
+    (model_dir / "mtp.safetensors").write_bytes(b"sidecar")
+    (model_dir / "model-not-a-safetensor.bin").write_bytes(b"ignored")
+    child_dir = model_dir / "model-subdir.safetensors"
+    child_dir.mkdir()
+    (child_dir / "nested.safetensors").write_bytes(b"ignored")
+
+    def fail_glob(self: Path, pattern: str):  # pragma: no cover - regression guard
+        raise AssertionError(
+            f"_model_safetensor_files() should not allocate Path.glob({pattern!r})"
+        )
+
+    monkeypatch.setattr(Path, "glob", fail_glob)
+
+    assert _model_safetensor_files(model_dir) == sorted(
+        str(path) for path in [*expected_files, child_dir]
+    )
+    assert _model_safetensor_files(tmp_path / "missing") == []
+
+
+def test_native_mtp_patched_loader_uses_scandir_model_weight_listing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import worker.runtime.native_mtp.mlx_lm_loader as loader_module
+
+    model_dir = tmp_path / "patched-model"
+    model_dir.mkdir()
+    (model_dir / "model.safetensors").write_bytes(b"base")
+    (model_dir / "mtp.safetensors").write_bytes(b"mtp")
+    (model_dir / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"language_model.mtp.fc.weight": "mtp.safetensors"}}),
+        encoding="utf-8",
+    )
+
+    loaded_weight_paths: list[str] = []
+
+    class FakeModelArgs:
+        @classmethod
+        def from_dict(cls, config: dict[str, object]) -> dict[str, object]:
+            return config
+
+    class FakeModel:
+        def __init__(self, args: dict[str, object]) -> None:
+            self.args = args
+            self.loaded_weights: list[tuple[str, object]] = []
+
+        def eval(self) -> None:
+            pass
+
+        def load_weights(self, weights: list[tuple[str, object]], *, strict: bool) -> None:
+            self.loaded_weights = weights
+            self.strict = strict
+
+        def parameters(self) -> list[object]:
+            return []
+
+    fake_mx = SimpleNamespace(
+        load=lambda path: loaded_weight_paths.append(path) or {path: path},
+        eval=lambda parameters: None,
+    )
+    fake_nn = SimpleNamespace(
+        Module=SimpleNamespace(is_module=lambda value: False),
+        QuantizedLinear=type("QuantizedLinear", (), {}),
+        quantize=lambda *args, **kwargs: None,
+    )
+    fake_utils = SimpleNamespace(
+        load_model=lambda *args, **kwargs: ("original", {}),
+        load_config=lambda path: {"model_type": "fake"},
+        _get_classes=lambda config: (FakeModel, FakeModelArgs),
+        _transform_awq_weights=lambda weights, quantization_config: (weights, {}),
+        tree_map=lambda callback, modules, is_leaf: modules,
+    )
+    fake_mlx_lm = ModuleType("mlx_lm")
+    fake_mlx_lm.utils = fake_utils
+    monkeypatch.setitem(sys.modules, "mlx", ModuleType("mlx"))
+    monkeypatch.setitem(sys.modules, "mlx.core", fake_mx)
+    monkeypatch.setitem(sys.modules, "mlx.nn", fake_nn)
+    monkeypatch.setitem(sys.modules, "mlx_lm", fake_mlx_lm)
+    monkeypatch.setitem(sys.modules, "mlx_lm.utils", fake_utils)
+    monkeypatch.setattr(loader_module, "_PATCHED", False)
+
+    assert loader_module.apply() is True
+    model, config = fake_utils.load_model(model_dir, lazy=True)
+
+    assert isinstance(model, FakeModel)
+    assert config == {"model_type": "fake"}
+    assert loaded_weight_paths == [str(model_dir / "model.safetensors"), str(model_dir / "mtp.safetensors")]
 
 
 def test_native_mtp_preload_patch_detects_qwen36_mtp_weights(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -230,6 +230,15 @@ def test_scope_report_selects_trajectory_provenance_copy_elision_probe() -> None
     assert _selected_probe_ids(scope) == ["trajectory-provenance-copy-elision"]
 
 
+def test_scope_report_selects_native_mtp_loader_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py"],
+    )
+
+    assert _selected_probe_ids(scope) == ["native-mtp-loader-safetensor-scandir"]
+
+
 def test_lora_aux_modules_scandir_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -264,6 +273,25 @@ def test_trajectory_provenance_copy_elision_probe_script_emits_metrics(
     assert metrics["sample_count"] == 1.0
     assert metrics["iteration_count"] == 10.0
     assert metrics["component_count"] == 4.0
+
+
+def test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MELIX_NATIVE_MTP_LOADER_MODEL_FILES", "8")
+    monkeypatch.setenv("MELIX_NATIVE_MTP_LOADER_DISTRACTOR_FILES", "8")
+    monkeypatch.setenv("MELIX_NATIVE_MTP_LOADER_SAMPLES", "1")
+    probe_script = runpy.run_path(
+        str(REPO_ROOT / "scripts/native_mtp_loader_safetensor_scandir_probe.py")
+    )
+
+    metrics = probe_script["run_probe"]()
+
+    assert metrics["old_mean_ms"] >= 0.0
+    assert metrics["new_mean_ms"] >= 0.0
+    assert metrics["result_count"] == 10
+    assert metrics["model_files"] == 8
+    assert metrics["distractor_files"] == 8
 
 
 def test_dataset_version_listing_probe_script_emits_metrics(
@@ -2721,6 +2749,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "lora-experiment-run-dir-name-scan",
         "lora-reward-summary-candidate-minmax",
         "mlx-lm-structured-result-tail-parse",
+        "native-mtp-loader-safetensor-scandir",
         "mlx-audio-local-uri-zero-copy-preprocess",
         "mlx-audio-generate-signature-cache",
         "mlx-audio-speech-signature-cache",

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import glob
 import importlib.util
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any, Callable, Type
 
@@ -23,6 +23,23 @@ def _load_json_payload(path: Path) -> dict[str, Any]:
 def _is_mtp_weight_key(key: Any) -> bool:
     value = str(key)
     return value.startswith("language_model.mtp.") or value.startswith("mtp.")
+
+
+def _model_safetensor_files(model_path: Path) -> list[str]:
+    """Return top-level ``model*.safetensors`` paths without glob allocation."""
+
+    try:
+        with os.scandir(model_path) as entries:
+            weight_files = [
+                entry.path
+                for entry in entries
+                if entry.name.startswith("model")
+                and entry.name.endswith(".safetensors")
+            ]
+    except FileNotFoundError:
+        return []
+    weight_files.sort()
+    return weight_files
 
 
 def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
@@ -92,7 +109,7 @@ def apply() -> bool:
         if model_config is not None:
             config.update(model_config)
 
-        weight_files = glob.glob(str(model_path / "model*.safetensors"))
+        weight_files = _model_safetensor_files(model_path)
         if not weight_files and strict:
             raise FileNotFoundError(f"No safetensors found in {model_path}")
 


### PR DESCRIPTION
## Summary
- Replace the native-MTP loader's `glob.glob(model*.safetensors)` scan with a top-level `os.scandir()` listing helper.
- Add a registered PR-scoped performance probe for the native-MTP safetensor listing path.
- Add focused regression coverage for listing parity and patched loader weight ordering.

## Plan or Spec
- `docs/plans/2026-05-25-native-mtp-loader-safetensor-scandir.md`
- Registered probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 7 passed.
- Changed-scope coverage: 100.00% for `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` changed lines.
- Local registered probe (Linux): `old_mean_ms=22.113150730729103`, `new_mean_ms=8.578930608928204`, `delta_ms=-13.5342201218009`, `speedup=2.577611562414978`, `old_peak_bytes_mean=338873.0`, `new_peak_bytes_mean=163000.0`, `result_count=1502`.

## Known Gaps
- This slice is Python-only and locally measurable on Linux. No Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance report is required before merge.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before the slice.
- [x] Registered PR-scoped probe covers the changed path with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows a positive performance delta.
- [ ] GitHub Actions and registered PR-scoped performance workflow are green.
