### PR TITLE
perf: load trajectory manifests from bytes

### DIFF
--- a/docs/plans/2026-05-25-trajectory-manifest-json-load.md
+++ b/docs/plans/2026-05-25-trajectory-manifest-json-load.md
@@ -1,0 +1,37 @@
+# Trajectory Manifest JSON Byte Loading
+
+## Scope
+
+This Python-only performance slice is limited to loading trajectory snapshot
+manifests in `services/mlx-worker-python/worker/trajectory_provenance.py`.
+The existing loader read UTF-8 text with `Path.read_text()` and then parsed the
+string with `json.loads()`. This slice reads manifest bytes directly and lets the
+JSON decoder consume the UTF-8 bytes, avoiding the separate Python string decode
+allocation while preserving the same provenance field normalization behavior.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`. The probe
+provides focused `test_command`, `coverage_command`, and `probe_command` entries
+for:
+
+- `services/mlx-worker-python/worker/trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/trajectory_manifest_json_load_probe.py`
+
+The probe builds a deterministic synthetic `agentic_tool_trace` manifest and
+compares the previous `read_text()` + `json.loads(str)` path against the new
+`read_bytes()` + `json.loads(bytes)` path. It reports elapsed mean, delta,
+speedup, peak memory, sample count, iteration count, and component count. The
+registered `probe_command` can fall back to the head checkout's probe script when
+a base checkout lacks the new probe file, while imports continue to run from the
+checkout under measurement.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, and local
+registered probe on Linux before opening the PR. The GitHub Actions PR-scoped
+performance workflow remains the merge gate for the registered probe result in
+CI.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4353,6 +4353,67 @@
     ]
   },
   {
+    "id": "trajectory-manifest-json-load",
+    "name": "Trajectory manifest JSON byte loading",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/trajectory_provenance.py",
+      "services/mlx-worker-python/tests/test_trajectory_provenance.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/trajectory_manifest_json_load_probe.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/trajectory_manifest_json_load_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "old_mean_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "new_mean_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "delta_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "speedup",
+        "unit": "x",
+        "direction": "higher_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "old_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "new_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "component_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      }
+    ]
+  },
+  {
     "id": "native-mtp-loader-safetensor-scandir",
     "name": "Native MTP loader safetensor scandir",
     "description": "List native-MTP base model safetensor shards with os.scandir instead of glob during sidecar shard attachment.",

--- a/scripts/trajectory_manifest_json_load_probe.py
+++ b/scripts/trajectory_manifest_json_load_probe.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(os.environ.get("MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT", Path.cwd()))
+WORKER_ROOT = REPO_ROOT / "services" / "mlx-worker-python"
+if str(WORKER_ROOT) not in sys.path:
+    sys.path.insert(0, str(WORKER_ROOT))
+
+from worker.trajectory_provenance import (  # noqa: E402
+    load_trajectory_provenance_from_snapshot_manifest,
+)
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return default
+
+
+def _manifest_payload(component_count: int) -> dict[str, Any]:
+    return {
+        "format": "agentic_tool_trace",
+        "source_dataset_id": "agentic-snapshot",
+        "version": "2026-05-25",
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "trajectory_split": "train",
+        "trajectory_trace_digest": "sha256:fixture",
+        "trajectory_quality_metrics": {
+            "reward_coverage_count": component_count,
+            "components": [
+                {
+                    "name": f"component-{index}",
+                    "score": float(index % 7) / 7.0,
+                    "passed": index % 3 != 0,
+                    "labels": ["agentic", "trajectory", str(index % 5)],
+                }
+                for index in range(component_count)
+            ],
+        },
+        "agentic_sft_token_metrics": {
+            "estimator": "fixture-tokenizer",
+            "source_trace_count": component_count,
+            "trace_tokens": component_count * 37,
+            "tool_call_tokens": component_count * 11,
+            "observation_tokens": component_count * 13,
+            "final_answer_tokens": component_count * 5,
+        },
+    }
+
+
+def _baseline_load(manifest_path: Path) -> dict[str, Any]:
+    payload = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return {}
+    # Import lazily so this script can execute against base checkouts that do not
+    # contain any helper refactors from the head checkout.
+    from worker.trajectory_provenance import trajectory_provenance_from_snapshot_manifest
+
+    return trajectory_provenance_from_snapshot_manifest(
+        payload,
+        snapshot_manifest_path=manifest_path,
+    )
+
+
+def _measure(func: Callable[[Path], dict[str, Any]], manifest_path: Path, iterations: int) -> tuple[float, int]:
+    tracemalloc.start()
+    start = time.perf_counter()
+    checksum = 0
+    for _ in range(iterations):
+        provenance = func(manifest_path)
+        checksum += int(provenance["trajectory_quality_metrics"]["reward_coverage_count"])
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    _, peak_bytes = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    expected = iterations * int(_manifest_payload(1)["trajectory_quality_metrics"]["reward_coverage_count"])
+    if checksum <= 0 or checksum % expected != 0:
+        raise RuntimeError("probe checksum mismatch")
+    return elapsed_ms, peak_bytes
+
+
+def _mean(values: list[float]) -> float:
+    return float(statistics.fmean(values)) if values else 0.0
+
+
+def run_probe() -> dict[str, float]:
+    iterations = _int_env("MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_ITERATIONS", 2000)
+    samples = _int_env("MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_SAMPLES", 5)
+    component_count = _int_env("MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_COMPONENTS", 64)
+
+    with tempfile.TemporaryDirectory(prefix="melix-trajectory-manifest-json-") as tmp:
+        manifest_path = Path(tmp) / "manifest.json"
+        manifest_path.write_bytes(
+            (json.dumps(_manifest_payload(component_count), separators=(",", ":")) + "\n").encode("utf-8")
+        )
+
+        baseline_ms: list[float] = []
+        optimized_ms: list[float] = []
+        baseline_peak: list[float] = []
+        optimized_peak: list[float] = []
+        for _ in range(samples):
+            elapsed, peak = _measure(_baseline_load, manifest_path, iterations)
+            baseline_ms.append(elapsed)
+            baseline_peak.append(float(peak))
+            elapsed, peak = _measure(
+                load_trajectory_provenance_from_snapshot_manifest,
+                manifest_path,
+                iterations,
+            )
+            optimized_ms.append(elapsed)
+            optimized_peak.append(float(peak))
+
+    old_mean = _mean(baseline_ms)
+    new_mean = _mean(optimized_ms)
+    return {
+        "old_mean_ms": old_mean,
+        "new_mean_ms": new_mean,
+        "elapsed_ms_mean": new_mean,
+        "delta_ms": new_mean - old_mean,
+        "speedup": old_mean / new_mean if new_mean > 0 else 0.0,
+        "old_peak_bytes_mean": _mean(baseline_peak),
+        "new_peak_bytes_mean": _mean(optimized_peak),
+        "peak_bytes_mean": _mean(optimized_peak),
+        "sample_count": float(samples),
+        "iteration_count": float(iterations),
+        "component_count": float(component_count),
+    }
+
+
+def main() -> int:
+    print(json.dumps(run_probe(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -236,7 +236,10 @@ def test_scope_report_selects_trajectory_provenance_copy_elision_probe() -> None
         changed_files=["services/mlx-worker-python/worker/trajectory_provenance.py"],
     )
 
-    assert _selected_probe_ids(scope) == ["trajectory-provenance-copy-elision"]
+    assert _selected_probe_ids(scope) == [
+        "trajectory-provenance-copy-elision",
+        "trajectory-manifest-json-load",
+    ]
 
 
 def test_scope_report_selects_native_mtp_loader_probe() -> None:
@@ -279,6 +282,24 @@ def test_trajectory_provenance_copy_elision_probe_script_emits_metrics(
     assert metrics["baseline_elapsed_ms_mean"] >= 0.0
     assert metrics["optimized_elapsed_ms_mean"] >= 0.0
     assert metrics["elapsed_ms_mean"] == metrics["optimized_elapsed_ms_mean"]
+    assert metrics["sample_count"] == 1.0
+    assert metrics["iteration_count"] == 10.0
+    assert metrics["component_count"] == 4.0
+
+
+def test_trajectory_manifest_json_load_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_ITERATIONS", "10")
+    monkeypatch.setenv("MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_COMPONENTS", "4")
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/trajectory_manifest_json_load_probe.py"))
+
+    metrics = probe_script["run_probe"]()
+
+    assert metrics["old_mean_ms"] >= 0.0
+    assert metrics["new_mean_ms"] >= 0.0
+    assert metrics["elapsed_ms_mean"] == metrics["new_mean_ms"]
     assert metrics["sample_count"] == 1.0
     assert metrics["iteration_count"] == 10.0
     assert metrics["component_count"] == 4.0
@@ -2782,6 +2803,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "training-dataset-validation-sample-limit",
         "training-dataset-chunker-top-level-base-copy",
         "trajectory-provenance-copy-elision",
+        "trajectory-manifest-json-load",
         "dataset-registry-preview-limit-short-circuit",
         "dataset-version-listing-scandir",
         "dataset-source-records-scandir",

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -208,6 +208,37 @@ def test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_nam
     }
 
 
+def test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_bytes(
+        json.dumps(
+            {
+                "format": "agentic_tool_trace",
+                "source_dataset_id": "agentic-snapshot",
+                "version": "2026-05-25",
+                "trajectory_trace_digest": "abc123",
+            }
+        ).encode("utf-8")
+    )
+
+    def fail_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        raise AssertionError("manifest loading should avoid Path.read_text()")
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+    assert load_trajectory_provenance_from_snapshot_manifest(manifest_path) == {
+        "trajectory_dataset_id": "agentic-snapshot",
+        "trajectory_dataset_version": "2026-05-25",
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "trajectory_snapshot_manifest_path": str(manifest_path),
+        "trajectory_split": "train",
+        "trajectory_trace_digest": "abc123",
+    }
+
+
 def test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -111,7 +111,8 @@ def trajectory_provenance_from_snapshot_manifest(
 def load_trajectory_provenance_from_snapshot_manifest(
     manifest_path: Path,
 ) -> dict[str, Any]:
-    payload = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    manifest_path = Path(manifest_path)
+    payload = json.loads(manifest_path.read_bytes())
     if not isinstance(payload, dict):
         return {}
     return trajectory_provenance_from_snapshot_manifest(


### PR DESCRIPTION
## Summary
- Load trajectory snapshot manifests with `Path.read_bytes()` before `json.loads()` to avoid a separate Python UTF-8 string decode/allocation.
- Register the `trajectory-manifest-json-load` PR-scoped performance probe and add focused regression/probe tests.
- Document the slice plan under `docs/plans/2026-05-25-trajectory-manifest-json-load.md`.

## Plan or Spec
- `docs/plans/2026-05-25-trajectory-manifest-json-load.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.json.check
# exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 7 passed in 1.06s; rerun after registry fix: 7 passed in 1.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
# 7 passed in 0.75s; changed_line_coverage=100.00%; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
# {"component_count": 64.0, "delta_ms": -27.47102417051792, "elapsed_ms_mean": 2106.933170091361, "iteration_count": 2000.0, "new_mean_ms": 2106.933170091361, "new_peak_bytes_mean": 98476.0, "old_mean_ms": 2134.4041942618787, "old_peak_bytes_mean": 115393.4, "peak_bytes_mean": 98476.0, "sample_count": 5.0, "speedup": 1.0130383936996572}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/trajectory_provenance.py` changed lines 114-115 covered, `TOTAL 2 0 100%`.
- Local registered probe equivalent on Linux: old_mean_ms=2134.404, new_mean_ms=2106.933, delta_ms=-27.471, speedup=1.013x, old_peak_bytes_mean=115393.4, new_peak_bytes_mean=98476.0.
- Registered PR-scoped performance CI is required for merge validation.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this slice used the focused registered commands and relies on GitHub Actions for full PR gating.
- Local validation covers the Python path on Linux only; no Swift runtime behavior is affected.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; runtime observability unchanged.
- [x] Deferred work and known gaps are stated explicitly.
