### PR TITLE
[Gemma E4B Perf] Guard release comparison metadata

### DIFF
--- a/docs/plans/2026-05-12-omlx-melix-serving-benchmark.md
+++ b/docs/plans/2026-05-12-omlx-melix-serving-benchmark.md
@@ -754,6 +754,19 @@ not a fair source for direct Melix optimization deltas.
   source builds before the benchmark can start.
 - Treat `model_listed=false` as an invalid comparison setup unless the operator
   explicitly requests `--allow-failed-preflight` to capture failure observations.
+- Peer comparison bundles use manifest schema version 2. For any report that
+  presents Melix numbers against OMLX, SwiftLM, or another peer runtime, record
+  the Melix Swift text-worker and control-plane binary paths, SHA-256 digests,
+  and detected build modes. A peer comparison is invalid unless both Melix
+  binaries are readable release artifacts. Debug builds are allowed only when
+  the run is explicitly marked `debug-only`, and those artifacts must not be
+  used as fair peer performance evidence.
+- Record peer reproducibility metadata alongside the scenario matrix: Melix and
+  OMLX revisions or versions when known, optional SwiftLM revision/version and
+  binary hash when a three-way run is assembled from this harness, local model
+  snapshot path, prompt/completion token source summaries, warmup count, cache
+  profile, prompt style, prompt targets, output lengths, concurrency values,
+  and repeat count.
 
 ## Current Known Gaps
 

--- a/scripts/omlx_melix_compare_benchmark.py
+++ b/scripts/omlx_melix_compare_benchmark.py
@@ -908,8 +908,8 @@ def file_sha256(path: Path) -> str:
 
 def detect_swift_build_mode(path: Path) -> str:
     parts = path.expanduser().parts
-    for index, part in enumerate(parts):
-        if part != ".build":
+    for index in range(len(parts) - 1, -1, -1):
+        if parts[index] != ".build":
             continue
         tail = parts[index + 1 :]
         if "debug" in tail:
@@ -1011,7 +1011,11 @@ def comparison_validity_metadata(
             reasons.append(f"Melix {name} binary metadata was not provided.")
             continue
         if entry.get("exists") is not True:
-            reasons.append(f"Melix {name} binary path is not readable: {entry.get('path')}")
+            reasons.append(
+                f"Melix {name} binary error: "
+                f"{entry.get('error') or 'binary path is not readable'} "
+                f"(path: {entry.get('path')})"
+            )
             continue
         if entry.get("build_mode") == "debug":
             reasons.append(
@@ -1109,9 +1113,11 @@ def token_accounting_metadata(
     }
 
 
-def _split_source_summary(values: Iterable[str]) -> list[str]:
+def _split_source_summary(values: Iterable[Any]) -> list[str]:
     sources: set[str] = set()
     for value in values:
+        if not isinstance(value, str):
+            continue
         for source in value.split(","):
             source = source.strip()
             if source and source != "unknown":

--- a/scripts/omlx_melix_compare_benchmark.py
+++ b/scripts/omlx_melix_compare_benchmark.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import hashlib
 import json
 import math
 import shutil
@@ -33,11 +34,13 @@ DEFAULT_TOP_P = 1.0
 DEFAULT_TOP_K = 0
 PROMPT_STYLES = ("concise", "saturating")
 MEASUREMENT_PROFILES = ("auto", "cold", "warm", "mixed")
-REPORT_SCHEMA_VERSION = 1
+COMPARISON_SCOPES = ("peer", "debug-only")
+REPORT_SCHEMA_VERSION = 2
 MELIX_VLM_BATCHING_BLOCKED_REASON_CODES = {
     1: "multimodal route does not expose a streaming continuous batching path",
     2: "python VLM request is not eligible for cooperative text-only token-step batching",
 }
+REQUIRED_MELIX_PEER_BINARY_NAMES = ("text_worker", "control_plane")
 
 
 @dataclass(frozen=True)
@@ -892,6 +895,230 @@ def metrics_manifest_entries(metrics_snapshot: dict[str, Any] | None, *, artifac
     return entries
 
 
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def detect_swift_build_mode(path: Path) -> str:
+    parts = path.expanduser().parts
+    for index, part in enumerate(parts):
+        if part != ".build":
+            continue
+        tail = parts[index + 1 :]
+        if "debug" in tail:
+            return "debug"
+        if "release" in tail:
+            return "release"
+    return "unknown"
+
+
+def binary_metadata(path: Path | None, *, build_mode_detector=detect_swift_build_mode) -> dict[str, Any]:
+    if path is None:
+        return {
+            "provided": False,
+            "path": None,
+            "exists": False,
+            "sha256": None,
+            "build_mode": "unknown",
+        }
+    expanded = path.expanduser().resolve(strict=False)
+    exists = expanded.is_file()
+    sha256 = None
+    read_error = None
+    if exists:
+        try:
+            sha256 = file_sha256(expanded)
+        except OSError as exc:
+            read_error = f"{type(exc).__name__}: {exc}"
+    entry = {
+        "provided": True,
+        "path": str(expanded),
+        "exists": exists and read_error is None,
+        "sha256": sha256,
+        "build_mode": build_mode_detector(expanded),
+    }
+    if not exists:
+        entry["error"] = "binary path does not exist or is not a file"
+    elif read_error is not None:
+        entry["error"] = f"binary path is not readable: {read_error}"
+    return entry
+
+
+def runtime_metadata_from_args(
+    args: argparse.Namespace,
+    *,
+    endpoints: list[EndpointConfig],
+) -> dict[str, Any]:
+    endpoint_by_name = {endpoint.name: endpoint for endpoint in endpoints}
+    melix = endpoint_by_name.get("melix")
+    omlx = endpoint_by_name.get("omlx")
+    metadata: dict[str, Any] = {
+        "melix": {
+            "base_url": melix.base_url if melix is not None else None,
+            "model": melix.model if melix is not None else None,
+            "revision": args.melix_revision or None,
+            "version": args.melix_version or None,
+            "binaries": {
+                "text_worker": binary_metadata(args.melix_text_worker_binary),
+                "control_plane": binary_metadata(args.melix_control_plane_binary),
+            },
+        },
+        "omlx": {
+            "base_url": omlx.base_url if omlx is not None else None,
+            "model": omlx.model if omlx is not None else None,
+            "revision": args.omlx_revision or None,
+            "version": args.omlx_version or None,
+        },
+        "model_snapshot": {
+            "path": str(args.model_snapshot_path.expanduser()) if args.model_snapshot_path else None,
+        },
+    }
+    if args.swiftlm_revision or args.swiftlm_version or args.swiftlm_binary is not None:
+        metadata["swiftlm"] = {
+            "revision": args.swiftlm_revision or None,
+            "version": args.swiftlm_version or None,
+            "binaries": {
+                "server": binary_metadata(args.swiftlm_binary),
+            },
+        }
+    return metadata
+
+
+def comparison_validity_metadata(
+    runtime_metadata: dict[str, Any],
+    *,
+    comparison_scope: str,
+    token_accounting: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    warnings: list[str] = []
+    melix = runtime_metadata.get("melix")
+    melix_binaries = melix.get("binaries", {}) if isinstance(melix, dict) else {}
+    binary_names = sorted({
+        *REQUIRED_MELIX_PEER_BINARY_NAMES,
+        *(melix_binaries.keys() if isinstance(melix_binaries, dict) else ()),
+    })
+    for name in binary_names:
+        entry = melix_binaries.get(name) if isinstance(melix_binaries, dict) else None
+        if not isinstance(entry, dict) or entry.get("provided") is not True:
+            reasons.append(f"Melix {name} binary metadata was not provided.")
+            continue
+        if entry.get("exists") is not True:
+            reasons.append(f"Melix {name} binary path is not readable: {entry.get('path')}")
+            continue
+        if entry.get("build_mode") == "debug":
+            reasons.append(
+                f"Melix {name} binary uses a debug build path: {entry.get('path')}"
+            )
+        elif entry.get("build_mode") != "release":
+            reasons.append(
+                f"Melix {name} binary is not a release build: build_mode={entry.get('build_mode')}"
+            )
+    if token_accounting is not None:
+        if (
+            token_accounting.get("mixed_prompt_token_sources") is True
+            and token_accounting.get("allow_mixed_token_accounting") is not True
+        ):
+            reasons.append(
+                "Prompt token accounting used mixed sources without --allow-mixed-token-accounting."
+            )
+        if (
+            token_accounting.get("mixed_completion_token_sources") is True
+            and token_accounting.get("allow_mixed_token_accounting") is not True
+        ):
+            reasons.append(
+                "Completion token accounting used mixed sources without --allow-mixed-token-accounting."
+            )
+        if (
+            token_accounting.get("allow_mixed_token_accounting") is True
+            and (
+                token_accounting.get("mixed_prompt_token_sources") is True
+                or token_accounting.get("mixed_completion_token_sources") is True
+            )
+        ):
+            warnings.append("Mixed token accounting was explicitly allowed for this run.")
+
+    if comparison_scope == "debug-only":
+        return {
+            "status": "debug_only",
+            "peer_comparison_valid": False,
+            "comparison_scope": comparison_scope,
+            "reasons": [
+                "Run was explicitly declared debug-only; do not use it as a fair peer performance comparison.",
+                *reasons,
+            ],
+            "warnings": warnings,
+        }
+    if reasons:
+        return {
+            "status": "invalid",
+            "peer_comparison_valid": False,
+            "comparison_scope": comparison_scope,
+            "reasons": reasons,
+            "warnings": warnings,
+        }
+    return {
+        "status": "valid",
+        "peer_comparison_valid": True,
+        "comparison_scope": comparison_scope,
+        "reasons": [],
+        "warnings": warnings,
+    }
+
+
+def scenario_matrix_metadata(scenarios: list[BenchmarkScenario]) -> dict[str, Any]:
+    repeat_indexes = [scenario.repeat_index for scenario in scenarios]
+    prompt_styles = sorted({scenario.prompt_style for scenario in scenarios})
+    return {
+        "prompt_style": prompt_styles[0] if len(prompt_styles) == 1 else None,
+        "prompt_token_targets": sorted({scenario.prompt_token_target for scenario in scenarios}),
+        "max_tokens": sorted({scenario.max_tokens for scenario in scenarios}),
+        "concurrency": sorted({scenario.concurrency for scenario in scenarios}),
+        "cache_profiles": sorted({scenario.cache_profile for scenario in scenarios}),
+        "prompt_styles": prompt_styles,
+        "repeat_count": (max(repeat_indexes) + 1) if repeat_indexes else 0,
+    }
+
+
+def token_accounting_metadata(
+    summaries: list[ScenarioSummary],
+    *,
+    include_usage_requested: bool,
+    allow_mixed_token_accounting: bool,
+) -> dict[str, Any]:
+    prompt_sources = _split_source_summary(
+        summary.prompt_token_sources for summary in summaries
+    )
+    completion_sources = _split_source_summary(
+        summary.completion_token_sources for summary in summaries
+    )
+    return {
+        "include_usage_requested": include_usage_requested,
+        "allow_mixed_token_accounting": allow_mixed_token_accounting,
+        "observed_prompt_token_sources": prompt_sources,
+        "observed_completion_token_sources": completion_sources,
+        "mixed_prompt_token_sources": len(prompt_sources) > 1,
+        "mixed_completion_token_sources": len(completion_sources) > 1,
+    }
+
+
+def _split_source_summary(values: Iterable[str]) -> list[str]:
+    sources: set[str] = set()
+    for value in values:
+        for source in value.split(","):
+            source = source.strip()
+            if source and source != "unknown":
+                sources.add(source)
+    return sorted(sources)
+
+
 def _numeric_metric(values: dict[str, Any], key: str) -> float | None:
     value = values.get(key)
     if isinstance(value, (int, float)) and not isinstance(value, bool):
@@ -913,6 +1140,9 @@ def write_artifacts(
     hints: list[dict[str, Any]],
     dry_run: bool,
     measurement_profile: dict[str, Any],
+    runtime_metadata: dict[str, Any],
+    comparison_validity: dict[str, Any],
+    token_accounting: dict[str, Any],
 ) -> dict[str, str]:
     staging_dir.mkdir(parents=True, exist_ok=True)
     generated_at = datetime.now(timezone.utc).isoformat()
@@ -942,11 +1172,12 @@ def write_artifacts(
             for endpoint in endpoints
         ],
         "scenario_count": len(scenarios),
-        "scenario_settings": {
-            "prompt_style": scenarios[0].prompt_style if scenarios else None,
-        },
+        "scenario_settings": scenario_matrix_metadata(scenarios),
         "warmup_count": len(warmups),
         "warmup_settings": warmup_settings,
+        "runtime_metadata": runtime_metadata,
+        "comparison_validity": comparison_validity,
+        "token_accounting": token_accounting,
         "observation_count": len(observations),
         "preflight": preflight,
         "metrics": metrics_manifest_entries(
@@ -972,6 +1203,9 @@ def write_artifacts(
         "schema_version": REPORT_SCHEMA_VERSION,
         "generated_at": generated_at,
         "measurement_profile": measurement_profile,
+        "runtime_metadata": runtime_metadata,
+        "comparison_validity": comparison_validity,
+        "token_accounting": token_accounting,
         "melix_metrics_snapshot": metrics_snapshot,
         "warmups": [asdict(observation) for observation in warmups],
         "summaries": [asdict(summary) for summary in summaries],
@@ -991,6 +1225,8 @@ def write_artifacts(
             metrics_snapshot=metrics_snapshot,
             dry_run=dry_run,
             measurement_profile=measurement_profile,
+            runtime_metadata=runtime_metadata,
+            comparison_validity=comparison_validity,
         ),
         encoding="utf-8",
     )
@@ -1006,6 +1242,41 @@ def write_summary_csv(path: Path, summaries: list[ScenarioSummary]) -> None:
             writer.writerow(asdict(summary))
 
 
+def runtime_metadata_markdown_rows(runtime_metadata: dict[str, Any]) -> list[str]:
+    rows: list[str] = []
+    for runtime_name in ("melix", "omlx", "swiftlm"):
+        runtime = runtime_metadata.get(runtime_name)
+        if not isinstance(runtime, dict):
+            continue
+        model = runtime.get("model") or ""
+        revision = runtime.get("revision") or ""
+        version = runtime.get("version") or ""
+        binaries = runtime.get("binaries")
+        if isinstance(binaries, dict) and binaries:
+            for binary_name, binary in sorted(binaries.items()):
+                if not isinstance(binary, dict):
+                    continue
+                rows.append(
+                    "| {runtime}:{binary_name} | `{model}` | `{revision}` | `{version}` | `{build_mode}` | `{sha256}` |".format(
+                        runtime=runtime_name,
+                        binary_name=binary_name,
+                        model=model,
+                        revision=revision,
+                        version=version,
+                        build_mode=binary.get("build_mode") or "unknown",
+                        sha256=binary.get("sha256") or "",
+                    )
+                )
+        else:
+            rows.append(
+                f"| {runtime_name} | `{model}` | `{revision}` | `{version}` | n/a | n/a |"
+            )
+    snapshot = runtime_metadata.get("model_snapshot")
+    if isinstance(snapshot, dict) and snapshot.get("path"):
+        rows.append(f"| model_snapshot | `{snapshot.get('path')}` |  |  | n/a | n/a |")
+    return rows
+
+
 def render_markdown_summary(
     summaries: list[ScenarioSummary],
     hints: list[dict[str, Any]],
@@ -1015,12 +1286,25 @@ def render_markdown_summary(
     metrics_snapshot: dict[str, Any] | None,
     dry_run: bool,
     measurement_profile: dict[str, Any],
+    runtime_metadata: dict[str, Any] | None = None,
+    comparison_validity: dict[str, Any] | None = None,
 ) -> str:
     lines = ["# OMLX And Melix Serving Benchmark Summary", ""]
     lines.append(f"- Dry run: `{str(dry_run).lower()}`")
     lines.append(f"- Measurement profile: `{measurement_profile.get('profile', 'unknown')}`")
+    if comparison_validity is not None:
+        lines.append(f"- Peer comparison status: `{comparison_validity.get('status', 'unknown')}`")
+        for reason in comparison_validity.get("reasons") or []:
+            lines.append(f"- Peer comparison warning: {reason}")
     if measurement_profile.get("operator_note"):
         lines.append(f"- Measurement note: {measurement_profile['operator_note']}")
+    if runtime_metadata:
+        lines.append("")
+        lines.append("## Reproducibility")
+        lines.append("")
+        lines.append("| Runtime | Model | Revision | Version | Binary Build | Binary SHA256 |")
+        lines.append("|---|---|---|---|---|---|")
+        lines.extend(runtime_metadata_markdown_rows(runtime_metadata))
     lines.append("")
     lines.append("## Preflight")
     lines.append("")
@@ -1387,6 +1671,17 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
         swift_text_worker_path=args.melix_swift_text_worker_metrics,
     )
     summaries = summarize_observations(observations)
+    runtime_metadata = runtime_metadata_from_args(args, endpoints=endpoints)
+    token_accounting = token_accounting_metadata(
+        summaries,
+        include_usage_requested=args.include_usage,
+        allow_mixed_token_accounting=args.allow_mixed_token_accounting,
+    )
+    comparison_validity = comparison_validity_metadata(
+        runtime_metadata,
+        comparison_scope=args.comparison_scope,
+        token_accounting=token_accounting,
+    )
     hints = enrich_hints_with_metrics(comparison_hints(summaries), metrics_snapshot)
     warmup_settings = {
         "request_count_per_endpoint": args.warmup_requests,
@@ -1407,6 +1702,9 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
         hints=hints,
         dry_run=args.dry_run,
         measurement_profile=measurement_profile,
+        runtime_metadata=runtime_metadata,
+        comparison_validity=comparison_validity,
+        token_accounting=token_accounting,
     )
     exported_to = None if args.no_export else export_bundle(staging_dir, args.export_dir)
     return {
@@ -1417,6 +1715,7 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
         "scenario_count": len(scenarios),
         "warmup_count": len(warmups),
         "measurement_profile": measurement_profile["profile"],
+        "comparison_validity": comparison_validity,
         "observation_count": len(observations),
         "summary_count": len(summaries),
         "optimization_hint_count": len(hints),
@@ -1437,6 +1736,42 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--model", default="", help="Model id to use for both endpoints.")
     parser.add_argument("--melix-model", default="", help="Melix model id; overrides --model.")
     parser.add_argument("--omlx-model", default="", help="OMLX model id; overrides --model.")
+    parser.add_argument("--melix-revision", default="", help="Melix git revision used for this run.")
+    parser.add_argument("--omlx-revision", default="", help="OMLX git revision used for this run.")
+    parser.add_argument("--swiftlm-revision", default="", help="Optional SwiftLM git revision used for an external peer run.")
+    parser.add_argument("--melix-version", default="", help="Melix build or CLI version used for this run.")
+    parser.add_argument("--omlx-version", default="", help="OMLX package/server version used for this run.")
+    parser.add_argument("--swiftlm-version", default="", help="Optional SwiftLM build or server version used for an external peer run.")
+    parser.add_argument(
+        "--melix-text-worker-binary",
+        type=Path,
+        default=None,
+        help="Melix Swift text-worker binary path; peer reports are invalid when this resolves to a debug build.",
+    )
+    parser.add_argument(
+        "--melix-control-plane-binary",
+        type=Path,
+        default=None,
+        help="Melix Swift control-plane binary path; peer reports are invalid when this resolves to a debug build.",
+    )
+    parser.add_argument(
+        "--swiftlm-binary",
+        type=Path,
+        default=None,
+        help="Optional SwiftLM binary path to hash into the reproducibility manifest.",
+    )
+    parser.add_argument(
+        "--model-snapshot-path",
+        type=Path,
+        default=None,
+        help="Optional local model snapshot path used by the compared servers.",
+    )
+    parser.add_argument(
+        "--comparison-scope",
+        choices=COMPARISON_SCOPES,
+        default="peer",
+        help="Use debug-only to explicitly mark artifacts as unsuitable for peer performance comparison.",
+    )
     parser.add_argument("--melix-header", action="append", default=[], help="Extra Melix header, 'Name: value'.")
     parser.add_argument("--omlx-header", action="append", default=[], help="Extra OMLX header, 'Name: value'.")
     parser.add_argument(
@@ -1482,6 +1817,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--top-p", type=float, default=DEFAULT_TOP_P)
     parser.add_argument("--top-k", type=int, default=DEFAULT_TOP_K)
     parser.add_argument("--include-usage", action="store_true", help="Request streaming usage chunks.")
+    parser.add_argument(
+        "--allow-mixed-token-accounting",
+        action="store_true",
+        help="Keep peer report artifacts when prompt/completion token counts come from mixed usage and estimate sources.",
+    )
     parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
     parser.add_argument("--preflight-timeout-seconds", type=float, default=10.0)
     parser.add_argument(

--- a/scripts/three_way_serving_compare.py
+++ b/scripts/three_way_serving_compare.py
@@ -424,6 +424,8 @@ def run_comparison(args: argparse.Namespace) -> dict[str, Any]:
                 prompt_style=args.prompt_style,
                 include_usage=args.include_usage,
                 temperature=args.temperature,
+                top_p=args.top_p,
+                top_k=args.top_k,
                 timeout_seconds=args.timeout_seconds,
             )
             observations = []
@@ -435,6 +437,8 @@ def run_comparison(args: argparse.Namespace) -> dict[str, Any]:
                             scenario,
                             include_usage=args.include_usage,
                             temperature=args.temperature,
+                            top_p=args.top_p,
+                            top_k=args.top_k,
                             timeout_seconds=args.timeout_seconds,
                         )
                     )
@@ -815,6 +819,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--cache-profile", choices=["cold_unique", "repeated"], default="cold_unique")
     parser.add_argument("--prompt-style", choices=base.PROMPT_STYLES, default="concise")
     parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--top-k", type=int, default=0)
     parser.add_argument("--include-usage", action="store_true")
     parser.add_argument("--timeout-seconds", type=float, default=3600.0)
     parser.add_argument("--preflight-timeout-seconds", type=float, default=10.0)

--- a/tests/test_omlx_melix_compare_benchmark.py
+++ b/tests/test_omlx_melix_compare_benchmark.py
@@ -668,6 +668,12 @@ def test_binary_metadata_detects_release_debug_and_sha256(tmp_path: Path) -> Non
     assert debug["sha256"] == hashlib.sha256(b"debug-binary").hexdigest()
 
 
+def test_detect_swift_build_mode_prefers_innermost_build_directory() -> None:
+    path = Path("/outer/.build/debug/package/services/worker/.build/release/melix-text-worker-swift")
+
+    assert bench.detect_swift_build_mode(path) == "release"
+
+
 def test_binary_metadata_marks_unreadable_binary_without_raising(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -688,6 +694,27 @@ def test_binary_metadata_marks_unreadable_binary_without_raising(
     assert metadata["build_mode"] == "release"
     assert metadata["sha256"] is None
     assert "not readable" in metadata["error"]
+
+
+def test_comparison_validity_uses_binary_error_reason(tmp_path: Path) -> None:
+    missing_binary = tmp_path / ".build/release/missing-text-worker"
+    release_control = tmp_path / "control/.build/release/melix-control-plane"
+    release_control.parent.mkdir(parents=True)
+    release_control.write_bytes(b"release")
+    metadata = {
+        "melix": {
+            "binaries": {
+                "text_worker": bench.binary_metadata(missing_binary),
+                "control_plane": bench.binary_metadata(release_control),
+            },
+        },
+    }
+
+    validity = bench.comparison_validity_metadata(metadata, comparison_scope="peer")
+
+    assert validity["status"] == "invalid"
+    assert "binary error: binary path does not exist or is not a file" in validity["reasons"][0]
+    assert str(missing_binary) in validity["reasons"][0]
 
 
 def test_comparison_validity_rejects_debug_melix_binary(tmp_path: Path) -> None:
@@ -749,6 +776,13 @@ def test_comparison_validity_rejects_unknown_melix_build_mode(tmp_path: Path) ->
 
     assert validity["status"] == "invalid"
     assert "not a release build" in validity["reasons"][0]
+
+
+def test_split_source_summary_skips_non_strings() -> None:
+    assert bench._split_source_summary(["usage,estimate", None, 123, "unknown", "usage"]) == [
+        "estimate",
+        "usage",
+    ]
 
 
 def test_comparison_validity_rejects_mixed_token_accounting_by_default(

--- a/tests/test_omlx_melix_compare_benchmark.py
+++ b/tests/test_omlx_melix_compare_benchmark.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import hashlib
+import io
 import json
 from pathlib import Path
 import sys
+import urllib.error
 
 import pytest
 
@@ -23,6 +26,56 @@ def test_parse_header_values_rejects_malformed_header() -> None:
     }
     with pytest.raises(ValueError, match="Header must use"):
         bench.parse_header_values(["Authorization"])
+    with pytest.raises(ValueError, match="Header name is empty"):
+        bench.parse_header_values([": value"])
+
+
+def test_prompt_text_and_sse_edge_cases() -> None:
+    assert bench.estimate_tokens_from_text("") == 0.0
+    assert bench.estimate_tokens_from_text("abcd") == 1.0
+    concise = bench.build_prompt(
+        32,
+        cache_profile="repeated",
+        request_key="request-1",
+        prompt_style="concise",
+    )
+    assert "MELIX-OMLX-BENCH-REPEATED" in concise
+    assert "Keep the answer concise" in concise
+
+    with pytest.raises(ValueError, match="prompt_token_target"):
+        bench.build_prompt(0, cache_profile="repeated", request_key="r")
+    with pytest.raises(ValueError, match="Unsupported cache profile"):
+        bench.build_prompt(32, cache_profile="unknown", request_key="r")
+    with pytest.raises(ValueError, match="Unsupported prompt style"):
+        bench.build_prompt(32, cache_profile="repeated", request_key="r", prompt_style="unknown")
+
+    assert bench.extract_openai_delta_text({"choices": "not-a-list"}) == ""
+    assert bench.extract_openai_delta_text({"choices": [None]}) == ""
+    assert bench.extract_openai_delta_text({
+        "choices": [{"delta": {"content": [{"text": "hel"}, {"text": "lo"}]}}],
+    }) == "hello"
+    assert bench.extract_openai_delta_text({
+        "choices": [{"message": {"reasoning_content": "think"}}],
+    }) == "think"
+    assert bench.extract_openai_delta_text({"choices": [{"text": "flat"}]}) == "flat"
+
+    content, chunk_count, usage, saw_done = bench.parse_sse_data_lines([
+        b": comment\n",
+        b"\n",
+        b"data: not-json\n",
+        b"data: {\"choices\":[{\"message\":{\"content\":[{\"text\":\"hi\"}]}}]}\n",
+        b"data: [DONE]\n",
+    ])
+    assert content == "hi"
+    assert chunk_count == 1
+    assert usage is None
+    assert saw_done is True
+
+
+def test_decode_json_body_handles_empty_invalid_and_array_payloads() -> None:
+    assert bench._decode_json_body(b"") == {}
+    assert bench._decode_json_body(b"not-json") == {"raw_body": "not-json"}
+    assert bench._decode_json_body(b"[1, 2]") == {"payload": [1, 2]}
 
 
 def test_parse_sse_data_lines_extracts_content_usage_and_done() -> None:
@@ -173,6 +226,111 @@ def test_stream_chat_completion_sends_explicit_sampling_shape(
     assert captured["payload"]["top_k"] == 0
 
 
+def test_stream_chat_completion_reports_http_and_transport_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    endpoint = bench.EndpointConfig(
+        name="melix",
+        base_url="http://127.0.0.1:12434/v1",
+        model="target-model",
+        headers={},
+    )
+    scenario = bench.BenchmarkScenario(
+        scenario_id="pt128-out16-c1-r0",
+        prompt_token_target=128,
+        max_tokens=16,
+        concurrency=1,
+        cache_profile="repeated",
+        repeat_index=0,
+    )
+
+    class FakeHttpError(urllib.error.HTTPError):
+        def read(self):
+            return b'{"error":{"message":"bad"}}'
+
+    def fake_http_error(_request, timeout):
+        raise FakeHttpError(
+            url="http://example.test/v1/chat/completions",
+            code=500,
+            msg="bad",
+            hdrs=None,
+            fp=None,
+        )
+
+    monkeypatch.setattr(bench.urllib.request, "urlopen", fake_http_error)
+    observation = bench.stream_chat_completion(
+        endpoint,
+        scenario,
+        request_index=0,
+        request_key="same",
+        include_usage=True,
+        temperature=0.0,
+        top_p=1.0,
+        top_k=0,
+        timeout_seconds=5.0,
+        group_id="group",
+        group_elapsed_ms=0.0,
+    )
+
+    assert observation.status == "error"
+    assert observation.http_status == 500
+    assert "bad" in observation.error
+
+    monkeypatch.setattr(bench.urllib.request, "urlopen", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
+    observation = bench.stream_chat_completion(
+        endpoint,
+        scenario,
+        request_index=0,
+        request_key="same",
+        include_usage=True,
+        temperature=0.0,
+        top_p=1.0,
+        top_k=0,
+        timeout_seconds=5.0,
+        group_id="group",
+        group_elapsed_ms=0.0,
+    )
+    assert observation.status == "error"
+    assert observation.error == "RuntimeError: boom"
+
+
+def test_stream_chat_completion_marks_empty_stream_as_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def readline(self):
+            return b""
+
+    monkeypatch.setattr(bench.urllib.request, "urlopen", lambda *_args, **_kwargs: FakeResponse())
+    endpoint = bench.EndpointConfig("melix", "http://127.0.0.1:12434/v1", "target-model", {})
+    scenario = bench.BenchmarkScenario("pt128-out16-c1-r0", 128, 16, 1, "repeated", 0)
+
+    observation = bench.stream_chat_completion(
+        endpoint,
+        scenario,
+        request_index=0,
+        request_key="same",
+        include_usage=False,
+        temperature=0.0,
+        top_p=1.0,
+        top_k=0,
+        timeout_seconds=5.0,
+        group_id="group",
+        group_elapsed_ms=0.0,
+    )
+
+    assert observation.status == "error"
+    assert observation.error == "stream completed without text deltas"
+
+
 def test_preflight_requires_target_model_to_be_listed(monkeypatch: pytest.MonkeyPatch) -> None:
     endpoint = bench.EndpointConfig(
         name="melix",
@@ -195,6 +353,65 @@ def test_preflight_requires_target_model_to_be_listed(monkeypatch: pytest.Monkey
     assert result["status_code"] == 200
     assert result["model_listed"] is False
     assert result["ok"] is False
+
+
+def test_request_json_handles_http_error_and_extract_model_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeHttpError(urllib.error.HTTPError):
+        def read(self):
+            return b'{"error":{"message":"missing"}}'
+
+    def fake_urlopen(_request, timeout):
+        raise FakeHttpError(
+            url="http://example.test/v1/models",
+            code=503,
+            msg="unavailable",
+            hdrs=None,
+            fp=None,
+        )
+
+    monkeypatch.setattr(bench.urllib.request, "urlopen", fake_urlopen)
+
+    status, payload = bench.request_json(
+        "http://example.test/v1/models",
+        headers={},
+        timeout_seconds=1.0,
+    )
+
+    assert status == 503
+    assert payload == {"error": {"message": "missing"}}
+    assert bench.extract_model_ids({"data": "not-a-list"}) == []
+    assert bench.extract_model_ids({"data": [{"id": "a"}, {"id": 1}, "x"]}) == ["a"]
+
+
+def test_preflight_wait_returns_when_timeout_expires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    endpoint = bench.EndpointConfig(
+        name="melix",
+        base_url="http://127.0.0.1:12434/v1",
+        model="target-model",
+        headers={},
+    )
+    times = iter([0.0, 0.2, 0.4])
+    monkeypatch.setattr(bench.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(bench.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        bench,
+        "preflight_endpoint",
+        lambda *args, **kwargs: {
+            "endpoint": "melix",
+            "ok": False,
+        },
+    )
+
+    preflight = bench.preflight_endpoints(
+        [endpoint],
+        timeout_seconds=1.0,
+        wait_seconds=0.1,
+        retry_interval_seconds=0.25,
+    )
+
+    assert preflight == [{"endpoint": "melix", "ok": False, "attempt_count": 1, "elapsed_seconds": 0.2}]
 
 
 def test_preflight_wait_retries_until_target_model_is_listed(
@@ -298,6 +515,62 @@ def test_summarize_observations_computes_latency_and_group_throughput() -> None:
     assert summary.prompt_style == "concise"
 
 
+def test_statistics_helpers_cover_empty_and_percentile_edges() -> None:
+    assert bench.median([None]) is None
+    assert bench.percentile([None], 95) is None
+    assert bench.percentile([5.0], 95) == 5.0
+    assert bench.percentile([1.0, 2.0, 3.0], 50) == 2.0
+    assert bench._is_regressed_latency(None, 100.0) is False
+    assert bench._is_regressed_throughput(None, 100.0) is False
+    assert bench._is_regressed_throughput(10.0, 0.0) is False
+
+
+def test_comparison_hints_skip_missing_peer_and_flag_reliability() -> None:
+    melix = bench.ScenarioSummary(
+        endpoint="melix",
+        model="model",
+        prompt_token_target=128,
+        max_tokens=64,
+        concurrency=1,
+        cache_profile="cold_unique",
+        request_count=2,
+        success_count=1,
+        error_count=1,
+        error_rate=0.5,
+        median_ttft_ms=100.0,
+        p95_ttft_ms=100.0,
+        median_total_ms=200.0,
+        p95_total_ms=200.0,
+        median_decode_tokens_per_second=60.0,
+        median_aggregate_output_tokens_per_second=60.0,
+        median_completion_tokens=64.0,
+    )
+    omlx = bench.ScenarioSummary(
+        endpoint="omlx",
+        model="model",
+        prompt_token_target=128,
+        max_tokens=64,
+        concurrency=1,
+        cache_profile="cold_unique",
+        request_count=2,
+        success_count=2,
+        error_count=0,
+        error_rate=0.0,
+        median_ttft_ms=100.0,
+        p95_ttft_ms=100.0,
+        median_total_ms=200.0,
+        p95_total_ms=200.0,
+        median_decode_tokens_per_second=60.0,
+        median_aggregate_output_tokens_per_second=60.0,
+        median_completion_tokens=64.0,
+    )
+
+    assert bench.comparison_hints([melix])[0:0] == []
+    hints = bench.comparison_hints([melix, omlx])
+
+    assert [hint["area"] for hint in hints] == ["reliability"]
+
+
 def test_comparison_hints_flags_melix_regressions() -> None:
     summaries = [
         bench.ScenarioSummary(
@@ -378,6 +651,195 @@ def test_metrics_snapshot_adds_multimodal_batching_hint(tmp_path: Path) -> None:
     assert "cooperative text-only token-step batching" in hints[0]["melix_blocked_reason"]
 
 
+def test_binary_metadata_detects_release_debug_and_sha256(tmp_path: Path) -> None:
+    release_binary = tmp_path / "services/mlx-text-worker-swift/.build/release/melix-text-worker-swift"
+    release_binary.parent.mkdir(parents=True)
+    release_binary.write_bytes(b"release-binary")
+    debug_binary = tmp_path / "services/control-plane-swift/.build/arm64-apple-macosx/debug/melix-control-plane"
+    debug_binary.parent.mkdir(parents=True)
+    debug_binary.write_bytes(b"debug-binary")
+
+    release = bench.binary_metadata(release_binary)
+    debug = bench.binary_metadata(debug_binary)
+
+    assert release["build_mode"] == "release"
+    assert release["sha256"] == hashlib.sha256(b"release-binary").hexdigest()
+    assert debug["build_mode"] == "debug"
+    assert debug["sha256"] == hashlib.sha256(b"debug-binary").hexdigest()
+
+
+def test_binary_metadata_marks_unreadable_binary_without_raising(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release_binary = tmp_path / ".build/release/melix-text-worker-swift"
+    release_binary.parent.mkdir(parents=True)
+    release_binary.write_bytes(b"release")
+    monkeypatch.setattr(
+        bench,
+        "file_sha256",
+        lambda _path: (_ for _ in ()).throw(PermissionError("denied")),
+    )
+
+    metadata = bench.binary_metadata(release_binary)
+
+    assert metadata["provided"] is True
+    assert metadata["exists"] is False
+    assert metadata["build_mode"] == "release"
+    assert metadata["sha256"] is None
+    assert "not readable" in metadata["error"]
+
+
+def test_comparison_validity_rejects_debug_melix_binary(tmp_path: Path) -> None:
+    debug_binary = tmp_path / ".build/debug/melix-text-worker-swift"
+    debug_binary.parent.mkdir(parents=True)
+    debug_binary.write_bytes(b"debug")
+    release_control = tmp_path / "control/.build/release/melix-control-plane"
+    release_control.parent.mkdir(parents=True)
+    release_control.write_bytes(b"release")
+    metadata = {
+        "melix": {
+            "binaries": {
+                "text_worker": bench.binary_metadata(debug_binary),
+                "control_plane": bench.binary_metadata(release_control),
+            },
+        },
+    }
+
+    validity = bench.comparison_validity_metadata(metadata, comparison_scope="peer")
+
+    assert validity["status"] == "invalid"
+    assert validity["peer_comparison_valid"] is False
+    assert "debug build path" in validity["reasons"][0]
+
+
+def test_comparison_validity_rejects_missing_melix_binary_metadata() -> None:
+    metadata = {
+        "melix": {
+            "binaries": {
+                "text_worker": bench.binary_metadata(None),
+                "control_plane": bench.binary_metadata(None),
+            },
+        },
+    }
+
+    validity = bench.comparison_validity_metadata(metadata, comparison_scope="peer")
+
+    assert validity["status"] == "invalid"
+    assert validity["peer_comparison_valid"] is False
+    assert "binary metadata was not provided" in validity["reasons"][0]
+
+
+def test_comparison_validity_rejects_unknown_melix_build_mode(tmp_path: Path) -> None:
+    binary = tmp_path / "melix-text-worker-swift"
+    binary.write_bytes(b"binary")
+    release_control = tmp_path / "control/.build/release/melix-control-plane"
+    release_control.parent.mkdir(parents=True)
+    release_control.write_bytes(b"release")
+    metadata = {
+        "melix": {
+            "binaries": {
+                "text_worker": bench.binary_metadata(binary),
+                "control_plane": bench.binary_metadata(release_control),
+            },
+        },
+    }
+
+    validity = bench.comparison_validity_metadata(metadata, comparison_scope="peer")
+
+    assert validity["status"] == "invalid"
+    assert "not a release build" in validity["reasons"][0]
+
+
+def test_comparison_validity_rejects_mixed_token_accounting_by_default(
+    tmp_path: Path,
+) -> None:
+    release_binary = tmp_path / ".build/release/melix-text-worker-swift"
+    release_binary.parent.mkdir(parents=True)
+    release_binary.write_bytes(b"release")
+    release_control = tmp_path / "control/.build/release/melix-control-plane"
+    release_control.parent.mkdir(parents=True)
+    release_control.write_bytes(b"release")
+    metadata = {
+        "melix": {
+            "binaries": {
+                "text_worker": bench.binary_metadata(release_binary),
+                "control_plane": bench.binary_metadata(release_control),
+            },
+        },
+    }
+    token_accounting = {
+        "mixed_prompt_token_sources": True,
+        "mixed_completion_token_sources": False,
+        "allow_mixed_token_accounting": False,
+    }
+
+    validity = bench.comparison_validity_metadata(
+        metadata,
+        comparison_scope="peer",
+        token_accounting=token_accounting,
+    )
+
+    assert validity["status"] == "invalid"
+    assert "Prompt token accounting used mixed sources" in validity["reasons"][0]
+
+
+def test_comparison_validity_allows_explicit_mixed_token_accounting(
+    tmp_path: Path,
+) -> None:
+    release_binary = tmp_path / ".build/release/melix-text-worker-swift"
+    release_binary.parent.mkdir(parents=True)
+    release_binary.write_bytes(b"release")
+    release_control = tmp_path / "control/.build/release/melix-control-plane"
+    release_control.parent.mkdir(parents=True)
+    release_control.write_bytes(b"release")
+    metadata = {
+        "melix": {
+            "binaries": {
+                "text_worker": bench.binary_metadata(release_binary),
+                "control_plane": bench.binary_metadata(release_control),
+            },
+        },
+    }
+    token_accounting = {
+        "mixed_prompt_token_sources": True,
+        "mixed_completion_token_sources": True,
+        "allow_mixed_token_accounting": True,
+    }
+
+    validity = bench.comparison_validity_metadata(
+        metadata,
+        comparison_scope="peer",
+        token_accounting=token_accounting,
+    )
+
+    assert validity["status"] == "valid"
+    assert validity["warnings"] == ["Mixed token accounting was explicitly allowed for this run."]
+
+
+def test_comparison_validity_marks_debug_only_scope(tmp_path: Path) -> None:
+    release_binary = tmp_path / ".build/release/melix-text-worker-swift"
+    release_binary.parent.mkdir(parents=True)
+    release_binary.write_bytes(b"release")
+    release_control = tmp_path / "control/.build/release/melix-control-plane"
+    release_control.parent.mkdir(parents=True)
+    release_control.write_bytes(b"release")
+    metadata = {
+        "melix": {
+            "binaries": {
+                "text_worker": bench.binary_metadata(release_binary),
+                "control_plane": bench.binary_metadata(release_control),
+            },
+        },
+    }
+
+    validity = bench.comparison_validity_metadata(metadata, comparison_scope="debug-only")
+
+    assert validity["status"] == "debug_only"
+    assert validity["peer_comparison_valid"] is False
+    assert "debug-only" in validity["reasons"][0]
+
+
 def test_melix_metrics_snapshot_merges_control_plane_and_swift_worker(tmp_path: Path) -> None:
     control_plane_path = tmp_path / "control-plane-metrics.json"
     swift_worker_path = tmp_path / "swift-text-worker-metrics.json"
@@ -425,6 +887,35 @@ def test_melix_metrics_snapshot_merges_control_plane_and_swift_worker(tmp_path: 
     assert snapshot["values"]["control_plane.text_first_load_ms"] == 8547.46
     assert snapshot["values"]["swift_text.prefill_ms"] == 3706
     assert snapshot["values"]["swift_text.decode_tokens_per_second"] == 2
+
+
+def test_metrics_snapshot_handles_missing_invalid_and_bad_sources(tmp_path: Path) -> None:
+    assert bench.load_metrics_snapshot(None) is None
+    missing_path = tmp_path / "missing.json"
+    missing = bench.load_metrics_snapshot(missing_path)
+    assert missing["ok"] is False
+    assert "FileNotFoundError" in missing["error"]
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("not-json", encoding="utf-8")
+    assert bench.load_metrics_snapshot(invalid)["ok"] is False
+    non_object = tmp_path / "array.json"
+    non_object.write_text("[]", encoding="utf-8")
+    assert bench.load_metrics_snapshot(non_object)["error"] == "metrics snapshot must be a JSON object"
+    missing_values = tmp_path / "missing-values.json"
+    missing_values.write_text("{}", encoding="utf-8")
+    assert bench.load_metrics_snapshot(missing_values)["error"] == "metrics snapshot is missing a values object"
+
+    snapshot = bench.load_melix_metrics_snapshot(
+        control_plane_path=missing_path,
+        swift_text_worker_path=None,
+    )
+    assert snapshot["ok"] is False
+    assert "control_plane" in snapshot["error"]
+    assert bench.load_melix_metrics_snapshot(control_plane_path=None, swift_text_worker_path=None) is None
+
+    assert bench.enrich_hints_with_metrics([{"area": "existing"}], None) == [{"area": "existing"}]
+    assert bench.enrich_hints_with_metrics([], {"ok": True, "values": []}) == []
+    assert bench.metrics_manifest_entries(None, artifact_name="metrics.json") == {}
 
 
 def test_markdown_summary_lists_text_batch_generator_metrics() -> None:
@@ -605,6 +1096,23 @@ def test_warmup_requests_mark_measurements_as_warm(tmp_path: Path, monkeypatch: 
     assert result["measurement_profile"] == "warm"
     assert manifest["measurement_profile"]["profile"] == "warm"
     assert summary["measurement_profile"]["warmup_requests_per_endpoint"] == 1
+    assert manifest["scenario_settings"] == {
+        "cache_profiles": ["cold_unique"],
+        "concurrency": [1],
+        "max_tokens": [128],
+        "prompt_style": "concise",
+        "prompt_styles": ["concise"],
+        "prompt_token_targets": [1024],
+        "repeat_count": 1,
+    }
+    assert manifest["token_accounting"] == {
+        "allow_mixed_token_accounting": False,
+        "include_usage_requested": False,
+        "mixed_completion_token_sources": False,
+        "mixed_prompt_token_sources": False,
+        "observed_completion_token_sources": ["usage"],
+        "observed_prompt_token_sources": ["usage"],
+    }
     assert manifest["metrics"]["melix"]["artifact"] == "melix-metrics.json"
     assert manifest["metrics"]["melix_control_plane"]["path"] == str(control_plane_path)
     assert manifest["metrics"]["melix_control_plane"]["artifact"] == "melix-metrics.json"
@@ -684,6 +1192,42 @@ def test_markdown_summary_lists_token_count_sources() -> None:
     assert "| omlx | 1024 | concise | estimated_chars | usage | 16 | 1 | 0 |" in markdown
 
 
+def test_runtime_metadata_markdown_rows_include_non_binary_runtime_and_snapshot() -> None:
+    rows = bench.runtime_metadata_markdown_rows({
+        "melix": {
+            "model": "melix-model",
+            "revision": "sha",
+            "version": "dev",
+            "binaries": {
+                "weird": "not-a-dict",
+            },
+        },
+        "omlx": {
+            "model": "omlx-model",
+            "revision": "omlx-sha",
+            "version": "0.3.12",
+        },
+        "swiftlm": {
+            "model": "",
+            "revision": "swift-sha",
+            "version": "",
+            "binaries": {
+                "server": {
+                    "build_mode": "release",
+                    "sha256": "abc",
+                },
+            },
+        },
+        "model_snapshot": {
+            "path": "/tmp/snapshot",
+        },
+    })
+
+    assert "| omlx | `omlx-model` | `omlx-sha` | `0.3.12` | n/a | n/a |" in rows
+    assert "| swiftlm:server | `` | `swift-sha` | `` | `release` | `abc` |" in rows
+    assert "| model_snapshot | `/tmp/snapshot` |  |  | n/a | n/a |" in rows
+
+
 def test_dry_run_writes_artifacts_without_export(tmp_path: Path) -> None:
     args = bench.build_arg_parser().parse_args(
         [
@@ -711,6 +1255,127 @@ def test_dry_run_writes_artifacts_without_export(tmp_path: Path) -> None:
     assert manifest["scenario_count"] == 3
     assert manifest["warmup_count"] == 0
     assert "warmups" not in manifest["artifacts"]
+
+
+def test_dry_run_manifest_records_runtime_metadata_and_invalid_debug_binary(
+    tmp_path: Path,
+) -> None:
+    debug_text_worker = tmp_path / "services/mlx-text-worker-swift/.build/debug/melix-text-worker-swift"
+    debug_text_worker.parent.mkdir(parents=True)
+    debug_text_worker.write_bytes(b"debug-text-worker")
+    release_control_plane = tmp_path / "services/control-plane-swift/.build/release/melix-control-plane"
+    release_control_plane.parent.mkdir(parents=True)
+    release_control_plane.write_bytes(b"release-control-plane")
+    args = bench.build_arg_parser().parse_args(
+        [
+            "--model",
+            "shared-model",
+            "--melix-model",
+            "melix-dev-text",
+            "--omlx-model",
+            "gemma-4-E4B-it-MLX-8bit",
+            "--run-id",
+            "metadata-run",
+            "--staging-root",
+            str(tmp_path),
+            "--no-export",
+            "--dry-run",
+            "--melix-revision",
+            "melix-sha",
+            "--omlx-revision",
+            "omlx-sha",
+            "--omlx-version",
+            "0.3.12",
+            "--melix-text-worker-binary",
+            str(debug_text_worker),
+            "--melix-control-plane-binary",
+            str(release_control_plane),
+            "--model-snapshot-path",
+            "/tmp/models--unsloth--gemma-4-E4B-it-MLX-8bit/snapshots/abc",
+        ]
+    )
+    bench.validate_args(args)
+
+    result = bench.run_benchmark(args)
+
+    staging_dir = tmp_path / "metadata-run"
+    manifest = json.loads((staging_dir / "manifest.json").read_text(encoding="utf-8"))
+    summary = json.loads((staging_dir / "summary.json").read_text(encoding="utf-8"))
+    markdown = (staging_dir / "summary.md").read_text(encoding="utf-8")
+
+    assert result["comparison_validity"]["status"] == "invalid"
+    assert manifest["comparison_validity"]["peer_comparison_valid"] is False
+    assert manifest["runtime_metadata"]["melix"]["revision"] == "melix-sha"
+    assert manifest["runtime_metadata"]["omlx"]["revision"] == "omlx-sha"
+    assert manifest["runtime_metadata"]["omlx"]["version"] == "0.3.12"
+    assert manifest["runtime_metadata"]["melix"]["binaries"]["text_worker"]["build_mode"] == "debug"
+    assert manifest["runtime_metadata"]["melix"]["binaries"]["text_worker"]["sha256"] == hashlib.sha256(
+        b"debug-text-worker"
+    ).hexdigest()
+    assert manifest["runtime_metadata"]["melix"]["binaries"]["control_plane"]["build_mode"] == "release"
+    assert summary["comparison_validity"]["status"] == "invalid"
+    assert "- Peer comparison status: `invalid`" in markdown
+    assert "Melix text_worker binary uses a debug build path" in markdown
+
+
+def test_dry_run_manifest_records_release_binary_as_peer_valid(tmp_path: Path) -> None:
+    release_text_worker = tmp_path / "services/mlx-text-worker-swift/.build/release/melix-text-worker-swift"
+    release_text_worker.parent.mkdir(parents=True)
+    release_text_worker.write_bytes(b"release-text-worker")
+    release_control_plane = tmp_path / "services/control-plane-swift/.build/release/melix-control-plane"
+    release_control_plane.parent.mkdir(parents=True)
+    release_control_plane.write_bytes(b"release-control-plane")
+    args = bench.build_arg_parser().parse_args(
+        [
+            "--model",
+            "shared-model",
+            "--run-id",
+            "release-metadata-run",
+            "--staging-root",
+            str(tmp_path),
+            "--no-export",
+            "--dry-run",
+            "--melix-text-worker-binary",
+            str(release_text_worker),
+            "--melix-control-plane-binary",
+            str(release_control_plane),
+        ]
+    )
+    bench.validate_args(args)
+
+    bench.run_benchmark(args)
+
+    manifest = json.loads((tmp_path / "release-metadata-run" / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["comparison_validity"]["status"] == "valid"
+    assert manifest["comparison_validity"]["peer_comparison_valid"] is True
+    assert manifest["runtime_metadata"]["melix"]["binaries"]["text_worker"]["build_mode"] == "release"
+    assert manifest["runtime_metadata"]["melix"]["binaries"]["control_plane"]["build_mode"] == "release"
+
+
+def test_export_bundle_uses_suffix_when_destination_exists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    (staging / "manifest.json").write_text("{}", encoding="utf-8")
+    export_dir = tmp_path / "exports"
+    existing = export_dir / "staging"
+    existing.mkdir(parents=True)
+
+    class FakeDateTime:
+        @staticmethod
+        def now(_timezone):
+            class FakeNow:
+                def strftime(self, _fmt):
+                    return "123456"
+
+            return FakeNow()
+
+    monkeypatch.setattr(bench, "datetime", FakeDateTime)
+
+    destination = bench.export_bundle(staging, export_dir)
+
+    assert destination == export_dir / "staging-123456"
+    assert (destination / "manifest.json").read_text(encoding="utf-8") == "{}"
+    assert bench.export_bundle(staging, None) is None
 
 
 def test_warmups_are_written_separately_from_summaries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -806,7 +1471,15 @@ def test_warmups_are_written_separately_from_summaries(tmp_path: Path, monkeypat
         "prompt_token_target": 128,
         "request_count_per_endpoint": 1,
     }
-    assert manifest["scenario_settings"] == {"prompt_style": "concise"}
+    assert manifest["scenario_settings"] == {
+        "cache_profiles": ["cold_unique"],
+        "concurrency": [1],
+        "max_tokens": [128],
+        "prompt_style": "concise",
+        "prompt_styles": ["concise"],
+        "prompt_token_targets": [1024],
+        "repeat_count": 1,
+    }
     assert manifest["artifacts"]["warmups"] == "warmups.jsonl"
     assert len(warmups) == 2
     assert len(observations) == 2
@@ -910,6 +1583,91 @@ def test_alternate_endpoint_order_reverses_odd_repeats(
     ]
 
 
+def test_preflight_only_skips_warmup_and_measurement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    endpoint_results = {
+        "melix": {
+            "endpoint": "melix",
+            "base_url": "http://127.0.0.1:12434/v1",
+            "status_code": 200,
+            "ok": True,
+            "model": "local-model",
+            "model_listed": True,
+            "model_count": 1,
+            "models": ["local-model"],
+            "error": None,
+        },
+        "omlx": {
+            "endpoint": "omlx",
+            "base_url": "http://127.0.0.1:8000/v1",
+            "status_code": 200,
+            "ok": True,
+            "model": "local-model",
+            "model_listed": True,
+            "model_count": 1,
+            "models": ["local-model"],
+            "error": None,
+        },
+    }
+    monkeypatch.setattr(
+        bench,
+        "preflight_endpoint",
+        lambda endpoint, *, timeout_seconds: endpoint_results[endpoint.name],
+    )
+    monkeypatch.setattr(
+        bench,
+        "run_group",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("run_group should not run")),
+    )
+    args = bench.build_arg_parser().parse_args([
+        "--model",
+        "local-model",
+        "--preflight-only",
+        "--run-id",
+        "preflight-only",
+        "--staging-root",
+        str(tmp_path),
+        "--no-export",
+    ])
+    bench.validate_args(args)
+
+    result = bench.run_benchmark(args)
+
+    assert result["observation_count"] == 0
+    assert result["warmup_count"] == 0
+    assert result["preflight"][0]["ok"] is True
+
+
+def test_run_benchmark_blocks_failed_preflight_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        bench,
+        "preflight_endpoint",
+        lambda endpoint, *, timeout_seconds: {
+            "endpoint": endpoint.name,
+            "ok": endpoint.name != "melix",
+            "model": endpoint.model,
+        },
+    )
+    args = bench.build_arg_parser().parse_args([
+        "--model",
+        "local-model",
+        "--run-id",
+        "failed-preflight",
+        "--staging-root",
+        str(tmp_path),
+        "--no-export",
+    ])
+    bench.validate_args(args)
+
+    with pytest.raises(RuntimeError, match="Endpoint preflight failed"):
+        bench.run_benchmark(args)
+
+
 def test_validate_args_rejects_invalid_warmup_values() -> None:
     args = bench.build_arg_parser().parse_args(["--model", "m", "--warmup-requests", "-1"])
     with pytest.raises(ValueError, match="--warmup-requests"):
@@ -937,3 +1695,49 @@ def test_validate_args_rejects_invalid_preflight_wait_values() -> None:
     ])
     with pytest.raises(ValueError, match="--preflight-retry-interval-seconds"):
         bench.validate_args(args)
+
+
+def test_validate_args_rejects_core_invalid_values() -> None:
+    cases = [
+        (["--model", "m", "--repeats", "0"], "--repeats"),
+        (["--model", "m", "--max-tokens", "0"], "--max-tokens"),
+        (["--model", "m", "--prompt-token-targets", "0"], "--prompt-token-targets"),
+        (["--model", "m", "--concurrency", "0"], "--concurrency"),
+        (["--model", "m", "--timeout-seconds", "0"], "Timeout values"),
+        (["--model", "m", "--preflight-timeout-seconds", "0"], "Timeout values"),
+    ]
+    for argv, expected in cases:
+        args = bench.build_arg_parser().parse_args(argv)
+        with pytest.raises(ValueError, match=expected):
+            bench.validate_args(args)
+
+
+def test_main_prints_json_text_and_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        bench,
+        "run_benchmark",
+        lambda args: {
+            "run_id": "run",
+            "staging_dir": str(tmp_path / "run"),
+            "exported_to": str(tmp_path / "exported"),
+            "scenario_count": 1,
+            "observation_count": 2,
+            "optimization_hint_count": 3,
+        },
+    )
+
+    assert bench.main(["--model", "m", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out)["run_id"] == "run"
+
+    assert bench.main(["--model", "m"]) == 0
+    text = capsys.readouterr().out
+    assert "Run id: run" in text
+    assert "Exported to:" in text
+
+    monkeypatch.setattr(bench, "run_benchmark", lambda args: (_ for _ in ()).throw(RuntimeError("bad")))
+    assert bench.main(["--model", "m"]) == 2
+    assert "error: bad" in capsys.readouterr().err

--- a/tests/test_three_way_serving_compare.py
+++ b/tests/test_three_way_serving_compare.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import io
 import importlib.util
 import json
 from pathlib import Path
 import sys
+import urllib.error
 
 import pytest
 
@@ -37,6 +39,19 @@ def test_parse_endpoint_spec_rejects_invalid_names() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("spec", "message"),
+    [
+        ("swiftlm-http://127.0.0.1:18062/v1::model", "format"),
+        ("swiftlm=::model", "base URL"),
+        ("swiftlm=http://127.0.0.1:18062/v1::", "model is empty"),
+    ],
+)
+def test_parse_endpoint_spec_rejects_malformed_specs(spec: str, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        three_way.parse_endpoint_spec(spec, headers={})
+
+
 def test_parse_endpoint_headers_are_grouped_by_endpoint() -> None:
     grouped = three_way.parse_endpoint_headers([
         "melix=Authorization: Bearer local",
@@ -49,10 +64,113 @@ def test_parse_endpoint_headers_are_grouped_by_endpoint() -> None:
     }
 
 
+def test_parse_endpoint_headers_rejects_missing_endpoint_name() -> None:
+    with pytest.raises(ValueError, match="format"):
+        three_way.parse_endpoint_headers(["Authorization: Bearer local"])
+
+
 def test_runtime_base_url_strips_openai_v1_prefix() -> None:
     assert three_way.runtime_base_url("http://127.0.0.1:12441/v1") == "http://127.0.0.1:12441"
     assert three_way.runtime_base_url("http://127.0.0.1:12441/custom/v1/") == "http://127.0.0.1:12441/custom"
     assert three_way.runtime_base_url("http://127.0.0.1:12441") == "http://127.0.0.1:12441"
+
+
+def test_request_optional_json_captures_success_http_error_and_url_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self) -> "FakeResponse":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b'{"status":"ok"}'
+
+    monkeypatch.setattr(three_way.urllib.request, "urlopen", lambda *_args, **_kwargs: FakeResponse())
+    assert three_way.request_optional_json(
+        "http://127.0.0.1:12441",
+        "/health",
+        headers={},
+        timeout_seconds=1,
+    ) == {
+        "ok": True,
+        "payload": {"status": "ok"},
+        "status_code": 200,
+        "url": "http://127.0.0.1:12441/health",
+    }
+
+    def raise_http_error(*_args: object, **_kwargs: object) -> None:
+        raise urllib.error.HTTPError(
+            "http://127.0.0.1:12441/metrics",
+            404,
+            "not found",
+            hdrs=None,
+            fp=io.BytesIO(b'{"error":"missing"}'),
+        )
+
+    monkeypatch.setattr(three_way.urllib.request, "urlopen", raise_http_error)
+    http_error = three_way.request_optional_json(
+        "http://127.0.0.1:12441",
+        "/metrics",
+        headers={},
+        timeout_seconds=1,
+    )
+    assert http_error["ok"] is False
+    assert http_error["status_code"] == 404
+    assert http_error["payload"] == {"error": "missing"}
+
+    monkeypatch.setattr(
+        three_way.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(urllib.error.URLError("offline")),
+    )
+    url_error = three_way.request_optional_json(
+        "http://127.0.0.1:12441",
+        "/health",
+        headers={},
+        timeout_seconds=1,
+    )
+    assert url_error["ok"] is False
+    assert url_error["status_code"] == 0
+    assert "URLError" in url_error["error"]
+
+
+def test_capture_runtime_snapshots_uses_runtime_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def fake_request_optional_json(
+        base_url: str,
+        path: str,
+        *,
+        headers: dict[str, str],
+        timeout_seconds: float,
+    ) -> dict[str, object]:
+        calls.append((base_url, path))
+        return {"ok": True, "status_code": 200, "payload": {"path": path}}
+
+    monkeypatch.setattr(three_way, "request_optional_json", fake_request_optional_json)
+
+    snapshots = three_way.capture_runtime_snapshots(
+        [
+            three_way.base.EndpointConfig(
+                name="melix",
+                base_url="http://127.0.0.1:12441/custom/v1",
+                model="model",
+                headers={"X-Test": "1"},
+            )
+        ],
+        timeout_seconds=3,
+    )
+
+    assert calls == [
+        ("http://127.0.0.1:12441/custom", "/health"),
+        ("http://127.0.0.1:12441/custom", "/metrics"),
+    ]
+    assert snapshots["melix"]["service_root_url"] == "http://127.0.0.1:12441/custom"
 
 
 def test_prompt_token_evidence_records_actual_token_range() -> None:
@@ -211,6 +329,82 @@ def test_peer_comparisons_identify_best_peer_and_melix_gaps() -> None:
     assert all(hint["best_peer"] == "swiftlm" for hint in hints)
 
 
+def test_peer_comparisons_records_target_errors_and_missing_target() -> None:
+    summaries = [
+        three_way.base.ScenarioSummary(
+            endpoint="melix",
+            model="model",
+            prompt_token_target=512,
+            max_tokens=16,
+            concurrency=1,
+            cache_profile="cold_unique",
+            request_count=1,
+            success_count=0,
+            error_count=1,
+            error_rate=1.0,
+            median_ttft_ms=None,
+            p95_ttft_ms=None,
+            median_total_ms=None,
+            p95_total_ms=None,
+            median_decode_tokens_per_second=None,
+            median_aggregate_output_tokens_per_second=None,
+            median_completion_tokens=None,
+        ),
+        three_way.base.ScenarioSummary(
+            endpoint="omlx",
+            model="model",
+            prompt_token_target=512,
+            max_tokens=16,
+            concurrency=1,
+            cache_profile="cold_unique",
+            request_count=1,
+            success_count=1,
+            error_count=0,
+            error_rate=0.0,
+            median_ttft_ms=10.0,
+            p95_ttft_ms=10.0,
+            median_total_ms=20.0,
+            p95_total_ms=20.0,
+            median_decode_tokens_per_second=30.0,
+            median_aggregate_output_tokens_per_second=20.0,
+            median_completion_tokens=16.0,
+        ),
+    ]
+
+    comparisons, hints = three_way.peer_comparisons(summaries, target_endpoint="melix")
+    missing_target_comparisons, missing_target_hints = three_way.peer_comparisons(
+        summaries,
+        target_endpoint="swiftlm",
+    )
+
+    assert comparisons[0]["winners"]["median_ttft_ms"] == "omlx"
+    assert hints == [
+        {
+            "scenario": {
+                "prompt_token_target": 512,
+                "max_tokens": 16,
+                "concurrency": 1,
+                "cache_profile": "cold_unique",
+                "prompt_style": "concise",
+            },
+            "area": "reliability",
+            "severity": "high",
+            "message": "melix returned errors in this scenario.",
+            "target_error_count": 1,
+        }
+    ]
+    assert missing_target_comparisons == []
+    assert missing_target_hints == []
+
+
+def test_gap_helpers_ignore_missing_and_zero_values() -> None:
+    assert three_way._latency_gap(None, 10.0) is False
+    assert three_way._latency_gap(20.0, None) is False
+    assert three_way._throughput_gap(None, 10.0) is False
+    assert three_way._throughput_gap(5.0, None) is False
+    assert three_way._throughput_gap(5.0, 0.0) is False
+
+
 def test_dry_run_writes_three_way_artifacts(tmp_path: Path) -> None:
     args = three_way.build_arg_parser().parse_args(
         [
@@ -247,6 +441,104 @@ def test_dry_run_writes_three_way_artifacts(tmp_path: Path) -> None:
     assert manifest["scenario_count"] == 3
 
 
+def test_preflight_only_captures_runtime_snapshots_without_requests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_preflight(
+        endpoints: list[three_way.base.EndpointConfig],
+        *,
+        timeout_seconds: float,
+        wait_seconds: float,
+        retry_interval_seconds: float,
+    ) -> list[dict[str, object]]:
+        return [
+            {
+                "endpoint": endpoint.name,
+                "base_url": endpoint.base_url,
+                "status_code": 200,
+                "ok": True,
+                "model": endpoint.model,
+                "model_listed": True,
+                "model_count": 1,
+                "models": [endpoint.model],
+                "error": None,
+            }
+            for endpoint in endpoints
+        ]
+
+    monkeypatch.setattr(three_way.base, "preflight_endpoints", fake_preflight)
+    monkeypatch.setattr(
+        three_way,
+        "capture_runtime_snapshots",
+        lambda endpoints, *, timeout_seconds: {
+            endpoint.name: {"health": {"status_code": 200}, "metrics": {"status_code": 404}}
+            for endpoint in endpoints
+        },
+    )
+    args = three_way.build_arg_parser().parse_args(
+        [
+            "--endpoint",
+            "melix=http://127.0.0.1:12441/v1::model",
+            "--endpoint",
+            "swiftlm=http://127.0.0.1:18062/v1::model",
+            "--preflight-only",
+            "--run-id",
+            "three-way-preflight",
+            "--staging-root",
+            str(tmp_path),
+            "--no-export",
+        ]
+    )
+
+    result = three_way.run_comparison(args)
+
+    runtime_snapshots = json.loads(
+        (tmp_path / "three-way-preflight" / "runtime-snapshots.json").read_text(encoding="utf-8")
+    )
+    assert result["observation_count"] == 0
+    assert runtime_snapshots["melix"]["health"]["status_code"] == 200
+
+
+def test_preflight_failure_requires_explicit_allowance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        three_way.base,
+        "preflight_endpoints",
+        lambda *_args, **_kwargs: [
+            {
+                "endpoint": "melix",
+                "status_code": 200,
+                "ok": False,
+                "model": "model",
+                "model_listed": False,
+                "model_count": 0,
+                "models": [],
+                "error": None,
+            }
+        ],
+    )
+    monkeypatch.setattr(three_way, "capture_runtime_snapshots", lambda *_args, **_kwargs: {})
+    args = three_way.build_arg_parser().parse_args(
+        [
+            "--endpoint",
+            "melix=http://127.0.0.1:12441/v1::model",
+            "--endpoint",
+            "omlx=http://127.0.0.1:18061/v1::model",
+            "--run-id",
+            "three-way-failed-preflight",
+            "--staging-root",
+            str(tmp_path),
+            "--no-export",
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="Endpoint preflight failed"):
+        three_way.run_comparison(args)
+
+
 def test_warmup_requests_mark_three_way_measurements_as_warm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_preflight(endpoint: three_way.base.EndpointConfig, *, timeout_seconds: float) -> dict[str, object]:
         return {
@@ -267,8 +559,13 @@ def test_warmup_requests_mark_three_way_measurements_as_warm(tmp_path: Path, mon
         *,
         include_usage: bool,
         temperature: float,
+        top_p: float,
+        top_k: int,
         timeout_seconds: float,
+        run_key: str = "",
     ) -> list[three_way.base.RequestObservation]:
+        assert top_p == 1.0
+        assert top_k == 0
         return [
             three_way.base.RequestObservation(
                 endpoint=endpoint.name,
@@ -364,8 +661,13 @@ def test_three_way_run_writes_merged_melix_metrics_snapshot(
         *,
         include_usage: bool,
         temperature: float,
+        top_p: float,
+        top_k: int,
         timeout_seconds: float,
+        run_key: str = "",
     ) -> list[three_way.base.RequestObservation]:
+        assert top_p == 1.0
+        assert top_k == 0
         return [
             three_way.base.RequestObservation(
                 endpoint=endpoint.name,
@@ -528,3 +830,244 @@ def test_three_way_markdown_lists_token_count_sources() -> None:
     assert "Prompt Source" in markdown
     assert "Completion Source" in markdown
     assert "| swiftlm | 1024 | concise | usage | estimated_chars | 16 | 1 | 0 |" in markdown
+
+
+def test_markdown_empty_sections_and_missing_metrics_are_explicit() -> None:
+    markdown = three_way.render_markdown_summary(
+        [],
+        [],
+        [],
+        preflight=[],
+        runtime_snapshots={},
+        prompt_evidence=[],
+        warmups=[],
+        metrics_snapshot={"ok": False, "error": "missing metrics"},
+        dry_run=True,
+        target_endpoint="melix",
+        measurement_profile={
+            "profile": "mixed",
+            "warmup_requests_per_endpoint": 0,
+            "operator_note": "",
+        },
+    )
+
+    assert "No prompt token evidence was collected." in markdown
+    assert "No peer comparison rows were generated." in markdown
+    assert "No runtime snapshots were captured." in markdown
+    assert "Metrics snapshot unavailable: `missing metrics`" in markdown
+    assert "No target endpoint bottleneck hints were generated." in markdown
+
+
+def test_export_bundle_uses_timestamp_suffix_when_destination_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    staging_dir = tmp_path / "run"
+    staging_dir.mkdir()
+    (staging_dir / "summary.md").write_text("# Summary\n", encoding="utf-8")
+    export_dir = tmp_path / "exports"
+    (export_dir / "run").mkdir(parents=True)
+
+    class FakeDateTime:
+        @staticmethod
+        def now(_timezone: object) -> object:
+            class FakeNow:
+                def strftime(self, _format: str) -> str:
+                    return "123456"
+
+            return FakeNow()
+
+    monkeypatch.setattr(three_way, "datetime", FakeDateTime)
+
+    destination = three_way.export_bundle(staging_dir, export_dir)
+
+    assert destination == export_dir / "run-123456"
+    assert (destination / "summary.md").read_text(encoding="utf-8") == "# Summary\n"
+
+
+def test_export_bundle_returns_none_when_disabled(tmp_path: Path) -> None:
+    assert three_way.export_bundle(tmp_path, None) is None
+
+
+@pytest.mark.parametrize(
+    ("argv", "message"),
+    [
+        ([], "Pass at least two"),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "melix=http://127.0.0.1:12442/v1::model",
+            ],
+            "unique",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
+                "--target-endpoint",
+                "swiftlm",
+            ],
+            "target-endpoint",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
+                "--repeats",
+                "0",
+            ],
+            "repeats",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
+                "--max-tokens",
+                "0",
+            ],
+            "max-tokens",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
+                "--warmup-requests",
+                "-1",
+            ],
+            "warmup-requests",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
+                "--warmup-prompt-token-target",
+                "0",
+            ],
+            "warmup-prompt-token-target",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
+                "--warmup-max-tokens",
+                "0",
+            ],
+            "warmup-max-tokens",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
+                "--prompt-token-targets",
+                "0",
+            ],
+            "prompt-token-targets",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
+                "--concurrency",
+                "0",
+            ],
+            "concurrency",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
+                "--timeout-seconds",
+                "0",
+            ],
+            "Timeout",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
+                "--preflight-wait-seconds",
+                "-1",
+            ],
+            "preflight-wait",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
+                "--preflight-retry-interval-seconds",
+                "0",
+            ],
+            "preflight-retry",
+        ),
+    ],
+)
+def test_validate_args_rejects_invalid_inputs(argv: list[str], message: str) -> None:
+    args = three_way.build_arg_parser().parse_args(argv)
+    with pytest.raises(ValueError, match=message):
+        three_way.validate_args(args)
+
+
+def test_main_prints_text_summary_and_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = {
+        "run_id": "run-1",
+        "staging_dir": str(tmp_path / "run-1"),
+        "exported_to": str(tmp_path / "exports" / "run-1"),
+        "endpoint_count": 3,
+        "scenario_count": 2,
+        "observation_count": 6,
+        "optimization_hint_count": 1,
+    }
+    monkeypatch.setattr(three_way, "run_comparison", lambda _args: dict(result))
+    assert three_way.main([
+        "--endpoint",
+        "melix=http://127.0.0.1:12441/v1::model",
+        "--endpoint",
+        "omlx=http://127.0.0.1:18061/v1::model",
+    ]) == 0
+    text_output = capsys.readouterr().out
+    assert "Run id: run-1" in text_output
+    assert "Exported to:" in text_output
+
+    assert three_way.main([
+        "--endpoint",
+        "melix=http://127.0.0.1:12441/v1::model",
+        "--endpoint",
+        "omlx=http://127.0.0.1:18061/v1::model",
+        "--json",
+    ]) == 0
+    json_output = json.loads(capsys.readouterr().out)
+    assert json_output["run_id"] == "run-1"
+    assert "elapsed_seconds" in json_output
+
+
+def test_main_returns_error_on_validation_failure(capsys: pytest.CaptureFixture[str]) -> None:
+    assert three_way.main([]) == 2
+    assert "Pass at least two" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- Adds schema-v2 reproducibility metadata to the OMLX/Melix comparison harness: Melix text-worker/control-plane binary paths, sha256 hashes, detected build modes, peer revisions/versions, model snapshot, scenario matrix, warmup count, and token-source accounting.
- Marks fair peer comparisons invalid when Melix release binaries are missing, unreadable, debug, unknown-mode, or when mixed token accounting is present without an explicit annotation.
- Restores the three-way serving comparison wrapper against the current shared benchmark helper signature by forwarding `top_p` and `top_k` defaults.

Addresses #1644.
Closes #1645.
Closes #1646.
Part of #1642; this PR is the benchmark-contract slice, not the root serving optimization.

## Plan or Spec
- Governing plan: `docs/plans/2026-05-12-omlx-melix-serving-benchmark.md`
- Issues: #1642, #1644, #1645, #1646

## Commands Run
```text
make bootstrap
# passed; configured hooks path and uv sync checked 79 packages

make proto
# passed; generated protocol artifacts unchanged

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py
# passed on latest merged HEAD 6513fd85: 90 passed in 0.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py && uv run --project services/mlx-worker-python coverage report -m scripts/omlx_melix_compare_benchmark.py scripts/three_way_serving_compare.py
# passed on latest merged HEAD 6513fd85: 90 passed; changed-script coverage: 97% total

python3 -m compileall scripts/omlx_melix_compare_benchmark.py scripts/three_way_serving_compare.py tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py
# passed

git diff --check origin/main...HEAD
# passed on latest merged HEAD 6513fd85

.githooks/pre-commit
# passed during commit on macOS 256 GiB host:
# - make swift-test: passed
# - make py-test: 3353 passed, 14 skipped, 2 warnings in 138.70s
# - make integration-test: 115 passed, 1 skipped in 652.19s
# - scoped performance report: Status ok, Regressions 0, Context regressions 0

make swift-test
# passed on latest merged HEAD 6513fd85

make py-test
# passed on latest merged HEAD 6513fd85: 3353 passed, 14 skipped, 2 warnings in 140.94s

make integration-test
# passed on latest merged HEAD 6513fd85: 115 passed, 1 skipped in 605.94s

uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report
root = Path.cwd()
changed = [line for line in subprocess.check_output(["git", "diff", "--name-only", "origin/main...HEAD"], cwd=root, text=True).splitlines() if line]
outcome = run_performance_report(root, changed, base_ref="origin/main")
print(f"STATUS={outcome.status}")
print(f"REPORT_DIR={outcome.report_dir}")
print(f"SELECTED={outcome.selected_probe_count}")
PY
# passed on latest merged HEAD 6513fd85: Status ok, Regressions 0, Context regressions 0, Selected probes 0
```

## Coverage and Metrics
- Changed-script coverage on latest merged HEAD 6513fd85: `scripts/omlx_melix_compare_benchmark.py` 96%, `scripts/three_way_serving_compare.py` 99%, combined 97%.
- Latest scoped performance report: `.runtime/pre-commit-performance/20260528-120103-6513fd85/report/report.md`
  - Status: ok
  - Changed files: 5
  - Selected probes: 0
  - Regressions: 0
  - Context regressions: 0
  - Verification failures: 0
  - Note: no registered performance probes were selected for this benchmark-harness/docs change set.
- Commit-time pre-commit scoped performance report: `.runtime/pre-commit-performance/20260528-113722-ce4c27b8/report/report.md`
  - Status: ok
  - Regressions: 0
  - Context regressions: 0
- Observability mode: evidence. The new fields are persisted in benchmark manifests/summaries/reports for reproducibility; there is no production runtime probe overhead.
- Probe overhead: N/A for runtime overhead; this is offline benchmark artifact generation.

## Known Gaps
- This does not close the root #1642 release serving performance gap; it prevents invalid or under-specified peer comparisons from being treated as release evidence.
- The scoped performance report did not select registered probes because this change touches benchmark harness/docs/tests rather than production runtime probe globs.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
