### PR TITLE
perf: skip empty benchmark parameter lookup

### DIFF
--- a/docs/plans/2026-05-29-maintenance-context-length-empty-parameters-fastpath.md
+++ b/docs/plans/2026-05-29-maintenance-context-length-empty-parameters-fastpath.md
@@ -1,0 +1,29 @@
+# Maintenance Context-Length Empty-Parameters Fast Path
+
+## Scope
+
+Optimize one Python hot path in `MaintenanceCore._benchmark_context_lengths`: resolving the default benchmark context length when callers pass an empty parameter mapping.
+
+## Probe
+
+The affected path is covered by the registered PR-scoped probe `maintenance-prompt-shape-vector-repeat` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes:
+
+- focused behavior tests through `test_command`
+- changed-scope coverage through `coverage_command`
+- repeated local/CI metrics through `scripts/maintenance_prompt_shape_probe.py`
+
+Primary metric for this slice: `elapsed_ms_mean` from the prompt-shaping/default-context loop. Guard metrics remain `token_count_mean` and `plain_token_count_mean`.
+
+## Plan
+
+1. Preserve default context-length behavior for empty parameter mappings and explicit parameter values.
+2. Avoid the redundant `parameters.get("context_lengths", "").strip()` lookup when the parameters mapping is empty.
+3. Add a regression test proving empty parameter mappings use the default prompt path without reading parameter keys.
+4. Run focused tests, changed-scope coverage, and the registered probe locally on Linux before PR creation.
+5. Use GitHub Actions PR-scoped performance output as the merge gate.
+
+## Verification Notes
+
+Local Linux verification is sufficient for this Python slice. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -11,6 +11,7 @@ import sys
 import threading
 import time
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -5917,6 +5918,27 @@ def test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs(
     assert core._benchmark_whitespace_token_count(unicode_space_prompt) == 3
     assert unicode_space_prompt.split_calls == 1
     default_prompt_suite = SimpleNamespace(prompt_batches=(normalized_prompt,), title="unused")
+
+    class EmptyTrackingParameters(dict[str, str]):
+        def __init__(self) -> None:
+            super().__init__()
+            self.get_calls = 0
+
+        def get(
+            self,
+            key: str,
+            default: Any = None,
+        ) -> Any:  # pragma: no cover - proves fast path skips lookup
+            self.get_calls += 1
+            return super().get(key, default)
+
+    empty_tracking_parameters = EmptyTrackingParameters()
+    assert MaintenanceCore._benchmark_context_lengths(
+        suite=default_prompt_suite,  # type: ignore[arg-type]
+        parameters=empty_tracking_parameters,
+    ) == (3,)
+    assert empty_tracking_parameters.get_calls == 0
+    assert normalized_prompt.split_calls == 0
     assert MaintenanceCore._benchmark_context_lengths(suite=default_prompt_suite, parameters={}) == (
         3,
     )

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -4155,10 +4155,10 @@ class MaintenanceCore:
         suite: ResolvedBenchmarkSuite,
         parameters: dict[str, str],
     ) -> tuple[int, ...]:
-        raw_value = parameters.get("context_lengths", "").strip()
-        if not raw_value and not parameters:
+        if not parameters:
             default_prompt = suite.prompt_batches[0] if suite.prompt_batches else suite.title
             return (MaintenanceCore._benchmark_prompt_token_count(default_prompt),)
+        raw_value = parameters.get("context_lengths", "").strip()
         values: list[int] = []
         if raw_value:
             for token in raw_value.split(","):


### PR DESCRIPTION
## Summary
- Adds an empty-parameter fast path in `MaintenanceCore._benchmark_context_lengths()` so the default benchmark context-length path skips the redundant parameter lookup/strip.
- Adds a regression guard proving empty parameter mappings do not read parameter keys.
- Documents the slice and its registered probe coverage.

## Plan or Spec
- `docs/plans/2026-05-29-maintenance-context-length-empty-parameters-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_prompt_shape_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_prompt_shape_probe_inline_fallback_is_base_compatible services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 4 passed in 2.24s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_prompt_shape_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_prompt_shape_probe_inline_fallback_is_base_compatible services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 4 passed in 2.20s; TOTAL 11 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/maintenance_prompt_shape_probe.py
# head sample outputs included elapsed_ms_mean 0.954081, 1.873204, 0.951261 ms (1.873204 was a local outlier)

python3 local repeated probe harness over scripts/maintenance_prompt_shape_probe.py
# base/origin-main: mean=1.1301129 ms, median=1.1178245 ms over 10 runs
# head: mean=1.0099139 ms, median=0.9835075 ms over 10 runs

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Registered probe: `maintenance-prompt-shape-vector-repeat` covers `services/mlx-worker-python/worker/engine/maintenance_core.py`, focused tests, coverage command, and `scripts/maintenance_prompt_shape_probe.py`.
- Local Linux probe delta over 10 repeated runs: `old_mean=1.1301129 ms`, `new_mean=1.0099139 ms`, `speedup=1.119x`, `delta_ms=-0.120199` for `elapsed_ms_mean`.
- Guard metrics remained stable: `token_count_mean=5160960.0`, `plain_token_count_mean=16384000.0`.
- CI PR-scoped performance is the final registered base-vs-head validation source before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this narrow Python slice.
- No Swift runtime effect is claimed; this is Linux-local Python verification only.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
