### PR TITLE
perf: fast-path dataset source suffix classification

### DIFF
--- a/docs/plans/2026-05-25-dataset-source-kind-suffix-fastpath.md
+++ b/docs/plans/2026-05-25-dataset-source-kind-suffix-fastpath.md
@@ -1,0 +1,29 @@
+# Dataset Source Kind Suffix Fast Path
+
+## Scope
+
+Optimize one Python hot path in dataset ingest: `_source_kind()` classification for source files discovered by `worker.productization.dataset_preparation._iter_source_records()`.
+
+The previous implementation built and lowercased the full `Path.suffixes` list for every candidate file, even though dataset ingest only needs the final suffix plus two compound extracted-text cases (`.pdf.txt` and `.docx.txt`). This slice preserves classification behavior while reading `Path.suffix` once and checking the lowered filename only for `.txt` files.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries. The local Linux probe reports:
+
+- `elapsed_ms_mean`
+- `elapsed_ms_min`
+- `elapsed_ms_p95`
+- `file_count_mean`
+
+## Plan
+
+1. Add focused behavior coverage for source-kind suffix classification, including uppercase compound `.PDF.TXT` and `.DOCX.txt` cases.
+2. Replace full suffix-list construction with a single final-suffix fast path and compound `.txt` filename checks.
+3. Run the registered focused test command, changed-scope coverage command, and local registered probe on Linux.
+4. Use GitHub Actions PR-scoped performance output as the merge gate.
+
+## Verification Notes
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -10,6 +10,7 @@ import pytest
 from worker.productization.dataset_preparation import (
     DatasetIngestRequest,
     _iter_source_file_paths,
+    _source_kind,
     prepare_dataset_ingest,
 )
 
@@ -45,6 +46,15 @@ def test_dataset_ingest_source_file_paths_use_scandir_without_rglob(
         "b/b.txt",
         "z.txt",
     ]
+
+
+def test_dataset_ingest_source_kind_uses_single_suffix_fast_path() -> None:
+    assert _source_kind(Path("paper.PDF.TXT")) == "pdf"
+    assert _source_kind(Path("brief.DOCX.txt")) == "docx"
+    assert _source_kind(Path("notes.text")) == "text"
+    assert _source_kind(Path("script.PY")) == "code"
+    assert _source_kind(Path("records.JSONL")) == "structured_data"
+    assert _source_kind(Path("archive.tar.gz")) is None
 
 
 def test_dataset_ingest_source_file_paths_skips_scandir_errors(

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -558,13 +558,15 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
 
 
 def _source_kind(path: Path) -> str | None:
-    suffixes = [suffix.lower() for suffix in path.suffixes]
-    if suffixes[-2:] == [".pdf", ".txt"]:
-        return "pdf"
-    if suffixes[-2:] == [".docx", ".txt"]:
-        return "docx"
-    suffix = suffixes[-1] if suffixes else ""
-    if suffix in {".txt", ".text"}:
+    suffix = path.suffix.lower()
+    if suffix == ".txt":
+        name = path.name.lower()
+        if name.endswith(".pdf.txt"):
+            return "pdf"
+        if name.endswith(".docx.txt"):
+            return "docx"
+        return "text"
+    if suffix == ".text":
         return "text"
     if suffix in {".md", ".markdown"}:
         return "markdown"


### PR DESCRIPTION
## Summary
- Fast-path dataset ingest source-kind classification by reading only the final suffix for ordinary files.
- Preserve `.pdf.txt` and `.docx.txt` extracted-text detection with a lowered-name check only on `.txt` candidates.
- Add focused coverage for uppercase compound suffixes and unsupported multi-suffix archives.

## Plan or Spec
- `docs/plans/2026-05-25-dataset-source-kind-suffix-fastpath.md`
- Registered PR-scoped probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_PROBE_FILES=3000 MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py`

## Coverage and Metrics
- Focused test: `1 passed`.
- Registered focused test scope plus new test: `9 passed`.
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Local Linux probe comparison (same 3000-file / 5-sample workload):
  - before: `elapsed_ms_mean=16.677462588995695`, `elapsed_ms_p95=21.498300600796938`, `file_count_mean=6000.0`
  - after: `elapsed_ms_mean=11.417096480727196`, `elapsed_ms_p95=11.796846985816956`, `file_count_mean=6000.0`
  - delta: `-5.260366 ms`, speedup `1.460745x`, improvement `31.54%`
- GitHub Actions PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- Python-only Linux verification; no Swift runtime effect is claimed.
- The exact registry shell wrapper includes `bash -c`; local execution used the same probe script directly because this scheduled environment requires approval for nested shell commands.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path.
- [x] Focused tests were run locally.
- [x] Changed-scope coverage was run locally and is at least 95%.
- [x] Local registered probe script was run on Linux.
- [ ] GitHub Actions PR-scoped performance completed successfully.
- [ ] PR checks are green before merge.
