### PR TITLE
perf: inline evaluation latency percentiles

### DIFF
--- a/docs/plans/2026-05-03-evaluation-latency-percentile-vector-reuse.md
+++ b/docs/plans/2026-05-03-evaluation-latency-percentile-vector-reuse.md
@@ -27,7 +27,7 @@ The probe must be base-compatible so `origin/main` still runs successfully durin
 ## Success Metrics
 
 - `_latency_stats()` performs one sort per invocation instead of two.
-- A follow-up micro-slice may keep the same behavior and one-sort invariant while removing repeated class attribute lookups from the return-path by binding `_round_ms` and `_ordered_percentile` once per call.
+- A 2026-05-28 follow-up micro-slice keeps the same behavior and one-sort invariant while inlining the two fixed percentile calculations inside `_latency_stats()`. The previous class-attribute binding step is already present on `main`, so this slice removes the remaining two `_ordered_percentile(...)` helper calls from the hot return path instead of rebinding them again.
 - Latency summary outputs (`mean`, `p50`, `p95`, `max`) remain unchanged.
 - Focused changed-scope coverage for touched executable files is at least 95%.
 - The registered local probe must show stable or lower `elapsed_ms_mean` versus `origin/main`; `sorted_calls_mean` must remain `1.0`.

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -720,12 +720,18 @@ def test_latency_stats_reuse_single_sorted_vector(monkeypatch: pytest.MonkeyPatc
         sorted_call_count += 1
         return original_sorted(*args, **kwargs)
 
+    def fail_ordered_percentile(*args, **kwargs):  # pragma: no cover - regression guard
+        raise AssertionError("_latency_stats should inline fixed percentile calculations")
+
     monkeypatch.setattr(builtins, "sorted", counting_sorted)
+    monkeypatch.setattr(EvaluationCore, "_ordered_percentile", fail_ordered_percentile)
 
     stats = EvaluationCore._latency_stats([40.0, 10.0, 30.0, 20.0])
 
     assert stats == {"mean": 25.0, "p50": 25.0, "p95": 38.5, "max": 40.0}
-    assert sorted_call_count == 1
+    assert EvaluationCore._latency_stats([10.0, 30.0, 20.0]) == {"mean": 20.0, "p50": 20.0, "p95": 29.0, "max": 30.0}
+    assert EvaluationCore._latency_stats([42.0]) == {"mean": 42.0, "p50": 42.0, "p95": 42.0, "max": 42.0}
+    assert sorted_call_count == 3
 
 
 def test_run_local_suite_executes_packaged_dataset_and_persists_result(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -1876,11 +1876,24 @@ class EvaluationCore:
         sorted_values = sorted(values)
         value_count = len(sorted_values)
         round_ms = cls._round_ms
-        ordered_percentile = cls._ordered_percentile
+        if value_count == 1:
+            p50 = p95 = sorted_values[0]
+        else:
+            p50_lower, p50_remainder = divmod(value_count - 1, 2)
+            if p50_remainder:
+                p50 = (sorted_values[p50_lower] + sorted_values[p50_lower + 1]) * 0.5
+            else:
+                p50 = sorted_values[p50_lower]
+            p95_index = (value_count - 1) * 0.95
+            p95_lower = int(p95_index)
+            p95_fraction = p95_index - p95_lower
+            p95 = sorted_values[p95_lower] + (
+                sorted_values[p95_lower + 1] - sorted_values[p95_lower]
+            ) * p95_fraction
         return {
             "mean": round_ms(sum(sorted_values) / value_count),
-            "p50": round_ms(ordered_percentile(sorted_values, 50.0)),
-            "p95": round_ms(ordered_percentile(sorted_values, 95.0)),
+            "p50": round_ms(p50),
+            "p95": round_ms(p95),
             "max": round_ms(sorted_values[-1]),
         }
 


### PR DESCRIPTION
## Summary
- Inline the fixed p50/p95 interpolation path inside `EvaluationCore._latency_stats()` while preserving the existing one-sort invariant.
- Extend the latency stats regression test to prove `_latency_stats()` no longer calls `_ordered_percentile()` for its fixed percentiles and still covers even, odd, and single-value inputs.
- Update the governing evaluation latency plan to record that the previous binding follow-up is already on `main` and this slice removes the remaining helper calls.

## Plan or Spec
- `docs/plans/2026-05-03-evaluation-latency-percentile-vector-reuse.md`
- Registered PR-scoped probe: `evaluation-latency-percentile-vector-reuse` in `infra/perf/pr_scoped_probes.json` (already has focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_percentile_preserves_interpolated_results services/mlx-worker-python/tests/test_evaluation_core.py::test_latency_stats_reuse_single_sorted_vector services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_latency_percentile_probe_command_emits_metrics services/mlx-worker-python/tests/test_event_extraction.py::test_event_extraction_dialogue_diagnostics_uses_top_k_for_slowest_dialogues services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_persists_agentic_tool_evidence services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_writes_agentic_judge_prompt_snapshot_and_audit services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_prompt_snapshot_rejects_hidden_gold_context services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_forbidden_keys services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_allows_explicit_answer_values services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_extra_payload_fields services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_returns_agentic_judge_artifacts_without_jobs_root services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_injects_agentic_tool_trace_before_scoring` → 17 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py` → 17 passed; changed-scope coverage 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-latency-percentile-vector-reuse --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-evaluation-latency-inline-percentile-20260528 --output /tmp/eval-latency-inline-probe3.json` → passed
- `git diff --check` → passed

## Coverage and Metrics
- Changed-scope coverage: 100% (`aggregate_measurable_changed_lines=14`, `aggregate_missed_changed_lines=0`).
- Local registered probe (`evaluation-latency-percentile-vector-reuse`, Linux):
  - base `elapsed_ms_mean=236.365499`
  - head `elapsed_ms_mean=234.188724`
  - delta `-2.176775 ms` (`-0.920936%`)
  - `sorted_calls_mean=1.0` on both base and head
- CI PR-scoped performance remains the merge gate for the registered probe result.

## Known Gaps
- This is a Python-only slice validated locally on Linux; no Swift runtime effects are involved.
- The local probe is a synthetic `_latency_stats()` workload; GitHub Actions PR-scoped performance is required before merge.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branch creation.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe shows an improvement.
- [ ] GitHub Actions PR-scoped performance completed successfully.
