### PR TITLE
perf: bind tool registry openai append

### DIFF
--- a/docs/plans/2026-05-25-tool-registry-openai-append-binding.md
+++ b/docs/plans/2026-05-25-tool-registry-openai-append-binding.md
@@ -1,0 +1,44 @@
+# Tool Registry OpenAI Tool Append Binding Slice
+
+## Scope
+
+This Python performance slice is limited to `ToolRegistry.as_openai_tools()` in
+`services/mlx-worker-python/worker/runtime/tool_registry.py`.
+
+The method is on the agentic tool-config hot path and constructs isolated
+OpenAI function-tool payloads repeatedly. The slice keeps payload semantics and
+mutation isolation unchanged while binding the result list append method once
+outside the per-tool loop.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `tool-registry-openai-tools-template-cache` in
+`infra/perf/pr_scoped_probes.json`.
+
+The probe provides:
+
+- focused pytest coverage for `test_tool_registry.py` and probe dispatch tests;
+- changed-scope coverage for `tool_registry.py`, `test_tool_registry.py`,
+  `test_pr_scoped_performance.py`, and `scripts/tool_registry_openai_tools_probe.py`;
+- a command-json performance probe that repeatedly calls
+  `ToolRegistry.as_openai_tools()`, verifies descriptor conversion is not
+  re-entered, and checks returned payloads remain mutation-isolated.
+
+## Verification Plan
+
+1. Run the registered focused tests locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run `scripts/tool_registry_openai_tools_probe.py` before and after the change
+   and compare `elapsed_ms_mean` while confirming unchanged descriptor and
+   isolation metrics.
+4. Use the hosted PR-scoped performance workflow as the merge gate.
+
+## Expected Behavior
+
+- `as_openai_tools()` continues returning fresh nested payloads so callers can
+  mutate returned `required` lists without polluting later calls.
+- `descriptor_as_openai_tool_calls_mean` remains `0.0` because the registry uses
+  cached templates instead of invoking descriptor conversion for every call.
+- Performance should be neutral-to-better by avoiding repeated `tools.append`
+  method lookup inside the loop.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -295,6 +295,7 @@ class ToolRegistry:
         copy_dict = _COPY_DICT
         copy_list = _COPY_LIST
         tools: list[dict[str, Any]] = []
+        append_tool = tools.append
         for (
             name,
             description,
@@ -306,7 +307,7 @@ class ToolRegistry:
             properties: dict[str, Any] = {}
             for argument_name, schema in schema_properties:
                 properties[argument_name] = copy_dict(schema)
-            tools.append(
+            append_tool(
                 {
                     "type": "function",
                     "function": {


### PR DESCRIPTION
## Summary
- Bind `tools.append` once in `ToolRegistry.as_openai_tools()` so the hot loop avoids repeated append method lookup.
- Add a scoped plan documenting the registered probe coverage and Linux verification workflow.

## Plan or Spec
- `docs/plans/2026-05-25-tool-registry-openai-append-binding.md`
- Registered probe: `tool-registry-openai-tools-template-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_openai_tools_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `53 passed in 0.77s`.
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Local registered probe baseline: `elapsed_ms_mean=454.446550`, `descriptor_as_openai_tool_calls_mean=0.0`, `isolated_payload_calls_mean=50000.0`.
- Local registered probe candidate: `elapsed_ms_mean=448.662482`, `descriptor_as_openai_tool_calls_mean=0.0`, `isolated_payload_calls_mean=50000.0`.
- Delta: `-5.784068 ms`, speedup `1.012892x`, improvement `1.273%`.

## Known Gaps
- Local Linux probe validates this Python path only. Hosted PR-scoped performance CI remains the merge gate for the registered report.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the changed path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Local registered probe shows neutral-to-better metrics with behavior counters unchanged.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
