### PR TITLE
perf: scan hub payload mlx tags directly

### DIFF
--- a/docs/plans/2026-05-25-hub-catalog-payload-mlx-tag-scan.md
+++ b/docs/plans/2026-05-25-hub-catalog-payload-mlx-tag-scan.md
@@ -1,0 +1,28 @@
+# Hub Catalog Payload MLX Tag Scan
+
+## Goal
+
+Reduce `mlx_only` Hub catalog prefilter overhead by avoiding temporary tag-list materialization when checking raw payload tags for the `mlx` compatibility signal.
+
+## Slice
+
+This Python-only slice is limited to `worker.model_ops.hub_catalog._payload_is_mlx_compatible(...)` and the existing registered PR-scoped probe `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe already covers:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+
+The registry entry provides focused `test_command`, `coverage_command`, and `probe_command` entries. This slice extends the registered probe metrics with `payload_compatibility_elapsed_ms_mean` and `payload_compatibility_calls_mean` so the raw payload `mlx_only` prefilter path is measured directly.
+
+## Implementation
+
+- Reuse the existing `_tag_payload_contains_mlx(...)` scanner for raw payload `tags` in `_payload_is_mlx_compatible(...)`.
+- Preserve existing behavior for string tags, mixed non-string list entries, library-name checks, repo-id suffix checks, and card-data tag fallback.
+- Add a regression test that monkeypatches `_string_list(...)` to prove the prefilter path does not allocate a normalized tag list.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and the `hub-catalog-size-hint-regex-precompile` probe locally on Linux. CI PR-scoped performance remains the merge gate for the registered probe report.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3411,6 +3411,17 @@
         "unit": "calls",
         "direction": "lower_is_better",
         "warn_pct": 0.0
+      },
+      {
+        "key": "payload_compatibility_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "payload_compatibility_calls_mean",
+        "unit": "calls",
+        "direction": "informational"
       }
     ]
   },

--- a/scripts/hub_catalog_size_hint_probe.py
+++ b/scripts/hub_catalog_size_hint_probe.py
@@ -34,6 +34,44 @@ def _payload(index: int) -> tuple[dict[str, Any], int]:
     }, 0
 
 
+def _compatibility_payload(index: int) -> tuple[dict[str, Any], bool]:
+    mode = index % 5
+    if mode == 0:
+        return {
+            "id": "plain/model",
+            "tags": ["Text-Generation", "MLX", object()],
+            "library_name": "transformers",
+            "cardData": {},
+        }, True
+    if mode == 1:
+        return {
+            "id": "plain/model",
+            "tags": ["Text-Generation", object()],
+            "library_name": "mlx",
+            "cardData": {},
+        }, True
+    if mode == 2:
+        return {
+            "id": "owner/model-mlx-suffix",
+            "tags": ["Text-Generation", object()],
+            "library_name": "transformers",
+            "cardData": {},
+        }, True
+    if mode == 3:
+        return {
+            "id": "plain/model",
+            "tags": ["Text-Generation", object()],
+            "library_name": "transformers",
+            "cardData": {"tags": ["MLX", object()]},
+        }, True
+    return {
+        "id": "plain/model",
+        "tags": ["Text-Generation", object()],
+        "library_name": "transformers",
+        "cardData": {"tags": ["audio", object()]},
+    }, False
+
+
 def _run_sample(iterations: int) -> tuple[float, int, int, int]:
     calls = 0
     original = hub_catalog._size_hint_from_text
@@ -61,12 +99,30 @@ def _run_sample(iterations: int) -> tuple[float, int, int, int]:
         hub_catalog._size_hint_from_text = original
 
 
+def _run_compatibility_sample(iterations: int) -> tuple[float, int]:
+    started = time.perf_counter()
+    matched = 0
+    for index in range(iterations):
+        payload, expected = _compatibility_payload(index)
+        compatible = hub_catalog._payload_is_mlx_compatible(payload)
+        if compatible != expected:
+            raise SystemExit(f"unexpected mlx compatibility at {index}: {compatible} != {expected}")
+        if compatible:
+            matched += 1
+    return (time.perf_counter() - started) * 1000.0, matched
+
+
 def main() -> int:
     iterations = int(os.environ.get("MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS", "200000"))
+    compatibility_iterations = int(
+        os.environ.get("MELIX_HUB_CATALOG_COMPATIBILITY_ITERATIONS", str(iterations))
+    )
     sample_count = int(os.environ.get("MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES", "5"))
     elapsed_samples: list[float] = []
     peak_samples: list[int] = []
     call_samples: list[int] = []
+    compatibility_elapsed_samples: list[float] = []
+    compatibility_matched_samples: list[int] = []
     checksum = 0
     matched = 0
 
@@ -75,15 +131,23 @@ def main() -> int:
         elapsed_ms, checksum, matched, calls = _run_sample(iterations)
         _, peak_bytes = tracemalloc.get_traced_memory()
         tracemalloc.stop()
+        compatibility_elapsed_ms, compatibility_matched = _run_compatibility_sample(
+            compatibility_iterations
+        )
         elapsed_samples.append(elapsed_ms)
         peak_samples.append(peak_bytes)
         call_samples.append(calls)
+        compatibility_elapsed_samples.append(compatibility_elapsed_ms)
+        compatibility_matched_samples.append(compatibility_matched)
 
     metrics = {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
         "peak_bytes_mean": statistics.fmean(peak_samples),
         "size_hint_calls_mean": statistics.fmean(call_samples),
         "matched_hint_count": float(matched),
+        "payload_compatibility_elapsed_ms_mean": statistics.fmean(compatibility_elapsed_samples),
+        "payload_compatibility_matched_count": float(compatibility_matched_samples[-1]),
+        "payload_compatibility_calls_mean": float(compatibility_iterations),
         "checksum": float(checksum),
         "sample_count": float(sample_count),
     }

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -18,6 +18,7 @@ from worker.model_ops.hub_catalog import (
     _bytes_per_parameter,
     _is_mlx_compatible,
     _local_fit_evidence,
+    _payload_is_mlx_compatible,
     _quantization_summary,
     _size_hint_from_text,
 )
@@ -238,6 +239,38 @@ def test_search_models_with_mlx_only_prefilters_payloads_before_local_fit(monkey
         "card/model",
         "owner/repo-mlx-suffix",
     ]
+
+
+def test_payload_mlx_filter_avoids_string_list_materialization(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_string_list(value: object) -> list[str]:
+        raise AssertionError(f"unexpected payload tag materialization: {value!r}")  # pragma: no cover
+
+    monkeypatch.setattr(hub_catalog_module, "_string_list", fail_string_list)
+
+    assert _payload_is_mlx_compatible(
+        {
+            "id": "plain/model",
+            "tags": ["Text-Generation", "MLX", object()],
+            "library_name": "transformers",
+            "cardData": {},
+        }
+    ) is True
+    assert _payload_is_mlx_compatible(
+        {
+            "id": "plain/model",
+            "tags": "mlx",
+            "library_name": "transformers",
+            "cardData": {},
+        }
+    ) is True
+    assert _payload_is_mlx_compatible(
+        {
+            "id": "plain/model",
+            "tags": ["Text-Generation", object()],
+            "library_name": "transformers",
+            "cardData": {},
+        }
+    ) is False
 
 
 def test_card_data_tag_mlx_check_avoids_string_list_materialization(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2079,6 +2079,9 @@ def test_hub_catalog_size_hint_probe_script_emits_metrics(
     assert metrics["sample_count"] == 1.0
     assert metrics["size_hint_calls_mean"] == 2.0
     assert metrics["matched_hint_count"] == 4.0
+    assert metrics["payload_compatibility_calls_mean"] == 8.0
+    assert metrics["payload_compatibility_matched_count"] == 7.0
+    assert metrics["payload_compatibility_elapsed_ms_mean"] >= 0
     assert metrics["elapsed_ms_mean"] >= 0
     assert metrics["peak_bytes_mean"] > 0
 

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -393,8 +393,7 @@ def _base_models(value: Any) -> list[str]:
 
 def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:
     card_data = payload.get("cardData") if isinstance(payload.get("cardData"), dict) else {}
-    tags = _string_list(payload.get("tags"))
-    if any(tag.lower() == "mlx" for tag in tags):
+    if _tag_payload_contains_mlx(payload.get("tags")):
         return True
     library_name = _string(payload.get("library_name") or card_data.get("library_name"))
     if library_name.lower() == "mlx":


### PR DESCRIPTION
## Summary
- Reuse the raw tag scanner for Hub payload `mlx_only` compatibility prefiltering to avoid temporary `_string_list(...)` materialization.
- Extend the registered Hub catalog PR-scoped probe with payload compatibility timing metrics.
- Add regression coverage and a plan note for this performance slice.

## Plan or Spec
- `docs/plans/2026-05-25-hub-catalog-payload-mlx-tag-scan.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- Base/head local comparison with `MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=80000`, `MELIX_HUB_CATALOG_COMPATIBILITY_ITERATIONS=160000`, `MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=5`

## Coverage and Metrics
- Focused tests: 61 passed.
- Changed-scope coverage: 97% aggregate changed-line coverage (37/38 covered); `hub_catalog.py` and `test_hub_catalog.py` changed lines were 100% covered.
- Local Linux registered probe (head): `payload_compatibility_elapsed_ms_mean=297.15884467586875`, `payload_compatibility_calls_mean=200000.0`, `elapsed_ms_mean=1520.06556680426`.
- Local base/head comparison for payload compatibility: base `237.48979093506932 ms`, head `229.60935216397047 ms`, delta `-7.88043877109885 ms` (`~3.32%` faster) over 160k compatibility calls/sample.

## Known Gaps
- Local validation is Linux/Python only; GitHub Actions PR-scoped performance is still required as the merge gate for the registered probe report.
- The existing size-hint metrics are retained; the behavior change targets only raw payload tag compatibility scanning.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path and has focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is above the repository 95% threshold.
- [x] Registered probe runs locally on Linux.
- [ ] PR-scoped performance workflow completed successfully in CI.
