### PR TITLE
perf: narrow serving diagnostics append saturation writes

### DIFF
--- a/docs/plans/2026-05-25-serving-diagnostics-append-local.md
+++ b/docs/plans/2026-05-25-serving-diagnostics-append-local.md
@@ -1,0 +1,13 @@
+# Serving diagnostics append local fast path
+
+## Scope
+
+This slice keeps the registered `serving-diagnostics-debug-queue-bounds` PR-scoped probe focused on `worker/productization/serving_diagnostics.py` and the bounded debug-event queue hot path.
+
+## Change
+
+The bounded diagnostics queue already keeps an explicit retained-event counter to avoid calling `len(_events)` while debug events are appended. This slice narrows the non-saturated append path so `_is_saturated` is written only once, when the retained count first reaches capacity. The saturated path remains unchanged semantically: it appends to the bounded deque, increments `dropped_count`, returns `False`, and keeps the newest retained events.
+
+## Verification
+
+Run the registered probe locally on Linux before opening the PR, then rely on the PR-scoped performance workflow for CI validation. The expected signal is lower `elapsed_ms_mean` for `serving-diagnostics-debug-queue-bounds` while retaining identical `dropped_count`, `retained_count`, serialization checksum, and serialized byte metrics.

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -102,12 +102,13 @@ class BoundedServingDiagnosticsEventQueue:
         try:
             if self._is_saturated:
                 append_event(event)
-                self._dropped_count += 1
+                self._dropped_count = self._dropped_count + 1
                 return False
             append_event(event)
             retained_count = self._retained_count + 1
             self._retained_count = retained_count
-            self._is_saturated = retained_count >= self._max_events
+            if retained_count >= self._max_events:
+                self._is_saturated = True
             return True
         finally:
             lock.release()


### PR DESCRIPTION
## Summary
- Narrow the bounded serving diagnostics queue append path so `_is_saturated` is written only when the queue first reaches capacity.
- Keep dropped-count, retained-events, and serialized diagnostics output semantics unchanged.
- Add a plan note for the registered `serving-diagnostics-debug-queue-bounds` probe slice.

## Plan or Spec
- `docs/plans/2026-05-25-serving-diagnostics-append-local.md`
- Registered probe: `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json` with focused test, coverage, and probe commands.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.productization.serving_diagnostics -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py`
- `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` (origin/main, 5 repeated samples)
- `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py` (head, 5 repeated samples)
- `git diff --check`

## Coverage and Metrics
- Focused tests: `50 passed in 0.88s`.
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Local Linux probe comparison for `elapsed_ms_mean` across five repeated 20-sample runs:
  - origin/main mean: `5.8871078 ms`
  - head mean: `5.5856876 ms`
  - delta: `-0.3014202 ms`
  - speedup: `1.05396x`
- Invariant probe outputs stayed unchanged: `dropped_count=4032`, `retained_count=64`, `serialization_checksum=260064`, `serialized_bytes=10944`.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime path is affected.
- The local micro-probe is noisy, so the registered PR-scoped performance workflow is the merge gate for this slice.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe was run against origin/main and head.
- [ ] GitHub Actions and PR-scoped performance workflow passed.
