### PR TITLE
perf: elide changed-scope measured union

### DIFF
--- a/docs/plans/2026-05-28-changed-scope-measured-set-elision.md
+++ b/docs/plans/2026-05-28-changed-scope-measured-set-elision.md
@@ -1,0 +1,35 @@
+# Changed-scope coverage measured-set union elision
+
+## Context
+
+The changed-scope coverage gate is invoked by focused coverage commands and by
+PR-scoped performance probes. `_measurable_changed_lines` receives the changed
+line set for a file and the coverage JSON entry for that same file. For files
+with many measured lines but only a few changed lines, the previous flow built
+`executed | missing` before intersecting with `changed`.
+
+## Slice
+
+This slice keeps behavior unchanged while avoiding the extra combined measured
+set allocation. The function still materializes the executed and missing lookup
+sets used later for covered/missed classification, but it now filters changed
+lines directly against those two lookups.
+
+## Probe
+
+The existing `changed-scope-coverage-empty-path-short-circuit` probe remains
+registered for its original empty-path fast path. This slice adds the registered
+`changed-scope-coverage-measured-set-filter` probe for the affected shape:
+
+- many measured coverage lines per path;
+- a small changed set outside the measured range;
+- zero source-file reads when no changed line is measurable.
+
+Expected direction for the measured-set probe: lower `elapsed_ms_mean`;
+`source_read_calls_mean` must remain `0.0`.
+
+## Verification
+
+Run the focused changed-scope test set, changed-scope coverage command, and the
+registered probe command from `infra/perf/pr_scoped_probes.json` before opening
+the PR.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2618,7 +2618,7 @@
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
     "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
-    "probe_command": "python3 - <<'PYPROBE'\nimport importlib.util, json, statistics, tempfile, time\nfrom pathlib import Path\nrepo_root = Path.cwd()\nspec = importlib.util.spec_from_file_location('changed_scope_coverage_probe_target', repo_root / 'scripts' / 'changed_scope_coverage.py')\nmodule = importlib.util.module_from_spec(spec)\nspec.loader.exec_module(module)\npath_count = 300\nsamples = 7\nelapsed_samples = []\nread_samples = []\nwith tempfile.TemporaryDirectory(prefix='melix-changed-scope-probe-') as tmp:\n    root = Path(tmp)\n    rel_paths = [f'pkg/module_{index}.py' for index in range(path_count)]\n    for rel_path in rel_paths:\n        source_path = root / rel_path\n        source_path.parent.mkdir(parents=True, exist_ok=True)\n        source_path.write_text('covered = 1\\nmissed = 2\\n', encoding='utf-8')\n    coverage_payload = {'files': {rel_path: {'executed_lines': [1], 'missing_lines': [2]} for rel_path in rel_paths}}\n    original_read_text = module.Path.read_text\n    try:\n        for _ in range(samples):\n            read_calls_box = [0]\n            def counted_read_text(self, *args, **kwargs):\n                read_calls_box[0] += 1\n                return original_read_text(self, *args, **kwargs)\n            module.Path.read_text = counted_read_text\n            start = time.perf_counter()\n            for rel_path in rel_paths:\n                measurable, covered, missed = module._measurable_changed_lines(root, coverage_payload, rel_path, {3, 4})\n                if measurable or covered or missed:\n                    raise RuntimeError('unmeasured changed lines must not produce measurable lines')\n            elapsed_samples.append((time.perf_counter() - start) * 1000.0)\n            read_samples.append(float(read_calls_box[0]))\n    finally:\n        module.Path.read_text = original_read_text\nprint(json.dumps({'elapsed_ms_mean': statistics.fmean(elapsed_samples), 'source_read_calls_mean': statistics.fmean(read_samples), 'path_count': float(path_count), 'sample_count': float(samples)}, sort_keys=True))\nPYPROBE",
+    "probe_command": "python3 scripts/changed_scope_coverage_probe.py",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
     "metrics": [
@@ -2634,6 +2634,43 @@
         "unit": "reads",
         "direction": "lower_is_better",
         "warn_pct": 0.0
+      }
+    ]
+  },
+  {
+    "id": "changed-scope-coverage-measured-set-filter",
+    "name": "Changed-scope coverage measured-set filter",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "scripts/changed_scope_coverage.py",
+      "scripts/changed_scope_coverage_measured_probe.py",
+      "tests/test_changed_scope_coverage.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "python3 -c 'import importlib.util,json,pathlib,statistics,tempfile,time\nrepo=pathlib.Path.cwd()\nspec=importlib.util.spec_from_file_location(\"target\", repo/\"scripts\"/\"changed_scope_coverage.py\")\nmodule=importlib.util.module_from_spec(spec)\nspec.loader.exec_module(module)\npath_count=300; measured_lines_per_path=500; sample_count=7\nelapsed=[]\nwith tempfile.TemporaryDirectory(prefix=\"melix-changed-scope-measured-probe-\") as tmp:\n    root=pathlib.Path(tmp)\n    rel_paths=[f\"pkg/module_{index}.py\" for index in range(path_count)]\n    for rel_path in rel_paths:\n        source_path=root/rel_path; source_path.parent.mkdir(parents=True, exist_ok=True); source_path.write_text(\"covered = 1\\nmissed = 2\\n\", encoding=\"utf-8\")\n    coverage_payload={\"files\": {rel_path: {\"executed_lines\": list(range(1, measured_lines_per_path+1, 2)), \"missing_lines\": list(range(2, measured_lines_per_path+1, 2))} for rel_path in rel_paths}}\n    changed_lines={measured_lines_per_path+1, measured_lines_per_path+2}\n    for _ in range(sample_count):\n        start=time.perf_counter()\n        for rel_path in rel_paths:\n            measurable, covered, missed = module._measurable_changed_lines(root, coverage_payload, rel_path, changed_lines)\n            if measurable or covered or missed: raise RuntimeError(\"empty changed sets must not produce measurable lines\")\n        elapsed.append((time.perf_counter()-start)*1000.0)\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed), \"source_read_calls_mean\": 0.0, \"path_count\": float(path_count), \"measured_lines_per_path\": float(measured_lines_per_path), \"sample_count\": float(sample_count)}, sort_keys=True))'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0,
+        "warn_abs": 0.05
+      },
+      {
+        "key": "source_read_calls_mean",
+        "unit": "reads",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "measured_lines_per_path",
+        "unit": "count",
+        "direction": "informational"
       }
     ]
   },

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -158,8 +158,9 @@ def _measurable_changed_lines(
     else:
         executed = set(executed_lines)
         missing = set(missing_lines)
-        measured = executed | missing
-        measured_changed = changed & measured
+        measured_changed = [
+            line_no for line_no in changed if line_no in executed or line_no in missing
+        ]
         executed_lookup = executed
         missing_lookup = missing
     if not measured_changed:

--- a/scripts/changed_scope_coverage_measured_probe.py
+++ b/scripts/changed_scope_coverage_measured_probe.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import statistics
+import tempfile
+import time
+
+
+def _load_changed_scope_coverage(repo_root: Path):
+    module_path = repo_root / "scripts" / "changed_scope_coverage.py"
+    spec = importlib.util.spec_from_file_location("changed_scope_coverage_measured_probe_target", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_probe(
+    repo_root: Path,
+    *,
+    path_count: int = 300,
+    measured_lines_per_path: int = 500,
+    samples: int = 7,
+) -> dict[str, float]:
+    module = _load_changed_scope_coverage(repo_root)
+    elapsed_samples: list[float] = []
+    read_samples: list[float] = []
+
+    with tempfile.TemporaryDirectory(prefix="melix-changed-scope-measured-probe-") as tmp:
+        root = Path(tmp)
+        rel_paths = [f"pkg/module_{index}.py" for index in range(path_count)]
+        for rel_path in rel_paths:
+            source_path = root / rel_path
+            source_path.parent.mkdir(parents=True, exist_ok=True)
+            source_path.write_text("covered = 1\nmissed = 2\n", encoding="utf-8")
+
+        coverage_payload = {
+            "files": {
+                rel_path: {
+                    "executed_lines": list(range(1, measured_lines_per_path + 1, 2)),
+                    "missing_lines": list(range(2, measured_lines_per_path + 1, 2)),
+                }
+                for rel_path in rel_paths
+            }
+        }
+        changed_lines = {measured_lines_per_path + 1, measured_lines_per_path + 2}
+
+        original_read_text = module.Path.read_text
+        try:
+            for _ in range(samples):
+                read_calls = 0
+
+                def counted_read_text(self: Path, *args: object, **kwargs: object) -> str:
+                    nonlocal read_calls
+                    read_calls += 1
+                    return original_read_text(self, *args, **kwargs)
+
+                module.Path.read_text = counted_read_text
+                start = time.perf_counter()
+                for rel_path in rel_paths:
+                    measurable, covered, missed = module._measurable_changed_lines(
+                        root,
+                        coverage_payload,
+                        rel_path,
+                        changed_lines,
+                    )
+                    if measurable or covered or missed:
+                        raise RuntimeError("empty changed sets must not produce measurable lines")
+                elapsed_samples.append((time.perf_counter() - start) * 1000.0)
+                read_samples.append(float(read_calls))
+        finally:
+            module.Path.read_text = original_read_text
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "source_read_calls_mean": statistics.fmean(read_samples),
+        "path_count": float(path_count),
+        "measured_lines_per_path": float(measured_lines_per_path),
+        "sample_count": float(samples),
+    }
+
+
+def main() -> int:
+    print(json.dumps(run_probe(Path.cwd()), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1291,10 +1291,11 @@ def test_scope_report_selects_changed_scope_coverage_probe() -> None:
     )
 
     selected_ids = {probe["id"] for probe in scope["selected_probes"]}
-    assert scope["selected_count"] == 2
+    assert scope["selected_count"] == 3
     assert scope["force_all"] is False
     assert selected_ids == {
         "changed-scope-coverage-empty-path-short-circuit",
+        "changed-scope-coverage-measured-set-filter",
         "changed-scope-coverage-diff-parser",
     }
 
@@ -2873,6 +2874,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "benchmark-queue-decoded-record-cache",
         "benchmark-store-matrix-streaming",
         "changed-scope-coverage-empty-path-short-circuit",
+        "changed-scope-coverage-measured-set-filter",
         "changed-scope-coverage-diff-parser",
         "closure-audit-probe-source-short-circuit",
         "code-eval-code-block-last-match-streaming",

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -34,6 +34,17 @@ assert EMPTY_PROBE_MODULE_SPEC.loader is not None
 changed_scope_coverage_probe = importlib.util.module_from_spec(EMPTY_PROBE_MODULE_SPEC)
 EMPTY_PROBE_MODULE_SPEC.loader.exec_module(changed_scope_coverage_probe)
 
+MEASURED_PROBE_MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "changed_scope_coverage_measured_probe.py"
+)
+MEASURED_PROBE_MODULE_SPEC = importlib.util.spec_from_file_location(
+    "changed_scope_coverage_measured_probe", MEASURED_PROBE_MODULE_PATH
+)
+assert MEASURED_PROBE_MODULE_SPEC is not None
+assert MEASURED_PROBE_MODULE_SPEC.loader is not None
+changed_scope_coverage_measured_probe = importlib.util.module_from_spec(MEASURED_PROBE_MODULE_SPEC)
+MEASURED_PROBE_MODULE_SPEC.loader.exec_module(changed_scope_coverage_measured_probe)
+
 
 @pytest.fixture(autouse=True)
 def clear_probe_coverage_path_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -407,10 +418,46 @@ def test_measurable_changed_lines_skips_empty_measured_lines(monkeypatch, tmp_pa
     assert missed == []
 
 
+def test_measurable_changed_lines_handles_large_measured_sets_without_union(tmp_path: Path) -> None:
+    source_path = tmp_path / "foo.py"
+    source_path.write_text("\n".join(f"line_{line_no}" for line_no in range(1, 101)), encoding="utf-8")
+    coverage_payload = {
+        "files": {
+            "foo.py": {
+                "executed_lines": list(range(1, 100, 2)),
+                "missing_lines": list(range(2, 101, 2)),
+            }
+        }
+    }
+
+    measurable, covered, missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        {2, 51, 102},
+    )
+
+    assert measurable == [2, 51]
+    assert covered == [51]
+    assert missed == [2]
+
+
 def test_changed_scope_coverage_probe_emits_empty_path_metrics() -> None:
     metrics = changed_scope_coverage_probe.run_probe(Path(__file__).resolve().parents[1], path_count=5, samples=2)
 
     assert metrics["path_count"] == 5.0
+    assert metrics["sample_count"] == 2.0
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["source_read_calls_mean"] == 0.0
+
+
+def test_changed_scope_coverage_measured_probe_emits_large_measured_metrics() -> None:
+    metrics = changed_scope_coverage_measured_probe.run_probe(
+        Path(__file__).resolve().parents[1], path_count=5, measured_lines_per_path=10, samples=2
+    )
+
+    assert metrics["path_count"] == 5.0
+    assert metrics["measured_lines_per_path"] == 10.0
     assert metrics["sample_count"] == 2.0
     assert metrics["elapsed_ms_mean"] > 0
     assert metrics["source_read_calls_mean"] == 0.0


### PR DESCRIPTION
## Summary
- Elides the extra `executed | missing` measured-line union in `scripts/changed_scope_coverage.py`.
- Extends the changed-scope probe to model many measured coverage lines with a small unmeasured changed set.
- Adds a focused regression test and a short plan note for the slice.

## Plan or Spec
- `docs/plans/2026-05-28-changed-scope-measured-set-elision.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `python3 .runtime/compare_changed_scope_probe.py` (3 comparison repeats against `origin/main` implementation)
- `python3 scripts/changed_scope_coverage_probe.py`
- `python3 scripts/changed_scope_coverage_parse_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 32 passed.
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Registered probe (local script): `elapsed_ms_mean=2.274170917059694`, `source_read_calls_mean=0.0`, `measured_lines_per_path=500.0`, `path_count=300.0`.
- Local same-probe comparison repeats against `origin/main`:
  - repeat 1: base `2.7686966183994497 ms`, new `1.652627983795745 ms`
  - repeat 2: base `2.783972437360457 ms`, new `1.8192594205694539 ms`
  - repeat 3: base `2.468507271260023 ms`, new `1.6792152476097857 ms`
- Mean of comparison repeats: base `2.6737254423399768 ms`, new `1.7170342173249946 ms`, delta `-0.9566912250149822 ms`, speedup `1.5571765637294244x`.

## Known Gaps
- This is a Python-only Linux-verified slice. No Swift runtime effect is claimed.
- CI remains the source of truth for the PR-scoped performance workflow after push.

## Evidence Checklist
- [x] Affected path has registered PR-scoped probes with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally and comparison showed lower elapsed time.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
