### PR TITLE
perf: bind schema payload copy helpers

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -80,6 +80,24 @@ Expected effect:
 - leave registry selection, schema payload construction, and protobuf config
   serialization unchanged.
 
+## Follow-up Slice: Schema Payload Copy Function Bindings
+
+The 2026-05-26 follow-up keeps the `ToolDescriptor.schema_payload()` API and
+copy-on-return behavior unchanged, but reuses the module-level `dict.copy` and
+`list.copy` bindings inside the schema-payload constructor. This mirrors the
+already-applied OpenAI tool payload slice and removes repeated bound-method
+lookups for every schema dictionary and required-argument list copied during the
+registered schema-payload probe.
+
+Expected effect:
+
+- reduce repeated schema payload construction overhead measured by
+  `tool-registry-schema-bytes-cache` `schema_payload_elapsed_ms_mean`;
+- preserve independently mutable returned `properties` dictionaries and
+  `required` lists;
+- leave tool selection, OpenAI tool payload construction, and protobuf config
+  serialization unchanged.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -136,11 +136,13 @@ class ToolDescriptor:
     def schema_payload(self) -> dict[str, Any]:
         schema_properties = self._cached_schema_properties
         required_arguments = self._cached_required_arguments_list
+        copy_dict = _COPY_DICT
+        copy_list = _COPY_LIST
         return {
             "type": "object",
             "additionalProperties": False,
-            "properties": {name: schema.copy() for name, schema in schema_properties},
-            "required": required_arguments.copy(),
+            "properties": {name: copy_dict(schema) for name, schema in schema_properties},
+            "required": copy_list(required_arguments),
         }
 
     def json_schema(self) -> str:


### PR DESCRIPTION
## Summary
- Bind the existing module-level `dict.copy` and `list.copy` helpers inside `ToolDescriptor.schema_payload()`.
- Preserve copy-on-return mutation isolation while avoiding repeated bound-method lookups in the schema payload hot path.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md`

## Commands Run
```text
# Baseline registered probe, origin/main, 3 repeats
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
exit 0; schema_payload_elapsed_ms_mean samples: 151.53015861287713, 147.5391904823482, 156.1959896236658

# Head registered probe, this branch, 3 repeats
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
exit 0; schema_payload_elapsed_ms_mean samples: 150.95849065110087, 149.19019509106874, 150.8662598207593

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
exit 0; 53 passed in 0.84s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py
exit 0; 53 passed in 0.36s; changed_line_coverage=100.00%; TOTAL 2 0 100%

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% for `services/mlx-worker-python/worker/runtime/tool_registry.py` changed lines.
- Registered probe: `tool-registry-schema-bytes-cache` is present in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command`.
- Local Linux probe metric: `schema_payload_elapsed_ms_mean` old_mean=151.755113 ms, new_mean=150.338315 ms, delta=-1.416798 ms (-0.933608%), speedup=1.009424x.
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Linux local validation covers the Python slice only; no Swift runtime behavior changed.
- CI must still run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode changes.
- [x] Deferred work and known gaps are stated explicitly.
