### PR TITLE
perf: load dataset version manifests from bytes

### DIFF
--- a/docs/plans/2026-05-24-dataset-version-listing-scandir.md
+++ b/docs/plans/2026-05-24-dataset-version-listing-scandir.md
@@ -1,6 +1,6 @@
 # Dataset version listing scandir slice
 
-This Python-only performance slice keeps dataset-version listing behavior unchanged while replacing the one-level `Path.glob("*/dataset-version.json")` scan with an explicit `os.scandir()` pass.
+This Python-only performance track keeps dataset-version listing behavior unchanged while reducing overhead in small, registered slices. The first slice replaced the one-level `Path.glob("*/dataset-version.json")` scan with an explicit `os.scandir()` pass. The current follow-up slice keeps the registered listing probe and changes shared JSON manifest loading from text decoding to direct byte loading for the listing hot path.
 
 ## Scope
 
@@ -12,7 +12,7 @@ This Python-only performance slice keeps dataset-version listing behavior unchan
 
 ## Registered probe
 
-This slice registers `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and runs on `ubuntu-latest`.
+This track uses `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and runs on `ubuntu-latest`. The current JSON byte-loading follow-up is covered by the same registered probe because `list_dataset_versions(...)` reads every discovered `dataset-version.json` manifest through `_read_json(...)`.
 
 Metrics:
 

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -806,7 +806,7 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 
 
 def _read_json(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    return json.loads(path.read_bytes())
 
 
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Load dataset preparation JSON manifests with `Path.read_bytes()` before `json.loads()`.
- Keep dataset-version listing behavior unchanged while reducing per-manifest decode overhead in the registered listing hot path.

## Plan or Spec
- `docs/plans/2026-05-24-dataset-version-listing-scandir.md`

## Commands Run
```text
# Baseline probe on origin/main (3 local runs, exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py
# elapsed_ms_mean: 82.988967, 86.746310, 76.727574

# Head probe after change (5 local runs, exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py
# elapsed_ms_mean: 69.088921, 69.167899, 72.162389, 68.739698, 76.517161

# Focused registered tests (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 7 passed in 0.87s

# Changed-scope coverage (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py
# TOTAL 1 0 100%

# Registered probe command equivalent (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py
# elapsed_ms_mean=69.258427, elapsed_ms_p95=72.088808, version_count=2500

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Local Linux registered probe baseline mean: `(82.988967 + 86.746310 + 76.727574) / 3 = 82.154284 ms`.
- Local Linux registered probe head mean: `(69.088921 + 69.167899 + 72.162389 + 68.739698 + 76.517161) / 5 = 71.135214 ms`.
- Local delta: `-11.019070 ms` (`~13.41%` lower mean elapsed time).
- CI PR-scoped performance remains the merge gate for the registered `dataset-version-listing-scandir` probe report.

## Known Gaps
- None. This is a Python-only slice and was locally verified on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
