### PR TITLE
perf: streamline benchmark queue cold record reads

### DIFF
--- a/docs/plans/2026-05-26-benchmark-queue-binary-open.md
+++ b/docs/plans/2026-05-26-benchmark-queue-binary-open.md
@@ -1,0 +1,29 @@
+# Benchmark Queue Binary Open Slice
+
+## Scope
+
+This performance slice keeps the benchmark queue persistence behavior unchanged while
+reducing cold decode overhead for `BenchmarkQueueStore.list_records`.
+
+## Plan
+
+1. Preserve the existing decoded-record cache and per-call cloned return records.
+2. Replace the uncached `Path(...).read_bytes()` decode path with direct binary
+   `open(cache_key, "rb")` on the already normalized filesystem key.
+3. Keep the `benchmark-queue-decoded-record-cache` PR-scoped probe as the source
+   of local and CI performance validation.
+
+## Verification
+
+- Focused queue store tests cover binary decoding, metadata cache invalidation,
+  and mutation isolation.
+- Changed-scope coverage must include `benchmark_queue.py`, its tests, and the
+  PR-scoped performance dispatch tests.
+- The registered `benchmark-queue-decoded-record-cache` probe reports cold and
+  warm elapsed times plus JSON load counts.
+
+## Expected impact
+
+The cold queue listing path avoids a transient `Path` allocation for each
+uncached queue record by reading bytes directly through the cached string path.
+Warm listings should remain cache-backed with zero JSON reloads.

--- a/services/mlx-worker-python/tests/test_benchmark_queue.py
+++ b/services/mlx-worker-python/tests/test_benchmark_queue.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import json
 from pathlib import Path
 from unittest.mock import Mock
@@ -449,7 +450,7 @@ def test_list_records_warm_cache_uses_direntry_string_paths(
     assert path_constructions == 0
 
 
-def test_list_records_decodes_uncached_records_from_bytes(
+def test_list_records_decodes_uncached_records_from_binary_file(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -468,25 +469,28 @@ def test_list_records_decodes_uncached_records_from_bytes(
     path = queue_root / "queue-1.json"
     path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
     store = BenchmarkQueueStore()
-    read_bytes_calls = 0
-    original_read_bytes = Path.read_bytes
+    binary_open_calls = 0
+    original_open = builtins.open
 
-    def tracked_read_bytes(self: Path) -> bytes:
-        nonlocal read_bytes_calls
-        if self == path:
-            read_bytes_calls += 1
-        return original_read_bytes(self)
+    def tracked_open(file: object, mode: str = "r", *args: object, **kwargs: object):
+        nonlocal binary_open_calls
+        if file == str(path) and mode == "rb":
+            binary_open_calls += 1
+        return original_open(file, mode, *args, **kwargs)
 
     read_text_mock = Mock(side_effect=AssertionError("uncached queue records should be decoded from bytes"))
+    read_bytes_mock = Mock(side_effect=AssertionError("uncached queue records should avoid Path allocation for byte reads"))
 
-    monkeypatch.setattr(Path, "read_bytes", tracked_read_bytes)
+    monkeypatch.setattr(builtins, "open", tracked_open)
     monkeypatch.setattr(Path, "read_text", read_text_mock)
+    monkeypatch.setattr(Path, "read_bytes", read_bytes_mock)
 
     records = store.list_records(queue_root=queue_root)
 
     assert [record.queue_item_id for record in records] == ["queue-1"]
-    assert read_bytes_calls == 1
+    assert binary_open_calls == 1
     read_text_mock.assert_not_called()
+    read_bytes_mock.assert_not_called()
 
 
 def test_list_records_reuses_direntry_stat_for_metadata_key(

--- a/services/mlx-worker-python/worker/productization/benchmark_queue.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_queue.py
@@ -106,7 +106,8 @@ class BenchmarkQueueStore:
         except OSError:
             return []
         records.sort(key=_RECORD_SORT_KEY)
-        return [self._clone_record(record) for record in records]
+        clone_record = self._clone_record
+        return [clone_record(record) for record in records]
 
     def transition(
         self,
@@ -163,7 +164,8 @@ class BenchmarkQueueStore:
         cached = self._decoded_record_cache.get(cache_key)
         if cached is not None and cached.metadata_key == current_metadata_key:
             return cached.record
-        record = BenchmarkQueueRecord.from_dict(json.loads(Path(path).read_bytes()))
+        with open(cache_key, "rb") as record_file:
+            record = BenchmarkQueueRecord.from_dict(json.loads(record_file.read()))
         self._decoded_record_cache[cache_key] = _RecordCacheEntry(
             metadata_key=current_metadata_key,
             record=record,


### PR DESCRIPTION
## Summary
- Streamline uncached benchmark queue record decoding by reading from the cached string path with binary `open()`.
- Keep warm listings cache-backed and preserve cloned public return records.
- Add a focused regression assertion that uncached queue records avoid `Path.read_text()` and `Path.read_bytes()`.

## Plan or Spec
- `docs/plans/2026-05-26-benchmark-queue-binary-open.md`
- Registered probe: `benchmark-queue-decoded-record-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
26 passed in 15.61s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_queue.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
26 passed in 48.35s
changed_line_coverage=100.00%; TOTAL 17 0 100%

$ for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_benchmark_queue_probe.py; done
new cold_elapsed_ms: 5.054817, 4.941273, 3.796737
new warm_elapsed_ms_mean: 0.880535, 0.671104, 0.688020
new warm_json_loads_mean: 0.0, 0.0, 0.0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 17 0 100%`).
- Local registered probe baseline before this change (3 runs):
  - `cold_elapsed_ms` old_mean=6.356270 ms
  - `warm_elapsed_ms_mean` old_mean=0.753052 ms
  - `warm_json_loads_mean` old_mean=0.0
- Local registered probe after this change (3 runs):
  - `cold_elapsed_ms` new_mean=4.597609 ms, delta=-1.758661 ms, speedup=1.3825x
  - `warm_elapsed_ms_mean` new_mean=0.746553 ms, delta=-0.006499 ms, speedup=1.0087x
  - `warm_json_loads_mean` new_mean=0.0
- CI PR-scoped performance report is required as the merge validation source.

## Known Gaps
- None for the Python/Linux slice. The PR-scoped CI performance workflow must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
