### PR TITLE
perf: bind startup version part scanner

### DIFF
--- a/docs/plans/2026-05-25-startup-version-next-part-binding.md
+++ b/docs/plans/2026-05-25-startup-version-next-part-binding.md
@@ -1,0 +1,31 @@
+# Startup Version Next-Part Binding Slice
+
+## Scope
+
+This Python-only performance slice is limited to `compare_versions()` in `services/mlx-worker-python/worker/productization/startup_signals.py`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `startup-signals-version-compare-single-pass` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry already has focused `test_command`, `coverage_command`, and `probe_command` entries for the startup-signal source path, tests, PR-scoped probe tests, and `scripts/startup_signals_version_probe.py`.
+
+## Implementation Plan
+
+1. Keep version comparison semantics unchanged.
+2. Bind `_next_normalized_version_part` once before the comparison loop so each component comparison avoids repeated module global lookup.
+3. Bind the character-code helper on `_next_normalized_version_part()` as a default argument so per-character scanning avoids repeated global lookup.
+4. Run the registered focused tests, changed-scope coverage, and registered probe locally on Linux.
+
+## Acceptance Criteria
+
+- Focused startup-signal tests and PR-scoped registry tests pass locally on Linux.
+- Changed-scope coverage for touched Python/probe files remains at or above 95%.
+- The registered probe shows lower `elapsed_ms_mean` than the pre-change baseline.
+- PR-scoped performance CI completes successfully before merge.
+
+## Non-Goals
+
+- No update-channel schema or behavior changes.
+- No change to normalized version parsing semantics.
+- No generated protocol or lockfile changes.

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -150,9 +150,10 @@ def compare_versions(left: str, right: str) -> int:
             return 0
         if right_index and right_length == left_length + 1 and right_cleaned.startswith(left_cleaned, 1):
             return 0
+    next_part = _next_normalized_version_part
     while True:
-        left_value, left_index, left_done = _next_normalized_version_part(left_cleaned, left_index)
-        right_value, right_index, right_done = _next_normalized_version_part(right_cleaned, right_index)
+        left_value, left_index, left_done = next_part(left_cleaned, left_index)
+        right_value, right_index, right_done = next_part(right_cleaned, right_index)
         if left_done and right_done:
             return 0
         if left_value < right_value:
@@ -165,7 +166,7 @@ def normalized_version_parts(value: str) -> list[int]:
     return list(_iter_normalized_version_parts(value)) or [0]
 
 
-def _next_normalized_version_part(value: str, index: int) -> tuple[int, int, bool]:
+def _next_normalized_version_part(value: str, index: int, _ord: Any = _ORD) -> tuple[int, int, bool]:
     current_value = 0
     digit_seen = False
     digit_prefix_active = True
@@ -173,7 +174,7 @@ def _next_normalized_version_part(value: str, index: int) -> tuple[int, int, boo
     value_length = len(value)
 
     while index < value_length:
-        character_code = _ORD(value[index])
+        character_code = _ord(value[index])
         index += 1
         if character_code == 43 or character_code == 45:
             index = value_length


### PR DESCRIPTION
## Summary
- Bind the startup version component scanner once before the comparison loop.
- Bind the character-code helper as a scanner default argument to avoid repeated global lookup while preserving parsing semantics.

## Plan or Spec
- `docs/plans/2026-05-25-startup-version-next-part-binding.md`
- Registered PR-scoped probe: `startup-signals-version-compare-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main before the accepted slice
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_does_not_allocate_streaming_part_generators services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_raw_values_skip_normalization services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_clean_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_v_prefix_equivalent_values_skip_part_parsing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics
# result: 10 passed in 2.89s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_version_probe.py
# baseline result: {"comparison_total": -32.0, "elapsed_ms_mean": 13.856669422239065, "pair_count": 12000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0, "update_result_available_count": 12500.0, "update_result_elapsed_ms_mean": 109.72838576084801, "update_result_iterations": 25000.0, "update_result_peak_bytes_mean": 560.0}

# Head verification
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_does_not_allocate_streaming_part_generators services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_raw_values_skip_normalization services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_clean_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_v_prefix_equivalent_values_skip_part_parsing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics
# result: 10 passed in 2.01s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_does_not_allocate_streaming_part_generators services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_raw_values_skip_normalization services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_clean_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_v_prefix_equivalent_values_skip_part_parsing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_version_probe.py
# result: 10 passed in 3.65s; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_version_probe.py
# head result: {"comparison_total": -32.0, "elapsed_ms_mean": 13.021887612662145, "pair_count": 12000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0, "update_result_available_count": 12500.0, "update_result_elapsed_ms_mean": 109.02590351179242, "update_result_iterations": 25000.0, "update_result_peak_bytes_mean": 560.0}

git diff --check
# result: exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Registered local probe delta: `elapsed_ms_mean` 13.856669422239065 ms -> 13.021887612662145 ms (`-0.8347818095769201 ms`, ~6.02% faster).
- `comparison_total` stayed `-32.0`; `pair_count` stayed `12000.0`.
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Linux local verification only; no Swift runtime path is touched.
- Full repository gates were not run locally because this slice is limited to the registered focused Python probe/test scope.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: existing PR-scoped evidence probe only; no runtime observability mode change.
- [x] Deferred work and known gaps are stated explicitly.
