### PR TITLE
Add homogeneous Swift text decode batch coordinator

### DIFF
--- a/docs/plans/2026-05-29-issue-1655-homogeneous-decode-coordinator.md
+++ b/docs/plans/2026-05-29-issue-1655-homogeneous-decode-coordinator.md
@@ -1,0 +1,56 @@
+# Issue 1655 Homogeneous Decode Coordinator
+
+Date: 2026-05-29
+
+## Context
+
+Issue #1642 tracks the remaining release Gemma E4B serving gap against OMLX
+and SwiftLM. The latest three-way report shows that the remaining threshold
+failures are concentrated in concurrency-2 decode scenarios. The control-plane
+same-cohort probe now separates scheduler admission from worker execution and
+currently reports a scheduler admission cohort size of two while the Swift text
+worker/model decode path remains singleton.
+
+Issue #1655 is the first implementation slice for closing that worker-side
+gap. It should add the narrow coordinator and backend contract needed to group
+eligible homogeneous decode requests without claiming fused model execution for
+backends that cannot actually provide it.
+
+## Plan
+
+1. Add a Swift text decode cohort contract.
+   - Represent each candidate request with its model handle, sampling,
+     acceleration policy, output limit, decode step size, prefill token, cache
+     snapshot requirement, and prepared prefill state.
+   - Build an eligibility key from those fields so only same-model,
+     same-sampling, same-acceleration, same-output-limit requests can batch.
+   - Exclude requests that need boundary snapshot creation in this first slice,
+     because snapshot persistence is per-request state that requires separate
+     hardening.
+2. Add a worker-local decode coordinator.
+   - Hold a short pending window for decode RPCs that enter with the same
+     eligibility key.
+   - Dispatch a cohort only when the backend advertises homogeneous batch
+     decode support and the cohort size is greater than one.
+   - Fall back to the existing single-request decode path otherwise.
+3. Add a backend batch decode event surface.
+   - Emit per-request token and summary events from one batch stream.
+   - Record worker decode batch size, model eval batch size, per-batch token
+     count, and per-batch token rate from the actual batch execution.
+   - Keep unsupported Swift MLX paths on the singleton event surface until a
+     real shared-cache MLX batch implementation lands.
+4. Prove the behavior with deterministic worker tests.
+   - Two homogeneous requests should observe worker/model batch size two.
+   - Existing singleton decode tests should continue to report batch size one.
+   - The deterministic integration evidence should avoid treating scheduler
+     admission as model-step execution.
+
+## Success Metrics
+
+- Homogeneous deterministic decode requests produce
+  `swift_text.decode_batch_size == 2` and
+  `swift_text.model_eval_batch_size == 2`.
+- Singleton fallback continues to produce batch size one.
+- Backend metrics are only recorded from the execution path actually used by
+  the worker; unsupported real Swift MLX batch decode does not emit synthetic
+  batch-size-two evidence.

--- a/services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeBatchCoordinator.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeBatchCoordinator.swift
@@ -94,6 +94,7 @@ actor TextDecodeBatchCoordinator {
     }
 
     private struct PendingCohort: @unchecked Sendable {
+        let id: UInt64
         var capacity: Int
         var items: [PendingItem]
     }
@@ -101,6 +102,7 @@ actor TextDecodeBatchCoordinator {
     private let registry: WorkerRuntimeRegistry
     private let pendingWindowNanos: UInt64
     private var pendingByKey: [TextDecodeBatchEligibilityKey: PendingCohort] = [:]
+    private var nextCohortID: UInt64 = 1
 
     init(
         registry: WorkerRuntimeRegistry,
@@ -113,10 +115,20 @@ actor TextDecodeBatchCoordinator {
     func enqueue(_ candidate: TextDecodeBatchCandidate) async -> TextDecodeBatchAssignment {
         await withCheckedContinuation { continuation in
             let item = PendingItem(candidate: candidate, continuation: continuation)
-            var cohort = pendingByKey[candidate.key] ?? PendingCohort(
-                capacity: max(2, candidate.maxBatchSize),
-                items: []
-            )
+            let shouldScheduleFlush: Bool
+            var cohort: PendingCohort
+            if let pending = pendingByKey[candidate.key] {
+                cohort = pending
+                shouldScheduleFlush = false
+            } else {
+                cohort = PendingCohort(
+                    id: nextCohortID,
+                    capacity: max(2, candidate.maxBatchSize),
+                    items: []
+                )
+                nextCohortID &+= 1
+                shouldScheduleFlush = true
+            }
             cohort.capacity = max(2, min(cohort.capacity, candidate.maxBatchSize))
             cohort.items.append(item)
 
@@ -126,28 +138,28 @@ actor TextDecodeBatchCoordinator {
                 return
             }
 
-            let shouldScheduleFlush = cohort.items.count == 1
             pendingByKey[candidate.key] = cohort
 
             if shouldScheduleFlush {
-                scheduleFlush(for: candidate.key)
+                scheduleFlush(for: candidate.key, cohortID: cohort.id)
             }
         }
     }
 
-    private func scheduleFlush(for key: TextDecodeBatchEligibilityKey) {
+    private func scheduleFlush(for key: TextDecodeBatchEligibilityKey, cohortID: UInt64) {
         Task { [pendingWindowNanos] in
             if pendingWindowNanos > 0 {
                 try? await Task.sleep(nanoseconds: pendingWindowNanos)
             }
-            self.flush(key: key)
+            self.flush(key: key, cohortID: cohortID)
         }
     }
 
-    private func flush(key: TextDecodeBatchEligibilityKey) {
-        guard let cohort = pendingByKey.removeValue(forKey: key) else {
+    private func flush(key: TextDecodeBatchEligibilityKey, cohortID: UInt64) {
+        guard let cohort = pendingByKey[key], cohort.id == cohortID else {
             return
         }
+        pendingByKey.removeValue(forKey: key)
         dispatch(cohort)
     }
 
@@ -170,7 +182,7 @@ actor TextDecodeBatchCoordinator {
         let items = cohort.items.map(\.candidate)
         let continuations = streams.map(\.continuation)
         let registry = self.registry
-        Task {
+        Task.detached {
             do {
                 let runtimeStream = try await registry.decodeBatchEvents(
                     items: items.map(\.workerItem)

--- a/services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeBatchCoordinator.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeBatchCoordinator.swift
@@ -1,0 +1,200 @@
+import Foundation
+import MelixWorkerProtocol
+
+struct TextDecodeSamplingKey: Hashable, Sendable {
+    let temperature: Float
+    let topP: Float
+    let topK: UInt32
+    let frequencyPenalty: Float
+    let presencePenalty: Float
+    let maxOutputTokens: UInt32
+    let stop: [String]
+    let seed: UInt32
+
+    init(_ sampling: Melix_Worker_V1_SamplingConfig) {
+        self.temperature = sampling.temperature
+        self.topP = sampling.topP
+        self.topK = sampling.topK
+        self.frequencyPenalty = sampling.frequencyPenalty
+        self.presencePenalty = sampling.presencePenalty
+        self.maxOutputTokens = sampling.maxOutputTokens
+        self.stop = sampling.stop
+        self.seed = sampling.seed
+    }
+}
+
+struct TextDecodeAccelerationKey: Hashable, Sendable {
+    let mode: Melix_Worker_V1_AccelerationMode
+    let profileID: String
+    let draftModelID: String
+    let prefillHint: String
+    let activeKVQuantProfile: String
+    let allowBaselineFallback: Bool
+    let numDraftTokens: UInt32
+    let ext: [String]
+
+    init(_ acceleration: Melix_Worker_V1_AccelerationPolicy) {
+        self.mode = acceleration.mode
+        self.profileID = acceleration.profileID
+        self.draftModelID = acceleration.draftModelID
+        self.prefillHint = acceleration.prefillHint
+        self.activeKVQuantProfile = acceleration.activeKvQuantProfile
+        self.allowBaselineFallback = acceleration.allowBaselineFallback
+        self.numDraftTokens = acceleration.numDraftTokens
+        self.ext = acceleration.ext
+            .map { "\($0.key)=\($0.value)" }
+            .sorted()
+    }
+}
+
+struct TextDecodeBatchEligibilityKey: Hashable, Sendable {
+    let modelHandle: String
+    let lane: String
+    let sampling: TextDecodeSamplingKey
+    let acceleration: TextDecodeAccelerationKey
+    let maxOutputTokens: UInt32
+    let decodeStepSize: UInt32
+    let prefillToken: String
+}
+
+struct TextDecodeBatchCandidate: @unchecked Sendable {
+    let requestID: String
+    let key: TextDecodeBatchEligibilityKey
+    let maxBatchSize: Int
+    let session: WorkerDecodeSession
+    let sampling: Melix_Worker_V1_SamplingConfig
+    let maxOutputTokens: UInt32
+    let decodeStepSize: UInt32
+    let prefillToken: String
+    let acceleration: Melix_Worker_V1_AccelerationPolicy
+    let shouldAbort: @Sendable () -> Bool
+
+    var workerItem: WorkerDecodeBatchItem {
+        WorkerDecodeBatchItem(
+            session: session,
+            sampling: sampling,
+            maxOutputTokens: maxOutputTokens,
+            decodeStepSize: decodeStepSize,
+            prefillToken: prefillToken,
+            acceleration: acceleration,
+            shouldAbort: shouldAbort
+        )
+    }
+}
+
+enum TextDecodeBatchAssignment: Sendable {
+    case single
+    case batched(stream: AsyncThrowingStream<TextGenerationEvent, Error>, batchSize: Int)
+}
+
+actor TextDecodeBatchCoordinator {
+    private struct PendingItem: @unchecked Sendable {
+        let candidate: TextDecodeBatchCandidate
+        let continuation: CheckedContinuation<TextDecodeBatchAssignment, Never>
+    }
+
+    private struct PendingCohort: @unchecked Sendable {
+        var capacity: Int
+        var items: [PendingItem]
+    }
+
+    private let registry: WorkerRuntimeRegistry
+    private let pendingWindowNanos: UInt64
+    private var pendingByKey: [TextDecodeBatchEligibilityKey: PendingCohort] = [:]
+
+    init(
+        registry: WorkerRuntimeRegistry,
+        pendingWindowNanos: UInt64 = 2_000_000
+    ) {
+        self.registry = registry
+        self.pendingWindowNanos = pendingWindowNanos
+    }
+
+    func enqueue(_ candidate: TextDecodeBatchCandidate) async -> TextDecodeBatchAssignment {
+        await withCheckedContinuation { continuation in
+            let item = PendingItem(candidate: candidate, continuation: continuation)
+            var cohort = pendingByKey[candidate.key] ?? PendingCohort(
+                capacity: max(2, candidate.maxBatchSize),
+                items: []
+            )
+            cohort.capacity = max(2, min(cohort.capacity, candidate.maxBatchSize))
+            cohort.items.append(item)
+
+            if cohort.items.count >= cohort.capacity {
+                pendingByKey[candidate.key] = nil
+                dispatch(cohort)
+                return
+            }
+
+            let shouldScheduleFlush = cohort.items.count == 1
+            pendingByKey[candidate.key] = cohort
+
+            if shouldScheduleFlush {
+                scheduleFlush(for: candidate.key)
+            }
+        }
+    }
+
+    private func scheduleFlush(for key: TextDecodeBatchEligibilityKey) {
+        Task { [pendingWindowNanos] in
+            if pendingWindowNanos > 0 {
+                try? await Task.sleep(nanoseconds: pendingWindowNanos)
+            }
+            self.flush(key: key)
+        }
+    }
+
+    private func flush(key: TextDecodeBatchEligibilityKey) {
+        guard let cohort = pendingByKey.removeValue(forKey: key) else {
+            return
+        }
+        dispatch(cohort)
+    }
+
+    private func dispatch(_ cohort: PendingCohort) {
+        guard cohort.items.count > 1 else {
+            cohort.items.first?.continuation.resume(returning: .single)
+            return
+        }
+
+        let streams = cohort.items.map { _ in
+            AsyncThrowingStream<TextGenerationEvent, Error>.makeStream()
+        }
+        for (index, item) in cohort.items.enumerated() {
+            item.continuation.resume(returning: .batched(
+                stream: streams[index].stream,
+                batchSize: cohort.items.count
+            ))
+        }
+
+        let items = cohort.items.map(\.candidate)
+        let continuations = streams.map(\.continuation)
+        let registry = self.registry
+        Task {
+            do {
+                let runtimeStream = try await registry.decodeBatchEvents(
+                    items: items.map(\.workerItem)
+                )
+                for try await event in runtimeStream {
+                    switch event {
+                    case .token(let requestIndex, let text):
+                        guard continuations.indices.contains(requestIndex) else {
+                            continue
+                        }
+                        continuations[requestIndex].yield(.token(text))
+                    case .summary(let requestIndex, let summary):
+                        guard continuations.indices.contains(requestIndex) else {
+                            continue
+                        }
+                        continuations[requestIndex].yield(.summary(summary))
+                    case .batchSummary:
+                        continue
+                    }
+                }
+                continuations.forEach { $0.finish() }
+            } catch {
+                continuations.forEach { $0.finish(throwing: error) }
+            }
+        }
+    }
+}

--- a/services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeEngine.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeEngine.swift
@@ -440,7 +440,7 @@ struct TextDecodeEngine: Sendable {
         )
         let completionBatchSize = parsePositiveInt(
             executionExt["melix.gateway.completion_batch_size"],
-            fallback: 1
+            fallback: maxConcurrent
         )
         return max(1, min(maxConcurrent, completionBatchSize))
     }

--- a/services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeEngine.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeEngine.swift
@@ -6,6 +6,7 @@ struct TextDecodeEngine: Sendable {
     let registry: WorkerRuntimeRegistry
     let abortRegistry: AbortRegistry
     let metrics: MetricsStore
+    let batchCoordinator: TextDecodeBatchCoordinator?
 
     func runDecode(
         request: Melix_Worker_V1_DecodeRequest,
@@ -50,20 +51,26 @@ struct TextDecodeEngine: Sendable {
             let acceleration = accelerationResolution.policy
             recordSpeculativeRequestMetrics(accelerationResolution)
 
-            let runtimeStream = try await registry.decodeEvents(
+            let shouldAbort: @Sendable () -> Bool = { abortHandle?.isAborted ?? false }
+            let runtimeStream = try await resolveRuntimeStream(
+                request: request,
+                requestID: requestID,
+                lane: lane,
                 session: session,
                 sampling: sampling,
-                maxOutputTokens: request.maxOutputTokens,
-                decodeStepSize: request.decodeStepSize,
-                prefillToken: request.prefillToken,
                 acceleration: acceleration,
-                shouldAbort: { abortHandle?.isAborted ?? false }
+                shouldAbort: shouldAbort
             )
 
             var seq: UInt64 = 1
             var completionTokens = 0
             var outputState = FilteredTextOutputState()
             var tokensPerSecond: Double?
+            var decodeBatchSize = 1
+            var modelEvalBatchSize = 1
+            var decodeLoopIterations = 1
+            var perBatchOutputTokenCount: Int?
+            var perBatchOutputTokensPerSecond: Double?
             var speculativeAccepted: Int?
             var speculativeRejected: Int?
             var speculativeFallbackCount: Int?
@@ -163,6 +170,15 @@ struct TextDecodeEngine: Sendable {
                 case .summary(let summary):
                     completionTokens = max(completionTokens, summary.completionTokens)
                     tokensPerSecond = summary.tokensPerSecond
+                    decodeBatchSize = max(decodeBatchSize, summary.decodeBatchSize ?? 1)
+                    modelEvalBatchSize = max(modelEvalBatchSize, summary.modelEvalBatchSize ?? 1)
+                    decodeLoopIterations = max(decodeLoopIterations, summary.decodeLoopIterations ?? 1)
+                    if let value = summary.perBatchOutputTokenCount {
+                        perBatchOutputTokenCount = max(perBatchOutputTokenCount ?? 0, value)
+                    }
+                    if let value = summary.perBatchOutputTokensPerSecond {
+                        perBatchOutputTokensPerSecond = value
+                    }
                     speculativeAccepted = summary.speculativeAcceptedTokens
                     speculativeRejected = summary.speculativeRejectedTokens
                     speculativeFallbackCount = summary.speculativeFallbackCount
@@ -255,18 +271,26 @@ struct TextDecodeEngine: Sendable {
             }
             metrics.recordMilliseconds("swift_text.decode_ms", value: elapsedMilliseconds(since: startedAt))
             let roundedTokensPerSecond = max(0, Int((tokensPerSecond ?? 0).rounded()))
+            let roundedPerBatchTokensPerSecond = max(
+                0,
+                Int((perBatchOutputTokensPerSecond ?? tokensPerSecond ?? 0).rounded())
+            )
             metrics.set("swift_text.decode_stream_event_count", value: outputState.eventCount)
-            metrics.set("swift_text.decode_batch_size", value: 1)
-            metrics.set("swift_text.model_eval_batch_size", value: 1)
+            metrics.set("swift_text.decode_batch_size", value: max(1, decodeBatchSize))
+            metrics.set("swift_text.model_eval_batch_size", value: max(1, modelEvalBatchSize))
             metrics.increment("swift_text.decode_batch_observation_count")
-            metrics.set("swift_text.per_batch_output_token_count", value: max(0, completionTokens))
+            metrics.set("swift_text.decode_loop_iterations", value: max(1, decodeLoopIterations))
+            metrics.set(
+                "swift_text.per_batch_output_token_count",
+                value: max(0, perBatchOutputTokenCount ?? completionTokens)
+            )
             metrics.set(
                 "swift_text.decode_tokens_per_second",
                 value: roundedTokensPerSecond
             )
             metrics.set(
                 "swift_text.per_batch_output_tokens_per_second",
-                value: roundedTokensPerSecond
+                value: roundedPerBatchTokensPerSecond
             )
             metrics.set(
                 "swift_text.active_kv_quantization_ratio",
@@ -319,6 +343,106 @@ struct TextDecodeEngine: Sendable {
                 message: error.localizedDescription
             ))
         }
+    }
+
+    private func resolveRuntimeStream(
+        request: Melix_Worker_V1_DecodeRequest,
+        requestID: String,
+        lane: String,
+        session: WorkerDecodeSession,
+        sampling: Melix_Worker_V1_SamplingConfig,
+        acceleration: Melix_Worker_V1_AccelerationPolicy,
+        shouldAbort: @escaping @Sendable () -> Bool
+    ) async throws -> AsyncThrowingStream<TextGenerationEvent, Error> {
+        if let candidate = await makeBatchCandidateIfEligible(
+            request: request,
+            requestID: requestID,
+            lane: lane,
+            session: session,
+            sampling: sampling,
+            acceleration: acceleration,
+            shouldAbort: shouldAbort
+        ), let batchCoordinator {
+            switch await batchCoordinator.enqueue(candidate) {
+            case .single:
+                break
+            case .batched(let stream, _):
+                return stream
+            }
+        }
+
+        return try await registry.decodeEvents(
+            session: session,
+            sampling: sampling,
+            maxOutputTokens: request.maxOutputTokens,
+            decodeStepSize: request.decodeStepSize,
+            prefillToken: request.prefillToken,
+            acceleration: acceleration,
+            shouldAbort: shouldAbort
+        )
+    }
+
+    private func makeBatchCandidateIfEligible(
+        request: Melix_Worker_V1_DecodeRequest,
+        requestID: String,
+        lane: String,
+        session: WorkerDecodeSession,
+        sampling: Melix_Worker_V1_SamplingConfig,
+        acceleration: Melix_Worker_V1_AccelerationPolicy,
+        shouldAbort: @escaping @Sendable () -> Bool
+    ) async -> TextDecodeBatchCandidate? {
+        guard batchCoordinator != nil,
+              await registry.supportsHomogeneousBatchDecode(),
+              !requestID.isEmpty,
+              !request.decodeHandle.isEmpty,
+              !request.execution.cacheHints.saveBoundarySnapshot else {
+            return nil
+        }
+        let maxBatchSize = decodeBatchSizeLimit(from: request.execution.ext)
+        guard maxBatchSize > 1 else {
+            return nil
+        }
+
+        let key = TextDecodeBatchEligibilityKey(
+            modelHandle: session.loadedModel.handle,
+            lane: lane,
+            sampling: TextDecodeSamplingKey(sampling),
+            acceleration: TextDecodeAccelerationKey(acceleration),
+            maxOutputTokens: request.maxOutputTokens,
+            decodeStepSize: request.decodeStepSize,
+            prefillToken: request.prefillToken
+        )
+        return TextDecodeBatchCandidate(
+            requestID: requestID,
+            key: key,
+            maxBatchSize: maxBatchSize,
+            session: session,
+            sampling: sampling,
+            maxOutputTokens: request.maxOutputTokens,
+            decodeStepSize: request.decodeStepSize,
+            prefillToken: request.prefillToken,
+            acceleration: acceleration,
+            shouldAbort: shouldAbort
+        )
+    }
+
+    private func decodeBatchSizeLimit(from executionExt: [String: String]) -> Int {
+        guard parseBool(
+            executionExt["melix.gateway.concurrent_processing"],
+            fallback: true
+        ) else {
+            return 1
+        }
+        let maxConcurrent = parsePositiveInt(
+            executionExt["melix.gateway.max_concurrent_sequences"]
+                ?? executionExt["melix.gateway.max_concurrent_requests"],
+            fallback: 4
+        )
+        let completionBatchSize = parsePositiveInt(
+            executionExt["melix.gateway.completion_batch_size"],
+            fallback: 1
+        )
+        return max(1, min(maxConcurrent, completionBatchSize))
     }
 
     private func recordSpeculativeMetrics(
@@ -583,6 +707,29 @@ private func isGreedySpeculativeSampling(_ sampling: Melix_Worker_V1_SamplingCon
     return sampling.temperature <= 0
         && effectiveTopP >= 1
         && sampling.topK == 0
+}
+
+private func parseBool(_ rawValue: String?, fallback: Bool) -> Bool {
+    guard let rawValue = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(), !rawValue.isEmpty else {
+        return fallback
+    }
+    switch rawValue {
+    case "1", "true", "yes", "on":
+        return true
+    case "0", "false", "no", "off":
+        return false
+    default:
+        return fallback
+    }
+}
+
+private func parsePositiveInt(_ rawValue: String?, fallback: Int) -> Int {
+    guard let rawValue = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+          let parsed = Int(rawValue),
+          parsed > 0 else {
+        return fallback
+    }
+    return parsed
 }
 
 private func effectiveRequestID(

--- a/services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift
@@ -122,6 +122,7 @@ final class MetricsStore: @unchecked Sendable {
         "swift_text.decode_stream_event_count": 0,
         "swift_text.decode_batch_size": 0,
         "swift_text.model_eval_batch_size": 0,
+        "swift_text.decode_loop_iterations": 0,
         "swift_text.decode_batch_observation_count": 0,
         "swift_text.per_batch_output_token_count": 0,
         "swift_text.per_batch_output_tokens_per_second": 0,

--- a/services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift
@@ -9,6 +9,10 @@ struct DeterministicTextBackend: TextRuntimeBackend {
         self.tokenDelayNanos = tokenDelayNanos
     }
 
+    var supportsHomogeneousBatchDecode: Bool {
+        true
+    }
+
     func loadModel(spec: Melix_Worker_V1_ModelSpec) async throws -> LoadedTextModel {
         let modelSource = spec.modelPath.isEmpty ? spec.modelID : spec.modelPath
         return LoadedTextModel(
@@ -200,6 +204,119 @@ struct DeterministicTextBackend: TextRuntimeBackend {
             }
         }
     }
+
+    func decodeBatchEvents(
+        requests: [TextRuntimeDecodeRequest]
+    ) async throws -> AsyncThrowingStream<TextBatchGenerationEvent, Error> {
+        let prepared = requests.map { request in
+            let prompt = deterministicPrompt(from: request.context)
+            let response = deterministicDecodeResponse(prompt: prompt, prefillToken: request.prefillToken)
+            return DeterministicBatchDecodeState(
+                promptTokens: max(1, request.context.promptTokens),
+                outputTokens: deterministicChunks(
+                    from: response,
+                    maxOutputTokens: request.maxOutputTokens
+                ),
+                tokenDelayNanos: deterministicDecodeDelay(
+                    baselineDelay: tokenDelayNanos,
+                    mode: request.acceleration.mode,
+                    context: request.context
+                ),
+                acceleration: request.acceleration,
+                shouldAbort: request.shouldAbort
+            )
+        }
+
+        return AsyncThrowingStream { continuation in
+            Task {
+                let startedAt = ContinuousClock.now
+                let batchSize = prepared.count
+                var emittedByRequest = Array(repeating: 0, count: prepared.count)
+                var active = Array(repeating: true, count: prepared.count)
+                var positionByRequest = Array(repeating: 0, count: prepared.count)
+                var decodeLoopIterations = 0
+
+                while active.contains(true) {
+                    var yieldedInIteration = false
+
+                    for index in prepared.indices where active[index] {
+                        let state = prepared[index]
+                        if state.shouldAbort() || positionByRequest[index] >= state.outputTokens.count {
+                            active[index] = false
+                            continue
+                        }
+                        if state.tokenDelayNanos > 0 {
+                            try? await Task.sleep(nanoseconds: state.tokenDelayNanos)
+                        }
+                        if state.shouldAbort() {
+                            active[index] = false
+                            continue
+                        }
+                        let chunk = state.outputTokens[positionByRequest[index]]
+                        positionByRequest[index] += 1
+                        emittedByRequest[index] += 1
+                        yieldedInIteration = true
+                        continuation.yield(.token(requestIndex: index, text: chunk))
+                    }
+
+                    if !yieldedInIteration {
+                        break
+                    }
+                    decodeLoopIterations += 1
+                }
+
+                let elapsed = startedAt.duration(to: .now)
+                let elapsedSeconds = max(
+                    Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1_000_000_000_000_000_000,
+                    0.000_001
+                )
+                let totalCompletionTokens = emittedByRequest.reduce(0, +)
+                let batchTokensPerSecond = totalCompletionTokens > 0
+                    ? Double(totalCompletionTokens) / elapsedSeconds
+                    : 0
+
+                for index in prepared.indices {
+                    let emitted = emittedByRequest[index]
+                    let state = prepared[index]
+                    let speculativeAccepted = state.acceleration.mode == .speculativeDecode ? max(emitted - 1, 0) : nil
+                    let speculativeRejected = state.acceleration.mode == .speculativeDecode && emitted > 0 ? 1 : nil
+                    continuation.yield(.summary(
+                        requestIndex: index,
+                        TextGenerationSummary(
+                            promptTokens: state.promptTokens,
+                            completionTokens: emitted,
+                            tokensPerSecond: emitted > 0 ? Double(emitted) / elapsedSeconds : 0,
+                            decodeBatchSize: batchSize,
+                            modelEvalBatchSize: batchSize,
+                            decodeLoopIterations: decodeLoopIterations,
+                            perBatchOutputTokenCount: totalCompletionTokens,
+                            perBatchOutputTokensPerSecond: batchTokensPerSecond,
+                            speculativeAcceptedTokens: speculativeAccepted,
+                            speculativeRejectedTokens: speculativeRejected
+                        )
+                    ))
+                }
+                continuation.yield(.batchSummary(
+                    TextBatchGenerationSummary(
+                        decodeBatchSize: batchSize,
+                        modelEvalBatchSize: batchSize,
+                        decodeLoopIterations: decodeLoopIterations,
+                        outputTokenCount: totalCompletionTokens,
+                        tokensPerSecond: batchTokensPerSecond
+                    )
+                ))
+                continuation.finish()
+            }
+        }
+    }
+}
+
+private struct DeterministicBatchDecodeState: @unchecked Sendable {
+    let promptTokens: Int
+    let outputTokens: [String]
+    let tokenDelayNanos: UInt64
+    let acceleration: Melix_Worker_V1_AccelerationPolicy
+    let shouldAbort: @Sendable () -> Bool
 }
 
 private func deterministicPrompt(

--- a/services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift
@@ -302,6 +302,11 @@ struct TextGenerationSummary: Sendable {
     let promptTokens: Int
     let completionTokens: Int
     let tokensPerSecond: Double?
+    let decodeBatchSize: Int?
+    let modelEvalBatchSize: Int?
+    let decodeLoopIterations: Int?
+    let perBatchOutputTokenCount: Int?
+    let perBatchOutputTokensPerSecond: Double?
     let speculativeAcceptedTokens: Int?
     let speculativeRejectedTokens: Int?
     let speculativeFallbackCount: Int?
@@ -317,6 +322,11 @@ struct TextGenerationSummary: Sendable {
         promptTokens: Int,
         completionTokens: Int,
         tokensPerSecond: Double?,
+        decodeBatchSize: Int? = nil,
+        modelEvalBatchSize: Int? = nil,
+        decodeLoopIterations: Int? = nil,
+        perBatchOutputTokenCount: Int? = nil,
+        perBatchOutputTokensPerSecond: Double? = nil,
         speculativeAcceptedTokens: Int? = nil,
         speculativeRejectedTokens: Int? = nil,
         speculativeFallbackCount: Int? = nil,
@@ -331,6 +341,11 @@ struct TextGenerationSummary: Sendable {
         self.promptTokens = promptTokens
         self.completionTokens = completionTokens
         self.tokensPerSecond = tokensPerSecond
+        self.decodeBatchSize = decodeBatchSize
+        self.modelEvalBatchSize = modelEvalBatchSize
+        self.decodeLoopIterations = decodeLoopIterations
+        self.perBatchOutputTokenCount = perBatchOutputTokenCount
+        self.perBatchOutputTokensPerSecond = perBatchOutputTokensPerSecond
         self.speculativeAcceptedTokens = speculativeAcceptedTokens
         self.speculativeRejectedTokens = speculativeRejectedTokens
         self.speculativeFallbackCount = speculativeFallbackCount
@@ -350,8 +365,35 @@ enum TextGenerationEvent: Sendable {
     case summary(TextGenerationSummary)
 }
 
+struct TextRuntimeDecodeRequest: @unchecked Sendable {
+    let model: LoadedTextModel
+    let draftModel: LoadedTextModel?
+    let context: TextPrefillContext
+    let sampling: Melix_Worker_V1_SamplingConfig
+    let maxOutputTokens: UInt32
+    let decodeStepSize: UInt32
+    let prefillToken: String
+    let acceleration: Melix_Worker_V1_AccelerationPolicy
+    let shouldAbort: @Sendable () -> Bool
+}
+
+struct TextBatchGenerationSummary: Sendable {
+    let decodeBatchSize: Int
+    let modelEvalBatchSize: Int
+    let decodeLoopIterations: Int
+    let outputTokenCount: Int
+    let tokensPerSecond: Double?
+}
+
+enum TextBatchGenerationEvent: Sendable {
+    case token(requestIndex: Int, text: String)
+    case summary(requestIndex: Int, TextGenerationSummary)
+    case batchSummary(TextBatchGenerationSummary)
+}
+
 protocol TextRuntimeBackend: Sendable {
     var runtimeName: String { get }
+    var supportsHomogeneousBatchDecode: Bool { get }
     func loadModel(spec: Melix_Worker_V1_ModelSpec) async throws -> LoadedTextModel
     func unloadModel(_ model: LoadedTextModel) async
     func prefill(
@@ -379,9 +421,14 @@ protocol TextRuntimeBackend: Sendable {
         acceleration: Melix_Worker_V1_AccelerationPolicy,
         shouldAbort: @escaping @Sendable () -> Bool
     ) async throws -> AsyncThrowingStream<TextGenerationEvent, Error>
+    func decodeBatchEvents(
+        requests: [TextRuntimeDecodeRequest]
+    ) async throws -> AsyncThrowingStream<TextBatchGenerationEvent, Error>
 }
 
 extension TextRuntimeBackend {
+    var supportsHomogeneousBatchDecode: Bool { false }
+
     func unloadModel(_ model: LoadedTextModel) async {}
 
     func prefill(
@@ -423,6 +470,14 @@ extension TextRuntimeBackend {
             message: "Decode is not available for the current backend."
         )
     }
+
+    func decodeBatchEvents(
+        requests: [TextRuntimeDecodeRequest]
+    ) async throws -> AsyncThrowingStream<TextBatchGenerationEvent, Error> {
+        throw RuntimeUnavailableError(
+            message: "Homogeneous batch decode is not available for the current backend."
+        )
+    }
 }
 
 struct TextRuntime: Sendable {
@@ -439,6 +494,10 @@ struct TextRuntime: Sendable {
 
     var runtimeName: String {
         backend.runtimeName
+    }
+
+    var supportsHomogeneousBatchDecode: Bool {
+        backend.supportsHomogeneousBatchDecode
     }
 
     func loadModel(spec: Melix_Worker_V1_ModelSpec) async throws -> RuntimeLoadResult {
@@ -510,6 +569,28 @@ struct TextRuntime: Sendable {
             acceleration: acceleration,
             shouldAbort: shouldAbort
         )
+    }
+
+    func decodeEvents(
+        request: TextRuntimeDecodeRequest
+    ) async throws -> AsyncThrowingStream<TextGenerationEvent, Error> {
+        try await decodeEvents(
+            model: request.model,
+            draftModel: request.draftModel,
+            context: request.context,
+            sampling: request.sampling,
+            maxOutputTokens: request.maxOutputTokens,
+            decodeStepSize: request.decodeStepSize,
+            prefillToken: request.prefillToken,
+            acceleration: request.acceleration,
+            shouldAbort: request.shouldAbort
+        )
+    }
+
+    func decodeBatchEvents(
+        requests: [TextRuntimeDecodeRequest]
+    ) async throws -> AsyncThrowingStream<TextBatchGenerationEvent, Error> {
+        try await backend.decodeBatchEvents(requests: requests)
     }
 }
 

--- a/services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift
@@ -45,6 +45,16 @@ struct WorkerDecodeSession: @unchecked Sendable {
     let prefill: StoredPrefillContext
 }
 
+struct WorkerDecodeBatchItem: @unchecked Sendable {
+    let session: WorkerDecodeSession
+    let sampling: Melix_Worker_V1_SamplingConfig
+    let maxOutputTokens: UInt32
+    let decodeStepSize: UInt32
+    let prefillToken: String
+    let acceleration: Melix_Worker_V1_AccelerationPolicy
+    let shouldAbort: @Sendable () -> Bool
+}
+
 struct SpeculativeDraftModelReadiness: Sendable {
     let available: Bool
     let compatible: Bool
@@ -631,6 +641,32 @@ actor WorkerRuntimeRegistry {
             acceleration: acceleration,
             shouldAbort: shouldAbort
         )
+    }
+
+    func supportsHomogeneousBatchDecode() -> Bool {
+        runtime.supportsHomogeneousBatchDecode
+    }
+
+    func decodeBatchEvents(
+        items: [WorkerDecodeBatchItem]
+    ) async throws -> AsyncThrowingStream<TextBatchGenerationEvent, Error> {
+        let requests = items.map { item in
+            TextRuntimeDecodeRequest(
+                model: item.session.loadedModel.runtimeModel,
+                draftModel: loadedDraftModel(
+                    id: item.acceleration.draftModelID,
+                    excludingModelHandle: item.session.loadedModel.handle
+                )?.runtimeModel,
+                context: item.session.prefill.context,
+                sampling: item.sampling,
+                maxOutputTokens: item.maxOutputTokens,
+                decodeStepSize: item.decodeStepSize,
+                prefillToken: item.prefillToken,
+                acceleration: item.acceleration,
+                shouldAbort: item.shouldAbort
+            )
+        }
+        return try await runtime.decodeBatchEvents(requests: requests)
     }
 
     func supportsSpeculativeDecoding() -> Bool {

--- a/services/mlx-text-worker-swift/Sources/Core/WorkerServices.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/WorkerServices.swift
@@ -239,7 +239,12 @@ final class InferenceRPCService: Melix_Worker_V1_InferenceService.SimpleServiceP
         self.metrics = metrics
         self.generationEngine = TextGenerationEngine(registry: registry, abortRegistry: abortRegistry, metrics: metrics)
         self.prefillEngine = TextPrefillEngine(registry: registry, abortRegistry: abortRegistry, metrics: metrics)
-        self.decodeEngine = TextDecodeEngine(registry: registry, abortRegistry: abortRegistry, metrics: metrics)
+        self.decodeEngine = TextDecodeEngine(
+            registry: registry,
+            abortRegistry: abortRegistry,
+            metrics: metrics,
+            batchCoordinator: TextDecodeBatchCoordinator(registry: registry)
+        )
     }
 
     func generate(

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -4057,7 +4057,6 @@ final class WorkerScaffoldTests: XCTestCase {
         request1.execution.scheduling.lane = "text.decode.batch"
         request1.execution.ext["melix.gateway.concurrent_processing"] = "true"
         request1.execution.ext["melix.gateway.max_concurrent_sequences"] = "2"
-        request1.execution.ext["melix.gateway.completion_batch_size"] = "2"
         request1.decodeHandle = prefillResponse1.decodeHandle
         request1.sampling = sampling
         request1.maxOutputTokens = 2
@@ -4070,7 +4069,6 @@ final class WorkerScaffoldTests: XCTestCase {
         request2.execution.scheduling.lane = "text.decode.batch"
         request2.execution.ext["melix.gateway.concurrent_processing"] = "true"
         request2.execution.ext["melix.gateway.max_concurrent_sequences"] = "2"
-        request2.execution.ext["melix.gateway.completion_batch_size"] = "2"
         request2.decodeHandle = prefillResponse2.decodeHandle
         request2.sampling = sampling
         request2.maxOutputTokens = 2

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -3984,9 +3984,213 @@ final class WorkerScaffoldTests: XCTestCase {
         XCTAssertEqual(services.metrics.counters["swift_text.decode_batch_size"], 1)
         XCTAssertEqual(services.metrics.counters["swift_text.model_eval_batch_size"], 1)
         XCTAssertEqual(services.metrics.counters["swift_text.decode_batch_observation_count"], 1)
+        XCTAssertEqual(services.metrics.counters["swift_text.decode_loop_iterations"], 1)
         XCTAssertEqual(services.metrics.counters["swift_text.per_batch_output_token_count"], 1)
         XCTAssertEqual(services.metrics.counters["swift_text.per_batch_output_tokens_per_second"], 8)
         XCTAssertEqual(services.metrics.counters["swift_text.decode_tokens_per_second"], 8)
+    }
+
+    func testDecodeStreamingRpcBatchesHomogeneousDeterministicDecodeRequests() async throws {
+        let services = makeServices(
+            environment: [
+                "MELIX_DEV_TEXT_MODEL_PATH": "mlx-community/melix-dev-text-4bit",
+                "MELIX_SWIFT_TEXT_WORKER_BACKEND_MODE": "deterministic",
+            ],
+            backend: DeterministicTextBackend(tokenDelayNanos: 0)
+        )
+        let loadResponse = try await withTestServerContextRPCCancellationHandle { handle in
+            var request = Melix_Worker_V1_LoadModelRequest()
+            request.model.modelID = "melix-dev-text"
+            return try await services.runtime.loadModel(
+                request: request,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_RuntimeService.Method.LoadModel.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        var prefillRequest1 = Melix_Worker_V1_PrefillRequest()
+        prefillRequest1.execution.id.requestID = "req-batch-decode-1"
+        prefillRequest1.execution.modelHandle = loadResponse.modelHandle
+        prefillRequest1.returnDecodeHandle = true
+        prefillRequest1.messages = [makeUserMessage("batch decode alpha")]
+
+        var prefillRequest2 = Melix_Worker_V1_PrefillRequest()
+        prefillRequest2.execution.id.requestID = "req-batch-decode-2"
+        prefillRequest2.execution.modelHandle = loadResponse.modelHandle
+        prefillRequest2.returnDecodeHandle = true
+        prefillRequest2.messages = [makeUserMessage("batch decode beta")]
+
+        let prefillResponse1 = try await withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.prefill(
+                request: prefillRequest1,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Prefill.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+        let prefillResponse2 = try await withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.prefill(
+                request: prefillRequest2,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Prefill.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        var sampling = Melix_Worker_V1_SamplingConfig()
+        sampling.maxOutputTokens = 2
+
+        let writer1 = RecordingRPCWriter<Melix_Worker_V1_ExecuteEvent>()
+        var request1 = Melix_Worker_V1_DecodeRequest()
+        request1.execution.id.requestID = "req-batch-decode-1"
+        request1.execution.modelHandle = loadResponse.modelHandle
+        request1.execution.scheduling.lane = "text.decode.batch"
+        request1.execution.ext["melix.gateway.concurrent_processing"] = "true"
+        request1.execution.ext["melix.gateway.max_concurrent_sequences"] = "2"
+        request1.execution.ext["melix.gateway.completion_batch_size"] = "2"
+        request1.decodeHandle = prefillResponse1.decodeHandle
+        request1.sampling = sampling
+        request1.maxOutputTokens = 2
+        request1.returnUsage = true
+
+        let writer2 = RecordingRPCWriter<Melix_Worker_V1_ExecuteEvent>()
+        var request2 = Melix_Worker_V1_DecodeRequest()
+        request2.execution.id.requestID = "req-batch-decode-2"
+        request2.execution.modelHandle = loadResponse.modelHandle
+        request2.execution.scheduling.lane = "text.decode.batch"
+        request2.execution.ext["melix.gateway.concurrent_processing"] = "true"
+        request2.execution.ext["melix.gateway.max_concurrent_sequences"] = "2"
+        request2.execution.ext["melix.gateway.completion_batch_size"] = "2"
+        request2.decodeHandle = prefillResponse2.decodeHandle
+        request2.sampling = sampling
+        request2.maxOutputTokens = 2
+        request2.returnUsage = true
+
+        async let decode1: Void = withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.decode(
+                request: request1,
+                response: RPCWriter(wrapping: writer1),
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Decode.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+        async let decode2: Void = withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.decode(
+                request: request2,
+                response: RPCWriter(wrapping: writer2),
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Decode.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+        _ = try await (decode1, decode2)
+
+        let recorded1 = await writer1.snapshot()
+        let recorded2 = await writer2.snapshot()
+        XCTAssertEqual(recorded1.first?.decodeStarted.decodeHandle, prefillResponse1.decodeHandle)
+        XCTAssertEqual(recorded2.first?.decodeStarted.decodeHandle, prefillResponse2.decodeHandle)
+        XCTAssertTrue(recorded1.contains(where: { matches($0.payload, .tokenDelta) }))
+        XCTAssertTrue(recorded2.contains(where: { matches($0.payload, .tokenDelta) }))
+        XCTAssertEqual(recorded1.first { matches($0.payload, .usageDelta) }?.usageDelta.completionTokens, 2)
+        XCTAssertEqual(recorded2.first { matches($0.payload, .usageDelta) }?.usageDelta.completionTokens, 2)
+        XCTAssertEqual(recorded1.last?.completed.finishReason, "stop")
+        XCTAssertEqual(recorded2.last?.completed.finishReason, "stop")
+
+        let metrics = services.metrics.counters
+        XCTAssertEqual(metrics["swift_text.decode_batch_size"], 2)
+        XCTAssertEqual(metrics["swift_text.model_eval_batch_size"], 2)
+        XCTAssertEqual(metrics["swift_text.decode_batch_observation_count"], 2)
+        XCTAssertEqual(metrics["swift_text.decode_loop_iterations"], 2)
+        XCTAssertEqual(metrics["swift_text.per_batch_output_token_count"], 4)
+        XCTAssertGreaterThan(metrics["swift_text.per_batch_output_tokens_per_second"] ?? 0, 0)
+    }
+
+    func testDecodeStreamingRpcFallsBackWhenHomogeneousBatchDecodeUnsupported() async throws {
+        let services = makeServices(
+            environment: [
+                "MELIX_DEV_TEXT_MODEL_PATH": "mlx-community/melix-dev-text-4bit",
+            ],
+            backend: FakeRuntimeBackend(decodedChunks: ["one"])
+        )
+        let loadResponse = try await withTestServerContextRPCCancellationHandle { handle in
+            var request = Melix_Worker_V1_LoadModelRequest()
+            request.model.modelID = "melix-dev-text"
+            return try await services.runtime.loadModel(
+                request: request,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_RuntimeService.Method.LoadModel.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        var prefillRequest = Melix_Worker_V1_PrefillRequest()
+        prefillRequest.execution.id.requestID = "req-unsupported-batch"
+        prefillRequest.execution.modelHandle = loadResponse.modelHandle
+        prefillRequest.returnDecodeHandle = true
+        prefillRequest.messages = [makeUserMessage("unsupported batch")]
+        let prefillResponse = try await withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.prefill(
+                request: prefillRequest,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Prefill.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        let writer = RecordingRPCWriter<Melix_Worker_V1_ExecuteEvent>()
+        var request = Melix_Worker_V1_DecodeRequest()
+        request.execution.id.requestID = "req-unsupported-batch"
+        request.execution.modelHandle = loadResponse.modelHandle
+        request.execution.ext["melix.gateway.concurrent_processing"] = "true"
+        request.execution.ext["melix.gateway.max_concurrent_sequences"] = "2"
+        request.execution.ext["melix.gateway.completion_batch_size"] = "2"
+        request.decodeHandle = prefillResponse.decodeHandle
+        request.maxOutputTokens = 1
+        request.returnUsage = true
+
+        try await withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.decode(
+                request: request,
+                response: RPCWriter(wrapping: writer),
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Decode.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        let recorded = await writer.snapshot()
+        XCTAssertEqual(recorded.first?.decodeStarted.decodeHandle, prefillResponse.decodeHandle)
+        XCTAssertTrue(recorded.contains(where: { matches($0.payload, .tokenDelta) }))
+        XCTAssertEqual(recorded.last?.completed.finishReason, "stop")
+        XCTAssertEqual(services.metrics.counters["swift_text.decode_batch_size"], 1)
+        XCTAssertEqual(services.metrics.counters["swift_text.model_eval_batch_size"], 1)
+        XCTAssertEqual(services.metrics.counters["swift_text.decode_batch_observation_count"], 1)
     }
 
     func testDecodeStreamingRpcReturnsStructuredNotFoundForMissingDecodeHandle() async throws {


### PR DESCRIPTION
## Summary
- Add a narrow Swift text decode batch coordinator for homogeneous decode requests.
- Wire deterministic text runtime batch decode through `TextDecodeEngine`, worker services, metrics, and scaffold tests.
- Keep unsupported Swift MLX real-model backends on singleton decode until shared-cache batch decode is implemented.

## Plan or Spec
- Governing plan: `docs/plans/2026-05-29-issue-1655-homogeneous-decode-coordinator.md`
- Closes #1655.
- Contributes evidence toward #1642 / #1654; real Gemma E4B Swift MLX batch decode remains deferred to #1656.

## Commands Run
```text
swift test --package-path services/mlx-text-worker-swift --filter WorkerScaffoldTests/testDecodeStreamingRpcBatchesHomogeneousDeterministicDecodeRequests
Result: pass

swift test --package-path services/mlx-text-worker-swift --filter 'WorkerScaffoldTests/testDecodeStreamingRpc'
Result: pass, 17 tests

swift test --package-path services/mlx-text-worker-swift
Result: pass, 204 tests, 41 skipped in the standalone run

python3 scripts/same_cohort_batching_probe.py --metrics
Result: pass with warning-path evidence; failure_count=0, scheduler_admission_cohort_size=2, worker_decode_batch_size=1

HOME="$PWD/.swift-home/mlx-text-worker-swift-coverage" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/mlx-text-worker-swift-coverage" xcrun swift test --package-path services/mlx-text-worker-swift --enable-code-coverage
python3 scripts/swift_coverage_summary.py services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/MelixTextWorkerSwift.json /services/mlx-text-worker-swift/Sources/
Result: pass; changed Swift source coverage 96.35%

git commit -m "perf: add homogeneous decode batch coordinator"
Result: pass; pre-commit ran make swift-test, make py-test, make integration-test, and PR-scoped performance probes.
Pre-commit details:
- make swift-test: rc=0, elapsed=580.7s
- make py-test: rc=0, 3360 passed, 14 skipped, 2 warnings in 143.83s
- make integration-test: rc=0, 115 passed, 1 skipped in 673.99s

git commit -m "fix: harden decode batch coordinator review feedback"
Result: pass; pre-commit ran make swift-test, make py-test, make integration-test, and PR-scoped performance probes.
Pre-commit details:
- make swift-test: rc=0, elapsed=243.1s
- make py-test: rc=0, 3360 passed, 14 skipped, 2 warnings in 135.52s
- make integration-test: rc=0, 115 passed, 1 skipped in 314.51s
- PR-scoped performance report: status ok, regressions 0

git merge origin/main
Result: pass; merged origin/main at b10334f4 into branch head 2addbe46 with no conflicts.

swift test --package-path services/mlx-text-worker-swift --filter 'WorkerScaffoldTests/testDecodeStreamingRpc'
Result: pass, 17 tests

python3 scripts/same_cohort_batching_probe.py --metrics
Result: pass with warning-path evidence; failure_count=0, scheduler_admission_cohort_size=2, worker_decode_batch_size=1

make swift-test
Result: pass after merging origin/main; final macOS menubar stage reported 779 tests passed.

make py-test
Result: pass, 3361 passed, 14 skipped, 2 warnings in 138.72s

make integration-test
Result: pass, 115 passed, 1 skipped in 601.85s

UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts.pre_commit_gate import run_performance_report
changed = [
    "docs/plans/2026-05-29-issue-1655-homogeneous-decode-coordinator.md",
    "services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeBatchCoordinator.swift",
    "services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeEngine.swift",
    "services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift",
    "services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift",
    "services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift",
    "services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift",
    "services/mlx-text-worker-swift/Sources/Core/WorkerServices.swift",
    "services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift",
]
outcome = run_performance_report(Path.cwd(), changed, base_ref="origin/main")
print(f"STATUS={outcome.status}")
print(f"REPORT={outcome.report_dir / 'report.md'}")
print(f"SELECTED={outcome.selected_probe_count}")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
Result: pass; STATUS=ok, SELECTED=1, regressions 0
```

## Coverage and Metrics
- Changed Swift source coverage: 96.35% (`3932 / 4081` changed-source executable lines).
- Focused deterministic batch scaffold test verifies two homogeneous decode RPCs share one batch with per-request tokens, usage, and completion, and observes `swift_text.decode_batch_size=2`, `swift_text.model_eval_batch_size=2`, `swift_text.decode_loop_iterations=2`, and `swift_text.per_batch_output_token_count=4`.
- PR-scoped performance reports:
  - `.runtime/pre-commit-performance/20260529-004723-b80c52c7/report/report.md`
  - `.runtime/pre-commit-performance/20260529-011944-2addbe46/report/report.md`
- PR-scoped performance status: `ok`; regressions: `0`; context regressions: `0`; verification failures: `0`.
- Same-cohort evidence-mode probe remains neutral against main because it exercises the existing control-plane fake worker path: base=head `worker_decode_batch_size=1`, `worker_model_eval_batch_size=1`, `scheduler_to_worker_batch_delta=1`.
- Observability mode: minimal runtime metrics for worker decode/model batch size and loop counters; evidence-mode comparison remains in `scripts/same_cohort_batching_probe.py` / `infra/perf/pr_scoped_probes.json`.
- Probe overhead: bounded to scaffold tests and pre-commit evidence probe; production path adds only metric recording and a narrow pending-window coordinator for eligible homogeneous decode requests.

## Known Gaps
- AutoSwiftMLX real-model shared-cache batch decode is intentionally not enabled in this slice; real Gemma E4B release benchmark movement remains for #1656 / #1654 / #1642.
- Boundary snapshot batching is excluded until request snapshot compatibility is specified.
- Cancellation and partial-error isolation for mixed request lifetimes should be hardened in the next worker-runtime slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
