### PR TITLE
perf: short-circuit dataset preview zero limit

### DIFF
--- a/docs/plans/2026-05-25-dataset-preview-zero-limit-pre-resolve.md
+++ b/docs/plans/2026-05-25-dataset-preview-zero-limit-pre-resolve.md
@@ -1,0 +1,63 @@
+# Dataset Preview Zero-Limit Pre-Resolve Fast Path
+
+## Slice
+
+This Python-only performance slice is limited to `read_hf_dataset_snapshot_rows()` in
+`services/mlx-worker-python/worker/dataset_registry/catalog.py`.
+
+The registered PR-scoped performance probe is
+`dataset-registry-preview-limit-short-circuit` in `infra/perf/pr_scoped_probes.json`.
+That probe already covers the affected path with focused `test_command`,
+`coverage_command`, and `probe_command` entries, including zero-limit latency and
+peak-memory metrics.
+
+## Optimization
+
+Return `[]` for `limit <= 0` before resolving the snapshot path, normalizing split
+state, or allocating the row accumulator. This preserves the existing zero-limit
+contract while avoiding all path setup work in the no-row preview path.
+
+## Verification Plan
+
+Run locally on Linux before opening the PR:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_respects_limit \
+  services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_json_row_reader_limit_uses_incremental_decode \
+  services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_zero_limit_returns_empty \
+  services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_snapshot_row_reader_zero_limit_skips_file_scan \
+  services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limit_one_preview_avoids_full_supported_file_iterator \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_respects_limit \
+  services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_json_row_reader_limit_uses_incremental_decode \
+  services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_zero_limit_returns_empty \
+  services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_snapshot_row_reader_zero_limit_skips_file_scan \
+  services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limit_one_preview_avoids_full_supported_file_iterator \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/dataset_registry/catalog.py \
+  services/mlx-worker-python/tests/test_dataset_registry.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/dataset_registry_preview_limit_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py
+```
+
+GitHub Actions PR-scoped performance remains the merge gate for the registered
+probe report.
+
+## Success Criteria
+
+- Focused dataset preview tests pass.
+- Changed-scope coverage remains at or above the repository threshold.
+- The registered probe shows lower `zero_limit_elapsed_ms_mean` and
+  `zero_limit_peak_bytes_mean` without regressing normal `limit=1` preview beyond
+  probe tolerance.

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -435,11 +435,11 @@ def read_hf_dataset_snapshot_rows(
     split: str = "",
     limit: int | None = None,
 ) -> list[dict[str, Any]]:
+    if limit is not None and limit <= 0:
+        return []
     resolved_snapshot_path = Path(snapshot_path).expanduser().resolve()
     normalized_split = _normalized(split)
     rows: list[dict[str, Any]] = []
-    if limit is not None and limit <= 0:
-        return rows
     if limit == 1 and not normalized_split:
         selected_files = _iter_first_preview_dataset_file(resolved_snapshot_path)
     else:


### PR DESCRIPTION
## Summary
- Short-circuit `read_hf_dataset_snapshot_rows(..., limit=0)` before path resolution, split normalization, and row-list allocation.
- Add a focused plan for the dataset preview zero-limit pre-resolve fast path.

## Plan or Spec
- `docs/plans/2026-05-25-dataset-preview-zero-limit-pre-resolve.md`
- Registered probe: `dataset-registry-preview-limit-short-circuit` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_respects_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_json_row_reader_limit_uses_incremental_decode services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_zero_limit_returns_empty services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_snapshot_row_reader_zero_limit_skips_file_scan services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limit_one_preview_avoids_full_supported_file_iterator services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...same focused tests...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_preview_limit_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 8 passed.
- Changed-scope coverage: 100.00% (`TOTAL 2 0 100%`).
- Baseline local probe before change: `elapsed_ms_mean=0.343800`, `zero_limit_elapsed_ms_mean=0.149148`, `zero_limit_peak_bytes_mean=2048.0`.
- Local probe after change: `elapsed_ms_mean=0.347438`, `zero_limit_elapsed_ms_mean=0.000685`, `zero_limit_peak_bytes_mean=0.0`.
- Zero-limit delta: `-0.148463 ms` mean, about `217.73x` faster for the zero-limit path; normal `limit=1` preview remains inside the registered probe tolerance (`+0.003638 ms`).
- CI PR-scoped performance is required for the registered probe validation before merge.

## Known Gaps
- Python-only slice verified locally on Linux; no Swift runtime effect is claimed.
- The normal `limit=1` preview path is not targeted by this slice, only checked for non-regression.

## Evidence Checklist
- [x] Affected path has registered PR-scoped performance probe.
- [x] Registered probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused local tests passed.
- [x] Changed-scope coverage met threshold.
- [x] Local registered probe ran and showed zero-limit improvement.
- [ ] GitHub Actions PR-scoped performance completed successfully.
