### PR TITLE
perf: fast-path native mtp sidecar filtering

### DIFF
--- a/docs/plans/2026-05-25-native-mtp-sidecar-filter-fast-path.md
+++ b/docs/plans/2026-05-25-native-mtp-sidecar-filter-fast-path.md
@@ -1,0 +1,28 @@
+# Native MTP sidecar filter fast path
+
+## Scope
+
+This Python-only performance slice is limited to native-MTP sidecar shard discovery in `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`.
+
+`extra_mtp_safetensor_files()` walks `model.safetensors.index.json` entries to attach native-MTP sidecar shards. The previous implementation joined every MTP weight-map file name to `model_path` before filtering out ordinary `model*.safetensors` shards or non-safetensor names. Large indexes with many ordinary MTP-prefixed records therefore paid avoidable `Path` join/allocation cost.
+
+## Registered probe
+
+Affected path coverage uses the existing registered PR-scoped probe `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+This slice extends that probe and its focused test command to include sidecar shard filtering metrics while preserving the existing index JSON byte-loading and scandir model-shard listing checks.
+
+## Implementation plan
+
+1. Add a regression test proving sidecar filtering skips irrelevant index names before joining them to `model_path`.
+2. Filter sidecar file names with basename string checks before constructing candidate `Path` objects.
+3. Extend `scripts/native_mtp_loader_safetensor_scandir_probe.py` to compare baseline sidecar listing against the optimized helper and emit sidecar-specific timing/peak-memory metrics.
+4. Run the registered focused test command, changed-scope coverage command, and registered probe locally on Linux before PR creation. CI remains the final registered PR-scoped performance gate.
+
+## Validation commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/native_mtp_loader_safetensor_scandir_probe.py"; python3 "$SCRIPT"'
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4426,8 +4426,8 @@
   },
   {
     "id": "native-mtp-loader-safetensor-scandir",
-    "name": "Native MTP loader index JSON bytes",
-    "description": "Load native-MTP safetensor index JSON directly from bytes before sidecar shard attachment while preserving the scandir shard listing guard.",
+    "name": "Native MTP loader sidecar filter fast path",
+    "description": "Filter native-MTP sidecar shard index names before Path joins while preserving index JSON byte loading and scandir shard listing guards.",
     "watch_globs": [
       "services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py",
       "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py",
@@ -4435,8 +4435,8 @@
       "scripts/native_mtp_loader_safetensor_scandir_probe.py",
       "infra/perf/pr_scoped_probes.json"
     ],
-    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics",
-    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py",
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py",
     "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_NATIVE_MTP_LOADER_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/native_mtp_loader_safetensor_scandir_probe.py\"; for CANDIDATE in \"${MELIX_NATIVE_MTP_LOADER_PROBE_SCRIPT:-}\" \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -n \"$CANDIDATE\" ] && [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
@@ -4479,6 +4479,48 @@
       },
       {
         "key": "result_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "extra_old_mean_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "extra_new_mean_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "extra_delta_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "extra_speedup",
+        "unit": "x",
+        "direction": "higher_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "extra_old_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "extra_new_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "extra_result_count",
         "unit": "count",
         "direction": "higher_is_better",
         "warn_pct": 0.0

--- a/scripts/native_mtp_loader_safetensor_scandir_probe.py
+++ b/scripts/native_mtp_loader_safetensor_scandir_probe.py
@@ -17,8 +17,13 @@ sys.path.insert(0, str(repo_root))
 sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
 
 try:
-    from worker.runtime.native_mtp.mlx_lm_loader import _load_json_payload, _model_safetensor_files
+    from worker.runtime.native_mtp.mlx_lm_loader import (
+        _load_json_payload,
+        _model_safetensor_files,
+        extra_mtp_safetensor_files,
+    )
 except ImportError:  # Base revisions before this slice do not expose the helpers.
+    extra_mtp_safetensor_files = None
     _load_json_payload = None
     _model_safetensor_files = None
 
@@ -55,6 +60,27 @@ def _read_text_json_payload(path: Path) -> dict[str, Any]:
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return {}
     return payload if isinstance(payload, dict) else {}
+
+
+def _baseline_extra_mtp_safetensor_files(model_dir: Path) -> list[Path]:
+    index_payload = _read_text_json_payload(model_dir / "model.safetensors.index.json")
+    weight_map = index_payload.get("weight_map")
+    if not isinstance(weight_map, dict):
+        return []
+    extra_files: list[Path] = []
+    seen: set[Path] = set()
+    for key, file_name in weight_map.items():
+        value = str(key)
+        if not (value.startswith("language_model.mtp.") or value.startswith("mtp.")):
+            continue
+        path = model_dir / str(file_name)
+        if path.name.startswith("model") or path.suffix != ".safetensors":
+            continue
+        if path in seen or not path.exists():
+            continue
+        seen.add(path)
+        extra_files.append(path)
+    return extra_files
 
 
 def _measure(
@@ -112,6 +138,12 @@ def run_probe() -> dict[str, float | int | str]:
         if old_payload != new_payload:
             raise SystemExit("candidate native-MTP index JSON payload differs from read_text baseline")
 
+        baseline_extra = _baseline_extra_mtp_safetensor_files(model_dir)
+        extra_callback = extra_mtp_safetensor_files or _baseline_extra_mtp_safetensor_files
+        candidate_extra = extra_callback(model_dir)
+        if baseline_extra != candidate_extra:
+            raise SystemExit("candidate native-MTP sidecar shard listing differs from baseline")
+
         old_ms, old_peaks, result_count = _measure(
             _read_text_json_payload,
             index_path,
@@ -124,10 +156,23 @@ def run_probe() -> dict[str, float | int | str]:
             samples=samples,
             result_count_getter=_weight_map_count,
         )
+        extra_old_ms, extra_old_peaks, extra_result_count = _measure(
+            _baseline_extra_mtp_safetensor_files,
+            model_dir,
+            samples=samples,
+        )
+        extra_new_ms, extra_new_peaks, _ = _measure(
+            extra_callback,
+            model_dir,
+            samples=samples,
+        )
     old_mean = statistics.mean(old_ms)
     new_mean = statistics.mean(new_ms)
+    extra_old_mean = statistics.mean(extra_old_ms)
+    extra_new_mean = statistics.mean(extra_new_ms)
     return {
         "result_count": result_count,
+        "extra_result_count": extra_result_count,
         "model_files": model_files,
         "distractor_files": distractor_files,
         "samples": samples,
@@ -137,6 +182,12 @@ def run_probe() -> dict[str, float | int | str]:
         "speedup": old_mean / new_mean if new_mean else 0.0,
         "old_peak_bytes_mean": statistics.mean(old_peaks),
         "new_peak_bytes_mean": statistics.mean(new_peaks),
+        "extra_old_mean_ms": extra_old_mean,
+        "extra_new_mean_ms": extra_new_mean,
+        "extra_delta_ms": extra_new_mean - extra_old_mean,
+        "extra_speedup": extra_old_mean / extra_new_mean if extra_new_mean else 0.0,
+        "extra_old_peak_bytes_mean": statistics.mean(extra_old_peaks),
+        "extra_new_peak_bytes_mean": statistics.mean(extra_new_peaks),
     }
 
 

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -45,7 +45,11 @@ from worker.runtime.mlx_vlm_runtime import (
     _patch_gemma4_scaled_linear_quantization,
 )
 from worker.runtime.mlx_executor import MLXRuntimeExecutor
-from worker.runtime.native_mtp.mlx_lm_loader import _load_json_payload, _model_safetensor_files
+from worker.runtime.native_mtp.mlx_lm_loader import (
+    _load_json_payload,
+    _model_safetensor_files,
+    extra_mtp_safetensor_files,
+)
 from worker.runtime.temp_media_lifecycle import TempMediaSession
 
 
@@ -1548,6 +1552,40 @@ def test_native_mtp_model_safetensor_listing_uses_scandir_without_glob(
         str(path) for path in [*expected_files, child_dir]
     )
     assert _model_safetensor_files(tmp_path / "missing") == []
+
+
+def test_native_mtp_extra_safetensor_files_filters_names_before_path_join(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    index_payload = {
+        "weight_map": {
+            "language_model.mtp.layers.0.weight": "model-00001-of-00002.safetensors",
+            "language_model.mtp.layers.1.weight": "mtp-00001.safetensors",
+            "language_model.mtp.layers.2.weight": "notes.txt",
+            "language_model.layers.0.weight": "ignored-mtp.safetensors",
+        }
+    }
+    (model_dir / "model.safetensors.index.json").write_text(
+        json.dumps(index_payload),
+        encoding="utf-8",
+    )
+    sidecar_path = model_dir / "mtp-00001.safetensors"
+    sidecar_path.write_bytes(b"mtp")
+
+    original_join = Path.__truediv__
+    joined_names: list[str] = []
+
+    def tracked_join(self: Path, key: object) -> Path:
+        joined_names.append(str(key))
+        return original_join(self, key)
+
+    monkeypatch.setattr(Path, "__truediv__", tracked_join)
+
+    assert extra_mtp_safetensor_files(model_dir) == [sidecar_path]
+    assert joined_names == ["model.safetensors.index.json", "mtp-00001.safetensors"]
 
 
 def test_native_mtp_patched_loader_uses_scandir_model_weight_listing(

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -53,8 +53,11 @@ def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
     for key, file_name in weight_map.items():
         if not _is_mtp_weight_key(key):
             continue
-        path = model_path / str(file_name)
-        if path.name.startswith("model") or path.suffix != ".safetensors":
+        file_name_text = str(file_name)
+        if file_name_text.startswith("model") or not file_name_text.endswith(".safetensors"):
+            continue
+        path = model_path / file_name_text
+        if path.name.startswith("model"):
             continue
         if path in seen:
             continue


### PR DESCRIPTION
## Summary
- Fast-path native-MTP sidecar shard filtering by rejecting top-level `model*` and non-`.safetensors` index names before joining them to `model_path`.
- Extend the registered native-MTP PR-scoped probe to report sidecar-specific timing and peak-memory metrics.
- Add a focused regression test and plan for the sidecar filter slice.

## Plan or Spec
- `docs/plans/2026-05-25-native-mtp-sidecar-filter-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics
# 7 passed in 0.23s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
# 5 passed in 0.28s; changed_line_coverage=100.00% (5/5)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
# {"delta_ms": -0.03978051245212555, "extra_delta_ms": -6.050613895058632, "extra_new_mean_ms": 73.36873803287745, "extra_old_mean_ms": 79.41935192793608, "extra_speedup": 1.0824685561900667, "new_mean_ms": 3.1820562668144703, "old_mean_ms": 3.221836779266596, "speedup": 1.0125015113236666, ...}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` changed lines 56-60: 100.00% (5/5).
- Local registered probe (Linux): sidecar filter `extra_old_mean_ms=79.41935192793608`, `extra_new_mean_ms=73.36873803287745`, `extra_delta_ms=-6.050613895058632`, `extra_speedup=1.0824685561900667`; existing JSON payload metric `old_mean_ms=3.221836779266596`, `new_mean_ms=3.1820562668144703`, `speedup=1.0125015113236666`.
- Registered PR-scoped performance CI is required as the final base-vs-head validation source before merge.

## Known Gaps
- Full repository test gates were not run locally; this slice used focused native-MTP tests, changed-scope coverage, and the registered probe.
- CI remains the merge gate for the registered PR-scoped performance workflow.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead is isolated to CI/local synthetic probe only.
- [x] Deferred work and known gaps are stated explicitly.
