### PR TITLE
perf: hoist dataset source kind suffix sets

### DIFF
--- a/docs/plans/2026-05-31-dataset-source-kind-constant-sets.md
+++ b/docs/plans/2026-05-31-dataset-source-kind-constant-sets.md
@@ -1,0 +1,29 @@
+# Dataset Source Kind Constant Suffix Sets
+
+## Scope
+
+Optimize one Python hot path in dataset ingest: `_source_kind()` classification for source files discovered by `worker.productization.dataset_preparation._iter_source_records()`.
+
+The previous suffix fast path still allocated three literal `set` objects on every non-`.txt` / non-`.text` classification call. This slice preserves accepted source-kind behavior while hoisting those suffix membership tables to module-level immutable `frozenset` constants.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries. The local Linux probe reports:
+
+- `elapsed_ms_mean`
+- `elapsed_ms_min`
+- `elapsed_ms_p95`
+- `file_count_mean`
+
+## Plan
+
+1. Reuse existing source-kind behavior coverage for uppercase compound `.PDF.TXT`, `.DOCX.txt`, code, structured-data, and unsupported suffix cases.
+2. Hoist markdown/code/structured-data suffix membership tables from per-call literals to module-level immutable constants.
+3. Run the registered focused test command, changed-scope coverage command, and local registered probe on Linux.
+4. Use GitHub Actions PR-scoped performance output as the merge gate.
+
+## Verification Notes
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -27,6 +27,11 @@ _EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
 _PHONE_RE = re.compile(r"\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b")
 _TOKEN_RE = re.compile(r"\b(?:sk|pk|rk|ghp|github_pat)-[A-Za-z0-9._-]{8,}\b")
 _WORD_RE = re.compile(r"[A-Za-z0-9]+")
+_TEXT_SOURCE_SUFFIXES = frozenset((".md", ".markdown"))
+_CODE_SOURCE_SUFFIXES = frozenset(
+    (".py", ".swift", ".js", ".ts", ".java", ".go", ".rs", ".cpp", ".c", ".h")
+)
+_STRUCTURED_DATA_SOURCE_SUFFIXES = frozenset((".jsonl", ".json", ".csv", ".tsv"))
 
 
 @dataclass(frozen=True)
@@ -568,11 +573,11 @@ def _source_kind(path: Path) -> str | None:
         return "text"
     if suffix == ".text":
         return "text"
-    if suffix in {".md", ".markdown"}:
+    if suffix in _TEXT_SOURCE_SUFFIXES:
         return "markdown"
-    if suffix in {".py", ".swift", ".js", ".ts", ".java", ".go", ".rs", ".cpp", ".c", ".h"}:
+    if suffix in _CODE_SOURCE_SUFFIXES:
         return "code"
-    if suffix in {".jsonl", ".json", ".csv", ".tsv"}:
+    if suffix in _STRUCTURED_DATA_SOURCE_SUFFIXES:
         return "structured_data"
     return None
 


### PR DESCRIPTION
## Summary
- Hoist dataset ingest source-kind suffix membership tables to module-level immutable constants.
- Preserve the existing `_source_kind()` behavior for text, markdown, code, structured data, PDF/DOCX extracted text, and unsupported suffixes.
- Add a small governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-05-31-dataset-source-kind-constant-sets.md`
- Registered probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` (exit 0, 9 passed)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py` (exit 0, changed-line coverage 100%)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py` (3 baseline runs, 3 changed runs)
- `git diff --check` (exit 0)

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Local Linux registered probe baseline `elapsed_ms_mean` runs: 12.132274, 13.452726, 13.746066 ms; aggregate mean 13.110355 ms.
- Local Linux registered probe changed `elapsed_ms_mean` runs: 11.176886, 14.989955, 11.597463 ms; aggregate mean 12.588101 ms.
- Delta: -0.522254 ms, speedup 1.0415x, -3.98% elapsed mean. The probe is noisy, but the aggregate direction is positive and the behavior surface is unchanged.

## Known Gaps
- This is Python-only and locally verified on Linux; no Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registry entry has focused `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe was run before and after the change.
- [ ] GitHub Actions PR-scoped performance completed successfully.
