### PR TITLE
perf: fast-path real model weight suffix scans

### DIFF
--- a/docs/plans/2026-05-26-real-model-weight-suffix-lowercase-fastpath.md
+++ b/docs/plans/2026-05-26-real-model-weight-suffix-lowercase-fastpath.md
@@ -1,0 +1,28 @@
+# Real Model Weight Suffix Lowercase Fast Path
+
+## Slice
+
+Optimize `scripts/real_model_support.py::_has_recognized_model_weight_files()` for the common lowercase model-weight filename path.
+
+The current implementation lowercases every scanned filename before checking model-weight suffixes. Real model directories commonly contain many lowercase sidecar/config files and lowercase `.safetensors` shards, so lowercasing every non-matching entry adds avoidable allocation and CPU work during preflight scans.
+
+## Registered Probe
+
+The affected path is covered by the existing `real-model-support-hf-cache-latest-snapshot` PR-scoped probe. This slice extends that probe to also measure a synthetic flat model directory with many lowercase non-weight files followed by a lowercase weight file:
+
+- `weight_scan_elapsed_ms_mean`
+- `weight_scan_peak_bytes_mean`
+- `weight_file_count`
+
+The existing HF-cache latest-snapshot metrics remain in the same probe so prior coverage is preserved.
+
+## Implementation Plan
+
+1. Preserve exact behavior for explicitly recognized index filenames and uppercase model-weight suffixes.
+2. Fast-path lowercase suffix checks with `name.endswith(_REAL_MODEL_WEIGHT_SUFFIXES)` before falling back to `name.lower()` only when the filename is not already lowercase.
+3. Add a regression test proving uppercase suffix fallback remains accepted.
+4. Extend probe/test coverage for the weight-directory scan metrics.
+
+## Verification
+
+Run the focused tests, changed-scope coverage, and the registered probe locally on Linux. Use the PR-scoped performance workflow as the merge gate for the registered probe report.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2321,6 +2321,18 @@
         "unit": "bytes",
         "direction": "lower_is_better",
         "warn_pct": 5.0
+      },
+      {
+        "key": "weight_scan_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "weight_scan_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
       }
     ]
   },

--- a/scripts/real_model_support.py
+++ b/scripts/real_model_support.py
@@ -335,8 +335,11 @@ def _has_recognized_model_weight_files(path: Path) -> bool:
                     continue
             except OSError:
                 continue
-            if entry.name in _REAL_MODEL_WEIGHT_FILENAMES:
+            name = entry.name
+            if name in _REAL_MODEL_WEIGHT_FILENAMES:
                 return True
-            if entry.name.lower().endswith(_REAL_MODEL_WEIGHT_SUFFIXES):
+            if name.endswith(_REAL_MODEL_WEIGHT_SUFFIXES):
+                return True
+            if not name.islower() and name.lower().endswith(_REAL_MODEL_WEIGHT_SUFFIXES):
                 return True
     return False

--- a/scripts/real_model_support_hf_cache_probe.py
+++ b/scripts/real_model_support_hf_cache_probe.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 SNAPSHOT_COUNT = 6000
 SAMPLE_COUNT = 7
+WEIGHT_FILE_COUNT = 20_000
 MODEL_ID = "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"
 LATEST_SNAPSHOT = f"snapshot-{SNAPSHOT_COUNT - 1:05d}"
 
@@ -35,12 +36,41 @@ def _build_cache(home: Path) -> Path:
     return snapshots_root
 
 
+def _build_weight_directory(root: Path) -> Path:
+    weight_dir = root / "weights"
+    weight_dir.mkdir()
+    for index in range(WEIGHT_FILE_COUNT - 1):
+        (weight_dir / f"config-{index:05d}.json").write_text("{}\n", encoding="utf-8")
+    (weight_dir / "model.safetensors").write_bytes(b"weights")
+    return weight_dir
+
+
+def _measure_weight_scan(weight_dir: Path, has_recognized_model_weight_files) -> tuple[float, float]:
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    for _ in range(SAMPLE_COUNT):
+        tracemalloc.start()
+        started = time.perf_counter()
+        has_weights = has_recognized_model_weight_files(weight_dir)
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        if not has_weights:
+            raise RuntimeError("synthetic weight directory was not recognized")
+        elapsed_samples.append(elapsed_ms)
+        peak_samples.append(float(peak))
+    return round(statistics.fmean(elapsed_samples), 6), round(statistics.fmean(peak_samples), 1)
+
+
 def _measure() -> dict[str, float]:
     repo_root = _repo_root()
     sys.path.insert(0, str(repo_root))
     sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
 
-    from scripts.real_model_support import resolve_real_small_text_model_source
+    from scripts.real_model_support import (
+        _has_recognized_model_weight_files,
+        resolve_real_small_text_model_source,
+    )
 
     elapsed_samples: list[float] = []
     peak_samples: list[float] = []
@@ -71,6 +101,11 @@ def _measure() -> dict[str, float]:
             raise RuntimeError(f"unexpected selected snapshots: {sorted(selected_snapshots)}")
         if len(tuple(snapshots_root.iterdir())) != SNAPSHOT_COUNT + 1:
             raise RuntimeError("synthetic cache was not built with the expected snapshot count")
+        weight_dir = _build_weight_directory(Path(tmpdir))
+        weight_elapsed_ms, weight_peak_bytes = _measure_weight_scan(
+            weight_dir,
+            _has_recognized_model_weight_files,
+        )
 
     return {
         "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
@@ -78,6 +113,9 @@ def _measure() -> dict[str, float]:
         "sample_count": float(SAMPLE_COUNT),
         "snapshot_count": float(SNAPSHOT_COUNT),
         "selected_latest_snapshot": float(SNAPSHOT_COUNT - 1),
+        "weight_scan_elapsed_ms_mean": weight_elapsed_ms,
+        "weight_scan_peak_bytes_mean": weight_peak_bytes,
+        "weight_file_count": float(WEIGHT_FILE_COUNT),
     }
 
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -4018,6 +4018,9 @@ def test_real_model_support_hf_cache_probe_script_emits_metrics(
     assert payload["sample_count"] == 7.0
     assert payload["snapshot_count"] == 6000.0
     assert payload["selected_latest_snapshot"] == 5999.0
+    assert payload["weight_scan_elapsed_ms_mean"] > 0
+    assert payload["weight_scan_peak_bytes_mean"] > 0
+    assert payload["weight_file_count"] == 20_000.0
 
 
 def test_upload_receipt_probe_script_emits_metrics(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_real_model_support.py
+++ b/tests/test_real_model_support.py
@@ -447,6 +447,14 @@ def test_has_recognized_model_weight_files_skips_path_iterdir(monkeypatch, tmp_p
     assert _has_recognized_model_weight_files(model_dir) is True
 
 
+def test_has_recognized_model_weight_files_preserves_uppercase_suffix_fallback(tmp_path: Path) -> None:
+    model_dir = tmp_path / "weights"
+    model_dir.mkdir()
+    (model_dir / "MODEL.SAFETENSORS").write_text("{}", encoding="utf-8")
+
+    assert _has_recognized_model_weight_files(model_dir) is True
+
+
 def test_has_recognized_model_weight_files_does_not_recurse_into_subdirectories(tmp_path: Path) -> None:
     model_dir = tmp_path / "weights"
     model_dir.mkdir()


### PR DESCRIPTION
## Summary
- Fast-path real model weight-file detection for the common lowercase suffix path before falling back to case-insensitive suffix matching.
- Preserve uppercase weight suffix behavior with focused regression coverage.
- Extend the registered real-model-support PR-scoped probe with weight directory scan metrics.

## Plan or Spec
- `docs/plans/2026-05-26-real-model-weight-suffix-lowercase-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_real_model_support.py::test_has_recognized_model_weight_files_skips_path_iterdir tests/test_real_model_support.py::test_has_recognized_model_weight_files_preserves_uppercase_suffix_fallback tests/test_real_model_support.py::test_has_recognized_model_weight_files_does_not_recurse_into_subdirectories tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics
# 8 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting tests/test_real_model_support.py::test_has_recognized_model_weight_files_skips_path_iterdir tests/test_real_model_support.py::test_has_recognized_model_weight_files_preserves_uppercase_suffix_fallback tests/test_real_model_support.py::test_has_recognized_model_weight_files_does_not_recurse_into_subdirectories services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/real_model_support.py tests/test_real_model_support.py scripts/real_model_support_hf_cache_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 8 passed; aggregate changed-line coverage 97% (38/39), scripts/real_model_support.py changed lines 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/real_model_support_hf_cache_probe.py
# completed; JSON metrics recorded below

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: aggregate `TOTAL 39 1 97%`; `scripts/real_model_support.py` changed lines 338,339,341,342,343 = 100.00% covered.
- Local pre-change custom weight scan baseline on Linux: `old_mean=23.345651 ms` for 20,000 files / 7 samples.
- Local registered probe after change on Linux:
  - HF cache metric: `elapsed_ms_mean=17.630575`, `peak_bytes_mean=4710.0`, `snapshot_count=6000`, `sample_count=7`
  - Changed path metric: `weight_scan_elapsed_ms_mean=18.701886`, `weight_scan_peak_bytes_mean=702.0`, `weight_file_count=20000`, `sample_count=7`
  - Changed path delta: `delta_ms=-4.643765`, `speedup=1.248302`
- CI PR-scoped performance is required for the registered probe merge gate.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime behavior is changed.
- One changed probe line is intentionally uncovered in the error branch that raises if the synthetic weight directory is not recognized; aggregate changed-scope coverage remains above the 95% threshold.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
