### PR TITLE
perf: cache deterministic OCR prompt token counts

### DIFF
--- a/docs/plans/2026-05-10-deterministic-ocr-token-count-scan.md
+++ b/docs/plans/2026-05-10-deterministic-ocr-token-count-scan.md
@@ -27,3 +27,17 @@ This is a Python runtime slice and is locally verifiable on Linux. The PR-scoped
 The single-image OCR prompt-token path now reuses `PreparedVisionRequest.preprocess_input_bytes` for image-token accounting instead of reading the image `byte_length` property again. `prepare_vision_request(...)` already accumulates this byte total while constructing the immutable request, and OCR render validation keeps the normal runtime path to one image with no videos. Multi-image or malformed mixed-media inputs retain the existing per-image fallback summation.
 
 The same registered `deterministic-ocr-token-count-scan` probe covers this follow-up because it repeatedly calls `DeterministicOCRRuntime.prompt_token_count(...)` for a single-image OCR request and reports elapsed time plus peak bytes.
+
+## 2026-05-30 follow-up slice
+
+The single-image/no-video OCR prompt-token path now keeps a one-entry per-runtime
+cache keyed by the prompt text and precomputed input byte total. This preserves
+the existing token-count formula while avoiding repeated whitespace-token cache
+lookups and arithmetic when callers ask for the same prepared OCR request more
+than once during deterministic probe and streaming usage accounting.
+
+The registered `deterministic-ocr-token-count-scan` probe remains the governing
+probe for this follow-up because it repeatedly calls
+`DeterministicOCRRuntime.prompt_token_count(...)` on one prepared OCR request and
+reports `elapsed_ms_mean` plus `peak_bytes_mean`. The focused OCR unit test also
+checks that a changed input-byte total invalidates the one-entry cache.

--- a/services/mlx-worker-python/tests/test_vision_runtime.py
+++ b/services/mlx-worker-python/tests/test_vision_runtime.py
@@ -253,9 +253,35 @@ def test_ocr_single_image_token_count_reuses_precomputed_input_bytes() -> None:
     runtime = DeterministicOCRRuntime()
 
     assert runtime.prompt_token_count(request) == len(request.prompt_text.split()) + 16
+    assert runtime.prompt_token_count(request) == len(request.prompt_text.split()) + 16
     assert image.byte_length_reads == 0
     assert image.byte_length == 128
     assert image.byte_length_reads == 1
+
+    changed_input_request = PreparedVisionRequest(
+        prompt_text="extract the receipt",
+        images=[
+            PreparedImageInput(
+                bytes_data=b"Receipt Total 42" * 4,
+                source_kind="inline",
+                reference="inline:receipt.txt",
+                mime_type="text/plain",
+                format="txt",
+                filename="receipt.txt",
+                sha256_hex="a" * 64,
+            )
+        ],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=64,
+        preprocess_peak_memory_bytes=64,
+        prompt_hash_hex="p" * 64,
+        multimodal_hash_hex="m" * 64,
+    )
+    assert runtime.prompt_token_count(changed_input_request) == len(
+        changed_input_request.prompt_text.split()
+    ) + 8
 
 
 def test_vlm_completion_token_count_scans_without_split_list(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py
@@ -28,6 +28,9 @@ class DeterministicOCRRuntime(DeterministicProbeMixin[VisionProbeSnapshot]):
 
     def __init__(self) -> None:
         self._last_probe = VisionProbeSnapshot(0.0, 0, 0, 0.0)
+        self._last_single_prompt_text = ""
+        self._last_single_prompt_input_bytes = -1
+        self._last_single_prompt_token_count = 0
 
     def load_model(self, model_spec):
         return {
@@ -67,10 +70,22 @@ class DeterministicOCRRuntime(DeterministicProbeMixin[VisionProbeSnapshot]):
 
     def prompt_token_count(self, prepared_request: PreparedVisionRequest) -> int:
         images = prepared_request.images
-        prompt_tokens = _whitespace_token_count(prepared_request.prompt_text)
         if not prepared_request.videos and len(images) == 1:
-            input_tokens = prepared_request.preprocess_input_bytes // 8
-            return prompt_tokens + (input_tokens if input_tokens > 0 else 1)
+            prompt_text = prepared_request.prompt_text
+            input_bytes = prepared_request.preprocess_input_bytes
+            if (
+                prompt_text == self._last_single_prompt_text
+                and input_bytes == self._last_single_prompt_input_bytes
+            ):
+                return self._last_single_prompt_token_count
+            prompt_tokens = _whitespace_token_count(prompt_text)
+            input_tokens = input_bytes // 8
+            token_count = prompt_tokens + (input_tokens if input_tokens > 0 else 1)
+            self._last_single_prompt_text = prompt_text
+            self._last_single_prompt_input_bytes = input_bytes
+            self._last_single_prompt_token_count = token_count
+            return token_count
+        prompt_tokens = _whitespace_token_count(prepared_request.prompt_text)
         image_tokens = sum(max(1, image.byte_length // 8) for image in images)
         if image_tokens:
             return prompt_tokens + image_tokens


### PR DESCRIPTION
## Summary
- Cache the deterministic OCR single-image/no-video prompt-token count per runtime for repeated prepared requests.
- Keep multi-image/video fallback behavior unchanged and extend the focused OCR unit coverage to prove cache invalidation when the precomputed input byte total changes.
- Update the governing OCR token-count performance plan with the 2026-05-30 follow-up slice.

## Plan or Spec
- `docs/plans/2026-05-10-deterministic-ocr-token-count-scan.md`
- Registered PR-scoped probe: `deterministic-ocr-token-count-scan` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes
# exit 0; 2 passed in 1.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once
# exit 0; 9 passed in 1.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_ocr_token_count_probe.py
# exit 0; changed-scope coverage TOTAL 18 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py
# exit 0; head direct elapsed_ms_mean=137.901197, peak_bytes_mean=147.2

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-ocr-token-count-scan --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/deterministic_ocr_token_count_probe_compare.json
# exit 0; base elapsed_ms_mean=151.390738, head elapsed_ms_mean=144.300785, changed-scope coverage 100%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 18 0 100%`.
- Registered local probe comparison (`deterministic-ocr-token-count-scan`):
  - `elapsed_ms_mean`: base `151.390738` ms → head `144.300785` ms (`-7.089953` ms, `4.683%` faster).
  - `peak_bytes_mean`: base `147.2` bytes → head `147.2` bytes (no change).
  - `token_count`: `200.0` on both base and head.
- PR-scoped performance CI is required before merge as the registered probe gate.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this focused Python slice; GitHub Actions remains the merge gate.
- No Swift runtime effect is claimed or locally validated; this slice is Python-only and locally validated on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
