### PR TITLE
perf: coalesce Gemma decode output cadence

### DIFF
--- a/docs/plans/2026-06-01-issue-1660-token-output-cadence.md
+++ b/docs/plans/2026-06-01-issue-1660-token-output-cadence.md
@@ -1,0 +1,178 @@
+# Issue 1660 Token Output Cadence Plan
+
+## Context
+
+Issue #1660 follows the #1659 output-overhead counter slice. The current Swift
+text decode path writes one worker gRPC `TokenDelta` for every visible decoded
+fragment after Harmony filtering. For Gemma E4B serving, that per-token write
+cadence can add avoidable worker, control-plane, and SSE overhead without
+changing the generated text.
+
+The governing root is #1642, which requires Gemma E4B release comparison
+evidence against peer runtimes. This slice must therefore preserve externally
+visible streaming semantics while giving the benchmark path a measurable
+reduction in output write pressure.
+
+## Goal
+
+Reduce avoidable per-token output overhead for Gemma-family Swift text decode
+requests by coalescing bounded runs of visible text deltas after the first
+visible token. Preserve ordering, first-token behavior, reasoning-channel
+events, usage, completion payloads, and non-Gemma streaming behavior.
+
+## Scope
+
+- Apply cadence optimization only to the Swift text decode worker path.
+- Scope the default optimization to Gemma/Gemma 4 model identifiers or model
+  metadata, with an execution metadata override for diagnosis.
+- Keep the first visible token delta immediate so TTFT and first SSE delivery
+  are not delayed.
+- Never coalesce reasoning deltas. Flush any pending visible text before a
+  reasoning delta to preserve stream order.
+- Flush pending visible text before usage, snapshot, and completion events.
+- Use existing #1659 counters and stream event counts as the primary evidence
+  surface.
+
+Out of scope:
+
+- Scheduler batching, model-step batching, sampling, tokenization, and lower
+  runtime decode-loop changes.
+- Broad generate-path cadence changes.
+- Protocol schema changes.
+
+## Implementation Steps
+
+1. Add red worker tests.
+   - Gemma decode: multiple visible fragments produce fewer `TokenDelta`
+     events than completion tokens while preserving the exact final assistant
+     text and usage token count.
+   - Non-Gemma decode: visible fragments remain one delta per fragment.
+   - Gemma reasoning transition: pending visible text is flushed before a
+     reasoning delta and reasoning deltas remain separate.
+2. Add a bounded visible-output cadence helper.
+   - Extend the filtered output writer state with pending visible text.
+   - Add a policy that writes the first visible token immediately, buffers
+     later visible fragments up to a small fragment/character limit, and
+     flushes before reasoning or terminal events.
+3. Wire the policy into `TextDecodeEngine`.
+   - Derive the policy from the loaded model spec and execution metadata.
+   - Keep non-Gemma and explicit disabled policy on immediate writes.
+4. Update focused verification and metrics notes.
+   - Use existing `swift_text.decode_grpc_write_call_count`,
+     `swift_text.decode_stream_event_count`, and final usage/completion
+     assertions as the functional and performance signal.
+   - Rerun the Gemma E4B three-way comparison after the code is green to verify
+     #1660 acceptance against real serving scenarios.
+
+## Performance Probes And Success Metrics
+
+Focused worker success metrics:
+
+- Gemma fake decode with six visible fragments emits three token delta writes:
+  first token immediately, one bounded coalesced chunk, and one final flush.
+- `swift_text.decode_grpc_write_call_count` and
+  `swift_text.decode_stream_event_count` are lower than the non-coalesced
+  equivalent for the Gemma test case.
+- Non-Gemma fake decode continues to emit one visible token delta per fragment.
+- Reasoning deltas remain separate and ordered after any pending visible flush.
+
+Release evidence metrics:
+
+- A Gemma E4B three-way benchmark rerun must show either improved Melix decode
+  tok/s or lower total latency for at least one scenario, without an in-scope
+  regression beyond the PR-scoped threshold.
+- The report must include the #1659 counters, especially
+  `swift_text.decode_grpc_write_call_count`, `http.worker_event_handle_*`, and
+  `http.sse_write_*`, so the output-cadence change is attributable.
+
+Observability mode: minimal. This slice reuses existing metrics and does not
+add per-token actor hops or debug artifacts.
+
+## Verification
+
+```bash
+swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testDecodeCoalescesGemmaVisibleTokenDeltasAfterFirstToken|WorkerScaffoldTests/testDecodeDoesNotCoalesceNonGemmaVisibleTokenDeltas|WorkerScaffoldTests/testDecodeFlushesPendingVisibleDeltasBeforeReasoningDeltas'
+
+swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testDecodeStreamingRpcBatchesHomogeneousDeterministicDecodeRequests|WorkerScaffoldTests/testGenerateSuppressesHarmonyThoughtChannelForLoadedModel'
+
+uv run --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/mlx-text-worker-swift/Sources/Core/Inference/FilteredTextOutputWriter.swift services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeEngine.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+
+uv run --project services/mlx-worker-python --extra mlx python scripts/same_cohort_batching_probe.py --metrics
+
+uv run --project services/mlx-worker-python --extra mlx python scripts/three_way_serving_compare.py --help
+
+git diff --check
+```
+
+The final PR gate must also follow the repository default commands and the
+pre-commit performance report rules before claiming PR readiness.
+
+## Metrics Report
+
+Verification was run on June 1, 2026 from the
+`codex/issue-1660-token-output-cadence-20260601` worktree.
+
+- `swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testDecodeCoalescesGemmaVisibleTokenDeltasAfterFirstToken|WorkerScaffoldTests/testDecodeDoesNotCoalesceNonGemmaVisibleTokenDeltas|WorkerScaffoldTests/testDecodeFlushesPendingVisibleDeltasBeforeReasoningDeltas'`
+  - Initial red result: Gemma cadence test failed because the existing path
+    emitted six token deltas and nine total events instead of three token
+    deltas and six total events.
+- `swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testDecodeOutputCadencePolicyScopesDefaultToGemmaAndHonorsOverrides|WorkerScaffoldTests/testDecodeCoalescesGemmaVisibleTokenDeltasAfterFirstToken|WorkerScaffoldTests/testDecodeDoesNotCoalesceNonGemmaVisibleTokenDeltas|WorkerScaffoldTests/testDecodeFlushesPendingVisibleDeltasBeforeReasoningDeltas|WorkerScaffoldTests/testDecodeStreamingRpcBatchesHomogeneousDeterministicDecodeRequests|WorkerScaffoldTests/testGenerateSuppressesHarmonyThoughtChannelForLoadedModel'`
+  - Result: passed, 6 tests, 0 failures.
+- `uv run --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/mlx-text-worker-swift/Sources/Core/Inference/FilteredTextOutputWriter.swift services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeEngine.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift`
+  - Result: `TOTAL 99.77% 433/434`.
+- `uv run --project services/mlx-worker-python --extra mlx python scripts/same_cohort_batching_probe.py --metrics`
+  - Result: completed with no failure count; current warning remains
+    `scheduler_admission_cohort_size=2`, `worker_model_eval_batch_size=1`,
+    `status_warning=1`.
+- `uv run --project services/mlx-worker-python --extra mlx python scripts/three_way_serving_compare.py --help`
+  - Result: passed; report CLI and Gemma comparison options remain available.
+- `make bootstrap`
+  - Result: passed; git hooks path configured and the locked Python
+    environment checked through `uv sync --project services/mlx-worker-python
+    --extra mlx`.
+- `make proto && git diff --exit-code -- packages/protocol/descriptors packages/protocol/python packages/protocol/swift`
+  - Result: passed; generated protocol artifacts had no drift.
+- `make swift-test`
+  - Result: passed. The macOS menu bar package shard completed with 779 tests
+    in 25 suites and 0 failures; earlier Swift shards also completed with
+    return code 0.
+- `make py-test`
+  - Result: passed, 3377 tests, 14 skipped, 2 warnings.
+- `make integration-test`
+  - Result: passed, 115 tests, 1 skipped.
+- `.githooks/pre-commit`
+  - Result: passed on a 256 GiB macOS host. The hook reran
+    `make swift-test`, `make py-test`, and `make integration-test`, then wrote
+    `.runtime/pre-commit-performance/20260601-052118-31a46494/report/report.md`
+    after the branch was updated to the current `origin/main`.
+    The scoped performance report status was `ok` with `Regressions: 0`,
+    `Context regressions: 0`, and `Verification failures: 0`.
+- Real Gemma E4B before/after benchmark:
+  - Command: `uv run --project services/mlx-worker-python --extra mlx python scripts/three_way_serving_compare.py --endpoint base=http://127.0.0.1:12445/v1::unsloth/gemma-4-E4B-it-MLX-8bit --endpoint head=http://127.0.0.1:12444/v1::unsloth/gemma-4-E4B-it-MLX-8bit --target-endpoint head --prompt-token-targets 1024 --max-tokens 128 --repeats 2 --warmup-requests 1 --warmup-prompt-token-target 512 --warmup-max-tokens 16 --concurrency 1 --cache-profile cold_unique --prompt-style saturating --temperature 0 --top-p 1 --top-k 0 --include-usage --timeout-seconds 900 --preflight-wait-seconds 30 --measurement-profile warm --run-id issue1660-gemma-e4b-output-cadence-20260601-045908`.
+  - Base endpoint: `origin/main` at `5f69a9c79f9d3bf5e0d98e8c3094210fd6ce88d5`, isolated runtime
+    `issue1660-base`, port `12445`.
+  - Head endpoint: `codex/issue-1660-token-output-cadence-20260601`, isolated
+    runtime `issue1660-head`, port `12444`.
+  - Note: `origin/main` later advanced to `31a46494`; the subsequent merge was
+    outside the Swift output-cadence path, and the full local pre-commit gate
+    above was rerun after updating the branch.
+  - Model: `unsloth/gemma-4-E4B-it-MLX-8bit`, local snapshot
+    `~/.cache/huggingface/hub/models--unsloth--gemma-4-E4B-it-MLX-8bit/snapshots/0b58ae760a389dcdda6d4e74eab1a41bede541d1`.
+  - Result: threshold status `ok`; failures `0`; both endpoints preflighted
+    with the target model listed and completed 2 measured requests with
+    `error_count=0`.
+  - Scenario: warm profile, prompt target `1024`, measured prompt tokens
+    `634`, `max_tokens=128`, `repeats=2`, `concurrency=1`, `prompt_style=saturating`.
+  - Median total latency improved from `32048.20 ms` to `31927.64 ms`
+    (`-0.38%`), and median decode throughput improved from `4.29 tok/s` to
+    `4.39 tok/s` (`+2.25%`).
+  - Decode write pressure dropped from `281` to `80` gRPC writes and from
+    `131` to `36` streamed decode events across the warmup plus measured run;
+    `swift_text.decode_grpc_write_total_us` dropped from `28047` to `8190`.
+  - Memory evidence: Swift text-worker peak resident bytes were
+    `8320598016` for base and `8338587648` for head. Both loaded one model.
+  - Artifacts:
+    `.runtime/issue1660-token-output-cadence-benchmark/issue1660-gemma-e4b-output-cadence-20260601-045908/summary.md`,
+    `summary.json`, `observations.jsonl`, `peer-delta-rows.json`,
+    `threshold-status.json`, `run-evidence.json`, and paired base/head
+    metrics and `ps` snapshots.

--- a/services/mlx-text-worker-swift/Sources/Core/Inference/FilteredTextOutputWriter.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Inference/FilteredTextOutputWriter.swift
@@ -7,6 +7,8 @@ struct FilteredTextOutputState {
     var reasoningText = ""
     var eventCount = 0
     var sawFirstToken = false
+    var pendingVisibleText = ""
+    var pendingVisibleFragmentCount = 0
 }
 
 struct FilteredTextOutputWriteSummary {
@@ -16,6 +18,40 @@ struct FilteredTextOutputWriteSummary {
     mutating func record(_ elapsedMicros: Int) {
         grpcWriteTotalMicros += max(1, elapsedMicros)
         grpcWriteCallCount += 1
+    }
+
+    mutating func merge(_ other: FilteredTextOutputWriteSummary) {
+        grpcWriteTotalMicros += other.grpcWriteTotalMicros
+        grpcWriteCallCount += other.grpcWriteCallCount
+    }
+}
+
+struct FilteredTextOutputCadencePolicy: Sendable, Equatable {
+    var coalesceVisibleDeltas: Bool
+    var maxBufferedVisibleFragments: Int
+    var maxBufferedVisibleCharacters: Int
+
+    static let immediate = FilteredTextOutputCadencePolicy(
+        coalesceVisibleDeltas: false,
+        maxBufferedVisibleFragments: 1,
+        maxBufferedVisibleCharacters: 0
+    )
+
+    static let gemmaDecodeDefault = FilteredTextOutputCadencePolicy(
+        coalesceVisibleDeltas: true,
+        maxBufferedVisibleFragments: 4,
+        maxBufferedVisibleCharacters: 96
+    )
+
+    var shouldBufferVisibleDeltas: Bool {
+        coalesceVisibleDeltas
+            && maxBufferedVisibleFragments > 1
+            && maxBufferedVisibleCharacters > 0
+    }
+
+    func shouldFlush(fragmentCount: Int, characterCount: Int) -> Bool {
+        fragmentCount >= maxBufferedVisibleFragments
+            || characterCount >= maxBufferedVisibleCharacters
     }
 }
 
@@ -29,25 +65,29 @@ func writeFilteredTextOutput(
     metrics: MetricsStore,
     ttftMetricName: String,
     startedAt: Date,
+    cadencePolicy: FilteredTextOutputCadencePolicy = .immediate,
     decorateEvent: (inout Melix_Worker_V1_ExecuteEvent) -> Void = { _ in }
 ) async throws -> FilteredTextOutputWriteSummary {
     var summary = FilteredTextOutputWriteSummary()
     if !output.reasoningText.isEmpty {
+        summary.merge(try await flushPendingFilteredTextOutput(
+            response: response,
+            requestID: requestID,
+            executionKind: executionKind,
+            seq: &seq,
+            state: &state,
+            decorateEvent: decorateEvent
+        ))
         state.reasoningText += output.reasoningText
 
-        var event = Melix_Worker_V1_ExecuteEvent()
-        event.requestID = requestID
-        event.executionKind = executionKind
-        event.seq = seq
-        seq += 1
-        decorateEvent(&event)
-
-        var payload = Melix_Worker_V1_ReasoningDelta()
-        payload.text = output.reasoningText
-        event.reasoningDelta = payload
-        let writeStartedAt = Date()
-        try await response.write(event)
-        summary.record(filteredOutputElapsedMicros(since: writeStartedAt))
+        summary.record(try await writeReasoningDelta(
+            output.reasoningText,
+            response: response,
+            requestID: requestID,
+            executionKind: executionKind,
+            seq: &seq,
+            decorateEvent: decorateEvent
+        ))
         state.eventCount += 1
     }
 
@@ -55,7 +95,8 @@ func writeFilteredTextOutput(
         return summary
     }
 
-    if !state.sawFirstToken {
+    let isFirstVisibleToken = !state.sawFirstToken
+    if isFirstVisibleToken {
         state.sawFirstToken = true
         metrics.recordMilliseconds(
             ttftMetricName,
@@ -64,7 +105,95 @@ func writeFilteredTextOutput(
     }
 
     state.assistantText += output.visibleText
+    if cadencePolicy.shouldBufferVisibleDeltas, !isFirstVisibleToken {
+        state.pendingVisibleText += output.visibleText
+        state.pendingVisibleFragmentCount += 1
+        if cadencePolicy.shouldFlush(
+            fragmentCount: state.pendingVisibleFragmentCount,
+            characterCount: state.pendingVisibleText.count
+        ) {
+            summary.merge(try await flushPendingFilteredTextOutput(
+                response: response,
+                requestID: requestID,
+                executionKind: executionKind,
+                seq: &seq,
+                state: &state,
+                decorateEvent: decorateEvent
+            ))
+        }
+        return summary
+    }
 
+    summary.record(try await writeVisibleTextDelta(
+        output.visibleText,
+        response: response,
+        requestID: requestID,
+        executionKind: executionKind,
+        seq: &seq,
+        decorateEvent: decorateEvent
+    ))
+    state.eventCount += 1
+    return summary
+}
+
+func flushPendingFilteredTextOutput(
+    response: GRPCCore.RPCWriter<Melix_Worker_V1_ExecuteEvent>,
+    requestID: String,
+    executionKind: String,
+    seq: inout UInt64,
+    state: inout FilteredTextOutputState,
+    decorateEvent: (inout Melix_Worker_V1_ExecuteEvent) -> Void = { _ in }
+) async throws -> FilteredTextOutputWriteSummary {
+    var summary = FilteredTextOutputWriteSummary()
+    guard !state.pendingVisibleText.isEmpty else {
+        return summary
+    }
+    let text = state.pendingVisibleText
+    state.pendingVisibleText.removeAll(keepingCapacity: true)
+    state.pendingVisibleFragmentCount = 0
+    summary.record(try await writeVisibleTextDelta(
+        text,
+        response: response,
+        requestID: requestID,
+        executionKind: executionKind,
+        seq: &seq,
+        decorateEvent: decorateEvent
+    ))
+    state.eventCount += 1
+    return summary
+}
+
+private func writeReasoningDelta(
+    _ text: String,
+    response: GRPCCore.RPCWriter<Melix_Worker_V1_ExecuteEvent>,
+    requestID: String,
+    executionKind: String,
+    seq: inout UInt64,
+    decorateEvent: (inout Melix_Worker_V1_ExecuteEvent) -> Void
+) async throws -> Int {
+    var event = Melix_Worker_V1_ExecuteEvent()
+    event.requestID = requestID
+    event.executionKind = executionKind
+    event.seq = seq
+    seq += 1
+    decorateEvent(&event)
+
+    var payload = Melix_Worker_V1_ReasoningDelta()
+    payload.text = text
+    event.reasoningDelta = payload
+    let writeStartedAt = Date()
+    try await response.write(event)
+    return filteredOutputElapsedMicros(since: writeStartedAt)
+}
+
+private func writeVisibleTextDelta(
+    _ text: String,
+    response: GRPCCore.RPCWriter<Melix_Worker_V1_ExecuteEvent>,
+    requestID: String,
+    executionKind: String,
+    seq: inout UInt64,
+    decorateEvent: (inout Melix_Worker_V1_ExecuteEvent) -> Void
+) async throws -> Int {
     var event = Melix_Worker_V1_ExecuteEvent()
     event.requestID = requestID
     event.executionKind = executionKind
@@ -73,13 +202,11 @@ func writeFilteredTextOutput(
     decorateEvent(&event)
 
     var payload = Melix_Worker_V1_TokenDelta()
-    payload.text = output.visibleText
+    payload.text = text
     event.tokenDelta = payload
     let writeStartedAt = Date()
     try await response.write(event)
-    summary.record(filteredOutputElapsedMicros(since: writeStartedAt))
-    state.eventCount += 1
-    return summary
+    return filteredOutputElapsedMicros(since: writeStartedAt)
 }
 
 private func filteredOutputElapsedMilliseconds(since startedAt: Date) -> Int {

--- a/services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeEngine.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeEngine.swift
@@ -87,6 +87,10 @@ struct TextDecodeEngine: Sendable {
             var grpcWriteTotalMicros = 0
             var grpcWriteCallCount = 0
             var outputFilter = HarmonyChannelOutputFilter()
+            let outputCadencePolicy = decodeOutputCadencePolicy(
+                model: session.loadedModel.spec,
+                execution: request.execution
+            )
 
             func writeOutput(_ output: HarmonyChannelOutputFilter.Output) async throws {
                 let writeSummary = try await writeFilteredTextOutput(
@@ -99,6 +103,25 @@ struct TextDecodeEngine: Sendable {
                     metrics: metrics,
                     ttftMetricName: "swift_text.decode_ttft_ms",
                     startedAt: startedAt,
+                    cadencePolicy: outputCadencePolicy,
+                    decorateEvent: { event in
+                        event.phase = .executionDecoding
+                        event.admissionState = .admissionAdmitted
+                        event.lane = lane
+                        event.accelerationMode = acceleration.mode
+                    }
+                )
+                grpcWriteTotalMicros += writeSummary.grpcWriteTotalMicros
+                grpcWriteCallCount += writeSummary.grpcWriteCallCount
+            }
+
+            func flushOutput() async throws {
+                let writeSummary = try await flushPendingFilteredTextOutput(
+                    response: response,
+                    requestID: requestID,
+                    executionKind: "decode",
+                    seq: &seq,
+                    state: &outputState,
                     decorateEvent: { event in
                         event.phase = .executionDecoding
                         event.admissionState = .admissionAdmitted
@@ -225,6 +248,7 @@ struct TextDecodeEngine: Sendable {
 
             let finalFiltered = finishFilteredOutput()
             try await writeOutput(finalFiltered)
+            try await flushOutput()
 
             if request.returnUsage && !(abortHandle?.isAborted ?? false) {
                 var event = Melix_Worker_V1_ExecuteEvent()
@@ -805,6 +829,45 @@ private func isGreedySpeculativeSampling(_ sampling: Melix_Worker_V1_SamplingCon
     return sampling.temperature <= 0
         && effectiveTopP >= 1
         && sampling.topK == 0
+}
+
+func decodeOutputCadencePolicy(
+    model: Melix_Worker_V1_ModelSpec,
+    execution: Melix_Worker_V1_ExecutionMetadata
+) -> FilteredTextOutputCadencePolicy {
+    switch normalizedOutputCadenceOverride(execution.ext["melix.output_cadence"]) {
+    case "immediate", "off", "disabled", "none":
+        return .immediate
+    case "coalesced", "coalesce", "gemma":
+        return .gemmaDecodeDefault
+    default:
+        break
+    }
+    return isGemmaOutputCadenceCandidate(model) ? .gemmaDecodeDefault : .immediate
+}
+
+private func normalizedOutputCadenceOverride(_ rawValue: String?) -> String {
+    rawValue?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+}
+
+private func isGemmaOutputCadenceCandidate(_ model: Melix_Worker_V1_ModelSpec) -> Bool {
+    let metadataValues = [
+        model.modelID,
+        model.modelPath,
+        model.ext["text_family_id"] ?? "",
+        model.ext["detected_family_id"] ?? "",
+        model.ext["model_architecture"] ?? "",
+        model.ext["detected_architecture"] ?? "",
+        model.settings.ext["text_family_id"] ?? "",
+        model.settings.ext["detected_family_id"] ?? "",
+        model.settings.ext["model_architecture"] ?? "",
+        model.settings.ext["detected_architecture"] ?? "",
+    ]
+    return metadataValues.contains { value in
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .contains("gemma")
+    }
 }
 
 private func parseBool(_ rawValue: String?, fallback: Bool) -> Bool {

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -140,6 +140,31 @@ final class WorkerScaffoldTests: XCTestCase {
         XCTAssertTrue(configuration.memoryEnforcementEnabled)
     }
 
+    func testDecodeOutputCadencePolicyScopesDefaultToGemmaAndHonorsOverrides() {
+        var gemmaModel = Melix_Worker_V1_ModelSpec()
+        gemmaModel.modelID = "unsloth/gemma-4-E4B-it-MLX-8bit"
+
+        var execution = Melix_Worker_V1_ExecutionMetadata()
+        XCTAssertEqual(
+            decodeOutputCadencePolicy(model: gemmaModel, execution: execution),
+            .gemmaDecodeDefault
+        )
+
+        execution.ext["melix.output_cadence"] = "off"
+        XCTAssertEqual(
+            decodeOutputCadencePolicy(model: gemmaModel, execution: execution),
+            .immediate
+        )
+
+        var nonGemmaModel = Melix_Worker_V1_ModelSpec()
+        nonGemmaModel.modelID = "melix-dev-text"
+        execution.ext["melix.output_cadence"] = "coalesced"
+        XCTAssertEqual(
+            decodeOutputCadencePolicy(model: nonGemmaModel, execution: execution),
+            .gemmaDecodeDefault
+        )
+    }
+
     func testDFlashSpeculativeProbeLoggerWritesJsonLinesWhenEnabled() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("melix-dflash-probe-\(UUID().uuidString)", isDirectory: true)
@@ -4469,6 +4494,261 @@ final class WorkerScaffoldTests: XCTestCase {
         XCTAssertGreaterThan(metrics["swift_text.generate_grpc_write_total_us"] ?? 0, 0)
         XCTAssertEqual(metrics["swift_text.generate_grpc_write_call_count"], recorded.count)
         XCTAssertGreaterThan(metrics["swift_text.generate_grpc_write_avg_us"] ?? 0, 0)
+    }
+
+    func testDecodeCoalescesGemmaVisibleTokenDeltasAfterFirstToken() async throws {
+        let services = makeServices(
+            backend: FakeRuntimeBackend(
+                generatedChunks: ["unused"],
+                decodedChunks: ["A", "B", "C", "D", "E", "F"]
+            )
+        )
+        let loadResponse = try await withTestServerContextRPCCancellationHandle { handle in
+            var request = Melix_Worker_V1_LoadModelRequest()
+            request.model.modelID = "unsloth/gemma-4-E4B-it-MLX-8bit"
+            request.model.modelPath = "unsloth/gemma-4-E4B-it-MLX-8bit"
+            return try await services.runtime.loadModel(
+                request: request,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_RuntimeService.Method.LoadModel.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        var prefillRequest = Melix_Worker_V1_PrefillRequest()
+        prefillRequest.execution.id.requestID = "req-gemma-cadence-prefill"
+        prefillRequest.execution.modelHandle = loadResponse.modelHandle
+        prefillRequest.returnDecodeHandle = true
+        var message = Melix_Worker_V1_ChatMessage()
+        message.role = "user"
+        var part = Melix_Worker_V1_MessagePart()
+        part.text = "Continue."
+        message.parts = [part]
+        prefillRequest.messages = [message]
+
+        let prefillResponse = try await withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.prefill(
+                request: prefillRequest,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Prefill.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        let writer = RecordingRPCWriter<Melix_Worker_V1_ExecuteEvent>()
+        var request = Melix_Worker_V1_DecodeRequest()
+        request.execution.id.requestID = "req-gemma-cadence"
+        request.execution.modelHandle = loadResponse.modelHandle
+        request.decodeHandle = prefillResponse.decodeHandle
+        request.maxOutputTokens = 6
+        request.returnUsage = true
+
+        try await withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.decode(
+                request: request,
+                response: RPCWriter(wrapping: writer),
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Decode.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        let recorded = await writer.snapshot()
+        let tokenText = recorded.compactMap { event -> String? in
+            guard case .tokenDelta(let token) = event.payload else {
+                return nil
+            }
+            return token.text
+        }
+        let usage = try XCTUnwrap(recorded.first { event in
+            matches(event.payload, .usageDelta)
+        }?.usageDelta)
+
+        XCTAssertEqual(tokenText, ["A", "BCDE", "F"])
+        XCTAssertEqual(usage.completionTokens, 6)
+        XCTAssertEqual(recorded.last?.completed.assistantText, "ABCDEF")
+        XCTAssertEqual(recorded.last?.completed.finishReason, "stop")
+        let metrics = services.metrics.counters
+        XCTAssertEqual(metrics["swift_text.decode_stream_event_count"], recorded.count)
+        XCTAssertEqual(metrics["swift_text.decode_grpc_write_call_count"], recorded.count)
+        XCTAssertEqual(recorded.count, 6)
+    }
+
+    func testDecodeDoesNotCoalesceNonGemmaVisibleTokenDeltas() async throws {
+        let services = makeServices(
+            environment: ["MELIX_DEV_TEXT_MODEL_PATH": "mlx-community/melix-dev-text-4bit"],
+            backend: FakeRuntimeBackend(
+                generatedChunks: ["unused"],
+                decodedChunks: ["A", "B", "C", "D", "E", "F"]
+            )
+        )
+        let loadResponse = try await withTestServerContextRPCCancellationHandle { handle in
+            var request = Melix_Worker_V1_LoadModelRequest()
+            request.model.modelID = "melix-dev-text"
+            return try await services.runtime.loadModel(
+                request: request,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_RuntimeService.Method.LoadModel.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        var prefillRequest = Melix_Worker_V1_PrefillRequest()
+        prefillRequest.execution.id.requestID = "req-non-gemma-cadence-prefill"
+        prefillRequest.execution.modelHandle = loadResponse.modelHandle
+        prefillRequest.returnDecodeHandle = true
+        var message = Melix_Worker_V1_ChatMessage()
+        message.role = "user"
+        var part = Melix_Worker_V1_MessagePart()
+        part.text = "Continue."
+        message.parts = [part]
+        prefillRequest.messages = [message]
+
+        let prefillResponse = try await withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.prefill(
+                request: prefillRequest,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Prefill.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        let writer = RecordingRPCWriter<Melix_Worker_V1_ExecuteEvent>()
+        var request = Melix_Worker_V1_DecodeRequest()
+        request.execution.id.requestID = "req-non-gemma-cadence"
+        request.execution.modelHandle = loadResponse.modelHandle
+        request.decodeHandle = prefillResponse.decodeHandle
+        request.maxOutputTokens = 6
+        request.returnUsage = true
+
+        try await withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.decode(
+                request: request,
+                response: RPCWriter(wrapping: writer),
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Decode.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        let recorded = await writer.snapshot()
+        let tokenText = recorded.compactMap { event -> String? in
+            guard case .tokenDelta(let token) = event.payload else {
+                return nil
+            }
+            return token.text
+        }
+        let usage = try XCTUnwrap(recorded.first { event in
+            matches(event.payload, .usageDelta)
+        }?.usageDelta)
+
+        XCTAssertEqual(tokenText, ["A", "B", "C", "D", "E", "F"])
+        XCTAssertEqual(usage.completionTokens, 6)
+        XCTAssertEqual(recorded.last?.completed.assistantText, "ABCDEF")
+        XCTAssertEqual(recorded.count, 9)
+    }
+
+    func testDecodeFlushesPendingVisibleDeltasBeforeReasoningDeltas() async throws {
+        let services = makeServices(
+            backend: FakeRuntimeBackend(
+                generatedChunks: ["unused"],
+                decodedChunks: [
+                    "A",
+                    "B",
+                    "<|channel>thought\n<channel|>R",
+                    "<|channel>final\n<channel|>C",
+                ]
+            )
+        )
+        let loadResponse = try await withTestServerContextRPCCancellationHandle { handle in
+            var request = Melix_Worker_V1_LoadModelRequest()
+            request.model.modelID = "unsloth/gemma-4-E4B-it-MLX-8bit"
+            request.model.modelPath = "unsloth/gemma-4-E4B-it-MLX-8bit"
+            return try await services.runtime.loadModel(
+                request: request,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_RuntimeService.Method.LoadModel.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        var prefillRequest = Melix_Worker_V1_PrefillRequest()
+        prefillRequest.execution.id.requestID = "req-gemma-reasoning-cadence-prefill"
+        prefillRequest.execution.modelHandle = loadResponse.modelHandle
+        prefillRequest.returnDecodeHandle = true
+        var message = Melix_Worker_V1_ChatMessage()
+        message.role = "user"
+        var part = Melix_Worker_V1_MessagePart()
+        part.text = "Think and answer."
+        message.parts = [part]
+        prefillRequest.messages = [message]
+
+        let prefillResponse = try await withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.prefill(
+                request: prefillRequest,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Prefill.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        let writer = RecordingRPCWriter<Melix_Worker_V1_ExecuteEvent>()
+        var request = Melix_Worker_V1_DecodeRequest()
+        request.execution.id.requestID = "req-gemma-reasoning-cadence"
+        request.execution.modelHandle = loadResponse.modelHandle
+        request.decodeHandle = prefillResponse.decodeHandle
+        request.maxOutputTokens = 4
+        request.returnUsage = true
+
+        try await withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.decode(
+                request: request,
+                response: RPCWriter(wrapping: writer),
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Decode.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        let payloadText = (await writer.snapshot()).compactMap { event -> String? in
+            switch event.payload {
+            case .tokenDelta(let token):
+                return "token:\(token.text)"
+            case .reasoningDelta(let reasoning):
+                return "reasoning:\(reasoning.text)"
+            default:
+                return nil
+            }
+        }
+
+        XCTAssertEqual(payloadText, ["token:A", "token:B", "reasoning:R", "token:C"])
     }
 
     func testGenerateReturnsNotFoundErrorEventForUnknownModelHandle() async throws {


### PR DESCRIPTION
## Summary
- Coalesces bounded visible token deltas for Gemma-family Swift decode after the first visible token to reduce worker gRPC and downstream stream write pressure.
- Keeps non-Gemma decode on immediate writes, preserves the first visible token for TTFT, and flushes pending visible text before reasoning and terminal events.
- Adds focused worker tests and a plan/metrics record for the #1660 output-cadence slice.

## Plan or Spec
- `docs/plans/2026-06-01-issue-1660-token-output-cadence.md`
- Closes #1660.

## Commands Run
```text
swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testDecodeCoalescesGemmaVisibleTokenDeltasAfterFirstToken|WorkerScaffoldTests/testDecodeDoesNotCoalesceNonGemmaVisibleTokenDeltas|WorkerScaffoldTests/testDecodeFlushesPendingVisibleDeltasBeforeReasoningDeltas'
Result: initial red; Gemma cadence test saw 6 token deltas / 9 total events before implementation, expected 3 token deltas / 6 total events.

swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testDecodeOutputCadencePolicyScopesDefaultToGemmaAndHonorsOverrides|WorkerScaffoldTests/testDecodeCoalescesGemmaVisibleTokenDeltasAfterFirstToken|WorkerScaffoldTests/testDecodeDoesNotCoalesceNonGemmaVisibleTokenDeltas|WorkerScaffoldTests/testDecodeFlushesPendingVisibleDeltasBeforeReasoningDeltas|WorkerScaffoldTests/testDecodeStreamingRpcBatchesHomogeneousDeterministicDecodeRequests|WorkerScaffoldTests/testGenerateSuppressesHarmonyThoughtChannelForLoadedModel'
Result: passed, 6 tests, 0 failures.

swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testDecodeOutputCadencePolicyAllowsFragmentOnlyFlushLimit'
Result: review follow-up initial red; fragment-only cadence policy did not buffer and flushed immediately when maxBufferedVisibleCharacters was 0.

swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testDecodeOutputCadencePolicyAllowsFragmentOnlyFlushLimit|WorkerScaffoldTests/testDecodeOutputCadencePolicyScopesDefaultToGemmaAndHonorsOverrides|WorkerScaffoldTests/testDecodeCoalescesGemmaVisibleTokenDeltasAfterFirstToken|WorkerScaffoldTests/testDecodeDoesNotCoalesceNonGemmaVisibleTokenDeltas|WorkerScaffoldTests/testDecodeFlushesPendingVisibleDeltasBeforeReasoningDeltas'
Result: passed, 5 tests, 0 failures.

uv run --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/mlx-text-worker-swift/Sources/Core/Inference/FilteredTextOutputWriter.swift services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeEngine.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
Result: TOTAL 99.77% 433/434.

uv run --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/mlx-text-worker-swift/Sources/Core/Inference/FilteredTextOutputWriter.swift services/mlx-text-worker-swift/Sources/Core/Inference/TextDecodeEngine.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
Result: review-fix staged delta TOTAL 100.00% 17/17.

uv run --project services/mlx-worker-python --extra mlx python scripts/same_cohort_batching_probe.py --metrics
Result: failure_count=0, status_warning=1; existing warning remained scheduler_admission_cohort_size=2 / worker_model_eval_batch_size=1.

uv run --project services/mlx-worker-python --extra mlx python scripts/three_way_serving_compare.py --help
Result: passed.

git diff --check
Result: passed.

make git-hooks-install
Result: passed.

make bootstrap
Result: passed.

make proto && git diff --exit-code -- packages/protocol/descriptors packages/protocol/python packages/protocol/swift
Result: passed; generated protocol artifacts had no drift.

make swift-test
Result: passed.

make py-test
Result: passed, 3377 passed, 14 skipped, 2 warnings.

make integration-test
Result: passed, 115 passed, 1 skipped.

.githooks/pre-commit
Result: passed on a 256 GiB macOS host after the review fix. The hook reran make swift-test, make py-test, make integration-test, and the scoped performance report.
Latest report: .runtime/pre-commit-performance/20260601-072552-2c84b023/report/report.md
Report status: ok; Regressions: 0; Context regressions: 0; Verification failures: 0.

Real Gemma E4B before/after benchmark:
uv run --project services/mlx-worker-python --extra mlx python scripts/three_way_serving_compare.py --endpoint base=http://127.0.0.1:12445/v1::unsloth/gemma-4-E4B-it-MLX-8bit --endpoint head=http://127.0.0.1:12444/v1::unsloth/gemma-4-E4B-it-MLX-8bit --target-endpoint head --prompt-token-targets 1024 --max-tokens 128 --repeats 2 --warmup-requests 1 --warmup-prompt-token-target 512 --warmup-max-tokens 16 --concurrency 1 --cache-profile cold_unique --prompt-style saturating --temperature 0 --top-p 1 --top-k 0 --include-usage --timeout-seconds 900 --preflight-wait-seconds 30 --measurement-profile warm --run-id issue1660-gemma-e4b-output-cadence-20260601-045908
Result: threshold status ok; failures 0; both endpoints completed 2 measured requests with error_count=0.
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 99.77% 433/434` for `FilteredTextOutputWriter.swift`, `TextDecodeEngine.swift`, and `WorkerScaffoldTests.swift`.
- Review-fix changed-line coverage: `TOTAL 100.00% 17/17` for the staged fragment-only cadence fix delta.
- Pre-commit scoped performance: `.runtime/pre-commit-performance/20260601-072552-2c84b023/report/report.md`; status `ok`, regressions `0`, context regressions `0`, verification failures `0`, targeted coverage `100.0%`.
- Gemma E4B real serving benchmark artifacts: `.runtime/issue1660-token-output-cadence-benchmark/issue1660-gemma-e4b-output-cadence-20260601-045908/`.
- Gemma E4B scenario: warm profile, prompt target `1024`, measured prompt tokens `634`, `max_tokens=128`, `repeats=2`, `concurrency=1`, `prompt_style=saturating`.
- Median total latency improved from `32048.20 ms` to `31927.64 ms` (`-0.38%`); median decode throughput improved from `4.29 tok/s` to `4.39 tok/s` (`+2.25%`).
- Output write pressure dropped from `281` to `80` decode gRPC writes and from `131` to `36` streamed decode events across warmup plus measured requests; `swift_text.decode_grpc_write_total_us` dropped from `28047` to `8190`.
- Memory evidence: Swift text-worker peak resident bytes were `8320598016` for base and `8338587648` for head; both loaded one model.
- Observability mode: minimal. This slice reuses existing #1659 counters and does not add new per-token runtime instrumentation.
- Probe overhead: N/A for production runtime; no new production probe was added.

## Known Gaps
- The real Gemma E4B before/after benchmark baseline was `origin/main` at `5f69a9c79f9d3bf5e0d98e8c3094210fd6ce88d5`. The branch was later updated to current `origin/main` `31a46494`; the subsequent main change was outside the Swift output-cadence path, and full local pre-commit verification was rerun after updating.
- This closes only #1660. Broader Gemma E4B parity work remains governed by the parent/root issue tree.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
