### PR TITLE
chore: add agent skills configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,3 +251,17 @@ replace the required PR evidence.
 - `docs/product-brief.md` remains intentionally ignored and untracked unless the user explicitly changes that policy.
 - Keep canonical top-level specs in place unless there is an explicit reorganization task.
 - New architecture, decision, and runbook material should use the structure documented in `docs/README.md`.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (`github.com/Keith-CY/melix`). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo: one `CONTEXT.md` at root + `docs/decisions/` for decision records. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — domain vocabulary and bounded-context glossary.
+- **`docs/decisions/`** — read decision records that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/decisions/
+│   ├── 2026-03-27-swift-text-runtime.md
+│   └── ...
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag decision-record conflicts
+
+If your output contradicts an existing decision record under `docs/decisions/`, surface it explicitly rather than silently overriding:
+
+> _Contradicts docs/decisions/2026-03-27-swift-text-runtime.md — but worth reopening because…_

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -19,7 +19,7 @@ Single-context repo:
 ├── docs/decisions/
 │   ├── 2026-03-27-swift-text-runtime.md
 │   └── ...
-└── src/
+└── packages/
 ```
 
 ## Use the glossary's vocabulary

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues at `github.com/Keith-CY/melix`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -5,8 +5,8 @@ Issues and PRDs for this repo live as GitHub issues at `github.com/Keith-CY/meli
 ## Conventions
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
-- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Read an issue**: `gh issue view <number> --json number,title,body,labels,comments --jq '{number, title, body, labels: [.labels[].name], comments: [.comments[].body]}'` to filter comments and fetch labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels --jq '[.[] | {number, title, body, labels: [.labels[].name]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
 - **Close**: `gh issue close <number> --comment "..."`

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary
- Adds `## Agent skills` section to `AGENTS.md` pointing agents at three new docs files.
- Creates `docs/agents/issue-tracker.md` — GitHub Issues via `gh` CLI.
- Creates `docs/agents/triage-labels.md` — default triage label vocabulary.
- Creates `docs/agents/domain.md` — single-context layout with `docs/decisions/` as the decision records directory.

These files are read by the Matt Pocock engineering skill suite (`to-issues`, `triage`, `qa`, `to-prd`, `improve-codebase-architecture`, `diagnose`, `tdd`, `grill-with-docs`) so they know where issues live, what labels to apply, and where domain docs are.

## Plan or Spec
N/A: tooling/meta change — no governing feature plan. Adds agent configuration docs only; no production code or protocol changes.

## Commands Run
```text
# Documentation-only change.
# Pre-commit hook ran full test gate: make swift-test, make py-test, make integration-test — all passed.
```

## Coverage and Metrics
N/A: documentation-only change, no executable code paths added.

## Known Gaps
- `CONTEXT.md` does not exist yet; `grill-with-docs` will create it lazily when domain terms get resolved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.