### PR TITLE
perf: tighten report evidence matrix matching

### DIFF
--- a/docs/plans/2026-05-31-report-evidence-metric-prefix-loop.md
+++ b/docs/plans/2026-05-31-report-evidence-metric-prefix-loop.md
@@ -1,0 +1,36 @@
+# Report Evidence Matrix Matching Loop Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to release-matrix matching in `services/mlx-worker-python/worker/productization/report_evidence_gate.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`. The probe defines focused `test_command`, `coverage_command`, and `probe_command` entries and emits:
+
+- `run_kind_elapsed_ms_mean`
+- `metric_prefix_elapsed_ms_mean`
+- `target_field_elapsed_ms_mean`
+- aggregate `elapsed_ms_mean`
+
+## Linux verification boundary
+
+This slice is Python-only and locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered command-json performance probe.
+
+## Optimization hypothesis
+
+`_rule_matches_report()` currently converts each observed run kind through `str()` before set membership and uses `any(...)` with a generator expression for metric-prefix matching. The normal report path uses string run kinds and can check direct set membership first while retaining a second-pass fallback for non-string values. The metric-prefix path can use an explicit short-circuit loop to avoid generator-frame overhead. Both changes preserve existing matching semantics while reducing hot-loop overhead in the registered release-matrix probe.
+
+## Validation plan
+
+1. Run the registered focused tests for `report-evidence-gate-run-kind-set-membership`.
+2. Run the registered changed-scope coverage command for the same probe.
+3. Run the registered probe locally on Linux before pushing.
+4. Use PR-scoped performance CI as the final registered probe gate before merge.
+
+## Acceptance criteria
+
+- Behavior remains unchanged for tuple/list run-kind rules, non-string run-kind values, and tuple/list metric prefix rules.
+- Changed-scope coverage remains at or above 95% for `report_evidence_gate.py`.
+- Local registered probe shows lower `run_kind_elapsed_ms_mean` and `metric_prefix_elapsed_ms_mean` versus the synced `origin/main` baseline sample.
+- PR-scoped performance CI selects and completes `report-evidence-gate-run-kind-set-membership` successfully.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -188,6 +188,16 @@ def test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set() -> Non
     assert cache_info.misses == 1
 
 
+def test_report_evidence_gate_run_kind_non_string_values_still_match_by_string() -> None:
+    assert report_evidence_gate_module._rule_matches_report(
+        rule={"run_kinds": ("42",)},
+        runs=[{"run_kind": 42}],
+        targets=[],
+        metrics=[],
+        probe_phases=set(),
+    )
+
+
 def test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple() -> None:
     report_evidence_gate_module._string_tuple_from_tuple.cache_clear()
     rule = {"metric_prefixes": ("adapter.", "runtime.")}

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -291,15 +291,22 @@ def _rule_matches_report(
     if run_kinds:
         run_kind_set = _string_frozenset(run_kinds)
         run_kind_key = "run_kind"
-        to_string = str
         for run in runs:
-            if to_string(run.get(run_kind_key, "")) in run_kind_set:
+            run_kind = run.get(run_kind_key, "")
+            if run_kind in run_kind_set:
+                return True
+        for run in runs:
+            run_kind = run.get(run_kind_key, "")
+            if type(run_kind) is not str and str(run_kind) in run_kind_set:
                 return True
     metric_prefixes = rule.get("metric_prefixes", ())
     if metric_prefixes:
         metric_prefix_tuple = _string_tuple(metric_prefixes)
-        if any(str(metric.get("metric", "")).startswith(metric_prefix_tuple) for metric in metrics):
-            return True
+        metric_key = "metric"
+        to_string = str
+        for metric in metrics:
+            if to_string(metric.get(metric_key, "")).startswith(metric_prefix_tuple):
+                return True
     target_fields = rule.get("target_fields", ())
     if target_fields:
         target_field_set = _string_frozenset(target_fields)


### PR DESCRIPTION
## Summary
- Check string run kinds directly before falling back to string coercion for unusual non-string payloads.
- Replace the report evidence metric-prefix `any(...)` generator with an explicit short-circuit loop.

## Plan or Spec
- `docs/plans/2026-05-31-report-evidence-metric-prefix-loop.md`

## Commands Run
```text
# Baseline before implementation, origin/main @ 9ebfdf29
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# exit 0; run_kind_elapsed_ms_mean=265.19742645323277; metric_prefix_elapsed_ms_mean=1634.2868597246706; elapsed_ms_mean=2476.136036310345

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_non_string_values_still_match_by_string services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_preserves_stringified_presence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# exit 0; 13 passed in 0.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_non_string_values_still_match_by_string services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_preserves_stringified_presence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
# exit 0; changed_line_coverage=100.00%; TOTAL 8 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# exit 0; run_kind_elapsed_ms_mean=219.20654233545065; metric_prefix_elapsed_ms_mean=1425.31518638134; elapsed_ms_mean=2224.845726415515

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%` for changed lines.
- Registered local probe: `report-evidence-gate-run-kind-set-membership` via `scripts/report_evidence_gate_run_kind_probe.py`.
- Run-kind mean: `265.19742645323277 ms` -> `219.20654233545065 ms` (delta `-45.99088411778212 ms`, `~1.21x` faster).
- Metric-prefix mean: `1634.2868597246706 ms` -> `1425.31518638134 ms` (delta `-208.9716733433306 ms`, `~1.15x` faster).
- Aggregate mean: `2476.136036310345 ms` -> `2224.845726415515 ms` (delta `-251.29030989482993 ms`, `~1.11x` faster).
- PR-scoped performance CI is required as the final registered probe validation before merge.

## Known Gaps
- None for the Python slice. Final registered probe validation is expected from PR-scoped CI.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.