### PR TITLE
perf: fast-path hub weight suffix checks

### DIFF
--- a/docs/plans/2026-05-31-hub-catalog-weight-config-suffix-fastpath.md
+++ b/docs/plans/2026-05-31-hub-catalog-weight-config-suffix-fastpath.md
@@ -1,0 +1,22 @@
+# Hub catalog weight/config suffix fast path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.model_ops.hub_catalog._is_weight_or_config_file`, the helper used while summarizing Hub sibling metadata for local-fit evidence.
+
+## Registered probe
+
+The affected source path is already covered by the registered PR-scoped probe `hub-catalog-tag-normalization-single-pass` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for `services/mlx-worker-python/worker/model_ops/hub_catalog.py`, `services/mlx-worker-python/tests/test_hub_catalog.py`, `services/mlx-worker-python/tests/test_pr_scoped_performance.py`, and `scripts/hub_catalog_tag_normalization_probe.py`.
+
+## Optimization hypothesis
+
+Hub sibling filenames are normally already lowercase (`config.json`, `tokenizer.json`, `.safetensors`, `.npz`, `.gguf`). The current helper lowercases every candidate filename before suffix checks. A case-sensitive fast path for the common lowercase suffixes can avoid per-file lowercase allocation while preserving the existing case-insensitive fallback for uncommon mixed-case metadata.
+
+## Validation plan
+
+1. Add a focused regression test that covers lowercase suffix matches, mixed-case fallback matches, and non-weight false positives.
+2. Implement only the lowercase suffix fast path plus unchanged case-insensitive fallback.
+3. Run the registered focused test command locally on Linux.
+4. Run changed-scope coverage locally on Linux and require at least 95% for the changed scope.
+5. Run the registered probe locally against this branch and compare with the pre-change baseline captured from `origin/main` in the same worktree.
+6. Use PR-scoped performance CI as the final registered probe gate before merge.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -188,6 +188,14 @@ def test_direct_card_size_hint_preserves_case_insensitive_label_prefix() -> None
     assert hub_catalog_module._direct_card_size_hint_from_text("model-size: 2 GB") == 0
 
 
+def test_weight_or_config_file_preserves_case_insensitive_matches() -> None:
+    assert hub_catalog_module._is_weight_or_config_file("config.json") is True
+    assert hub_catalog_module._is_weight_or_config_file("model.safetensors") is True
+    assert hub_catalog_module._is_weight_or_config_file("Tokenizer.JSON") is True
+    assert hub_catalog_module._is_weight_or_config_file("weights.SAFETENSORS") is True
+    assert hub_catalog_module._is_weight_or_config_file("notes.json") is False
+
+
 def test_search_models_with_mlx_only_prefilters_payloads_before_local_fit(monkeypatch: pytest.MonkeyPatch) -> None:
     payload = [
         {

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -27,6 +27,7 @@ _SIZE_HINT_MULTIPLIERS = {
 _BARE_SIZE_HINT_RE = re.compile(r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _EXPLICIT_SIZE_HINT_RE = re.compile(r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _NEXT_LINK_REL_MARKER = 'rel="next"'
+_LOWERCASE_WEIGHT_OR_CONFIG_SUFFIXES = (".safetensors", ".npz", ".gguf", "config.json", "tokenizer.json")
 @dataclass(frozen=True, slots=True)
 class HubModelSummaryRecord:
     repo_id: str
@@ -585,8 +586,10 @@ def _sibling_file_bytes(value: Any) -> int:
 
 
 def _is_weight_or_config_file(filename: str) -> bool:
+    if filename.endswith(_LOWERCASE_WEIGHT_OR_CONFIG_SUFFIXES):
+        return True
     lowered = filename.lower()
-    return lowered.endswith((".safetensors", ".npz", ".gguf", "config.json", "tokenizer.json"))
+    return lowered.endswith(_LOWERCASE_WEIGHT_OR_CONFIG_SUFFIXES)
 
 
 def _size_hint_bytes(payload: dict[str, Any]) -> int:


### PR DESCRIPTION
## Summary
- Add a lowercase suffix fast path for Hub sibling weight/config filename checks.
- Preserve the existing case-insensitive fallback for mixed-case Hub metadata.
- Add a focused regression test for lowercase, mixed-case, and non-weight filenames.

## Plan or Spec
- `docs/plans/2026-05-31-hub-catalog-weight-config-suffix-fastpath.md`
- Registered PR-scoped probe: `hub-catalog-tag-normalization-single-pass` in `infra/perf/pr_scoped_probes.json` (already includes `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# Pre-change local probe baseline on origin/main checkout:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
exit 0; elapsed_ms_mean=238.03172949701548; peak_bytes_mean=9835217.2; tag_normalization_calls_mean=5000.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
exit 0; 65 passed in 1.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py
exit 0; 65 passed in 0.41s; TOTAL 10 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
exit 0; elapsed_ms_mean=234.73026724532247; peak_bytes_mean=9835382.0; tag_normalization_calls_mean=5000.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-tag-normalization-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-hub-catalog-mlx-tag-atom-fastpath-20260531-base --head-repo "$PWD" --output /tmp/hub_catalog_mlx_tag_atom_probe.json
exit 0; head verification ok; base/head probes ok
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Local registered probe comparison (`hub-catalog-tag-normalization-single-pass`, base vs head via `scripts/pr_scoped_performance_run.py`):
  - `elapsed_ms_mean`: base `232.127848546952` ms -> head `226.1576478369534` ms (`-5.970200709998608` ms, `2.571945049837925%` faster).
  - `tag_normalization_calls_mean`: base `5000.0` -> head `5000.0` (unchanged expected structural count).
  - `peak_bytes_mean`: base `9835193.2` -> head `9835442.8` bytes (informational small increase).
- Earlier single local pre/post probe run: `238.03172949701548` ms -> `234.73026724532247` ms (`1.3869841044592357%` faster).
- CI PR-scoped performance is required as the final registered probe validation before merge.

## Known Gaps
- This is a Python-only Linux-verified slice; no Swift runtime effect is claimed.
- The selected registered probe is synthetic and focused on Hub summary-record construction; it does not measure live Hugging Face network latency.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
