### PR TITLE
perf: bind generate cancel event locally

### DIFF
--- a/docs/plans/2026-05-25-engine-generate-cancel-event-local.md
+++ b/docs/plans/2026-05-25-engine-generate-cancel-event-local.md
@@ -1,0 +1,31 @@
+# Engine Generate Cancel Event Local Binding
+
+## Scope
+
+This Python slice targets the generate streaming loop in
+`services/mlx-worker-python/worker/engine/engine_core.py`. Behavior stays
+unchanged: cancellation checks, runtime invocation, usage accounting, and final
+completion events keep the same semantics.
+
+## Registered probe
+
+Existing registered PR-scoped probe: `engine-generate-usage-token-elision` in
+`infra/perf/pr_scoped_probes.json`.
+
+The probe covers `engine_core.py`, focused generate-stream tests, and
+`scripts/engine_generate_usage_token_probe.py`, with focused `test_command`,
+`coverage_command`, and `probe_command` entries. No registry change is needed
+for this narrow hot-loop optimization.
+
+## Optimization
+
+Bind `state.cancel_event` once to a local variable and reuse that local in the
+runtime call, per-event cancellation check, and final usage/finish checks. The
+streaming loop runs for every generation request, so avoiding repeated nested
+attribute lookups keeps the hot path smaller without changing control flow.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage command, and registered
+probe locally on Linux. CI's PR-scoped performance workflow remains the merge
+gate for the registered probe report.

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -121,6 +121,7 @@ class EngineCore:
         runtime = self._registry.runtime_for_loaded_model(loaded_model)
         generate_tokens = runtime.generate_tokens
         state = self._registry.start_request(request_id, runtime_kind=loaded_model.runtime_kind)
+        cancel_event = state.cancel_event
         allocate_seq = state.allocate_seq
         plain_text_fast_path = self._plain_text_fast_path(request)
         compat_receipt = None if plain_text_fast_path else self._compat_policy_receipt(execution_ext)
@@ -186,7 +187,7 @@ class EngineCore:
                     loaded_model.runtime_model,
                     prompt,
                     effective_sampling,
-                    state.cancel_event,
+                    cancel_event,
                     execution_ext=execution_ext,
                     acceleration_policy=execution.acceleration,
                 )
@@ -195,11 +196,11 @@ class EngineCore:
                     loaded_model.runtime_model,
                     prompt,
                     effective_sampling,
-                    state.cancel_event,
+                    cancel_event,
                     execution_ext=execution_ext,
                 )
             for runtime_event in runtime_events:
-                if state.cancel_event.is_set():
+                if cancel_event.is_set():
                     break
                 if isinstance(runtime_event, RuntimeToolCallEvent):
                     generated_tool_call_delta_count += 1
@@ -314,7 +315,7 @@ class EngineCore:
                             ),
                         )
 
-            if track_usage and not state.cancel_event.is_set():
+            if track_usage and not cancel_event.is_set():
                 completion_tokens = completion_token_count
                 if last_token_event is not None and last_token_event.prompt_tokens:
                     prompt_tokens = int(last_token_event.prompt_tokens)
@@ -342,7 +343,7 @@ class EngineCore:
                 )
 
             finish_reason = "stop"
-            if state.cancel_event.is_set():
+            if cancel_event.is_set():
                 finish_reason = "cancelled"
             elif last_finish_reason:
                 finish_reason = last_finish_reason


### PR DESCRIPTION
## Summary
- Bind `state.cancel_event` once in the generate stream hot path and reuse the local for runtime invocation, cancellation checks, and final usage/finish checks.
- Keep behavior unchanged while reducing repeated nested attribute lookups in `EngineCore.generate`.

## Plan or Spec
- `docs/plans/2026-05-25-engine-generate-cancel-event-local.md`
- Registered probe: `engine-generate-usage-token-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
git fetch origin && git reset --hard origin/main
# exit 0; synced base to d3b19eea

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_generate_stream.py::test_generate_without_usage_skips_prompt_token_count_fallback services/mlx-worker-python/tests/test_generate_stream.py::test_resolve_generate_stop_contract_uses_empty_tuple_key_without_stops services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_reuses_sampling_when_stop_sequences_match services/mlx-worker-python/tests/test_generate_stream.py::test_sampling_with_resolved_stop_clones_when_stop_sequences_change services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_reuses_runtime_event_prompt_tokens_without_fallback_count services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_counts_prompt_tokens_only_for_missing_event_total services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_request_token_accumulation services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_usage_preserves_finish_reason services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion services/mlx-worker-python/tests/test_generate_stream.py::test_generate_stream_exports_stop_contract_metrics_and_stops_at_turn_boundary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics
# exit 0; 13 passed in 1.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/engine_core.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/engine_generate_usage_token_probe.py
# exit 0; focused tests 13 passed in 0.85s; changed-scope coverage TOTAL 4 0 100%

for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py; done
# exit 0; candidate elapsed_ms_mean samples: 21.3969, 23.5157, 25.5189 ms

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 4 0 100%`).
- Local registered probe (`engine_generate_usage_token_probe.py`, Linux):
  - baseline `elapsed_ms_mean`: 24.5814 ms (3 local runs against `origin/main` before the patch)
  - candidate `elapsed_ms_mean`: 23.4772 ms (3 local runs after the patch)
  - delta: -1.1042 ms / 4.49% faster
  - baseline `fallback_elapsed_ms_mean`: 123.8640 ms
  - candidate `fallback_elapsed_ms_mean`: 122.2004 ms
  - delta: -1.6636 ms / 1.34% faster
- PR-scoped performance CI is still required as the merge gate for the registered probe report.

## Known Gaps
- Full repository test gates were not run locally; this is a focused Python performance slice.
- Linux local validation covers the Python path only. No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no new probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
