### PR TITLE
Add release Homebrew and Nix distribution CI

### DIFF
--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -219,3 +219,19 @@ jobs:
           files: ${{ runner.temp }}/${{ needs.package-app.outputs.artifact_name }}.zip
           # Tag pushes are the release source of truth for this workflow, so generated notes own the body.
           generate_release_notes: true
+
+      - name: Trigger release distribution workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_ARCHIVE_NAME: ${{ needs.package-app.outputs.artifact_name }}.zip
+        run: |
+          set -euo pipefail
+          gh api \
+            --method POST \
+            "repos/$RELEASE_REPOSITORY/dispatches" \
+            --field "event_type=melix-release-asset-published" \
+            --field "client_payload[tag_name]=$RELEASE_TAG" \
+            --field "client_payload[repository]=$RELEASE_REPOSITORY" \
+            --field "client_payload[archive_name]=$RELEASE_ARCHIVE_NAME"

--- a/.github/workflows/release-homebrew-distribution.yml
+++ b/.github/workflows/release-homebrew-distribution.yml
@@ -1,0 +1,122 @@
+name: release-homebrew-distribution
+
+on:
+  release:
+    types: [published]
+  repository_dispatch:
+    types: [melix-release-asset-published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag to distribute, for example v1.2.3.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-homebrew-distribution-${{ github.event.release.tag_name || github.event.client_payload.tag_name || inputs.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish-homebrew:
+    runs-on: ubuntu-latest
+
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || github.event.client_payload.tag_name || inputs.tag_name }}
+      RELEASE_REPOSITORY: ${{ github.event.client_payload.repository || github.repository }}
+      RELEASE_ARCHIVE_NAME: ${{ github.event.client_payload.archive_name }}
+      HOMEBREW_TAP_REPOSITORY: ${{ vars.MELIX_HOMEBREW_TAP_REPOSITORY }}
+      HOMEBREW_CASK_PATH: Casks/melix.rb
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Validate Homebrew distribution configuration
+        shell: bash
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.MELIX_HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$RELEASE_TAG" ]]; then
+            echo "RELEASE_TAG is required." >&2
+            exit 1
+          fi
+          if [[ -z "$HOMEBREW_TAP_REPOSITORY" ]]; then
+            echo "Set repository variable MELIX_HOMEBREW_TAP_REPOSITORY to owner/repo." >&2
+            exit 1
+          fi
+          if [[ -z "$HOMEBREW_TAP_TOKEN" ]]; then
+            echo "Set repository secret MELIX_HOMEBREW_TAP_TOKEN with write access to the tap repository." >&2
+            exit 1
+          fi
+
+      - name: Checkout Melix renderer
+        uses: actions/checkout@v4
+
+      - name: Resolve release archive name
+        id: archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          archive_name="${RELEASE_ARCHIVE_NAME:-Melix-${version}-macos.zip}"
+          {
+            echo "version=$version"
+            echo "archive_name=$archive_name"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download release archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/release-asset"
+          for attempt in {1..20}; do
+            if gh release download "$RELEASE_TAG" \
+              --repo "$RELEASE_REPOSITORY" \
+              --pattern "${{ steps.archive.outputs.archive_name }}" \
+              --dir "$RUNNER_TEMP/release-asset" \
+              --clobber \
+              && test -s "$RUNNER_TEMP/release-asset/${{ steps.archive.outputs.archive_name }}"; then
+              exit 0
+            fi
+            echo "Release archive not available yet; retry $attempt/20."
+            sleep 15
+          done
+          echo "Could not download ${{ steps.archive.outputs.archive_name }} from release $RELEASE_TAG." >&2
+          gh release view "$RELEASE_TAG" --repo "$RELEASE_REPOSITORY" --json assets >&2 || true
+          exit 1
+
+      - name: Render Homebrew distribution
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/render_release_distribution.py \
+            --tag-name "$RELEASE_TAG" \
+            --repository "$RELEASE_REPOSITORY" \
+            --archive-path "$RUNNER_TEMP/release-asset/${{ steps.archive.outputs.archive_name }}" \
+            --output-root "$RUNNER_TEMP/release-distribution" \
+            --json
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ vars.MELIX_HOMEBREW_TAP_REPOSITORY }}
+          token: ${{ secrets.MELIX_HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update Homebrew cask
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "homebrew-tap/$(dirname "$HOMEBREW_CASK_PATH")"
+          cp "$RUNNER_TEMP/release-distribution/homebrew/Casks/melix.rb" "homebrew-tap/$HOMEBREW_CASK_PATH"
+          ruby -c "homebrew-tap/$HOMEBREW_CASK_PATH"
+
+      - name: Commit Homebrew cask update
+        uses: EndBug/add-and-commit@v9
+        with:
+          cwd: homebrew-tap
+          add: ${{ env.HOMEBREW_CASK_PATH }}
+          message: "chore: update melix Homebrew cask ${{ steps.archive.outputs.version }}"
+          default_author: github_actions

--- a/.github/workflows/release-nix-distribution.yml
+++ b/.github/workflows/release-nix-distribution.yml
@@ -1,0 +1,126 @@
+name: release-nix-distribution
+
+on:
+  release:
+    types: [published]
+  repository_dispatch:
+    types: [melix-release-asset-published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag to distribute, for example v1.2.3.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-nix-distribution-${{ github.event.release.tag_name || github.event.client_payload.tag_name || inputs.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish-nix:
+    runs-on: ubuntu-latest
+
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || github.event.client_payload.tag_name || inputs.tag_name }}
+      RELEASE_REPOSITORY: ${{ github.event.client_payload.repository || github.repository }}
+      RELEASE_ARCHIVE_NAME: ${{ github.event.client_payload.archive_name }}
+      NIX_REPOSITORY: ${{ vars.MELIX_NIX_REPOSITORY }}
+      NIX_FLAKE_PATH: flake.nix
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Validate Nix distribution configuration
+        shell: bash
+        env:
+          NIX_REPOSITORY_TOKEN: ${{ secrets.MELIX_NIX_REPOSITORY_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$RELEASE_TAG" ]]; then
+            echo "RELEASE_TAG is required." >&2
+            exit 1
+          fi
+          if [[ -z "$NIX_REPOSITORY" ]]; then
+            echo "Set repository variable MELIX_NIX_REPOSITORY to owner/repo." >&2
+            exit 1
+          fi
+          if [[ -z "$NIX_REPOSITORY_TOKEN" ]]; then
+            echo "Set repository secret MELIX_NIX_REPOSITORY_TOKEN with write access to the Nix repository." >&2
+            exit 1
+          fi
+
+      - name: Checkout Melix renderer
+        uses: actions/checkout@v4
+
+      - name: Resolve release archive name
+        id: archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          archive_name="${RELEASE_ARCHIVE_NAME:-Melix-${version}-macos.zip}"
+          {
+            echo "version=$version"
+            echo "archive_name=$archive_name"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download release archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/release-asset"
+          for attempt in {1..20}; do
+            if gh release download "$RELEASE_TAG" \
+              --repo "$RELEASE_REPOSITORY" \
+              --pattern "${{ steps.archive.outputs.archive_name }}" \
+              --dir "$RUNNER_TEMP/release-asset" \
+              --clobber \
+              && test -s "$RUNNER_TEMP/release-asset/${{ steps.archive.outputs.archive_name }}"; then
+              exit 0
+            fi
+            echo "Release archive not available yet; retry $attempt/20."
+            sleep 15
+          done
+          echo "Could not download ${{ steps.archive.outputs.archive_name }} from release $RELEASE_TAG." >&2
+          gh release view "$RELEASE_TAG" --repo "$RELEASE_REPOSITORY" --json assets >&2 || true
+          exit 1
+
+      - name: Render Nix distribution
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/render_release_distribution.py \
+            --tag-name "$RELEASE_TAG" \
+            --repository "$RELEASE_REPOSITORY" \
+            --archive-path "$RUNNER_TEMP/release-asset/${{ steps.archive.outputs.archive_name }}" \
+            --output-root "$RUNNER_TEMP/release-distribution" \
+            --json
+
+      - name: Checkout Nix repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ vars.MELIX_NIX_REPOSITORY }}
+          token: ${{ secrets.MELIX_NIX_REPOSITORY_TOKEN }}
+          path: nix-distribution
+
+      - name: Update Nix flake
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "nix-distribution/$(dirname "$NIX_FLAKE_PATH")"
+          cp "$RUNNER_TEMP/release-distribution/nix/flake.nix" "nix-distribution/$NIX_FLAKE_PATH"
+          if command -v nix >/dev/null 2>&1; then
+            nix --extra-experimental-features "nix-command flakes" flake check "./nix-distribution" --no-build
+          else
+            echo "nix is not installed on this runner; skipped flake check after rendering flake.nix."
+          fi
+
+      - name: Commit Nix flake update
+        uses: EndBug/add-and-commit@v9
+        with:
+          cwd: nix-distribution
+          add: ${{ env.NIX_FLAKE_PATH }}
+          message: "chore: update melix Nix package ${{ steps.archive.outputs.version }}"
+          default_author: github_actions

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ Step-by-step operating procedures for specific workflows. Use these when you nee
 | [LoRA Adapter Workflow](runbooks/phase-8-lora-adapter-workflow.md) | Training, activating, publishing, and removing LoRA adapters |
 | [Local Install](runbooks/phase-8-local-install.md) | Install Melix as a persistent local service via launch agent |
 | [Homebrew Install](runbooks/homebrew-install.md) | Install and manage Melix through Homebrew |
-| [Packaging Targets](runbooks/platform-packaging-targets.md) | Launch agent, Homebrew service, and preview app-bundle delivery options |
+| [Packaging Targets](runbooks/platform-packaging-targets.md) | Launch agent, Homebrew, Nix, and preview app-bundle delivery options |
 | [Release Gates](runbooks/phase-8-release-gates.md) | Automated release gate workflow and verification criteria |
 | [Product Acceptance](runbooks/phase-8-product-acceptance.md) | Acceptance evidence and product-level smoke procedures |
 | [Structured Streaming](runbooks/structured-streaming-reasoning-continuity.md) | Streaming and reasoning continuity behavior |

--- a/docs/plans/2026-05-26-release-homebrew-nix-distribution-ci.md
+++ b/docs/plans/2026-05-26-release-homebrew-nix-distribution-ci.md
@@ -1,0 +1,73 @@
+# Release Homebrew And Nix Distribution CI
+
+## Goal
+
+Publish Melix release artifacts to Homebrew and Nix distribution repositories when a GitHub Release
+is published and the packaged app archive is attached.
+
+## Non-Goals
+
+- Do not replace the existing `package-self-contained-app` workflow that builds and attaches `Melix-<version>-macos.zip`.
+- Do not make local checkout Homebrew development installs depend on a published tap.
+
+## Context
+
+- The existing `.github/workflows/package-self-contained-app.yml` workflow attaches the self-contained macOS app archive to GitHub Releases for `v*` tags.
+- Release updates made with the repository `GITHUB_TOKEN` do not reliably fan out through a second
+  `release` event workflow. After uploading the archive, the packaging workflow therefore emits a
+  `repository_dispatch` event with the release tag and archive name so distribution workflows can
+  run after the asset exists.
+- `infra/homebrew/Formula/melix.rb` remains a repository-local source formula for development and service validation.
+- There is no current Nix distribution artifact in the repository.
+- Release distribution must be reproducible from the GitHub Release asset URL and the measured SHA-256 digest of the downloaded archive.
+
+## Assumptions
+
+- Release assets follow the existing package metadata convention: tag `v1.2.3` produces `Melix-1.2.3-macos.zip`.
+- Homebrew distribution uses a cask because the release asset is a self-contained `Melix.app` archive.
+- Nix distribution uses a Darwin-only flake that fetches the same release archive with `fetchurl`, unzips it, and exposes `packages.aarch64-darwin.melix`.
+- Target repositories are configured through repository variables and tokens:
+  - `MELIX_HOMEBREW_TAP_REPOSITORY` plus `MELIX_HOMEBREW_TAP_TOKEN`
+  - `MELIX_NIX_REPOSITORY` plus `MELIX_NIX_REPOSITORY_TOKEN`
+
+## Work Plan
+
+1. Add a release-distribution renderer for Homebrew cask and Nix flake content.
+2. Add focused tests that prove the generated Homebrew and Nix files point at the release archive URL, version, and hashes.
+3. Add two GitHub Actions workflows:
+   - `release-homebrew-distribution.yml`
+   - `release-nix-distribution.yml`
+4. Each workflow waits for or downloads the existing release archive, computes SHA-256 locally, renders the distribution file, checks out the configured target repository, commits the rendered update, and pushes it.
+5. Bridge the existing release packaging workflow to the distribution workflows with a
+   `melix-release-asset-published` `repository_dispatch` event after the archive upload succeeds.
+6. Update runbooks to document release-time distribution configuration and failure modes.
+
+## Verification
+
+```bash
+PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_distribution.py
+python3 -m py_compile scripts/render_release_distribution.py services/mlx-worker-python/worker/productization/release_distribution.py
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/package-self-contained-app.yml"); YAML.load_file(".github/workflows/release-homebrew-distribution.yml"); YAML.load_file(".github/workflows/release-nix-distribution.yml")'
+```
+
+Expected evidence:
+
+- The pytest target passes and validates rendered Homebrew and Nix distribution files.
+- Python compilation succeeds for the release-distribution renderer and CLI.
+- Ruby YAML parsing succeeds for the packaging workflow and both new workflows.
+
+## Acceptance Criteria
+
+- Publishing a GitHub Release can trigger a Homebrew distribution workflow.
+- Publishing a GitHub Release can trigger a Nix distribution workflow.
+- Uploading the packaged release archive from the existing packaging workflow dispatches both
+  distribution workflows after the release asset exists.
+- Both workflows derive the version, asset name, release URL, and digest from the release event and downloaded asset.
+- Both workflows fail with an explicit configuration error if the target repository variable or token is missing.
+- Documentation tells operators which variables and secrets are required.
+
+## Rollback or Safe Exit
+
+- Disable either release workflow from the GitHub Actions UI if an external distribution repository is misconfigured.
+- Revert the generated commit in the external Homebrew tap or Nix repository if a published formula or flake points to the wrong release asset.
+- The existing GitHub Release artifact remains the source of truth and is not modified by either distribution workflow.

--- a/docs/runbooks/homebrew-install.md
+++ b/docs/runbooks/homebrew-install.md
@@ -79,3 +79,27 @@ python3 scripts/m8_homebrew_formula_smoke.py --json
 python3 scripts/m8_homebrew_service_smoke.py --json
 python3 scripts/m8_packaging_target_smoke.py --json
 ```
+
+## Release Distribution
+
+The checked-in formula above remains the local checkout formula. Published
+GitHub Releases distribute the self-contained `Melix.app` archive through a
+Homebrew cask in a configured tap repository.
+
+When a GitHub Release is published, the
+`release-homebrew-distribution` workflow runs from the release event or from the
+`melix-release-asset-published` repository dispatch emitted after the packaging
+workflow attaches the archive. It:
+
+1. downloads the existing `Melix-<version>-macos.zip` release asset,
+2. computes its SHA-256 digest,
+3. renders `Casks/melix.rb` for the configured tap repository,
+4. commits the cask update to that tap.
+
+Required repository configuration:
+
+- variable `MELIX_HOMEBREW_TAP_REPOSITORY`: target tap in `owner/repo` form
+- secret `MELIX_HOMEBREW_TAP_TOKEN`: token with write access to that tap
+
+The workflow fails before checkout if either value is missing. It does not
+rebuild the app archive; the GitHub Release asset remains the source of truth.

--- a/docs/runbooks/platform-packaging-targets.md
+++ b/docs/runbooks/platform-packaging-targets.md
@@ -26,6 +26,8 @@ Target differentiation is expressed through `packaging_target_id`, `packaging_ki
 | `launch_agents_checkout` | `launch_agents` | local checkout | `repo_checkout` | `install_manifest_v1` | repository update channel |
 | `homebrew_service` | `homebrew` | Homebrew formula | `repo_checkout_with_installed_binaries` | `service_manifest_v1` | `brew upgrade` plus repository update metadata |
 | `macos_app_bundle_preview` | `app_bundle` | archive or drag install | `self_contained_bundle` | `embedded_target_manifest_v1` | manual bundle refresh with embedded update metadata |
+| `homebrew_release_cask` | `homebrew_cask` | published Homebrew tap | `self_contained_bundle` | `release_asset_digest_v1` | GitHub Release published workflow |
+| `nix_release_flake` | `nix_flake` | published Nix flake repository | `self_contained_bundle` | `release_asset_digest_v1` | GitHub Release published workflow |
 
 ## Target Outputs
 
@@ -43,6 +45,27 @@ Target differentiation is expressed through `packaging_target_id`, `packaging_ki
 - keeps the `homebrew` sidecar instance while projecting the same logical Melix identity and
   version or update metadata as the launch-agent flow
 - differentiates only through Homebrew supervision and installed-binary paths
+
+### `homebrew_release_cask`
+
+- rendered by `scripts/render_release_distribution.py`
+- writes `Casks/melix.rb` in the configured Homebrew tap repository
+- points at the existing GitHub Release asset `Melix-<version>-macos.zip`
+- records the SHA-256 digest computed from the downloaded release asset
+- is triggered by `.github/workflows/release-homebrew-distribution.yml` when a GitHub Release is
+  published, or when the package workflow dispatches `melix-release-asset-published` after
+  attaching the release archive
+
+### `nix_release_flake`
+
+- rendered by `scripts/render_release_distribution.py`
+- writes `flake.nix` in the configured Nix distribution repository
+- exposes `packages.aarch64-darwin.melix` and `packages.aarch64-darwin.default`
+- points at the existing GitHub Release asset `Melix-<version>-macos.zip`
+- records the Nix SRI SHA-256 source hash computed from the downloaded release asset
+- is triggered by `.github/workflows/release-nix-distribution.yml` when a GitHub Release is
+  published, or when the package workflow dispatches `melix-release-asset-published` after
+  attaching the release archive
 
 ### `macos_app_bundle_preview`
 
@@ -64,3 +87,16 @@ PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" \
 uv run --project services/mlx-worker-python --extra mlx \
 python scripts/m8_packaging_target_smoke.py --json
 ```
+
+Run the release-distribution renderer tests after changing Homebrew or Nix release publishing:
+
+```bash
+PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" \
+uv run --project services/mlx-worker-python \
+pytest -q services/mlx-worker-python/tests/test_release_distribution.py
+```
+
+Release distribution workflows require these repository variables and secrets:
+
+- `MELIX_HOMEBREW_TAP_REPOSITORY` and `MELIX_HOMEBREW_TAP_TOKEN`
+- `MELIX_NIX_REPOSITORY` and `MELIX_NIX_REPOSITORY_TOKEN`

--- a/scripts/render_release_distribution.py
+++ b/scripts/render_release_distribution.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "services/mlx-worker-python"))
+
+from worker.productization.release_distribution import (  # noqa: E402
+    DEFAULT_RELEASE_REPOSITORY,
+    write_distribution_files,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tag-name", required=True)
+    parser.add_argument("--repository", default=DEFAULT_RELEASE_REPOSITORY)
+    parser.add_argument("--archive-path", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    payload = write_distribution_files(
+        tag_name=args.tag_name,
+        repository=args.repository,
+        archive_path=args.archive_path,
+        output_root=args.output_root,
+    )
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_release_distribution.py
+++ b/services/mlx-worker-python/tests/test_release_distribution.py
@@ -67,6 +67,28 @@ def test_release_asset_from_archive_rejects_missing_file(tmp_path: Path) -> None
         )
 
 
+def test_release_asset_from_archive_hashes_without_whole_file_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = tmp_path / "Melix-1.2.3-macos.zip"
+    payload = b"melix archive" * 1024
+    archive.write_bytes(payload)
+
+    def fail_whole_file_read(self: Path) -> bytes:
+        raise AssertionError("release archive hashing must stream bytes instead of read_bytes")
+
+    monkeypatch.setattr(Path, "read_bytes", fail_whole_file_read)
+
+    asset = release_asset_from_archive(
+        tag_name="v1.2.3",
+        repository="Keith-CY/melix",
+        archive_path=archive,
+    )
+
+    assert asset.sha256_hex == hashlib.sha256(payload).hexdigest()
+
+
 def test_render_homebrew_cask_points_to_release_asset_and_service_metadata() -> None:
     asset = ReleaseAsset(
         version="1.2.3",

--- a/services/mlx-worker-python/tests/test_release_distribution.py
+++ b/services/mlx-worker-python/tests/test_release_distribution.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import re
+import runpy
+import sys
+from pathlib import Path
+
+import pytest
+
+from worker.productization.release_distribution import (
+    ReleaseAsset,
+    release_asset_from_archive,
+    release_asset_from_tag,
+    render_homebrew_cask,
+    render_nix_flake,
+    write_distribution_files,
+)
+
+
+def test_release_asset_from_tag_derives_existing_app_archive_url() -> None:
+    asset = release_asset_from_tag(
+        tag_name="v1.2.3",
+        repository="Keith-CY/melix",
+        sha256_hex="a" * 64,
+    )
+
+    assert asset.version == "1.2.3"
+    assert asset.archive_name == "Melix-1.2.3-macos.zip"
+    assert asset.download_url == (
+        "https://github.com/Keith-CY/melix/releases/download/v1.2.3/Melix-1.2.3-macos.zip"
+    )
+    assert asset.sha256_hex == "a" * 64
+    assert asset.nix_hash == "sha256-qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqo="
+
+
+def test_release_asset_from_tag_rejects_invalid_digest() -> None:
+    with pytest.raises(ValueError, match="64 lowercase hexadecimal"):
+        release_asset_from_tag(tag_name="v1.2.3", repository="Keith-CY/melix", sha256_hex="ABC")
+
+
+@pytest.mark.parametrize(
+    ("tag_name", "repository", "message"),
+    (
+        ("", "Keith-CY/melix", "tag_name must not be empty"),
+        ("v", "Keith-CY/melix", "release version must not be empty"),
+        ("v1.2.3", "melix", "repository must use owner/name format"),
+    ),
+)
+def test_release_asset_from_tag_rejects_invalid_release_metadata(
+    tag_name: str,
+    repository: str,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        release_asset_from_tag(tag_name=tag_name, repository=repository, sha256_hex="a" * 64)
+
+
+def test_release_asset_from_archive_rejects_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="Release archive does not exist"):
+        release_asset_from_archive(
+            tag_name="v1.2.3",
+            repository="Keith-CY/melix",
+            archive_path=tmp_path / "Melix-1.2.3-macos.zip",
+        )
+
+
+def test_render_homebrew_cask_points_to_release_asset_and_service_metadata() -> None:
+    asset = ReleaseAsset(
+        version="1.2.3",
+        tag_name="v1.2.3",
+        repository="Keith-CY/melix",
+        archive_name="Melix-1.2.3-macos.zip",
+        download_url="https://github.com/Keith-CY/melix/releases/download/v1.2.3/Melix-1.2.3-macos.zip",
+        sha256_hex="b" * 64,
+    )
+
+    cask = render_homebrew_cask(asset)
+
+    assert 'cask "melix"' in cask
+    assert 'version "1.2.3"' in cask
+    assert 'sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' in cask
+    assert 'url "https://github.com/Keith-CY/melix/releases/download/v1.2.3/Melix-1.2.3-macos.zip"' in cask
+    assert 'app "Melix.app"' in cask
+    assert 'zap trash: ["~/.melix"]' in cask
+
+
+def test_render_nix_flake_exposes_darwin_package_from_release_asset() -> None:
+    asset = ReleaseAsset(
+        version="1.2.3",
+        tag_name="v1.2.3",
+        repository="Keith-CY/melix",
+        archive_name="Melix-1.2.3-macos.zip",
+        download_url="https://github.com/Keith-CY/melix/releases/download/v1.2.3/Melix-1.2.3-macos.zip",
+        sha256_hex="c" * 64,
+    )
+
+    flake = render_nix_flake(asset)
+
+    assert 'description = "Melix local-first AI runtime for Apple Silicon";' in flake
+    assert 'nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";' in flake
+    assert "import <nixpkgs>" not in flake
+    assert "system = \"aarch64-darwin\";" in flake
+    assert 'version = "1.2.3";' in flake
+    assert "pkgs.fetchurl" in flake
+    assert "fetchzip" not in flake
+    assert "nativeBuildInputs = [ pkgs.unzip ];" in flake
+    assert 'url = "https://github.com/Keith-CY/melix/releases/download/v1.2.3/Melix-1.2.3-macos.zip";' in flake
+    assert 'hash = "sha256-zMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMw=";' in flake
+    assert 'unzip -q "$src" -d "$TMPDIR/melix-app"' in flake
+    assert 'cp -R "$TMPDIR/melix-app/Melix.app" "$out/Applications/Melix.app"' in flake
+
+
+def test_write_distribution_files_rejects_archive_name_that_does_not_match_release_tag(tmp_path: Path) -> None:
+    archive = tmp_path / "Melix-wrong-macos.zip"
+    archive.write_bytes(b"wrong release asset")
+
+    with pytest.raises(ValueError, match="archive path name"):
+        write_distribution_files(
+            tag_name="v1.2.3",
+            repository="Keith-CY/melix",
+            archive_path=archive,
+            output_root=tmp_path / "dist",
+        )
+
+
+def test_write_distribution_files_writes_manifest_for_ci_commit(tmp_path: Path) -> None:
+    archive = tmp_path / "Melix-1.2.3-macos.zip"
+    archive.write_bytes(b"melix archive")
+    sha256_hex = hashlib.sha256(b"melix archive").hexdigest()
+    output_root = tmp_path / "dist"
+
+    payload = write_distribution_files(
+        tag_name="v1.2.3",
+        repository="Keith-CY/melix",
+        archive_path=archive,
+        output_root=output_root,
+    )
+
+    assert (output_root / "homebrew/Casks/melix.rb").exists()
+    assert (output_root / "nix/flake.nix").exists()
+    manifest = json.loads((output_root / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest == payload
+    assert payload["version"] == "1.2.3"
+    assert payload["archive_name"] == "Melix-1.2.3-macos.zip"
+    assert payload["sha256_hex"] == sha256_hex
+    assert payload["nix_hash"].startswith("sha256-")
+    assert payload["homebrew_cask_path"] == "homebrew/Casks/melix.rb"
+    assert payload["nix_flake_path"] == "nix/flake.nix"
+
+
+def test_render_release_distribution_cli_writes_distribution_files(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_render_release_distribution_cli()
+    archive = tmp_path / "Melix-1.2.3-macos.zip"
+    archive.write_bytes(b"melix cli archive")
+    output_root = tmp_path / "dist"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "render_release_distribution.py",
+            "--tag-name",
+            "v1.2.3",
+            "--repository",
+            "Keith-CY/melix",
+            "--archive-path",
+            str(archive),
+            "--output-root",
+            str(output_root),
+            "--json",
+        ],
+    )
+
+    assert module.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["archive_name"] == "Melix-1.2.3-macos.zip"
+    assert (output_root / "homebrew/Casks/melix.rb").exists()
+    assert (output_root / "nix/flake.nix").exists()
+
+
+def test_render_release_distribution_cli_writes_compact_json_without_pretty_flag(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_render_release_distribution_cli()
+    archive = tmp_path / "Melix-1.2.3-macos.zip"
+    archive.write_bytes(b"melix compact cli archive")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "render_release_distribution.py",
+            "--tag-name",
+            "v1.2.3",
+            "--repository",
+            "Keith-CY/melix",
+            "--archive-path",
+            str(archive),
+            "--output-root",
+            str(tmp_path / "dist"),
+        ],
+    )
+
+    assert module.main() == 0
+    output = capsys.readouterr().out
+    assert "\n  " not in output
+    assert json.loads(output)["archive_name"] == "Melix-1.2.3-macos.zip"
+
+
+def test_render_release_distribution_cli_main_guard_exits_zero(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    module_path = repo_root / "scripts/render_release_distribution.py"
+    archive = tmp_path / "Melix-1.2.3-macos.zip"
+    archive.write_bytes(b"melix main guard archive")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "render_release_distribution.py",
+            "--tag-name",
+            "v1.2.3",
+            "--repository",
+            "Keith-CY/melix",
+            "--archive-path",
+            str(archive),
+            "--output-root",
+            str(tmp_path / "dist"),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as error:
+        runpy.run_path(str(module_path), run_name="__main__")
+
+    assert error.value.code == 0
+    assert json.loads(capsys.readouterr().out)["archive_name"] == "Melix-1.2.3-macos.zip"
+
+
+def _load_render_release_distribution_cli():
+    repo_root = Path(__file__).resolve().parents[3]
+    module_path = repo_root / "scripts/render_release_distribution.py"
+    spec = importlib.util.spec_from_file_location("render_release_distribution_cli", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _workflow_step(workflow: str, name: str) -> str:
+    match = re.search(
+        rf"^[ \t]*-[ \t]+name:[ \t]+{re.escape(name)}[ \t]*\n"
+        r"(?P<body>.*?)(?=^[ \t]*-[ \t]+name:|\Z)",
+        workflow,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"Workflow step not found: {name}"
+    return match.group("body")
+
+
+def test_release_homebrew_distribution_workflow_publishes_configured_tap() -> None:
+    workflow = (
+        Path(__file__).resolve().parents[3]
+        / ".github/workflows/release-homebrew-distribution.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "types: [published]" in workflow
+    assert "repository_dispatch:" in workflow
+    assert "types: [melix-release-asset-published]" in workflow
+    assert "github.event.client_payload.tag_name" in workflow
+    assert "github.event.release.prerelease" not in workflow
+    assert "MELIX_HOMEBREW_TAP_REPOSITORY" in workflow
+    assert "MELIX_HOMEBREW_TAP_TOKEN" in workflow
+    assert "scripts/render_release_distribution.py" in workflow
+    assert "Casks/melix.rb" in workflow
+    assert "EndBug/add-and-commit@v9" in workflow
+    assert 'message: "chore: update melix Homebrew cask ${{ steps.archive.outputs.version }}"' in workflow
+    download_step = _workflow_step(workflow, "Download release archive")
+    assert "gh release download" in download_step
+    assert "&& test -s" in download_step
+    assert "Validate Homebrew distribution configuration" in workflow
+
+
+def test_release_nix_distribution_workflow_publishes_configured_repo() -> None:
+    workflow = (
+        Path(__file__).resolve().parents[3]
+        / ".github/workflows/release-nix-distribution.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "types: [published]" in workflow
+    assert "repository_dispatch:" in workflow
+    assert "types: [melix-release-asset-published]" in workflow
+    assert "github.event.client_payload.tag_name" in workflow
+    assert "github.event.release.prerelease" not in workflow
+    assert "MELIX_NIX_REPOSITORY" in workflow
+    assert "MELIX_NIX_REPOSITORY_TOKEN" in workflow
+    assert "scripts/render_release_distribution.py" in workflow
+    assert "nix/flake.nix" in workflow
+    assert "command -v nix" in workflow
+    assert 'nix --extra-experimental-features "nix-command flakes" flake check "./nix-distribution" --no-build' in workflow
+    assert "EndBug/add-and-commit@v9" in workflow
+    assert 'message: "chore: update melix Nix package ${{ steps.archive.outputs.version }}"' in workflow
+    download_step = _workflow_step(workflow, "Download release archive")
+    assert "gh release download" in download_step
+    assert "&& test -s" in download_step
+    assert "Validate Nix distribution configuration" in workflow
+
+
+def test_package_workflow_dispatches_distribution_after_release_asset_upload() -> None:
+    workflow = (
+        Path(__file__).resolve().parents[3]
+        / ".github/workflows/package-self-contained-app.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "softprops/action-gh-release" in workflow
+    assert "Trigger release distribution workflows" in workflow
+    assert '--field "event_type=melix-release-asset-published"' in workflow
+    assert '--field "client_payload[tag_name]=$RELEASE_TAG"' in workflow
+    assert '--field "client_payload[repository]=$RELEASE_REPOSITORY"' in workflow
+    assert '--field "client_payload[archive_name]=$RELEASE_ARCHIVE_NAME"' in workflow
+    assert "RELEASE_ARCHIVE_NAME" in workflow

--- a/services/mlx-worker-python/worker/productization/release_distribution.py
+++ b/services/mlx-worker-python/worker/productization/release_distribution.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from base64 import b64encode
+from dataclasses import dataclass
+from pathlib import Path
+
+
+_SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+DEFAULT_RELEASE_REPOSITORY = "Keith-CY/melix"
+DEFAULT_HOMEBREW_CASK_RELATIVE_PATH = Path("homebrew/Casks/melix.rb")
+DEFAULT_NIX_FLAKE_RELATIVE_PATH = Path("nix/flake.nix")
+
+
+@dataclass(frozen=True)
+class ReleaseAsset:
+    version: str
+    tag_name: str
+    repository: str
+    archive_name: str
+    download_url: str
+    sha256_hex: str
+
+    @property
+    def nix_hash(self) -> str:
+        return "sha256-" + b64encode(bytes.fromhex(self.sha256_hex)).decode("ascii")
+
+
+def release_asset_from_tag(
+    *,
+    tag_name: str,
+    repository: str = DEFAULT_RELEASE_REPOSITORY,
+    sha256_hex: str,
+) -> ReleaseAsset:
+    normalized_tag = tag_name.strip()
+    if not normalized_tag:
+        raise ValueError("tag_name must not be empty")
+    version = normalized_tag[1:] if normalized_tag.startswith("v") else normalized_tag
+    if not version:
+        raise ValueError("release version must not be empty")
+    normalized_repository = repository.strip("/")
+    if "/" not in normalized_repository:
+        raise ValueError("repository must use owner/name format")
+    _validate_sha256_hex(sha256_hex)
+    archive_name = f"Melix-{version}-macos.zip"
+    download_url = f"https://github.com/{normalized_repository}/releases/download/{normalized_tag}/{archive_name}"
+    return ReleaseAsset(
+        version=version,
+        tag_name=normalized_tag,
+        repository=normalized_repository,
+        archive_name=archive_name,
+        download_url=download_url,
+        sha256_hex=sha256_hex,
+    )
+
+
+def release_asset_from_archive(
+    *,
+    tag_name: str,
+    repository: str,
+    archive_path: str | Path,
+) -> ReleaseAsset:
+    archive = Path(archive_path).expanduser().resolve()
+    if not archive.is_file():
+        raise FileNotFoundError(f"Release archive does not exist: {archive}")
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    asset = release_asset_from_tag(
+        tag_name=tag_name,
+        repository=repository,
+        sha256_hex=digest,
+    )
+    if archive.name != asset.archive_name:
+        raise ValueError(
+            f"archive path name must be {asset.archive_name} for tag {asset.tag_name}: {archive.name}"
+        )
+    return asset
+
+
+def render_homebrew_cask(asset: ReleaseAsset) -> str:
+    return f"""cask "melix" do
+  version "{asset.version}"
+  sha256 "{asset.sha256_hex}"
+
+  url "{asset.download_url}"
+  name "Melix"
+  desc "Local-first AI runtime for Apple Silicon"
+  homepage "https://github.com/{asset.repository}"
+
+  app "Melix.app"
+
+  zap trash: ["~/.melix"]
+end
+"""
+
+
+def render_nix_flake(asset: ReleaseAsset) -> str:
+    return f"""{{
+  description = "Melix local-first AI runtime for Apple Silicon";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = {{ self, nixpkgs }}:
+    let
+      system = "aarch64-darwin";
+      pkgs = nixpkgs.legacyPackages.${{system}};
+    in {{
+      packages.${{system}}.melix = pkgs.stdenvNoCC.mkDerivation {{
+        pname = "melix";
+        version = "{asset.version}";
+
+        src = pkgs.fetchurl {{
+          url = "{asset.download_url}";
+          hash = "{asset.nix_hash}";
+        }};
+
+        nativeBuildInputs = [ pkgs.unzip ];
+        dontBuild = true;
+        dontConfigure = true;
+
+        installPhase = ''
+          runHook preInstall
+          mkdir -p "$out/Applications"
+          unzip -q "$src" -d "$TMPDIR/melix-app"
+          cp -R "$TMPDIR/melix-app/Melix.app" "$out/Applications/Melix.app"
+          runHook postInstall
+        '';
+
+        meta = {{
+          description = "Local-first AI runtime for Apple Silicon";
+          homepage = "https://github.com/{asset.repository}";
+          platforms = [ "aarch64-darwin" ];
+        }};
+      }};
+
+      packages.${{system}}.default = self.packages.${{system}}.melix;
+    }};
+}}
+"""
+
+
+def write_distribution_files(
+    *,
+    tag_name: str,
+    repository: str,
+    archive_path: str | Path,
+    output_root: str | Path,
+) -> dict[str, str]:
+    root = Path(output_root).expanduser().resolve()
+    asset = release_asset_from_archive(
+        tag_name=tag_name,
+        repository=repository,
+        archive_path=archive_path,
+    )
+    homebrew_path = root / DEFAULT_HOMEBREW_CASK_RELATIVE_PATH
+    nix_path = root / DEFAULT_NIX_FLAKE_RELATIVE_PATH
+    homebrew_path.parent.mkdir(parents=True, exist_ok=True)
+    nix_path.parent.mkdir(parents=True, exist_ok=True)
+    homebrew_path.write_text(render_homebrew_cask(asset), encoding="utf-8")
+    nix_path.write_text(render_nix_flake(asset), encoding="utf-8")
+    payload = {
+        "version": asset.version,
+        "tag_name": asset.tag_name,
+        "repository": asset.repository,
+        "archive_name": asset.archive_name,
+        "download_url": asset.download_url,
+        "sha256_hex": asset.sha256_hex,
+        "nix_hash": asset.nix_hash,
+        "homebrew_cask_path": DEFAULT_HOMEBREW_CASK_RELATIVE_PATH.as_posix(),
+        "nix_flake_path": DEFAULT_NIX_FLAKE_RELATIVE_PATH.as_posix(),
+    }
+    manifest_path = root / "manifest.json"
+    manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+def _validate_sha256_hex(value: str) -> None:
+    if _SHA256_HEX_RE.fullmatch(value) is None:
+        raise ValueError("sha256_hex must be 64 lowercase hexadecimal characters")

--- a/services/mlx-worker-python/worker/productization/release_distribution.py
+++ b/services/mlx-worker-python/worker/productization/release_distribution.py
@@ -12,6 +12,7 @@ _SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
 DEFAULT_RELEASE_REPOSITORY = "Keith-CY/melix"
 DEFAULT_HOMEBREW_CASK_RELATIVE_PATH = Path("homebrew/Casks/melix.rb")
 DEFAULT_NIX_FLAKE_RELATIVE_PATH = Path("nix/flake.nix")
+_HASH_CHUNK_SIZE = 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -65,7 +66,7 @@ def release_asset_from_archive(
     archive = Path(archive_path).expanduser().resolve()
     if not archive.is_file():
         raise FileNotFoundError(f"Release archive does not exist: {archive}")
-    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    digest = _sha256_file(archive)
     asset = release_asset_from_tag(
         tag_name=tag_name,
         repository=repository,
@@ -178,3 +179,11 @@ def write_distribution_files(
 def _validate_sha256_hex(value: str) -> None:
     if _SHA256_HEX_RE.fullmatch(value) is None:
         raise ValueError("sha256_hex must be 64 lowercase hexadecimal characters")
+
+
+def _sha256_file(path: Path) -> str:
+    sha256 = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(_HASH_CHUNK_SIZE):
+            sha256.update(chunk)
+    return sha256.hexdigest()


### PR DESCRIPTION
## Summary
- Add release-published distribution workflows for Homebrew tap and Nix flake repositories.
- Add a release distribution renderer that computes archive hashes and writes Homebrew cask, Nix flake, and manifest outputs from the packaged macOS archive.
- Bridge the existing package artifact workflow into both distribution workflows with a repository_dispatch event after the release asset is attached.

## Plan or Spec
- `docs/plans/2026-05-26-release-homebrew-nix-distribution-ci.md`
- `docs/runbooks/platform-packaging-targets.md`
- `docs/runbooks/homebrew-install.md`

## Commands Run
```text
make bootstrap
Result: passed; git hooks configured and Python dependencies synced.

make proto
Result: passed.

make swift-test
Result: passed twice after the PR branch was updated; latest pre-commit run completed rc=0 in 635.0s, with macOS menubar package reporting 778 tests in 25 suites passed.

make py-test
Result: passed after the PR branch was updated; latest pre-commit run reported 3330 passed, 14 skipped, 2 warnings in 134.06s.

make integration-test
Result: passed after the PR branch was updated; latest pre-commit run reported 115 passed, 1 skipped in 675.19s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_distribution.py
Result: passed; latest focused run reported 17 passed in 0.03s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_release_distribution.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/release_distribution.py scripts/render_release_distribution.py services/mlx-worker-python/tests/test_release_distribution.py
Result: passed; latest focused run reported 17 passed in 0.06s, changed-scope report total 265 statements, 1 missed, 99% coverage. Production renderer and CLI files were 100% covered.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python python - <<'PY'
from pathlib import Path
from scripts import pre_commit_gate
root = Path.cwd()
changed_files = pre_commit_gate.run_git(root, ["diff", "--name-only", "origin/main...HEAD"]).splitlines()
outcome = pre_commit_gate.run_performance_report(root, changed_files, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
Result: passed before the review fix; Melix PR Scoped Performance Report status ok, changed files 10, selected probes 0, regressions 0.

git commit -m "Stream release archive hashing"
Result: passed; pre-commit ran make swift-test, make py-test, make integration-test, and scoped performance report. Final scoped performance report status ok, changed files 2, selected probes 0, regressions 0.

git diff --check origin/main...HEAD
Result: passed.

python3 -m py_compile scripts/render_release_distribution.py services/mlx-worker-python/worker/productization/release_distribution.py
Result: passed.

ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/release-homebrew-distribution.yml .github/workflows/release-nix-distribution.yml .github/workflows/package-self-contained-app.yml
Result: passed.
```

## Coverage and Metrics
- Changed-scope coverage: `scripts/render_release_distribution.py`, `services/mlx-worker-python/worker/productization/release_distribution.py`, and `services/mlx-worker-python/tests/test_release_distribution.py` reported 265 statements, 1 missed, 99% coverage. Production files were 100% covered.
- Scoped performance report: `.runtime/pre-commit-performance/20260526-044825-0b47225f/report/report.md`
- Performance report status: `ok`; selected probes 0; direct/gated probes 0; regressions 0; context regressions 0; verification failures 0.
- Observability mode: `minimal` for workflow logs and generated manifests; no runtime probes were added.
- Probe overhead: `N/A`; this change adds release distribution CI and renderer tests, not runtime observability probes.

## Known Gaps
- The distribution workflows require repository variables and secrets before real release publication can distribute externally: `MELIX_HOMEBREW_TAP_REPOSITORY`, `MELIX_HOMEBREW_TAP_TOKEN`, `MELIX_NIX_REPOSITORY`, and `MELIX_NIX_REPOSITORY_TOKEN`.
- Local `actionlint` was unavailable, so workflow syntax was checked with Ruby YAML parsing and covered by repository tests instead.
- Local `nix` was unavailable, so no local flake check was run; the Nix workflow runs `nix flake check --no-build` only when `nix` is present on the runner.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
