### PR TITLE
perf: fast path dataset split alias lookup

### DIFF
--- a/docs/plans/2026-05-31-dataset-split-lowercase-fastpath.md
+++ b/docs/plans/2026-05-31-dataset-split-lowercase-fastpath.md
@@ -1,0 +1,19 @@
+# Dataset split alias lowercase fast path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.dataset_registry.catalog._split_alias_from_candidate(...)`, the hot helper used while inferring dataset split/config metadata for Hugging Face snapshot files.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probes `dataset-registry-snapshot-inference-single-pass` and `dataset-registry-limited-read-streaming` in `infra/perf/pr_scoped_probes.json`. Both probes watch `services/mlx-worker-python/worker/dataset_registry/catalog.py` and include focused `test_command`, `coverage_command`, and `probe_command` entries. The snapshot inference probe is the primary validation source for this slice because it repeatedly infers split/config metadata across synthetic snapshot files.
+
+## Plan
+
+Dataset snapshot paths normally use lowercase split prefixes such as `train`, `validation`, and `test`. The current alias helper lowercases every candidate prefix before looking it up, even when the prefix is already in canonical lowercase form. Add a direct alias lookup first and only allocate a lowercase fallback for uncommon mixed-case inputs.
+
+Behavior stays equivalent because the fallback keeps the existing case-insensitive matching semantics for mixed-case dataset paths and unknown lowercase prefixes still return no alias.
+
+## Verification
+
+Run the registered focused dataset-registry tests, changed-scope coverage, and the registered snapshot-inference probe locally on Linux before pushing. GitHub Actions PR-scoped performance remains the merge gate.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -883,6 +883,23 @@ def test_dataset_catalog_split_matching_skips_stem_for_direct_prefix_hits(
     assert stem_calls == []
 
 
+def test_dataset_catalog_split_alias_skips_lower_for_common_lowercase_prefix() -> None:
+    class LowerCountingStr(str):
+        lower_calls = 0
+
+        def lower(self) -> str:
+            type(self).lower_calls += 1
+            return super().lower()
+
+    assert catalog._split_alias_from_candidate(LowerCountingStr("validation")) == "validation"
+    assert LowerCountingStr.lower_calls == 0
+
+    assert catalog._split_alias_from_candidate(LowerCountingStr("Validation")) == "validation"
+    assert LowerCountingStr.lower_calls == 1
+    assert catalog._split_alias_from_candidate("validation-00000") == "validation"
+    assert catalog._split_alias_from_candidate("Validation-00000") == "validation"
+
+
 def test_dataset_catalog_string_stem_matches_pathlib_for_split_names() -> None:
     expected = {
         "train.jsonl": "train",

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -941,8 +941,14 @@ def _inferred_split_and_config(relative_path: str) -> tuple[str, str]:
 
 def _split_alias_from_candidate(candidate: str) -> str:
     delimiter_index = _first_split_alias_delimiter(candidate)
-    prefix = candidate[:delimiter_index].lower() if delimiter_index >= 0 else candidate.lower()
-    return _SPLIT_ALIASES.get(prefix, "")
+    prefix = candidate[:delimiter_index] if delimiter_index >= 0 else candidate
+    split = _SPLIT_ALIASES.get(prefix)
+    if split is not None:
+        return split
+    lowered = prefix.lower()
+    if lowered == prefix:
+        return ""
+    return _SPLIT_ALIASES.get(lowered, "")
 
 
 def _first_split_alias_delimiter(candidate: str) -> int:


### PR DESCRIPTION
## Summary
- Fast-path lowercase dataset split alias lookup before falling back to case-insensitive normalization.
- Add regression coverage proving canonical lowercase aliases avoid the `.lower()` call while mixed-case aliases still match.

## Plan or Spec
- `docs/plans/2026-05-31-dataset-split-lowercase-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics
# 52 passed in 0.30s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py
# changed-scope coverage: TOTAL 20 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py
# {"elapsed_ms_mean": 676.9205106422305, "file_count_mean": 2401.0, "legacy_inference_helper_calls_mean": 0.0, "peak_bytes_mean": 780889.0, "sample_count": 5.0}
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 20 0 100%`).
- Local Linux same-command probe comparison against `origin/main`:
  - baseline: `elapsed_ms_mean=667.526532523334`, `peak_bytes_mean=780889.0`, `file_count_mean=2401.0`, `sample_count=5.0`
  - candidate: `elapsed_ms_mean=655.1527730189264`, `peak_bytes_mean=780889.0`, `file_count_mean=2401.0`, `sample_count=5.0`
  - delta: `-12.374ms` (`~1.85%` faster), peak bytes unchanged.
- Registered PR-scoped performance CI is required before merge.

## Known Gaps
- Local validation is Linux/Python only; CI remains the registered probe merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
