### PR TITLE
perf: hoist trajectory manifest field map

### DIFF
--- a/docs/plans/2026-05-26-trajectory-manifest-field-map-constant.md
+++ b/docs/plans/2026-05-26-trajectory-manifest-field-map-constant.md
@@ -1,0 +1,45 @@
+# Trajectory manifest field-map constant
+
+## Scope
+
+This Python-only performance slice is limited to trajectory snapshot manifest
+provenance extraction in
+`services/mlx-worker-python/worker/trajectory_provenance.py`.
+
+`trajectory_provenance_from_snapshot_manifest(...)` is called repeatedly by the
+registered `trajectory-manifest-json-load` probe. The optional source-to-output
+field mapping was previously rebuilt as a tuple literal on each call. This slice
+hoists that immutable mapping to module scope so the hot path reuses the same
+field-map object while preserving the returned provenance payload and detached
+nested-container behavior.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry already includes focused `test_command`, `coverage_command`,
+and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/trajectory_manifest_json_load_probe.py`
+
+## Verification plan
+
+1. Run the registered focused test command locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux and require
+   at least 95% coverage for `worker.trajectory_provenance`.
+3. Run the registered `trajectory-manifest-json-load` probe locally before and
+   after the change to compare `new_mean_ms`, peak bytes, and speedup.
+4. Use the GitHub Actions PR-scoped performance workflow as the final merge gate
+   before merging.
+
+## Success criteria
+
+- Snapshot manifest provenance field names and optional field behavior remain
+  unchanged.
+- Changed-scope coverage remains at least 95% for the touched worker module.
+- The registered probe shows a neutral-or-better local direction and CI validates
+  the registered base-vs-head probe report before merge.

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -26,6 +26,15 @@ TRAJECTORY_PROVENANCE_FIELDS = (
 TRAJECTORY_PROVENANCE_CSV_FIELDS = TRAJECTORY_PROVENANCE_FIELDS
 
 _JSON_IMMUTABLE_TYPES = (str, int, float, bool, type(None))
+_TRAJECTORY_MANIFEST_OPTIONAL_FIELD_MAP = (
+    ("trajectory_toolset_version", "trajectory_toolset_version"),
+    ("trajectory_registry_schema_version", "trajectory_registry_schema_version"),
+    ("trajectory_reward_policy_id", "trajectory_reward_policy_id"),
+    ("trajectory_leakage_policy_id", "trajectory_leakage_policy_id"),
+    ("source_package_path", "trajectory_package_path"),
+    ("trajectory_quality_metrics", "trajectory_quality_metrics"),
+    ("agentic_sft_token_metrics", "agentic_sft_token_metrics"),
+)
 
 
 def _copy_trajectory_provenance_value(value: Any) -> Any:
@@ -92,15 +101,7 @@ def trajectory_provenance_from_snapshot_manifest(
     }
     if snapshot_manifest_path is not None:
         provenance["trajectory_snapshot_manifest_path"] = str(snapshot_manifest_path)
-    for source_field, output_field in (
-        ("trajectory_toolset_version", "trajectory_toolset_version"),
-        ("trajectory_registry_schema_version", "trajectory_registry_schema_version"),
-        ("trajectory_reward_policy_id", "trajectory_reward_policy_id"),
-        ("trajectory_leakage_policy_id", "trajectory_leakage_policy_id"),
-        ("source_package_path", "trajectory_package_path"),
-        ("trajectory_quality_metrics", "trajectory_quality_metrics"),
-        ("agentic_sft_token_metrics", "agentic_sft_token_metrics"),
-    ):
+    for source_field, output_field in _TRAJECTORY_MANIFEST_OPTIONAL_FIELD_MAP:
         value = manifest.get(source_field)
         if value in ("", None):
             continue


### PR DESCRIPTION
## Summary
- Hoists the trajectory snapshot optional source-to-output field map to module scope.
- Keeps `trajectory_provenance_from_snapshot_manifest(...)` behavior unchanged while avoiding per-call tuple literal reconstruction on the registered manifest load path.
- Adds a governing plan for this narrow Python performance slice.

## Plan or Spec
- `docs/plans/2026-05-26-trajectory-manifest-field-map-constant.md`
- Registered probe: `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_ITERATIONS=3000 MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py` (baseline before change)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_ITERATIONS=3000 MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_ITERATIONS=3000 MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_SAMPLES=9 uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 7 passed.
- Changed-scope coverage: `TOTAL 2 0 100%` for changed lines in `worker.trajectory_provenance`.
- Baseline local registered probe before change, 3000 iterations x 5 samples: `old_mean_ms=2285.8336369507015`, `new_mean_ms=2235.309148300439`, `delta_ms=-50.524488650262356`, `speedup=1.022602908724584`, `new_peak_bytes_mean=80044.0`.
- Local registered probe after change, 3000 iterations x 9 samples: `old_mean_ms=2305.6829252487255`, `new_mean_ms=2219.038380879081`, `delta_ms=-86.64454436964434`, `speedup=1.0390459872691882`, `new_peak_bytes_mean=80044.0`.
- CI PR-scoped performance is required before merge for registered base-vs-head validation.

## Known Gaps
- Linux local verification covers the Python path only; no Swift runtime effect is claimed.
- The local probe's internal `old_mean_ms` vs `new_mean_ms` primarily compares text-vs-bytes manifest load paths inside the current checkout. The before/after `new_mean_ms` evidence is directional; the registered PR-scoped CI report remains the merge gate for base-vs-head validation.

## Evidence Checklist
- [x] Registered PR-scoped probe exists for the affected path and includes focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >= 95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
- [ ] All required PR checks passed.
