### PR TITLE
perf: trim redundant work in hot scan/dedup paths

### DIFF
--- a/services/control-plane-swift/Sources/XPCService/BenchmarkExportBundle.swift
+++ b/services/control-plane-swift/Sources/XPCService/BenchmarkExportBundle.swift
@@ -2249,11 +2249,15 @@ public struct ControlPlaneBenchmarkExportBundle: Codable, Equatable, Sendable {
         // Track membership in a Set so dedup stays O(1) per check instead of
         // scanning the growing suiteIDs array on every candidate.
         var seen = Set(suiteIDs)
-        for suiteID in job.suiteMetadata.keys.sorted() where seen.insert(suiteID).inserted {
-            suiteIDs.append(suiteID)
+        for suiteID in job.suiteMetadata.keys.sorted() {
+            if seen.insert(suiteID).inserted {
+                suiteIDs.append(suiteID)
+            }
         }
-        for suiteID in results.map(\.suite).sorted() where seen.insert(suiteID).inserted {
-            suiteIDs.append(suiteID)
+        for suiteID in results.map(\.suite).sorted() {
+            if seen.insert(suiteID).inserted {
+                suiteIDs.append(suiteID)
+            }
         }
         return suiteIDs
     }

--- a/services/control-plane-swift/Sources/XPCService/BenchmarkExportBundle.swift
+++ b/services/control-plane-swift/Sources/XPCService/BenchmarkExportBundle.swift
@@ -2246,10 +2246,13 @@ public struct ControlPlaneBenchmarkExportBundle: Codable, Equatable, Sendable {
         results: [ControlPlaneBenchmarkResultRecord]
     ) -> [String] {
         var suiteIDs = job.suites
-        for suiteID in job.suiteMetadata.keys.sorted() where suiteIDs.contains(suiteID) == false {
+        // Track membership in a Set so dedup stays O(1) per check instead of
+        // scanning the growing suiteIDs array on every candidate.
+        var seen = Set(suiteIDs)
+        for suiteID in job.suiteMetadata.keys.sorted() where seen.insert(suiteID).inserted {
             suiteIDs.append(suiteID)
         }
-        for suiteID in results.map(\.suite).sorted() where suiteIDs.contains(suiteID) == false {
+        for suiteID in results.map(\.suite).sorted() where seen.insert(suiteID).inserted {
             suiteIDs.append(suiteID)
         }
         return suiteIDs

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -2247,11 +2247,8 @@ def _dirty_sample_reasons(sample: dict[str, Any], *, format_name: str = "") -> l
         if _agentic_trace_leakage_terms(sample):
             reasons.append("leakage_terms")
 
-    unique_reasons: list[str] = []
-    for reason in reasons:
-        if reason not in unique_reasons:
-            unique_reasons.append(reason)
-    return unique_reasons
+    # dict.fromkeys deduplicates while preserving first-seen order in O(n).
+    return list(dict.fromkeys(reasons))
 
 
 def _prompt_completion_dirty_sample_reasons(sample: dict[str, Any]) -> list[str]:

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -257,12 +257,16 @@ def _tensor_index_evidence(
             counts["audio"] += 1
         elif _tensor_name_is_video(name):
             counts["video"] += 1
-        elif _tensor_name_is_projector(name):
-            counts["projector"] += 1
-        elif _tensor_name_is_draft(name):
-            counts["draft"] += 1
-        elif _tensor_name_is_text(name):
-            counts["text"] += 1
+        else:
+            # Lowercase once and reuse for the projector/draft checks that need it
+            # instead of recomputing it inside each helper.
+            lowered = name.lower()
+            if _tensor_name_is_projector(name, lowered):
+                counts["projector"] += 1
+            elif _tensor_name_is_draft(name, lowered):
+                counts["draft"] += 1
+            elif _tensor_name_is_text(name):
+                counts["text"] += 1
 
     modalities = tuple(
         modality
@@ -303,8 +307,9 @@ def _tensor_name_is_video(name: str) -> bool:
     return name.startswith(("video_tower.", "video_model.", "embed_video.", "video_encoder."))
 
 
-def _tensor_name_is_projector(name: str) -> bool:
-    lowered = name.lower()
+def _tensor_name_is_projector(name: str, lowered: str | None = None) -> bool:
+    if lowered is None:
+        lowered = name.lower()
     return (
         name.startswith(("multi_modal_projector.", "multimodal_projector.", "mm_projector.", "projector."))
         or ".multi_modal_projector." in lowered
@@ -313,12 +318,15 @@ def _tensor_name_is_projector(name: str) -> bool:
     )
 
 
-def _tensor_name_is_gemma4_vision_weight_remap(name: str) -> bool:
-    return name.startswith("embed_vision.proj.") or ".embed_vision.proj." in name.lower()
+def _tensor_name_is_gemma4_vision_weight_remap(name: str, lowered: str | None = None) -> bool:
+    if lowered is None:
+        lowered = name.lower()
+    return name.startswith("embed_vision.proj.") or ".embed_vision.proj." in lowered
 
 
-def _tensor_name_is_draft(name: str) -> bool:
-    lowered = name.lower()
+def _tensor_name_is_draft(name: str, lowered: str | None = None) -> bool:
+    if lowered is None:
+        lowered = name.lower()
     return name.startswith(("draft_model.", "mtp.", "dflash.")) or ".draft_" in lowered or ".mtp_" in lowered
 
 
@@ -1311,11 +1319,7 @@ def _count_media_placeholder_keys(payload: Mapping[str, object], prefixes: tuple
         if value in (None, "", [], {}):
             continue
         normalized_key = str(key).lower()
-        if any(normalized_key.startswith(prefix) for prefix in prefixes) and (
-            normalized_key.endswith("_token")
-            or normalized_key.endswith("_token_id")
-            or normalized_key.endswith("_token_ids")
-        ):
+        if normalized_key.startswith(prefixes) and normalized_key.endswith(("_token", "_token_id", "_token_ids")):
             count += 1
     return count
 
@@ -1375,17 +1379,15 @@ def _has_renamed_projector_tensor(
     if tensor_evidence.status != "ok":
         return False
     for name in _weight_map_tensor_names(model_dir, json_cache=json_cache):
-        if (
-            not _tensor_name_is_text(name)
-            and not _tensor_name_is_vision(name)
-            and not _tensor_name_is_audio(name)
-            and not _tensor_name_is_video(name)
-            and not _tensor_name_is_projector(name)
-            and not _tensor_name_is_draft(name)
-        ):
-            lowered = name.lower()
-            if "connector" in lowered or "projector" in lowered:
-                return True
+        if _tensor_name_is_text(name) or _tensor_name_is_vision(name) or _tensor_name_is_audio(name) or _tensor_name_is_video(name):
+            continue
+        # Reuse a single lowercase form across the projector/draft helpers and the
+        # connector/projector substring check below.
+        lowered = name.lower()
+        if _tensor_name_is_projector(name, lowered) or _tensor_name_is_draft(name, lowered):
+            continue
+        if "connector" in lowered or "projector" in lowered:
+            return True
     return False
 
 

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -318,10 +318,8 @@ def _tensor_name_is_projector(name: str, lowered: str | None = None) -> bool:
     )
 
 
-def _tensor_name_is_gemma4_vision_weight_remap(name: str, lowered: str | None = None) -> bool:
-    if lowered is None:
-        lowered = name.lower()
-    return name.startswith("embed_vision.proj.") or ".embed_vision.proj." in lowered
+def _tensor_name_is_gemma4_vision_weight_remap(name: str) -> bool:
+    return name.startswith("embed_vision.proj.") or ".embed_vision.proj." in name.lower()
 
 
 def _tensor_name_is_draft(name: str, lowered: str | None = None) -> bool:

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -1377,7 +1377,12 @@ def _has_renamed_projector_tensor(
     if tensor_evidence.status != "ok":
         return False
     for name in _weight_map_tensor_names(model_dir, json_cache=json_cache):
-        if _tensor_name_is_text(name) or _tensor_name_is_vision(name) or _tensor_name_is_audio(name) or _tensor_name_is_video(name):
+        if (
+            _tensor_name_is_text(name)
+            or _tensor_name_is_vision(name)
+            or _tensor_name_is_audio(name)
+            or _tensor_name_is_video(name)
+        ):
             continue
         # Reuse a single lowercase form across the projector/draft helpers and the
         # connector/projector substring check below.

--- a/services/mlx-worker-python/worker/productization/family_support_matrix.py
+++ b/services/mlx-worker-python/worker/productization/family_support_matrix.py
@@ -352,18 +352,32 @@ def build_family_support_matrix() -> dict[str, Any]:
             }
         )
 
-    live_verified_count = sum(1 for row in families if row["live_path"]["status"] == "verified")
+    live_verified_count = 0
+    capability_counts: dict[str, int] = {
+        "text": 0,
+        "transcription": 0,
+        "speech": 0,
+        "embedding": 0,
+        "rerank": 0,
+        "image": 0,
+    }
+    for row in families:
+        if row["live_path"]["status"] == "verified":
+            live_verified_count += 1
+        capability = row["capability"]
+        if capability in capability_counts:
+            capability_counts[capability] += 1
     contract_only_count = len(families) - live_verified_count
 
     return {
         "summary": {
             "family_count": len(families),
-            "text_family_count": sum(1 for row in families if row["capability"] == "text"),
-            "transcription_family_count": sum(1 for row in families if row["capability"] == "transcription"),
-            "speech_family_count": sum(1 for row in families if row["capability"] == "speech"),
-            "embedding_family_count": sum(1 for row in families if row["capability"] == "embedding"),
-            "rerank_family_count": sum(1 for row in families if row["capability"] == "rerank"),
-            "image_family_count": sum(1 for row in families if row["capability"] == "image"),
+            "text_family_count": capability_counts["text"],
+            "transcription_family_count": capability_counts["transcription"],
+            "speech_family_count": capability_counts["speech"],
+            "embedding_family_count": capability_counts["embedding"],
+            "rerank_family_count": capability_counts["rerank"],
+            "image_family_count": capability_counts["image"],
             "live_verified_count": live_verified_count,
             "contract_only_count": contract_only_count,
         },

--- a/services/mlx-worker-python/worker/productization/family_support_matrix.py
+++ b/services/mlx-worker-python/worker/productization/family_support_matrix.py
@@ -354,8 +354,10 @@ def build_family_support_matrix() -> dict[str, Any]:
         )
 
     live_verified_count = 0
-    # Tally every capability that appears so a future capability added to
-    # FAMILY_SPECS can't be silently dropped; missing keys read back as 0.
+    # Count capabilities in a single pass instead of seven separate sum() scans.
+    # The summary below still emits a fixed set of *_family_count keys, so a new
+    # capability would also need a key added there; Counter just supplies a 0
+    # default for any of those keys that has no matching rows.
     capability_counts: Counter[str] = Counter()
     for row in families:
         if row["live_path"]["status"] == "verified":

--- a/services/mlx-worker-python/worker/productization/family_support_matrix.py
+++ b/services/mlx-worker-python/worker/productization/family_support_matrix.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections import Counter
 from typing import Any
 
 from worker.model_registry.catalog import WorkerModelCatalog
@@ -353,20 +354,13 @@ def build_family_support_matrix() -> dict[str, Any]:
         )
 
     live_verified_count = 0
-    capability_counts: dict[str, int] = {
-        "text": 0,
-        "transcription": 0,
-        "speech": 0,
-        "embedding": 0,
-        "rerank": 0,
-        "image": 0,
-    }
+    # Tally every capability that appears so a future capability added to
+    # FAMILY_SPECS can't be silently dropped; missing keys read back as 0.
+    capability_counts: Counter[str] = Counter()
     for row in families:
         if row["live_path"]["status"] == "verified":
             live_verified_count += 1
-        capability = row["capability"]
-        if capability in capability_counts:
-            capability_counts[capability] += 1
+        capability_counts[row["capability"]] += 1
     contract_only_count = len(families) - live_verified_count
 
     return {

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -55,7 +55,7 @@ _GEMMA4_PRESENCE_AUDIO = (False, True)
 _GEMMA4_PRESENCE_BOTH = (True, True)
 # Gemma model types that require `add_special_tokens` to follow the chat-template
 # presence. Frozenset gives O(1) membership instead of scanning a list literal.
-_GEMMA_CHAT_TEMPLATE_MODEL_TYPES = frozenset({"gemma3", "gemma3n", "gemma4"})
+_GEMMA_CHAT_TEMPLATE_MODEL_TYPES = frozenset(("gemma3", "gemma3n", "gemma4"))
 
 _TEXT_ONLY_BATCH_GENERATOR_EXT_KEY = "melix.vlm.text_only_batch_generator"
 _TEXT_ONLY_STEP_COOPERATIVE_EXT_KEY = "melix.vlm.text_only_step_cooperative"

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -53,6 +53,9 @@ _GEMMA4_PRESENCE_NONE = (False, False)
 _GEMMA4_PRESENCE_VISION = (True, False)
 _GEMMA4_PRESENCE_AUDIO = (False, True)
 _GEMMA4_PRESENCE_BOTH = (True, True)
+# Gemma model types that require `add_special_tokens` to follow the chat-template
+# presence. Frozenset gives O(1) membership instead of scanning a list literal.
+_GEMMA_CHAT_TEMPLATE_MODEL_TYPES = frozenset({"gemma3", "gemma3n", "gemma4"})
 
 _TEXT_ONLY_BATCH_GENERATOR_EXT_KEY = "melix.vlm.text_only_batch_generator"
 _TEXT_ONLY_STEP_COOPERATIVE_EXT_KEY = "melix.vlm.text_only_step_cooperative"
@@ -2287,7 +2290,7 @@ class MLXVLMRuntime:
         )
         add_special_tokens = (
             getattr(loaded_model["processor"], "chat_template", None) is None
-            if getattr(loaded_model["model"].config, "model_type", "") in ["gemma3", "gemma3n", "gemma4"]
+            if getattr(loaded_model["model"].config, "model_type", "") in _GEMMA_CHAT_TEMPLATE_MODEL_TYPES
             else True
         )
         inputs = prepare_inputs(
@@ -2394,7 +2397,7 @@ class MLXVLMRuntime:
         )
         add_special_tokens = (
             getattr(loaded_model["processor"], "chat_template", None) is None
-            if getattr(loaded_model["model"].config, "model_type", "") in ["gemma3", "gemma3n", "gemma4"]
+            if getattr(loaded_model["model"].config, "model_type", "") in _GEMMA_CHAT_TEMPLATE_MODEL_TYPES
             else True
         )
         inputs = prepare_inputs(
@@ -2631,7 +2634,7 @@ class MLXVLMRuntime:
             )
         add_special_tokens = (
             getattr(loaded_model["processor"], "chat_template", None) is None
-            if getattr(loaded_model["model"].config, "model_type", "") in ["gemma3", "gemma3n", "gemma4"]
+            if getattr(loaded_model["model"].config, "model_type", "") in _GEMMA_CHAT_TEMPLATE_MODEL_TYPES
             else True
         )
         inputs = self._run_on_executor(


### PR DESCRIPTION
A focused, behavior-preserving performance pass over a few hot or repeatedly-scanned paths found while going through the codebase. No public behavior changes — only reduced redundant work.

## Plan or Spec

Go through the codebase, find concrete (non-cosmetic) performance inefficiencies on paths that run with non-trivial input, and fix the ones that are clearly correct and behavior-preserving. Scope intentionally limited to safe, local algorithmic/data-structure cleanups — no API or output changes.

Changes:
- `model_registry/catalog.py` — tensor-index scan runs over every tensor of every model during registry scans. Compute `name.lower()` once per tensor and share it across the projector/draft classifiers instead of recomputing it 2x per text tensor (the bulk of weights). Vision/audio/video matches still pay zero lowercasing via the lazy `else` branch, so there is no regression for vision-heavy models. `_has_renamed_projector_tensor` now reuses a single lowercase form across the projector/draft helpers and the trailing `connector`/`projector` substring check (was computing `.lower()` up to 3x per tensor). `_count_media_placeholder_keys` uses native tuple `startswith`/`endswith` instead of a generator + triple `or`.
- `productization/family_support_matrix.py` — count capability families and live-verified families in a single pass instead of seven separate `sum(...)` scans of the same list.
- `model_ops/training_dataset.py` — deduplicate dirty-sample reasons with `dict.fromkeys` (O(n), order-preserving) instead of O(n^2) `not in list` membership.
- `runtime/mlx_vlm_runtime.py` — hoist the gemma chat-template model types into a module-level `frozenset` for O(1) membership instead of scanning a `["gemma3", "gemma3n", "gemma4"]` list literal on every generate request (3 call sites).
- `XPCService/BenchmarkExportBundle.swift` — back the ordered suite-id dedup with a `Set` (`seen.insert(_).inserted`) so each membership check is O(1) instead of `Array.contains` over the growing array (O(n^2) → O(n)) while preserving the exact output order.

## Commands Run

```
# Python — touched modules' suites (run via uv, no mlx extra needed)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --with pytest \
  pytest services/mlx-worker-python/tests/test_model_registry_catalog.py \
         services/mlx-worker-python/tests/test_acceptance_metrics.py \
         services/mlx-worker-python/tests/test_training_dataset_builder.py -q
# -> 212 passed, 1 failed (environmental: `hf` CLI not installed; fails identically on the unmodified tree)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --with pytest \
  pytest services/mlx-worker-python/tests/ -q -k "family_support or tensor or media_placeholder"
# -> 13 passed

# Equivalence check for the single-pass family-matrix counts
uv run --project services/mlx-worker-python python -c "from worker.productization.family_support_matrix import build_family_support_matrix; ..."
# -> capability counts match a direct recount of families; verified + contract_only == family_count
```

## Coverage and Metrics

- Touched Python modules are exercised by existing suites: `test_model_registry_catalog.py` and the `family_support`/`tensor`/`media_placeholder` selections pass (212 + 13 passed).
- Verified `build_family_support_matrix()` summary counts equal a direct recount of `families`, and `live_verified_count + contract_only_count == family_count`, before vs after the refactor.
- The one failing test (`test_acceptance_metrics.py::test_collect_operator_action_evidence_reports_registry_counts`) fails identically on the unmodified tree — it is environmental (`hf` CLI not installed in the sandbox), not introduced by this change.
- No microbenchmark numbers are claimed; the wins are complexity/redundant-work reductions (O(n^2) → O(n) dedup, 7 scans → 1, fewer per-tensor `.lower()` calls, O(1) frozenset/Set membership).

## Known Gaps

- The Swift change (`BenchmarkExportBundle.swift`) could not be compiled in this Linux sandbox — the control-plane is an Apple-Silicon/macOS target. The change uses the standard `Set.insert(_:).inserted` idiom and preserves output ordering; it needs Swift CI / a reviewer on macOS to confirm the build.
- Several lower-impact micro-optimizations surfaced during the sweep were intentionally left out to keep this change behavior-preserving and easy to review (e.g. the tool-observation redaction loop, where collapsing terms into one regex would change the redaction-count semantics).

https://claude.ai/code/session_014qXGNWGzLLKhgKxtHqDByF