### PR TITLE
Add Melix metrics snapshot CLI

### DIFF
--- a/docs/plans/2026-05-12-omlx-melix-serving-benchmark.md
+++ b/docs/plans/2026-05-12-omlx-melix-serving-benchmark.md
@@ -44,6 +44,22 @@ not a fair source for direct Melix optimization deltas.
   gateway or queue overhead, prefill/runtime preparation, decode throughput,
   streaming assembly, and continuous batching behavior.
 
+## Melix Metrics Snapshot Interface
+
+Benchmark runs should capture Melix runtime metrics through the stable local CLI
+instead of scraping sidecar files directly:
+
+```bash
+python3 scripts/melix_metrics_snapshot.py \
+  --runtime-dir .runtime/sidecars/<instance-name>
+```
+
+The CLI emits one JSON payload with top-level flattened `values` for existing
+reports, per-source `source_values`, and `sources.<source_name>.freshness`
+metadata. Control-plane metrics and worker metrics are kept distinct in the
+`sources` map, and missing required sources are represented as `ok: false` with
+`missing_required_sources` so the benchmark report can preserve partial evidence.
+
 ## Fairness Rules
 
 - Use streaming requests for both systems; non-streaming requests are out of

--- a/docs/plans/2026-05-28-gemma-e4b-metrics-snapshot-cli.md
+++ b/docs/plans/2026-05-28-gemma-e4b-metrics-snapshot-cli.md
@@ -1,0 +1,66 @@
+# Gemma E4B Metrics Snapshot CLI
+
+## Goal
+
+Expose Melix serving metrics through a stable local command that benchmark
+harnesses can consume without scraping sidecar state ad hoc or depending on a
+public `/metrics` HTTP endpoint.
+
+This is the implementation slice for issue #1648 under the Gemma E4B serving
+performance investigation. It supports the phase-attribution work in #1647 and
+the root comparison gate in #1642.
+
+## Scope
+
+- Add a JSON-emitting CLI under `scripts/` that reads the current Melix
+  control-plane, Swift text-worker, and optional Python-worker metrics exports.
+- Support explicit metrics paths and worktree-local `MELIX_RUNTIME_DIR`
+  discovery, so benchmark runners can call the command from a separate shell.
+- Preserve the existing flattened `values` object consumed by comparison
+  reports while also distinguishing per-source values and source metadata.
+- Record source freshness for each configured source from the runtime
+  `updated_at_unix_ms` payload when available, falling back to file mtime.
+- Keep missing-source output machine-readable. The default command emits
+  `ok: false` and exits successfully so reports can preserve evidence; `--strict`
+  exits non-zero for shell gates.
+
+## Non-Goals
+
+- Do not add a public HTTP `/metrics` endpoint in this slice.
+- Do not change the runtime metrics exporters or metric names.
+- Do not add the phase-delta report rows from #1649; this slice only exposes the
+  stable snapshot interface that #1649 will consume.
+
+## CLI Contract
+
+Benchmark harnesses should call:
+
+```bash
+python3 scripts/melix_metrics_snapshot.py \
+  --runtime-dir .runtime/sidecars/<instance-name>
+```
+
+or pass explicit paths:
+
+```bash
+python3 scripts/melix_metrics_snapshot.py \
+  --control-plane-metrics "$MELIX_CONTROL_PLANE_METRICS_PATH" \
+  --swift-text-worker-metrics "$MELIX_SWIFT_TEXT_WORKER_METRICS_PATH"
+```
+
+The JSON payload includes:
+
+- `schema_version`, `generated_at`, and `generated_at_unix_ms`.
+- top-level `ok`, `missing_required_sources`, `updated_at_unix_ms`, and
+  flattened `values` for existing report consumers.
+- `sources.<source_name>` metadata, including `component`, `source_kind`,
+  `required`, `path`, `ok`, and `freshness`.
+- `source_values.<source_name>` metric maps to keep control-plane metrics
+  separate from worker metrics.
+
+## Verification
+
+- Unit tests cover successful multi-source export, runtime-dir discovery, missing
+  required sources, and strict-mode exit behavior.
+- Existing OMLX/Melix and three-way comparison tests continue to cover report
+  artifact integration.

--- a/scripts/melix_metrics_snapshot.py
+++ b/scripts/melix_metrics_snapshot.py
@@ -68,10 +68,13 @@ def discover_latest_metrics_path(runtime_dir: Path | None, source_name: str) -> 
     if runtime_dir is None:
         return None
     pattern = SOURCE_DEFINITIONS[source_name]["runtime_pattern"]
-    candidates = [path for path in runtime_dir.expanduser().glob(pattern) if path.is_file()]
-    if not candidates:
+    try:
+        candidates = [path for path in runtime_dir.expanduser().glob(pattern) if path.is_file()]
+        if not candidates:
+            return None
+        return max(candidates, key=lambda path: path.stat().st_mtime)
+    except OSError:
         return None
-    return max(candidates, key=lambda path: path.stat().st_mtime)
 
 
 def resolve_source_paths(
@@ -347,7 +350,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     sys.stdout.write(json.dumps(snapshot, indent=2, sort_keys=True) + "\n")
     if args.strict and snapshot.get("ok") is not True:
-        return 2
+        return 1
     return 0
 
 

--- a/scripts/melix_metrics_snapshot.py
+++ b/scripts/melix_metrics_snapshot.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+DEFAULT_STALE_AFTER_SECONDS = 30.0
+REQUIRED_SOURCES = ("control_plane", "swift_text_worker")
+SOURCE_DEFINITIONS = {
+    "control_plane": {
+        "component": "control_plane",
+        "source_kind": "control_plane",
+        "env": "MELIX_CONTROL_PLANE_METRICS_PATH",
+        "runtime_pattern": "control-plane-metrics*.json",
+    },
+    "swift_text_worker": {
+        "component": "swift_text_worker",
+        "source_kind": "worker",
+        "env": "MELIX_SWIFT_TEXT_WORKER_METRICS_PATH",
+        "runtime_pattern": "swift-text-worker-metrics*.json",
+    },
+    "python_worker": {
+        "component": "python_worker",
+        "source_kind": "worker",
+        "env": "MELIX_PYTHON_WORKER_METRICS_PATH",
+        "runtime_pattern": "python-worker-metrics*.json",
+    },
+}
+
+
+@dataclass(frozen=True)
+class SourcePath:
+    name: str
+    path: Path | None
+    configured_by: str
+
+
+def utc_iso_from_unix_seconds(value: float) -> str:
+    return datetime.fromtimestamp(value, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def unix_ms_to_iso(value: int | float | None) -> str | None:
+    if value is None:
+        return None
+    return utc_iso_from_unix_seconds(float(value) / 1000.0)
+
+
+def normalize_path(value: str | os.PathLike[str] | None) -> Path | None:
+    if value is None:
+        return None
+    text = os.fspath(value).strip()
+    if not text:
+        return None
+    return Path(text).expanduser()
+
+
+def discover_latest_metrics_path(runtime_dir: Path | None, source_name: str) -> Path | None:
+    if runtime_dir is None:
+        return None
+    pattern = SOURCE_DEFINITIONS[source_name]["runtime_pattern"]
+    candidates = [path for path in runtime_dir.expanduser().glob(pattern) if path.is_file()]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda path: path.stat().st_mtime)
+
+
+def resolve_source_paths(
+    *,
+    control_plane_metrics: Path | None = None,
+    swift_text_worker_metrics: Path | None = None,
+    python_worker_metrics: Path | None = None,
+    runtime_dir: Path | None = None,
+    environment: dict[str, str] | None = None,
+) -> dict[str, SourcePath]:
+    if environment is None:
+        environment = dict(os.environ)
+    explicit = {
+        "control_plane": control_plane_metrics,
+        "swift_text_worker": swift_text_worker_metrics,
+        "python_worker": python_worker_metrics,
+    }
+    resolved: dict[str, SourcePath] = {}
+    for name, definition in SOURCE_DEFINITIONS.items():
+        explicit_path = normalize_path(explicit[name])
+        if explicit_path is not None:
+            resolved[name] = SourcePath(name=name, path=explicit_path, configured_by="argument")
+            continue
+
+        env_path = normalize_path(environment.get(definition["env"]))
+        if env_path is not None:
+            resolved[name] = SourcePath(name=name, path=env_path, configured_by="environment")
+            continue
+
+        runtime_path = discover_latest_metrics_path(runtime_dir, name)
+        if runtime_path is not None:
+            resolved[name] = SourcePath(name=name, path=runtime_path, configured_by="runtime_dir")
+            continue
+
+        resolved[name] = SourcePath(name=name, path=None, configured_by="not_configured")
+    return resolved
+
+
+def load_metrics_payload(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("metrics snapshot must be a JSON object")
+    values = payload.get("values")
+    if not isinstance(values, dict):
+        raise ValueError("metrics snapshot is missing a values object")
+    return payload
+
+
+def _numeric_updated_at(value: Any) -> int | float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    return None
+
+
+def _freshness_from_payload(
+    *,
+    payload_updated_at_ms: int | float | None,
+    file_modified_at: float | None,
+    generated_at_unix_ms: int,
+    stale_after_seconds: float,
+) -> dict[str, Any]:
+    observed_at_unix_ms = payload_updated_at_ms
+    observed_source = "payload.updated_at_unix_ms"
+    if observed_at_unix_ms is None and file_modified_at is not None:
+        observed_at_unix_ms = int(file_modified_at * 1000)
+        observed_source = "file.mtime"
+
+    if observed_at_unix_ms is None:
+        return {
+            "status": "unknown",
+            "observed_at_unix_ms": None,
+            "observed_at": None,
+            "observed_source": "unavailable",
+            "age_ms": None,
+            "stale_after_seconds": stale_after_seconds,
+        }
+
+    age_ms = max(0, generated_at_unix_ms - int(observed_at_unix_ms))
+    status = "fresh" if age_ms <= int(stale_after_seconds * 1000) else "stale"
+    return {
+        "status": status,
+        "observed_at_unix_ms": int(observed_at_unix_ms),
+        "observed_at": unix_ms_to_iso(observed_at_unix_ms),
+        "observed_source": observed_source,
+        "age_ms": age_ms,
+        "stale_after_seconds": stale_after_seconds,
+    }
+
+
+def _missing_freshness(status: str, stale_after_seconds: float) -> dict[str, Any]:
+    return {
+        "status": status,
+        "observed_at_unix_ms": None,
+        "observed_at": None,
+        "observed_source": "unavailable",
+        "age_ms": None,
+        "stale_after_seconds": stale_after_seconds,
+    }
+
+
+def build_source_snapshot(
+    source_path: SourcePath,
+    *,
+    generated_at_unix_ms: int,
+    stale_after_seconds: float,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    definition = SOURCE_DEFINITIONS[source_path.name]
+    required = source_path.name in REQUIRED_SOURCES
+    source = {
+        "component": definition["component"],
+        "source_kind": definition["source_kind"],
+        "required": required,
+        "configured_by": source_path.configured_by,
+        "path": str(source_path.path) if source_path.path is not None else None,
+        "ok": False,
+    }
+
+    if source_path.path is None:
+        source["error"] = "metrics source is not configured"
+        source["freshness"] = _missing_freshness("not_configured", stale_after_seconds)
+        return source, {}
+
+    try:
+        stat = source_path.path.stat()
+    except OSError as exc:
+        source["error"] = f"{type(exc).__name__}: {exc}"
+        source["freshness"] = _missing_freshness("missing", stale_after_seconds)
+        return source, {}
+
+    try:
+        payload = load_metrics_payload(source_path.path)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        source["error"] = f"{type(exc).__name__}: {exc}"
+        source["freshness"] = _freshness_from_payload(
+            payload_updated_at_ms=None,
+            file_modified_at=stat.st_mtime,
+            generated_at_unix_ms=generated_at_unix_ms,
+            stale_after_seconds=stale_after_seconds,
+        )
+        return source, {}
+
+    values = payload["values"]
+    updated_at_unix_ms = _numeric_updated_at(payload.get("updated_at_unix_ms"))
+    source.update({
+        "ok": True,
+        "metric_count": len(values),
+        "updated_at_unix_ms": int(updated_at_unix_ms) if updated_at_unix_ms is not None else None,
+        "freshness": _freshness_from_payload(
+            payload_updated_at_ms=updated_at_unix_ms,
+            file_modified_at=stat.st_mtime,
+            generated_at_unix_ms=generated_at_unix_ms,
+            stale_after_seconds=stale_after_seconds,
+        ),
+    })
+    return source, dict(values)
+
+
+def build_snapshot(
+    *,
+    source_paths: dict[str, SourcePath],
+    generated_at_unix_ms: int | None = None,
+    stale_after_seconds: float = DEFAULT_STALE_AFTER_SECONDS,
+) -> dict[str, Any]:
+    if generated_at_unix_ms is None:
+        generated_at_unix_ms = int(time.time() * 1000)
+    sources: dict[str, dict[str, Any]] = {}
+    source_values: dict[str, dict[str, Any]] = {}
+    values: dict[str, Any] = {}
+    updated_at_values: list[int] = []
+    missing_required_sources: list[str] = []
+    errors: list[str] = []
+
+    for name in SOURCE_DEFINITIONS:
+        source, metrics = build_source_snapshot(
+            source_paths[name],
+            generated_at_unix_ms=generated_at_unix_ms,
+            stale_after_seconds=stale_after_seconds,
+        )
+        sources[name] = source
+        source_values[name] = metrics
+        if source["ok"] is True:
+            values.update(metrics)
+            updated_at_unix_ms = source.get("updated_at_unix_ms")
+            if isinstance(updated_at_unix_ms, int):
+                updated_at_values.append(updated_at_unix_ms)
+        elif source.get("required") is True:
+            missing_required_sources.append(name)
+            errors.append(f"{name}: {source.get('error', 'unknown')}")
+
+    ok = not missing_required_sources
+    primary_path = next(
+        (source["path"] for source in sources.values() if source.get("path")),
+        None,
+    )
+    snapshot = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": unix_ms_to_iso(generated_at_unix_ms),
+        "generated_at_unix_ms": generated_at_unix_ms,
+        "ok": ok,
+        "path": primary_path,
+        "updated_at_unix_ms": max(updated_at_values) if updated_at_values else None,
+        "missing_required_sources": missing_required_sources,
+        "sources": sources,
+        "source_values": source_values,
+        "values": values,
+    }
+    if errors:
+        snapshot["error"] = "; ".join(errors)
+    return snapshot
+
+
+def build_snapshot_from_paths(
+    *,
+    control_plane_metrics: Path | None = None,
+    swift_text_worker_metrics: Path | None = None,
+    python_worker_metrics: Path | None = None,
+    runtime_dir: Path | None = None,
+    environment: dict[str, str] | None = None,
+    generated_at_unix_ms: int | None = None,
+    stale_after_seconds: float = DEFAULT_STALE_AFTER_SECONDS,
+) -> dict[str, Any]:
+    source_paths = resolve_source_paths(
+        control_plane_metrics=control_plane_metrics,
+        swift_text_worker_metrics=swift_text_worker_metrics,
+        python_worker_metrics=python_worker_metrics,
+        runtime_dir=runtime_dir,
+        environment=environment,
+    )
+    return build_snapshot(
+        source_paths=source_paths,
+        generated_at_unix_ms=generated_at_unix_ms,
+        stale_after_seconds=stale_after_seconds,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Emit a benchmark-consumable Melix metrics snapshot as JSON.",
+    )
+    parser.add_argument("--control-plane-metrics", type=Path, default=None)
+    parser.add_argument("--swift-text-worker-metrics", type=Path, default=None)
+    parser.add_argument("--python-worker-metrics", type=Path, default=None)
+    parser.add_argument(
+        "--runtime-dir",
+        type=Path,
+        default=normalize_path(os.environ.get("MELIX_RUNTIME_DIR")),
+        help="Melix runtime directory used to discover the newest metrics exports.",
+    )
+    parser.add_argument(
+        "--stale-after-seconds",
+        type=float,
+        default=DEFAULT_STALE_AFTER_SECONDS,
+        help="Freshness threshold recorded for each source.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when required metrics sources are missing or invalid.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    snapshot = build_snapshot_from_paths(
+        control_plane_metrics=args.control_plane_metrics,
+        swift_text_worker_metrics=args.swift_text_worker_metrics,
+        python_worker_metrics=args.python_worker_metrics,
+        runtime_dir=args.runtime_dir,
+        stale_after_seconds=args.stale_after_seconds,
+    )
+    sys.stdout.write(json.dumps(snapshot, indent=2, sort_keys=True) + "\n")
+    if args.strict and snapshot.get("ok") is not True:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/omlx_melix_compare_benchmark.py
+++ b/scripts/omlx_melix_compare_benchmark.py
@@ -19,6 +19,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import melix_metrics_snapshot
+
 
 DEFAULT_PROMPT_TOKEN_TARGETS = [1024]
 DEFAULT_CONCURRENCY = [1]
@@ -773,60 +779,27 @@ def load_melix_metrics_snapshot(
     *,
     control_plane_path: Path | None,
     swift_text_worker_path: Path | None,
+    python_worker_path: Path | None = None,
+    runtime_dir: Path | None = None,
+    stale_after_seconds: float = melix_metrics_snapshot.DEFAULT_STALE_AFTER_SECONDS,
 ) -> dict[str, Any] | None:
-    source_paths = {
-        "control_plane": control_plane_path,
-        "swift_text_worker": swift_text_worker_path,
-    }
-    source_snapshots = {
-        name: load_metrics_snapshot(path)
-        for name, path in source_paths.items()
-        if path is not None
-    }
-    if not source_snapshots:
+    if (
+        control_plane_path is None
+        and swift_text_worker_path is None
+        and python_worker_path is None
+        and runtime_dir is None
+    ):
         return None
 
-    values: dict[str, Any] = {}
-    sources: dict[str, dict[str, Any]] = {}
-    updated_at_values: list[Any] = []
-    errors: list[str] = []
-    primary_path: str | None = None
-    ok = True
-    for name, snapshot in source_snapshots.items():
-        if snapshot is None:
-            continue
-        if primary_path is None:
-            primary_path = snapshot.get("path")
-        source = {
-            "ok": snapshot.get("ok"),
-            "path": snapshot.get("path"),
-            "updated_at_unix_ms": snapshot.get("updated_at_unix_ms"),
-        }
-        if snapshot.get("error"):
-            source["error"] = snapshot.get("error")
-        sources[name] = source
-        if snapshot.get("ok") is True:
-            snapshot_values = snapshot.get("values")
-            if isinstance(snapshot_values, dict):
-                values.update(snapshot_values)
-            updated_at_values.append(snapshot.get("updated_at_unix_ms"))
-        else:
-            ok = False
-            errors.append(f"{name}: {snapshot.get('error', 'unknown')}")
-
-    numeric_updates = [
-        value
-        for value in updated_at_values
-        if isinstance(value, (int, float)) and not isinstance(value, bool)
-    ]
-    return {
-        "path": primary_path,
-        "ok": ok,
-        "updated_at_unix_ms": max(numeric_updates) if numeric_updates else None,
-        "sources": sources,
-        "values": values,
-        **({"error": "; ".join(errors)} if errors else {}),
-    }
+    snapshot = melix_metrics_snapshot.build_snapshot_from_paths(
+        control_plane_metrics=control_plane_path,
+        swift_text_worker_metrics=swift_text_worker_path,
+        python_worker_metrics=python_worker_path,
+        runtime_dir=runtime_dir,
+        environment={},
+        stale_after_seconds=stale_after_seconds,
+    )
+    return snapshot
 
 
 def enrich_hints_with_metrics(
@@ -884,14 +857,18 @@ def metrics_manifest_entries(metrics_snapshot: dict[str, Any] | None, *, artifac
     }
     entries: dict[str, Any] = {"melix": entry}
     sources = metrics_snapshot.get("sources")
-    if isinstance(sources, dict) and isinstance(sources.get("control_plane"), dict):
-        control_plane = sources["control_plane"]
-        entries["melix_control_plane"] = {
-            "ok": control_plane.get("ok"),
-            "path": control_plane.get("path"),
-            "updated_at_unix_ms": control_plane.get("updated_at_unix_ms"),
-            "artifact": artifact_name,
-        }
+    if isinstance(sources, dict):
+        for source_name in ("control_plane", "swift_text_worker", "python_worker"):
+            source = sources.get(source_name)
+            if not isinstance(source, dict):
+                continue
+            entries[f"melix_{source_name}"] = {
+                "ok": source.get("ok"),
+                "path": source.get("path"),
+                "updated_at_unix_ms": source.get("updated_at_unix_ms"),
+                "freshness": source.get("freshness"),
+                "artifact": artifact_name,
+            }
     return entries
 
 
@@ -1675,6 +1652,9 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
     metrics_snapshot = load_melix_metrics_snapshot(
         control_plane_path=args.melix_control_plane_metrics,
         swift_text_worker_path=args.melix_swift_text_worker_metrics,
+        python_worker_path=args.melix_python_worker_metrics,
+        runtime_dir=args.melix_metrics_runtime_dir,
+        stale_after_seconds=args.melix_metrics_stale_after_seconds,
     )
     summaries = summarize_observations(observations)
     runtime_metadata = runtime_metadata_from_args(args, endpoints=endpoints)
@@ -1853,6 +1833,24 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help="Optional Melix Swift text worker metrics JSON to merge into the report.",
+    )
+    parser.add_argument(
+        "--melix-python-worker-metrics",
+        type=Path,
+        default=None,
+        help="Optional Melix Python worker metrics JSON to merge into the report.",
+    )
+    parser.add_argument(
+        "--melix-metrics-runtime-dir",
+        type=Path,
+        default=None,
+        help="Optional Melix runtime directory used to discover the newest metrics exports.",
+    )
+    parser.add_argument(
+        "--melix-metrics-stale-after-seconds",
+        type=float,
+        default=melix_metrics_snapshot.DEFAULT_STALE_AFTER_SECONDS,
+        help="Freshness threshold recorded for Melix metrics sources.",
     )
     parser.add_argument(
         "--measurement-profile",

--- a/scripts/omlx_melix_compare_benchmark.py
+++ b/scripts/omlx_melix_compare_benchmark.py
@@ -796,7 +796,6 @@ def load_melix_metrics_snapshot(
         swift_text_worker_metrics=swift_text_worker_path,
         python_worker_metrics=python_worker_path,
         runtime_dir=runtime_dir,
-        environment={},
         stale_after_seconds=stale_after_seconds,
     )
     return snapshot

--- a/scripts/three_way_serving_compare.py
+++ b/scripts/three_way_serving_compare.py
@@ -446,6 +446,9 @@ def run_comparison(args: argparse.Namespace) -> dict[str, Any]:
     metrics_snapshot = base.load_melix_metrics_snapshot(
         control_plane_path=args.melix_control_plane_metrics,
         swift_text_worker_path=args.melix_swift_text_worker_metrics,
+        python_worker_path=args.melix_python_worker_metrics,
+        runtime_dir=args.melix_metrics_runtime_dir,
+        stale_after_seconds=args.melix_metrics_stale_after_seconds,
     )
     summaries = base.summarize_observations(observations)
     prompt_evidence = prompt_token_evidence(observations)
@@ -828,6 +831,13 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--preflight-retry-interval-seconds", type=float, default=2.0)
     parser.add_argument("--melix-control-plane-metrics", type=Path, default=None)
     parser.add_argument("--melix-swift-text-worker-metrics", type=Path, default=None)
+    parser.add_argument("--melix-python-worker-metrics", type=Path, default=None)
+    parser.add_argument("--melix-metrics-runtime-dir", type=Path, default=None)
+    parser.add_argument(
+        "--melix-metrics-stale-after-seconds",
+        type=float,
+        default=base.melix_metrics_snapshot.DEFAULT_STALE_AFTER_SECONDS,
+    )
     parser.add_argument(
         "--measurement-profile",
         choices=base.MEASUREMENT_PROFILES,

--- a/tests/test_melix_metrics_snapshot.py
+++ b/tests/test_melix_metrics_snapshot.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "melix_metrics_snapshot.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("melix_metrics_snapshot", MODULE_PATH)
+assert MODULE_SPEC is not None
+assert MODULE_SPEC.loader is not None
+snapshot_cli = importlib.util.module_from_spec(MODULE_SPEC)
+sys.modules[MODULE_SPEC.name] = snapshot_cli
+MODULE_SPEC.loader.exec_module(snapshot_cli)
+
+
+def write_metrics(path: Path, *, updated_at_unix_ms: int, values: dict[str, float]) -> None:
+    path.write_text(
+        json.dumps({
+            "updated_at_unix_ms": updated_at_unix_ms,
+            "values": values,
+        }),
+        encoding="utf-8",
+    )
+
+
+def test_build_snapshot_exports_sources_values_and_freshness(tmp_path: Path) -> None:
+    control_plane_path = tmp_path / "control-plane-metrics.json"
+    swift_worker_path = tmp_path / "swift-text-worker-metrics.json"
+    python_worker_path = tmp_path / "python-worker-metrics.json"
+    write_metrics(
+        control_plane_path,
+        updated_at_unix_ms=1_000,
+        values={
+            "control_plane.text_first_load_ms": 8547.46,
+            "http.ttfd_ms": 3447.17,
+        },
+    )
+    write_metrics(
+        swift_worker_path,
+        updated_at_unix_ms=2_000,
+        values={
+            "swift_text.prefill_ms": 3706,
+            "swift_text.decode_tokens_per_second": 2,
+        },
+    )
+    write_metrics(
+        python_worker_path,
+        updated_at_unix_ms=1_500,
+        values={"python_worker.bootstrap_ms": 25},
+    )
+
+    snapshot = snapshot_cli.build_snapshot_from_paths(
+        control_plane_metrics=control_plane_path,
+        swift_text_worker_metrics=swift_worker_path,
+        python_worker_metrics=python_worker_path,
+        generated_at_unix_ms=2_500,
+        stale_after_seconds=10,
+    )
+
+    assert snapshot["ok"] is True
+    assert snapshot["path"] == str(control_plane_path)
+    assert snapshot["updated_at_unix_ms"] == 2_000
+    assert snapshot["missing_required_sources"] == []
+    assert snapshot["values"]["control_plane.text_first_load_ms"] == 8547.46
+    assert snapshot["values"]["swift_text.prefill_ms"] == 3706
+    assert snapshot["source_values"]["control_plane"] == {
+        "control_plane.text_first_load_ms": 8547.46,
+        "http.ttfd_ms": 3447.17,
+    }
+    control_source = snapshot["sources"]["control_plane"]
+    assert control_source["component"] == "control_plane"
+    assert control_source["source_kind"] == "control_plane"
+    assert control_source["required"] is True
+    assert control_source["configured_by"] == "argument"
+    assert control_source["freshness"] == {
+        "status": "fresh",
+        "observed_at_unix_ms": 1_000,
+        "observed_at": "1970-01-01T00:00:01Z",
+        "observed_source": "payload.updated_at_unix_ms",
+        "age_ms": 1_500,
+        "stale_after_seconds": 10,
+    }
+    python_source = snapshot["sources"]["python_worker"]
+    assert python_source["required"] is False
+    assert python_source["source_kind"] == "worker"
+
+
+def test_runtime_dir_discovers_latest_metrics_files(tmp_path: Path) -> None:
+    older = tmp_path / "control-plane-metrics-old.json"
+    newer = tmp_path / "control-plane-metrics-new.json"
+    swift_worker_path = tmp_path / "swift-text-worker-metrics.json"
+    write_metrics(older, updated_at_unix_ms=1_000, values={"old": 1})
+    write_metrics(newer, updated_at_unix_ms=2_000, values={"new": 2})
+    write_metrics(swift_worker_path, updated_at_unix_ms=3_000, values={"swift_text.prefill_ms": 3})
+    os.utime(older, (1, 1))
+    os.utime(newer, (2, 2))
+
+    resolved = snapshot_cli.resolve_source_paths(
+        runtime_dir=tmp_path,
+        environment={},
+    )
+    snapshot = snapshot_cli.build_snapshot(
+        source_paths=resolved,
+        generated_at_unix_ms=3_100,
+    )
+
+    assert resolved["control_plane"].path == newer
+    assert resolved["control_plane"].configured_by == "runtime_dir"
+    assert snapshot["ok"] is True
+    assert snapshot["values"]["new"] == 2
+
+
+def test_env_and_not_configured_sources_are_resolved(tmp_path: Path) -> None:
+    control_plane_path = tmp_path / "env-control-plane-metrics.json"
+    write_metrics(
+        control_plane_path,
+        updated_at_unix_ms=1_000,
+        values={"control_plane.text_first_load_ms": 1},
+    )
+
+    assert snapshot_cli.normalize_path(None) is None
+    assert snapshot_cli.normalize_path("   ") is None
+    assert snapshot_cli.discover_latest_metrics_path(None, "control_plane") is None
+    assert snapshot_cli.discover_latest_metrics_path(tmp_path / "missing", "control_plane") is None
+    assert snapshot_cli.unix_ms_to_iso(None) is None
+
+    resolved = snapshot_cli.resolve_source_paths(
+        environment={"MELIX_CONTROL_PLANE_METRICS_PATH": str(control_plane_path)},
+    )
+
+    assert resolved["control_plane"].path == control_plane_path
+    assert resolved["control_plane"].configured_by == "environment"
+    assert resolved["swift_text_worker"].path is None
+    assert resolved["swift_text_worker"].configured_by == "not_configured"
+
+
+def test_invalid_payload_uses_file_mtime_freshness(tmp_path: Path) -> None:
+    invalid_path = tmp_path / "control-plane-metrics.json"
+    invalid_path.write_text("not-json", encoding="utf-8")
+    os.utime(invalid_path, (1, 1))
+
+    resolved = {
+        "control_plane": snapshot_cli.SourcePath(
+            name="control_plane",
+            path=invalid_path,
+            configured_by="argument",
+        ),
+        "swift_text_worker": snapshot_cli.SourcePath(
+            name="swift_text_worker",
+            path=None,
+            configured_by="not_configured",
+        ),
+        "python_worker": snapshot_cli.SourcePath(
+            name="python_worker",
+            path=None,
+            configured_by="not_configured",
+        ),
+    }
+    snapshot = snapshot_cli.build_snapshot(
+        source_paths=resolved,
+        generated_at_unix_ms=2_500,
+        stale_after_seconds=1,
+    )
+
+    source = snapshot["sources"]["control_plane"]
+    assert source["ok"] is False
+    assert "JSONDecodeError" in source["error"]
+    assert source["freshness"]["status"] == "stale"
+    assert source["freshness"]["observed_source"] == "file.mtime"
+    assert source["freshness"]["observed_at_unix_ms"] == 1_000
+
+
+def test_payload_validation_rejects_bad_shapes_and_non_numeric_updates(tmp_path: Path) -> None:
+    non_object = tmp_path / "non-object.json"
+    non_object.write_text("[]", encoding="utf-8")
+    missing_values = tmp_path / "missing-values.json"
+    missing_values.write_text("{}", encoding="utf-8")
+    bool_update = tmp_path / "bool-update.json"
+    bool_update.write_text(
+        json.dumps({
+            "updated_at_unix_ms": True,
+            "values": {"swift_text.prefill_ms": 1},
+        }),
+        encoding="utf-8",
+    )
+
+    for path, message in (
+        (non_object, "metrics snapshot must be a JSON object"),
+        (missing_values, "metrics snapshot is missing a values object"),
+    ):
+        try:
+            snapshot_cli.load_metrics_payload(path)
+        except ValueError as exc:
+            assert str(exc) == message
+        else:
+            raise AssertionError(f"expected ValueError for {path}")
+
+    resolved = {
+        "control_plane": snapshot_cli.SourcePath(
+            name="control_plane",
+            path=None,
+            configured_by="not_configured",
+        ),
+        "swift_text_worker": snapshot_cli.SourcePath(
+            name="swift_text_worker",
+            path=bool_update,
+            configured_by="argument",
+        ),
+        "python_worker": snapshot_cli.SourcePath(
+            name="python_worker",
+            path=None,
+            configured_by="not_configured",
+        ),
+    }
+    snapshot = snapshot_cli.build_snapshot(source_paths=resolved, generated_at_unix_ms=2_000)
+    assert snapshot["sources"]["swift_text_worker"]["ok"] is True
+    assert snapshot["sources"]["swift_text_worker"]["updated_at_unix_ms"] is None
+    assert snapshot["sources"]["swift_text_worker"]["freshness"]["observed_source"] == "file.mtime"
+
+
+def test_missing_required_source_is_machine_readable(tmp_path: Path) -> None:
+    control_plane_path = tmp_path / "control-plane-metrics.json"
+    missing_swift_path = tmp_path / "swift-text-worker-metrics.json"
+    write_metrics(
+        control_plane_path,
+        updated_at_unix_ms=1_000,
+        values={"control_plane.text_first_load_ms": 1},
+    )
+
+    snapshot = snapshot_cli.build_snapshot_from_paths(
+        control_plane_metrics=control_plane_path,
+        swift_text_worker_metrics=missing_swift_path,
+        generated_at_unix_ms=2_000,
+    )
+
+    assert snapshot["ok"] is False
+    assert snapshot["missing_required_sources"] == ["swift_text_worker"]
+    assert snapshot["sources"]["control_plane"]["ok"] is True
+    missing_source = snapshot["sources"]["swift_text_worker"]
+    assert missing_source["ok"] is False
+    assert missing_source["path"] == str(missing_swift_path)
+    assert missing_source["freshness"]["status"] == "missing"
+    assert "swift_text_worker" in snapshot["error"]
+
+
+def test_cli_emits_json_and_strict_mode_fails_on_missing_source(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    control_plane_path = tmp_path / "control-plane-metrics.json"
+    write_metrics(
+        control_plane_path,
+        updated_at_unix_ms=1_000,
+        values={"control_plane.text_first_load_ms": 1},
+    )
+
+    default_exit = snapshot_cli.main([
+        "--control-plane-metrics",
+        str(control_plane_path),
+        "--swift-text-worker-metrics",
+        str(tmp_path / "missing-swift-text-worker-metrics.json"),
+    ])
+    default_payload = json.loads(capsys.readouterr().out)
+    assert default_exit == 0
+    assert default_payload["ok"] is False
+    assert default_payload["missing_required_sources"] == ["swift_text_worker"]
+
+    strict_exit = snapshot_cli.main([
+        "--control-plane-metrics",
+        str(control_plane_path),
+        "--swift-text-worker-metrics",
+        str(tmp_path / "missing-swift-text-worker-metrics.json"),
+        "--strict",
+    ])
+    strict_payload = json.loads(capsys.readouterr().out)
+    assert strict_exit == 2
+    assert strict_payload["ok"] is False

--- a/tests/test_melix_metrics_snapshot.py
+++ b/tests/test_melix_metrics_snapshot.py
@@ -276,5 +276,5 @@ def test_cli_emits_json_and_strict_mode_fails_on_missing_source(
         "--strict",
     ])
     strict_payload = json.loads(capsys.readouterr().out)
-    assert strict_exit == 2
+    assert strict_exit == 1
     assert strict_payload["ok"] is False

--- a/tests/test_omlx_melix_compare_benchmark.py
+++ b/tests/test_omlx_melix_compare_benchmark.py
@@ -906,18 +906,15 @@ def test_melix_metrics_snapshot_merges_control_plane_and_swift_worker(tmp_path: 
 
     assert snapshot["ok"] is True
     assert snapshot["updated_at_unix_ms"] == 200
-    assert snapshot["sources"] == {
-        "control_plane": {
-            "ok": True,
-            "path": str(control_plane_path),
-            "updated_at_unix_ms": 100,
-        },
-        "swift_text_worker": {
-            "ok": True,
-            "path": str(swift_worker_path),
-            "updated_at_unix_ms": 200,
-        },
-    }
+    assert snapshot["sources"]["control_plane"]["ok"] is True
+    assert snapshot["sources"]["control_plane"]["path"] == str(control_plane_path)
+    assert snapshot["sources"]["control_plane"]["updated_at_unix_ms"] == 100
+    assert snapshot["sources"]["control_plane"]["source_kind"] == "control_plane"
+    assert snapshot["sources"]["swift_text_worker"]["ok"] is True
+    assert snapshot["sources"]["swift_text_worker"]["path"] == str(swift_worker_path)
+    assert snapshot["sources"]["swift_text_worker"]["updated_at_unix_ms"] == 200
+    assert snapshot["sources"]["swift_text_worker"]["source_kind"] == "worker"
+    assert snapshot["source_values"]["control_plane"]["http.ttfd_ms"] == 3447.17
     assert snapshot["values"]["control_plane.text_first_load_ms"] == 8547.46
     assert snapshot["values"]["swift_text.prefill_ms"] == 3706
     assert snapshot["values"]["swift_text.decode_tokens_per_second"] == 2
@@ -950,6 +947,47 @@ def test_metrics_snapshot_handles_missing_invalid_and_bad_sources(tmp_path: Path
     assert bench.enrich_hints_with_metrics([{"area": "existing"}], None) == [{"area": "existing"}]
     assert bench.enrich_hints_with_metrics([], {"ok": True, "values": []}) == []
     assert bench.metrics_manifest_entries(None, artifact_name="metrics.json") == {}
+
+
+def test_benchmark_metrics_snapshot_discovers_runtime_dir_sources(tmp_path: Path) -> None:
+    control_plane_path = tmp_path / "control-plane-metrics-abc.json"
+    swift_worker_path = tmp_path / "swift-text-worker-metrics-abc.json"
+    python_worker_path = tmp_path / "python-worker-metrics-abc.json"
+    control_plane_path.write_text(
+        json.dumps({
+            "updated_at_unix_ms": 100,
+            "values": {"control_plane.text_first_load_ms": 10},
+        }),
+        encoding="utf-8",
+    )
+    swift_worker_path.write_text(
+        json.dumps({
+            "updated_at_unix_ms": 200,
+            "values": {"swift_text.prefill_ms": 20},
+        }),
+        encoding="utf-8",
+    )
+    python_worker_path.write_text(
+        json.dumps({
+            "updated_at_unix_ms": 150,
+            "values": {"python_worker.bootstrap_ms": 30},
+        }),
+        encoding="utf-8",
+    )
+
+    snapshot = bench.load_melix_metrics_snapshot(
+        control_plane_path=None,
+        swift_text_worker_path=None,
+        runtime_dir=tmp_path,
+    )
+
+    assert snapshot["ok"] is True
+    assert snapshot["sources"]["control_plane"]["configured_by"] == "runtime_dir"
+    assert snapshot["sources"]["python_worker"]["ok"] is True
+    assert snapshot["values"]["python_worker.bootstrap_ms"] == 30
+    entries = bench.metrics_manifest_entries(snapshot, artifact_name="melix-metrics.json")
+    assert entries["melix_swift_text_worker"]["freshness"]["observed_at_unix_ms"] == 200
+    assert entries["melix_python_worker"]["path"] == str(python_worker_path)
 
 
 def test_markdown_summary_lists_text_batch_generator_metrics() -> None:

--- a/tests/test_three_way_serving_compare.py
+++ b/tests/test_three_way_serving_compare.py
@@ -750,6 +750,8 @@ def test_three_way_run_writes_merged_melix_metrics_snapshot(
 
     assert metrics_snapshot["values"]["control_plane.text_first_load_ms"] == 8547.46
     assert metrics_snapshot["values"]["swift_text.prefill_ms"] == 3706
+    assert metrics_snapshot["sources"]["control_plane"]["source_kind"] == "control_plane"
+    assert metrics_snapshot["sources"]["swift_text_worker"]["source_kind"] == "worker"
     assert "`swift_text.prefill_ms` | 3706.00" in markdown
 
 


### PR DESCRIPTION
## Summary
- Add `scripts/melix_metrics_snapshot.py`, a stable benchmark-facing JSON snapshot CLI for Melix metrics evidence.
- Snapshot output records source freshness, required-source missing state, and separates control-plane metrics from Swift/Python worker metrics.
- Wire the OMLX/Melix and three-way benchmark harnesses to consume the same snapshot builder, including runtime-dir discovery.

Closes #1648.
Part of #1647 and #1642.

## Plan or Spec
- `docs/plans/2026-05-28-gemma-e4b-metrics-snapshot-cli.md`
- `docs/plans/2026-05-12-omlx-melix-serving-benchmark.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_melix_metrics_snapshot.py tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py
# 98 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_melix_metrics_snapshot.py tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m scripts/melix_metrics_snapshot.py scripts/omlx_melix_compare_benchmark.py scripts/three_way_serving_compare.py tests/test_melix_metrics_snapshot.py tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py
# total 98%; scripts/melix_metrics_snapshot.py 98%

python3 -m compileall -q scripts/melix_metrics_snapshot.py scripts/omlx_melix_compare_benchmark.py scripts/three_way_serving_compare.py tests/test_melix_metrics_snapshot.py tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py
# passed

git diff --check
# passed

python3 scripts/melix_metrics_snapshot.py --runtime-dir "$tmpdir" --strict
# smoke output validated: True control_plane worker 2

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-scoped-performance/issue-1648/changed-files.json --output .runtime/pr-scoped-performance/issue-1648/scope.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_report.py --scope .runtime/pr-scoped-performance/issue-1648/scope.json --results-dir .runtime/pr-scoped-performance/issue-1648/results --format markdown --output-dir .runtime/pr-scoped-performance/issue-1648/report
# status ok; selected probes 0; regressions 0

git commit -m "Add Melix metrics snapshot CLI"
# pre-commit full local gate passed:
# make swift-test passed
# make py-test passed: 3353 passed, 14 skipped
# make integration-test passed: 115 passed, 1 skipped
# pre-commit scoped performance status ok; selected probes 0; regressions 0

git fetch origin main
git merge --no-edit origin/main
# merged db7c4a3b cleanly after origin/main advanced

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_melix_metrics_snapshot.py tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 350 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-scoped-performance/issue-1648-post-merge/changed-files.json --output .runtime/pr-scoped-performance/issue-1648-post-merge/scope.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_report.py --scope .runtime/pr-scoped-performance/issue-1648-post-merge/scope.json --results-dir .runtime/pr-scoped-performance/issue-1648-post-merge/results --format markdown --output-dir .runtime/pr-scoped-performance/issue-1648-post-merge/report
# status ok; selected probes 0; regressions 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_melix_metrics_snapshot.py tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py services/mlx-worker-python/tests/test_pr_scoped_performance.py services/mlx-worker-python/tests/test_dataset_registry.py
# 397 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_melix_metrics_snapshot.py tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m scripts/melix_metrics_snapshot.py scripts/omlx_melix_compare_benchmark.py scripts/three_way_serving_compare.py tests/test_melix_metrics_snapshot.py tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py
# total 98%; scripts/melix_metrics_snapshot.py 97%

git diff --check
# passed

python3 -m compileall -q scripts/melix_metrics_snapshot.py scripts/omlx_melix_compare_benchmark.py scripts/three_way_serving_compare.py tests/test_melix_metrics_snapshot.py tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-scoped-performance/issue-1648-review/changed-files.json --output .runtime/pr-scoped-performance/issue-1648-review/scope.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_report.py --scope .runtime/pr-scoped-performance/issue-1648-review/scope.json --results-dir .runtime/pr-scoped-performance/issue-1648-review/results --format markdown --output-dir .runtime/pr-scoped-performance/issue-1648-review/report
# status ok; selected probes 0; regressions 0

git commit -m "Harden metrics snapshot review paths"
# pre-commit full local gate passed:
# make swift-test passed
# make py-test passed: 3354 passed, 14 skipped
# make integration-test passed: 115 passed, 1 skipped
# pre-commit scoped performance status ok; selected probes 0; regressions 0
```

## Coverage and Metrics
- Changed-scope coverage: 98% total across the metrics snapshot CLI, benchmark harness plumbing, and focused tests.
- `scripts/melix_metrics_snapshot.py`: 97% coverage.
- Pre-commit scoped performance report: `.runtime/pre-commit-performance/20260528-125005-653c7300/report/report.md`; status `ok`, selected probes `0`, regressions `0`.
- Review-fix pre-commit scoped performance report: `.runtime/pre-commit-performance/20260528-131012-5193dd41/report/report.md`; status `ok`, selected probes `0`, regressions `0`.
- Post-merge scoped performance report: `.runtime/pr-scoped-performance/issue-1648-post-merge/report/report.md`; status `ok`, selected probes `0`, regressions `0`.
- Review-fix scoped performance report: `.runtime/pr-scoped-performance/issue-1648-review/report/report.md`; status `ok`, selected probes `0`, regressions `0`.
- Observability mode: evidence. The CLI reads existing metrics export artifacts and does not add hot-path runtime probes.
- Probe overhead: N/A because this change does not add runtime instrumentation or registered PR-scoped probes.

## Known Gaps
- #1649 still needs to add phase-attributed report rows and peer delta presentation on top of this snapshot interface.
- #1642 remains open until the release Melix vs SwiftLM vs OMLX benchmark gap is resolved and remeasured.
- This PR documents a local CLI interface, not an HTTP metrics endpoint.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema change.
- [x] Dependency changes include updated lockfiles. N/A: no dependency change.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
