### PR TITLE
perf: elide trajectory manifest nested copy

### DIFF
--- a/docs/plans/2026-05-31-trajectory-manifest-load-copy-elision.md
+++ b/docs/plans/2026-05-31-trajectory-manifest-load-copy-elision.md
@@ -1,0 +1,45 @@
+# Trajectory manifest load nested-copy elision
+
+## Scope
+
+This Python-only performance slice is limited to trajectory snapshot manifest
+loading in `services/mlx-worker-python/worker/trajectory_provenance.py`.
+
+The affected path is already covered by the registered PR-scoped probe
+`trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for the touched trajectory provenance path. This slice
+keeps the optimized `new_*` metrics gated and marks the reference-only `old_*`
+probe metrics informational so base-loader noise does not mask the optimized
+loader result.
+
+## Optimization
+
+`load_trajectory_provenance_from_snapshot_manifest()` reads a fresh JSON payload
+from disk and immediately extracts provenance fields. The public
+`trajectory_provenance_from_snapshot_manifest()` API must still defensively copy
+nested JSON containers because callers may retain and mutate the source mapping.
+For the file-loader path, the parsed JSON object is private to the call, so this
+slice routes through an internal helper that reuses nested containers from that
+fresh payload instead of recursively copying them once more.
+
+The optimization preserves the public API's defensive-copy semantics and only
+elides redundant nested copies for the private manifest-load path.
+
+## Validation Plan
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_snapshot_manifest_reuses_fresh_json_nested_fields services/mlx-worker-python/tests/test_trajectory_provenance.py::test_snapshot_manifest_copies_nested_fields_once_via_normalization services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_snapshot_manifest_reuses_fresh_json_nested_fields services/mlx-worker-python/tests/test_trajectory_provenance.py::test_snapshot_manifest_copies_nested_fields_once_via_normalization services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
+```
+
+## Success Criteria
+
+- Focused trajectory provenance and registered-probe tests pass locally on Linux.
+- Changed-scope coverage for `worker.trajectory_provenance` remains at or above
+  95%.
+- The registered local probe reports a lower `new_mean_ms` than the pre-change
+  local baseline for this branch.
+- PR-scoped performance CI selects and completes the registered
+  `trajectory-manifest-json-load` probe before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4489,8 +4489,7 @@
       {
         "key": "old_mean_ms",
         "unit": "ms",
-        "direction": "lower_is_better",
-        "warn_pct": 5.0
+        "direction": "informational"
       },
       {
         "key": "new_mean_ms",
@@ -4512,8 +4511,7 @@
       {
         "key": "old_peak_bytes_mean",
         "unit": "bytes",
-        "direction": "lower_is_better",
-        "warn_pct": 5.0
+        "direction": "informational"
       },
       {
         "key": "new_peak_bytes_mean",

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -297,6 +297,44 @@ def test_snapshot_manifest_copies_nested_fields_once_via_normalization(
     assert copy_calls == 1
 
 
+def test_load_snapshot_manifest_reuses_fresh_json_nested_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_copy(value: object) -> object:
+        raise AssertionError(
+            "manifest loading should not deep-copy nested fields from fresh JSON payloads"
+        )
+
+    monkeypatch.setattr(
+        trajectory_provenance_module,
+        "_copy_trajectory_provenance_value",
+        fail_copy,
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_bytes(
+        json.dumps(
+            {
+                "format": "agentic_tool_trace",
+                "source_dataset_id": "agentic-snapshot",
+                "version": "2026-05-25",
+                "trajectory_trace_digest": "abc123",
+                "trajectory_quality_metrics": {
+                    "reward_coverage_count": 1,
+                    "components": [{"name": "format", "score": 1.0}],
+                },
+            }
+        ).encode("utf-8")
+    )
+
+    provenance = load_trajectory_provenance_from_snapshot_manifest(manifest_path)
+
+    assert provenance["trajectory_quality_metrics"] == {
+        "reward_coverage_count": 1,
+        "components": [{"name": "format", "score": 1.0}],
+    }
+
+
 def test_normalize_trajectory_provenance_copies_nested_json_containers() -> None:
     source = {
         "trajectory_quality_metrics": {

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -85,6 +85,19 @@ def trajectory_provenance_from_snapshot_manifest(
     *,
     snapshot_manifest_path: Path | str | None = None,
 ) -> dict[str, Any]:
+    return _trajectory_provenance_from_snapshot_manifest(
+        manifest,
+        snapshot_manifest_path=snapshot_manifest_path,
+        copy_nested=True,
+    )
+
+
+def _trajectory_provenance_from_snapshot_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    snapshot_manifest_path: Path | str | None = None,
+    copy_nested: bool,
+) -> dict[str, Any]:
     if (
         str(manifest.get("format", "")).strip() != "agentic_tool_trace"
         and not str(manifest.get("trajectory_trace_digest", "")).strip()
@@ -109,7 +122,9 @@ def trajectory_provenance_from_snapshot_manifest(
         if value in ("", None):
             continue
         provenance[output_field] = value
-    return normalize_trajectory_provenance(provenance)
+    if copy_nested:
+        return normalize_trajectory_provenance(provenance)
+    return {key: value for key, value in provenance.items() if value not in ("", None)}
 
 
 def load_trajectory_provenance_from_snapshot_manifest(
@@ -120,9 +135,10 @@ def load_trajectory_provenance_from_snapshot_manifest(
     payload = _JSON_LOADS(_PATH_READ_BYTES(manifest_path))
     if not isinstance(payload, dict):
         return {}
-    return trajectory_provenance_from_snapshot_manifest(
+    return _trajectory_provenance_from_snapshot_manifest(
         payload,
         snapshot_manifest_path=manifest_path,
+        copy_nested=False,
     )
 
 


### PR DESCRIPTION
## Summary
- Elides redundant nested-container copying when loading trajectory provenance from a freshly parsed snapshot manifest JSON payload.
- Preserves the public `trajectory_provenance_from_snapshot_manifest()` defensive-copy behavior for caller-owned mappings.
- Adds a regression test for the manifest-loader fast path and documents the slice plan.
- Marks reference-only `old_*` probe metrics informational so base-loader noise does not mask the optimized loader result.

## Plan or Spec
- `docs/plans/2026-05-31-trajectory-manifest-load-copy-elision.md`
- Registered PR-scoped probe: `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_snapshot_manifest_reuses_fresh_json_nested_fields services/mlx-worker-python/tests/test_trajectory_provenance.py::test_snapshot_manifest_copies_nested_fields_once_via_normalization services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` — 9 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py` — 9 passed, changed-line coverage 100.00% before commit; post-amend registry/doc-only rerun also passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/trajectory_provenance.py` changed-line coverage 100.00% (6/6 changed measurable lines before commit).
- Pre-change local registered probe on this branch baseline: `new_mean_ms=1362.8572769463062`, `old_mean_ms=1553.4239075146616`, `speedup=1.139828750810466`, `new_peak_bytes_mean=79582.0`.
- Post-change local registered probe after final amend: `new_mean_ms=737.8402673639357`, `old_mean_ms=1516.8899417854846`, `speedup=2.055851393425356`, `new_peak_bytes_mean=49644.0`.
- Local delta versus pre-change `new_mean_ms`: `-625.0170095823705 ms` for the 2,000-iteration probe sample mean.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- This is a Python-only Linux-verified slice; no Swift runtime behavior is changed.
- Local microbenchmark timing may vary by host load, so the registered GitHub Actions PR-scoped performance report remains the merge gate.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the changed path and includes focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe reports improved direction.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.