### PR TITLE
perf: summarize closure audit severities in one pass

### DIFF
--- a/docs/plans/2026-05-31-closure-audit-severity-single-pass.md
+++ b/docs/plans/2026-05-31-closure-audit-severity-single-pass.md
@@ -1,0 +1,22 @@
+# Closure Audit Severity Metrics Single Pass
+
+## Scope
+
+This Python performance slice is limited to `services/mlx-worker-python/worker/productization/closure_audit.py`.
+It keeps closure-audit report behavior unchanged while computing severity metrics and unresolved finding summaries in one pass over the already ordered findings.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `closure-audit-probe-source-short-circuit` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries that exercise closure-audit behavior and report `elapsed_ms_mean`, `peak_bytes_mean`, and `probe_file_reads_mean`.
+
+## Implementation Plan
+
+1. Add a focused regression test for the severity-metric helper so count and unresolved-summary parity is explicit.
+2. Replace the four repeated severity scans plus separate unresolved scan with a single loop over `ordered_findings`.
+3. Run the registered focused test command, changed-scope coverage command, and local registered probe on Linux.
+4. Use GitHub Actions and the registered PR-scoped performance report as the merge gate before squash merging.
+
+## Metrics
+
+Local Linux verification will compare the registered probe against an `origin/main` baseline using `scripts/pr_scoped_performance_run.py`.

--- a/services/mlx-worker-python/tests/test_closure_audit.py
+++ b/services/mlx-worker-python/tests/test_closure_audit.py
@@ -9,6 +9,7 @@ import pytest
 
 from worker.productization import closure_audit as closure_audit_module
 from worker.productization.closure_audit import (
+    ClosureAuditFinding,
     build_closure_audit,
     render_closure_audit_json,
 )
@@ -37,6 +38,55 @@ def test_build_closure_audit_classifies_accepted_risk_and_deferred_work(
     emitted = render_closure_audit_json(report)
     assert emitted == render_closure_audit_json(report)
     assert json.loads(emitted) == payload
+
+
+def test_finding_metrics_and_unresolved_summaries_share_single_pass() -> None:
+    findings = (
+        ClosureAuditFinding(
+            finding_id="blocker",
+            severity="blocker",
+            category="milestone_status",
+            summary="Blocker summary",
+            evidence_sources=("progress.md",),
+            probe_coverage=(),
+        ),
+        ClosureAuditFinding(
+            finding_id="risk",
+            severity="accepted_risk",
+            category="scope_constraint",
+            summary="Risk summary",
+            evidence_sources=("docs/scope.md",),
+            probe_coverage=(),
+        ),
+        ClosureAuditFinding(
+            finding_id="gap",
+            severity="evidence_gap",
+            category="runbook",
+            summary="Gap summary",
+            evidence_sources=("docs/runbooks/missing.md",),
+            probe_coverage=(),
+        ),
+        ClosureAuditFinding(
+            finding_id="deferred",
+            severity="deferred_work",
+            category="release_gate_followup",
+            summary="Deferred summary",
+            evidence_sources=("docs/plans/index.md",),
+            probe_coverage=(),
+        ),
+    )
+
+    metrics, unresolved = closure_audit_module._finding_metrics_and_unresolved_summaries(
+        findings
+    )
+
+    assert metrics == {
+        "closure_audit.blocker_count": 1.0,
+        "closure_audit.accepted_risk_count": 1.0,
+        "closure_audit.evidence_gap_count": 1.0,
+        "closure_audit.deferred_work_count": 1.0,
+    }
+    assert unresolved == ["Blocker summary", "Gap summary", "Deferred summary"]
 
 
 def test_build_closure_audit_reports_evidence_gap_for_missing_runbook_and_probe(

--- a/services/mlx-worker-python/worker/productization/closure_audit.py
+++ b/services/mlx-worker-python/worker/productization/closure_audit.py
@@ -87,6 +87,15 @@ _FINDING_CATEGORY_PRIORITY = {
     "release_gate_followup": 5,
     "scope_constraint": 6,
 }
+_FINDING_SEVERITY_METRIC_KEYS = {
+    "blocker": "closure_audit.blocker_count",
+    "accepted_risk": "closure_audit.accepted_risk_count",
+    "evidence_gap": "closure_audit.evidence_gap_count",
+    "deferred_work": "closure_audit.deferred_work_count",
+}
+_UNRESOLVED_FINDING_SEVERITIES = frozenset(
+    ("blocker", "evidence_gap", "deferred_work")
+)
 
 
 @dataclass(frozen=True)
@@ -296,25 +305,9 @@ def build_closure_audit(
             ),
         )
     )
-    metrics = {
-        "closure_audit.blocker_count": float(
-            sum(1 for finding in ordered_findings if finding.severity == "blocker")
-        ),
-        "closure_audit.accepted_risk_count": float(
-            sum(1 for finding in ordered_findings if finding.severity == "accepted_risk")
-        ),
-        "closure_audit.evidence_gap_count": float(
-            sum(1 for finding in ordered_findings if finding.severity == "evidence_gap")
-        ),
-        "closure_audit.deferred_work_count": float(
-            sum(1 for finding in ordered_findings if finding.severity == "deferred_work")
-        ),
-    }
-    unresolved_findings = [
-        finding.summary
-        for finding in ordered_findings
-        if finding.severity in {"blocker", "evidence_gap", "deferred_work"}
-    ]
+    metrics, unresolved_findings = _finding_metrics_and_unresolved_summaries(
+        ordered_findings
+    )
     summary = {
         "top_unresolved_findings": unresolved_findings[:3],
         "required_runbooks": list(_REQUIRED_RUNBOOKS),
@@ -332,6 +325,20 @@ def build_closure_audit(
         metrics=metrics,
         summary=summary,
     )
+
+
+def _finding_metrics_and_unresolved_summaries(
+    ordered_findings: tuple[ClosureAuditFinding, ...],
+) -> tuple[dict[str, float], list[str]]:
+    metrics = {metric_key: 0.0 for metric_key in _FINDING_SEVERITY_METRIC_KEYS.values()}
+    unresolved_findings: list[str] = []
+    for finding in ordered_findings:
+        metric_key = _FINDING_SEVERITY_METRIC_KEYS.get(finding.severity)
+        if metric_key is not None:
+            metrics[metric_key] += 1.0
+        if finding.severity in _UNRESOLVED_FINDING_SEVERITIES:
+            unresolved_findings.append(finding.summary)
+    return metrics, unresolved_findings
 
 
 def render_closure_audit_json(report: ClosureAuditReport) -> str:


### PR DESCRIPTION
## Summary
- Compute closure-audit severity metrics and unresolved summaries in a single pass over ordered findings.
- Add a focused regression test for the helper that preserves metric counts and unresolved ordering.
- Document the slice and registered probe gate under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-05-31-closure-audit-severity-single-pass.md`
- Registered PR-scoped probe: `closure-audit-probe-source-short-circuit`.

## Commands Run
```bash
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_closure_audit.py::test_finding_metrics_and_unresolved_summaries_share_single_pass
# 1 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
# 19 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/closure_audit.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 19 passed; TOTAL 18 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id closure-audit-probe-source-short-circuit --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-closure-audit-severity --head-repo "$PWD" --output /tmp/closure_audit_probe.json
# ok
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 18 0 100%`.
- Local registered probe (`closure-audit-probe-source-short-circuit`):
  - `elapsed_ms_mean`: base `3.668 ms`, head `3.472 ms`, delta `-0.196 ms` (`-5.34%`).
  - `peak_bytes_mean`: base `33147`, head `33039`, delta `-108` (`-0.33%`).
  - `probe_file_reads_mean`: base `1.0`, head `1.0`, delta `0.0`.

## Known Gaps
- This is a Python-only slice verified locally on Linux. CI PR-scoped performance remains the registered probe validation source before merge.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows an improvement direction for `elapsed_ms_mean`.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
