### PR TITLE
[codex] Add manual main app packaging download

### DIFF
--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -41,7 +41,6 @@ on:
 permissions:
   actions: read
   contents: read
-  issues: write
   pull-requests: write
 
 concurrency:
@@ -122,13 +121,25 @@ jobs:
 
       - name: Compute build metadata
         id: compute-build-metadata
+        env:
+          SOURCE_REF: ${{ inputs.source_ref }}
         run: |
           ref_type="${GITHUB_REF_TYPE:-branch}"
           ref_name="${GITHUB_REF_NAME:-}"
           sha="${GITHUB_SHA:-}"
           if [ "${GITHUB_EVENT_NAME:-}" = "workflow_dispatch" ]; then
-            ref_type="branch"
-            ref_name="${{ inputs.source_ref }}"
+            ref_name="$SOURCE_REF"
+            source_ref_name="${SOURCE_REF#refs/heads/}"
+            source_ref_name="${source_ref_name#refs/tags/}"
+            if git show-ref --verify --quiet "refs/tags/${source_ref_name}"; then
+              ref_type="tag"
+              ref_name="$source_ref_name"
+            elif git show-ref --verify --quiet "refs/heads/${source_ref_name}" || git show-ref --verify --quiet "refs/remotes/origin/${source_ref_name}"; then
+              ref_type="branch"
+              ref_name="$source_ref_name"
+            else
+              ref_type="branch"
+            fi
             sha="$(git rev-parse HEAD)"
           fi
 

--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -2,6 +2,12 @@ name: package-self-contained-app
 
 on:
   workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Git ref to package. Keep the default to build the latest main branch app archive."
+        required: true
+        default: "main"
+        type: string
   pull_request:
     types:
       - opened
@@ -33,7 +39,9 @@ on:
       - "services/mlx-worker-python/**"
 
 permissions:
+  actions: read
   contents: read
+  issues: write
   pull-requests: write
 
 concurrency:
@@ -48,7 +56,15 @@ jobs:
       artifact_name: ${{ steps.compute-build-metadata.outputs.artifact_name }}
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout manual package source
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.source_ref }}
+
+      - name: Checkout event source
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
@@ -107,15 +123,24 @@ jobs:
       - name: Compute build metadata
         id: compute-build-metadata
         run: |
+          ref_type="${GITHUB_REF_TYPE:-branch}"
+          ref_name="${GITHUB_REF_NAME:-}"
+          sha="${GITHUB_SHA:-}"
+          if [ "${GITHUB_EVENT_NAME:-}" = "workflow_dispatch" ]; then
+            ref_type="branch"
+            ref_name="${{ inputs.source_ref }}"
+            sha="$(git rev-parse HEAD)"
+          fi
+
           bash scripts/ci_progress.sh "Package app build metadata" \
             env PYTHONPATH="$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/services/mlx-worker-python" \
             UV_CACHE_DIR="$GITHUB_WORKSPACE/.uv-cache" \
             uv run --project services/mlx-worker-python \
             python scripts/compute_build_metadata.py \
             --repo-root "$GITHUB_WORKSPACE" \
-            --ref-type "${GITHUB_REF_TYPE:-branch}" \
-            --ref-name "${GITHUB_REF_NAME:-}" \
-            --sha "${GITHUB_SHA:-}" \
+            --ref-type "$ref_type" \
+            --ref-name "$ref_name" \
+            --sha "$sha" \
             --github-output "$GITHUB_OUTPUT" \
             --json
 
@@ -143,6 +168,44 @@ jobs:
           name: ${{ steps.compute-build-metadata.outputs.artifact_name }}
           path: ${{ runner.temp }}/${{ steps.compute-build-metadata.outputs.artifact_name }}.zip
           if-no-files-found: error
+
+      - name: Publish app artifact download summary
+        if: github.event_name != 'pull_request' && success()
+        uses: actions/github-script@v9
+        env:
+          ARTIFACT_NAME: ${{ steps.compute-build-metadata.outputs.artifact_name }}
+        with:
+          script: |
+            const fs = require('fs');
+            const artifactName = process.env.ARTIFACT_NAME || 'melix-app';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { owner, repo } = context.repo;
+            const artifactResponse = await github.rest.actions.listWorkflowRunArtifacts({
+              owner,
+              repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+            const artifact = artifactResponse.data.artifacts.find((entry) => entry.name === artifactName);
+            const artifactUrl = artifact
+              ? `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${artifact.id}`
+              : `${runUrl}#artifacts`;
+            const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+            if (!summaryPath) {
+              core.warning('GITHUB_STEP_SUMMARY is not set; skipping artifact summary.');
+            } else {
+              const body = [
+                '## Download packaged Melix.app',
+                '',
+                `- Artifact: **${artifactName}.zip**`,
+                `- Download: ${artifactUrl}`,
+                `- Workflow run: ${runUrl}`,
+                '',
+                '> GitHub authentication may be required to download workflow artifacts.',
+                '',
+              ].join('\n');
+              fs.appendFileSync(summaryPath, body, 'utf8');
+            }
 
       - name: Update PR artifact comment
         if: github.event_name == 'pull_request' && success()

--- a/docs/plans/2026-05-27-manual-main-app-packaging-ci.md
+++ b/docs/plans/2026-05-27-manual-main-app-packaging-ci.md
@@ -1,0 +1,35 @@
+# Manual Main App Packaging CI Plan
+
+## Goal
+
+Allow operators to manually package the self-contained Melix macOS app from the
+`main` branch and make the resulting archive easy to download from the GitHub
+Actions run.
+
+## Scope
+
+- Update `.github/workflows/package-self-contained-app.yml`.
+- Keep the existing pull-request `package-app` label gate unchanged.
+- Keep tag release attachment behavior unchanged.
+- Add focused regression coverage for the workflow contract.
+- Document the manual packaging path in the packaging runbook.
+
+## Design
+
+The existing `package-self-contained-app` workflow remains the single packaging
+entry point. `workflow_dispatch` gets an explicit source-ref input that defaults
+to `main`, so a manual run packages `main` unless the operator intentionally
+overrides it. Manual runs use a dedicated checkout step for the selected source
+ref; push, pull request, and tag runs keep the default event checkout behavior.
+
+After uploading the app archive, the workflow writes a GitHub Actions step
+summary with the artifact name, direct artifact URL when available, and workflow
+run URL. Pull requests keep their sticky artifact comment.
+
+## Verification
+
+- Focused Python tests assert the workflow exposes the manual `main` default,
+  keeps event checkout behavior for non-manual runs, grants artifact-read
+  permissions, and publishes a download summary.
+- The change is workflow and documentation only; coverage metrics are `N/A`
+  because no executable Melix runtime code path changes.

--- a/docs/plans/2026-05-27-manual-main-app-packaging-ci.md
+++ b/docs/plans/2026-05-27-manual-main-app-packaging-ci.md
@@ -20,7 +20,9 @@ The existing `package-self-contained-app` workflow remains the single packaging
 entry point. `workflow_dispatch` gets an explicit source-ref input that defaults
 to `main`, so a manual run packages `main` unless the operator intentionally
 overrides it. Manual runs use a dedicated checkout step for the selected source
-ref; push, pull request, and tag runs keep the default event checkout behavior.
+ref and pass that ref into shell steps through environment variables before
+resolving branch or tag build metadata. Push, pull request, and tag runs keep the
+default event checkout behavior.
 
 After uploading the app archive, the workflow writes a GitHub Actions step
 summary with the artifact name, direct artifact URL when available, and workflow

--- a/docs/runbooks/platform-packaging-targets.md
+++ b/docs/runbooks/platform-packaging-targets.md
@@ -77,6 +77,21 @@ Target differentiation is expressed through `packaging_target_id`, `packaging_ki
 - keeps the same logical Melix identity while making the bundle-specific distribution and update
   strategy explicit
 
+## Manual App Archive From `main`
+
+The GitHub Actions workflow `package-self-contained-app` can be run manually when an operator
+needs a fresh downloadable `Melix.app` archive from the repository `main` branch:
+
+1. Open **Actions** > **package-self-contained-app**.
+2. Select **Run workflow**.
+3. Keep `source_ref` set to `main` unless intentionally packaging another ref.
+4. Wait for the `package-app` job to complete on the macOS runner.
+5. Download the archive from the run summary under **Download packaged Melix.app** or from the
+   workflow run's **Artifacts** section.
+
+The manual archive uses the same self-contained app-bundle packaging path as push and tag runs.
+GitHub authentication may be required to download workflow artifacts.
+
 ## Deterministic Validation
 
 Run the repository-owned smoke command to verify the shared packaging target matrix across all

--- a/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
+++ b/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
@@ -27,7 +27,7 @@ def find_named_workflow_step(workflow: str, name: str) -> re.Match[str]:
 def find_workflow_step(workflow: str, name: str) -> str:
     match = re.search(
         rf"^[ \t]*-[ \t]+name:[ \t]+{re.escape(name)}[ \t]*\n"
-        r"(?P<body>.*?)(?=^[ \t]*-[ \t]+(?:name:|uses:)|\Z)",
+        r"(?P<body>.*?)(?=^[ \t]*-[ \t]+|\Z)",
         workflow,
         flags=re.MULTILINE | re.DOTALL,
     )
@@ -325,6 +325,26 @@ def test_package_workflow_wraps_long_packaging_steps_with_ci_progress() -> None:
 
     for label in progress_labels:
         assert f'bash scripts/ci_progress.sh "{label}"' in workflow
+
+
+def test_find_workflow_step_stops_before_any_next_yaml_list_item() -> None:
+    workflow = """
+jobs:
+  package-app:
+    steps:
+      - name: Publish app artifact download summary
+        if: github.event_name != 'pull_request' && success()
+        uses: actions/github-script@v9
+      - run: echo should-not-be-included
+      - id: next-step
+        run: echo also-should-not-be-included
+"""
+
+    step = find_workflow_step(workflow, "Publish app artifact download summary")
+
+    assert "uses: actions/github-script@v9" in step
+    assert "should-not-be-included" not in step
+    assert "next-step" not in step
 
 
 def test_package_workflow_manual_dispatch_defaults_to_main_checkout() -> None:

--- a/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
+++ b/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
@@ -366,11 +366,31 @@ def test_package_workflow_manual_dispatch_defaults_to_main_checkout() -> None:
     assert "ref:" not in event_checkout
 
 
-def test_package_workflow_publishes_download_summary_for_uploaded_app_artifact() -> None:
+def test_package_workflow_keeps_permissions_minimal_for_artifact_summary() -> None:
     workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
 
     assert re.search(r"^[ \t]*permissions:[ \t]*$", workflow, flags=re.MULTILINE)
     assert re.search(r"^[ \t]+actions:[ \t]+read[ \t]*$", workflow, flags=re.MULTILINE)
+    assert re.search(r"^[ \t]+contents:[ \t]+read[ \t]*$", workflow, flags=re.MULTILINE)
+    assert re.search(r"^[ \t]+pull-requests:[ \t]+write[ \t]*$", workflow, flags=re.MULTILINE)
+    assert not re.search(r"^[ \t]+issues:[ \t]+write[ \t]*$", workflow, flags=re.MULTILINE)
+
+
+def test_package_workflow_passes_manual_source_ref_through_env_before_shell_use() -> None:
+    workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    compute_step = find_workflow_step(workflow, "Compute build metadata")
+    assert "env:" in compute_step
+    assert "SOURCE_REF: ${{ inputs.source_ref }}" in compute_step
+    run_body = compute_step.split("run: |", maxsplit=1)[1]
+    assert "${{ inputs.source_ref }}" not in run_body
+    assert 'ref_name="$SOURCE_REF"' in run_body
+    assert 'refs/tags/${source_ref_name}' in run_body
+    assert 'ref_type="tag"' in run_body
+
+
+def test_package_workflow_publishes_download_summary_for_uploaded_app_artifact() -> None:
+    workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
 
     summary_step = find_workflow_step(workflow, "Publish app artifact download summary")
     assert "github.event_name != 'pull_request' && success()" in summary_step

--- a/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
+++ b/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
@@ -24,6 +24,17 @@ def find_named_workflow_step(workflow: str, name: str) -> re.Match[str]:
     return match
 
 
+def find_workflow_step(workflow: str, name: str) -> str:
+    match = re.search(
+        rf"^[ \t]*-[ \t]+name:[ \t]+{re.escape(name)}[ \t]*\n"
+        r"(?P<body>.*?)(?=^[ \t]*-[ \t]+(?:name:|uses:)|\Z)",
+        workflow,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"Workflow step not found: {name}"
+    return match.group(0)
+
+
 def find_run_workflow_step(workflow: str, name: str, command: str) -> re.Match[str]:
     match = re.search(
         rf"^[ \t]*-[ \t]+name:[ \t]+{re.escape(name)}[ \t]*\n"
@@ -314,6 +325,42 @@ def test_package_workflow_wraps_long_packaging_steps_with_ci_progress() -> None:
 
     for label in progress_labels:
         assert f'bash scripts/ci_progress.sh "{label}"' in workflow
+
+
+def test_package_workflow_manual_dispatch_defaults_to_main_checkout() -> None:
+    workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert re.search(r"^[ \t]*workflow_dispatch:[ \t]*$", workflow, flags=re.MULTILINE)
+    assert "source_ref:" in workflow
+    assert 'default: "main"' in workflow
+    assert "type: string" in workflow
+
+    manual_checkout = find_workflow_step(workflow, "Checkout manual package source")
+    assert "if: github.event_name == 'workflow_dispatch'" in manual_checkout
+    assert "uses: actions/checkout@v6" in manual_checkout
+    assert "ref: ${{ inputs.source_ref }}" in manual_checkout
+
+    event_checkout = find_workflow_step(workflow, "Checkout event source")
+    assert "if: github.event_name != 'workflow_dispatch'" in event_checkout
+    assert "uses: actions/checkout@v6" in event_checkout
+    assert "ref:" not in event_checkout
+
+
+def test_package_workflow_publishes_download_summary_for_uploaded_app_artifact() -> None:
+    workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert re.search(r"^[ \t]*permissions:[ \t]*$", workflow, flags=re.MULTILINE)
+    assert re.search(r"^[ \t]+actions:[ \t]+read[ \t]*$", workflow, flags=re.MULTILINE)
+
+    summary_step = find_workflow_step(workflow, "Publish app artifact download summary")
+    assert "github.event_name != 'pull_request' && success()" in summary_step
+    assert "github.rest.actions.listWorkflowRunArtifacts" in summary_step
+    assert "process.env.GITHUB_STEP_SUMMARY" in summary_step
+    assert "Download packaged Melix.app" in summary_step
+    assert "Artifact:" in summary_step
+    assert "Download:" in summary_step
+    assert "Workflow run:" in summary_step
+    assert "artifacts/${artifact.id}" in summary_step
 
 
 def test_main_resolves_default_build_outputs_and_prints_app_path(


### PR DESCRIPTION
## Summary
- Add a manual `package-self-contained-app` workflow input that defaults to packaging `main`.
- Publish a GitHub Actions run summary with the packaged Melix.app artifact name, download link, and run link for non-PR packaging runs.
- Keep the packaging workflow token least-privilege, pass manual source refs through the step environment before shell use, and preserve branch/tag metadata for manual refs.
- Document the manual app archive flow and add workflow contract tests.

## Plan or Spec
- `docs/plans/2026-05-27-manual-main-app-packaging-ci.md`

## Commands Run
```text
PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py -q
Result: 18 passed in 0.05s

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py::test_find_workflow_step_stops_before_any_next_yaml_list_item -q
Red result before fix: failed because the helper consumed the following `- run:` / `- id:` workflow steps.
Green result after fix: 1 passed in 0.03s

PYTHONPATH="$(pwd):$(pwd)/services/mlx-worker-python" UV_CACHE_DIR="$(pwd)/.uv-cache" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py::test_package_workflow_keeps_permissions_minimal_for_artifact_summary services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py::test_package_workflow_passes_manual_source_ref_through_env_before_shell_use -q
Red result before fix: both tests failed because `issues: write` was present and `source_ref` was interpolated directly in the shell step.
Green result after fix: 2 passed in 0.01s

ruby -e 'require "yaml"; YAML.load_file(".github/workflows/package-self-contained-app.yml"); puts "workflow yaml ok"'
Result: workflow yaml ok

git diff --check
Result: passed

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-bodies/manual-main-app-packaging-ci.md
Result: PR evidence looks valid.
```

## Coverage and Metrics
- N/A: workflow, documentation, and workflow-structure test changes only. No executable Melix runtime code path changed, so changed-line runtime coverage and performance probes are not applicable.

## Known Gaps
- GitHub-hosted manual workflow execution is not run before this draft PR; the PR validates the workflow contract locally and leaves the actual macOS packaging run to GitHub Actions after merge or manual dispatch.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
