### PR TITLE
fix: increase gRPC max receive message size for lora train responses

### DIFF
--- a/services/control-plane-swift/Sources/WorkerClient/PythonBridgeWorkerClient.swift
+++ b/services/control-plane-swift/Sources/WorkerClient/PythonBridgeWorkerClient.swift
@@ -1835,7 +1835,9 @@ public struct GRPCPythonWorkerRunner: PythonWorkerRPCRunning, Sendable {
             let task = Task {
                 do {
                     try await withRPCClients(socketPath: socketPath) { _, _, _, maintenanceClient in
-                        try await maintenanceClient.convertModel(request) { response in
+                        var convertModelOptions = GRPCCore.CallOptions.defaults
+                        convertModelOptions.maxRequestMessageBytes = 64 * 1024 * 1024
+                        try await maintenanceClient.convertModel(request, options: convertModelOptions) { response in
                             for try await event in response.messages {
                                 continuation.yield(event)
                             }

--- a/services/mlx-worker-python/tests/test_control_plane_bridge.py
+++ b/services/mlx-worker-python/tests/test_control_plane_bridge.py
@@ -150,7 +150,7 @@ class FakeRpcError(grpc.RpcError):
 
 
 def test_bridge_helper_handles_health_load_and_generate(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target: FakeChannel())
+    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target, options=None: FakeChannel())
     monkeypatch.setattr(control_plane_bridge.runtime_pb2_grpc, "RuntimeServiceStub", lambda channel: FakeRuntimeStub())
     monkeypatch.setattr(control_plane_bridge.cache_pb2_grpc, "CacheServiceStub", lambda channel: FakeCacheStub())
     monkeypatch.setattr(control_plane_bridge.inference_pb2_grpc, "InferenceServiceStub", lambda channel: FakeInferenceStub())
@@ -292,7 +292,7 @@ def test_bridge_helper_handles_health_load_and_generate(monkeypatch, capsys) -> 
 
 
 def test_bridge_helper_forwards_abort(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target: FakeChannel())
+    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target, options=None: FakeChannel())
     monkeypatch.setattr(control_plane_bridge.inference_pb2_grpc, "InferenceServiceStub", lambda channel: FakeInferenceStub())
 
     abort_request = inference_pb2.AbortRequest(request_id="req-abort")
@@ -316,7 +316,7 @@ def test_bridge_helper_forwards_abort(monkeypatch, capsys) -> None:
 
 
 def test_bridge_helper_forwards_prefill_and_decode(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target: FakeChannel())
+    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target, options=None: FakeChannel())
     monkeypatch.setattr(control_plane_bridge.inference_pb2_grpc, "InferenceServiceStub", lambda channel: FakeInferenceStub())
 
     prefill_request = inference_pb2.PrefillRequest(
@@ -373,7 +373,7 @@ def test_bridge_helper_forwards_prefill_and_decode(monkeypatch, capsys) -> None:
 
 
 def test_bridge_helper_forwards_speak_stream(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target: FakeChannel())
+    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target, options=None: FakeChannel())
     monkeypatch.setattr(control_plane_bridge.inference_pb2_grpc, "InferenceServiceStub", lambda channel: FakeInferenceStub())
 
     request = inference_pb2.SpeakRequest(
@@ -416,7 +416,7 @@ def test_bridge_helper_emits_error_payloads_for_rpc_failures(monkeypatch, capsys
         def Abort(self, request):
             raise FakeRpcError()
 
-    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target: FakeChannel())
+    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target, options=None: FakeChannel())
     monkeypatch.setattr(control_plane_bridge.inference_pb2_grpc, "InferenceServiceStub", lambda channel: FailingInferenceStub())
 
     abort_request = inference_pb2.AbortRequest(request_id="req-abort")

--- a/services/mlx-worker-python/tests/test_control_plane_bridge_phase5.py
+++ b/services/mlx-worker-python/tests/test_control_plane_bridge_phase5.py
@@ -259,7 +259,7 @@ class FakeMaintenanceStub:
 
 
 def test_bridge_helper_forwards_phase5_unary_and_streaming_commands(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target: FakeChannel())
+    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target, options=None: FakeChannel())
     monkeypatch.setattr(control_plane_bridge.inference_pb2_grpc, "InferenceServiceStub", lambda channel: FakeInferenceStub())
     monkeypatch.setattr(control_plane_bridge.maintenance_pb2_grpc, "MaintenanceServiceStub", lambda channel: FakeMaintenanceStub())
 
@@ -547,7 +547,7 @@ def test_bridge_helper_forwards_phase5_unary_and_streaming_commands(monkeypatch,
 
 
 def test_bridge_helper_forwards_download_stream_manifest_events(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target: FakeChannel())
+    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target, options=None: FakeChannel())
     monkeypatch.setattr(control_plane_bridge.maintenance_pb2_grpc, "MaintenanceServiceStub", lambda channel: FakeMaintenanceStub())
 
     convert_request = maintenance_pb2.ConvertModelRequest(
@@ -584,7 +584,7 @@ def test_bridge_helper_forwards_download_stream_manifest_events(monkeypatch, cap
 
 
 def test_bridge_helper_forwards_phase6_audio_unary_commands(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target: FakeChannel())
+    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target, options=None: FakeChannel())
     monkeypatch.setattr(control_plane_bridge.inference_pb2_grpc, "InferenceServiceStub", lambda channel: FakeInferenceStub())
 
     transcribe_request = inference_pb2.TranscribeRequest(
@@ -640,7 +640,7 @@ def test_bridge_helper_forwards_phase6_audio_unary_commands(monkeypatch, capsys)
 
 
 def test_bridge_helper_forwards_phase7_image_unary_commands(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target: FakeChannel())
+    monkeypatch.setattr(control_plane_bridge.grpc, "insecure_channel", lambda target, options=None: FakeChannel())
     stub = FakeInferenceStub()
     monkeypatch.setattr(control_plane_bridge.inference_pb2_grpc, "InferenceServiceStub", lambda channel: stub)
 

--- a/services/mlx-worker-python/worker/control_plane_bridge.py
+++ b/services/mlx-worker-python/worker/control_plane_bridge.py
@@ -61,7 +61,7 @@ def main() -> None:
     request_bytes = base64.b64decode(args.request_b64)
 
     try:
-        with grpc.insecure_channel(f"unix://{socket_path}") as channel:
+        with grpc.insecure_channel(f"unix://{socket_path}", options=[("grpc.max_receive_message_length", 64 * 1024 * 1024)]) as channel:
             if args.command == "handshake":
                 stub = runtime_pb2_grpc.RuntimeServiceStub(channel)
                 request = runtime_pb2.HandshakeRequest.FromString(request_bytes)


### PR DESCRIPTION
## Summary

- \`control_plane_bridge.py\`: set \`grpc.max_receive_message_length = 64 MB\` on the Python gRPC channel — this is the actual fix that unblocked training
- \`PythonBridgeWorkerClient.swift\`: set \`maxRequestMessageBytes = 64 MB\` on the \`convertModel\` \`CallOptions\` for the RPC transport path (defensive fix)
- Update \`insecure_channel\` test mocks to accept the new \`options\` keyword argument

## Root cause

LoRA adapter receipts for \`NUM_LAYERS >= 16\` exceed the default 4 MB gRPC message limit. \`NUM_LAYERS=16\` produces 112 \`target_modules\` entries (vs 56 for \`NUM_LAYERS=8\`), which roughly doubles the receipt JSON size to ~4.02 MB.

The Python bridge subprocess (\`control_plane_bridge.py\`) opens a \`grpc.insecure_channel\` with no options, so it uses the gRPC default \`max_receive_message_length\` of 4 MB. When the Python worker sends back the training receipt, the bridge's gRPC client rejects it with \`RESOURCE_EXHAUSTED: CLIENT: Received message larger than max\`.

## Plan or Spec

Increase the gRPC receive message size limit in two places:
1. Python bridge (\`control_plane_bridge.py\`): add \`grpc.max_receive_message_length\` channel option — primary fix for the bridge transport path used by default
2. Swift RPC runner (\`PythonBridgeWorkerClient.swift\`): set \`maxRequestMessageBytes\` on \`CallOptions\` — defensive fix for the RPC transport path

## Commands Run

```
# Verified end-to-end with NUM_LAYERS=16 training run
RANK=16 ALPHA=32 NUM_LAYERS=16 LEARNING_RATE=1e-5 MAX_STEPS=8 \
  ./lora-trains/v1/run_lora_dialogue_v1.sh --ensure-server --export-only
# Result: adapter model-ops-3671, 112 target_modules, loss_final=0.304
```

## Coverage and Metrics

- All pre-commit checks pass (swift-test + py-test)
- 9 previously failing bridge tests now pass after updating \`insecure_channel\` mocks to accept \`options=None\`
- End-to-end training with \`NUM_LAYERS=16\` completes: adapter \`model-ops-3671\`, \`loss_final=0.304\`, \`peak_memory_gb=16.0\`

## Known Gaps

- The 64 MB limit is a conservative ceiling; the actual receipt size for \`NUM_LAYERS=16\` is ~4.02 MB. No tuning was done.
- \`maxResponseMessageBytes\` in \`GRPCCore.CallOptions\` is semantically the right field but is not read by the grpc-swift-nio-transport layer (\`Connection.swift\` only reads \`maxRequestMessageBytes\`); the Swift fix uses the field that actually takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)