### PR TITLE
perf: fast-path dataset registry suffix lookup

### DIFF
--- a/docs/plans/2026-05-28-dataset-registry-suffix-fastpath.md
+++ b/docs/plans/2026-05-28-dataset-registry-suffix-fastpath.md
@@ -1,0 +1,38 @@
+# Dataset Registry Suffix Fast Path
+
+## Goal
+
+Reduce per-file suffix normalization overhead in `worker.dataset_registry.catalog._dataset_file_format(...)` during dataset registry snapshot scans.
+
+## Scope
+
+This slice is Python-only and limited to the dataset registry file-format classification path:
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+
+It does not change dataset discovery order, supported dataset formats, row parsing, Hugging Face cache resolution, generated protocol artifacts, or Swift/macOS runtime behavior.
+
+## Registered Probe
+
+Registered PR-scoped probe: `dataset-registry-snapshot-inference-single-pass` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and scans a synthetic Hugging Face dataset cache with thousands of files. Relevant metrics:
+
+- `elapsed_ms_mean` — lower is better.
+- `peak_bytes_mean` — lower is better as an allocation signal.
+- `legacy_inference_helper_calls_mean` — must remain `0.0`, proving the snapshot builder still uses the combined split/config inference helper.
+
+## Implementation Plan
+
+1. Keep README metadata handling and the supported suffix table unchanged.
+2. Replace `Path.suffix.lower()` with a direct filename `rfind(".")` suffix lookup so each dataset file avoids `Path.suffix` property work on the scan hot path.
+3. Add focused regression coverage for uppercase supported suffixes, trailing-dot names, dotfiles, and README metadata.
+4. Reuse the registered dataset registry tests, changed-scope coverage, and local PR-scoped probe before opening the PR.
+
+## Success Criteria
+
+- Focused dataset registry tests pass on Linux.
+- Changed-scope coverage for the touched executable scope is at least 95%.
+- The registered local probe shows a clear `elapsed_ms_mean` direction without changing `legacy_inference_helper_calls_mean`.
+- `git diff --check` passes.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -162,6 +162,13 @@ def test_dataset_catalog_inferred_split_and_config_preserves_legacy_helpers() ->
     assert catalog._inferred_split_and_config("") == ("", "default")
 
 
+def test_dataset_catalog_file_format_uses_supported_suffixes() -> None:
+    assert catalog._dataset_file_format(Path("README.md")) == "metadata"
+    assert catalog._dataset_file_format(Path("train.JSONL")) == "jsonl"
+    assert catalog._dataset_file_format(Path("train.jsonl.")) == ""
+    assert catalog._dataset_file_format(Path(".jsonl")) == ""
+
+
 def test_dataset_catalog_split_alias_prefix_scan_matches_legacy_delimiters() -> None:
     assert catalog._split_alias_from_candidate("train-00000-of-00001") == "train"
     assert catalog._split_alias_from_candidate("validation_shard_00000") == "validation"

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -898,9 +898,13 @@ def _iter_supported_dataset_files(snapshot_dir: Path) -> Iterator[Path]:
 
 
 def _dataset_file_format(path: Path) -> str:
-    if path.name in _README_NAMES:
+    name = path.name
+    if name in _README_NAMES:
         return "metadata"
-    return _SUPPORTED_DATASET_SUFFIXES.get(path.suffix.lower(), "")
+    dot_index = name.rfind(".")
+    if dot_index <= 0 or dot_index == len(name) - 1:
+        return ""
+    return _SUPPORTED_DATASET_SUFFIXES.get(name[dot_index:].lower(), "")
 
 
 def _inferred_split(relative_path: str) -> str:


### PR DESCRIPTION
## Summary
- Fast-path dataset registry file-format detection by deriving the suffix directly from the filename instead of `Path.suffix.lower()` on every scanned dataset file.
- Add regression coverage for README metadata, uppercase supported suffixes, trailing-dot names, and dotfiles.

## Plan or Spec
- `docs/plans/2026-05-28-dataset-registry-suffix-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics
# 50 passed in 0.36s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py
# TOTAL 11 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_REGISTRY_PROBE_FILE_COUNT=2400 MELIX_DATASET_REGISTRY_PROBE_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py
# head: {"elapsed_ms_mean": 662.8794694053275, "file_count_mean": 2401.0, "legacy_inference_helper_calls_mean": 0.0, "peak_bytes_mean": 779246.2857142857, "sample_count": 7.0}

(cd /root/.hermes/profiles/coder/workspace/melix && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_REGISTRY_PROBE_FILE_COUNT=2400 MELIX_DATASET_REGISTRY_PROBE_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py)
# origin/main baseline: {"elapsed_ms_mean": 663.9424154002752, "file_count_mean": 2401.0, "legacy_inference_helper_calls_mean": 0.0, "peak_bytes_mean": 779254.7142857143, "sample_count": 7.0}

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 11 0 100%`).
- Registered local probe: `dataset-registry-snapshot-inference-single-pass`.
- Local default probe delta: `elapsed_ms_mean` 663.9424154002752 ms → 662.8794694053275 ms (delta -1.062945994947668 ms, ~0.16% faster); `peak_bytes_mean` 779254.7142857143 → 779246.2857142857 bytes; `legacy_inference_helper_calls_mean` stayed `0.0`.
- CI PR-scoped performance report is required as the merge validation source.

## Known Gaps
- The local Linux probe is synthetic and filesystem-heavy, so the runtime effect is intentionally gated on the registered PR-scoped performance workflow in CI before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
