### PR TITLE
perf: fast-path native mtp weight key prefixes

### DIFF
--- a/docs/plans/2026-05-26-native-mtp-weight-key-type-fastpath.md
+++ b/docs/plans/2026-05-26-native-mtp-weight-key-type-fastpath.md
@@ -1,0 +1,15 @@
+# Native MTP weight-key type fast path
+
+## Scope
+
+This Python-only slice narrows `worker.runtime.native_mtp.mlx_lm_loader._is_mtp_weight_key()` inside the registered native-MTP loader sidecar scan path. Native safetensor index `weight_map` keys are checked repeatedly while filtering sidecar MTP shards, so the hot path now uses one tuple-prefix `startswith()` call instead of two separate prefix checks while preserving the same `str(key)` fallback behavior for custom/non-string mapping keys.
+
+## Probe
+
+Registered PR-scoped probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+The affected path is covered by focused `test_command`, `coverage_command`, and `probe_command` entries. This slice extends the registered probe with a dedicated key-prefix predicate measurement (`key_old_mean_ms`, `key_new_mean_ms`, `key_delta_ms`, `key_speedup`) in addition to the existing sidecar scan metrics (`extra_old_mean_ms`, `extra_new_mean_ms`, `extra_delta_ms`, `extra_speedup`) for `extra_mtp_safetensor_files()`.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and `native-mtp-loader-safetensor-scandir` probe locally on Linux before opening the PR. PR-scoped performance CI remains the merge gate for the registered probe report.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4446,8 +4446,8 @@
       "scripts/native_mtp_loader_safetensor_scandir_probe.py",
       "infra/perf/pr_scoped_probes.json"
     ],
-    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics",
-    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py",
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py",
     "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_NATIVE_MTP_LOADER_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/native_mtp_loader_safetensor_scandir_probe.py\"; for CANDIDATE in \"${MELIX_NATIVE_MTP_LOADER_PROBE_SCRIPT:-}\" \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -n \"$CANDIDATE\" ] && [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
@@ -4535,6 +4535,35 @@
         "unit": "count",
         "direction": "higher_is_better",
         "warn_pct": 0.0
+      },
+      {
+        "key": "key_old_mean_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "key_new_mean_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "key_delta_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "key_speedup",
+        "unit": "x",
+        "direction": "higher_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "key_count",
+        "unit": "count",
+        "direction": "informational"
       }
     ]
   }

--- a/scripts/native_mtp_loader_safetensor_scandir_probe.py
+++ b/scripts/native_mtp_loader_safetensor_scandir_probe.py
@@ -18,12 +18,14 @@ sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
 
 try:
     from worker.runtime.native_mtp.mlx_lm_loader import (
+        _is_mtp_weight_key,
         _load_json_payload,
         _model_safetensor_files,
         extra_mtp_safetensor_files,
     )
 except ImportError:  # Base revisions before this slice do not expose the helpers.
     extra_mtp_safetensor_files = None
+    _is_mtp_weight_key = None
     _load_json_payload = None
     _model_safetensor_files = None
 
@@ -61,6 +63,11 @@ def _read_text_json_payload(path: Path) -> dict[str, Any]:
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return {}
     return payload if isinstance(payload, dict) else {}
+
+
+def _baseline_is_mtp_weight_key(key: Any) -> bool:
+    value = str(key)
+    return value.startswith("language_model.mtp.") or value.startswith("mtp.")
 
 
 def _baseline_extra_mtp_safetensor_files(model_dir: Path) -> list[Path]:
@@ -115,10 +122,32 @@ def _weight_map_count(result: object) -> int:
     return len(weight_map) if isinstance(weight_map, dict) else 0
 
 
+def _measure_key_predicate(
+    callback: Callable[[Any], bool],
+    keys: list[Any],
+    *,
+    samples: int,
+    iterations: int,
+) -> tuple[list[float], int]:
+    elapsed_ms: list[float] = []
+    expected_true_count = sum(1 for key in keys if _baseline_is_mtp_weight_key(key))
+    for _ in range(samples):
+        start = time.perf_counter()
+        true_count = 0
+        for _ in range(iterations):
+            for key in keys:
+                true_count += int(callback(key))
+        elapsed_ms.append((time.perf_counter() - start) * 1000.0)
+        if true_count != expected_true_count * iterations:
+            raise RuntimeError("candidate native-MTP key predicate differs from baseline")
+    return elapsed_ms, expected_true_count
+
+
 def run_probe() -> dict[str, float | int | str]:
     model_files = int(os.environ.get("MELIX_NATIVE_MTP_LOADER_MODEL_FILES", "1500"))
     distractor_files = int(os.environ.get("MELIX_NATIVE_MTP_LOADER_DISTRACTOR_FILES", "1500"))
     samples = int(os.environ.get("MELIX_NATIVE_MTP_LOADER_SAMPLES", "5"))
+    key_iterations = int(os.environ.get("MELIX_NATIVE_MTP_LOADER_KEY_ITERATIONS", "2500"))
     with tempfile.TemporaryDirectory() as tmp:
         model_dir = Path(tmp) / "model"
         _populate_model_dir(
@@ -167,10 +196,30 @@ def run_probe() -> dict[str, float | int | str]:
             model_dir,
             samples=samples,
         )
+        key_candidates = [
+            *old_payload["weight_map"].keys(),
+            "mtp.direct.weight",
+            "language_model.layers.0.weight",
+        ]
+        key_callback = _is_mtp_weight_key or _baseline_is_mtp_weight_key
+        key_old_ms, key_true_count = _measure_key_predicate(
+            _baseline_is_mtp_weight_key,
+            key_candidates,
+            samples=samples,
+            iterations=key_iterations,
+        )
+        key_new_ms, _ = _measure_key_predicate(
+            key_callback,
+            key_candidates,
+            samples=samples,
+            iterations=key_iterations,
+        )
     old_mean = statistics.mean(old_ms)
     new_mean = statistics.mean(new_ms)
     extra_old_mean = statistics.mean(extra_old_ms)
     extra_new_mean = statistics.mean(extra_new_ms)
+    key_old_mean = statistics.mean(key_old_ms)
+    key_new_mean = statistics.mean(key_new_ms)
     return {
         "result_count": result_count,
         "extra_result_count": extra_result_count,
@@ -178,6 +227,13 @@ def run_probe() -> dict[str, float | int | str]:
         "distractor_files": distractor_files,
         "duplicate_mtp_entries": distractor_files,
         "samples": samples,
+        "key_iterations": key_iterations,
+        "key_count": len(key_candidates),
+        "key_true_count": key_true_count,
+        "key_old_mean_ms": key_old_mean,
+        "key_new_mean_ms": key_new_mean,
+        "key_delta_ms": key_new_mean - key_old_mean,
+        "key_speedup": key_old_mean / key_new_mean if key_new_mean else 0.0,
         "old_mean_ms": old_mean,
         "new_mean_ms": new_mean,
         "delta_ms": new_mean - old_mean,

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -46,6 +46,7 @@ from worker.runtime.mlx_vlm_runtime import (
 )
 from worker.runtime.mlx_executor import MLXRuntimeExecutor
 from worker.runtime.native_mtp.mlx_lm_loader import (
+    _is_mtp_weight_key,
     _load_json_payload,
     _model_safetensor_files,
     extra_mtp_safetensor_files,
@@ -1520,6 +1521,17 @@ def test_native_mtp_index_payload_loads_from_bytes(
 
     assert _load_json_payload(index_path) == index_payload
     assert _load_json_payload(tmp_path / "missing.json") == {}
+
+
+def test_native_mtp_weight_key_detection_preserves_string_and_custom_keys() -> None:
+    class CustomKey:
+        def __str__(self) -> str:
+            return "mtp.custom.weight"
+
+    assert _is_mtp_weight_key("language_model.mtp.layers.0.weight") is True
+    assert _is_mtp_weight_key("mtp.layers.0.weight") is True
+    assert _is_mtp_weight_key("language_model.layers.0.weight") is False
+    assert _is_mtp_weight_key(CustomKey()) is True
 
 
 def test_native_mtp_model_safetensor_listing_uses_scandir_without_glob(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -311,6 +311,7 @@ def test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics(
     monkeypatch.setenv("MELIX_NATIVE_MTP_LOADER_MODEL_FILES", "8")
     monkeypatch.setenv("MELIX_NATIVE_MTP_LOADER_DISTRACTOR_FILES", "8")
     monkeypatch.setenv("MELIX_NATIVE_MTP_LOADER_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_NATIVE_MTP_LOADER_KEY_ITERATIONS", "2")
     probe_script = runpy.run_path(
         str(REPO_ROOT / "scripts/native_mtp_loader_safetensor_scandir_probe.py")
     )
@@ -324,6 +325,11 @@ def test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics(
     assert metrics["model_files"] == 8
     assert metrics["distractor_files"] == 8
     assert metrics["duplicate_mtp_entries"] == 8
+    assert metrics["key_count"] == 26
+    assert metrics["key_true_count"] == 17
+    assert metrics["key_iterations"] == 2
+    assert metrics["key_old_mean_ms"] >= 0.0
+    assert metrics["key_new_mean_ms"] >= 0.0
 
 
 def test_dataset_version_listing_probe_script_emits_metrics(

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -21,8 +21,7 @@ def _load_json_payload(path: Path) -> dict[str, Any]:
 
 
 def _is_mtp_weight_key(key: Any) -> bool:
-    value = str(key)
-    return value.startswith("language_model.mtp.") or value.startswith("mtp.")
+    return str(key).startswith(("language_model.mtp.", "mtp."))
 
 
 def _model_safetensor_files(model_path: Path) -> list[str]:


### PR DESCRIPTION
## Summary
- Fast-path native-MTP weight-key prefix checks by using one tuple-prefix `startswith()` call.
- Extend the registered `native-mtp-loader-safetensor-scandir` probe with dedicated key predicate metrics.
- Add regression coverage for string/custom key behavior and include it in the registered focused commands.

## Plan or Spec
- `docs/plans/2026-05-26-native-mtp-weight-key-type-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics
# 8 passed in 0.24s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
# 6 passed; changed_line_coverage=100.00%; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id native-mtp-loader-safetensor-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-native-mtp-key-type-fastpath-20260526-base --head-repo "$PWD" --output /tmp/native_mtp_key_type_pr_probe_final.json
# head verification ok; head probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` changed lines 1/1 covered, 100.00%.
- Registered local probe (`native-mtp-loader-safetensor-scandir`, head): `key_old_mean_ms=2314.579`, `key_new_mean_ms=2060.515`, `key_delta_ms=-254.064`, `key_speedup=1.123x`.
- Existing sidecar scan metric remains positive vs baked baseline in the head probe: `extra_old_mean_ms=141.612`, `extra_new_mean_ms=73.319`, `extra_delta_ms=-68.293`, `extra_speedup=1.931x`.
- CI is required for the final registered PR-scoped performance report before merge.

## Known Gaps
- None. This is Python-only and locally verified on Linux; no Swift runtime validation is required.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
