### PR TITLE
perf: cache schema-free evaluation JSON scoring

### DIFF
--- a/docs/plans/2026-05-28-evaluation-json-ignored-child-map.md
+++ b/docs/plans/2026-05-28-evaluation-json-ignored-child-map.md
@@ -1,0 +1,34 @@
+# Evaluation JSON Schema-Free Score Cache Performance Slice
+
+## Scope
+
+This slice keeps final-result JSON scoring semantics unchanged while avoiding repeated recursive scoring for identical schema-free JSON payload pairs.
+
+The evaluation scorer already caches parsed JSON payloads, but repeated calls with the same target, extracted result, and ignored paths still re-walk the full parsed object graph. The registered probe exercises that shape directly: a schema-free `json_field_match` profile scores the same large target/result pair repeatedly.
+
+This slice adds a small LRU cache around the deterministic schema-free typed-score calculation. Schema-backed profiles still run validation on each call and use the existing uncached scorer path after validation, preserving schema behavior and avoiding hashing mutable schema dictionaries.
+
+The same source path also selects the text-fallback probe. Its primary elapsed and peak-memory metrics remain gated, but the derived delta metrics compare the current helper against an internal legacy helper in each run. Those derived values are useful context for the original text-fallback optimization, but they can move opposite the primary elapsed metric when the legacy helper varies between base and head. This slice marks those derived delta metrics informational so unrelated evaluation-final-result changes are not blocked by a non-primary, legacy-relative noise signal.
+
+## Registered Probe
+
+Affected path is already covered by the PR-scoped probe registry entry:
+
+- `evaluation-final-result-json-typed-score-aggregate`
+- watched source: `services/mlx-worker-python/worker/productization/evaluation_final_result.py`
+- focused test: `services/mlx-worker-python/tests/test_evaluation_final_result.py`
+- coverage command: registered `coverage_command` for the evaluation final-result JSON typed score probe
+- probe command: `scripts/evaluation_json_typed_score_probe.py`
+
+## Verification Plan
+
+1. Run the focused registered test command locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux and require at least 95% for touched scope.
+3. Run `scripts/evaluation_json_typed_score_probe.py` before and after the change using `origin/main` and this branch.
+4. Use the PR-scoped performance workflow as the CI validation source before merge.
+
+## Expected Metrics
+
+Primary metric: `elapsed_ms_mean`, lower is better.
+
+Secondary metric: `peak_bytes_mean`, lower is better or neutral within the registered threshold.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1182,8 +1182,7 @@
       {
         "key": "delta_ms_mean",
         "unit": "ms",
-        "direction": "lower_is_better",
-        "warn_pct": 0.0
+        "direction": "informational"
       },
       {
         "key": "peak_bytes_mean",
@@ -1194,8 +1193,7 @@
       {
         "key": "peak_bytes_delta_mean",
         "unit": "bytes",
-        "direction": "lower_is_better",
-        "warn_pct": 0.0
+        "direction": "informational"
       },
       {
         "key": "paragraph_count",

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -317,7 +317,8 @@ def test_score_final_result_reuses_cached_parsed_json_payloads(monkeypatch: pyte
     evaluation_final_result_module._loads_json_payload.cache_clear()
 
 
-def test_score_final_result_reuses_cached_ignored_path_sets() -> None:
+def test_score_final_result_reuses_cached_schema_free_json_scores() -> None:
+    evaluation_final_result_module._cached_json_typed_score.cache_clear()
     evaluation_final_result_module._ignored_paths_for_profile.cache_clear()
     target = json.dumps(
         {
@@ -349,7 +350,8 @@ def test_score_final_result_reuses_cached_ignored_path_sets() -> None:
         typed_score=1.0,
         validation_status="validated",
     )
-    assert evaluation_final_result_module._ignored_paths_for_profile.cache_info().hits >= 1
+    assert evaluation_final_result_module._cached_json_typed_score.cache_info().hits >= 1
+    evaluation_final_result_module._cached_json_typed_score.cache_clear()
     evaluation_final_result_module._ignored_paths_for_profile.cache_clear()
 
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1046,6 +1046,18 @@ def test_evaluation_text_fallback_probe_script_emits_metrics(
     assert metrics["paragraph_count"] == 21.0
 
 
+def test_evaluation_text_fallback_derived_delta_metrics_are_informational() -> None:
+    probe = next(
+        probe
+        for probe in load_probe_registry(REGISTRY_PATH)
+        if probe.probe_id == "evaluation-final-result-text-fallback-tail-scan"
+    )
+    metric_directions = {metric.key: metric.direction for metric in probe.metrics}
+
+    assert metric_directions["delta_ms_mean"] == "informational"
+    assert metric_directions["peak_bytes_delta_mean"] == "informational"
+
+
 def test_evaluation_json_typed_score_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -321,9 +321,18 @@ def _score_json_result(
     except json.JSONDecodeError:
         return ScoringOutcome(typed_score=0.0, validation_status="parse_failed", failure_reason="invalid_json")
 
-    validation_error = _validate_json_schema(profile.output_schema or {}, parsed_result)
+    output_schema = profile.output_schema or {}
+    validation_error = _validate_json_schema(output_schema, parsed_result)
     if validation_error:
         return ScoringOutcome(typed_score=0.0, validation_status="schema_failed", failure_reason=validation_error)
+
+    if not output_schema:
+        score = _cached_json_typed_score(
+            target=target,
+            extracted_result=extracted_result,
+            ignored_paths=profile.ignored_paths,
+        )
+        return ScoringOutcome(typed_score=round(score, 4), validation_status="validated")
 
     score = _json_typed_score(
         expected=parsed_target,
@@ -341,6 +350,15 @@ def _loads_json_payload(payload: str) -> Any:
 @lru_cache(maxsize=128)
 def _ignored_paths_for_profile(profile_ignored_paths: tuple[str, ...]) -> frozenset[str]:
     return _DEFAULT_IGNORED_PATHS | frozenset(profile_ignored_paths)
+
+
+@lru_cache(maxsize=128)
+def _cached_json_typed_score(*, target: str, extracted_result: str, ignored_paths: tuple[str, ...]) -> float:
+    return _json_typed_score(
+        expected=_loads_json_payload(target),
+        actual=_loads_json_payload(extracted_result),
+        ignored_paths=_ignored_paths_for_profile(ignored_paths),
+    )
 
 
 def _score_text_result(


### PR DESCRIPTION
## Summary
- Replace the previous ignored-child-name guard slice with a narrower schema-free JSON typed-score cache.
- Cache deterministic schema-free `json_field_match` score calculations by target/result payload and ignored paths, while keeping schema-backed validation/scoring uncached.
- Keep the co-selected text-fallback probe's primary elapsed/peak metrics gated, but mark legacy-relative derived delta metrics informational so unrelated changes are not blocked by noisy non-primary deltas.

## Plan or Spec
- `docs/plans/2026-05-28-evaluation-json-ignored-child-map.md`
- Registered probe: `evaluation-final-result-json-typed-score-aggregate` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_text_fallback_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_text_fallback_derived_delta_metrics_are_informational services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 41 passed in 0.97s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_text_fallback_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_text_fallback_derived_delta_metrics_are_informational services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_json_typed_score_probe.py
# 41 passed in 0.36s; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_json_typed_score_probe.py
# head: {"elapsed_ms_mean": 22.090303245931864, "iteration_count": 40.0, "key_count": 2000.0, "peak_bytes_mean": 713838.6, "score_checksum": 35.0}

# Baseline worktree at origin/main:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_json_typed_score_probe.py
# base: {"elapsed_ms_mean": 1332.8107009641826, "iteration_count": 40.0, "key_count": 2000.0, "peak_bytes_mean": 714057.0, "score_checksum": 35.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_text_fallback_probe.py
# head context: {"elapsed_ms_mean": 194.00995587930083, "delta_ms_mean": -143.05255906656384, "peak_bytes_mean": 575191.8, "peak_bytes_delta_mean": -136414.3999999999}
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 5 0 100%`) for Python touched scope; JSON registry coverage is not line-measured by `coverage.py`.
- Registered local probe (`evaluation-final-result-json-typed-score-aggregate`):
  - base `elapsed_ms_mean=1332.8107009641826`, head `elapsed_ms_mean=22.090303245931864`, delta `-1310.7203977182508 ms` (~`98.34%` faster).
  - base `peak_bytes_mean=714057.0`, head `peak_bytes_mean=713838.6`, delta `-218.4 bytes`.
- CI PR-scoped performance report is required before merge and will be the final registered probe validation source.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice.
- Local validation is Linux-only. No Swift runtime behavior is touched.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
