### PR TITLE
perf: bound hub catalog size hint split

### DIFF
--- a/docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md
+++ b/docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md
@@ -39,3 +39,12 @@ keeps invalid/labeled values on the existing generic parser fallback path.
 - Preserve all existing size-hint parsing behavior by falling back to `_size_hint_from_text(...)` when the direct parser cannot handle the value.
 - Keep `_size_hint_from_text(...)` call counts unchanged for this bounded-split follow-up.
 - Improve or hold steady `elapsed_ms_mean` in the local registered probe.
+
+## 2026-05-29 Follow-up: Direct Parser Bounded Split Implementation
+
+This slice implements the bounded split in `_direct_size_hint_from_text(...)` by
+using `text.split(maxsplit=2)` and rejecting any shape that does not produce
+exactly two tokens. Two-token values keep the existing integer/float multiplier
+semantics, while values with extra words still return `0` so callers can fall
+back to the regex parser when appropriate. The registered
+`hub-catalog-size-hint-regex-precompile` probe remains the validation gate.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -16,6 +16,7 @@ from worker.model_ops.hub_catalog import (
     HubModelSummaryRecord,
     HubSearchPage,
     _bytes_per_parameter,
+    _direct_size_hint_from_text,
     _is_mlx_compatible,
     _local_fit_evidence,
     _payload_is_mlx_compatible,
@@ -173,6 +174,11 @@ def test_payload_mlx_tag_match_stays_exact_and_case_insensitive() -> None:
     assert _payload_is_mlx_compatible({"tags": "MLX", "cardData": {}}) is True
     assert _payload_is_mlx_compatible({"tags": ["mlx-compatible"], "cardData": {}}) is False
     assert _payload_is_mlx_compatible({"tags": ["ammlx"], "cardData": {}}) is False
+
+
+def test_direct_size_hint_rejects_extra_tokens_without_full_split() -> None:
+    assert _direct_size_hint_from_text("12 GB extra") == 0
+    assert _direct_size_hint_from_text("12 GB") == 12 * 1024 * 1024 * 1024
 
 
 def test_search_models_with_mlx_only_prefilters_payloads_before_local_fit(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -650,10 +650,10 @@ def _direct_size_hint_from_text(text: str) -> int:
         value_text = text[:-3]
         if value_text.isdecimal():
             return int(value_text) * _SIZE_HINT_KB
-    try:
-        value_text, unit_text = text.split()
-    except ValueError:
+    parts = text.split(maxsplit=2)
+    if len(parts) != 2:
         return 0
+    value_text, unit_text = parts
     multiplier = _SIZE_HINT_MULTIPLIERS.get(unit_text.lower())
     if multiplier is None:
         return 0


### PR DESCRIPTION
## Summary
- Bound the fallback direct Hub catalog size-hint parser to a two-token split with `maxsplit=2`.
- Preserve existing semantics by rejecting extra-token direct values so callers continue to fall back to the regex parser where applicable.
- Add a regression test for extra-token direct size hints and update the governing plan.

## Plan or Spec
- `docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py` (3x before and after)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 63 passed.
- Changed-scope coverage: 100% (`TOTAL 6 0 100%`).
- Local registered probe baseline (`origin/main`, 3 runs): elapsed means `1573.809945`, `1507.229866`, `1562.202073` ms; mean `1547.747295` ms.
- Local registered probe head (3 runs): elapsed means `1592.879074`, `1512.547583`, `1497.925737` ms; mean `1534.450798` ms.
- Local delta: `-13.296497` ms (`0.859%` faster); checksum, matched hint count, and size hint call count unchanged.

## Known Gaps
- Local validation is Linux/Python only. The registered PR-scoped performance workflow in GitHub Actions is the merge gate for CI validation.
- The improvement is small and may be close to local timing noise; behavior parity is covered by focused tests and CI probe gating.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at 100%.
- [x] Registered probe ran locally against baseline and head.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
