### PR TITLE
perf: fast-path labeled hub size hints

### DIFF
--- a/docs/plans/2026-05-25-hub-catalog-direct-card-size-label-fastpath.md
+++ b/docs/plans/2026-05-25-hub-catalog-direct-card-size-label-fastpath.md
@@ -1,0 +1,36 @@
+# Hub Catalog Direct Card Size Label Fast Path
+
+## Scope
+
+This Python-only performance slice narrows Hub catalog size-hint parsing in
+`services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+
+The affected path is covered by the registered PR-scoped probe
+`hub-catalog-size-hint-regex-precompile` in
+`infra/perf/pr_scoped_probes.json`, which declares focused `test_command`,
+`coverage_command`, and `probe_command` entries.
+
+## Behavior
+
+Hub card metadata can expose `cardData.model_size` either as a bare size such as
+`128 MB` or as a labeled value such as `Model size: 128 MB`. The previous direct
+card helper attempted the bare-size parser before stripping the label, causing
+labeled values to pay an avoidable split/error path before reaching the intended
+labeled parser.
+
+This slice checks and strips the `Model size` label first, then falls back to the
+bare-size parser for unlabeled values. Parsing semantics stay unchanged for bare,
+labeled, decimal, invalid, and empty values.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage command, and registered
+size-hint probe locally on Linux. The PR-scoped performance workflow remains the
+CI merge gate for the registered probe report.
+
+Success criteria:
+
+- focused Hub catalog tests pass;
+- changed-scope coverage for the touched Hub catalog path remains at least 95%;
+- the registered size-hint probe shows a neutral-to-improved elapsed mean versus
+  the `origin/main` baseline.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -661,13 +661,10 @@ def _direct_size_hint_from_text(text: str) -> int:
 
 
 def _direct_card_size_hint_from_text(text: str) -> int:
-    hint = _direct_size_hint_from_text(text)
-    if hint > 0:
-        return hint
     stripped_text = _strip_model_size_label(text)
-    if not stripped_text:
-        return 0
-    return _direct_size_hint_from_text(stripped_text)
+    if stripped_text:
+        return _direct_size_hint_from_text(stripped_text)
+    return _direct_size_hint_from_text(text)
 
 
 def _strip_model_size_label(text: str) -> str:


### PR DESCRIPTION
## Summary
- Fast-path `cardData.model_size` values that start with the `Model size` label before falling back to the bare-size parser.
- Keep bare, labeled, decimal, invalid, and empty size-hint semantics unchanged.

## Plan or Spec
- `docs/plans/2026-05-25-hub-catalog-direct-card-size-label-fastpath.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# exit 0; baseline before change: {"elapsed_ms_mean": 1914.5863116718829, "peak_bytes_mean": 1833.0, "size_hint_calls_mean": 40000.0, "matched_hint_count": 80000.0, "sample_count": 3.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# exit 0; 60 passed in 0.99s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# exit 0; 60 passed; changed-scope coverage TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# exit 0; head after change: {"elapsed_ms_mean": 1508.5748434066772, "peak_bytes_mean": 1833.0, "size_hint_calls_mean": 40000.0, "matched_hint_count": 80000.0, "sample_count": 3.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for the registered coverage command.
- Local Linux probe (`MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=3`): old_mean=1914.586 ms, new_mean=1508.575 ms, delta=-406.011 ms, speedup=1.269x.
- CI PR-scoped performance report is required as the registered probe validation gate before merge.

## Known Gaps
- Full default registered probe command was not run verbatim because the local tool guard blocked the nested `bash -c` wrapper; the same script and environment were run directly with the same probe inputs and a 3-sample local comparison. CI must run the registered workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode behavior changed; existing evidence-mode PR-scoped probe remains the validation source.
- [x] Deferred work and known gaps are stated explicitly.
