### PR TITLE
perf: use regex for code eval nonblank fallback

### DIFF
--- a/docs/plans/2026-05-08-code-eval-count-tests-line-scan.md
+++ b/docs/plans/2026-05-08-code-eval-count-tests-line-scan.md
@@ -30,6 +30,13 @@ Register `code-eval-count-tests-line-scan` in the PR-scoped performance registry
 - Changed-scope coverage is at least 95%.
 - Local base-vs-head probe shows lower peak allocation and no severe latency regression on the fallback line-count path.
 
+## 2026-05-30 regex fallback slice
+
+The follow-up slice keeps the same registered probe and replaces the manual
+character-by-character fallback line counter with a compiled regex that matches
+each line containing at least one non-whitespace character while preserving LF,
+CRLF, CR, and Unicode whitespace behavior.
+
 ## Verification commands
 
 ```bash

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -443,11 +443,16 @@ def test_count_assert_nodes_returns_zero_without_asserts() -> None:
 
 
 def test_count_nonblank_test_lines_matches_splitlines_semantics() -> None:
-    test_code = "\n assert one\r\n\t\rassert two\n   \nassert three"
+    samples = [
+        "\n assert one\r\n\t\rassert two\n   \nassert three",
+        "\r\n\t\r\nassert one\rassert two\n\u2003assert three\n",
+        "   \n\t\r\n\r",
+    ]
 
-    assert code_eval_runner._count_nonblank_test_lines(test_code) == len(
-        [line for line in test_code.splitlines() if line.strip()]
-    )
+    for test_code in samples:
+        assert code_eval_runner._count_nonblank_test_lines(test_code) == len(
+            [line for line in test_code.splitlines() if line.strip()]
+        )
 
 
 class _SplitlinesGuard(str):

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import sys
@@ -18,6 +19,8 @@ _JSON_LOADS = json.loads
 _JSON_DECODE_ERROR = json.JSONDecodeError
 _PYTHON_CODE_BLOCK_TAG = "python"
 _PYTHON_CODE_BLOCK_TAG_LENGTH = len(_PYTHON_CODE_BLOCK_TAG)
+_NONBLANK_TEST_LINE_LF_PATTERN = re.compile(r"(?m)^[^\S\n]*[^\s]")
+_NONBLANK_TEST_LINE_CR_PATTERN = re.compile(r"(?:^|[\r\n])[^\S\r\n]*[^\s]")
 
 
 @dataclass(frozen=True)
@@ -282,16 +285,12 @@ def _count_assert_nodes(
 
 
 def _count_nonblank_test_lines(test_code: str) -> int:
-    count = 0
-    in_line = False
-    is_space = str.isspace
-    for char in test_code:
-        if char in "\r\n":
-            in_line = False
-        elif not in_line and not is_space(char):
-            count += 1
-            in_line = True
-    return count
+    pattern = (
+        _NONBLANK_TEST_LINE_CR_PATTERN
+        if "\r" in test_code
+        else _NONBLANK_TEST_LINE_LF_PATTERN
+    )
+    return sum(1 for _ in pattern.finditer(test_code))
 
 
 def _load_payload_file(


### PR DESCRIPTION
## Summary
- Replaces the code-eval fallback nonblank-line counter's manual character loop with compiled regex finditer paths.
- Preserves CR/LF/CRLF and Unicode whitespace behavior with expanded regression samples.
- Updates the active optimization plan with the regex fallback slice scope.

## Plan or Spec
- `docs/plans/2026-05-08-code-eval-count-tests-line-scan.md`
- Registered probe: `code-eval-count-tests-line-scan` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_reuses_cached_counts_for_repeated_payloads services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_assert_nodes_counts_nested_asserts services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_assert_nodes_uses_exact_type_for_direct_asserts services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fast_path_skips_ast_parse services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_count_tests_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_reuses_cached_counts_for_repeated_payloads services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_assert_nodes_counts_nested_asserts services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_assert_nodes_uses_exact_type_for_direct_asserts services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_avoids_splitlines_materialization services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fast_path_skips_ast_parse services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_count_tests_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_count_tests_probe.py`
- `python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-count-tests-line-scan --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-code-eval-nonblank-regex-20260530-base --head-repo "$PWD" --output /tmp/code-eval-count-tests-probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `11 passed`.
- Changed-scope coverage: `TOTAL 8 0 100%`.
- Local registered probe (`code-eval-count-tests-line-scan`, Linux):
  - `elapsed_ms_mean`: base `1.7863 ms`, head `1.7236 ms`, delta `-3.51%`.
  - `assert_elapsed_ms_mean`: base `62.3987 ms`, head `63.9268 ms`, delta `+2.45%` (within 5% warn threshold).
  - `peak_bytes_mean`: base `25143.7 bytes`, head `25143.7 bytes`, unchanged.

## Known Gaps
- Local measurements are Linux-only and can be noisy at this scale; the registered PR-scoped performance workflow is required before merge.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe was run against base and head.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
