### PR TITLE
perf: skip unrelated report target field scans

### DIFF
--- a/docs/plans/2026-06-01-report-evidence-target-field-disjoint.md
+++ b/docs/plans/2026-06-01-report-evidence-target-field-disjoint.md
@@ -1,0 +1,25 @@
+# Report evidence target-field disjoint slice
+
+## Scope
+
+Optimize the Python report-evidence release-matrix target-field rule matcher without changing gate semantics.
+
+The slice is intentionally limited to `worker.productization.report_evidence_gate._rule_matches_report` and its focused unit/performance coverage.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped performance probe `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes:
+
+- `test_command` for `test_report_evidence_gate.py` and PR-scoped probe selection/script tests.
+- `coverage_command` for changed-scope coverage over the gate module, tests, probe script, and registry.
+- `probe_command` running `scripts/report_evidence_gate_run_kind_probe.py`.
+
+## Optimization
+
+Target-field rules used to iterate every field/value pair in every target row before checking membership in the configured target-field set. Most rows in the release-matrix scan are unrelated, so the matcher now performs a C-level `frozenset.isdisjoint(target)` key check first and only reads values from rows that contain at least one candidate target field.
+
+## Success metrics
+
+Accept only if the registered local probe remains behaviorally green and reports lower `target_field_elapsed_ms_mean` with no regression in focused tests/coverage.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -267,6 +267,28 @@ def test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple() 
     assert cache_info.misses == 1
 
 
+def test_report_evidence_gate_target_field_rules_skip_unrelated_target_items() -> None:
+    class ItemsCountingDict(dict[str, object]):
+        items_calls = 0
+
+        def items(self):  # type: ignore[override]  # pragma: no cover
+            type(self).items_calls += 1
+            return super().items()
+
+    unrelated_targets: list[dict[str, object]] = [
+        ItemsCountingDict({f"unrelated_{index}": index}) for index in range(8)
+    ]
+
+    assert not report_evidence_gate_module._rule_matches_report(
+        rule={"target_fields": ("adapter_id", "adapter_snapshot")},
+        runs=[],
+        targets=unrelated_targets,
+        metrics=[],
+        probe_phases=set(),
+    )
+    assert ItemsCountingDict.items_calls == 0
+
+
 def test_report_evidence_gate_target_field_list_rules_reflect_mutation() -> None:
     target_fields = ["adapter_id"]
     rule = {"target_fields": target_fields}

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -310,9 +310,14 @@ def _rule_matches_report(
     target_fields = rule.get("target_fields", ())
     if target_fields:
         target_field_set = _string_frozenset(target_fields)
+        target_fields_are_disjoint = target_field_set.isdisjoint
         for target in targets:
-            for field, value in target.items():
-                if field not in target_field_set:
+            if target_fields_are_disjoint(target):
+                continue
+            for field in target_field_set:
+                try:
+                    value = target[field]
+                except KeyError:
                     continue
                 if isinstance(value, str):
                     if value.strip():


### PR DESCRIPTION
## Summary
- Optimizes report-evidence target-field rule matching by skipping unrelated target rows with `frozenset.isdisjoint` before reading field values.
- Adds a regression test proving unrelated target rows no longer require `items()` iteration.
- Documents the slice plan and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-06-01-report-evidence-target-field-disjoint.md`
- Registered probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py infra/perf/pr_scoped_probes.json`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 21 passed.
- Changed-scope coverage: 100% (`TOTAL 13 0 100%`).
- Baseline registered probe on `origin/main`: `elapsed_ms_mean=2216.6047`, `target_field_elapsed_ms_mean=579.2861`.
- Candidate registered probe: `elapsed_ms_mean=2002.5695`, `target_field_elapsed_ms_mean=346.3087`.
- Target-field slice delta: `-232.9774 ms` (`~40.2%` faster for `target_field_elapsed_ms_mean`).

## Known Gaps
- Local validation is Linux/Python-only. GitHub Actions PR-scoped performance workflow remains the authoritative CI validation for the registered probe.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally and improved the targeted metric.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
