### PR TITLE
perf: filter scope coverage paths by selected probes

### DIFF
--- a/docs/plans/2026-05-24-pr-scope-selected-indexes.md
+++ b/docs/plans/2026-05-24-pr-scope-selected-indexes.md
@@ -19,3 +19,17 @@ Run the registered focused test command, changed-scope coverage command, and loc
 - `build_scope_report_ms_mean`: lower is better; expected to improve for small changed-file sets that select a subset of probes.
 - `selected_probe_count_mean`: unchanged.
 - `force_all_selected_mean`: unchanged.
+
+## Follow-up: selected coverage path filtering
+
+This follow-up slice keeps the same registered probe and narrows the coverage-path
+attachment step after scope selection. For non-force-all scope reports,
+`_selected_probes_with_coverage_paths()` now passes the selected probe IDs into
+the coverage-path collector so the wildcard matcher set is reduced to the probes
+that will actually be emitted. This preserves coverage-path output while avoiding
+unneeded wildcard checks against unselected probes in the common small-selection
+case.
+
+Verification remains the registered `pr-scoped-performance-scope-matcher` focused
+test, coverage, and probe commands on Linux, with PR-scoped performance CI as the
+merge gate.

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1859,6 +1859,19 @@ def test_match_probe_indexes_deduplicates_repeated_watch_globs() -> None:
         "beta": ("shared.py", "services/b.py"),
         "gamma": ("shared.py",),
     }
+    assert _coverage_paths_by_probe_id(
+        changed_paths=("shared.py", "services/b.py", "unmatched.py"),
+        probes=probes,
+        selected_probe_ids=frozenset({"beta"}),
+    ) == {"beta": ("shared.py", "services/b.py")}
+    assert (
+        _coverage_paths_by_probe_id(
+            changed_paths=("shared.py", "services/b.py"),
+            probes=probes,
+            selected_probe_ids=frozenset({"missing"}),
+        )
+        == {}
+    )
 
 
 def test_match_probe_indexes_exact_only_intersects_changed_paths() -> None:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -2453,10 +2453,32 @@ def _coverage_paths_by_probe_id(
     *,
     changed_paths: tuple[str, ...],
     probes: tuple[ProbeDefinition, ...],
+    selected_probe_ids: frozenset[str] | None = None,
 ) -> dict[str, tuple[str, ...]]:
     if not changed_paths:
         return {}
     exact_path_to_probe_indexes, wildcard_glob_matchers = _probe_match_indexes(probes)
+    selected_probe_indexes: frozenset[int] | None = None
+    if selected_probe_ids is not None and len(selected_probe_ids) < len(probes):
+        probe_id_to_index = _probe_id_to_index(probes)
+        selected_probe_indexes = frozenset(
+            index
+            for probe_id in selected_probe_ids
+            if (index := probe_id_to_index.get(probe_id)) is not None
+        )
+        if not selected_probe_indexes:
+            return {}
+        wildcard_glob_matchers = tuple(
+            (prefix, pattern, filtered_probe_indexes)
+            for prefix, pattern, probe_indexes in wildcard_glob_matchers
+            if (
+                filtered_probe_indexes := tuple(
+                    probe_index
+                    for probe_index in probe_indexes
+                    if probe_index in selected_probe_indexes
+                )
+            )
+        )
     coverage_paths_by_probe_index: dict[int, list[str]] = {}
     for path in changed_paths:
         direct_probe_ids = _FORCE_ALL_DIRECT_PROBE_IDS_BY_EXACT_PATH.get(path)
@@ -2470,6 +2492,11 @@ def _coverage_paths_by_probe_id(
         probe_indexes = exact_path_to_probe_indexes.get(path)
         if probe_indexes is not None:
             for probe_index in probe_indexes:
+                if (
+                    selected_probe_indexes is not None
+                    and probe_index not in selected_probe_indexes
+                ):
+                    continue
                 coverage_paths_by_probe_index.setdefault(probe_index, []).append(path)
         for prefix, pattern, probe_indexes in wildcard_glob_matchers:
             if prefix and not path.startswith(prefix):
@@ -2493,9 +2520,11 @@ def _selected_probes_with_coverage_paths(
     cached = _SCOPE_SELECTED_PROBES_WITH_COVERAGE_CACHE.get(cache_key)
     if cached is not None:
         return cached
+    selected_probe_ids = frozenset(str(probe_entry["id"]) for probe_entry in selected_probes)
     coverage_paths_by_probe_id = _coverage_paths_by_probe_id(
         changed_paths=changed_paths,
         probes=probes,
+        selected_probe_ids=selected_probe_ids,
     )
     cached = tuple(
         {


### PR DESCRIPTION
## Summary
- Filter PR-scoped coverage-path collection to the probe IDs selected for emission.
- Preserve force-all and selected-probe coverage semantics while reducing wildcard matcher work for small selected subsets.
- Update the active performance plan with the selected coverage-path filtering slice.

## Plan or Spec
- Updated `docs/plans/2026-05-24-pr-scope-selected-indexes.md`.
- Existing registered probe: `pr-scoped-performance-scope-matcher` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (registered focused `pr-scoped-performance-scope-matcher` test command) → 16 passed.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && ... coverage json ... && python3 scripts/changed_scope_coverage.py ...` → changed-scope coverage 100%.
- Local registered probe command via `_probe_pr_scoped_scope_matcher(Path.cwd())` on Linux.

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Baseline local probe samples from `origin/main`: `build_scope_report_ms_mean` = [2.280769, 1.938016, 1.904567], aggregate mean 2.041117 ms.
- New local probe samples: `build_scope_report_ms_mean` = [1.853125, 1.918132, 1.896483, 1.982816], aggregate mean 1.912639 ms.
- Local delta: -0.128478 ms, speedup 1.067173x. `selected_probe_count_mean` stayed 7.0 and `force_all_selected_mean` stayed 0.0.

## Known Gaps
- Linux local verification covers this Python tooling path. The registered PR-scoped performance GitHub Actions report remains the merge gate.
- The timing delta is small and should be treated as directional until CI repeats the registered probe.

## Evidence Checklist
- [x] Registered probe exists with focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe ran locally on Linux.
- [ ] PR-scoped performance CI completed successfully.
