### PR TITLE
perf: bind runtime weight entry helper

### DIFF
--- a/docs/plans/2026-05-26-runtime-utils-entry-size-local-binding.md
+++ b/docs/plans/2026-05-26-runtime-utils-entry-size-local-binding.md
@@ -1,0 +1,28 @@
+# Runtime utils top-level weight entry-size local binding
+
+## Scope
+
+This Python-only performance slice is limited to `worker.runtime.runtime_utils._top_level_weight_file_bytes()`.
+It preserves model weight resident-byte semantics while reducing repeated global helper lookup overhead during flat model-bundle scans.
+
+## Registered performance probe
+
+The existing `runtime-utils-top-level-weight-streaming` PR-scoped probe covers:
+
+- `services/mlx-worker-python/worker/runtime/runtime_utils.py`
+- `services/mlx-worker-python/tests/test_runtime_utils.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/runtime_utils_top_level_weights_probe.py`
+
+The registry entry already includes focused `test_command`, `coverage_command`, and `probe_command` entries, so this slice does not need probe registration changes.
+
+## Plan
+
+1. Bind `_weight_dir_entry_file_size` once before the directory-entry loop in `_top_level_weight_file_bytes()`.
+2. Keep the existing `os.scandir()` streaming behavior and error handling unchanged.
+3. Run the registered focused tests, changed-scope coverage, and local registered probe on Linux.
+4. Use the PR-scoped performance workflow as the CI merge gate.
+
+## Verification
+
+Run the registered probe commands from `infra/perf/pr_scoped_probes.json` for `runtime-utils-top-level-weight-streaming` locally before opening the PR. CI remains the source of truth for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -171,13 +171,14 @@ def _indexed_safetensors_shard_bytes(model_dir: Path) -> int:
 
 def _top_level_weight_file_bytes(model_dir: Path) -> int:
     total = 0
+    entry_file_size = _weight_dir_entry_file_size
     try:
         entries = os.scandir(model_dir)
     except OSError:
         return 0
     with entries:
         for entry in entries:
-            total += _weight_dir_entry_file_size(entry)
+            total += entry_file_size(entry)
     return total
 
 


### PR DESCRIPTION
## Summary
- Bind `_weight_dir_entry_file_size` once before the top-level model weight scan loop to avoid repeated global helper lookups per directory entry.
- Keep existing `os.scandir()` streaming behavior and model weight resident-byte semantics unchanged.

## Plan or Spec
- `docs/plans/2026-05-26-runtime-utils-entry-size-local-binding.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics
# 9 passed in 0.11s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_top_level_weights_probe.py
# 9 passed in 0.24s; changed_line_coverage=100.00%; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-utils-top-level-weight-streaming --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-runtime-utils-suffix-binding-20260526-base --head-repo "$PWD" --output /tmp/runtime_utils_entry_size_local_binding_probe.json
# ok; base elapsed_ms_mean=172.89874898269773, head elapsed_ms_mean=168.6950015835464
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`aggregate_measurable_changed_lines=2`, `aggregate_covered_changed_lines=2`, `aggregate_missed_changed_lines=0`).
- Registered local probe: `runtime-utils-top-level-weight-streaming`.
- Local probe metrics: `old_mean=172.89874898269773 ms`, `new_mean=168.6950015835464 ms`, `delta_ms=-4.203747399151325`, `speedup=1.0249192172837998x`; `peak_bytes_mean` unchanged at `2040.8` bytes.
- CI PR-scoped performance workflow is required as the merge gate for registered probe validation.

## Known Gaps
- None. Linux local validation covers this Python slice; CI remains the registered probe merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability/debug mode changes.
- [x] Deferred work and known gaps are stated explicitly.
