### PR TITLE
perf: summarize statistical outcomes in one pass

### DIFF
--- a/docs/plans/2026-05-26-statistical-outcome-summary-single-pass.md
+++ b/docs/plans/2026-05-26-statistical-outcome-summary-single-pass.md
@@ -1,0 +1,33 @@
+# Statistical outcome summary single pass
+
+## Scope
+
+This Python-only performance slice keeps paired statistical evidence semantics unchanged while computing the paired-outcome mean and constant-outcome flag in one pass.
+
+## Registered probe
+
+Existing registered probe: `statistical-evidence-bootstrap-single-sort` in `infra/perf/pr_scoped_probes.json`.
+
+The probe covers:
+
+- `services/mlx-worker-python/worker/productization/statistical_evidence.py`
+- `services/mlx-worker-python/tests/test_statistical_evidence.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/statistical_evidence_bootstrap_probe.py`
+
+The registry already defines focused `test_command`, `coverage_command`, and `probe_command` entries, so no probe registry change is needed for this narrow Python optimization.
+
+## Optimization
+
+`build_paired_statistical_evidence()` previously scanned the normalized outcome tuple once for the mean and once for the equality guard before passing both values downstream. This slice replaces those two top-level scans with `_outcome_summary()`, which accumulates the sum and detects non-constant outcomes in the same loop.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage, and the registered `statistical-evidence-bootstrap-single-sort` probe locally on Linux before pushing. GitHub Actions PR-scoped performance remains the final registered-probe merge gate.
+
+## Success criteria
+
+- Focused statistical evidence tests pass.
+- Changed-scope coverage for the affected source/test/probe files is at least 95%.
+- Local registered probe shows non-regression or improvement for `elapsed_ms_mean` and `peak_bytes_mean`.
+- PR-scoped performance CI selects and completes the registered probe successfully.

--- a/services/mlx-worker-python/tests/test_statistical_evidence.py
+++ b/services/mlx-worker-python/tests/test_statistical_evidence.py
@@ -79,6 +79,29 @@ def test_build_paired_statistical_evidence_still_normalizes_non_float_inputs(
     assert evidence["sample_size"] == 3
 
 
+def test_build_paired_statistical_evidence_summarizes_outcomes_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_mean(values: object) -> float:  # pragma: no cover - regression guard
+        raise AssertionError(f"build_paired_statistical_evidence rescanned mean for {values!r}")
+
+    def fail_values_equal(values: object) -> bool:  # pragma: no cover - regression guard
+        raise AssertionError(f"build_paired_statistical_evidence rescanned equality for {values!r}")
+
+    monkeypatch.setattr(statistical_evidence_module, "_mean", fail_mean)
+    monkeypatch.setattr(statistical_evidence_module, "_outcome_values_equal", fail_values_equal)
+
+    evidence = build_paired_statistical_evidence(
+        paired_outcomes=(1.0, 0.0, -1.0, 1.0),
+        confidence_level=0.95,
+        bootstrap_iterations=8,
+        bootstrap_seed=17,
+    )
+
+    assert evidence["sample_size"] == 4
+    assert evidence["delta_accuracy"] == 0.25
+
+
 def test_build_paired_statistical_evidence_reports_bootstrap_and_analytical_intervals() -> None:
     evidence = build_paired_statistical_evidence(
         paired_outcomes=(1, 1, 1, 0, 1, 1),
@@ -210,7 +233,7 @@ def test_bootstrap_interval_sorts_replicates_in_place(monkeypatch: pytest.Monkey
     }
 
 
-def test_bootstrap_interval_sums_replicates_without_per_replicate_mean_helper_calls(
+def test_bootstrap_interval_sums_replicates_without_mean_helper_calls(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     mean_lengths: list[int] = []
@@ -229,7 +252,7 @@ def test_bootstrap_interval_sums_replicates_without_per_replicate_mean_helper_ca
         bootstrap_seed=13,
     )
 
-    assert mean_lengths == [8]
+    assert mean_lengths == []
     assert evidence["bootstrap"] == {
         "method": "paired_bootstrap_percentile",
         "confidence_level": 0.9,
@@ -269,7 +292,7 @@ def test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling(
     assert evidence["analytical"]["upper_bound"] == 1.0
 
 
-def test_build_paired_statistical_evidence_reuses_constant_scan_between_intervals(
+def test_build_paired_statistical_evidence_reuses_summary_scan_between_intervals(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     equality_scan_lengths: list[int] = []
@@ -288,7 +311,7 @@ def test_build_paired_statistical_evidence_reuses_constant_scan_between_interval
         bootstrap_seed=17,
     )
 
-    assert equality_scan_lengths == [5]
+    assert equality_scan_lengths == []
     assert evidence["bootstrap"]["lower_bound"] == 1.0
     assert evidence["bootstrap"]["upper_bound"] == 1.0
     assert evidence["analytical"]["lower_bound"] == 1.0

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -17,8 +17,7 @@ def build_paired_statistical_evidence(
 ) -> dict[str, object]:
     outcomes = _normalized_outcomes(paired_outcomes)
     sample_size = len(outcomes)
-    mean_value = _mean(outcomes)
-    all_values_equal = _outcome_values_equal(outcomes)
+    mean_value, all_values_equal = _outcome_summary(outcomes)
     delta_accuracy = _rounded(mean_value)
     bootstrap_interval = _paired_bootstrap_interval(
         outcomes=outcomes,
@@ -194,6 +193,23 @@ def _outcome_values_equal(values: tuple[float, ...]) -> bool:
     if values[0] != values[-1]:
         return False
     return _all_values_equal(values)
+
+
+def _outcome_summary(values: tuple[float, ...]) -> tuple[float, bool]:
+    iterator = iter(values)
+    try:
+        first_value = next(iterator)
+    except StopIteration:
+        return 0.0, False
+    total = first_value
+    all_values_equal = True
+    sample_size = 1
+    for value in iterator:
+        sample_size += 1
+        total += value
+        if value != first_value:
+            all_values_equal = False
+    return total / sample_size, all_values_equal
 
 
 def _all_values_equal(values: tuple[float, ...]) -> bool:


### PR DESCRIPTION
## Summary
- Add a one-pass paired outcome summary for statistical evidence generation.
- Update regression coverage so the evidence builder no longer rescans outcomes through the mean or equality helpers before passing the summary downstream.

## Plan or Spec
- `docs/plans/2026-05-26-statistical-outcome-summary-single-pass.md`
- Registered probe: `statistical-evidence-bootstrap-single-sort` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics
21 passed in 0.13s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_bootstrap_probe.py
21 passed in 0.23s
TOTAL 26 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id statistical-evidence-bootstrap-single-sort --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-statistical-outcome-summary-single-pass-20260526-base --head-repo "$PWD" --output /tmp/statistical_outcome_summary_probe.json
head verification ok; base probe ok; head probe ok
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 26 0 100%`.
- Local registered probe (`statistical-evidence-bootstrap-single-sort`, Linux):
  - `elapsed_ms_mean`: base `138.41334180906415`, head `134.12852389737964` (delta `-4.28481791168451 ms`, about `3.10%` faster).
  - `peak_bytes_mean`: base `44553.6`, head `44635.2` (delta `+81.6 bytes`, about `0.18%`; below the probe warn threshold).
  - `sorted_calls_mean`: base `0.0`, head `0.0`.
- CI PR-scoped performance remains the merge gate for the registered probe report.

## Known Gaps
- None. This is a Python-only slice locally verified on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
