### PR TITLE
perf: avoid trajectory manifest return filter

### DIFF
--- a/docs/plans/2026-05-31-trajectory-manifest-fast-return.md
+++ b/docs/plans/2026-05-31-trajectory-manifest-fast-return.md
@@ -1,0 +1,38 @@
+# Trajectory Manifest Fast Return Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to trajectory provenance manifest loading in `services/mlx-worker-python/worker/trajectory_provenance.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`. The probe defines focused `test_command`, `coverage_command`, and `probe_command` entries and emits:
+
+- `old_mean_ms`
+- `new_mean_ms`
+- `delta_ms`
+- `speedup`
+- `old_peak_bytes_mean`
+- `new_peak_bytes_mean`
+
+## Linux verification boundary
+
+This slice is Python-only and locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered command-json performance probe.
+
+## Optimization hypothesis
+
+`load_trajectory_provenance_from_snapshot_manifest()` reads fresh JSON payloads and uses `copy_nested=False`, so the manifest-load path does not need the final dictionary-comprehension pass that re-filters empty values after provenance fields are already assembled. Building the provenance mapping with non-empty scalar fields up front preserves empty-field omission while avoiding the extra pass on every manifest load.
+
+## Validation plan
+
+1. Run the registered focused tests for `trajectory-manifest-json-load`.
+2. Run the registered changed-scope coverage command for the same probe.
+3. Run the registered probe locally on Linux before pushing.
+4. Use PR-scoped performance CI as the final registered probe gate before merge.
+
+## Acceptance criteria
+
+- Behavior remains unchanged for empty/unrelated manifest inputs and fresh JSON nested fields.
+- Changed-scope coverage remains at or above 95% for `trajectory_provenance.py`.
+- Local registered probe shows lower `new_mean_ms` versus the synced `origin/main` baseline sample.
+- PR-scoped performance CI selects and completes `trajectory-manifest-json-load` successfully.

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -254,6 +254,18 @@ def test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs(
     assert trajectory_provenance_from_snapshot_manifest({"format": "text"}) == {}
     assert load_trajectory_provenance_from_snapshot_manifest(non_mapping_manifest) == {}
     assert load_trajectory_provenance_from_snapshot_manifest(str(non_mapping_manifest)) == {}
+    assert trajectory_provenance_from_snapshot_manifest(
+        {
+            "format": "agentic_tool_trace",
+            "source_dataset_id": "",
+            "version": "",
+            "trajectory_trace_digest": "abc123",
+        }
+    ) == {
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "trajectory_split": "train",
+        "trajectory_trace_digest": "abc123",
+    }
     assert (
         load_trajectory_provenance_from_normalized_snapshot(
             format_name="text",

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -104,17 +104,26 @@ def _trajectory_provenance_from_snapshot_manifest(
     ):
         return {}
 
-    provenance: dict[str, Any] = {
-        "trajectory_dataset_id": str(
-            manifest.get("source_dataset_id") or manifest.get("dataset_id") or ""
-        ).strip(),
-        "trajectory_dataset_version": str(manifest.get("version") or "").strip(),
-        "trajectory_schema_version": str(
-            manifest.get("trajectory_schema_version") or "melix.agentic_tool_trace.v1"
-        ).strip(),
-        "trajectory_split": str(manifest.get("trajectory_split") or "train").strip(),
-        "trajectory_trace_digest": str(manifest.get("trajectory_trace_digest") or "").strip(),
-    }
+    provenance: dict[str, Any] = {}
+    dataset_id = str(
+        manifest.get("source_dataset_id") or manifest.get("dataset_id") or ""
+    ).strip()
+    if dataset_id:
+        provenance["trajectory_dataset_id"] = dataset_id
+    dataset_version = str(manifest.get("version") or "").strip()
+    if dataset_version:
+        provenance["trajectory_dataset_version"] = dataset_version
+    schema_version = str(
+        manifest.get("trajectory_schema_version") or "melix.agentic_tool_trace.v1"
+    ).strip()
+    if schema_version:
+        provenance["trajectory_schema_version"] = schema_version
+    split = str(manifest.get("trajectory_split") or "train").strip()
+    if split:
+        provenance["trajectory_split"] = split
+    trace_digest = str(manifest.get("trajectory_trace_digest") or "").strip()
+    if trace_digest:
+        provenance["trajectory_trace_digest"] = trace_digest
     if snapshot_manifest_path is not None:
         provenance["trajectory_snapshot_manifest_path"] = str(snapshot_manifest_path)
     for source_field, output_field in _TRAJECTORY_MANIFEST_OPTIONAL_FIELD_MAP:
@@ -124,7 +133,7 @@ def _trajectory_provenance_from_snapshot_manifest(
         provenance[output_field] = value
     if copy_nested:
         return normalize_trajectory_provenance(provenance)
-    return {key: value for key, value in provenance.items() if value not in ("", None)}
+    return provenance
 
 
 def load_trajectory_provenance_from_snapshot_manifest(


### PR DESCRIPTION
## Summary
- Avoid the final empty-value filtering pass in trajectory snapshot manifest loading by building the provenance mapping with non-empty scalar fields up front.
- Add a regression assertion that empty manifest provenance fields remain omitted while defaults and trace digest are preserved.
- Document the Python-only performance slice and registered probe gate.

## Plan or Spec
- `docs/plans/2026-05-31-trajectory-manifest-fast-return.md`

## Commands Run
```text
# Synced branch from origin/main before starting:
git fetch origin && git reset --hard origin/main
# result: HEAD f878fbdd, clean main

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# result: 7 passed in 1.66s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
# result: 7 passed in 0.76s; changed_line_coverage=100.00%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_ITERATIONS=2000 MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
# baseline before edit: {"new_mean_ms": 729.3937155045569, "old_mean_ms": 1518.3872113004327, "speedup": 2.0817113981439928}
# result after edit: {"new_mean_ms": 710.477498639375, "old_mean_ms": 1505.9771228581667, "delta_ms": -795.4996242187917, "speedup": 2.119668991266073, "new_peak_bytes_mean": 49580.0}

git diff --check
# result: pass
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` for `services/mlx-worker-python/worker/trajectory_provenance.py` changed lines.
- Registered probe: `trajectory-manifest-json-load`.
- Local Linux probe comparison for this slice: `new_mean_ms` improved from the pre-edit sample `729.394 ms` to the post-edit sample `710.477 ms` (`delta=-18.916 ms`, about `2.59%` lower for the optimized path sample). Probe internal baseline after edit: `old_mean_ms=1505.977`, `new_mean_ms=710.477`, `speedup=2.1197x`.
- Observability mode: `N/A` (no runtime observability behavior changed). Probe overhead: `N/A` (existing command-json PR-scoped performance probe reused).

## Known Gaps
- Full repository `make py-test`, Swift, and integration gates were not run locally; this is a Python-only focused slice. GitHub Actions and PR-scoped performance CI are required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
