### PR TITLE
perf: fast-path changed-scope diff line splitting

### DIFF
--- a/docs/plans/2026-05-26-changed-scope-diff-line-split.md
+++ b/docs/plans/2026-05-26-changed-scope-diff-line-split.md
@@ -1,0 +1,21 @@
+# Changed-Scope Coverage Diff Line Split Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to the changed-scope coverage unified-diff parser in `scripts/changed_scope_coverage.py`.
+
+The parser already dispatches hot-loop work from the first character. This slice keeps that behavior and changes line iteration from `str.splitlines()` to `str.split("\n")` for the Git unified diff payload returned by `git diff --unified=0`. Git diff output is line-feed delimited in this workflow, so the change avoids the broader universal-newline handling that is not needed on the registered probe path.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry already provides:
+
+- focused `test_command` coverage for parser behavior and probe registry selection;
+- focused `coverage_command` for changed-scope coverage on the touched parser/probe/test files;
+- `probe_command` using `scripts/changed_scope_coverage_parse_probe.py`, which builds a deterministic synthetic multi-file unified diff and reports `elapsed_ms_mean`, `elapsed_ms_min`, `line_count`, `file_count`, and `changed_line_count`.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage command, and local registered probe on Linux before opening the PR. The GitHub PR-scoped performance workflow remains the merge gate for registered base-vs-head validation before merge.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -63,7 +63,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     header_separator_len = len(header_separator)
     add_changed_line = None
     new_line: int | None = None
-    for line in diff_text.splitlines():
+    for line in diff_text.split("\n"):
         if not line:
             if add_changed_line is not None and new_line is not None:
                 new_line += 1


### PR DESCRIPTION
## Summary
- Fast-path changed-scope coverage unified-diff line iteration by using `str.split("\n")` for the Git diff payload instead of universal-newline `splitlines()`.
- Add the governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-05-26-changed-scope-diff-line-split.md`

## Commands Run
```text
# Focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# Result: 31 passed in 0.18s

# Changed-scope coverage for the registered probe scope
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# Result: 31 passed in 0.53s; TOTAL 1 0 100%

# Local registered PR-scoped performance probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-diff-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-changed-scope-diff-parser-fastpath-20260526-base --head-repo "$PWD" --output /tmp/changed_scope_diff_parser_probe.json
# Result: verification OK; base/head probe OK

git diff --check
# Result: exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `scripts/changed_scope_coverage.py` measurable changed lines `[66]`, covered `[66]`, missed `[]`; aggregate `TOTAL 1 0 100%`.
- Registered probe: `changed-scope-coverage-diff-parser`.
- Local Linux probe metrics:
  - base `elapsed_ms_mean=3.285682061687`, `elapsed_ms_min=3.027075901628`
  - head `elapsed_ms_mean=3.154606403162`, `elapsed_ms_min=3.034770954400`
  - delta `-0.131075658525 ms`, speedup `3.989%` on `elapsed_ms_mean`
  - guardrails unchanged: `line_count=16080.0`, `file_count=240.0`, `changed_line_count=7680.0`
- CI PR-scoped performance validation is still required before merge.

## Known Gaps
- None for the Python slice. The runtime effect is locally validated on Linux and remains gated by the registered GitHub PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
