### PR TITLE
perf: skip trailing split entry in changed-scope parser

### DIFF
--- a/docs/plans/2026-05-28-changed-scope-splitlines-parser.md
+++ b/docs/plans/2026-05-28-changed-scope-splitlines-parser.md
@@ -1,0 +1,40 @@
+# Changed-scope coverage splitlines parser slice
+
+## Linux-only constraint
+
+This is a Python CI-tooling slice. It is locally verifiable on Linux with the focused changed-scope coverage tests, changed-scope coverage report, and the registered PR-scoped performance probe.
+
+## Optimization
+
+`changed_scope_coverage._parse_changed_lines()` parses the zero-context `git diff` text used by changed-scope coverage gates. The previous loop used `diff_text.split("\n")`, which materialized an extra empty trailing entry for newline-terminated diffs and routed that entry through the blank-line context handler even though it cannot affect reported changed lines.
+
+This slice keeps parser behavior unchanged while iterating with `diff_text.splitlines()`. Blank context lines inside hunks are still preserved, while the synthetic trailing empty entry is avoided.
+
+## Registered probe
+
+Existing registered probe: `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.
+
+The registry already defines focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `scripts/changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_parse_probe.py`
+- `tests/test_changed_scope_coverage.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `infra/perf/pr_scoped_probes.json`
+
+No new probe registration is required for this narrow parser optimization.
+
+## Verification plan
+
+- Focused changed-scope tests and PR-scoped registry tests.
+- Changed-scope coverage command from the registered probe.
+- Registered `changed-scope-coverage-diff-parser` probe locally on Linux.
+- Direct old/new comparison against `HEAD:scripts/changed_scope_coverage.py` on the same synthetic diff workload.
+- `git diff --check`.
+
+## Acceptance criteria
+
+- Focused tests pass.
+- Changed executable line coverage is at least 95%.
+- Registered probe reports stable parser metrics.
+- Direct old/new comparison shows lower mean elapsed time for the parser on the same workload.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -63,7 +63,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     header_separator_len = len(header_separator)
     add_changed_line = None
     new_line: int | None = None
-    for line in diff_text.split("\n"):
+    for line in diff_text.splitlines():
         if not line:
             if add_changed_line is not None and new_line is not None:
                 new_line += 1


### PR DESCRIPTION
## Summary
- Optimize `scripts/changed_scope_coverage.py` by iterating diff text with `splitlines()` instead of `split("\n")` in the hot changed-line parser.
- Preserve parser behavior for blank context lines and newline-terminated diffs while avoiding the synthetic trailing empty split entry.
- Add a focused plan note for this registered performance slice.

## Plan or Spec
- `docs/plans/2026-05-28-changed-scope-splitlines-parser.md`
- Registered probe already exists: `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- Registered probe locally: `changed-scope-coverage-diff-parser` via `infra/perf/pr_scoped_probes.json` `probe_command` (3 runs).
- Direct old/new comparison against `HEAD:scripts/changed_scope_coverage.py` on the same synthetic diff workload.
- `git diff --check`

## Coverage and Metrics
- Focused tests: `31 passed`.
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Direct old/new parser comparison (100 samples, same synthetic diff): old mean `3.7757 ms`, new mean `3.2347 ms`, delta `-0.5411 ms`, speedup `1.17x`.
- Registered local probe post-change samples:
  - `elapsed_ms_mean=3.2394 ms`, `changed_line_count=7680`, `line_count=16080`
  - `elapsed_ms_mean=3.4509 ms`, `changed_line_count=7680`, `line_count=16080`
  - `elapsed_ms_mean=3.2865 ms`, `changed_line_count=7680`, `line_count=16080`
- CI PR-scoped performance report is required before merge.

## Known Gaps
- This is Python CI tooling only and was locally validated on Linux.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Fresh worktree from `origin/main`.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe ran successfully.
- [x] `git diff --check` passed.
- [ ] GitHub Actions completed successfully, including registered PR-scoped performance.
