### PR TITLE
perf: streamline report evidence target field matching

### DIFF
--- a/docs/plans/2026-05-26-report-evidence-target-field-sentinel.md
+++ b/docs/plans/2026-05-26-report-evidence-target-field-sentinel.md
@@ -1,0 +1,33 @@
+# Report evidence target-field sentinel lookup
+
+## Scope
+
+This Python performance slice is limited to `worker.productization.report_evidence_gate._rule_matches_report(...)` target-field matching. The run-kind and metric-prefix behavior remain unchanged.
+
+## Registered probe
+
+Existing registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.
+
+The probe already covers:
+
+- `services/mlx-worker-python/worker/productization/report_evidence_gate.py`
+- `services/mlx-worker-python/tests/test_report_evidence_gate.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/report_evidence_gate_run_kind_probe.py`
+
+The registry defines focused `test_command`, `coverage_command`, and `probe_command` entries for Linux CI, so no probe registry change is needed.
+
+## Optimization
+
+The target-field loop previously used `target.get(field, "")` followed by `field not in target` to distinguish absent fields from present falsey values. This slice replaces that with a module-level sentinel and a single `dict.get(field, sentinel)` lookup, preserving the existing behavior that present falsey non-string values such as `None` and `0` count as present after stringification.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and local registered probe on Linux before opening the PR. The PR-scoped performance workflow remains the merge gate for the registered probe result in CI.
+
+## Success criteria
+
+- Focused report evidence gate tests pass.
+- Changed-scope coverage remains at or above 95% for the touched Python paths.
+- The registered probe shows lower `target_field_elapsed_ms_mean` / `elapsed_ms_mean` on the same synthetic workload.
+- `git diff --check` passes.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -302,6 +302,13 @@ def test_report_evidence_gate_target_field_preserves_stringified_presence() -> N
         metrics=[],
         probe_phases=set(),
     )
+    assert not report_evidence_gate_module._rule_matches_report(
+        rule=rule,
+        runs=[],
+        targets=[{"unrelated_field": 0}],
+        metrics=[],
+        probe_phases=set(),
+    )
 
 
 def test_report_evidence_gate_probe_phase_tuple_rules_reuse_normalized_set() -> None:

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -8,6 +8,7 @@ from typing import Any
 from worker.productization.benchmark_evaluation_report import validate_report_payload
 
 REPORT_EVIDENCE_GATE_SCHEMA_VERSION = "melix.report_evidence_gate.v1"
+_ABSENT_TARGET_FIELD = object()
 
 DEFAULT_RELEASE_EVIDENCE_MATRIX: dict[str, dict[str, object]] = {
     "serving_benchmark": {
@@ -303,10 +304,11 @@ def _rule_matches_report(
     target_fields = rule.get("target_fields", ())
     if target_fields:
         target_field_tuple = _string_tuple(target_fields)
+        absent = _ABSENT_TARGET_FIELD
         for target in targets:
             for field in target_field_tuple:
-                value = target.get(field, "")
-                if not value and field not in target:
+                value = target.get(field, absent)
+                if value is absent:
                     continue
                 if isinstance(value, str):
                     if value.strip():


### PR DESCRIPTION
## Summary
- Streamlines report evidence target-field rule matching by replacing the `get(...)` plus membership check with a single sentinel-backed dictionary lookup.
- Adds a regression assertion that absent unrelated falsey fields still do not satisfy target-field rules.

## Plan or Spec
- `docs/plans/2026-05-26-report-evidence-target-field-sentinel.md`
- Registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_preserves_stringified_presence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# 12 passed in 0.87s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
# 12 passed in 0.34s; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# baseline before change: elapsed_ms_mean=14214.280327875167, target_field_elapsed_ms_mean=12364.209166541696
# candidate after change: elapsed_ms_mean=11754.625166300684, target_field_elapsed_ms_mean=9960.638692323118

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Local registered probe (Linux): `elapsed_ms_mean` improved from `14214.280327875167` to `11754.625166300684` ms (`1.209x` speedup, `-2459.655` ms); `target_field_elapsed_ms_mean` improved from `12364.209166541696` to `9960.638692323118` ms (`1.241x` speedup, `-2403.570` ms).
- CI PR-scoped performance report is required as the merge gate for registered probe validation.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice. GitHub Actions and the PR-scoped performance workflow are the merge gates.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via the registered PR-scoped probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
