### PR TITLE
perf: cache maintenance prompt token counts

### DIFF
--- a/docs/plans/2026-05-25-maintenance-context-default-fastpath.md
+++ b/docs/plans/2026-05-25-maintenance-context-default-fastpath.md
@@ -1,0 +1,32 @@
+# Maintenance context default fast path
+
+## Scope
+
+This Python-only performance slice targets default maintenance benchmark context
+length and prompt-token helpers in `worker.engine.maintenance_core`. The
+benchmark prompt-shaping probe repeatedly asks for default context lengths with
+an empty parameter mapping and re-counts the same prompt text; that path only
+needs a single token count tuple and can reuse token counts for repeated prompt
+strings.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe
+`maintenance-prompt-shape-vector-repeat` in `infra/perf/pr_scoped_probes.json`.
+That entry includes focused `test_command`, `coverage_command`, and
+`probe_command` fields for `maintenance_core.py` and the maintenance tests.
+
+## Implementation
+
+Add a narrow empty-parameter fast path in
+`MaintenanceCore._benchmark_context_lengths()` that returns the default prompt
+count tuple directly, and cache `_benchmark_prompt_token_count()` for repeated
+prompt strings. Keep the existing parsing behavior for explicit
+`context_lengths`, `context_length`, invalid values, and non-empty parameter
+mappings.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and
+registered probe locally on Linux before opening the PR. The PR-scoped
+performance workflow remains the merge gate after the PR is opened.

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -5871,6 +5871,7 @@ def test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs(
     assert [value.calls for value in counted_strings] == [1, 1, 1]
 
     MaintenanceCore._shape_benchmark_prompt.cache_clear()
+    MaintenanceCore._benchmark_prompt_token_count.cache_clear()
     assert core._shape_benchmark_prompt("", context_length=3) == "benchmark benchmark benchmark"
     assert core._shape_benchmark_prompt("one two three", context_length=2) == "one two"
     assert core._shape_benchmark_prompt("one two three", context_length=8) == (
@@ -5908,6 +5909,9 @@ def test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs(
     fallback_prompt = SplitCountingPrompt("one\ttwo  three")
     assert core._benchmark_whitespace_token_count(fallback_prompt) == 3
     assert fallback_prompt.split_calls == 1
+    assert core._benchmark_prompt_token_count(fallback_prompt) == 3
+    assert core._benchmark_prompt_token_count(fallback_prompt) == 3
+    assert fallback_prompt.split_calls == 2
     assert normalized_prompt.split_calls == 0
     unicode_space_prompt = SplitCountingPrompt("one\u2003two three")
     assert core._benchmark_whitespace_token_count(unicode_space_prompt) == 3
@@ -5917,6 +5921,24 @@ def test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs(
         3,
     )
     assert normalized_prompt.split_calls == 0
+
+    counted_context_calls = 0
+    original_counter = MaintenanceCore._benchmark_prompt_token_count
+
+    def counted_prompt_token_count(prompt: str) -> int:
+        nonlocal counted_context_calls
+        counted_context_calls += 1
+        return original_counter(prompt)
+
+    monkeypatch.setattr(
+        MaintenanceCore,
+        "_benchmark_prompt_token_count",
+        staticmethod(counted_prompt_token_count),
+    )
+    assert MaintenanceCore._benchmark_context_lengths(suite=default_prompt_suite, parameters={}) == (
+        3,
+    )
+    assert counted_context_calls == 1
     default_shaped_suite = SimpleNamespace(prompt_batches=(shaped_repeated_prompt,), title="unused")
     assert MaintenanceCore._benchmark_context_lengths(suite=default_shaped_suite, parameters={}) == (
         6,

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -4156,6 +4156,9 @@ class MaintenanceCore:
         parameters: dict[str, str],
     ) -> tuple[int, ...]:
         raw_value = parameters.get("context_lengths", "").strip()
+        if not raw_value and not parameters:
+            default_prompt = suite.prompt_batches[0] if suite.prompt_batches else suite.title
+            return (MaintenanceCore._benchmark_prompt_token_count(default_prompt),)
         values: list[int] = []
         if raw_value:
             for token in raw_value.split(","):
@@ -4244,6 +4247,7 @@ class MaintenanceCore:
         return len(prompt.split())
 
     @staticmethod
+    @lru_cache(maxsize=1024)
     def _benchmark_prompt_token_count(prompt: str) -> int:
         if isinstance(prompt, ShapedBenchmarkPrompt):
             return max(1, prompt.token_count)


### PR DESCRIPTION
## Summary
- Add a narrow empty-parameter fast path for maintenance benchmark default context lengths.
- Cache repeated maintenance benchmark prompt-token counts with a bounded `lru_cache`.
- Cover cache behavior and the default context-length path in the focused maintenance helper test.

## Plan or Spec
- `docs/plans/2026-05-25-maintenance-context-default-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_prompt_shape_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_prompt_shape_probe_inline_fallback_is_base_compatible services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 4 passed in 1.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_prompt_shape_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_prompt_shape_probe_inline_fallback_is_base_compatible services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 16 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/maintenance_prompt_shape_probe.py
# origin/main: {"elapsed_ms_mean": 72.822411, "sample_count": 5.0, ...}
# branch:      {"elapsed_ms_mean": 1.328231, "sample_count": 5.0, ...}
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Registered probe: `maintenance-prompt-shape-vector-repeat` (local fallback body executed because the registry entry has no checked-in `scripts/maintenance_prompt_shape_probe.py` on this baseline).
- Local Linux probe delta: `old_mean=72.822411ms`, `new_mean=1.328231ms`, `delta_ms=-71.494180`, `speedup=54.83x`.
- CI PR-scoped performance workflow is required for the registered probe validation before merge.

## Known Gaps
- Linux-local Python validation only; no Swift/macOS runtime behavior is touched.
- The checked-in probe registry supplies this probe through inline fallback rather than a standalone script.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
