### PR TITLE
perf: map lora run dir paths directly

### DIFF
--- a/docs/plans/2026-05-30-lora-run-dir-path-map.md
+++ b/docs/plans/2026-05-30-lora-run-dir-path-map.md
@@ -1,0 +1,40 @@
+# LoRA Experiment Run Directory Path Map
+
+## Linux-only constraint
+
+This slice is Python-only and locally verifiable on Linux with focused pytest,
+changed-scope coverage, and the registered PR-scoped performance probe.
+
+## Optimization
+
+`lora_experiment_store._iter_lora_run_dirs()` scans LoRA training run
+directories and filters `model-ops-` entries before sorting names. The function
+then rebuilds `Path` values from the sorted names.
+
+This slice keeps the scan and sorting semantics unchanged while using
+`tuple(map(root_join, run_dir_names))` for the final sorted-name-to-`Path`
+conversion. That avoids the generator frame used by the previous tuple
+comprehension and slightly reduces allocation overhead in the registered scan
+probe.
+
+## Registered probe
+
+Existing registered probe: `lora-experiment-run-dir-name-scan` in
+`infra/perf/pr_scoped_probes.json`.
+
+The probe covers:
+
+- `services/mlx-worker-python/worker/productization/lora_experiment_store.py`
+- `services/mlx-worker-python/tests/test_lora_experiment_store.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/lora_experiment_run_dir_scan_probe.py`
+
+The registry already defines focused `test_command`, `coverage_command`, and
+`probe_command` entries, so no probe registry change is needed for this narrow
+prefix-binding optimization.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage, and local registered
+probe on Linux before opening the PR. The PR-scoped performance workflow remains
+the merge gate for the registered probe result in CI.

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -43,7 +43,7 @@ def _iter_lora_run_dirs(train_root: Path) -> tuple[Path, ...]:
 
     run_dir_names.sort()
     root_join = train_root.__truediv__
-    return tuple(root_join(name) for name in run_dir_names)
+    return tuple(map(root_join, run_dir_names))
 
 
 class LoraExperimentStore:


### PR DESCRIPTION
## Summary
- Map sorted LoRA experiment run directory names to `Path` objects with `tuple(map(...))` instead of a tuple comprehension.
- Keep `_iter_lora_run_dirs()` scan/filter/sort semantics unchanged while reducing the final conversion overhead in the registered scan probe.

## Plan or Spec
- `docs/plans/2026-05-30-lora-run-dir-path-map.md`

## Commands Run
```text
# Baseline registered probe on origin/main, three runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/lora_experiment_run_dir_scan_probe.py
# elapsed_ms_mean: 1060.4184217751026, 1094.0147846005857, 1075.353803113103; peak_bytes_mean: 3027991.2 each

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py::test_iter_lora_run_dirs_sorts_names_without_reading_entry_paths services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_prefers_run_record_over_manifest_when_both_exist services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_experiment_run_dir_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_experiment_run_dir_scan_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 5 passed in 7.36s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py::test_iter_lora_run_dirs_sorts_names_without_reading_entry_paths services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_prefers_run_record_over_manifest_when_both_exist services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_experiment_run_dir_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_experiment_run_dir_scan_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 5 passed in 33.01s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/lora_experiment_store.py services/mlx-worker-python/tests/test_lora_experiment_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_experiment_run_dir_scan_probe.py
# TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/lora_experiment_run_dir_scan_probe.py
# {"elapsed_ms_mean": 1072.5464968010783, "iteration_count": 24, "path_attr_reads_mean": 0.0, "peak_bytes_mean": 3027623.2, "run_dir_count": 8000, "sample_count": 5}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Registered probe: `lora-experiment-run-dir-name-scan`.
- Baseline three-run mean: `old_mean=1076.595669829597ms`; candidate three-run mean: `new_mean=1076.1063359367351ms`; `delta_ms=-0.4893338928618505`; `speedup=1.0004547263374635x`.
- Peak memory changed from `3027991.2` to `3027623.2` bytes (`delta=-368.0` bytes). `path_attr_reads_mean` remained `0.0`.
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime behavior is affected.
- The elapsed-time delta is intentionally small and may be noise-sensitive; the registered CI probe report remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
