### PR TITLE
perf: reuse tool registry missing sentinel

### DIFF
--- a/docs/plans/2026-05-26-tool-registry-select-missing-sentinel.md
+++ b/docs/plans/2026-05-26-tool-registry-select-missing-sentinel.md
@@ -1,0 +1,32 @@
+# Tool registry selection missing sentinel reuse
+
+## Scope
+
+This Python performance slice is limited to `worker.runtime.tool_registry.ToolRegistry.select()`.
+It preserves tool-selection behavior, ordering, duplicate suppression, cache hits, and unknown-name
+error reporting while avoiding a per-cache-miss `object()` allocation on the selected-name lookup path.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped registered probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`. The registry entry
+already includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_select_probe.py`
+
+## Implementation plan
+
+- Add a focused regression test proving unknown-name lookups reuse the same missing-name sentinel across
+  calls rather than allocating a fresh sentinel object for each selection attempt.
+- Extend the existing registered select probe with a missing-selection timing metric so this slice's
+  affected path is measured by the PR-scoped performance workflow.
+- Hoist the missing-tool sentinel to module scope and keep the existing single lookup pass unchanged.
+- Run the registered focused tests, changed-scope coverage command, and registered probe locally on Linux.
+
+## Validation boundary
+
+This is a Python-only slice and is locally verifiable on Linux. CI must still run the registered
+PR-scoped performance workflow before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4025,6 +4025,17 @@
         "unit": "ms",
         "direction": "lower_is_better",
         "warn_pct": 5.0
+      },
+      {
+        "key": "missing_selection_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "missing_selection_errors_mean",
+        "unit": "errors",
+        "direction": "informational"
       }
     ]
   },

--- a/scripts/tool_registry_select_probe.py
+++ b/scripts/tool_registry_select_probe.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
 from worker.runtime.tool_registry import (  # noqa: E402
+    ToolRegistryError,
     built_in_tool_config,
     built_in_tool_registry,
 )
@@ -32,6 +33,8 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     full_list_self_samples: list[float] = []
     full_config_template_elapsed_samples: list[float] = []
     full_config_template_samples: list[float] = []
+    missing_selection_elapsed_samples: list[float] = []
+    missing_selection_error_samples: list[float] = []
     checksum = 0
 
     for _ in range(sample_count):
@@ -60,6 +63,19 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         )
         full_config_template_samples.append(float(full_config_template_count))
 
+        missing_selection_started = time.perf_counter()
+        missing_selection_count = 0
+        for index in range(full_config_iterations):
+            try:
+                registry.select((f"missing_tool_{index}",))
+            except ToolRegistryError:
+                missing_selection_count += 1
+        missing_selection_elapsed_samples.append(
+            (time.perf_counter() - missing_selection_started) * 1000.0
+        )
+        missing_selection_error_samples.append(float(missing_selection_count))
+        checksum += missing_selection_count
+
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
         "select_calls_mean": float(iterations),
@@ -68,6 +84,10 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
             full_config_template_elapsed_samples
         ),
         "full_config_template_hits_mean": statistics.fmean(full_config_template_samples),
+        "missing_selection_elapsed_ms_mean": statistics.fmean(
+            missing_selection_elapsed_samples
+        ),
+        "missing_selection_errors_mean": statistics.fmean(missing_selection_error_samples),
         "checksum": float(checksum),
         "iterations": float(iterations),
         "sample_count": float(sample_count),

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -424,6 +424,8 @@ def test_tool_registry_select_probe_script_emits_metrics(
     assert metrics["full_list_self_hits_mean"] == 4.0
     assert metrics["full_config_template_elapsed_ms_mean"] >= 0.0
     assert metrics["full_config_template_hits_mean"] == 4.0
+    assert metrics["missing_selection_elapsed_ms_mean"] >= 0.0
+    assert metrics["missing_selection_errors_mean"] == 4.0
 
 
 def test_tool_registry_names_probe_script_emits_metrics(

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -269,6 +269,27 @@ def test_tool_registry_select_looks_up_each_selected_name_once() -> None:
     assert index.contains_calls == 0
 
 
+def test_tool_registry_select_reuses_missing_name_sentinel_between_calls() -> None:
+    class DefaultRecordingIndex(dict[str, ToolDescriptor]):
+        def __init__(self, values: dict[str, ToolDescriptor]) -> None:
+            super().__init__(values)
+            self.default_ids: list[int] = []
+
+        def get(self, key: str, default: object = None) -> ToolDescriptor | object:
+            self.default_ids.append(id(default))
+            return super().get(key, default)
+
+    registry = ToolRegistry(built_in_tool_registry().tools)
+    index = DefaultRecordingIndex(registry._tool_by_name)
+    object.__setattr__(registry, "_tool_by_name", index)
+
+    for missing_name in ("missing_one", "missing_two"):
+        with pytest.raises(ToolRegistryError, match="Unknown tool registry entry requested"):
+            registry.select([missing_name])
+
+    assert len(set(index.default_ids)) == 1
+
+
 def test_tool_registry_select_reuses_cached_selected_registry() -> None:
     registry = ToolRegistry(built_in_tool_registry().tools)
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -13,6 +13,7 @@ _TOOL_CONFIG_FROM_BYTES = _TOOL_CONFIG.FromString
 _COMPACT_SORTED_JSON_ENCODER = json.JSONEncoder(separators=(",", ":"), sort_keys=True)
 _COPY_DICT = dict.copy
 _COPY_LIST = list.copy
+_MISSING_TOOL_SENTINEL = object()
 
 
 def _copy_tool_config(template: common_pb2.ToolConfig) -> common_pb2.ToolConfig:
@@ -264,12 +265,11 @@ class ToolRegistry:
         if cached_selection is not None:
             return cached_selection
         tool_by_name = self._tool_by_name
-        missing_sentinel = object()
         selected: list[ToolDescriptor] = []
         missing_names: list[str] = []
         for name in requested_names:
-            tool = tool_by_name.get(name, missing_sentinel)
-            if tool is missing_sentinel:
+            tool = tool_by_name.get(name, _MISSING_TOOL_SENTINEL)
+            if tool is _MISSING_TOOL_SENTINEL:
                 missing_names.append(name)
             else:
                 selected.append(tool)


### PR DESCRIPTION
## Summary
- Reuse a module-level missing-tool sentinel in `ToolRegistry.select()` instead of allocating a fresh `object()` for every selected-name cache miss.
- Extend the registered tool-registry select probe with missing-selection timing/error metrics so the unknown-name path is exercised by the PR-scoped probe.
- Add a regression test proving missing-name lookups reuse the same sentinel across selection attempts.

## Plan or Spec
- `docs/plans/2026-05-26-tool-registry-select-missing-sentinel.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 54 passed in 0.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# TOTAL 32 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# {"elapsed_ms_mean": 22.353014443069696, "missing_selection_elapsed_ms_mean": 20.153367891907692, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-select-name-index-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/tool_registry_select_missing_sentinel_probe.json
# head verification coverage_ok=True, coverage_pct=100.0; base/head probe ok=True

python3 - <<'PY'
# Custom same-workload missing-selection microbenchmark against origin/main and HEAD
PY
# base elapsed_ms_mean=112.16817144304514, head elapsed_ms_mean=104.53270701691508

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 32 0 100%`).
- Registered probe: `tool-registry-select-name-index-cache` completed locally with head verification and base/head probe success.
  - Registered overall `elapsed_ms_mean`: base `22.50695712864399` ms, head `21.353681664913893` ms, delta `-1.1532754637300968` ms (`-5.12%`, `1.054x`).
  - Registered `full_config_template_elapsed_ms_mean`: base `23.224336002022028` ms, head `21.752129588276148` ms.
  - New head-only registered metric: `missing_selection_elapsed_ms_mean=23.842128459364176` ms for 16,000 unknown-name selections/sample; base lacks this metric because the metric is introduced in this PR.
- Same-workload local microbenchmark for the unknown-name path: base `112.16817144304514` ms, head `104.53270701691508` ms, delta `-7.635464426130056` ms (`-6.81%`, `1.073x`).

## Known Gaps
- CI is required for the authoritative PR-scoped performance workflow/report before merge.
- The newly added missing-selection registered metric is head-only for this PR because `origin/main` does not emit that metric yet; the same-workload local microbenchmark records the base-vs-head comparison for the optimized path.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; probe overhead is bounded to synthetic CI/local probe execution.
- [x] Deferred work and known gaps are stated explicitly.
