### PR TITLE
perf: bind tool schema payload copy helpers

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -98,6 +98,23 @@ Expected effect:
 - leave schema payload shape, registry selection, and protobuf serialization
   unchanged.
 
+## Follow-up Slice: Schema Payload Copy Helper Bindings
+
+The 2026-05-31 follow-up keeps `ToolDescriptor.schema_payload()` behavior
+unchanged and still returns isolated mutable schema dictionaries/lists, but uses
+the module-level `dict.copy` and `list.copy` helper bindings while cloning cached
+schema payload snapshots. This mirrors the existing `as_openai_tools()` hot-loop
+pattern and avoids repeated bound-method lookups inside the schema-payload probe.
+
+Expected effect:
+
+- reduce repeated schema payload construction overhead measured by
+  `tool-registry-schema-bytes-cache` `schema_payload_elapsed_ms_mean`;
+- preserve copy-on-return isolation for nested schema property dictionaries and
+  required-argument lists;
+- leave registry selection, protobuf config serialization, and tool definitions
+  unchanged.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -138,12 +138,12 @@ class ToolDescriptor:
 
     def schema_payload(self) -> dict[str, Any]:
         schema_properties = self._cached_schema_properties
-        required_arguments = self._cached_required_arguments_list
+        copy_dict = _COPY_DICT
         return {
             "type": "object",
             "additionalProperties": False,
-            "properties": {name: schema.copy() for name, schema in schema_properties},
-            "required": required_arguments.copy(),
+            "properties": {name: copy_dict(schema) for name, schema in schema_properties},
+            "required": _COPY_LIST(self._cached_required_arguments_list),
         }
 
     def json_schema(self) -> str:


### PR DESCRIPTION
## Summary
- Bind module-level `dict.copy` / `list.copy` helpers inside `ToolDescriptor.schema_payload()` to avoid repeated bound-method lookups while preserving copy-on-return isolation.
- Document the 2026-05-31 schema payload copy-helper performance slice.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md`

## Commands Run
```text
# Baseline on origin/main before the slice
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
# schema_payload_elapsed_ms_mean samples: 147.41520723327994, 155.20006520673633, 154.21518124639988; mean=152.27681789547205

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 55 passed in 0.22s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py
# 55 passed in 0.37s; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
# head schema_payload_elapsed_ms_mean samples: 139.25026673823595, 154.74154511466622, 146.0419594310224; mean=146.6779237613082

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 1 0 100%`).
- Registered local probe: `tool-registry-schema-bytes-cache`.
- Primary metric: `schema_payload_elapsed_ms_mean` improved from `old_mean=152.27681789547205 ms` to `new_mean=146.6779237613082 ms` (`delta_ms=-5.5988941341638565`, `speedup=3.6767869276117437%`).
- CI PR-scoped performance workflow is required as the registered merge gate.

## Known Gaps
- Local evidence is Linux/Python only; no Swift runtime effect is claimed.
- Probe timing is microbenchmark-level and somewhat noisy, so CI registered probe output remains the source of merge validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
