### PR TITLE
Avoid false singleton batch hint when worker metrics are missing

### DIFF
--- a/scripts/omlx_melix_compare_benchmark.py
+++ b/scripts/omlx_melix_compare_benchmark.py
@@ -1110,6 +1110,7 @@ def enrich_hints_with_metrics(
     if (
         admission_cohort_size is not None
         and admission_cohort_size > 1
+        and (worker_decode_batch_size is not None or model_eval_batch_size is not None)
         and worker_execution_batch_size <= 1
     ):
         hints.append({

--- a/tests/test_omlx_melix_compare_benchmark.py
+++ b/tests/test_omlx_melix_compare_benchmark.py
@@ -849,6 +849,18 @@ def test_metrics_snapshot_adds_multimodal_batching_hint(tmp_path: Path) -> None:
     assert hints[1]["melix_per_batch_output_tokens_per_second"] == 8
 
 
+def test_metrics_snapshot_does_not_treat_missing_worker_batches_as_singleton() -> None:
+    snapshot = {
+        "ok": True,
+        "values": {
+            "scheduler.admission_cohort_size": 2,
+            "swift_text.per_batch_output_tokens_per_second": 8,
+        },
+    }
+
+    assert bench.enrich_hints_with_metrics([], snapshot) == []
+
+
 def test_binary_metadata_detects_release_debug_and_sha256(tmp_path: Path) -> None:
     release_binary = tmp_path / "services/mlx-text-worker-swift/.build/release/melix-text-worker-swift"
     release_binary.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- Avoid emitting the singleton worker/model execution hint when a metrics snapshot does not contain any worker batch metrics.
- Add regression coverage for a snapshot that only has admission and throughput metrics, following the review finding on #1675.

## Plan or Spec
- `docs/plans/2026-05-28-gemma-e4b-metrics-snapshot-cli.md`

## Commands Run
```text
git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest tests/test_omlx_melix_compare_benchmark.py::test_metrics_snapshot_adds_multimodal_batching_hint tests/test_omlx_melix_compare_benchmark.py::test_metrics_snapshot_does_not_treat_missing_worker_batches_as_singleton -q
# 2 passed in 0.08s

.githooks/pre-commit
# make swift-test: completed rc=0 elapsed=658.3s
# make py-test: 3360 passed, 14 skipped, 2 warnings in 152.86s
# make integration-test: 115 passed, 1 skipped in 673.65s
# scoped performance: Status ok; regressions 0; context regressions 0; verification failures 0
```

## Coverage and Metrics
- Changed-scope coverage: scoped performance probe verification reported coverage pass at 100.0%.
- Metrics report: `.runtime/pre-commit-performance/20260528-224508-2236043f/report/report.md`
- Probe: Same-cohort batching probe evidence; base and head both reported `scheduler_admission_cohort_size=2`, `worker_decode_batch_size=1`, `worker_model_eval_batch_size=1`, `scheduler_to_worker_batch_delta=1`, with no regression.
- Observability mode: evidence.
- Probe overhead: pre-commit base probe elapsed 122.9s; head probe elapsed 125.9s.

## Known Gaps
- None for this guard fix. The broader worker/model execution batching gap remains tracked by #1642.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
