### PR TITLE
perf: bind schema payload copy helpers locally

### DIFF
--- a/docs/plans/2026-05-25-tool-registry-schema-payload-local-copy.md
+++ b/docs/plans/2026-05-25-tool-registry-schema-payload-local-copy.md
@@ -1,0 +1,32 @@
+# Tool Registry Schema Payload Local Copy Helpers
+
+## Scope
+
+This Python performance slice targets `ToolDescriptor.schema_payload()` in
+`services/mlx-worker-python/worker/runtime/tool_registry.py`. The behavior stays
+unchanged: each call still returns an isolated OpenAI-compatible schema payload
+with copied property dictionaries and a copied `required` list.
+
+## Registered probe
+
+Existing registered PR-scoped probe: `tool-registry-schema-bytes-cache` in
+`infra/perf/pr_scoped_probes.json`.
+
+The probe covers `tool_registry.py`, focused tool-registry tests, and
+`scripts/tool_registry_schema_bytes_probe.py`. It includes focused
+`test_command`, `coverage_command`, and `probe_command` entries, and records
+`schema_payload_elapsed_ms_mean` for this call path.
+
+## Optimization
+
+Bind the module-level `_COPY_DICT` and `_COPY_LIST` helpers once inside
+`schema_payload()` and call those local bindings while building the returned
+payload. This mirrors the existing `as_openai_tools()` hot-path pattern and
+avoids repeated method attribute lookup during the per-tool property/list copy
+work.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage command, and registered
+probe locally on Linux. CI's PR-scoped performance workflow remains the merge
+gate for the registered probe report.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -202,6 +202,37 @@ def test_tool_descriptor_schema_payload_returns_isolated_mutable_payloads() -> N
     assert second_payload["required"] == ["media_ref", "region"]
 
 
+def test_tool_descriptor_schema_payload_uses_cached_local_copy_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool = built_in_tool_registry().tools[0]
+    dict_copy_calls = 0
+    list_copy_calls = 0
+
+    def counting_dict_copy(value: dict[str, object]) -> dict[str, object]:
+        nonlocal dict_copy_calls
+        dict_copy_calls += 1
+        return dict.copy(value)
+
+    def counting_list_copy(value: list[str]) -> list[str]:
+        nonlocal list_copy_calls
+        list_copy_calls += 1
+        return list.copy(value)
+
+    monkeypatch.setattr(tool_registry_module, "_COPY_DICT", counting_dict_copy)
+    monkeypatch.setattr(tool_registry_module, "_COPY_LIST", counting_list_copy)
+
+    payload = tool.schema_payload()
+
+    assert payload["properties"]["media_ref"] == {
+        "type": "string",
+        "description": "Identifier or URI for the source image.",
+    }
+    assert payload["required"] == ["media_ref", "region"]
+    assert dict_copy_calls == len(tool._cached_schema_properties)
+    assert list_copy_calls == 1
+
+
 def test_tool_registry_rejects_duplicate_tool_names() -> None:
     registry = built_in_tool_registry()
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -134,13 +134,15 @@ class ToolDescriptor:
         return self._cached_required_arguments
 
     def schema_payload(self) -> dict[str, Any]:
+        copy_dict = _COPY_DICT
+        copy_list = _COPY_LIST
         schema_properties = self._cached_schema_properties
         required_arguments = self._cached_required_arguments_list
         return {
             "type": "object",
             "additionalProperties": False,
-            "properties": {name: schema.copy() for name, schema in schema_properties},
-            "required": required_arguments.copy(),
+            "properties": {name: copy_dict(schema) for name, schema in schema_properties},
+            "required": copy_list(required_arguments),
         }
 
     def json_schema(self) -> str:


### PR DESCRIPTION
## Summary
- Bind `ToolDescriptor.schema_payload()` copy helpers to locals before building each isolated schema payload.
- Add a focused regression test that exercises the module-level copy helpers while preserving payload isolation.

## Plan or Spec
- `docs/plans/2026-05-25-tool-registry-schema-payload-local-copy.md`

## Commands Run
```text
# baseline on origin/main before implementation
MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=40000 MELIX_TOOL_REGISTRY_METRICS_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
exit 0; schema_payload_elapsed_ms_mean=159.4538482837379

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_tool_descriptor_schema_payload_uses_cached_local_copy_helpers
exit 1 before implementation (RED), proving the new regression test covered the intended path

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_tool_descriptor_schema_payload_uses_cached_local_copy_helpers services/mlx-worker-python/tests/test_tool_registry.py::test_tool_descriptor_schema_payload_returns_isolated_mutable_payloads
exit 0; 2 passed

# registered focused test_command for tool-registry-schema-bytes-cache
bash /tmp/tool_registry_schema_test_command.sh
exit 0; 54 passed

# registered coverage_command for tool-registry-schema-bytes-cache
bash /tmp/tool_registry_schema_coverage_command.sh
exit 0; changed-scope coverage TOTAL 19 0 100%

# registered probe_command for tool-registry-schema-bytes-cache
MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=40000 MELIX_TOOL_REGISTRY_METRICS_SAMPLES=5 bash /tmp/tool_registry_schema_probe_command.sh
exit 0; schema_payload_elapsed_ms_mean=153.3708301372826

git diff --check
exit 0
```

## Coverage and Metrics
- Registered probe: `tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`.
- Local Linux changed-scope coverage: `100%` (`TOTAL 19 0 100%`).
- Local Linux registered probe metric: `schema_payload_elapsed_ms_mean` improved from `159.4538482837379` ms to `153.3708301372826` ms (`delta=-6.083018` ms, `speedup=1.039662x`, `improvement=3.815%`).
- CI PR-scoped performance report is required as the merge gate for the registered probe validation.

## Known Gaps
- No Swift runtime validation applies; this is a Python-only tool-registry slice verified locally on Linux.
- Full repository gates were not run locally; this PR relies on focused local verification plus GitHub Actions for the broader gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability behavior change; existing evidence-mode registered probe is used.
- [x] Deferred work and known gaps are stated explicitly.
