### PR TITLE
perf: sort model registry child names in place

### DIFF
--- a/docs/plans/2026-05-03-model-registry-scandir-direntry-name-reuse.md
+++ b/docs/plans/2026-05-03-model-registry-scandir-direntry-name-reuse.md
@@ -6,6 +6,8 @@ This performance slice keeps model registry discovery behavior unchanged while n
 
 The scan loop already uses `os.scandir()` and `DirEntry` descriptor checks. This slice reuses each entry name once per loop iteration and hoists the pruned directory-name collection out of the loop so large registry roots avoid repeated `DirEntry.name` lookups and per-directory set allocation.
 
+The 2026-05-31 follow-up slice keeps the same registered probe and narrows the remaining child-directory scheduling cost by sorting the collected child names in place before extending the DFS stack, avoiding the extra list allocated by `sorted(...)` while preserving deterministic traversal order.
+
 ## Registered probe
 
 The affected path is covered by the existing PR-scoped probe `model-registry-plain-local-manifest-stat-elision` in `infra/perf/pr_scoped_probes.json`.

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -2134,7 +2134,8 @@ class WorkerModelCatalog:
                     )
                 )
                 continue
-            stack.extend(current / name for name in sorted(child_names, reverse=True))
+            child_names.sort(reverse=True)
+            stack.extend(current / name for name in child_names)
         return tuple(manifest_paths), tuple(plain_local_model_dirs), tuple(sorted(hf_cache_repo_dirs))
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Sort model registry child names in place before extending the DFS stack.
- Avoids the extra list allocated by `sorted(child_names, reverse=True)` while preserving deterministic traversal order.
- Updates the model-registry scandir plan with this follow-up slice.

## Plan or Spec
- `docs/plans/2026-05-03-model-registry-scandir-direntry-name-reuse.md`
- Registered probe: `model-registry-plain-local-manifest-stat-elision` in `infra/perf/pr_scoped_probes.json` (already has focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# baseline probe on origin/main before this change (3 runs)
bash /tmp/model_registry_probe_command.sh
-> elapsed_ms_mean: 116.558115, 114.008290, 128.725610; mean=119.764005 ms

# focused registered test command
bash /tmp/model_registry_test_command.sh
-> 19 passed in 2.30s

# changed-scope registered coverage command
bash /tmp/model_registry_coverage_command.sh
-> 19 passed in 2.55s; TOTAL 2 0 100%

# registered probe on this branch (3-run conservative comparison)
bash /tmp/model_registry_probe_command.sh
-> elapsed_ms_mean: 112.527877, 126.537151, 119.653200; mean=119.572743 ms

# additional branch probe stability sample (5 runs)
python3 - <<'PY' ...
-> elapsed_ms_mean: 122.534159, 129.239013, 113.693184, 109.232477, 117.276050; mean=118.394977 ms

git diff --check
-> passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 2 0 100%`).
- Registered local probe: `model-registry-plain-local-manifest-stat-elision`.
- Conservative 3-run comparison: old_mean=119.764005 ms, new_mean=119.572743 ms, delta=-0.191262 ms, speedup=1.0016x.
- Probe counters remained stable: `config_load_calls_mean=400.0`, `discovered_model_count_mean=400.0`, `generation_config_stat_calls_mean=0.0`, `manifest_is_file_calls_mean=0.0`, `manifest_parse_calls_mean=0.0`.

## Known Gaps
- No Swift runtime validation is applicable; this is a Python-only model registry scan slice verified locally on Linux.
- The elapsed delta is intentionally small and bounded to a single allocation-elision slice; CI registered probe validation is still required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no new probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
