### PR TITLE
perf: fast-path hub catalog mlx library checks

### DIFF
--- a/docs/plans/2026-05-25-hub-catalog-mlx-tag-fastpath.md
+++ b/docs/plans/2026-05-25-hub-catalog-mlx-tag-fastpath.md
@@ -1,0 +1,24 @@
+# Hub Catalog MLX Library Fast Path
+
+## Scope
+
+This slice keeps the existing Hub catalog PR-scoped probe and narrows one Python hot path: raw Hub payload MLX compatibility detection before catalog record construction.
+
+## Registered Probe
+
+Affected paths are already covered by `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.
+
+- `test_command`: focused Hub catalog tests plus PR-scoped performance registry checks.
+- `coverage_command`: focused coverage for `hub_catalog.py`, tests, registry checks, and the probe script.
+- `probe_command`: `scripts/hub_catalog_size_hint_probe.py`, including `payload_compatibility_elapsed_ms_mean` for `_payload_is_mlx_compatible`.
+
+## Change
+
+Check the payload `library_name` / card `library_name` field before scanning tag lists, using an exact three-character ASCII case-insensitive comparison for the literal `mlx` value. This preserves the existing exact-match semantics for library names while avoiding tag-list scanning on library-signaled MLX payloads. Tag matching itself remains exact and case-insensitive via the existing lower-case path, so longer tag strings such as `mlx-compatible` remain non-matches in tag fields.
+
+## Validation Plan
+
+1. Run focused Hub catalog tests.
+2. Run the registered changed-scope coverage command.
+3. Run the registered probe locally on Linux and compare against the pre-change baseline.
+4. Push and rely on the PR-scoped performance workflow for CI validation before merge.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -168,6 +168,13 @@ def test_search_models_with_mlx_only_keeps_repo_ids_with_mlx_suffix() -> None:
     assert [item.repo_id for item in page.items] == ["unsloth/gemma-4-E4B-it-MLX-8bit"]
 
 
+def test_payload_mlx_tag_match_stays_exact_and_case_insensitive() -> None:
+    assert _payload_is_mlx_compatible({"tags": ["mLx", object()], "cardData": {}}) is True
+    assert _payload_is_mlx_compatible({"tags": "MLX", "cardData": {}}) is True
+    assert _payload_is_mlx_compatible({"tags": ["mlx-compatible"], "cardData": {}}) is False
+    assert _payload_is_mlx_compatible({"tags": ["ammlx"], "cardData": {}}) is False
+
+
 def test_search_models_with_mlx_only_prefilters_payloads_before_local_fit(monkeypatch: pytest.MonkeyPatch) -> None:
     payload = [
         {

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -334,6 +334,10 @@ def _lowered_tag_set(tags: list[str]) -> set[str]:
     return {tag.lower() for tag in tags}
 
 
+def _is_mlx_atom(value: str) -> bool:
+    return len(value) == 3 and value[0] in "mM" and value[1] in "lL" and value[2] in "xX"
+
+
 def _tag_payload_contains_mlx(value: Any) -> bool:
     if isinstance(value, str):
         return value.lower() == "mlx"
@@ -393,10 +397,10 @@ def _base_models(value: Any) -> list[str]:
 
 def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:
     card_data = payload.get("cardData") if isinstance(payload.get("cardData"), dict) else {}
-    if _tag_payload_contains_mlx(payload.get("tags")):
-        return True
     library_name = _string(payload.get("library_name") or card_data.get("library_name"))
-    if library_name.lower() == "mlx":
+    if library_name and _is_mlx_atom(library_name):
+        return True
+    if _tag_payload_contains_mlx(payload.get("tags")):
         return True
     repo_id = _string(payload.get("id") or payload.get("modelId"))
     if "mlx" in repo_id.lower():


### PR DESCRIPTION
## Summary
- Fast-path Hub payload MLX compatibility checks by testing `library_name` before scanning tag lists.
- Add an exact/case-insensitive compatibility regression test for raw MLX tag payloads.
- Document the slice plan and registered probe coverage.

## Plan or Spec
- `docs/plans/2026-05-25-hub-catalog-mlx-tag-fastpath.md`
- Existing registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_COMPATIBILITY_ITERATIONS=200000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 62 passed.
- Changed-scope coverage: 100.00% (10/10 changed measurable lines).
- Local registered probe baseline before change: `payload_compatibility_elapsed_ms_mean=291.1447999998927`, `elapsed_ms_mean=1595.0392013415694`.
- Local registered probe after change: `payload_compatibility_elapsed_ms_mean=277.40313233807683`, `elapsed_ms_mean=1552.142291329801`.
- Local probe delta: payload compatibility `-13.74166766181586 ms` (`~4.72%` faster); overall size-hint probe `-42.89691001176834 ms` (`~2.69%` faster).

## Known Gaps
- Linux local verification covers this Python slice. CI is still required for the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Worktree started from `origin/main`.
- [x] Registered PR-scoped probe exists with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally and showed improvement.
- [ ] GitHub Actions completed successfully, including PR-scoped performance report.
