### PR TITLE
perf: tighten native MTP safetensor listing loop

### DIFF
--- a/docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md
+++ b/docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md
@@ -1,0 +1,26 @@
+# Native MTP model safetensor name loop slice
+
+This Python-only performance slice is limited to the native-MTP loader's top-level `model*.safetensors` listing helper in `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`.
+
+## Scope
+
+Registered PR-scoped probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+The prior helper used a list comprehension that read `entry.name` twice for every directory entry while filtering a large model directory. This slice keeps the existing `os.scandir()` behavior and sorted `glob`-compatible output, but switches the hot path to an explicit loop that binds `entry.name` once and reuses a bound append method.
+
+The probe is extended to measure the model safetensor listing path directly against the historical `glob.glob(str(model_dir / "model*.safetensors"))` baseline, while preserving the existing index JSON, sidecar shard, and key predicate metrics.
+
+## Verification plan
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/native_mtp_loader_safetensor_scandir_probe.py"; python3 "$SCRIPT"'
+```
+
+## Success criteria
+
+- Focused native-MTP tests pass locally on Linux.
+- Changed-scope coverage for `mlx_lm_loader.py` remains at least 95%.
+- Registered probe emits `model_listing_*` metrics and keeps behavior parity with the `glob` baseline.
+- `model_listing_new_mean_ms` is lower than `model_listing_old_mean_ms` on the local Linux probe run or CI report.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4583,6 +4583,46 @@
         "warn_pct": 0.0
       },
       {
+        "key": "model_listing_old_mean_ms",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "model_listing_new_mean_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "model_listing_delta_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "model_listing_speedup",
+        "unit": "x",
+        "direction": "higher_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "model_listing_old_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      },
+      {
+        "key": "model_listing_new_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "model_listing_result_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      },
+      {
         "key": "extra_old_mean_ms",
         "unit": "ms",
         "direction": "informational"

--- a/scripts/native_mtp_loader_safetensor_scandir_probe.py
+++ b/scripts/native_mtp_loader_safetensor_scandir_probe.py
@@ -160,6 +160,16 @@ def run_probe() -> dict[str, float | int | str]:
         candidate = candidate_callback(model_dir)
         if baseline != candidate:
             raise SystemExit("candidate safetensor listing differs from glob baseline")
+        model_listing_old_ms, model_listing_old_peaks, model_listing_result_count = _measure(
+            _glob_model_safetensors,
+            model_dir,
+            samples=samples,
+        )
+        model_listing_new_ms, model_listing_new_peaks, _ = _measure(
+            candidate_callback,
+            model_dir,
+            samples=samples,
+        )
 
         index_path = model_dir / "model.safetensors.index.json"
         old_payload = _read_text_json_payload(index_path)
@@ -220,8 +230,11 @@ def run_probe() -> dict[str, float | int | str]:
     extra_new_mean = statistics.mean(extra_new_ms)
     key_old_mean = statistics.mean(key_old_ms)
     key_new_mean = statistics.mean(key_new_ms)
+    model_listing_old_mean = statistics.mean(model_listing_old_ms)
+    model_listing_new_mean = statistics.mean(model_listing_new_ms)
     return {
         "result_count": result_count,
+        "model_listing_result_count": model_listing_result_count,
         "extra_result_count": extra_result_count,
         "model_files": model_files,
         "distractor_files": distractor_files,
@@ -234,6 +247,14 @@ def run_probe() -> dict[str, float | int | str]:
         "key_new_mean_ms": key_new_mean,
         "key_delta_ms": key_new_mean - key_old_mean,
         "key_speedup": key_old_mean / key_new_mean if key_new_mean else 0.0,
+        "model_listing_old_mean_ms": model_listing_old_mean,
+        "model_listing_new_mean_ms": model_listing_new_mean,
+        "model_listing_delta_ms": model_listing_new_mean - model_listing_old_mean,
+        "model_listing_speedup": model_listing_old_mean / model_listing_new_mean
+        if model_listing_new_mean
+        else 0.0,
+        "model_listing_old_peak_bytes_mean": statistics.mean(model_listing_old_peaks),
+        "model_listing_new_peak_bytes_mean": statistics.mean(model_listing_new_peaks),
         "old_mean_ms": old_mean,
         "new_mean_ms": new_mean,
         "delta_ms": new_mean - old_mean,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -321,6 +321,9 @@ def test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics(
     assert metrics["old_mean_ms"] >= 0.0
     assert metrics["new_mean_ms"] >= 0.0
     assert metrics["result_count"] == 24
+    assert metrics["model_listing_old_mean_ms"] >= 0.0
+    assert metrics["model_listing_new_mean_ms"] >= 0.0
+    assert metrics["model_listing_result_count"] == 10
     assert metrics["extra_result_count"] == 8
     assert metrics["model_files"] == 8
     assert metrics["distractor_files"] == 8
@@ -3187,10 +3190,15 @@ def test_registered_probe_registry_entries_validate_commands_and_watch_globs() -
         "old_peak_bytes_mean",
         "extra_old_mean_ms",
         "extra_old_peak_bytes_mean",
+        "model_listing_old_mean_ms",
+        "model_listing_old_peak_bytes_mean",
         "key_old_mean_ms",
     ):
         assert native_mtp_metrics[metric_key]["direction"] == "informational"
         assert "warn_pct" not in native_mtp_metrics[metric_key]
+    assert native_mtp_metrics["model_listing_new_mean_ms"]["direction"] == "lower_is_better"
+    assert native_mtp_metrics["model_listing_delta_ms"]["direction"] == "lower_is_better"
+    assert native_mtp_metrics["model_listing_speedup"]["direction"] == "higher_is_better"
     assert native_mtp_metrics["key_new_mean_ms"]["direction"] == "lower_is_better"
     assert native_mtp_metrics["key_delta_ms"]["direction"] == "lower_is_better"
     assert native_mtp_metrics["key_speedup"]["direction"] == "higher_is_better"

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -31,14 +31,14 @@ def _is_mtp_weight_key(key: Any) -> bool:
 def _model_safetensor_files(model_path: Path) -> list[str]:
     """Return top-level ``model*.safetensors`` paths without glob allocation."""
 
+    weight_files: list[str] = []
+    append_weight_file = weight_files.append
     try:
         with os.scandir(model_path) as entries:
-            weight_files = [
-                entry.path
-                for entry in entries
-                if entry.name.startswith("model")
-                and entry.name.endswith(".safetensors")
-            ]
+            for entry in entries:
+                name = entry.name
+                if name.startswith("model") and name.endswith(".safetensors"):
+                    append_weight_file(entry.path)
     except FileNotFoundError:
         return []
     weight_files.sort()


### PR DESCRIPTION
## Summary
- Tightens the native-MTP top-level `model*.safetensors` listing loop by reading each `DirEntry.name` once and reusing a bound append method.
- Extends the registered `native-mtp-loader-safetensor-scandir` probe with direct `model_listing_*` metrics against the historical `glob` baseline.

## Plan or Spec
- `docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md`

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics
8 passed in 0.89s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
6 passed in 0.29s
changed_line_coverage=100.00%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
2 passed in 0.08s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
exit 0; metrics captured below
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` changed lines 34,35,38,39,40,41: 6/6 covered, `100.00%`.
- Registered local Linux probe (`native-mtp-loader-safetensor-scandir`):
  - `model_listing_old_mean_ms=21.47027850151062`
  - `model_listing_new_mean_ms=9.114708565175533`
  - `model_listing_delta_ms=-12.355569936335087`
  - `model_listing_speedup=2.355563905086541`
  - `model_listing_old_peak_bytes_mean=338942.0`
  - `model_listing_new_peak_bytes_mean=163217.0`
- Existing probe dimensions remained positive: `extra_speedup=1.9758032806280768`, `key_speedup=1.1801670004872669`, `speedup=1.0460497847546395`.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Linux local validation only; no Swift runtime behavior is changed.
- Full repository `make py-test` / `make integration-test` not run locally for this focused Python slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; probe overhead is bounded to synthetic CI/local probe execution.
- [x] Deferred work and known gaps are stated explicitly.
