### PR TITLE
perf: slot job registry cache rows

### DIFF
--- a/docs/plans/2026-06-01-job-registry-slotted-caches.md
+++ b/docs/plans/2026-06-01-job-registry-slotted-caches.md
@@ -1,0 +1,35 @@
+# Job Registry Slotted Cache Rows
+
+## Scope
+
+This performance slice is limited to Python model-ops job registry row objects used while restoring jobs and building active derived-model lookup caches.
+
+Affected files:
+
+- `services/mlx-worker-python/worker/model_ops/job_registry.py`
+- `services/mlx-worker-python/tests/test_model_ops_job_registry.py`
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped probe `job-registry-derived-model-single-pass` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes focused `test_command`, `coverage_command`, and `probe_command` entries. Its `restore_elapsed_ms_mean`, `resolve_target_elapsed_ms_mean`, `manifest_path_elapsed_ms_mean`, and `active_manifest_elapsed_ms_mean` metrics cover the restored `ModelOpsJob` instances and active derived-model lookup cache entries touched by this slice.
+
+## Implementation Plan
+
+1. Keep the existing job registry data model semantics unchanged.
+2. Convert `ModelOpsJob` and `_ActiveDerivedModelLookup` dataclasses to slotted dataclasses so per-row instances avoid per-object dictionaries during restore and lookup-cache construction.
+3. Add regression assertions that restored/cached job rows and active lookup cache entries remain dict-less.
+4. Run the registered focused tests, changed-scope coverage, and registered probe locally on Linux before opening a PR.
+
+## Validation Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py
+```
+
+CI remains the merge gate for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/tests/test_model_ops_job_registry.py
+++ b/services/mlx-worker-python/tests/test_model_ops_job_registry.py
@@ -853,6 +853,7 @@ def test_active_derived_model_row_cache_reuses_rows_and_invalidates() -> None:
     second_manifests = registry.active_derived_model_manifests()
 
     assert first_rows is second_rows
+    assert not hasattr(first_rows[0][0], "__dict__")
     assert first_manifests is registry._active_derived_model_manifests_cache
     assert first_manifests is second_manifests
     assert first_manifests == (
@@ -914,6 +915,10 @@ def test_resolve_derived_model_target_reuses_active_row_cache(
 
     assert registry.resolve_derived_model_target(derived_model_id="melix-dev-active") is not None
     assert registry.resolve_derived_model_target(derived_model_id="melix-dev-active") is not None
+    by_id_cache = registry._active_derived_model_by_id_cache
+    assert by_id_cache is not None
+    cached_lookup = by_id_cache["melix-dev-active"]
+    assert not hasattr(cached_lookup, "__dict__")
     assert build_calls == 1
 
 

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -41,7 +41,7 @@ def _runtime_mode_from_activation(activation_mode: str) -> int:
     return int(common_pb2.RUNTIME_MODE_UNSPECIFIED)
 
 
-@dataclass
+@dataclass(slots=True)
 class ModelOpsJob:
     job_id: str
     operation: str
@@ -57,7 +57,7 @@ class ModelOpsJob:
     error_message: str = ""
 
 
-@dataclass
+@dataclass(slots=True)
 class _ActiveDerivedModelLookup:
     job: ModelOpsJob
     manifest: dict[str, Any]


### PR DESCRIPTION
## Summary
- Convert job registry row/cache dataclasses to `slots=True` so restored `ModelOpsJob` rows and active derived-model lookup entries avoid per-instance dictionaries.
- Add focused regression assertions that cached rows and lookup entries remain dict-less.

## Plan or Spec
- Added `docs/plans/2026-06-01-job-registry-slotted-caches.md`.
- Registered probe: `job-registry-derived-model-single-pass` already covers this path with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_derived_model_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_derived_model_probe.py` (3 baseline samples before change, 3 samples after change)
- `git diff --check`

## Coverage and Metrics
- Focused tests: `39 passed in 1.32s`.
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Local Linux probe comparison across three runs:
  - `elapsed_ms_mean`: old_mean=42.382081 ms, new_mean=37.267488 ms, delta=-5.114593 ms, speedup=1.137x (12.07% lower).
  - `restore_elapsed_ms_mean`: old_mean=42.377271 ms, new_mean=37.263507 ms, delta=-5.113764 ms, speedup=1.137x (12.07% lower).
- Registered PR-scoped CI probe remains the merge gate.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime effects are part of this slice.
- The probe is noisy at sub-ms lookup/cache timings, so the accepted local signal is focused on combined and restore timings plus CI validation.

## Evidence Checklist
- [x] Synced from `origin/main` before starting the slice.
- [x] Confirmed affected path has a registered PR-scoped probe with test, coverage, and probe commands.
- [x] Implemented exactly one small Python performance slice.
- [x] Added/updated governing plan under `docs/plans/`.
- [x] Ran focused tests, changed-scope coverage, and local registered probe.
- [ ] PR-scoped GitHub Actions performance report completed successfully.
