### PR TITLE
perf: load dataset version manifests from string paths

### DIFF
--- a/docs/plans/2026-05-24-dataset-version-listing-scandir.md
+++ b/docs/plans/2026-05-24-dataset-version-listing-scandir.md
@@ -1,6 +1,6 @@
 # Dataset version listing scandir slice
 
-This Python-only performance track keeps dataset-version listing behavior unchanged while reducing overhead in small, registered slices. The first slice replaced the one-level `Path.glob("*/dataset-version.json")` scan with an explicit `os.scandir()` pass. The current follow-up slice keeps the registered listing probe and changes shared JSON manifest loading from text decoding to direct byte loading for the listing hot path.
+This Python-only performance track keeps dataset-version listing behavior unchanged while reducing overhead in small, registered slices. The first slice replaced the one-level `Path.glob("*/dataset-version.json")` scan with an explicit `os.scandir()` pass. A follow-up changed shared JSON manifest loading from text decoding to byte loading. The current slice keeps the same registered listing probe and removes per-manifest `Path` construction from the listing hot path by carrying `os.scandir()` string paths into a direct binary JSON load.
 
 ## Scope
 
@@ -12,7 +12,7 @@ This Python-only performance track keeps dataset-version listing behavior unchan
 
 ## Registered probe
 
-This track uses `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and runs on `ubuntu-latest`. The current JSON byte-loading follow-up is covered by the same registered probe because `list_dataset_versions(...)` reads every discovered `dataset-version.json` manifest through `_read_json(...)`.
+This track uses `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and runs on `ubuntu-latest`. The current string-path JSON loading follow-up is covered by the same registered probe because `list_dataset_versions(...)` discovers and reads every `dataset-version.json` manifest in the listing workload.
 
 Metrics:
 

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -213,6 +213,13 @@ def test_dataset_version_listing_uses_scandir_without_path_glob(
 
     monkeypatch.setattr(Path, "glob", fail_glob)
 
+    def fail_read_json(path: Path):  # pragma: no cover - exercised only on regression
+        raise AssertionError(
+            f"list_dataset_versions() should read manifest bytes directly without Path.read_bytes({path!s})"
+        )
+
+    monkeypatch.setattr("worker.productization.dataset_preparation._read_json", fail_read_json)
+
     listing = list_dataset_versions(
         workspace_manifest_path=tmp_path / "workspace-manifest.json",
         output_root=output_root,

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -453,7 +453,7 @@ def list_dataset_versions(
     versions_root = Path(output_root).expanduser() / dataset_id / "versions"
     versions: list[dict[str, Any]] = []
     for manifest_path in _iter_dataset_version_manifest_paths(versions_root):
-        version = _read_json(manifest_path)
+        version = _read_json_file(manifest_path)
         versions.append(
             {
                 "dataset_id": version.get("dataset_id", ""),
@@ -480,8 +480,8 @@ def list_dataset_versions(
     }
 
 
-def _iter_dataset_version_manifest_paths(versions_root: Path) -> list[Path]:
-    manifest_paths: list[Path] = []
+def _iter_dataset_version_manifest_paths(versions_root: Path) -> list[str]:
+    manifest_paths: list[str] = []
     try:
         with os.scandir(versions_root) as entries:
             for entry in entries:
@@ -489,7 +489,7 @@ def _iter_dataset_version_manifest_paths(versions_root: Path) -> list[Path]:
                     continue
                 manifest_path = os.path.join(entry.path, "dataset-version.json")
                 if os.path.isfile(manifest_path):
-                    manifest_paths.append(Path(manifest_path))
+                    manifest_paths.append(manifest_path)
     except OSError:
         return []
     return manifest_paths
@@ -807,6 +807,11 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 
 def _read_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_bytes())
+
+
+def _read_json_file(path: str) -> dict[str, Any]:
+    with open(path, "rb") as handle:
+        return json.load(handle)
 
 
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Optimize dataset version listing by carrying `os.scandir()` string paths through the listing hot path.
- Load each `dataset-version.json` through direct binary file handles instead of constructing a `Path` for every discovered manifest.
- Extend the focused regression test to fail if listing falls back to the shared `Path.read_bytes()` JSON helper.

## Plan or Spec
- `docs/plans/2026-05-24-dataset-version-listing-scandir.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 7 passed in 1.01s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py
# 7 passed in 0.36s; TOTAL 8 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-version-listing-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-dataset-version-string-json-load-20260531-base --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-tool-config-bytes-single-encode-20260531 --output /tmp/dataset-version-string-json-load-probe.json
# ok; base elapsed_ms_mean=74.906612, head elapsed_ms_mean=47.409239
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%`.
- Registered local probe `dataset-version-listing-scandir`:
  - `elapsed_ms_mean`: base `74.906612 ms`, head `47.409239 ms`, delta `-27.497373 ms` (`~36.71%` faster).
  - `elapsed_ms_min`: base `63.638401 ms`, head `43.998416 ms`.
  - `elapsed_ms_p95`: base `81.140468 ms`, head `48.429899 ms`.
  - workload: `version_count=2500`, `sample_count=7`.
- CI PR-scoped performance report is still required as the merge-gating registered probe validation.

## Known Gaps
- Full repository gates were not run locally; this Python-only slice was verified with the registered focused tests, changed-scope coverage, and registered local performance probe on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
