### PR TITLE
fix: harden batch decode review findings

### DIFF
--- a/services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift
@@ -1690,22 +1690,26 @@ private func updatePendingTokensFromBatchLogits(
     }
 
     let sampleStartedAt = Date.timeIntervalSinceReferenceDate
-    let tokenIDs = argMax(logits[0..., -1, 0...], axis: -1)
+    let tokenIDs = batchedArgMaxTokenIDs(from: logits)
     decodeSampleCallCount += activeIndices.count
     decodeSampleTotalMicros += elapsedMicros(since: sampleStartedAt)
     let tokenIDStartedAt = Date.timeIntervalSinceReferenceDate
-    let ids = tokenIDs.asArray(Int.self)
+    let ids = tokenIDs.asArray(UInt32.self)
     decodeTokenIDCallCount += 1
     decodeTokenIDTotalMicros += elapsedMicros(since: tokenIDStartedAt)
 
     for (batchIndex, requestIndex) in activeIndices.enumerated() {
-        let tokenID = ids[batchIndex]
+        let tokenID = Int(ids[batchIndex])
         states[requestIndex].output = LMOutput(
             logits: logits[batchIndex ..< (batchIndex + 1), 0..., 0...]
         )
         states[requestIndex].pendingToken = MLXArray([tokenID])
         states[requestIndex].pendingTokenID = tokenID
     }
+}
+
+private func batchedArgMaxTokenIDs(from logits: MLXArray) -> MLXArray {
+    argMax(logits[0..., -1, 0...], axis: -1)
 }
 
 private final class BatchPositionedKVCacheAdapter: KVCache, BatchPositionedKVCache {
@@ -1720,6 +1724,7 @@ private final class BatchPositionedKVCacheAdapter: KVCache, BatchPositionedKVCac
     }
 
     var offset: Int { wrapped.offset }
+    fileprivate var underlyingLayer: KVCache { wrapped }
     var batchOffset: MLXArray { currentBatchOffset }
     var maxSize: Int? { wrapped.maxSize }
     var state: [MLXArray] {
@@ -1848,6 +1853,7 @@ private func splitBatchDecodeCache(_ cache: [KVCache], batchSize: Int) -> [[KVCa
 
 private func splitBatchDecodeCacheLayer(_ layer: KVCache, batchIndex: Int) -> KVCache {
     let adapter = layer as? BatchPositionedKVCacheAdapter
+    let underlyingLayer = adapter?.underlyingLayer ?? layer
     let state = layer.state
     let metaState = layer.metaState
     let splitState = state.map { array in
@@ -1855,14 +1861,14 @@ private func splitBatchDecodeCacheLayer(_ layer: KVCache, batchIndex: Int) -> KV
     }
 
     var split: KVCache
-    if layer is RotatingKVCache || metaState.count == 5 {
-        let maxSize = layer.maxSize ?? Int(metaState.dropFirst().first ?? "0") ?? 0
+    if underlyingLayer is RotatingKVCache {
+        let maxSize = underlyingLayer.maxSize ?? Int(metaState.dropFirst().first ?? "0") ?? 0
         split = RotatingKVCache(maxSize: max(1, maxSize))
     } else {
         let simple = KVCacheSimple()
         if let sourceStep = adapter?.sourceSimpleStep {
             simple.step = sourceStep
-        } else if let source = layer as? KVCacheSimple {
+        } else if let source = underlyingLayer as? KVCacheSimple {
             simple.step = source.step
         }
         split = simple
@@ -1873,6 +1879,18 @@ private func splitBatchDecodeCacheLayer(_ layer: KVCache, batchIndex: Int) -> KV
         split.metaState = metaState
     }
     return split
+}
+
+func melixTestingBatchedArgMaxTokenIDs(from logits: MLXArray) -> [Int] {
+    batchedArgMaxTokenIDs(from: logits).asArray(UInt32.self).map(Int.init)
+}
+
+func melixTestingMakeBatchDecodeCache(from caches: [[KVCache]]) -> [KVCache]? {
+    makeBatchDecodeCache(from: caches)
+}
+
+func melixTestingSplitBatchDecodeCache(_ cache: [KVCache], batchSize: Int) -> [[KVCache]] {
+    splitBatchDecodeCache(cache, batchSize: batchSize)
 }
 
 #if canImport(MLXLLM)

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -1727,6 +1727,45 @@ final class WorkerScaffoldTests: XCTestCase {
         XCTAssertEqual(recorder.cacheMaxSizes, [8, 8])
     }
 
+    func testAutoSwiftMLXBackendBatchArgMaxTokenIDsBridgeThroughUInt32() async throws {
+        try await withTemporaryDefaultMetallib {
+            Device.withDefaultDevice(.cpu) {
+                let logits = MLXArray([
+                    Float(-3), Float(1), Float(8), Float(0),
+                    Float(2), Float(4), Float(-1), Float(9),
+                ], [2, 1, 4])
+
+                XCTAssertEqual(argMax(logits[0..., -1, 0...], axis: -1).dtype, .uint32)
+                XCTAssertEqual(melixTestingBatchedArgMaxTokenIDs(from: logits), [2, 3])
+            }
+        }
+    }
+
+    func testAutoSwiftMLXBackendBatchDecodeSplitsRotatingAdapterByUnderlyingCacheType() async throws {
+        try await withTemporaryDefaultMetallib {
+            try Device.withDefaultDevice(.cpu) {
+                let cache1 = RotatingKVCache(maxSize: 8)
+                let cache2 = RotatingKVCache(maxSize: 8)
+                let keys1 = MLXArray.zeros([1, 1, 3, 4])
+                let values1 = MLXArray.zeros([1, 1, 3, 4])
+                let keys2 = MLXArray.zeros([1, 1, 3, 4])
+                let values2 = MLXArray.zeros([1, 1, 3, 4])
+                _ = cache1.update(keys: keys1, values: values1)
+                _ = cache2.update(keys: keys2, values: values2)
+
+                let batchedCache = try XCTUnwrap(melixTestingMakeBatchDecodeCache(from: [[cache1], [cache2]]))
+                let splitCaches = melixTestingSplitBatchDecodeCache(batchedCache, batchSize: 2)
+
+                XCTAssertEqual(splitCaches.count, 2)
+                for splitCache in splitCaches {
+                    let splitLayer = try XCTUnwrap(splitCache.first)
+                    XCTAssertTrue(splitLayer is RotatingKVCache)
+                    XCTAssertEqual(splitLayer.maxSize, 8)
+                }
+            }
+        }
+    }
+
     func testAutoSwiftMLXBackendBatchDecodeStopsOnAdditionalEOSToken() async throws {
         let backend = AutoSwiftMLXBackend()
         var sampling = Melix_Worker_V1_SamplingConfig()


### PR DESCRIPTION
## Summary
- Follow up #1712 by hardening batched argmax token ID bridging through the MLX `.uint32` result dtype.
- Remove RotatingKVCache split detection from the fragile `metaState.count == 5` heuristic by checking the batch adapter underlying cache type.
- Add focused Swift text worker tests for both review findings.

## Plan or Spec
- `docs/plans/2026-05-29-issue-1655-homogeneous-decode-coordinator.md`
- `docs/adr/0001-homogeneous-batch-decode-cache-compatibility.md`

## Commands Run
```text
make bootstrap
# Passed. Configured .githooks and uv sync reported resolved/checked packages.

make proto
# Passed. No generated artifact changes.

swift test --package-path services/mlx-text-worker-swift --filter 'WorkerScaffoldTests/testAutoSwiftMLXBackendReusesBatchCacheAcrossHomogeneousDecodeSteps|WorkerScaffoldTests/testAutoSwiftMLXBackendBatchDecodeSupportsRotatingCacheState|WorkerScaffoldTests/testAutoSwiftMLXBackendBatchDecodeSplitsRotatingAdapterByUnderlyingCacheType|WorkerScaffoldTests/testAutoSwiftMLXBackendBatchArgMaxTokenIDsBridgeThroughUInt32|WorkerScaffoldTests/testAutoSwiftMLXBackendBatchDecodeRebuildsCacheWhenOneOfThreePeersAborts|WorkerScaffoldTests/testAutoSwiftMLXBackendBatchDecodeMaterializesCacheForSingleRemainingPeer|WorkerScaffoldTests/testAutoSwiftMLXBackendBatchDecodeUsesProcessorPathForRepetitionPenalty|WorkerScaffoldTests/testAutoSwiftMLXBackendDecodeBatchFallsBackForUnsupportedCacheSignature'
# Passed. 8 tests, 0 failures.

swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter WorkerScaffoldTests
# Passed. 221 tests, 0 failures.

.venv/bin/python scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
# Passed. TOTAL 100.00% (57/57).

git diff --check origin/main..HEAD
# Passed.

git commit -m "fix: harden batch decode review findings"
# Passed pre-commit full gate on a 256 GiB macOS host:
# - make swift-test: passed.
# - make py-test: 3373 passed, 14 skipped, 2 warnings.
# - make integration-test: 115 passed, 1 skipped.
# - PR-scoped performance report: ok, regressions 0, context regressions 0, verification failures 0.
```

## Coverage and Metrics
- Swift text worker changed-line coverage: `100.00%` (`57/57`).
- Pre-commit scoped performance report: `.runtime/pre-commit-performance/20260531-213345-f878fbdd/report/report.md`.
- Same-cohort batching probe evidence: status `ok`; direct/gated probe `1`; regressions `0`; context regressions `0`; verification failures `0`; coverage `100.0%`.
- Observability mode: evidence, via the existing same-cohort batching probe. No new production observability or probe overhead was added.

## Known Gaps
- This is a #1712 review-hardening follow-up only. It does not close #1642; the latest #1642 25% acceptance recompute still fails 128/c1, 128/c2, and 1024/c1.
- It also does not close #1654 by itself.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. N/A: this hardens implementation under the existing plan/ADR without changing the documented behavior contract.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
