### PR TITLE
perf: inline native MTP key prefix checks

### DIFF
--- a/docs/plans/2026-05-26-native-mtp-key-prefix-inline.md
+++ b/docs/plans/2026-05-26-native-mtp-key-prefix-inline.md
@@ -1,0 +1,41 @@
+# Native MTP key prefix inline fast path
+
+## Scope
+
+This Python-only performance slice is limited to native-MTP sidecar shard
+discovery in `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`.
+The behavior remains unchanged: only MTP weight-map keys with
+`language_model.mtp.` or `mtp.` prefixes can contribute non-`model*.safetensors`
+sidecar shard paths, duplicates are still skipped, missing files are still
+warned and ignored, and the top-level model shard listing keeps the existing
+`os.scandir()` path.
+
+## Probe coverage
+
+The affected path is already covered by the registered PR-scoped performance
+probe `native-mtp-loader-safetensor-scandir` in
+`infra/perf/pr_scoped_probes.json`. That entry has focused `test_command`,
+`coverage_command`, and `probe_command` values for the native-MTP loader,
+focused tests, and `scripts/native_mtp_loader_safetensor_scandir_probe.py`.
+
+## Plan
+
+1. Keep the registered probe definition stable; do not mix registry behavior
+   changes with this runtime slice.
+2. Preserve behavior with the existing focused native-MTP regression tests,
+   including duplicate sidecar filtering and avoiding unnecessary path joins.
+3. Inline the MTP key prefix check inside the weight-map loop so JSON string
+   keys avoid the per-entry helper call and unconditional `str()` conversion,
+   while retaining the fallback conversion for non-string mappings.
+4. Run focused pytest, changed-scope coverage, and the registered probe locally
+   on Linux before opening the PR.
+5. Use GitHub Actions and the registered PR-scoped performance report as the
+   merge gate.
+
+## Local verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
+```

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -20,11 +20,6 @@ def _load_json_payload(path: Path) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-def _is_mtp_weight_key(key: Any) -> bool:
-    value = str(key)
-    return value.startswith("language_model.mtp.") or value.startswith("mtp.")
-
-
 def _model_safetensor_files(model_path: Path) -> list[str]:
     """Return top-level ``model*.safetensors`` paths without glob allocation."""
 
@@ -51,7 +46,8 @@ def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
     extra_files: list[Path] = []
     seen: set[str] = set()
     for key, file_name in weight_map.items():
-        if not _is_mtp_weight_key(key):
+        key_text = key if isinstance(key, str) else str(key)
+        if not (key_text.startswith("language_model.mtp.") or key_text.startswith("mtp.")):
             continue
         file_name_text = str(file_name)
         file_basename = os.path.basename(file_name_text)


### PR DESCRIPTION
## Summary
- Inline the native-MTP sidecar weight-map key prefix check inside the hot loop.
- Preserve non-string key fallback behavior while avoiding the helper call and unconditional `str()` conversion for JSON string keys.
- Add the scoped plan for this Python performance slice.

## Plan or Spec
- `docs/plans/2026-05-26-native-mtp-key-prefix-inline.md`
- Registered PR-scoped probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/native_mtp_key_prefix_bench.py "$PWD"`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `7 passed`.
- Changed-scope coverage: `100.00%` for changed lines in `mlx_lm_loader.py`.
- Registered probe sample after change: `extra_new_mean_ms=66.5825`, `extra_old_mean_ms=134.1463`, `extra_delta_ms=-67.5638`, `extra_speedup=2.0147`.
- Same-host microbenchmark for this exact key-prefix slice: `old_mean_ms=85.2466`, `new_mean_ms=72.0960`, `delta_ms=-13.1506`, `speedup=1.1824`, `candidate_count=6000`.

## Known Gaps
- Linux local verification covers the Python native-MTP loader path only.
- The registered PR-scoped performance workflow must complete in CI before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused regression tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally on Linux.
- [x] CI PR-scoped performance report required before merge.
