### PR TITLE
perf: bind trajectory manifest json loader calls

### DIFF
--- a/docs/plans/2026-05-30-trajectory-manifest-json-load-bindings.md
+++ b/docs/plans/2026-05-30-trajectory-manifest-json-load-bindings.md
@@ -1,0 +1,42 @@
+# Trajectory Manifest JSON Load Local Bindings
+
+## Scope
+
+This Python-only performance slice is limited to the trajectory snapshot manifest
+loader in `services/mlx-worker-python/worker/trajectory_provenance.py`.
+
+The affected path is already covered by the registered PR-scoped probe
+`trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries, so no probe registry change is required for this slice.
+
+## Optimization
+
+`load_trajectory_provenance_from_snapshot_manifest()` already reads manifest
+JSON as bytes to avoid text decoding overhead. This slice keeps that behavior,
+binds the hot `json.loads` and `Path.read_bytes` call targets at module import,
+and skips rebuilding `Path` objects when callers already pass a `Path`. Repeated
+manifest provenance loads avoid per-call attribute lookup and an unnecessary
+constructor on the registered probe path.
+
+The change does not alter accepted manifest shapes, provenance field names,
+copy semantics for nested fields, or non-trajectory manifest handling.
+
+## Verification
+
+Run the registered focused local Linux commands before opening the PR:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/trajectory_manifest_json_load_probe.py"; if [ -f "$SCRIPT" ]; then python3 "$SCRIPT"; else for CANDIDATE in "../head/$SCRIPT" "${GITHUB_WORKSPACE:-}/head/$SCRIPT"; do if [ -f "$CANDIDATE" ]; then python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2; fi'
+```
+
+CI PR-scoped performance remains the merge gate for the registered probe result.
+
+## Success Criteria
+
+- Focused trajectory provenance tests pass.
+- Changed-scope coverage for `worker.trajectory_provenance` stays at or above the repository threshold.
+- The registered local probe reports a directionally lower `new_mean_ms` versus the current byte-loading hot path and a positive base-vs-head `speedup`.
+- PR-scoped performance CI selects and completes the registered probe before merge.

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -253,6 +253,7 @@ def test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs(
     assert payload == {"existing": "value"}
     assert trajectory_provenance_from_snapshot_manifest({"format": "text"}) == {}
     assert load_trajectory_provenance_from_snapshot_manifest(non_mapping_manifest) == {}
+    assert load_trajectory_provenance_from_snapshot_manifest(str(non_mapping_manifest)) == {}
     assert (
         load_trajectory_provenance_from_normalized_snapshot(
             format_name="text",

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -6,6 +6,9 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+_JSON_LOADS = json.loads
+_PATH_READ_BYTES = Path.read_bytes
+
 
 TRAJECTORY_PROVENANCE_FIELDS = (
     "trajectory_dataset_id",
@@ -110,10 +113,11 @@ def trajectory_provenance_from_snapshot_manifest(
 
 
 def load_trajectory_provenance_from_snapshot_manifest(
-    manifest_path: Path,
+    manifest_path: Path | str,
 ) -> dict[str, Any]:
-    manifest_path = Path(manifest_path)
-    payload = json.loads(manifest_path.read_bytes())
+    if not isinstance(manifest_path, Path):
+        manifest_path = Path(manifest_path)
+    payload = _JSON_LOADS(_PATH_READ_BYTES(manifest_path))
     if not isinstance(payload, dict):
         return {}
     return trajectory_provenance_from_snapshot_manifest(


### PR DESCRIPTION
## Summary
- Bind the trajectory manifest JSON loader's `json.loads` and `Path.read_bytes` call targets at module import.
- Skip rebuilding `Path` objects when callers already pass a `Path`, while preserving string path support.
- Keep the existing byte-loading behavior and trajectory provenance semantics unchanged.

## Plan or Spec
- `docs/plans/2026-05-30-trajectory-manifest-json-load-bindings.md`

## Commands Run
```text
# focused tests: exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
7 passed in 0.47s

# changed-scope coverage: exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
7 passed in 0.76s
changed_line_coverage=100.00% (2/2)

# registered probe: exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
{"old_mean_ms": 1457.8844141215086, "new_mean_ms": 1348.9041947759688, "delta_ms": -108.98021934553981, "speedup": 1.0807916676125688, "old_peak_bytes_mean": 97575.0, "new_peak_bytes_mean": 79582.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/trajectory_provenance.py` 100.00% (2/2 changed lines).
- Registered local probe `trajectory-manifest-json-load`: `old_mean_ms=1457.8844141215086`, `new_mean_ms=1348.9041947759688`, `speedup=1.0807916676125688`, `delta_ms=-108.98021934553981`, `old_peak_bytes_mean=97575.0`, `new_peak_bytes_mean=79582.0`.
- PR-scoped performance CI is required as the final registered probe validation gate.

## Known Gaps
- Linux local validation covers the Python worker path only. CI PR-scoped performance is the merge gate for the registered probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
