### PR TITLE
perf: fast-path hub size label parsing

### DIFF
--- a/docs/plans/2026-05-31-hub-size-label-prefix-fastpath.md
+++ b/docs/plans/2026-05-31-hub-size-label-prefix-fastpath.md
@@ -1,0 +1,31 @@
+# Hub Catalog Size Label Prefix Fast Path
+
+## Scope
+
+This Python-only performance slice keeps hub catalog behavior unchanged while reducing allocation on the direct `cardData.model_size` parsing path in `services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.
+
+Focused commands:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
+```
+
+## Implementation Plan
+
+- Replace the `text[:10].lower() == "model size"` label check with a no-allocation ASCII prefix predicate.
+- Preserve the existing case-insensitive `Model size` / `MODEL SIZE` / `model size` behavior and existing `:` / `|` / whitespace separator handling.
+- Keep the change limited to direct `cardData.model_size` label parsing; regex-based README/description parsing remains unchanged.
+
+## Success Metrics
+
+- Focused hub catalog tests pass.
+- Changed-scope coverage is at least 95%.
+- The local registered probe reports a lower `elapsed_ms_mean` for the synthetic size-hint workload, with `size_hint_calls_mean` unchanged.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -181,6 +181,13 @@ def test_direct_size_hint_rejects_extra_tokens_without_full_split() -> None:
     assert _direct_size_hint_from_text("12 GB") == 12 * 1024 * 1024 * 1024
 
 
+def test_direct_card_size_hint_preserves_case_insensitive_label_prefix() -> None:
+    assert hub_catalog_module._direct_card_size_hint_from_text("Model size: 12 MB") == 12 * MB
+    assert hub_catalog_module._direct_card_size_hint_from_text("MODEL SIZE | 7 kb") == 7 * KB
+    assert hub_catalog_module._direct_card_size_hint_from_text("model size 2 GB") == 2 * GB
+    assert hub_catalog_module._direct_card_size_hint_from_text("model-size: 2 GB") == 0
+
+
 def test_search_models_with_mlx_only_prefilters_payloads_before_local_fit(monkeypatch: pytest.MonkeyPatch) -> None:
     payload = [
         {

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -671,7 +671,9 @@ def _direct_card_size_hint_from_text(text: str) -> int:
 
 
 def _strip_model_size_label(text: str) -> str:
-    if len(text) < 10 or text[:10].lower() != "model size":
+    if text.startswith("Model size: "):
+        return text[12:]
+    if not _starts_with_model_size_label(text):
         return ""
     cursor = 10
     text_length = len(text)
@@ -682,6 +684,22 @@ def _strip_model_size_label(text: str) -> str:
     while cursor < text_length and text[cursor].isspace():
         cursor += 1
     return text[cursor:]
+
+
+def _starts_with_model_size_label(text: str) -> bool:
+    return (
+        len(text) >= 10
+        and (text[0] == "m" or text[0] == "M")
+        and (text[1] == "o" or text[1] == "O")
+        and (text[2] == "d" or text[2] == "D")
+        and (text[3] == "e" or text[3] == "E")
+        and (text[4] == "l" or text[4] == "L")
+        and text[5] == " "
+        and (text[6] == "s" or text[6] == "S")
+        and (text[7] == "i" or text[7] == "I")
+        and (text[8] == "z" or text[8] == "Z")
+        and (text[9] == "e" or text[9] == "E")
+    )
 
 
 def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:


### PR DESCRIPTION
## Summary
- Fast-path the common `Model size: ...` card-data label before the generic case-insensitive scanner.
- Replace the remaining `text[:10].lower()` prefix check with a no-allocation ASCII predicate.
- Add regression coverage for mixed-case `model size` labels and document the slice plan.

## Plan or Spec
- `docs/plans/2026-05-31-hub-size-label-prefix-fastpath.md`
- Registered PR-scoped probe: `hub-catalog-size-hint-regex-precompile`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`

## Coverage and Metrics
- Focused tests: 64 passed.
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Local registered probe baseline (`origin/main`): `elapsed_ms_mean=1544.3354067392647`, `payload_compatibility_elapsed_ms_mean=278.76502564176917`, `size_hint_calls_mean=40000.0`.
- Local registered probe candidate: `elapsed_ms_mean=1416.908242739737`, `payload_compatibility_elapsed_ms_mean=278.5422785207629`, `size_hint_calls_mean=40000.0`.
- Delta: `elapsed_ms_mean -127.427ms` (`~8.25%` faster), compatibility metric effectively unchanged (`-0.223ms`).

## Known Gaps
- Linux local validation covers the Python path only; CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused behavior tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Local registered probe shows a positive size-hint latency delta.
- [ ] GitHub Actions and registered PR-scoped performance report complete successfully.
