### PR TITLE
perf: inline evaluation normalized answer literals

### DIFF
--- a/docs/plans/2026-05-25-evaluation-normalized-answer-inline-literals.md
+++ b/docs/plans/2026-05-25-evaluation-normalized-answer-inline-literals.md
@@ -1,0 +1,24 @@
+# Evaluation Normalized Answer Inline Literals
+
+## Scope
+
+Optimize the Python evaluation answer-normalization hot path by avoiding generic extraction helpers for cases that `_normalized_answer` has already proven to be simple single-letter options or full numeric literals.
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped probe `evaluation-answer-normalization-fast-path` in `infra/perf/pr_scoped_probes.json`.
+
+- `test_command`: focused evaluation helper tests plus PR-scoped performance registry tests.
+- `coverage_command`: focused coverage for `evaluation_core.py`, evaluation tests, and PR-scoped performance tests.
+- `probe_command`: command-json probe measuring answer-normalization elapsed time plus numeric/option extractor calls.
+
+## Implementation Plan
+
+1. Keep `_parse_candidate_for_expected` and multi-token extraction behavior unchanged.
+2. Inline single-character option normalization in `_normalized_answer` after wrapping is stripped.
+3. Add a narrow numeric-literal normalizer for values that already match `_looks_like_numeric`.
+4. Update the focused regression test to assert the normalized-answer fast path preserves output while skipping both extraction helpers for literal inputs.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage command, and registered probe locally on Linux. CI remains the authoritative registered PR-scoped performance gate after the PR is opened.

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -3321,11 +3321,12 @@ def test_normalized_answer_skips_extractors_for_free_text(monkeypatch: pytest.Mo
     assert EvaluationCore._normalized_answer("'quoted'") == "quoted"
     assert EvaluationCore._normalized_answer("''") == ""
     assert EvaluationCore._normalized_answer("9.0") == "9"
+    assert EvaluationCore._normalized_answer("+9.00") == "9"
     assert EvaluationCore._normalized_answer("b") == "B"
     assert EvaluationCore._normalized_answer("Option C is correct") == "option c is correct"
 
-    assert numeric_calls == 1
-    assert option_calls == 1
+    assert numeric_calls == 0
+    assert option_calls == 0
 
 
 def test_evaluation_helpers_cover_timeout_fallback_and_digit_choice_resolution() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -863,8 +863,8 @@ def test_evaluation_answer_normalization_probe_command_emits_metrics() -> None:
     metrics = _probe_command_json(probe=probe, repo_root=REPO_ROOT)
 
     assert metrics["elapsed_ms_mean"] > 0
-    assert metrics["numeric_extract_calls_mean"] == 300.0
-    assert metrics["option_extract_calls_mean"] == 300.0
+    assert metrics["numeric_extract_calls_mean"] == 0.0
+    assert metrics["option_extract_calls_mean"] == 0.0
     assert metrics["answer_count"] == 3000.0
     assert metrics["free_text_answer_count"] == 2400.0
     assert metrics["normalization_checksum"] > 0

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -3921,13 +3921,11 @@ class EvaluationCore:
     def _normalized_answer(value: str) -> str:
         stripped = EvaluationCore._strip_wrapping(value)
         if len(stripped) == 1:
-            option = EvaluationCore._extract_option_value(stripped)
-            if option is not None:
+            option = stripped.upper()
+            if option.isalpha():
                 return option
         if stripped and stripped[0] in "+-0123456789" and EvaluationCore._looks_like_numeric(stripped):
-            numeric = EvaluationCore._extract_numeric_value(stripped)
-            if numeric is not None:
-                return numeric
+            return EvaluationCore._normalized_numeric_literal(stripped)
         if (
             "  " in stripped
             or "\t" in stripped
@@ -3959,6 +3957,13 @@ class EvaluationCore:
         if stripped.endswith("."):
             stripped = stripped.rstrip(".")
         return stripped
+
+    @staticmethod
+    def _normalized_numeric_literal(value: str) -> str:
+        numeric = value.lstrip("+")
+        if "." in numeric:
+            numeric = numeric.rstrip("0").rstrip(".")
+        return numeric
 
     @staticmethod
     def _looks_like_numeric(value: str) -> bool:


### PR DESCRIPTION
## Summary
- Inline normalized-answer handling for single-letter options and full numeric literals after wrapping is stripped.
- Keep the generic extraction helpers for parsing free-form candidate responses while removing helper calls from the `_normalized_answer` literal fast path.
- Update focused regression/probe expectations for the reduced helper-call counts.

## Plan or Spec
- `docs/plans/2026-05-25-evaluation-normalized-answer-inline-literals.md`
- Registered PR-scoped probe: `evaluation-answer-normalization-fast-path` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe on origin/main before edits
bash /tmp/eval_answer_probe_cmd.sh
# exit 0; {"elapsed_ms_mean": 187.925069, "numeric_extract_calls_mean": 300.0, "option_extract_calls_mean": 300.0, ...}

bash /tmp/eval_answer_test_cmd.sh
# exit 0; 17 passed in 3.27s

bash /tmp/eval_answer_cov_cmd.sh
# exit 0; 17 passed; changed_line_coverage=100.00% (14/14)

bash /tmp/eval_answer_probe_cmd.sh
# exit 0; {"elapsed_ms_mean": 181.833769, "numeric_extract_calls_mean": 0.0, "option_extract_calls_mean": 0.0, ...}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (14/14 changed measurable lines covered).
- Local Linux registered probe (`evaluation-answer-normalization-fast-path`):
  - baseline: `elapsed_ms_mean=187.925069`, `numeric_extract_calls_mean=300.0`, `option_extract_calls_mean=300.0`
  - new: `elapsed_ms_mean=181.833769`, `numeric_extract_calls_mean=0.0`, `option_extract_calls_mean=0.0`
  - delta: `-6.091300 ms` (`~3.24%` faster), helper calls eliminated for literal normalization.
- CI is still required for the authoritative registered PR-scoped performance validation.

## Known Gaps
- Linux local verification covers the Python slice only; no Swift runtime effect is claimed.
- End-to-end CI and PR-scoped performance report are pending on this PR.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
