### PR TITLE
perf: add ascii token count fast path

### DIFF
--- a/docs/plans/2026-05-31-token-count-ascii-fastpath.md
+++ b/docs/plans/2026-05-31-token-count-ascii-fastpath.md
@@ -1,0 +1,29 @@
+# Token count ASCII whitespace fast path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.runtime.token_counting.whitespace_token_count()` and its existing deterministic vision callers. The helper remains the shared token-counting implementation for deterministic OCR/VLM usage metrics.
+
+## Registered probes
+
+The affected helper is already covered by registered PR-scoped probes in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries:
+
+- `deterministic-ocr-token-count-scan`
+- `deterministic-vlm-completion-token-scan`
+
+Both probes watch `services/mlx-worker-python/worker/runtime/token_counting.py` plus their focused tests and probe scripts. The OCR probe is used as the primary local Linux probe for this slice; CI remains the repository merge gate and will run the registered PR-scoped performance workflow for the changed scope.
+
+## Plan
+
+1. Preserve the non-allocating single-pass token counter semantics.
+2. Add an ASCII-only whitespace membership fast path using the exact ASCII whitespace set recognized by `str.split()`/`str.isspace()` for ASCII text.
+3. Keep the existing Unicode fallback path through `str.isspace()` so non-ASCII whitespace semantics are unchanged.
+4. Add regression coverage for ASCII vertical-tab/form-feed whitespace and non-ASCII Unicode whitespace.
+5. Run focused OCR/VLM token-count tests, changed-scope coverage, and the registered OCR/VLM probes locally on Linux before opening the PR.
+
+## Acceptance
+
+- Focused behavior tests pass locally.
+- Changed-scope coverage for `token_counting.py` and touched tests is at least 95%.
+- Registered local probes report directionally lower elapsed time for the ASCII-heavy synthetic token-count workload.
+- GitHub Actions and the PR-scoped performance report complete successfully before merge.

--- a/scripts/deterministic_ocr_token_count_probe.py
+++ b/scripts/deterministic_ocr_token_count_probe.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
 
 from worker.runtime.deterministic_ocr_runtime import DeterministicOCRRuntime  # noqa: E402
 from worker.runtime.multimodal_preprocessing import PreparedImageInput, PreparedVisionRequest  # noqa: E402
+from worker.runtime.token_counting import whitespace_token_count  # noqa: E402
 
 
 def _request(prompt_text: str, image_bytes: bytes) -> PreparedVisionRequest:
@@ -45,6 +46,8 @@ def main() -> None:
     prompt_text = "\tExtract   the receipt text and preserve\nline breaks  " * 8
     image_bytes = (b"Receipt Total 42\n" * 64) + b"end"
     request = _request(prompt_text, image_bytes)
+    helper_texts = tuple(f"{prompt_text}sample-{index}" for index in range(1024))
+    helper_expected = tuple(len(text.split()) for text in helper_texts)
     runtime = DeterministicOCRRuntime()
     expected = max(1, len(prompt_text.split()) + max(1, len(image_bytes) // 8))
 
@@ -58,7 +61,12 @@ def main() -> None:
             token_count = runtime.prompt_token_count(request)
             if token_count != expected:
                 raise AssertionError(f"unexpected token count: {token_count} != {expected}")
-            checksum += token_count
+            helper_index = _index % len(helper_texts)
+            whitespace_token_count.cache_clear()
+            helper_token_count = whitespace_token_count(helper_texts[helper_index])
+            if helper_token_count != helper_expected[helper_index]:
+                raise AssertionError("unexpected helper token count")
+            checksum += token_count + helper_token_count
         elapsed_samples.append((time.perf_counter() - started) * 1000.0)
         _, peak = tracemalloc.get_traced_memory()
         peak_samples.append(float(peak))
@@ -73,6 +81,7 @@ def main() -> None:
                 "iterations": float(iterations),
                 "token_count": float(expected),
                 "checksum": float(checksum),
+                "helper_token_count": float(helper_expected[-1]),
             },
             sort_keys=True,
         )

--- a/scripts/deterministic_vlm_completion_token_probe.py
+++ b/scripts/deterministic_vlm_completion_token_probe.py
@@ -57,6 +57,7 @@ def _run_once(*, iterations: int, word_count: int) -> tuple[float, int, float, i
     def counting_token_count(text: str) -> int:
         nonlocal token_count_calls
         token_count_calls += 1
+        original_token_count.cache_clear()
         return original_token_count(text)
 
     try:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -5755,6 +5755,7 @@ def test_deterministic_ocr_token_count_probe_script_emits_metrics(
     assert metrics["sample_count"] == 1.0
     assert metrics["iterations"] == 10.0
     assert metrics["token_count"] > 0
+    assert metrics["helper_token_count"] > 0
 
 
 def test_deterministic_vlm_completion_token_probe_script_emits_metrics(

--- a/services/mlx-worker-python/tests/test_vision_runtime.py
+++ b/services/mlx-worker-python/tests/test_vision_runtime.py
@@ -169,6 +169,8 @@ def test_ocr_token_count_scans_whitespace_without_split_list() -> None:
     runtime = DeterministicOCRRuntime()
 
     assert whitespace_token_count(prompt_text) == len(prompt_text.split())
+    assert whitespace_token_count("alpha beta\v gamma\fdelta") == 4
+    assert whitespace_token_count("alpha\u2003beta gamma") == 3
     assert runtime.prompt_token_count(request) == len(prompt_text.split()) + max(
         1,
         request.images[0].byte_length // 8,

--- a/services/mlx-worker-python/worker/runtime/token_counting.py
+++ b/services/mlx-worker-python/worker/runtime/token_counting.py
@@ -2,11 +2,23 @@ from __future__ import annotations
 
 from functools import lru_cache
 
+_ASCII_WHITESPACE = frozenset(" \t\n\r\v\f")
+
 
 @lru_cache(maxsize=512)
 def whitespace_token_count(text: str) -> int:
     token_count = 0
     in_token = False
+    if text.isascii():
+        whitespace = _ASCII_WHITESPACE
+        for character in text:
+            if character in whitespace:
+                in_token = False
+            elif not in_token:
+                token_count += 1
+                in_token = True
+        return token_count
+
     is_space = str.isspace
     for character in text:
         if is_space(character):


### PR DESCRIPTION
## Summary
- Adds an ASCII whitespace fast path to the shared Python `whitespace_token_count()` helper while preserving the Unicode `str.isspace()` fallback.
- Extends focused OCR/VLM token-count probes so the registered PR-scoped performance workflow exercises the helper instead of only cached runtime paths.
- Adds regression coverage for ASCII vertical-tab/form-feed whitespace and Unicode whitespace parity.

## Plan or Spec
- Plan: `docs/plans/2026-05-31-token-count-ascii-fastpath.md`
- Registered PR-scoped probes: `deterministic-ocr-token-count-scan` and `deterministic-vlm-completion-token-scan` in `infra/perf/pr_scoped_probes.json`.
- No API, protocol, dependency, or generated protobuf changes.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_same_request_cache services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_completion_token_count_scans_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_completion_token_count_reuses_last_response_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_vlm_completion_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_vlm_completion_token_probe_script_emits_metrics
# 10 passed in 1.42s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_same_request_cache services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_completion_token_count_scans_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_completion_token_count_reuses_last_response_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_vlm_completion_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_vlm_completion_token_probe_script_emits_metrics
# rerun with corrected test path: 10 passed in 1.04s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_ocr_token_count_probe.py scripts/deterministic_vlm_completion_token_probe.py
# TOTAL 23 1 96%

# Baseline with updated OCR probe script against origin/main implementation:
PYTHONPATH="$BASE:$BASE/services/mlx-worker-python" uv run --project "$BASE/services/mlx-worker-python" python3 /tmp/deterministic_ocr_token_count_probe.py
# elapsed_ms_mean=1572.279881
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py
# elapsed_ms_mean=1404.948579

# Baseline with updated VLM probe script against origin/main implementation:
PYTHONPATH="$BASE:$BASE/services/mlx-worker-python" uv run --project "$BASE/services/mlx-worker-python" python3 /tmp/deterministic_vlm_completion_token_probe.py
# elapsed_ms_mean=53.1625029630959
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_vlm_completion_token_probe.py
# elapsed_ms_mean=46.81934332475066

git diff --check
# passed
```

## Coverage and Metrics
- Focused tests: `10 passed`.
- Changed-scope coverage: `TOTAL 23 1 96%`.
- OCR registered probe path, updated script vs `origin/main`: old_mean=`1572.279881 ms`, new_mean=`1404.948579 ms`, delta=`-167.331302 ms`, speedup=`1.1191x`.
- VLM registered probe path, updated script vs `origin/main`: old_mean=`53.1625029630959 ms`, new_mean=`46.81934332475066 ms`, delta=`-6.343160 ms`, speedup=`1.1355x`.
- CI PR-scoped performance workflow is required as the repository merge gate.

## Known Gaps
- Local validation ran on Linux only; this slice changes Python runtime/probe code and does not claim Swift runtime validation.
- The local probe comparison used the updated probe scripts against the `origin/main` implementation to make the helper hot path measurable.
- `uv` printed a non-blocking warning that the ambient Hermes `VIRTUAL_ENV` differs from the project `.venv`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or N/A: probe-only overhead is documented through the registered OCR/VLM probe updates.
- [x] Deferred work and known gaps are stated explicitly.
