### PR TITLE
Expose worker prefill window metrics

### DIFF
--- a/docs/plans/2026-06-01-issue-1662-prefill-metrics.md
+++ b/docs/plans/2026-06-01-issue-1662-prefill-metrics.md
@@ -1,0 +1,114 @@
+# Issue 1662 Prefill Metrics Reconciliation Plan
+
+## Context
+
+Issue #1662 is an open child of the #1642 Gemma E4B serving performance root.
+Recent release evidence showed `scheduler.prefill_chunk_target_tokens=16` while
+the Swift text worker reported `swift_text.prefill_chunk_target_tokens=512`.
+Those values are both expected today, but the metric names do not explain their
+different semantics.
+
+The scheduler value is the boundary-safe progress chunk used for request
+admission and streamed progress accounting. The worker value is the prefill step
+requested from the runtime, and the actual model-call window can diverge again
+when acceleration policies widen or reshape the prefill window.
+
+## Goal
+
+Expose explicit Swift text worker metrics that identify the requested worker
+prefill step and the effective model prefill window used by the runtime call, so
+benchmark artifacts can distinguish scheduler progress boundaries from worker
+runtime windows.
+
+## Scope
+
+- Preserve the existing `swift_text.prefill_chunk_target_tokens` metric for
+  compatibility.
+- Add explicit worker prefill metrics for the requested step and the effective
+  model window.
+- Thread the effective window from the runtime backend through the worker
+  prefill result.
+- Cover both text-only and vision-bearing prompt paths in focused Swift worker
+  tests.
+- Document the new metric semantics in this plan.
+
+Out of scope:
+
+- Changing scheduler prefill progress chunk selection.
+- Changing worker prefill batching or runtime window policy.
+- Regenerating protobuf schemas.
+- Running the full Gemma E4B release comparison; this slice only closes the
+  metric attribution gap needed by that comparison.
+
+## Metric Keys
+
+- `swift_text.worker_prefill_requested_step_tokens`: the prefill step size the
+  worker received in the prefill request and passed toward the runtime.
+- `swift_text.worker_prefill_effective_window_tokens`: the runtime window size
+  used for the model prepare/prefill call after applying worker-side
+  acceleration policy.
+- `swift_text.prefill_chunk_target_tokens`: existing compatibility metric. It
+  remains the worker request step size and should not be compared directly with
+  `scheduler.prefill_chunk_target_tokens` without the two worker-prefill metrics
+  above.
+
+## Implementation Steps
+
+1. Add red worker tests.
+   - Text-only prompt with a 512-token worker prefill step records requested and
+     effective worker window metrics as 512 while the compatibility chunk metric
+     remains 512.
+   - Vision-bearing prompt with a 16-token worker prefill step records requested
+     and effective worker window metrics as 16.
+2. Extend runtime prefill results.
+   - Add requested-step and effective-window fields to `RuntimePrefillResult`.
+   - Populate them from the deterministic backend, Swift MLX backend, and test
+     fake backend.
+3. Surface the metrics in `TextPrefillEngine`.
+   - Record the explicit worker prefill metrics after successful prefill.
+   - Keep the existing compatibility metric unchanged.
+4. Update metric defaults and verify changed-line coverage.
+
+## Performance Probes And Success Metrics
+
+- Metrics are written once per successful prefill request, not from the runtime
+  token loop.
+- The deterministic focused tests should pass with code coverage enabled.
+- Changed-line coverage for the touched Swift worker files must be at least
+  95 percent before commit.
+- A follow-up Gemma E4B serving report can use the new metric pair to explain a
+  scheduler progress target of 16 alongside a worker model window of 512.
+
+## Verification
+
+```bash
+swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testPrefillMetricsSeparateTextWorkerWindowFromChunkCompatibility|WorkerScaffoldTests/testPrefillMetricsRecordVisionWorkerWindow'
+
+uv run --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/mlx-text-worker-swift/Sources/Core/Inference/TextPrefillEngine.swift services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+
+git diff --check
+```
+
+The final PR gate must also follow the repository default commands and
+pre-commit performance report rules before claiming PR readiness.
+
+## Metrics Report
+
+Verification was run on June 1, 2026 from the
+`codex/issue-1662-prefill-metrics-20260601` worktree.
+
+- Initial red run:
+  - `swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testPrefillMetricsSeparateTextWorkerWindowFromChunkCompatibility|WorkerScaffoldTests/testPrefillMetricsRecordVisionWorkerWindow'`
+  - Result: failed because `swift_text.worker_prefill_requested_step_tokens`
+    and `swift_text.worker_prefill_effective_window_tokens` were not recorded.
+- Focused final run:
+  - `swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testMetricsStoreTracksCountersAndTimings|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillUsesLiveModelContainerBridge|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillAppliesAcceleratedPrefillPolicyForLiveBridge|WorkerScaffoldTests/testTextRuntimeForwardsPrefillAndDefaultPrefillThrowsUnavailable|WorkerScaffoldTests/testPrefillCanRestoreBoundarySnapshotsFromCacheHints|WorkerScaffoldTests/testPrefillRestoreWalksBackPartialPrefixesToSafeBoundary|WorkerScaffoldTests/testPrefillRecordsBoundarySafeChunkMetricsForLongPrompts|WorkerScaffoldTests/testPrefillMetricsSeparateTextWorkerWindowFromChunkCompatibility|WorkerScaffoldTests/testPrefillMetricsRecordVisionWorkerWindow'`
+  - Result: passed, 9 tests, 0 failures.
+- Changed-line coverage:
+  - `uv run --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/mlx-text-worker-swift/Sources/Core/Inference/TextPrefillEngine.swift services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift`
+  - Result: `TOTAL 100.00% 128/128`.
+- Runtime metrics:
+  - New metrics are written once per successful prefill request in
+    `TextPrefillEngine`.
+  - The change is observational and does not alter scheduler chunk selection,
+    worker prefill batching, or runtime window policy.

--- a/services/mlx-text-worker-swift/Sources/Core/Inference/TextPrefillEngine.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Inference/TextPrefillEngine.swift
@@ -50,6 +50,14 @@ struct TextPrefillEngine: Sendable {
                 value: Int(clamping: request.prefillStepSize)
             )
             metrics.set(
+                "swift_text.worker_prefill_requested_step_tokens",
+                value: result.requestedPrefillStepTokens
+            )
+            metrics.set(
+                "swift_text.worker_prefill_effective_window_tokens",
+                value: result.effectivePrefillWindowTokens
+            )
+            metrics.set(
                 "swift_text.prefill_last_chunk_tokens",
                 value: Int(clamping: prefillChunkBoundaries.last ?? 0)
             )

--- a/services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift
@@ -17,6 +17,8 @@ final class MetricsStore: @unchecked Sendable {
         "swift_text.prefill_prompt_tokens": 0,
         "swift_text.prefill_chunk_count": 0,
         "swift_text.prefill_chunk_target_tokens": 0,
+        "swift_text.worker_prefill_requested_step_tokens": 0,
+        "swift_text.worker_prefill_effective_window_tokens": 0,
         "swift_text.prefill_last_chunk_tokens": 0,
         "swift_text.prefill_context_count": 0,
         "swift_text.prefill_guard_rejection_count": 0,

--- a/services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift
@@ -72,12 +72,15 @@ struct DeterministicTextBackend: TextRuntimeBackend {
         try throwIfTextRuntimeCancellationRequested(shouldAbort)
 
         storage["prefill_step_size"] = String(prefillStepSize)
+        let effectiveWindowSize = Int(clamping: max(prefillStepSize, 1))
         return RuntimePrefillResult(
             context: TextPrefillContext(
                 storage: storage,
                 promptTokens: promptTokens
             ),
             promptTokens: promptTokens,
+            requestedPrefillStepTokens: Int(clamping: prefillStepSize),
+            effectivePrefillWindowTokens: effectiveWindowSize,
             appliedAcceleration: appliedAcceleration,
             acceleratedPrefillGainPct: prefillGainPct,
             activeKVQuantizationRatio: activeKVRatio

--- a/services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift
@@ -27,6 +27,7 @@ struct PreparedTextGeneration: Sendable {
 struct PreparedPrefillContext: @unchecked Sendable {
     let preparedInput: Any
     let promptTokens: Int
+    let effectivePrefillWindowTokens: Int
     let activeKVQuantizationRatio: Int
 }
 
@@ -201,12 +202,7 @@ struct AutoSwiftMLXBackend: TextRuntimeBackend {
         shouldAbort: @escaping @Sendable () -> Bool
     ) async throws -> RuntimePrefillResult {
         let appliedAcceleration = resolveSwiftPrefillAcceleration(acceleration, messages: messages)
-        let baseWindowSize = Int(max(prefillStepSize, 1))
-        let effectiveWindowSize = acceleratedPrefillWindowSize(
-            baseWindowSize: baseWindowSize,
-            policy: appliedAcceleration,
-            messages: messages
-        )
+        let baseWindowSize = Int(clamping: max(prefillStepSize, 1))
         let prepared = try await makePreparedPromptContext(
             model: model,
             messages: messages,
@@ -220,10 +216,12 @@ struct AutoSwiftMLXBackend: TextRuntimeBackend {
                 promptTokens: prepared.promptTokens
             ),
             promptTokens: prepared.promptTokens,
+            requestedPrefillStepTokens: Int(clamping: prefillStepSize),
+            effectivePrefillWindowTokens: prepared.effectivePrefillWindowTokens,
             appliedAcceleration: appliedAcceleration,
             acceleratedPrefillGainPct: estimatedPrefillGainPercent(
                 baselineWindowSize: baseWindowSize,
-                effectiveWindowSize: effectiveWindowSize
+                effectiveWindowSize: prepared.effectivePrefillWindowTokens
             ),
             activeKVQuantizationRatio: prepared.activeKVQuantizationRatio
         )
@@ -509,7 +507,7 @@ private func makePreparedPromptContext(
     let chat = try convertChatMessages(messages)
     let userInput = UserInput(chat: chat)
     let effectiveWindowSize = acceleratedPrefillWindowSize(
-        baseWindowSize: Int(max(prefillStepSize, 1)),
+        baseWindowSize: Int(clamping: max(prefillStepSize, 1)),
         policy: acceleration,
         messages: messages
     )
@@ -549,6 +547,7 @@ private func makePreparedPromptContext(
     return PreparedPrefillContext(
         preparedInput: preparedState,
         promptTokens: preparedState.input.text.tokens.size,
+        effectivePrefillWindowTokens: effectiveWindowSize,
         activeKVQuantizationRatio: preparedState.activeKVQuantizationRatio
     )
     #else

--- a/services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift
@@ -48,6 +48,8 @@ enum ActiveKVQuantizationProfiles {
 struct RuntimePrefillResult: Sendable {
     let context: TextPrefillContext
     let promptTokens: Int
+    let requestedPrefillStepTokens: Int
+    let effectivePrefillWindowTokens: Int
     let appliedAcceleration: Melix_Worker_V1_AccelerationPolicy
     let acceleratedPrefillGainPct: Int
     let activeKVQuantizationRatio: Int

--- a/services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift
@@ -33,6 +33,8 @@ struct WorkerPrefillResult: Sendable {
     let restoredSnapshotID: String
     let appliedAcceleration: Melix_Worker_V1_AccelerationPolicy
     let acceleratedPrefillGainPct: Int
+    let requestedPrefillStepTokens: Int
+    let effectivePrefillWindowTokens: Int
     let activeKVQuantizationRatio: Int
     let cacheStats: Melix_Worker_V1_CacheStats
     let hotPrefixCount: Int
@@ -474,6 +476,8 @@ actor WorkerRuntimeRegistry {
                     restoredSnapshotID: restored.snapshot.snapshotID,
                     appliedAcceleration: runtimePrefill.appliedAcceleration,
                     acceleratedPrefillGainPct: runtimePrefill.acceleratedPrefillGainPct,
+                    requestedPrefillStepTokens: runtimePrefill.requestedPrefillStepTokens,
+                    effectivePrefillWindowTokens: runtimePrefill.effectivePrefillWindowTokens,
                     activeKVQuantizationRatio: runtimePrefill.activeKVQuantizationRatio,
                     cacheStats: cacheStats,
                     hotPrefixCount: cacheSnapshot.hotPrefixes.count,
@@ -541,6 +545,8 @@ actor WorkerRuntimeRegistry {
             restoredSnapshotID: "",
             appliedAcceleration: result.appliedAcceleration,
             acceleratedPrefillGainPct: result.acceleratedPrefillGainPct,
+            requestedPrefillStepTokens: result.requestedPrefillStepTokens,
+            effectivePrefillWindowTokens: result.effectivePrefillWindowTokens,
             activeKVQuantizationRatio: result.activeKVQuantizationRatio,
             cacheStats: cacheStats,
             hotPrefixCount: cacheSnapshot.hotPrefixes.count,

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -5114,7 +5114,8 @@ final class WorkerScaffoldTests: XCTestCase {
             environment: [
                 "MELIX_DEV_TEXT_MODEL_PATH": "mlx-community/melix-dev-text-4bit",
                 "MELIX_SWIFT_TEXT_WORKER_BACKEND_MODE": "deterministic",
-                "MELIX_SWIFT_TEXT_WORKER_DECODE_BATCH_PENDING_WINDOW_MS": "50",
+                // Keep the window above CI scheduling jitter; this test asserts batching, not a timing SLA.
+                "MELIX_SWIFT_TEXT_WORKER_DECODE_BATCH_PENDING_WINDOW_MS": "1000",
             ],
             backend: DeterministicTextBackend(tokenDelayNanos: 0)
         )

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -257,6 +257,8 @@ final class WorkerScaffoldTests: XCTestCase {
         XCTAssertEqual(counters["swift_text.unimplemented_rpc_count"], 1)
         XCTAssertEqual(counters["swift_text.custom_counter"], 3)
         XCTAssertEqual(counters["swift_text.runtime_stats_ms"], 12)
+        XCTAssertEqual(counters["swift_text.worker_prefill_requested_step_tokens"], 0)
+        XCTAssertEqual(counters["swift_text.worker_prefill_effective_window_tokens"], 0)
         XCTAssertEqual(counters["swift_text.active_kv_backend_code"], 0)
         XCTAssertEqual(counters["swift_text.active_kv_kernel_path_code"], 0)
         XCTAssertEqual(counters["swift_text.active_kv_runtime_route_code"], 0)
@@ -1159,6 +1161,8 @@ final class WorkerScaffoldTests: XCTestCase {
 
         XCTAssertEqual(result.promptTokens, promptTokens.count)
         XCTAssertEqual(result.context.promptTokens, promptTokens.count)
+        XCTAssertEqual(result.requestedPrefillStepTokens, 32)
+        XCTAssertEqual(result.effectivePrefillWindowTokens, 32)
     }
 
     func testAutoSwiftMLXBackendPrefillAppliesAcceleratedPrefillPolicyForLiveBridge() async throws {
@@ -1185,6 +1189,8 @@ final class WorkerScaffoldTests: XCTestCase {
 
         XCTAssertEqual(result.appliedAcceleration.mode, .acceleratedPrefill)
         XCTAssertEqual(result.appliedAcceleration.prefillHint, "json-schema")
+        XCTAssertEqual(result.requestedPrefillStepTokens, 4)
+        XCTAssertGreaterThan(result.effectivePrefillWindowTokens, result.requestedPrefillStepTokens)
         XCTAssertGreaterThan(result.acceleratedPrefillGainPct, 0)
         XCTAssertEqual(result.activeKVQuantizationRatio, 0)
     }
@@ -2438,6 +2444,8 @@ final class WorkerScaffoldTests: XCTestCase {
 
         XCTAssertEqual(result.promptTokens, 1)
         XCTAssertEqual(result.context.promptTokens, 1)
+        XCTAssertEqual(result.requestedPrefillStepTokens, 8)
+        XCTAssertEqual(result.effectivePrefillWindowTokens, 8)
         XCTAssertEqual((result.context.storage as? [String: String])?["resume_hint"], "runtime-resume")
         XCTAssertEqual((result.context.storage as? [String: String])?["prefill_step_size"], "8")
 
@@ -10793,6 +10801,98 @@ final class WorkerScaffoldTests: XCTestCase {
         XCTAssertEqual(metrics["swift_text.prefill_chunk_target_tokens"], 16)
         XCTAssertEqual(metrics["swift_text.prefill_last_chunk_tokens"], 24)
     }
+
+    func testPrefillMetricsSeparateTextWorkerWindowFromChunkCompatibility() async throws {
+        let services = makeServices(
+            backend: DeterministicTextBackend(tokenDelayNanos: 0)
+        )
+
+        let loadResponse = try await withTestServerContextRPCCancellationHandle { handle in
+            var request = Melix_Worker_V1_LoadModelRequest()
+            request.model.modelID = "melix-dev-text"
+            return try await services.runtime.loadModel(
+                request: request,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_RuntimeService.Method.LoadModel.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        let prompt = (1...24).map { "token\($0)" }.joined(separator: " ")
+        var prefill = Melix_Worker_V1_PrefillRequest()
+        prefill.execution.id.requestID = "req-text-window-prefill"
+        prefill.execution.modelHandle = loadResponse.modelHandle
+        prefill.prefillStepSize = 512
+        prefill.returnDecodeHandle = true
+        prefill.messages = [makeUserMessage(prompt)]
+
+        let response = try await withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.prefill(
+                request: prefill,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Prefill.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+        XCTAssertTrue(response.ok, response.error.message)
+
+        let metrics = services.metrics.counters
+        XCTAssertEqual(metrics["swift_text.prefill_chunk_target_tokens"], 512)
+        XCTAssertEqual(metrics["swift_text.worker_prefill_requested_step_tokens"], 512)
+        XCTAssertEqual(metrics["swift_text.worker_prefill_effective_window_tokens"], 512)
+    }
+
+    func testPrefillMetricsRecordVisionWorkerWindow() async throws {
+        let services = makeServices(
+            backend: FakeRuntimeBackend()
+        )
+
+        let loadResponse = try await withTestServerContextRPCCancellationHandle { handle in
+            var request = Melix_Worker_V1_LoadModelRequest()
+            request.model.modelID = "melix-dev-text"
+            request.model.maxContext = 1024
+            return try await services.runtime.loadModel(
+                request: request,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_RuntimeService.Method.LoadModel.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+
+        var prefill = Melix_Worker_V1_PrefillRequest()
+        prefill.execution.id.requestID = "req-vision-window-prefill"
+        prefill.execution.modelHandle = loadResponse.modelHandle
+        prefill.prefillStepSize = 16
+        prefill.returnDecodeHandle = false
+        prefill.messages = [makeVisionBearingMessage("describe this image")]
+
+        let response = try await withTestServerContextRPCCancellationHandle { handle in
+            try await services.inference.prefill(
+                request: prefill,
+                context: ServerContext(
+                    descriptor: Melix_Worker_V1_InferenceService.Method.Prefill.descriptor,
+                    remotePeer: "in-process:test",
+                    localPeer: "in-process:test",
+                    cancellation: handle
+                )
+            )
+        }
+        XCTAssertTrue(response.ok, response.error.message)
+
+        let metrics = services.metrics.counters
+        XCTAssertEqual(metrics["swift_text.prefill_chunk_target_tokens"], 16)
+        XCTAssertEqual(metrics["swift_text.worker_prefill_requested_step_tokens"], 16)
+        XCTAssertEqual(metrics["swift_text.worker_prefill_effective_window_tokens"], 16)
+    }
 }
 
 @available(macOS 15.0, *)
@@ -10982,6 +11082,8 @@ private final class FakeRuntimeBackend: TextRuntimeBackend, @unchecked Sendable 
                 promptTokens: promptTokens
             ),
             promptTokens: promptTokens,
+            requestedPrefillStepTokens: Int(clamping: prefillStepSize),
+            effectivePrefillWindowTokens: Int(clamping: max(prefillStepSize, 1)),
             appliedAcceleration: normalizedAccelerationPolicy(acceleration),
             acceleratedPrefillGainPct: acceleration.mode == .acceleratedPrefill ? 50 : 0,
             activeKVQuantizationRatio: activeKVQuantizationRatioPercent(for: acceleration)
@@ -11263,6 +11365,15 @@ private func makeMediaRichMessage() -> Melix_Worker_V1_ChatMessage {
 
     let empty = Melix_Worker_V1_MessagePart()
     message.parts = [imageURI, imageBytes, audioURI, audioBytes, videoURI, videoBytes, empty]
+    return message
+}
+
+@available(macOS 15.0, *)
+private func makeVisionBearingMessage(_ text: String) -> Melix_Worker_V1_ChatMessage {
+    var message = makeUserMessage(text)
+    var imageURI = Melix_Worker_V1_MessagePart()
+    imageURI.imageUri = "file:///tmp/image.png"
+    message.parts.append(imageURI)
     return message
 }
 


### PR DESCRIPTION
## Summary
- Exposes worker-side prefill window observability separately from the existing scheduler/request chunk compatibility metric.
- Documents why scheduler chunk progress can report 16 while the Swift worker runtime uses a 512-token prefill step/window.
- Adds text-only and vision-bearing worker tests that assert the request receipts/metrics identify the actual worker prefill step/window.
- Stabilizes the existing decode batching pending-window test after the remote text-worker CI shard exposed CI scheduling jitter.

## Plan or Spec
- `docs/plans/2026-06-01-issue-1662-prefill-metrics.md`
- Addresses #1662 as part of the #1642 Gemma E4B performance issue tree.

## Commands Run
```text
$ swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testPrefillMetricsSeparateTextWorkerWindowFromChunkCompatibility|WorkerScaffoldTests/testPrefillMetricsRecordVisionWorkerWindow'
Outcome: initial red run failed because the new worker prefill metrics did not exist yet.

$ swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testMetricsStoreTracksCountersAndTimings|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillUsesLiveModelContainerBridge|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillAppliesAcceleratedPrefillPolicyForLiveBridge|WorkerScaffoldTests/testTextRuntimeForwardsPrefillAndDefaultPrefillThrowsUnavailable|WorkerScaffoldTests/testPrefillCanRestoreBoundarySnapshotsFromCacheHints|WorkerScaffoldTests/testPrefillRestoreWalksBackPartialPrefixesToSafeBoundary|WorkerScaffoldTests/testPrefillRecordsBoundarySafeChunkMetricsForLongPrompts|WorkerScaffoldTests/testPrefillMetricsSeparateTextWorkerWindowFromChunkCompatibility|WorkerScaffoldTests/testPrefillMetricsRecordVisionWorkerWindow'
Outcome: passed, 9 tests.

$ uv run --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/mlx-text-worker-swift/Sources/Core/Inference/TextPrefillEngine.swift services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
Outcome: TOTAL 100.00% 128/128 changed lines.

$ uv run --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --diff-from origin/main --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/mlx-text-worker-swift/Sources/Core/Inference/TextPrefillEngine.swift services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
Outcome: TOTAL 100.00% 130/130 changed lines after addressing review feedback.

$ git diff --check
Outcome: passed.

$ make bootstrap
Outcome: passed. Configured `.githooks` and checked the locked Python environment.

$ make proto
Outcome: passed. No generated protobuf artifacts changed.

$ .githooks/pre-commit
Outcome: passed. Includes make swift-test, make py-test, make integration-test, and PR-scoped performance probe.
- make swift-test: passed, including protocol package, Swift text worker package (228 tests), control-plane core/request-coordinator shards, and macOS menu bar package (779 tests).
- make py-test: 3379 passed, 14 skipped, 2 warnings.
- make integration-test: 115 passed, 1 skipped.
- Re-run after review feedback: passed again; make py-test 3379 passed, 14 skipped; make integration-test 115 passed, 1 skipped; performance status ok with 0 regressions.

$ git diff --check HEAD~1..HEAD && git diff --check origin/main...HEAD
Outcome: passed after merging origin/main at 8b51908b.

$ swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testMetricsStoreTracksCountersAndTimings|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillUsesLiveModelContainerBridge|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillAppliesAcceleratedPrefillPolicyForLiveBridge|WorkerScaffoldTests/testTextRuntimeForwardsPrefillAndDefaultPrefillThrowsUnavailable|WorkerScaffoldTests/testPrefillCanRestoreBoundarySnapshotsFromCacheHints|WorkerScaffoldTests/testPrefillRestoreWalksBackPartialPrefixesToSafeBoundary|WorkerScaffoldTests/testPrefillRecordsBoundarySafeChunkMetricsForLongPrompts|WorkerScaffoldTests/testPrefillMetricsSeparateTextWorkerWindowFromChunkCompatibility|WorkerScaffoldTests/testPrefillMetricsRecordVisionWorkerWindow'
Outcome: passed, 9 tests after merging origin/main at 8b51908b.

$ uv run --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --diff-from origin/main --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/mlx-text-worker-swift/Sources/Core/Inference/TextPrefillEngine.swift services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
Outcome: TOTAL 100.00% 130/130 changed lines after merging origin/main at 8b51908b.

$ make swift-test
Outcome: passed after merging origin/main at 8b51908b; includes protocol package, Swift text worker package (228 tests), control-plane core/request-coordinator shards, worker clients (114 tests), and macOS menu bar package (779 tests).

$ make py-test
Outcome: passed after merging origin/main at 8b51908b; 3379 passed, 14 skipped, 2 warnings.

$ make integration-test
Outcome: passed after merging origin/main at 8b51908b; 115 passed, 1 skipped.

$ uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts import pre_commit_gate

root = Path.cwd()
changed_files = pre_commit_gate.run_git(root, ["diff", "--name-only", "origin/main...HEAD"]).splitlines()
outcome = pre_commit_gate.run_performance_report(root, changed_files, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
Outcome: passed after merging origin/main at 8b51908b; performance status ok with 0 regressions.

$ git diff --check HEAD~1..HEAD && git diff --check origin/main...HEAD
Outcome: passed after merging origin/main at 6362c364.

$ swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testMetricsStoreTracksCountersAndTimings|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillUsesLiveModelContainerBridge|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillAppliesAcceleratedPrefillPolicyForLiveBridge|WorkerScaffoldTests/testTextRuntimeForwardsPrefillAndDefaultPrefillThrowsUnavailable|WorkerScaffoldTests/testPrefillCanRestoreBoundarySnapshotsFromCacheHints|WorkerScaffoldTests/testPrefillRestoreWalksBackPartialPrefixesToSafeBoundary|WorkerScaffoldTests/testPrefillRecordsBoundarySafeChunkMetricsForLongPrompts|WorkerScaffoldTests/testPrefillMetricsSeparateTextWorkerWindowFromChunkCompatibility|WorkerScaffoldTests/testPrefillMetricsRecordVisionWorkerWindow'
Outcome: passed, 9 tests after merging origin/main at 6362c364.

$ uv run --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --diff-from origin/main --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/mlx-text-worker-swift/Sources/Core/Inference/TextPrefillEngine.swift services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
Outcome: TOTAL 100.00% 130/130 changed lines after merging origin/main at 6362c364.

$ make swift-test
Outcome: passed after merging origin/main at 6362c364; includes protocol package, Swift text worker package (228 tests), control-plane shards, worker clients (114 tests), and macOS menu bar package (779 tests).

$ make py-test
Outcome: passed after merging origin/main at 6362c364; 3379 passed, 14 skipped, 2 warnings.

$ make integration-test
Outcome: passed after merging origin/main at 6362c364; 115 passed, 1 skipped.

$ uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts import pre_commit_gate

root = Path.cwd()
changed_files = pre_commit_gate.run_git(root, ["diff", "--name-only", "origin/main...HEAD"]).splitlines()
outcome = pre_commit_gate.run_performance_report(root, changed_files, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
Outcome: passed after merging origin/main at 6362c364; performance status ok with 0 regressions.

$ git diff --check HEAD~1..HEAD && git diff --check origin/main...HEAD
Outcome: passed after merging origin/main at 66e3ae1b.

$ swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testMetricsStoreTracksCountersAndTimings|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillUsesLiveModelContainerBridge|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillAppliesAcceleratedPrefillPolicyForLiveBridge|WorkerScaffoldTests/testTextRuntimeForwardsPrefillAndDefaultPrefillThrowsUnavailable|WorkerScaffoldTests/testPrefillCanRestoreBoundarySnapshotsFromCacheHints|WorkerScaffoldTests/testPrefillRestoreWalksBackPartialPrefixesToSafeBoundary|WorkerScaffoldTests/testPrefillRecordsBoundarySafeChunkMetricsForLongPrompts|WorkerScaffoldTests/testPrefillMetricsSeparateTextWorkerWindowFromChunkCompatibility|WorkerScaffoldTests/testPrefillMetricsRecordVisionWorkerWindow'
Outcome: passed, 9 tests after merging origin/main at 66e3ae1b.

$ uv run --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --diff-from origin/main --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/mlx-text-worker-swift/Sources/Core/Inference/TextPrefillEngine.swift services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
Outcome: TOTAL 100.00% 130/130 changed lines after merging origin/main at 66e3ae1b.

$ make swift-test
Outcome: passed after merging origin/main at 66e3ae1b; includes protocol package, Swift text worker package (228 tests), control-plane shards, worker clients (114 tests), and macOS menu bar package (779 tests).

$ make py-test
Outcome: passed after merging origin/main at 66e3ae1b; 3379 passed, 14 skipped, 2 warnings.

$ make integration-test
Outcome: passed after merging origin/main at 66e3ae1b; 115 passed, 1 skipped.

$ uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts import pre_commit_gate

root = Path.cwd()
changed_files = pre_commit_gate.run_git(root, ["diff", "--name-only", "origin/main...HEAD"]).splitlines()
outcome = pre_commit_gate.run_performance_report(root, changed_files, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
Outcome: passed after merging origin/main at 66e3ae1b; performance status ok with 0 regressions.

$ for i in {1..20}; do swift test --package-path services/mlx-text-worker-swift --filter 'WorkerScaffoldTests/testDecodeStreamingRpcBatchesHomogeneousRequestsAcrossConfiguredPendingWindow'; done
Outcome: passed 20/20 runs after increasing the test-only pending window to absorb CI scheduling jitter.

$ swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testMetricsStoreTracksCountersAndTimings|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillUsesLiveModelContainerBridge|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillAppliesAcceleratedPrefillPolicyForLiveBridge|WorkerScaffoldTests/testTextRuntimeForwardsPrefillAndDefaultPrefillThrowsUnavailable|WorkerScaffoldTests/testPrefillCanRestoreBoundarySnapshotsFromCacheHints|WorkerScaffoldTests/testPrefillRestoreWalksBackPartialPrefixesToSafeBoundary|WorkerScaffoldTests/testPrefillRecordsBoundarySafeChunkMetricsForLongPrompts|WorkerScaffoldTests/testPrefillMetricsSeparateTextWorkerWindowFromChunkCompatibility|WorkerScaffoldTests/testPrefillMetricsRecordVisionWorkerWindow|WorkerScaffoldTests/testDecodeStreamingRpcBatchesHomogeneousRequestsAcrossConfiguredPendingWindow'
Outcome: passed, 10 tests after the CI stability fix.

$ uv run --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --diff-from origin/main --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/mlx-text-worker-swift/Sources/Core/Inference/TextPrefillEngine.swift services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
Outcome: TOTAL 100.00% 132/132 changed lines after the CI stability fix.

$ make swift-test-text-worker
Outcome: passed after the CI stability fix; 228 tests, 0 failures.

$ git commit -m "test: stabilize decode batch pending window"
Outcome: passed. The versioned pre-commit hook ran make swift-test, make py-test, make integration-test, and the scoped performance probe before creating commit 7493b8f5.
- make swift-test: passed, including protocol package, Swift text worker package (228 tests), control-plane shards, worker clients (114 tests), and macOS menu bar package (779 tests).
- make py-test: 3379 passed, 14 skipped, 2 warnings.
- make integration-test: 115 passed, 1 skipped.
- Scoped performance: status ok with 0 regressions; report `.runtime/pre-commit-performance/20260601-153819-801138f2/report/report.md`.

$ git fetch origin main && git merge --no-edit origin/main
Outcome: passed after origin/main advanced to 2782d9ae; merge commit ce7a06b8.

$ git diff --check HEAD~1..HEAD && git diff --check origin/main...HEAD
Outcome: passed after merging origin/main at 2782d9ae.

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
Outcome: passed after merging origin/main at 2782d9ae; 100 passed.

$ swift test --package-path services/mlx-text-worker-swift --enable-code-coverage --filter 'WorkerScaffoldTests/testMetricsStoreTracksCountersAndTimings|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillUsesLiveModelContainerBridge|WorkerScaffoldTests/testAutoSwiftMLXBackendPrefillAppliesAcceleratedPrefillPolicyForLiveBridge|WorkerScaffoldTests/testTextRuntimeForwardsPrefillAndDefaultPrefillThrowsUnavailable|WorkerScaffoldTests/testPrefillCanRestoreBoundarySnapshotsFromCacheHints|WorkerScaffoldTests/testPrefillRestoreWalksBackPartialPrefixesToSafeBoundary|WorkerScaffoldTests/testPrefillRecordsBoundarySafeChunkMetricsForLongPrompts|WorkerScaffoldTests/testPrefillMetricsSeparateTextWorkerWindowFromChunkCompatibility|WorkerScaffoldTests/testPrefillMetricsRecordVisionWorkerWindow|WorkerScaffoldTests/testDecodeStreamingRpcBatchesHomogeneousRequestsAcrossConfiguredPendingWindow'
Outcome: passed, 10 tests after merging origin/main at 2782d9ae.

$ UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/MelixTextWorkerSwiftPackageTests.xctest/Contents/MacOS/MelixTextWorkerSwiftPackageTests --profdata services/mlx-text-worker-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/mlx-text-worker-swift/Sources/Core/Runtime/TextRuntime.swift services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicTextBackend.swift services/mlx-text-worker-swift/Sources/Core/Runtime/SwiftMLXBackend.swift services/mlx-text-worker-swift/Sources/Core/WorkerRuntimeRegistry.swift services/mlx-text-worker-swift/Sources/Core/Inference/TextPrefillEngine.swift services/mlx-text-worker-swift/Sources/Core/MetricsStore.swift services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
Outcome: TOTAL 100.00% 132/132 changed lines after merging origin/main at 2782d9ae.

$ make swift-test
Outcome: passed after merging origin/main at 2782d9ae; includes protocol package, Swift text worker package (228 tests), control-plane shards, worker clients, and macOS menu bar package (779 tests).

$ make py-test
Outcome: passed after merging origin/main at 2782d9ae; 3379 passed, 14 skipped, 2 warnings.

$ make integration-test
Outcome: passed after merging origin/main at 2782d9ae; 115 passed, 1 skipped.

$ uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts import pre_commit_gate

root = Path.cwd()
changed_files = pre_commit_gate.run_git(root, ["diff", "--name-only", "origin/main...HEAD"]).splitlines()
outcome = pre_commit_gate.run_performance_report(root, changed_files, base_ref="origin/main")
print(f"status={outcome.status}")
print(f"report_dir={outcome.report_dir}")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
Outcome: passed after merging origin/main at 2782d9ae; performance status ok with 0 regressions; report `.runtime/pre-commit-performance/20260601-170005-ce7a06b8/report/report.md`.
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 100.00% 132/132` for the touched Swift worker source/tests against `origin/main`.
- Branch-scoped performance report after the #1662 implementation: `.runtime/pre-commit-performance/20260601-142302-801138f2/report/report.md`.
- Latest pre-commit scoped performance report for the CI stability commit: `.runtime/pre-commit-performance/20260601-153819-801138f2/report/report.md`.
- Latest scoped performance report after merging origin/main at 2782d9ae: `.runtime/pre-commit-performance/20260601-170005-ce7a06b8/report/report.md`.
- Performance status: `ok`; regressions: `0`; context regressions: `0`; verification failures: `0`.
- Selected probe: same-cohort batching probe evidence; targeted tests passed; probe coverage passed at 100.0%.
- Observability mode: minimal runtime metrics. Probe overhead: N/A, this change adds two counters recorded once per successful prefill from already computed runtime values.

## Known Gaps
- The existing `swift_text.prefill_chunk_target_tokens` metric remains compatibility-oriented and keeps its current name; consumers should migrate to `swift_text.worker_prefill_requested_step_tokens` and `swift_text.worker_prefill_effective_window_tokens` when they need worker-runtime prefill semantics.
- Protocol changes: N/A, no protobuf schema change.
- Dependency changes: N/A, no dependency or lockfile change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A is stated explicitly.
- [x] Dependency changes include updated lockfiles, or N/A is stated explicitly.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
