### PR TITLE
perf: build Swift CLI metric placeholders by scalar

### DIFF
--- a/Sources/MelixCLICore/MelixCLIJSON.swift
+++ b/Sources/MelixCLICore/MelixCLIJSON.swift
@@ -9,6 +9,7 @@ func elapsedMilliseconds(since start: DispatchTime) -> Double {
 
 enum MelixCLIJSONMetricPatch {
     private static let metricLiteralLocale = Locale(identifier: "en_US_POSIX")
+    private static let metricNameAlphanumerics = CharacterSet.alphanumerics
 
     struct Placeholder {
         let token: String
@@ -23,11 +24,14 @@ enum MelixCLIJSONMetricPatch {
     }
 
     static func makePlaceholder(metricName: String) -> Placeholder {
-        let safeMetricName = metricName
-            .map { character in
-                character.isLetter || character.isNumber ? character : "_"
-            }
-        return Placeholder(token: "__MELIX_METRIC_\(String(safeMetricName))_\(UUID().uuidString)__")
+        var safeMetricName = String()
+        safeMetricName.reserveCapacity(metricName.count)
+        for scalar in metricName.unicodeScalars {
+            safeMetricName.unicodeScalars.append(
+                metricNameAlphanumerics.contains(scalar) ? scalar : "_"
+            )
+        }
+        return Placeholder(token: "__MELIX_METRIC_\(safeMetricName)_\(UUID().uuidString)__")
     }
 
     static func literal(for value: Double) -> String {

--- a/docs/plans/2026-05-26-swift-cli-placeholder-scalar-build.md
+++ b/docs/plans/2026-05-26-swift-cli-placeholder-scalar-build.md
@@ -1,0 +1,34 @@
+# Swift CLI metric placeholder scalar build
+
+## Scope
+
+This Swift performance slice keeps CLI JSON envelope behavior unchanged while reducing the temporary allocation cost of metric-placeholder token construction.
+
+## Registered probe
+
+Existing registered probe: `swift-cli-json-envelope-encoding` in `infra/perf/pr_scoped_probes.json`.
+
+The probe covers:
+
+- `Sources/MelixCLICore/MelixCLIJSON.swift`
+- `tests/MelixCLITests/MelixCLIRunnerTests.swift`
+- `infra/perf/pr_scoped_probes.json` focused command selection
+
+The registry defines focused `test_command`, `coverage_command`, and `probe_command` entries and runs on `macos-15`. Linux cannot validate Swift runtime performance for this slice, so the PR-scoped macOS CI probe is the authoritative performance validation source.
+
+## Optimization
+
+`MelixCLIJSONMetricPatch.makePlaceholder(metricName:)` previously used `String.map` over `Character` values, creating an intermediate array before rebuilding the sanitized metric-name string. This slice builds the sanitized name directly from Unicode scalars into a reserved `String` and reuses a static alphanumeric character set, preserving the same token shape while avoiding the intermediate mapped array.
+
+## Behavior
+
+The placeholder still:
+
+- preserves alphanumeric metric-name scalars;
+- replaces non-alphanumeric scalars with `_`;
+- wraps the sanitized metric name and UUID with `__MELIX_METRIC_...__`;
+- keeps `jsonLiteral` and `jsonLiteralData` synchronized with the token.
+
+## Verification plan
+
+Run any available local static/unit Swift command on the current host. Because this scheduled job runs on Linux and Swift runtime validation is macOS-only for this probe, rely on the registered `swift-cli-json-envelope-encoding` GitHub Actions probe and green PR checks before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2344,8 +2344,8 @@
       "Sources/MelixCLICore/MelixCLIJSON.swift",
       "tests/MelixCLITests/MelixCLIRunnerTests.swift"
     ],
-    "test_command": "swift test --filter 'MelixCLIRunnerTests/(jsonV1WrapsCommandResultsInAStableEnvelope|jsonV1ErrorEnvelopesAreMachineReadable|jsonMetricPatchingRejectsMissingPlaceholders|jsonMetricPatchingPreservesUserArtifactStringsThatLookLikeTheOldSentinel)'",
-    "coverage_command": "swift test --filter 'MelixCLIRunnerTests/(jsonV1WrapsCommandResultsInAStableEnvelope|jsonV1ErrorEnvelopesAreMachineReadable|jsonMetricPatchingRejectsMissingPlaceholders|jsonMetricPatchingPreservesUserArtifactStringsThatLookLikeTheOldSentinel)'",
+    "test_command": "swift test --filter 'MelixCLIRunnerTests/(jsonV1WrapsCommandResultsInAStableEnvelope|jsonV1ErrorEnvelopesAreMachineReadable|jsonMetricPlaceholdersSanitizeScalarNamesWithoutChangingTokenShape|jsonMetricPatchingRejectsMissingPlaceholders|jsonMetricPatchingPreservesUserArtifactStringsThatLookLikeTheOldSentinel)'",
+    "coverage_command": "swift test --filter 'MelixCLIRunnerTests/(jsonV1WrapsCommandResultsInAStableEnvelope|jsonV1ErrorEnvelopesAreMachineReadable|jsonMetricPlaceholdersSanitizeScalarNamesWithoutChangingTokenShape|jsonMetricPatchingRejectsMissingPlaceholders|jsonMetricPatchingPreservesUserArtifactStringsThatLookLikeTheOldSentinel)'",
     "coverage_replays_tests": true,
     "probe_impl": "command_json",
     "probe_command": "python3 - <<'PY'\nimport json\nimport subprocess\nimport sys\nimport time\n\nprobe_filter = 'MelixCLIRunnerTests/(jsonV1WrapsCommandResultsInAStableEnvelope|jsonV1ErrorEnvelopesAreMachineReadable|jsonMetricPatchingPreservesUserArtifactStringsThatLookLikeTheOldSentinel)'\nstarted = time.perf_counter()\ncompleted = subprocess.run(\n    ['swift', 'test', '--filter', probe_filter],\n    stdout=sys.stderr,\n    stderr=sys.stderr,\n    text=True,\n    timeout=600,\n)\nelapsed_ms = (time.perf_counter() - started) * 1000.0\nif completed.returncode != 0:\n    raise SystemExit(completed.returncode)\n\nprint(json.dumps({\n    'elapsed_ms_mean': round(elapsed_ms, 3),\n    'sample_count': 1.0,\n}, sort_keys=True))\nPY",

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2949,6 +2949,7 @@ def test_registered_probes_expose_focused_commands() -> None:
     swift_verification_tests = (
         "jsonV1WrapsCommandResultsInAStableEnvelope",
         "jsonV1ErrorEnvelopesAreMachineReadable",
+        "jsonMetricPlaceholdersSanitizeScalarNamesWithoutChangingTokenShape",
         "jsonMetricPatchingRejectsMissingPlaceholders",
         "jsonMetricPatchingPreservesUserArtifactStringsThatLookLikeTheOldSentinel",
     )

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -324,6 +324,16 @@ struct MelixCLIRunnerTests {
         #expect(metrics["melix.cli.parse_ms"] as? Double == 0.25)
     }
 
+    @Test("json metric placeholders sanitize scalar names without changing token shape")
+    func jsonMetricPlaceholdersSanitizeScalarNamesWithoutChangingTokenShape() {
+        let placeholder = MelixCLIJSONMetricPatch.makePlaceholder(metricName: "melix.cli.json_encode-ms")
+
+        #expect(placeholder.token.hasPrefix("__MELIX_METRIC_melix_cli_json_encode_ms_"))
+        #expect(placeholder.token.hasSuffix("__"))
+        #expect(placeholder.jsonLiteral == "\"\(placeholder.token)\"")
+        #expect(placeholder.jsonLiteralData == Data(placeholder.jsonLiteral.utf8))
+    }
+
     @Test("settings show resolves precedence and reports source metadata")
     func settingsShowResolvesPrecedenceAndReportsSourceMetadata() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
## Summary
- Build Swift CLI metric placeholder names directly from Unicode scalars instead of `String.map` over `Character` values.
- Reuse a static alphanumeric character set and add a focused regression test for placeholder token shape.
- Extend the registered Swift CLI JSON envelope probe focused test/coverage command to include the new placeholder-shape test.

## Plan or Spec
- `docs/plans/2026-05-26-swift-cli-placeholder-scalar-build.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.json.check
# exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 1 passed in 0.80s

swift test --filter 'MelixCLIRunnerTests/(jsonV1WrapsCommandResultsInAStableEnvelope|jsonV1ErrorEnvelopesAreMachineReadable|jsonMetricPlaceholdersSanitizeScalarNamesWithoutChangingTokenShape|jsonMetricPatchingRejectsMissingPlaceholders|jsonMetricPatchingPreservesUserArtifactStringsThatLookLikeTheOldSentinel)'
# not run locally: swift unavailable on this Linux runner; macOS CI registered probe is required

git diff --check
# exit 0
```

## Coverage and Metrics
- Local changed-scope Swift coverage: N/A on this Linux runner because `swift` is unavailable.
- Registered probe: `swift-cli-json-envelope-encoding` (`macos-15`) covers the affected Swift path with focused `test_command`, `coverage_command`, and `probe_command` entries.
- Metrics delta: pending PR-scoped performance CI report; local Swift runtime performance is intentionally not claimed from Linux.

## Known Gaps
- Swift unit/runtime validation and performance metrics must come from macOS GitHub Actions for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run where locally available; Swift tests are deferred to macOS CI because this runner has no `swift` binary.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe; probe overhead change: N/A, no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
