### PR TITLE
Add serving report phase delta rows

### DIFF
--- a/docs/plans/2026-05-28-gemma-e4b-phase-delta-report-rows.md
+++ b/docs/plans/2026-05-28-gemma-e4b-phase-delta-report-rows.md
@@ -1,0 +1,53 @@
+# Gemma E4B Phase And Delta Report Rows
+
+## Goal
+
+Close #1649 by making the Gemma E4B comparison artifacts carry structured
+per-request phase rows, scenario-level Melix versus best-peer deltas, and
+threshold status rows that can be read by scripts or rendered in Markdown.
+
+## Scope
+
+- Extend the two-way and three-way serving comparison reports.
+- Keep client-measured phases separate from runtime metrics snapshots.
+- Record unavailable phase fields explicitly as `null` instead of inferring
+  queue, prefill, or worker internals from TTFT.
+- Render the new rows in Markdown and persist them in `summary.json` plus the
+  artifact manifest.
+
+## Non-Goals
+
+- Do not add new runtime instrumentation.
+- Do not change benchmark request scheduling or endpoint behavior.
+- Do not claim the root #1642 performance acceptance is met.
+
+## Contract
+
+Per-request phase rows include:
+
+- endpoint, model, scenario identifiers, repeat and request indexes
+- status and HTTP status
+- prompt/output token counts and token sources
+- client-observed first HTTP/SSE event latency, decode latency, total latency,
+  streamed chunk count, and aggregate group elapsed time
+- queue, prefill, and worker-stream phase fields as `null` unless a future
+  source can populate them directly
+
+Peer-delta rows include, per scenario:
+
+- target endpoint
+- best peer for total latency and decode throughput
+- signed percent deltas versus that best peer
+- configured threshold values
+- status flags for total latency and decode throughput
+
+The threshold status rolls these rows into report-level `ok` or
+`threshold_failed` status.
+
+## Verification
+
+- Focused pytest for the two-way and three-way report helpers.
+- Coverage report for changed scripts and tests.
+- `python3 -m compileall` for changed Python files.
+- `git diff --check`.
+- Scoped performance report for the PR file set.

--- a/scripts/omlx_melix_compare_benchmark.py
+++ b/scripts/omlx_melix_compare_benchmark.py
@@ -2298,8 +2298,8 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("Timeout values must be positive")
     if args.total_latency_threshold_ratio < 0:
         raise ValueError("--total-latency-threshold-ratio must be at least 0")
-    if args.decode_throughput_threshold_ratio < 0:
-        raise ValueError("--decode-throughput-threshold-ratio must be at least 0")
+    if not 0.0 <= args.decode_throughput_threshold_ratio <= 1.0:
+        raise ValueError("--decode-throughput-threshold-ratio must be between 0.0 and 1.0")
     if args.preflight_wait_seconds < 0:
         raise ValueError("--preflight-wait-seconds must be at least 0")
     if args.preflight_retry_interval_seconds <= 0:

--- a/scripts/omlx_melix_compare_benchmark.py
+++ b/scripts/omlx_melix_compare_benchmark.py
@@ -41,7 +41,9 @@ DEFAULT_TOP_K = 0
 PROMPT_STYLES = ("concise", "saturating")
 MEASUREMENT_PROFILES = ("auto", "cold", "warm", "mixed")
 COMPARISON_SCOPES = ("peer", "debug-only")
-REPORT_SCHEMA_VERSION = 2
+REPORT_SCHEMA_VERSION = 3
+DEFAULT_TOTAL_LATENCY_THRESHOLD_RATIO = 0.25
+DEFAULT_DECODE_THROUGHPUT_THRESHOLD_RATIO = 0.25
 MELIX_VLM_BATCHING_BLOCKED_REASON_CODES = {
     1: "multimodal route does not expose a streaming continuous batching path",
     2: "python VLM request is not eligible for cooperative text-only token-step batching",
@@ -741,6 +743,252 @@ def comparison_hints(summaries: list[ScenarioSummary]) -> list[dict[str, Any]]:
     return hints
 
 
+def build_request_phase_rows(observations: list[RequestObservation]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for observation in observations:
+        rows.append({
+            "endpoint": observation.endpoint,
+            "model": observation.model,
+            "scenario_id": observation.scenario_id,
+            "group_id": observation.group_id,
+            "prompt_token_target": observation.prompt_token_target,
+            "max_tokens": observation.max_tokens,
+            "concurrency": observation.concurrency,
+            "cache_profile": observation.cache_profile,
+            "prompt_style": observation.prompt_style,
+            "repeat_index": observation.repeat_index,
+            "request_index": observation.request_index,
+            "status": observation.status,
+            "http_status": observation.http_status,
+            "error": observation.error,
+            "prompt_tokens": observation.prompt_tokens,
+            "prompt_token_source": observation.prompt_token_source,
+            "output_tokens": observation.completion_tokens,
+            "output_token_source": observation.completion_token_source,
+            "queue_ms": None,
+            "prefill_ms": None,
+            "first_http_sse_event_ms": observation.ttft_ms,
+            "decode_ms": observation.decode_ms,
+            "worker_stream_ms": None,
+            "total_ms": observation.total_ms,
+            "streamed_chunks": observation.streamed_chunks,
+            "completion_chars": observation.completion_chars,
+            "decode_tokens_per_second": observation.decode_tokens_per_second,
+            "group_elapsed_ms": observation.group_elapsed_ms,
+            "phase_sources": {
+                "queue_ms": "unavailable",
+                "prefill_ms": "unavailable",
+                "first_http_sse_event_ms": "client_stream_first_delta",
+                "decode_ms": "client_total_minus_first_delta",
+                "worker_stream_ms": "unavailable",
+                "total_ms": "client_elapsed",
+            },
+        })
+    return rows
+
+
+def build_peer_delta_rows(
+    summaries: list[ScenarioSummary],
+    *,
+    target_endpoint: str = "melix",
+    total_latency_threshold_ratio: float = DEFAULT_TOTAL_LATENCY_THRESHOLD_RATIO,
+    decode_throughput_threshold_ratio: float = DEFAULT_DECODE_THROUGHPUT_THRESHOLD_RATIO,
+) -> list[dict[str, Any]]:
+    grouped: dict[tuple[int, int, int, str, str], list[ScenarioSummary]] = {}
+    for summary in summaries:
+        grouped.setdefault(_scenario_key(summary), []).append(summary)
+
+    rows: list[dict[str, Any]] = []
+    for key, scenario_rows in sorted(grouped.items()):
+        target = next((row for row in scenario_rows if row.endpoint == target_endpoint), None)
+        if target is None:
+            continue
+        best_total_peer = _best_peer_summary(
+            scenario_rows,
+            target_endpoint,
+            "median_total_ms",
+            lower_is_better=True,
+        )
+        best_decode_peer = _best_peer_summary(
+            scenario_rows,
+            target_endpoint,
+            "median_decode_tokens_per_second",
+            lower_is_better=False,
+        )
+        total_status = _latency_threshold_status(
+            target.median_total_ms,
+            best_total_peer.median_total_ms if best_total_peer else None,
+            total_latency_threshold_ratio,
+        )
+        decode_status = _throughput_threshold_status(
+            target.median_decode_tokens_per_second,
+            best_decode_peer.median_decode_tokens_per_second if best_decode_peer else None,
+            decode_throughput_threshold_ratio,
+        )
+        row_status = (
+            "threshold_failed"
+            if total_status == "failed" or decode_status == "failed"
+            else "ok"
+            if total_status == "ok" and decode_status == "ok"
+            else "insufficient_data"
+        )
+        rows.append({
+            "scenario": _scenario_dict_from_key(key),
+            "target_endpoint": target_endpoint,
+            "status": row_status,
+            "total_latency": {
+                "status": total_status,
+                "threshold_ratio": total_latency_threshold_ratio,
+                "threshold_pct": total_latency_threshold_ratio * 100.0,
+                "target_median_ms": target.median_total_ms,
+                "best_peer": best_total_peer.endpoint if best_total_peer else None,
+                "best_peer_median_ms": best_total_peer.median_total_ms if best_total_peer else None,
+                "delta_ms": _delta(target.median_total_ms, best_total_peer.median_total_ms if best_total_peer else None),
+                "delta_pct": _percent_delta(
+                    target.median_total_ms,
+                    best_total_peer.median_total_ms if best_total_peer else None,
+                ),
+            },
+            "decode_throughput": {
+                "status": decode_status,
+                "threshold_ratio": decode_throughput_threshold_ratio,
+                "threshold_pct": decode_throughput_threshold_ratio * 100.0,
+                "target_median_tokens_per_second": target.median_decode_tokens_per_second,
+                "best_peer": best_decode_peer.endpoint if best_decode_peer else None,
+                "best_peer_median_tokens_per_second": (
+                    best_decode_peer.median_decode_tokens_per_second if best_decode_peer else None
+                ),
+                "delta_tokens_per_second": _delta(
+                    target.median_decode_tokens_per_second,
+                    best_decode_peer.median_decode_tokens_per_second if best_decode_peer else None,
+                ),
+                "delta_pct": _percent_delta(
+                    target.median_decode_tokens_per_second,
+                    best_decode_peer.median_decode_tokens_per_second if best_decode_peer else None,
+                ),
+            },
+        })
+    return rows
+
+
+def build_threshold_status(
+    peer_delta_rows: list[dict[str, Any]],
+    *,
+    total_latency_threshold_ratio: float = DEFAULT_TOTAL_LATENCY_THRESHOLD_RATIO,
+    decode_throughput_threshold_ratio: float = DEFAULT_DECODE_THROUGHPUT_THRESHOLD_RATIO,
+) -> dict[str, Any]:
+    failures: list[dict[str, Any]] = []
+    has_insufficient = False
+    for row in peer_delta_rows:
+        scenario = row.get("scenario", {})
+        for area in ("total_latency", "decode_throughput"):
+            area_payload = row.get(area, {})
+            status = area_payload.get("status") if isinstance(area_payload, dict) else None
+            if status == "failed":
+                failures.append({
+                    "scenario": scenario,
+                    "area": area,
+                    "target_endpoint": row.get("target_endpoint"),
+                    "best_peer": area_payload.get("best_peer"),
+                    "delta_pct": area_payload.get("delta_pct"),
+                    "threshold_pct": area_payload.get("threshold_pct"),
+                })
+            elif status != "ok":
+                has_insufficient = True
+    if not peer_delta_rows:
+        status = "no_data"
+    elif failures:
+        status = "threshold_failed"
+    elif has_insufficient:
+        status = "insufficient_data"
+    else:
+        status = "ok"
+    return {
+        "status": status,
+        "row_count": len(peer_delta_rows),
+        "failure_count": len(failures),
+        "failures": failures,
+        "total_latency_threshold_pct": total_latency_threshold_ratio * 100.0,
+        "decode_throughput_threshold_pct": decode_throughput_threshold_ratio * 100.0,
+    }
+
+
+def _scenario_key(summary: ScenarioSummary) -> tuple[int, int, int, str, str]:
+    return (
+        summary.prompt_token_target,
+        summary.max_tokens,
+        summary.concurrency,
+        summary.cache_profile,
+        summary.prompt_style,
+    )
+
+
+def _scenario_dict_from_key(key: tuple[int, int, int, str, str]) -> dict[str, Any]:
+    prompt_token_target, max_tokens, concurrency, cache_profile, prompt_style = key
+    return {
+        "prompt_token_target": prompt_token_target,
+        "max_tokens": max_tokens,
+        "concurrency": concurrency,
+        "cache_profile": cache_profile,
+        "prompt_style": prompt_style,
+    }
+
+
+def _best_peer_summary(
+    rows: list[ScenarioSummary],
+    target_endpoint: str,
+    metric: str,
+    *,
+    lower_is_better: bool,
+) -> ScenarioSummary | None:
+    clean = [
+        row
+        for row in rows
+        if row.endpoint != target_endpoint
+        and row.error_count == 0
+        and getattr(row, metric) is not None
+    ]
+    if not clean:
+        return None
+    return (
+        min(clean, key=lambda row: getattr(row, metric))
+        if lower_is_better
+        else max(clean, key=lambda row: getattr(row, metric))
+    )
+
+
+def _latency_threshold_status(
+    target_value: float | None,
+    peer_value: float | None,
+    threshold_ratio: float,
+) -> str:
+    if target_value is None or peer_value is None:
+        return "missing"
+    return "failed" if target_value > peer_value * (1.0 + threshold_ratio) else "ok"
+
+
+def _throughput_threshold_status(
+    target_value: float | None,
+    peer_value: float | None,
+    threshold_ratio: float,
+) -> str:
+    if target_value is None or peer_value is None or peer_value <= 0:
+        return "missing"
+    return "failed" if target_value < peer_value * (1.0 - threshold_ratio) else "ok"
+
+
+def _delta(target_value: float | None, peer_value: float | None) -> float | None:
+    if target_value is None or peer_value is None:
+        return None
+    return target_value - peer_value
+
+
+def _percent_delta(target_value: float | None, peer_value: float | None) -> float | None:
+    if target_value is None or peer_value is None or peer_value == 0:
+        return None
+    return ((target_value - peer_value) / peer_value) * 100.0
+
+
 def _is_regressed_latency(melix_value: float | None, omlx_value: float | None) -> bool:
     if melix_value is None or omlx_value is None:
         return False
@@ -1119,6 +1367,9 @@ def write_artifacts(
     metrics_snapshot: dict[str, Any] | None,
     observations: list[RequestObservation],
     summaries: list[ScenarioSummary],
+    request_phase_rows: list[dict[str, Any]],
+    peer_delta_rows: list[dict[str, Any]],
+    threshold_status: dict[str, Any],
     hints: list[dict[str, Any]],
     dry_run: bool,
     measurement_profile: dict[str, Any],
@@ -1134,6 +1385,9 @@ def write_artifacts(
         "summary_json": staging_dir / "summary.json",
         "summary_csv": staging_dir / "summary.csv",
         "summary_markdown": staging_dir / "summary.md",
+        "request_phase_rows": staging_dir / "request-phase-rows.json",
+        "peer_delta_rows": staging_dir / "peer-delta-rows.json",
+        "threshold_status": staging_dir / "threshold-status.json",
     }
     if warmups:
         paths["warmups"] = staging_dir / "warmups.jsonl"
@@ -1161,6 +1415,9 @@ def write_artifacts(
         "comparison_validity": comparison_validity,
         "token_accounting": token_accounting,
         "observation_count": len(observations),
+        "request_phase_row_count": len(request_phase_rows),
+        "peer_delta_row_count": len(peer_delta_rows),
+        "threshold_status": threshold_status,
         "preflight": preflight,
         "metrics": metrics_manifest_entries(
             metrics_snapshot,
@@ -1181,6 +1438,18 @@ def write_artifacts(
     with paths["observations"].open("w", encoding="utf-8") as handle:
         for observation in observations:
             handle.write(json.dumps(asdict(observation), sort_keys=True) + "\n")
+    paths["request_phase_rows"].write_text(
+        json.dumps(request_phase_rows, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    paths["peer_delta_rows"].write_text(
+        json.dumps(peer_delta_rows, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    paths["threshold_status"].write_text(
+        json.dumps(threshold_status, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     summary_payload = {
         "schema_version": REPORT_SCHEMA_VERSION,
         "generated_at": generated_at,
@@ -1191,6 +1460,9 @@ def write_artifacts(
         "melix_metrics_snapshot": metrics_snapshot,
         "warmups": [asdict(observation) for observation in warmups],
         "summaries": [asdict(summary) for summary in summaries],
+        "request_phase_rows": request_phase_rows,
+        "peer_delta_rows": peer_delta_rows,
+        "threshold_status": threshold_status,
         "optimization_hints": hints,
     }
     paths["summary_json"].write_text(
@@ -1205,6 +1477,9 @@ def write_artifacts(
             preflight=preflight,
             warmups=warmups,
             metrics_snapshot=metrics_snapshot,
+            request_phase_rows=request_phase_rows,
+            peer_delta_rows=peer_delta_rows,
+            threshold_status=threshold_status,
             dry_run=dry_run,
             measurement_profile=measurement_profile,
             runtime_metadata=runtime_metadata,
@@ -1259,6 +1534,90 @@ def runtime_metadata_markdown_rows(runtime_metadata: dict[str, Any]) -> list[str
     return rows
 
 
+def append_peer_delta_markdown(
+    lines: list[str],
+    peer_delta_rows: list[dict[str, Any]],
+    threshold_status: dict[str, Any] | None,
+) -> None:
+    lines.append("")
+    lines.append("## Peer Delta Rows")
+    lines.append("")
+    if threshold_status is not None:
+        lines.append(
+            "- Status: `{status}`; failures: `{failures}`".format(
+                status=threshold_status.get("status", "unknown"),
+                failures=threshold_status.get("failure_count", 0),
+            )
+        )
+        lines.append("")
+    if not peer_delta_rows:
+        lines.append("No peer delta rows were generated.")
+        return
+    lines.append(
+        "| Scenario | Total Status | Total Best Peer | Total Target ms | Total Best ms | "
+        "Total Delta % | Decode Status | Decode Best Peer | Decode Target tok/s | "
+        "Decode Best tok/s | Decode Delta % |"
+    )
+    lines.append("|---|---|---|---:|---:|---:|---|---|---:|---:|---:|")
+    for row in peer_delta_rows:
+        scenario = row.get("scenario", {})
+        total = row.get("total_latency", {})
+        decode = row.get("decode_throughput", {})
+        lines.append(
+            "| pt={prompt} out={out} c={concurrency} | {total_status} | {total_peer} | {total_target} | {total_best} | {total_delta} | {decode_status} | {decode_peer} | {decode_target} | {decode_best} | {decode_delta} |".format(
+                prompt=scenario.get("prompt_token_target", "n/a"),
+                out=scenario.get("max_tokens", "n/a"),
+                concurrency=scenario.get("concurrency", "n/a"),
+                total_status=total.get("status", "missing") if isinstance(total, dict) else "missing",
+                total_peer=total.get("best_peer") or "n/a" if isinstance(total, dict) else "n/a",
+                total_target=_fmt(total.get("target_median_ms") if isinstance(total, dict) else None),
+                total_best=_fmt(total.get("best_peer_median_ms") if isinstance(total, dict) else None),
+                total_delta=_fmt(total.get("delta_pct") if isinstance(total, dict) else None),
+                decode_status=decode.get("status", "missing") if isinstance(decode, dict) else "missing",
+                decode_peer=decode.get("best_peer") or "n/a" if isinstance(decode, dict) else "n/a",
+                decode_target=_fmt(
+                    decode.get("target_median_tokens_per_second") if isinstance(decode, dict) else None
+                ),
+                decode_best=_fmt(
+                    decode.get("best_peer_median_tokens_per_second") if isinstance(decode, dict) else None
+                ),
+                decode_delta=_fmt(decode.get("delta_pct") if isinstance(decode, dict) else None),
+            )
+        )
+
+
+def append_request_phase_markdown(lines: list[str], request_phase_rows: list[dict[str, Any]]) -> None:
+    lines.append("")
+    lines.append("## Request Phase Rows")
+    lines.append("")
+    if not request_phase_rows:
+        lines.append("No request phase rows were generated.")
+        return
+    lines.append(
+        "| Endpoint | Scenario | Repeat | Request | Status | Queue ms | Prefill ms | "
+        "First HTTP/SSE Event ms | Decode ms | Worker Stream ms | Total ms | Output Tokens | Decode tok/s |"
+    )
+    lines.append("|---|---|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|")
+    for row in request_phase_rows:
+        lines.append(
+            "| {endpoint} | {scenario} | {repeat} | {request} | {status} | {queue} | {prefill} | {first_event} | {decode_ms} | {worker_stream} | {total} | {output_tokens} | {decode_tps} |".format(
+                endpoint=row.get("endpoint", ""),
+                scenario=row.get("scenario_id", ""),
+                repeat=row.get("repeat_index", ""),
+                request=row.get("request_index", ""),
+                status=row.get("status", ""),
+                queue=_fmt(row.get("queue_ms")),
+                prefill=_fmt(row.get("prefill_ms")),
+                first_event=_fmt(row.get("first_http_sse_event_ms")),
+                decode_ms=_fmt(row.get("decode_ms")),
+                worker_stream=_fmt(row.get("worker_stream_ms")),
+                total=_fmt(row.get("total_ms")),
+                output_tokens=_fmt(row.get("output_tokens")),
+                decode_tps=_fmt(row.get("decode_tokens_per_second")),
+            )
+        )
+
+
 def render_markdown_summary(
     summaries: list[ScenarioSummary],
     hints: list[dict[str, Any]],
@@ -1266,6 +1625,9 @@ def render_markdown_summary(
     preflight: list[dict[str, Any]],
     warmups: list[RequestObservation],
     metrics_snapshot: dict[str, Any] | None,
+    request_phase_rows: list[dict[str, Any]] | None = None,
+    peer_delta_rows: list[dict[str, Any]] | None = None,
+    threshold_status: dict[str, Any] | None = None,
     dry_run: bool,
     measurement_profile: dict[str, Any],
     runtime_metadata: dict[str, Any] | None = None,
@@ -1280,6 +1642,8 @@ def render_markdown_summary(
             lines.append(f"- Peer comparison warning: {reason}")
     if measurement_profile.get("operator_note"):
         lines.append(f"- Measurement note: {measurement_profile['operator_note']}")
+    if threshold_status is not None:
+        lines.append(f"- Threshold status: `{threshold_status.get('status', 'unknown')}`")
     if runtime_metadata:
         lines.append("")
         lines.append("## Reproducibility")
@@ -1347,6 +1711,8 @@ def render_markdown_summary(
                 aggregate=_fmt(summary.median_aggregate_output_tokens_per_second),
             )
         )
+    append_peer_delta_markdown(lines, peer_delta_rows or [], threshold_status)
+    append_request_phase_markdown(lines, request_phase_rows or [])
     if metrics_snapshot is not None:
         lines.append("")
         lines.append("## Melix Metrics Snapshot")
@@ -1668,6 +2034,18 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
         token_accounting=token_accounting,
     )
     hints = enrich_hints_with_metrics(comparison_hints(summaries), metrics_snapshot)
+    request_phase_rows = build_request_phase_rows(observations)
+    peer_delta_rows = build_peer_delta_rows(
+        summaries,
+        target_endpoint="melix",
+        total_latency_threshold_ratio=args.total_latency_threshold_ratio,
+        decode_throughput_threshold_ratio=args.decode_throughput_threshold_ratio,
+    )
+    threshold_status = build_threshold_status(
+        peer_delta_rows,
+        total_latency_threshold_ratio=args.total_latency_threshold_ratio,
+        decode_throughput_threshold_ratio=args.decode_throughput_threshold_ratio,
+    )
     warmup_settings = {
         "request_count_per_endpoint": args.warmup_requests,
         "prompt_token_target": args.warmup_prompt_token_target,
@@ -1684,6 +2062,9 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
         metrics_snapshot=metrics_snapshot,
         observations=observations,
         summaries=summaries,
+        request_phase_rows=request_phase_rows,
+        peer_delta_rows=peer_delta_rows,
+        threshold_status=threshold_status,
         hints=hints,
         dry_run=args.dry_run,
         measurement_profile=measurement_profile,
@@ -1703,6 +2084,9 @@ def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
         "comparison_validity": comparison_validity,
         "observation_count": len(observations),
         "summary_count": len(summaries),
+        "request_phase_row_count": len(request_phase_rows),
+        "peer_delta_row_count": len(peer_delta_rows),
+        "threshold_status": threshold_status,
         "optimization_hint_count": len(hints),
         "melix_metrics_snapshot": {
             "ok": metrics_snapshot.get("ok"),
@@ -1808,6 +2192,18 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Keep peer report artifacts when prompt/completion token counts come from mixed usage and estimate sources.",
     )
     parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument(
+        "--total-latency-threshold-ratio",
+        type=float,
+        default=DEFAULT_TOTAL_LATENCY_THRESHOLD_RATIO,
+        help="Scenario status fails when target total latency is more than this ratio above the best peer.",
+    )
+    parser.add_argument(
+        "--decode-throughput-threshold-ratio",
+        type=float,
+        default=DEFAULT_DECODE_THROUGHPUT_THRESHOLD_RATIO,
+        help="Scenario status fails when target decode tok/s is more than this ratio below the best peer.",
+    )
     parser.add_argument("--preflight-timeout-seconds", type=float, default=10.0)
     parser.add_argument(
         "--preflight-wait-seconds",
@@ -1900,6 +2296,10 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("--concurrency values must be positive")
     if args.timeout_seconds <= 0 or args.preflight_timeout_seconds <= 0:
         raise ValueError("Timeout values must be positive")
+    if args.total_latency_threshold_ratio < 0:
+        raise ValueError("--total-latency-threshold-ratio must be at least 0")
+    if args.decode_throughput_threshold_ratio < 0:
+        raise ValueError("--decode-throughput-threshold-ratio must be at least 0")
     if args.preflight_wait_seconds < 0:
         raise ValueError("--preflight-wait-seconds must be at least 0")
     if args.preflight_retry_interval_seconds <= 0:

--- a/scripts/three_way_serving_compare.py
+++ b/scripts/three_way_serving_compare.py
@@ -949,8 +949,8 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("Timeout values must be positive")
     if args.total_latency_threshold_ratio < 0:
         raise ValueError("--total-latency-threshold-ratio must be at least 0")
-    if args.decode_throughput_threshold_ratio < 0:
-        raise ValueError("--decode-throughput-threshold-ratio must be at least 0")
+    if not 0.0 <= args.decode_throughput_threshold_ratio <= 1.0:
+        raise ValueError("--decode-throughput-threshold-ratio must be between 0.0 and 1.0")
     if args.preflight_wait_seconds < 0:
         raise ValueError("--preflight-wait-seconds must be at least 0")
     if args.preflight_retry_interval_seconds <= 0:

--- a/scripts/three_way_serving_compare.py
+++ b/scripts/three_way_serving_compare.py
@@ -25,6 +25,7 @@ import omlx_melix_compare_benchmark as base
 
 ENDPOINT_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 DEFAULT_RUN_ROOT = Path(".runtime/three-way-gemma31b128k")
+REPORT_SCHEMA_VERSION = 2
 
 
 def parse_endpoint_headers(values: Iterable[str]) -> dict[str, dict[str, str]]:
@@ -454,6 +455,18 @@ def run_comparison(args: argparse.Namespace) -> dict[str, Any]:
     prompt_evidence = prompt_token_evidence(observations)
     comparisons, peer_hints = peer_comparisons(summaries, target_endpoint=args.target_endpoint)
     hints = base.enrich_hints_with_metrics(peer_hints, metrics_snapshot)
+    request_phase_rows = base.build_request_phase_rows(observations)
+    peer_delta_rows = base.build_peer_delta_rows(
+        summaries,
+        target_endpoint=args.target_endpoint,
+        total_latency_threshold_ratio=args.total_latency_threshold_ratio,
+        decode_throughput_threshold_ratio=args.decode_throughput_threshold_ratio,
+    )
+    threshold_status = base.build_threshold_status(
+        peer_delta_rows,
+        total_latency_threshold_ratio=args.total_latency_threshold_ratio,
+        decode_throughput_threshold_ratio=args.decode_throughput_threshold_ratio,
+    )
     warmup_settings = {
         "request_count_per_endpoint": args.warmup_requests,
         "prompt_token_target": args.warmup_prompt_token_target,
@@ -473,6 +486,9 @@ def run_comparison(args: argparse.Namespace) -> dict[str, Any]:
         summaries=summaries,
         prompt_evidence=prompt_evidence,
         comparisons=comparisons,
+        request_phase_rows=request_phase_rows,
+        peer_delta_rows=peer_delta_rows,
+        threshold_status=threshold_status,
         hints=hints,
         dry_run=args.dry_run,
         target_endpoint=args.target_endpoint,
@@ -491,6 +507,9 @@ def run_comparison(args: argparse.Namespace) -> dict[str, Any]:
         "observation_count": len(observations),
         "summary_count": len(summaries),
         "comparison_count": len(comparisons),
+        "request_phase_row_count": len(request_phase_rows),
+        "peer_delta_row_count": len(peer_delta_rows),
+        "threshold_status": threshold_status,
         "optimization_hint_count": len(hints),
         "artifacts": artifact_paths,
     }
@@ -510,6 +529,9 @@ def write_artifacts(
     summaries: list[base.ScenarioSummary],
     prompt_evidence: list[dict[str, Any]],
     comparisons: list[dict[str, Any]],
+    request_phase_rows: list[dict[str, Any]],
+    peer_delta_rows: list[dict[str, Any]],
+    threshold_status: dict[str, Any],
     hints: list[dict[str, Any]],
     dry_run: bool,
     target_endpoint: str,
@@ -524,6 +546,9 @@ def write_artifacts(
         "summary_csv": staging_dir / "summary.csv",
         "summary_markdown": staging_dir / "summary.md",
         "runtime_snapshots": staging_dir / "runtime-snapshots.json",
+        "request_phase_rows": staging_dir / "request-phase-rows.json",
+        "peer_delta_rows": staging_dir / "peer-delta-rows.json",
+        "threshold_status": staging_dir / "threshold-status.json",
     }
     if warmups:
         paths["warmups"] = staging_dir / "warmups.jsonl"
@@ -531,7 +556,7 @@ def write_artifacts(
         paths["melix_metrics"] = staging_dir / "melix-metrics.json"
 
     manifest = {
-        "schema_version": 1,
+        "schema_version": REPORT_SCHEMA_VERSION,
         "generated_at": generated_at,
         "dry_run": dry_run,
         "target_endpoint": target_endpoint,
@@ -552,6 +577,9 @@ def write_artifacts(
         "warmup_count": len(warmups),
         "warmup_settings": warmup_settings,
         "observation_count": len(observations),
+        "request_phase_row_count": len(request_phase_rows),
+        "peer_delta_row_count": len(peer_delta_rows),
+        "threshold_status": threshold_status,
         "preflight": preflight,
         "artifacts": {key: path.name for key, path in paths.items()},
     }
@@ -572,8 +600,20 @@ def write_artifacts(
     with paths["observations"].open("w", encoding="utf-8") as handle:
         for observation in observations:
             handle.write(json.dumps(asdict(observation), sort_keys=True) + "\n")
+    paths["request_phase_rows"].write_text(
+        json.dumps(request_phase_rows, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    paths["peer_delta_rows"].write_text(
+        json.dumps(peer_delta_rows, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    paths["threshold_status"].write_text(
+        json.dumps(threshold_status, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     summary_payload = {
-        "schema_version": 1,
+        "schema_version": REPORT_SCHEMA_VERSION,
         "generated_at": generated_at,
         "target_endpoint": target_endpoint,
         "measurement_profile": measurement_profile,
@@ -583,6 +623,9 @@ def write_artifacts(
         "prompt_token_evidence": prompt_evidence,
         "summaries": [asdict(summary) for summary in summaries],
         "peer_comparisons": comparisons,
+        "request_phase_rows": request_phase_rows,
+        "peer_delta_rows": peer_delta_rows,
+        "threshold_status": threshold_status,
         "optimization_hints": hints,
     }
     paths["summary_json"].write_text(
@@ -600,6 +643,9 @@ def write_artifacts(
             prompt_evidence=prompt_evidence,
             warmups=warmups,
             metrics_snapshot=metrics_snapshot,
+            request_phase_rows=request_phase_rows,
+            peer_delta_rows=peer_delta_rows,
+            threshold_status=threshold_status,
             dry_run=dry_run,
             target_endpoint=target_endpoint,
             measurement_profile=measurement_profile,
@@ -619,6 +665,9 @@ def render_markdown_summary(
     prompt_evidence: list[dict[str, Any]],
     warmups: list[base.RequestObservation],
     metrics_snapshot: dict[str, Any] | None,
+    request_phase_rows: list[dict[str, Any]] | None = None,
+    peer_delta_rows: list[dict[str, Any]] | None = None,
+    threshold_status: dict[str, Any] | None = None,
     dry_run: bool,
     target_endpoint: str,
     measurement_profile: dict[str, Any],
@@ -629,6 +678,8 @@ def render_markdown_summary(
     lines.append(f"- Measurement profile: `{measurement_profile.get('profile', 'unknown')}`")
     if measurement_profile.get("operator_note"):
         lines.append(f"- Measurement note: {measurement_profile['operator_note']}")
+    if threshold_status is not None:
+        lines.append(f"- Threshold status: `{threshold_status.get('status', 'unknown')}`")
     lines.append("")
     lines.append("## Preflight")
     lines.append("")
@@ -714,6 +765,8 @@ def render_markdown_summary(
             )
     else:
         lines.append("No peer comparison rows were generated.")
+    base.append_peer_delta_markdown(lines, peer_delta_rows or [], threshold_status)
+    base.append_request_phase_markdown(lines, request_phase_rows or [])
     lines.append("")
     lines.append("## Runtime Snapshots")
     lines.append("")
@@ -826,6 +879,16 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--top-k", type=int, default=0)
     parser.add_argument("--include-usage", action="store_true")
     parser.add_argument("--timeout-seconds", type=float, default=3600.0)
+    parser.add_argument(
+        "--total-latency-threshold-ratio",
+        type=float,
+        default=base.DEFAULT_TOTAL_LATENCY_THRESHOLD_RATIO,
+    )
+    parser.add_argument(
+        "--decode-throughput-threshold-ratio",
+        type=float,
+        default=base.DEFAULT_DECODE_THROUGHPUT_THRESHOLD_RATIO,
+    )
     parser.add_argument("--preflight-timeout-seconds", type=float, default=10.0)
     parser.add_argument("--preflight-wait-seconds", type=float, default=0.0)
     parser.add_argument("--preflight-retry-interval-seconds", type=float, default=2.0)
@@ -884,6 +947,10 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("--concurrency values must be positive")
     if args.timeout_seconds <= 0 or args.preflight_timeout_seconds <= 0:
         raise ValueError("Timeout values must be positive")
+    if args.total_latency_threshold_ratio < 0:
+        raise ValueError("--total-latency-threshold-ratio must be at least 0")
+    if args.decode_throughput_threshold_ratio < 0:
+        raise ValueError("--decode-throughput-threshold-ratio must be at least 0")
     if args.preflight_wait_seconds < 0:
         raise ValueError("--preflight-wait-seconds must be at least 0")
     if args.preflight_retry_interval_seconds <= 0:

--- a/tests/test_omlx_melix_compare_benchmark.py
+++ b/tests/test_omlx_melix_compare_benchmark.py
@@ -515,6 +515,79 @@ def test_summarize_observations_computes_latency_and_group_throughput() -> None:
     assert summary.prompt_style == "concise"
 
 
+def test_request_phase_rows_record_client_phases_and_unavailable_runtime_phases() -> None:
+    rows = bench.build_request_phase_rows([
+        bench.RequestObservation(
+            endpoint="melix",
+            model="model",
+            scenario_id="pt1024-out64-c1-r0",
+            group_id="melix-pt1024-out64-c1-r0",
+            prompt_token_target=1024,
+            prompt_token_source="usage",
+            max_tokens=64,
+            concurrency=1,
+            cache_profile="cold_unique",
+            repeat_index=0,
+            request_index=0,
+            status="ok",
+            http_status=200,
+            error="",
+            ttft_ms=125.0,
+            total_ms=400.0,
+            decode_ms=275.0,
+            completion_tokens=64.0,
+            completion_token_source="usage",
+            prompt_tokens=1020.0,
+            streamed_chunks=64,
+            completion_chars=256,
+            decode_tokens_per_second=232.73,
+            group_elapsed_ms=410.0,
+            prompt_style="saturating",
+        )
+    ])
+
+    assert rows == [
+        {
+            "endpoint": "melix",
+            "model": "model",
+            "scenario_id": "pt1024-out64-c1-r0",
+            "group_id": "melix-pt1024-out64-c1-r0",
+            "prompt_token_target": 1024,
+            "max_tokens": 64,
+            "concurrency": 1,
+            "cache_profile": "cold_unique",
+            "prompt_style": "saturating",
+            "repeat_index": 0,
+            "request_index": 0,
+            "status": "ok",
+            "http_status": 200,
+            "error": "",
+            "prompt_tokens": 1020.0,
+            "prompt_token_source": "usage",
+            "output_tokens": 64.0,
+            "output_token_source": "usage",
+            "queue_ms": None,
+            "prefill_ms": None,
+            "first_http_sse_event_ms": 125.0,
+            "decode_ms": 275.0,
+            "worker_stream_ms": None,
+            "total_ms": 400.0,
+            "streamed_chunks": 64,
+            "completion_chars": 256,
+            "decode_tokens_per_second": 232.73,
+            "group_elapsed_ms": 410.0,
+            "phase_sources": {
+                "queue_ms": "unavailable",
+                "prefill_ms": "unavailable",
+                "first_http_sse_event_ms": "client_stream_first_delta",
+                "decode_ms": "client_total_minus_first_delta",
+                "worker_stream_ms": "unavailable",
+                "total_ms": "client_elapsed",
+            },
+        }
+    ]
+
+
 def test_statistics_helpers_cover_empty_and_percentile_edges() -> None:
     assert bench.median([None]) is None
     assert bench.percentile([None], 95) is None
@@ -621,6 +694,122 @@ def test_comparison_hints_flags_melix_regressions() -> None:
         "decode_throughput",
         "continuous_batching",
     }
+
+
+def test_peer_delta_rows_and_threshold_status_flag_best_peer_gaps() -> None:
+    summaries = [
+        bench.ScenarioSummary(
+            endpoint="melix",
+            model="model",
+            prompt_token_target=1024,
+            max_tokens=64,
+            concurrency=2,
+            cache_profile="cold_unique",
+            request_count=2,
+            success_count=2,
+            error_count=0,
+            error_rate=0.0,
+            median_ttft_ms=100.0,
+            p95_ttft_ms=100.0,
+            median_total_ms=260.0,
+            p95_total_ms=260.0,
+            median_decode_tokens_per_second=60.0,
+            median_aggregate_output_tokens_per_second=120.0,
+            median_completion_tokens=64.0,
+            prompt_style="saturating",
+        ),
+        bench.ScenarioSummary(
+            endpoint="omlx",
+            model="model",
+            prompt_token_target=1024,
+            max_tokens=64,
+            concurrency=2,
+            cache_profile="cold_unique",
+            request_count=2,
+            success_count=2,
+            error_count=0,
+            error_rate=0.0,
+            median_ttft_ms=80.0,
+            p95_ttft_ms=80.0,
+            median_total_ms=100.0,
+            p95_total_ms=100.0,
+            median_decode_tokens_per_second=80.0,
+            median_aggregate_output_tokens_per_second=160.0,
+            median_completion_tokens=64.0,
+            prompt_style="saturating",
+        ),
+        bench.ScenarioSummary(
+            endpoint="swiftlm",
+            model="model",
+            prompt_token_target=1024,
+            max_tokens=64,
+            concurrency=2,
+            cache_profile="cold_unique",
+            request_count=2,
+            success_count=2,
+            error_count=0,
+            error_rate=0.0,
+            median_ttft_ms=90.0,
+            p95_ttft_ms=90.0,
+            median_total_ms=120.0,
+            p95_total_ms=120.0,
+            median_decode_tokens_per_second=100.0,
+            median_aggregate_output_tokens_per_second=200.0,
+            median_completion_tokens=64.0,
+            prompt_style="saturating",
+        ),
+    ]
+
+    rows = bench.build_peer_delta_rows(
+        summaries,
+        target_endpoint="melix",
+        total_latency_threshold_ratio=0.25,
+        decode_throughput_threshold_ratio=0.25,
+    )
+    status = bench.build_threshold_status(
+        rows,
+        total_latency_threshold_ratio=0.25,
+        decode_throughput_threshold_ratio=0.25,
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["status"] == "threshold_failed"
+    assert row["scenario"] == {
+        "prompt_token_target": 1024,
+        "max_tokens": 64,
+        "concurrency": 2,
+        "cache_profile": "cold_unique",
+        "prompt_style": "saturating",
+    }
+    assert row["total_latency"]["status"] == "failed"
+    assert row["total_latency"]["best_peer"] == "omlx"
+    assert row["total_latency"]["delta_ms"] == 160.0
+    assert row["total_latency"]["delta_pct"] == 160.0
+    assert row["decode_throughput"]["status"] == "failed"
+    assert row["decode_throughput"]["best_peer"] == "swiftlm"
+    assert row["decode_throughput"]["delta_tokens_per_second"] == -40.0
+    assert row["decode_throughput"]["delta_pct"] == -40.0
+    assert status["status"] == "threshold_failed"
+    assert status["failure_count"] == 2
+    assert status["failures"] == [
+        {
+            "scenario": row["scenario"],
+            "area": "total_latency",
+            "target_endpoint": "melix",
+            "best_peer": "omlx",
+            "delta_pct": 160.0,
+            "threshold_pct": 25.0,
+        },
+        {
+            "scenario": row["scenario"],
+            "area": "decode_throughput",
+            "target_endpoint": "melix",
+            "best_peer": "swiftlm",
+            "delta_pct": -40.0,
+            "threshold_pct": 25.0,
+        },
+    ]
 
 
 def test_metrics_snapshot_adds_multimodal_batching_hint(tmp_path: Path) -> None:
@@ -1063,6 +1252,77 @@ def test_metrics_snapshot_reports_text_batch_generator_http_gap() -> None:
     assert "`http.stream_first_event_ms` | 1552.02" in markdown
     assert "`http.parser.text_batch_generator_first_visible_ms` | 1435.31" in markdown
     assert "`http.text_batch_generator_first_visible_to_stream_first_event_ms` | 116.71" in markdown
+
+
+def test_markdown_summary_lists_peer_delta_and_request_phase_rows() -> None:
+    markdown = bench.render_markdown_summary(
+        [],
+        [],
+        preflight=[],
+        warmups=[],
+        metrics_snapshot=None,
+        request_phase_rows=[
+            {
+                "endpoint": "melix",
+                "scenario_id": "pt1024-out16-c1-r0",
+                "repeat_index": 0,
+                "request_index": 0,
+                "status": "ok",
+                "queue_ms": None,
+                "prefill_ms": None,
+                "first_http_sse_event_ms": 42.0,
+                "decode_ms": 58.0,
+                "worker_stream_ms": None,
+                "total_ms": 100.0,
+                "output_tokens": 16.0,
+                "decode_tokens_per_second": 275.86,
+            }
+        ],
+        peer_delta_rows=[
+            {
+                "scenario": {
+                    "prompt_token_target": 1024,
+                    "max_tokens": 16,
+                    "concurrency": 1,
+                    "cache_profile": "cold_unique",
+                    "prompt_style": "concise",
+                },
+                "target_endpoint": "melix",
+                "status": "threshold_failed",
+                "total_latency": {
+                    "status": "failed",
+                    "best_peer": "omlx",
+                    "target_median_ms": 150.0,
+                    "best_peer_median_ms": 100.0,
+                    "delta_pct": 50.0,
+                },
+                "decode_throughput": {
+                    "status": "ok",
+                    "best_peer": "swiftlm",
+                    "target_median_tokens_per_second": 80.0,
+                    "best_peer_median_tokens_per_second": 90.0,
+                    "delta_pct": -11.111,
+                },
+            }
+        ],
+        threshold_status={
+            "status": "threshold_failed",
+            "failure_count": 1,
+        },
+        dry_run=False,
+        measurement_profile={
+            "profile": "warm",
+            "warmup_requests_per_endpoint": 1,
+            "operator_note": "",
+        },
+    )
+
+    assert "- Threshold status: `threshold_failed`" in markdown
+    assert "## Peer Delta Rows" in markdown
+    assert "| pt=1024 out=16 c=1 | failed | omlx | 150.00 | 100.00 | 50.00 | ok | swiftlm | 80.00 | 90.00 | -11.11 |" in markdown
+    assert "## Request Phase Rows" in markdown
+    assert "First HTTP/SSE Event ms" in markdown
+    assert "| melix | pt1024-out16-c1-r0 | 0 | 0 | ok | n/a | n/a | 42.00 | 58.00 | n/a | 100.00 | 16.00 | 275.86 |" in markdown
 
 
 def test_warmup_requests_mark_measurements_as_warm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1533,10 +1793,20 @@ def test_warmups_are_written_separately_from_summaries(tmp_path: Path, monkeypat
     summary = json.loads((staging_dir / "summary.json").read_text(encoding="utf-8"))
     warmups = (staging_dir / "warmups.jsonl").read_text(encoding="utf-8").strip().splitlines()
     observations = (staging_dir / "observations.jsonl").read_text(encoding="utf-8").strip().splitlines()
+    request_phase_rows = json.loads((staging_dir / "request-phase-rows.json").read_text(encoding="utf-8"))
+    peer_delta_rows = json.loads((staging_dir / "peer-delta-rows.json").read_text(encoding="utf-8"))
+    threshold_status = json.loads((staging_dir / "threshold-status.json").read_text(encoding="utf-8"))
+    markdown = (staging_dir / "summary.md").read_text(encoding="utf-8")
 
     assert result["warmup_count"] == 2
     assert result["observation_count"] == 2
+    assert result["request_phase_row_count"] == 2
+    assert result["peer_delta_row_count"] == 1
+    assert result["threshold_status"]["status"] == "ok"
     assert manifest["warmup_count"] == 2
+    assert manifest["request_phase_row_count"] == 2
+    assert manifest["peer_delta_row_count"] == 1
+    assert manifest["threshold_status"]["status"] == "ok"
     assert manifest["warmup_settings"] == {
         "max_tokens": 8,
         "prompt_style": "concise",
@@ -1553,14 +1823,33 @@ def test_warmups_are_written_separately_from_summaries(tmp_path: Path, monkeypat
         "repeat_count": 1,
     }
     assert manifest["artifacts"]["warmups"] == "warmups.jsonl"
+    assert manifest["artifacts"]["request_phase_rows"] == "request-phase-rows.json"
+    assert manifest["artifacts"]["peer_delta_rows"] == "peer-delta-rows.json"
+    assert manifest["artifacts"]["threshold_status"] == "threshold-status.json"
     assert len(warmups) == 2
     assert len(observations) == 2
+    assert len(request_phase_rows) == 2
+    assert len(peer_delta_rows) == 1
+    assert request_phase_rows[0]["first_http_sse_event_ms"] == 100.0
+    assert request_phase_rows[0]["queue_ms"] is None
+    assert request_phase_rows[0]["worker_stream_ms"] is None
+    assert peer_delta_rows[0]["status"] == "ok"
+    assert peer_delta_rows[0]["target_endpoint"] == "melix"
+    assert threshold_status["status"] == "ok"
+    assert threshold_status["row_count"] == 1
     assert len(summary["warmups"]) == 2
+    assert summary["request_phase_rows"] == request_phase_rows
+    assert summary["peer_delta_rows"] == peer_delta_rows
+    assert summary["threshold_status"] == threshold_status
     assert all(json.loads(line)["scenario_id"].startswith("warmup") for line in warmups)
     assert {
         (item["cache_profile"], item["prompt_token_target"], item["max_tokens"], item["prompt_style"])
         for item in summary["summaries"]
     } == {("cold_unique", 1024, 128, "concise")}
+    assert "## Peer Delta Rows" in markdown
+    assert "## Request Phase Rows" in markdown
+    assert "First HTTP/SSE Event ms" in markdown
+    assert "- Threshold status: `ok`" in markdown
     assert run_keys == ["warmup", "warmup", "warm-run", "warm-run"]
 
 
@@ -1777,6 +2066,8 @@ def test_validate_args_rejects_core_invalid_values() -> None:
         (["--model", "m", "--concurrency", "0"], "--concurrency"),
         (["--model", "m", "--timeout-seconds", "0"], "Timeout values"),
         (["--model", "m", "--preflight-timeout-seconds", "0"], "Timeout values"),
+        (["--model", "m", "--total-latency-threshold-ratio", "-0.1"], "total-latency"),
+        (["--model", "m", "--decode-throughput-threshold-ratio", "-0.1"], "decode-throughput"),
     ]
     for argv, expected in cases:
         args = bench.build_arg_parser().parse_args(argv)

--- a/tests/test_omlx_melix_compare_benchmark.py
+++ b/tests/test_omlx_melix_compare_benchmark.py
@@ -2068,6 +2068,7 @@ def test_validate_args_rejects_core_invalid_values() -> None:
         (["--model", "m", "--preflight-timeout-seconds", "0"], "Timeout values"),
         (["--model", "m", "--total-latency-threshold-ratio", "-0.1"], "total-latency"),
         (["--model", "m", "--decode-throughput-threshold-ratio", "-0.1"], "decode-throughput"),
+        (["--model", "m", "--decode-throughput-threshold-ratio", "1.1"], "decode-throughput"),
     ]
     for argv, expected in cases:
         args = bench.build_arg_parser().parse_args(argv)

--- a/tests/test_three_way_serving_compare.py
+++ b/tests/test_three_way_serving_compare.py
@@ -1059,6 +1059,17 @@ def test_export_bundle_returns_none_when_disabled(tmp_path: Path) -> None:
                 "melix=http://127.0.0.1:12441/v1::model",
                 "--endpoint",
                 "omlx=http://127.0.0.1:18061/v1::model",
+                "--decode-throughput-threshold-ratio",
+                "1.1",
+            ],
+            "decode-throughput",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
                 "--preflight-wait-seconds",
                 "-1",
             ],

--- a/tests/test_three_way_serving_compare.py
+++ b/tests/test_three_way_serving_compare.py
@@ -742,16 +742,44 @@ def test_three_way_run_writes_merged_melix_metrics_snapshot(
     )
     three_way.validate_args(args)
 
-    three_way.run_comparison(args)
+    result = three_way.run_comparison(args)
 
     staging_dir = tmp_path / "three-way-metrics"
+    manifest = json.loads((staging_dir / "manifest.json").read_text(encoding="utf-8"))
+    summary = json.loads((staging_dir / "summary.json").read_text(encoding="utf-8"))
     metrics_snapshot = json.loads((staging_dir / "melix-metrics.json").read_text(encoding="utf-8"))
+    request_phase_rows = json.loads((staging_dir / "request-phase-rows.json").read_text(encoding="utf-8"))
+    peer_delta_rows = json.loads((staging_dir / "peer-delta-rows.json").read_text(encoding="utf-8"))
+    threshold_status = json.loads((staging_dir / "threshold-status.json").read_text(encoding="utf-8"))
     markdown = (staging_dir / "summary.md").read_text(encoding="utf-8")
 
+    assert result["request_phase_row_count"] == 3
+    assert result["peer_delta_row_count"] == 1
+    assert result["threshold_status"]["status"] == "ok"
+    assert manifest["request_phase_row_count"] == 3
+    assert manifest["peer_delta_row_count"] == 1
+    assert manifest["threshold_status"]["status"] == "ok"
+    assert manifest["artifacts"]["request_phase_rows"] == "request-phase-rows.json"
+    assert manifest["artifacts"]["peer_delta_rows"] == "peer-delta-rows.json"
+    assert manifest["artifacts"]["threshold_status"] == "threshold-status.json"
+    assert len(request_phase_rows) == 3
+    assert len(peer_delta_rows) == 1
+    assert request_phase_rows[0]["first_http_sse_event_ms"] == 100.0
+    assert request_phase_rows[0]["output_tokens"] == 5.0
+    assert peer_delta_rows[0]["target_endpoint"] == "melix"
+    assert peer_delta_rows[0]["status"] == "ok"
+    assert threshold_status["row_count"] == 1
+    assert summary["request_phase_rows"] == request_phase_rows
+    assert summary["peer_delta_rows"] == peer_delta_rows
+    assert summary["threshold_status"] == threshold_status
     assert metrics_snapshot["values"]["control_plane.text_first_load_ms"] == 8547.46
     assert metrics_snapshot["values"]["swift_text.prefill_ms"] == 3706
     assert metrics_snapshot["sources"]["control_plane"]["source_kind"] == "control_plane"
     assert metrics_snapshot["sources"]["swift_text_worker"]["source_kind"] == "worker"
+    assert "- Threshold status: `ok`" in markdown
+    assert "## Peer Delta Rows" in markdown
+    assert "## Request Phase Rows" in markdown
+    assert "First HTTP/SSE Event ms" in markdown
     assert "`swift_text.prefill_ms` | 3706.00" in markdown
 
 
@@ -1002,6 +1030,28 @@ def test_export_bundle_returns_none_when_disabled(tmp_path: Path) -> None:
                 "0",
             ],
             "Timeout",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
+                "--total-latency-threshold-ratio",
+                "-0.1",
+            ],
+            "total-latency",
+        ),
+        (
+            [
+                "--endpoint",
+                "melix=http://127.0.0.1:12441/v1::model",
+                "--endpoint",
+                "omlx=http://127.0.0.1:18061/v1::model",
+                "--decode-throughput-threshold-ratio",
+                "-0.1",
+            ],
+            "decode-throughput",
         ),
         (
             [


### PR DESCRIPTION
## Summary
- Adds schema-versioned request phase rows to the Gemma E4B serving comparison artifacts so Melix, OMLX, and SwiftLM request data can be compared in one report.
- Adds Melix-vs-best-peer scenario delta rows for total latency and decode throughput, with threshold status surfaced in JSON, manifest metadata, and Markdown.
- Extends the three-way comparison wrapper to preserve the same request phase, peer delta, and threshold artifacts in combined Melix/OMLX/SwiftLM reports.
- Constrains decode throughput degradation thresholds to `0.0...1.0` so threshold failure logic cannot be disabled by values over 100%.

Closes #1649. Part of #1647 and #1642.

## Plan or Spec
- `docs/plans/2026-05-28-gemma-e4b-phase-delta-report-rows.md`
- `docs/plans/2026-05-12-omlx-melix-serving-benchmark.md`

## Commands Run
```text
python3 -m compileall -q scripts/omlx_melix_compare_benchmark.py scripts/three_way_serving_compare.py tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py
# 97 passed in 0.21s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py
# 97 passed in 0.23s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m scripts/omlx_melix_compare_benchmark.py scripts/three_way_serving_compare.py tests/test_omlx_melix_compare_benchmark.py tests/test_three_way_serving_compare.py
# scripts/omlx_melix_compare_benchmark.py: 96%
# scripts/three_way_serving_compare.py: 99%
# tests/test_omlx_melix_compare_benchmark.py: 100%
# tests/test_three_way_serving_compare.py: 100%
# total: 98%

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-scoped-performance/issue-1649/changed-files.json --output .runtime/pr-scoped-performance/issue-1649/scope.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_report.py --scope .runtime/pr-scoped-performance/issue-1649/scope.json --results-dir .runtime/pr-scoped-performance/issue-1649/results --format terminal --output-dir .runtime/pr-scoped-performance/issue-1649/report --sticky-comment
# Melix PR Scoped Performance Report: Status ok, Changed files 5, Selected probes 0, Regressions 0, Verification failures 0

git commit -m "Add serving report phase delta rows"
# pre-commit ran make swift-test: rc=0, elapsed=654.1s
# pre-commit ran make py-test: 3354 passed, 14 skipped, 2 warnings in 151.06s, rc=0
# pre-commit ran make integration-test: 115 passed, 1 skipped in 673.36s, rc=0
# pre-commit performance report: Status ok, Changed files 5, Selected probes 0, Regressions 0, Verification failures 0

git commit -m "Constrain decode throughput threshold ratio"
# pre-commit ran make swift-test: rc=0, elapsed=203.3s
# pre-commit ran make py-test: 3354 passed, 14 skipped, 2 warnings in 130.96s, rc=0
# pre-commit ran make integration-test: 115 passed, 1 skipped in 312.05s, rc=0
# pre-commit performance report: Status ok, Changed files 4, Selected probes 0, Regressions 0, Verification failures 0

git merge origin/main
# merged origin/main@a0a3a487

make swift-test && make py-test && make integration-test
# run after merging origin/main@a0a3a487
# make swift-test: rc=0; final macOS menubar package stage rc=0, elapsed=170s
# make py-test: 3356 passed, 14 skipped, 2 warnings in 130.01s, rc=0
# make integration-test: 115 passed, 1 skipped in 597.45s, rc=0
```

## Coverage and Metrics
- Changed-scope automated coverage: 98% total across the touched scripts and focused tests.
- `scripts/omlx_melix_compare_benchmark.py`: 96% coverage.
- `scripts/three_way_serving_compare.py`: 99% coverage.
- Local PR-scoped performance report: `Status: ok`, `Regressions: 0`, `Verification failures: 0`, `Selected probes: 0` because no registered probe selected this report-only change set.
- Full local gate was rerun after merging `origin/main@a0a3a487`: `make swift-test`, `make py-test`, and `make integration-test` all returned rc=0.
- Observability mode: `evidence`; the change emits benchmark/report artifacts only and does not add runtime production probes.
- Probe overhead: `N/A`; no runtime probe is added, and the new rows are derived from existing benchmark observations during report generation.

## Known Gaps
- #1647 and #1642 still require a fresh Gemma E4B benchmark run using the new report shape before the root performance acceptance can be claimed.
- Queue, prefill, and worker stream durations remain explicit `null`/unavailable fields until a runtime metrics source or instrumentation is added for those phases.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
