### PR TITLE
perf: cache report evidence probe phase rules

### DIFF
--- a/docs/plans/2026-05-26-report-evidence-probe-phase-cache.md
+++ b/docs/plans/2026-05-26-report-evidence-probe-phase-cache.md
@@ -1,0 +1,45 @@
+# Report evidence probe-phase tuple cache
+
+## Scope
+
+This Python-only performance slice is limited to release evidence matrix rule
+matching in `services/mlx-worker-python/worker/productization/report_evidence_gate.py`.
+
+The optimization preserves existing release-matrix semantics while reusing the
+existing tuple-normalization cache for tuple-valued `probe_phases` rules. Mutable
+non-tuple inputs remain uncached so list/set-style rule updates continue to be
+reflected on the next match.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`report-evidence-gate-run-kind-set-membership` in
+`infra/perf/pr_scoped_probes.json`.
+
+The registry entry already provides focused `test_command`, `coverage_command`,
+and `probe_command` entries for the touched worker path. To avoid mixing probe
+registration with the runtime optimization, this slice keeps the registered
+probe definition stable and uses an additional local same-script microbenchmark
+for the tuple-valued `probe_phases` path.
+
+## Plan
+
+1. Add regression tests proving tuple-valued probe-phase rules reuse the cached
+   normalized set while mutable list rules still reflect mutation.
+2. Replace per-call `set(str(...))` materialization for probe phases with the
+   existing `_string_frozenset()` helper.
+3. Keep the registered report-evidence probe stable and use it as the CI guard.
+4. Run focused pytest, changed-scope coverage, the registered probe, and a
+   local same-script probe-phase microbenchmark on Linux before opening the PR.
+5. Use GitHub Actions and the registered PR-scoped performance report as the
+   merge gate.
+
+## Verification
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_preserves_stringified_presence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_probe_phase_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_probe_phase_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_preserves_stringified_presence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_probe_phase_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_probe_phase_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
+```

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -304,6 +304,51 @@ def test_report_evidence_gate_target_field_preserves_stringified_presence() -> N
     )
 
 
+def test_report_evidence_gate_probe_phase_tuple_rules_reuse_normalized_set() -> None:
+    report_evidence_gate_module._string_frozenset_from_tuple.cache_clear()
+    rule = {"probe_phases": ("runtime_prepare", "model_load", "decode")}
+
+    assert report_evidence_gate_module._rule_matches_report(
+        rule=rule,
+        runs=[],
+        targets=[],
+        metrics=[],
+        probe_phases={"runtime_prepare", "model_load", "decode"},
+    )
+    assert not report_evidence_gate_module._rule_matches_report(
+        rule=rule,
+        runs=[],
+        targets=[],
+        metrics=[],
+        probe_phases={"runtime_prepare", "decode"},
+    )
+
+    cache_info = report_evidence_gate_module._string_frozenset_from_tuple.cache_info()
+    assert cache_info.hits >= 1
+    assert cache_info.misses == 1
+
+
+def test_report_evidence_gate_probe_phase_list_rules_reflect_mutation() -> None:
+    probe_phases = ["runtime_prepare", "model_load", "decode", "embedding"]
+    rule = {"probe_phases": probe_phases}
+
+    assert not report_evidence_gate_module._rule_matches_report(
+        rule=rule,
+        runs=[],
+        targets=[],
+        metrics=[],
+        probe_phases={"runtime_prepare", "model_load", "decode"},
+    )
+    probe_phases.pop()
+    assert report_evidence_gate_module._rule_matches_report(
+        rule=rule,
+        runs=[],
+        targets=[],
+        metrics=[],
+        probe_phases={"runtime_prepare", "model_load", "decode"},
+    )
+
+
 def test_report_evidence_gate_run_kind_list_rules_reflect_mutation() -> None:
     run_kinds = ["evaluation"]
     rule = {"run_kinds": run_kinds}

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -313,7 +313,7 @@ def _rule_matches_report(
                         return True
                 elif str(value).strip():
                     return True
-    required_probe_phases = set(str(item) for item in rule.get("probe_phases", ()))
+    required_probe_phases = _string_frozenset(rule.get("probe_phases", ()))
     return bool(required_probe_phases and required_probe_phases.issubset(probe_phases))
 
 


### PR DESCRIPTION
## Summary
- Cache tuple-valued report-evidence `probe_phases` rule normalization through the existing `_string_frozenset()` helper.
- Add regression coverage for tuple cache reuse and mutable list semantics.
- Keep the registered `report-evidence-gate-run-kind-set-membership` probe definition stable; use an additional local same-script microbenchmark for the probe-phase-only path.

## Plan or Spec
- `docs/plans/2026-05-26-report-evidence-probe-phase-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_preserves_stringified_presence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
Result: 12 passed in 0.84s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused test list> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
Result: 12 passed in 0.34s; changed-scope coverage TOTAL 0 0 100% (post-amend diff has no measurable changed lines in the covered scope)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" MELIX_REPORT_EVIDENCE_RUN_KIND_ITERATIONS=10000 MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
Result: exit 0; elapsed_ms_mean=2849.827379; run_kind_elapsed_ms_mean=51.570126; metric_prefix_elapsed_ms_mean=303.330041; target_field_elapsed_ms_mean=2494.927212

Local probe-phase microbenchmark against origin/main-equivalent base worktree using the same /tmp/report_evidence_probe_phase_compare.py harness:
Result: exit 0; old_mean=990.335 ms; new_mean=301.259 ms; delta_ms=-689.076; speedup=3.2873x; improvement=69.58%
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 0 0 100%` for the post-amend focused scope; the focused behavior tests above exercise the tuple/list rule semantics.
- Registered probe: `report-evidence-gate-run-kind-set-membership` (unchanged definition; provides focused `test_command`, `coverage_command`, and `probe_command` for this path).
- Local same-script probe-phase microbenchmark:
  - `elapsed_ms_mean`: 990.335 ms -> 301.259 ms (delta -689.076 ms, 3.2873x, 69.58% lower).
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- None. This is a Python-only slice locally verified on Linux; CI must still validate the registered PR-scoped probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe and local same-script microbenchmark; no debug artifacts.
- [x] Deferred work and known gaps are stated explicitly.
