### PR TITLE
perf: fast path dataset preview json limit one

### DIFF
--- a/docs/plans/2026-05-25-dataset-preview-limit-one-json-fastpath.md
+++ b/docs/plans/2026-05-25-dataset-preview-limit-one-json-fastpath.md
@@ -1,0 +1,23 @@
+# Dataset preview limit-one JSON fast path
+
+## Scope
+
+This slice keeps the registered `dataset-registry-preview-limit-short-circuit`
+probe focused on `worker/dataset_registry/catalog.py` and narrows the JSON
+preview hot path used by `read_hf_dataset_snapshot_rows(..., limit=1)`.
+
+## Change
+
+- Avoid rebuilding the first preview chunk with `"".join(chunks)` before parsing.
+- Return immediately when the limited JSON preview parser decodes the first dict
+  and the requested limit is exactly one.
+
+The behavior stays unchanged for empty files, multi-row limits, non-dict array
+entries, and fallback full JSON loading.
+
+## Verification
+
+Run the registered probe locally on Linux before opening the PR, then rely on the
+PR-scoped performance workflow for CI validation. The expected signal is lower
+`elapsed_ms_mean` and a small reduction in `peak_bytes_mean` for the registered
+`dataset-registry-preview-limit-short-circuit` probe.

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -642,19 +642,19 @@ def _limit_rows(rows: list[dict[str, Any]], limit: int | None) -> list[dict[str,
 def _limited_rows_from_json_file(path: Path, *, limit: int) -> list[dict[str, Any]] | None:
     if limit <= 0:
         return []
-    chunks: list[str] = []
+    json_text = ""
     with path.open("r", encoding="utf-8") as handle:
         while True:
             chunk = handle.read(_JSON_LIMITED_PREVIEW_CHUNK_CHARS)
             if not chunk:
                 break
-            chunks.append(chunk)
-            limited_rows = _limited_rows_from_json_text("".join(chunks), limit=limit)
+            json_text = chunk if not json_text else json_text + chunk
+            limited_rows = _limited_rows_from_json_text(json_text, limit=limit)
             if limited_rows is not None and len(limited_rows) >= limit:
                 return limited_rows
-    if not chunks:
+    if not json_text:
         return None
-    return _limited_rows_from_json_text("".join(chunks), limit=limit)
+    return _limited_rows_from_json_text(json_text, limit=limit)
 
 
 def _limited_rows_from_json_text(json_text: str, *, limit: int) -> list[dict[str, Any]] | None:
@@ -677,6 +677,8 @@ def _limited_rows_from_json_text(json_text: str, *, limit: int) -> list[dict[str
         except json.JSONDecodeError:
             return None
         if isinstance(value, dict):
+            if limit == 1:
+                return [value]
             rows.append(value)
             if len(rows) >= limit:
                 return rows


### PR DESCRIPTION
## Summary
- Fast-path limited JSON dataset previews when `limit == 1` by returning the first decoded row immediately.
- Avoid the first-chunk `"".join(chunks)` rebuild in `_limited_rows_from_json_file` while preserving fallback parsing for multi-chunk and multi-row cases.

## Plan or Spec
- Added `docs/plans/2026-05-25-dataset-preview-limit-one-json-fastpath.md` for this slice.
- Registered probe: `dataset-registry-preview-limit-short-circuit` already covers `services/mlx-worker-python/worker/dataset_registry/catalog.py` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (registered focused test set; 21 passed)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_preview_limit_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py` (base/head repeated locally on Linux)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 21 passed.
- Changed-scope coverage: 100.00% (`7/7` measurable changed lines covered).
- Local registered probe comparison over 5 base/head runs on Linux:
  - `elapsed_ms_mean`: base `0.479617` ms, head `0.366984` ms, delta `-0.112632` ms (`-23.484%`).
  - `peak_bytes_mean`: base `39210.286` bytes, head `39157.714` bytes, delta `-52.572` bytes (`-0.134%`).
  - `zero_limit_elapsed_ms_mean`: base `0.000696` ms, head `0.000719` ms, delta `+0.000023` ms (`+3.334%`, near timer noise).
  - `zero_limit_peak_bytes_mean`: unchanged at `0.0` bytes.
- CI PR-scoped performance report is required as the final registered probe validation source.

## Known Gaps
- Local validation was Linux/Python only; no Swift runtime effect is claimed.
- Timing is sub-millisecond and noisy, so the memory reduction plus CI probe result are used to confirm the direction.

## Evidence Checklist
- [x] Registered PR-scoped performance probe exists for the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
