### PR TITLE
perf: scan report evidence target keys

### DIFF
--- a/docs/plans/2026-05-26-report-evidence-target-fields-key-scan.md
+++ b/docs/plans/2026-05-26-report-evidence-target-fields-key-scan.md
@@ -1,0 +1,33 @@
+# Report evidence target-fields key scan
+
+## Scope
+
+This Python performance slice is limited to `worker.productization.report_evidence_gate._rule_matches_report(...)` target-field matching. The run-kind, metric-prefix, and probe-phase paths remain unchanged.
+
+## Registered probe
+
+Existing registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.
+
+The probe already covers:
+
+- `services/mlx-worker-python/worker/productization/report_evidence_gate.py`
+- `services/mlx-worker-python/tests/test_report_evidence_gate.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/report_evidence_gate_run_kind_probe.py`
+
+The registry defines focused `test_command`, `coverage_command`, and `probe_command` entries for Linux CI, so no probe registry change is needed.
+
+## Optimization
+
+The target-field path previously iterated over every configured target field for every target row and performed a dictionary lookup for each candidate field. This slice normalizes the configured fields once to a cached `frozenset` and scans each target row's actual keys, checking set membership before evaluating the value. The behavior remains the same for present string values, whitespace-only strings, present falsey non-string values such as `None` and `0`, and absent fields.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and local registered probe on Linux before opening the PR. The PR-scoped performance workflow remains the merge gate for the registered probe result in CI.
+
+## Success criteria
+
+- Focused report evidence gate tests pass.
+- Changed-scope coverage remains at or above 95% for the touched Python paths.
+- The registered probe shows lower `target_field_elapsed_ms_mean` / `elapsed_ms_mean` on the same synthetic workload.
+- `git diff --check` passes.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -234,7 +234,7 @@ def test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation() -> Non
 
 
 def test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple() -> None:
-    report_evidence_gate_module._string_tuple_from_tuple.cache_clear()
+    report_evidence_gate_module._string_frozenset_from_tuple.cache_clear()
     rule = {"target_fields": ("adapter_id", "adapter_snapshot")}
 
     assert report_evidence_gate_module._rule_matches_report(
@@ -252,7 +252,7 @@ def test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple() 
         probe_phases=set(),
     )
 
-    cache_info = report_evidence_gate_module._string_tuple_from_tuple.cache_info()
+    cache_info = report_evidence_gate_module._string_frozenset_from_tuple.cache_info()
     assert cache_info.hits >= 1
     assert cache_info.misses == 1
 

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -8,7 +8,6 @@ from typing import Any
 from worker.productization.benchmark_evaluation_report import validate_report_payload
 
 REPORT_EVIDENCE_GATE_SCHEMA_VERSION = "melix.report_evidence_gate.v1"
-_ABSENT_TARGET_FIELD = object()
 
 DEFAULT_RELEASE_EVIDENCE_MATRIX: dict[str, dict[str, object]] = {
     "serving_benchmark": {
@@ -303,12 +302,10 @@ def _rule_matches_report(
             return True
     target_fields = rule.get("target_fields", ())
     if target_fields:
-        target_field_tuple = _string_tuple(target_fields)
-        absent = _ABSENT_TARGET_FIELD
+        target_field_set = _string_frozenset(target_fields)
         for target in targets:
-            for field in target_field_tuple:
-                value = target.get(field, absent)
-                if value is absent:
+            for field, value in target.items():
+                if field not in target_field_set:
                     continue
                 if isinstance(value, str):
                     if value.strip():


### PR DESCRIPTION
## Summary
- Optimizes report evidence target-field matching by normalizing configured target fields to a cached set and scanning each target row's keys.
- Preserves existing target-field presence behavior for non-empty strings, whitespace-only strings, present falsey non-string values, and absent fields.
- Adds a governing plan for this performance slice.

## Plan or Spec
- `docs/plans/2026-05-26-report-evidence-target-fields-key-scan.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_preserves_stringified_presence
# exit 0; 3 passed

# Registered probe test_command for report-evidence-gate-run-kind-set-membership
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_preserves_stringified_presence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_probe_phase_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_probe_phase_list_rules_reflect_mutation services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# exit 0; 12 passed

# Registered coverage_command for report-evidence-gate-run-kind-set-membership
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
# exit 0; changed-line coverage 100% (5/5)

# Registered probe_command for report-evidence-gate-run-kind-set-membership
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/report_evidence_gate_run_kind_probe.py"; if [ -f "$SCRIPT" ]; then python3 "$SCRIPT"; else ...; fi'
# exit 0; JSON metrics recorded below

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (5/5 measurable changed lines).
- Registered local Linux probe baseline on `origin/main` before the change:
  - `elapsed_ms_mean=11840.9447`
  - `target_field_elapsed_ms_mean=10011.2093`
- Registered local Linux probe after the change:
  - `elapsed_ms_mean=2426.9745`
  - `target_field_elapsed_ms_mean=577.7198`
- Local delta:
  - `elapsed_ms_mean`: -9413.9702 ms (~4.88x faster overall probe)
  - `target_field_elapsed_ms_mean`: -9433.4895 ms (~17.33x faster target-field segment)
- Registered PR-scoped performance CI is required before merge and remains the authoritative PR validation source.

## Known Gaps
- Full repository `make py-test` / `make integration-test` were not run locally; this is a focused Python performance slice covered by the registered probe commands.
- CI must complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
