### PR TITLE
perf: clamp maintenance percentiles directly

### DIFF
--- a/docs/plans/2026-05-31-maintenance-percentile-clamp-fastpath.md
+++ b/docs/plans/2026-05-31-maintenance-percentile-clamp-fastpath.md
@@ -1,0 +1,44 @@
+# Maintenance percentile clamp fast path
+
+## Scope
+
+This Python-only performance slice is limited to percentile calculation in
+`services/mlx-worker-python/worker/engine/maintenance_core.py`.
+
+Benchmark reporting calls `_ordered_percentile()` repeatedly for already-sorted
+latency vectors. The helper currently clamps percentile input with nested
+`min()` / `max()` calls and reads the ordered vector length twice on the common
+multi-value path. The slice keeps interpolation behavior unchanged while
+reducing helper overhead.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped performance probe
+`maintenance-percentile-vector-reuse` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` values for:
+
+- `services/mlx-worker-python/worker/engine/maintenance_core.py`
+- `services/mlx-worker-python/tests/test_maintenance_service.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+No probe registration change is required for this slice.
+
+## Implementation plan
+
+1. Preserve percentile interpolation, empty-list handling, singleton handling,
+   and out-of-range percentile clamping.
+2. Cache the ordered vector length once inside `_ordered_percentile()`.
+3. Replace nested clamp helper calls with explicit branch clamping before rank
+   calculation.
+4. Run the registered focused tests, changed-scope coverage command, and
+   registered probe locally on Linux before opening the PR.
+5. Use the GitHub PR-scoped performance report as the merge gate.
+
+## Local metrics plan
+
+Compare `origin/main` and this branch with the registered
+`maintenance-percentile-vector-reuse` probe settings. The accepted direction is
+lower `elapsed_ms_mean` with unchanged percentile helper behavior and no
+coverage loss.

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -5129,8 +5129,13 @@ def test_percentiles_reuse_one_sorted_vector_and_preserve_interpolation(
     assert MaintenanceCore._percentiles(values) == ()
     assert MaintenanceCore._percentiles([], 50.0, 95.0) == (0.0, 0.0)
     assert MaintenanceCore._percentiles(values, 50.0, 95.0) == (6.0, 8.7)
+    assert MaintenanceCore._percentiles(values, -25.0, 125.0) == (1.0, 9.0)
     assert MaintenanceCore._percentile(values, 95.0) == 8.7
-    assert sorted_calls == [[1.0, 5.0, 7.0, 9.0], [1.0, 5.0, 7.0, 9.0]]
+    assert sorted_calls == [
+        [1.0, 5.0, 7.0, 9.0],
+        [1.0, 5.0, 7.0, 9.0],
+        [1.0, 5.0, 7.0, 9.0],
+    ]
 
 
 def test_run_bench_latency_and_summary_reuse_single_sorted_request_latency_vector(

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -4475,9 +4475,16 @@ class MaintenanceCore:
 
     @staticmethod
     def _ordered_percentile(ordered: list[float], percentile: float) -> float:
-        if len(ordered) == 1:
+        ordered_count = len(ordered)
+        if ordered_count == 1:
             return round(ordered[0], 2)
-        rank = (len(ordered) - 1) * max(0.0, min(percentile, 100.0)) / 100.0
+        if percentile <= 0.0:
+            clamped_percentile = 0.0
+        elif percentile >= 100.0:
+            clamped_percentile = 100.0
+        else:
+            clamped_percentile = percentile
+        rank = (ordered_count - 1) * clamped_percentile / 100.0
         lower_index = math.floor(rank)
         upper_index = math.ceil(rank)
         lower_value = ordered[lower_index]


### PR DESCRIPTION
## Summary
- Cache the ordered percentile vector length once in `MaintenanceCore._ordered_percentile()`.
- Replace nested `min()` / `max()` percentile clamping with explicit branch clamps on the hot multi-value path.
- Extend the focused percentile regression test to cover out-of-range clamp behavior.

## Plan or Spec
- `docs/plans/2026-05-31-maintenance-percentile-clamp-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_percentiles_reuse_one_sorted_vector_and_preserve_interpolation
# 1 passed in 1.70s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_percentiles_reuse_one_sorted_vector_and_preserve_interpolation services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_latency_and_summary_reuse_single_sorted_request_latency_vector services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_reuses_single_sorted_latency_vectors services/mlx-worker-python/tests/test_maintenance_service.py::test_measure_vlm_latency_metrics_reuse_single_sorted_total_latency_vector services/mlx-worker-python/tests/test_maintenance_service.py::test_image_latency_metrics_reuse_single_sorted_job_latency_vector services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_measures_runtime_behavior_from_loaded_backend services/mlx-worker-python/tests/test_maintenance_service.py::test_run_bench_matrix_returns_summary_rows_and_persists_matrix_artifacts services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_percentile_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 10 passed in 1.89s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 10 passed in 1.16s; TOTAL 10 0 100%

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id maintenance-percentile-vector-reuse --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-maintenance-percentile-clamp-fastpath-20260531b --output /tmp/maintenance-percentile-clamp-pr-probe.json
# head verification ok; coverage TOTAL 10 0 100%; base/head probes ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%` from the registered `maintenance-percentile-vector-reuse` coverage command.
- Local Linux registered probe (`maintenance-percentile-vector-reuse`):
  - `elapsed_ms_mean`: base `326.299969` -> head `318.858661` ms (`-7.441308` ms, ~2.3% faster).
  - `sort_calls_mean`: base `300.0` -> head `300.0` calls (unchanged; this slice only changes the already-sorted percentile helper overhead).
  - Percentile outputs unchanged: `p50_ms=499.5`, `p95_ms=949.05` for both base and head.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed.
- The registered probe’s elapsed timing is small and may be noisy; merge decision should use the CI PR-scoped performance report as the final gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
