### PR TITLE
perf: inline multimodal signature top-level repr

### DIFF
--- a/docs/plans/2026-06-01-multimodal-signature-inline-repr.md
+++ b/docs/plans/2026-06-01-multimodal-signature-inline-repr.md
@@ -1,0 +1,36 @@
+# Multimodal fast-path signature inline top-level representation
+
+## Scope
+
+This Python-only performance slice is limited to `fast_path_probe_signature()` in
+`services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py`.
+
+The slice keeps signature semantics unchanged while reducing per-call overhead
+for the fixed four top-level loaded-model fields used by the VLM fast-path probe
+signature. It does not change metadata precedence, image preprocessing, cache
+admission, or runtime decode behavior.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`multimodal-fast-path-signature-top-level-key-cache` in
+`infra/perf/pr_scoped_probes.json`.
+
+That registry entry already defines focused `test_command`, `coverage_command`,
+and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py`
+- `services/mlx-worker-python/tests/test_multimodal_fast_paths.py`
+- `scripts/multimodal_fast_path_signature_probe.py`
+
+## Measurement plan
+
+Run the registered focused tests, changed-scope coverage command, and probe on
+Linux before PR creation. The probe metric of record is `elapsed_ms_mean` with
+lower values preferred; `peak_bytes_mean` remains a guardrail metric.
+
+## Acceptance
+
+Accept the slice only if behavior tests pass, changed-scope coverage remains at
+or above repository policy for the touched path, and the registered probe shows a
+clear non-regressing direction locally and in PR-scoped CI.

--- a/services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py
+++ b/services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py
@@ -296,9 +296,20 @@ def fast_path_probe_signature(
 
 
 def _top_level_signature_repr(loaded_model: dict[str, Any]) -> str:
-    return _signature_pairs_repr(
-        (key, str(loaded_model.get(key, "")))
-        for key in _FAST_PATH_SIGNATURE_TOP_LEVEL_KEYS_SORTED
+    model_id = str(loaded_model.get("model_id", ""))
+    quant_profile_id = str(loaded_model.get("quant_profile_id", ""))
+    revision = str(loaded_model.get("revision", ""))
+    tokenizer_hash = str(loaded_model.get("tokenizer_hash", ""))
+    return (
+        "(('model_id', "
+        + repr(model_id)
+        + "), ('quant_profile_id', "
+        + repr(quant_profile_id)
+        + "), ('revision', "
+        + repr(revision)
+        + "), ('tokenizer_hash', "
+        + repr(tokenizer_hash)
+        + "))"
     )
 
 


### PR DESCRIPTION
## Summary
- Inline the fixed four-field top-level loaded-model signature representation used by `fast_path_probe_signature()`.
- Preserve the existing tuple-repr-compatible string shape and nested metadata precedence while avoiding the generic generator/list/join path for this hot call.

## Plan or Spec
- `docs/plans/2026-06-01-multimodal-signature-inline-repr.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_multimodal_fast_paths.py::test_fast_path_probe_signature_reuses_pre_sorted_top_level_keys services/mlx-worker-python/tests/test_multimodal_fast_paths.py::test_fast_path_probe_signature_uses_nested_metadata_precedence
# 2 passed in 0.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_fast_path_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_fast_path_signature_probe_script_emits_metrics
# 26 passed in 0.85s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_multimodal_fast_path_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_multimodal_fast_path_signature_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py services/mlx-worker-python/tests/test_multimodal_fast_paths.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/multimodal_fast_path_signature_probe.py
# 26 passed in 0.27s; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/multimodal_fast_path_signature_probe.py
# {"elapsed_ms_mean": 2741.9895716011524, "iterations_per_sample": 120000.0, "peak_bytes_mean": 1944.0, "sample_count": 5.0, "signature_count": 600000.0, "top_level_item_count": 4.0}

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% for 5 measurable changed lines.
- Registered probe: `multimodal-fast-path-signature-top-level-key-cache`.
- Local Linux baseline before change: `elapsed_ms_mean=3161.261696089059`, `peak_bytes_mean=1944.0`.
- Local Linux after change: `elapsed_ms_mean=2741.9895716011524`, `peak_bytes_mean=1944.0`.
- Delta: `-419.2721244879067 ms` over 120k iterations/sample, ~13.26% faster locally.
- PR-scoped CI registered probe validation is required before merge.

## Known Gaps
- None for the Python path. Swift/runtime effects are not involved in this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change; probe overhead tracked by the registered probe.
- [x] Deferred work and known gaps are stated explicitly.
