### PR TITLE
perf: cache report evidence metric prefixes

### DIFF
--- a/docs/plans/2026-05-25-report-evidence-metric-prefix-cache.md
+++ b/docs/plans/2026-05-25-report-evidence-metric-prefix-cache.md
@@ -1,0 +1,38 @@
+# Report Evidence Metric Prefix Cache Slice
+
+## Scope
+
+This Python-only performance slice is limited to release-matrix metric-prefix rule matching in `services/mlx-worker-python/worker/productization/report_evidence_gate.py`.
+
+The existing run-kind fast path already caches tuple-backed `run_kinds` normalization. This slice applies the same immutable-rule strategy to tuple-backed `metric_prefixes` rules while preserving mutation visibility for non-tuple iterables.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.
+
+This slice extends that probe to measure both:
+
+- `run_kind_elapsed_ms_mean` for the existing tuple-backed `run_kinds` rule path;
+- `metric_prefix_elapsed_ms_mean` for the tuple-backed `metric_prefixes` path added here.
+
+The registered entry keeps focused `test_command`, `coverage_command`, and `probe_command` coverage for the source path, tests, registry entry, and probe script.
+
+## Implementation Plan
+
+1. Add a cached tuple normalizer for immutable tuple-backed `metric_prefixes` rules.
+2. Keep non-tuple `metric_prefixes` rules uncached so caller-visible mutation behavior remains unchanged.
+3. Add regression tests for tuple cache reuse and mutable list behavior.
+4. Extend the registered probe script and registry metrics to report the new metric-prefix timing.
+
+## Acceptance Criteria
+
+- Focused report evidence gate tests pass locally on Linux.
+- Changed-scope coverage for the touched Python path remains at or above 95%.
+- The registered probe reports a lower `metric_prefix_elapsed_ms_mean` than the pre-change baseline.
+- PR-scoped performance CI completes successfully before merge.
+
+## Non-Goals
+
+- No release evidence schema changes.
+- No generated protocol or lockfile changes.
+- No Swift runtime performance claims from local Linux validation.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4114,8 +4114,8 @@
       "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
       "scripts/report_evidence_gate_run_kind_probe.py"
     ],
-    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics",
-    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py",
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py",
     "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/report_evidence_gate_run_kind_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
@@ -4127,12 +4127,34 @@
         "warn_pct": 5.0
       },
       {
+        "key": "run_kind_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "metric_prefix_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
         "key": "run_kind_count",
         "unit": "items",
         "direction": "informational"
       },
       {
         "key": "runs_per_call",
+        "unit": "items",
+        "direction": "informational"
+      },
+      {
+        "key": "metric_prefix_count",
+        "unit": "items",
+        "direction": "informational"
+      },
+      {
+        "key": "metrics_per_call",
         "unit": "items",
         "direction": "informational"
       }

--- a/scripts/report_evidence_gate_run_kind_probe.py
+++ b/scripts/report_evidence_gate_run_kind_probe.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 from worker.productization.report_evidence_gate import _rule_matches_report  # noqa: E402
 
 
-def _measure(iterations: int, sample_count: int) -> dict[str, float]:
+def _measure_run_kind(iterations: int, sample_count: int) -> tuple[dict[str, float], float]:
     run_kinds = tuple(f"probe_kind_{index}" for index in range(64)) + ("target_kind",)
     rule = {"run_kinds": run_kinds}
     runs = [{"run_kind": f"observed_kind_{index}"} for index in range(79)] + [{"run_kind": "target_kind"}]
@@ -36,13 +36,62 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
             match_count += 1
         elapsed_samples.append((time.perf_counter() - started) * 1000.0)
 
+    elapsed_mean = statistics.fmean(elapsed_samples)
+    return (
+        {
+            "run_kind_elapsed_ms_mean": elapsed_mean,
+            "run_kind_count": float(len(run_kinds)),
+            "runs_per_call": float(len(runs)),
+            "match_count": float(match_count),
+        },
+        elapsed_mean,
+    )
+
+
+def _measure_metric_prefix(iterations: int, sample_count: int) -> tuple[dict[str, float], float]:
+    metric_prefixes = tuple(f"probe.metric.{index}." for index in range(64)) + ("target.metric.",)
+    rule = {"metric_prefixes": metric_prefixes}
+    metrics = [{"metric": f"observed.metric.{index}.latency_ms"} for index in range(79)] + [
+        {"metric": "target.metric.decode_ms"}
+    ]
+    elapsed_samples: list[float] = []
+    match_count = 0
+
+    for _ in range(sample_count):
+        started = time.perf_counter()
+        for _index in range(iterations):
+            if not _rule_matches_report(
+                rule=rule,
+                runs=[],
+                targets=[],
+                metrics=metrics,
+                probe_phases=set(),
+            ):
+                raise RuntimeError("expected metric-prefix rule to match target metric")
+            match_count += 1
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+
+    elapsed_mean = statistics.fmean(elapsed_samples)
+    return (
+        {
+            "metric_prefix_elapsed_ms_mean": elapsed_mean,
+            "metric_prefix_count": float(len(metric_prefixes)),
+            "metrics_per_call": float(len(metrics)),
+            "metric_prefix_match_count": float(match_count),
+        },
+        elapsed_mean,
+    )
+
+
+def _measure(iterations: int, sample_count: int) -> dict[str, float]:
+    run_kind_metrics, run_kind_elapsed = _measure_run_kind(iterations, sample_count)
+    metric_prefix_metrics, metric_prefix_elapsed = _measure_metric_prefix(iterations, sample_count)
     return {
-        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "elapsed_ms_mean": run_kind_elapsed + metric_prefix_elapsed,
         "iterations": float(iterations),
         "sample_count": float(sample_count),
-        "run_kind_count": float(len(run_kinds)),
-        "runs_per_call": float(len(runs)),
-        "match_count": float(match_count),
+        **run_kind_metrics,
+        **metric_prefix_metrics,
     }
 
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -198,7 +198,12 @@ def test_report_evidence_gate_run_kind_probe_script_emits_metrics(
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["elapsed_ms_mean"] >= 0.0
     assert metrics["match_count"] == metrics["iterations"] * metrics["sample_count"]
+    assert metrics["metric_prefix_match_count"] == metrics["iterations"] * metrics["sample_count"]
+    assert metrics["run_kind_elapsed_ms_mean"] >= 0.0
+    assert metrics["metric_prefix_elapsed_ms_mean"] >= 0.0
     assert metrics["run_kind_count"] == 65.0
+    assert metrics["metric_prefix_count"] == 65.0
+    assert metrics["metrics_per_call"] == 80.0
 
 
 def test_scope_report_selects_dataset_version_listing_probe() -> None:

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -188,6 +188,51 @@ def test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set() -> Non
     assert cache_info.misses == 1
 
 
+def test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple() -> None:
+    report_evidence_gate_module._string_tuple_from_tuple.cache_clear()
+    rule = {"metric_prefixes": ("adapter.", "runtime.")}
+
+    assert report_evidence_gate_module._rule_matches_report(
+        rule=rule,
+        runs=[],
+        targets=[],
+        metrics=[{"metric": "adapter.loss"}],
+        probe_phases=set(),
+    )
+    assert report_evidence_gate_module._rule_matches_report(
+        rule=rule,
+        runs=[],
+        targets=[],
+        metrics=[{"metric": "runtime.decode_ms"}],
+        probe_phases=set(),
+    )
+
+    cache_info = report_evidence_gate_module._string_tuple_from_tuple.cache_info()
+    assert cache_info.hits >= 1
+    assert cache_info.misses == 1
+
+
+def test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation() -> None:
+    metric_prefixes = ["adapter."]
+    rule = {"metric_prefixes": metric_prefixes}
+
+    assert not report_evidence_gate_module._rule_matches_report(
+        rule=rule,
+        runs=[],
+        targets=[],
+        metrics=[{"metric": "runtime.decode_ms"}],
+        probe_phases=set(),
+    )
+    metric_prefixes.append("runtime.")
+    assert report_evidence_gate_module._rule_matches_report(
+        rule=rule,
+        runs=[],
+        targets=[],
+        metrics=[{"metric": "runtime.decode_ms"}],
+        probe_phases=set(),
+    )
+
+
 def test_report_evidence_gate_run_kind_list_rules_reflect_mutation() -> None:
     run_kinds = ["evaluation"]
     rule = {"run_kinds": run_kinds}

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -295,11 +295,11 @@ def _rule_matches_report(
         for run in runs:
             if to_string(run.get(run_kind_key, "")) in run_kind_set:
                 return True
-    metric_prefixes = tuple(str(item) for item in rule.get("metric_prefixes", ()))
-    if metric_prefixes and any(
-        str(metric.get("metric", "")).startswith(metric_prefixes) for metric in metrics
-    ):
-        return True
+    metric_prefixes = rule.get("metric_prefixes", ())
+    if metric_prefixes:
+        metric_prefix_tuple = _string_tuple(metric_prefixes)
+        if any(str(metric.get("metric", "")).startswith(metric_prefix_tuple) for metric in metrics):
+            return True
     target_fields = tuple(str(item) for item in rule.get("target_fields", ()))
     if target_fields and any(str(target.get(field, "")).strip() for target in targets for field in target_fields):
         return True
@@ -312,10 +312,21 @@ def _string_frozenset_from_tuple(values: tuple[object, ...]) -> frozenset[str]:
     return frozenset(str(item) for item in values)
 
 
+@lru_cache(maxsize=128)
+def _string_tuple_from_tuple(values: tuple[object, ...]) -> tuple[str, ...]:
+    return tuple(str(item) for item in values)
+
+
 def _string_frozenset(values: object) -> frozenset[str]:
     if isinstance(values, tuple):
         return _string_frozenset_from_tuple(values)
     return frozenset(str(item) for item in values)  # type: ignore[union-attr]
+
+
+def _string_tuple(values: object) -> tuple[str, ...]:
+    if isinstance(values, tuple):
+        return _string_tuple_from_tuple(values)
+    return tuple(str(item) for item in values)  # type: ignore[union-attr]
 
 
 def _telemetry_failures(report: dict[str, object]) -> list[str]:


### PR DESCRIPTION
## Summary
- Cache tuple-backed report evidence gate `metric_prefixes` normalization with the same immutable-rule strategy used for `run_kinds`.
- Preserve mutable non-tuple prefix behavior with focused regression coverage.
- Extend the registered PR-scoped probe to report metric-prefix timing alongside the existing run-kind timing.

## Plan or Spec
- `docs/plans/2026-05-25-report-evidence-metric-prefix-cache.md`

## Commands Run
```text
# Baseline before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# exit 0; elapsed_ms_mean=278.398ms for the pre-change run-kind-only probe

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# exit 0; 9 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
# exit 0; aggregate changed-line coverage 98%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# exit 0; direct registered probe script smoke

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 98% aggregate changed-line coverage.
  - `report_evidence_gate.py`: 100.00%
  - `test_report_evidence_gate.py`: 100.00%
  - `test_pr_scoped_performance.py`: 100.00%
  - `report_evidence_gate_run_kind_probe.py`: 95.24%
- Local Linux probe comparison using the updated registered probe script against `origin/main` source vs this branch (`MELIX_REPORT_EVIDENCE_RUN_KIND_ITERATIONS=30000`, 3 paired runs):
  - `metric_prefix_elapsed_ms_mean`: old_mean=1019.488ms, new_mean=958.779ms, delta=-60.710ms (-5.95%).
  - `elapsed_ms_mean`: old_mean=1186.914ms, new_mean=1121.611ms, delta=-65.303ms (-5.50%).
- Registered PR-scoped performance CI is required before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed.
- The registry command's bash fallback is exercised in CI; locally I ran the equivalent direct probe script because this environment blocks `bash -c` execution.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
