### PR TITLE
perf: load dataset version manifests from bytes

### DIFF
--- a/docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md
+++ b/docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md
@@ -318,10 +318,11 @@ retry. `retry_failed_dataset_version(...)` reads the base version manifest and
 failed-segment file, copies successful sample rows unchanged into a new version,
 regenerates only failed segment ids, and writes `dataset-retry-receipt.json`
 with `rewritten_successful_sample_count` fixed at `0`. `list_dataset_versions(...)`
-reads version manifests from the dataset root, sorts by `created_at` and
-`version_id`, and records listing latency. The matching operator surface adds
-`melix dataset prepare version`, `retry-failed`, and `list-versions`, plus
-Desktop decoders for dataset version, retry receipt, and quality summary states.
+reads version manifests from the dataset root with streamed scandir manifest paths
+and whole-file byte JSON loads, sorts by `created_at` and `version_id`, and records
+listing latency. The matching operator surface adds `melix dataset prepare version`,
+`retry-failed`, and `list-versions`, plus Desktop decoders for dataset version,
+retry receipt, and quality summary states.
 Report evidence consumes the same schema-backed paths by rendering
 `dataset_version_path`, `dataset_quality_summary_path`,
 `dataset_ingest_receipt_path`, and `workspace_preflight_receipt_path` artifact

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -485,8 +485,7 @@ def list_dataset_versions(
     }
 
 
-def _iter_dataset_version_manifest_paths(versions_root: Path) -> list[str]:
-    manifest_paths: list[str] = []
+def _iter_dataset_version_manifest_paths(versions_root: Path) -> Iterable[str]:
     try:
         with os.scandir(versions_root) as entries:
             for entry in entries:
@@ -494,10 +493,9 @@ def _iter_dataset_version_manifest_paths(versions_root: Path) -> list[str]:
                     continue
                 manifest_path = os.path.join(entry.path, "dataset-version.json")
                 if os.path.isfile(manifest_path):
-                    manifest_paths.append(manifest_path)
+                    yield manifest_path
     except OSError:
-        return []
-    return manifest_paths
+        return
 
 
 def _iter_source_records(
@@ -818,7 +816,7 @@ def _read_json(path: Path) -> dict[str, Any]:
 
 def _read_json_file(path: str) -> dict[str, Any]:
     with open(path, "rb") as handle:
-        return json.load(handle)
+        return json.loads(handle.read())
 
 
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Stream dataset version manifest paths from `os.scandir` instead of materializing a temporary manifest-path list.
- Load each manifest by reading bytes before `json.loads`, avoiding `json.load` file-object parser overhead in the registered version-listing hot path.
- Keep deterministic version ordering and manifest fields unchanged, and update the dataset preparation plan for this performance slice.

## Plan or Spec
- `docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md`

## Commands Run
```text
# Baseline before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
Result: passed, 7 tests.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py
Baseline result: {"elapsed_ms_mean": 54.318687, "elapsed_ms_min": 42.554257, "elapsed_ms_p95": 61.504784, "sample_count": 7.0, "version_count": 2500.0}

# After implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
Result: passed, 7 tests.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py
Result: passed; changed-line coverage TOTAL 3 0 100%.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py
Result: {"elapsed_ms_mean": 47.095582, "elapsed_ms_min": 44.116537, "elapsed_ms_p95": 49.507277, "sample_count": 7.0, "version_count": 2500.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py
Result: {"elapsed_ms_mean": 52.733782, "elapsed_ms_min": 44.461364, "elapsed_ms_p95": 56.463047, "sample_count": 7.0, "version_count": 2500.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py
Result: {"elapsed_ms_mean": 53.663103, "elapsed_ms_min": 45.427157, "elapsed_ms_p95": 63.349045, "sample_count": 7.0, "version_count": 2500.0}

git diff --check
Result: passed.
```

## Coverage and Metrics
- Registered probe: `dataset-version-listing-scandir` covers `services/mlx-worker-python/worker/productization/dataset_preparation.py`, focused tests, and `scripts/dataset_version_listing_probe.py` with `test_command`, `coverage_command`, and `probe_command` entries.
- Changed-line coverage: `TOTAL 3 0 100%` for the changed executable lines.
- Local baseline probe mean: `54.318687 ms` over 7 samples and 2500 manifests.
- Local post-change probe means: `47.095582 ms`, `52.733782 ms`, `53.663103 ms` over repeated registered probe runs.
- Best local post-change comparison: `delta_ms=-7.223105`, `speedup=1.153369x`, `13.30%` lower mean latency; repeated local probes show this path is noisy on the Linux runner.
- CI PR-scoped performance must validate the registered base/head probe on GitHub Actions before merge.
- Observability mode: N/A; this slice changes local manifest listing/parsing only and adds no runtime instrumentation.
- Probe overhead: N/A for production runtime; uses the existing PR-scoped command-json probe only.

## Known Gaps
- Full `make py-test` was not run locally; this slice used the registered focused test, coverage, and probe commands for the affected Python hot path.
- CI PR-scoped performance is the merge gate for the registered probe base/head report. A previous CI run for commit `8c1bff2c` flagged a noisy `elapsed_ms_p95` regression, so this amended commit must not merge unless the current registered CI report is green.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
