### PR TITLE
perf: compact OpenAI tool payload construction

### DIFF
--- a/docs/plans/2026-06-01-tool-registry-openai-tools-listcomp-performance.md
+++ b/docs/plans/2026-06-01-tool-registry-openai-tools-listcomp-performance.md
@@ -1,0 +1,32 @@
+# Tool Registry OpenAI Tools List Construction Performance Slice
+
+## Scope
+
+This slice optimizes `ToolRegistry.as_openai_tools()` for the built-in agentic
+registry. Behavior remains unchanged: each call still returns fresh OpenAI tool
+payload dictionaries, nested `parameters.properties` dictionaries, and fresh
+`required` lists so callers cannot mutate registry-owned templates.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`tool-registry-openai-tools-template-cache` in
+`infra/perf/pr_scoped_probes.json`. The probe runs focused tool-registry tests,
+changed-scope coverage, and `scripts/tool_registry_openai_tools_probe.py`, which
+checks payload isolation and reports elapsed time plus descriptor-call counts.
+
+## Verification plan
+
+- Run the focused registered probe test command for tool registry behavior and
+  PR-scoped probe selection.
+- Run the registered changed-scope coverage command.
+- Run `scripts/tool_registry_openai_tools_probe.py` locally on Linux and compare
+  against the current `origin/main` baseline.
+- Rely on GitHub Actions PR-scoped performance workflow for the final registered
+  CI probe report before merge.
+
+## Expected outcome
+
+Replacing the manual append loop with a single list comprehension keeps the
+same fresh nested payload construction while reducing Python loop overhead in
+high-frequency OpenAI tool payload generation.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -329,37 +329,34 @@ class ToolRegistry:
     def as_openai_tools(self) -> list[dict[str, Any]]:
         copy_dict = _COPY_DICT
         copy_list = _COPY_LIST
-        tools: list[dict[str, Any]] = []
-        append_tool = tools.append
-        for (
-            name,
-            description,
-            tool_kind,
-            observation_kind,
-            schema_properties,
-            required_arguments,
-        ) in self._openai_tool_templates:
-            properties: dict[str, Any] = {}
-            for argument_name, schema in schema_properties:
-                properties[argument_name] = copy_dict(schema)
-            append_tool(
-                {
-                    "type": "function",
-                    "function": {
-                        "name": name,
-                        "description": description,
-                        "parameters": {
-                            "type": "object",
-                            "additionalProperties": False,
-                            "properties": properties,
-                            "required": copy_list(required_arguments),
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": description,
+                    "parameters": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            argument_name: copy_dict(schema)
+                            for argument_name, schema in schema_properties
                         },
+                        "required": copy_list(required_arguments),
                     },
-                    "x-melix-tool-kind": tool_kind,
-                    "x-melix-observation-kind": observation_kind,
-                }
-            )
-        return tools
+                },
+                "x-melix-tool-kind": tool_kind,
+                "x-melix-observation-kind": observation_kind,
+            }
+            for (
+                name,
+                description,
+                tool_kind,
+                observation_kind,
+                schema_properties,
+                required_arguments,
+            ) in self._openai_tool_templates
+        ]
 
     def as_worker_tool_config(self) -> common_pb2.ToolConfig:
         if self._worker_tool_config_bytes:


### PR DESCRIPTION
## Summary
- Compact `ToolRegistry.as_openai_tools()` into a single list-comprehension payload builder.
- Preserve fresh nested OpenAI tool payload dictionaries/lists so caller mutations do not leak back into the registry templates.

## Plan or Spec
- `docs/plans/2026-06-01-tool-registry-openai-tools-listcomp-performance.md`
- Registered probe: `tool-registry-openai-tools-template-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_OPENAI_TOOLS_ITERATIONS=50000 MELIX_TOOL_REGISTRY_OPENAI_TOOLS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
# exit 0; elapsed_ms_mean=467.4363755621016, descriptor_as_openai_tool_calls_mean=0.0, isolated_payload_calls_mean=50000.0

# Candidate worktree local probe during implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_OPENAI_TOOLS_ITERATIONS=50000 MELIX_TOOL_REGISTRY_OPENAI_TOOLS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
# exit 0; elapsed_ms_mean=452.0637028850615, descriptor_as_openai_tool_calls_mean=0.0, isolated_payload_calls_mean=50000.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 57 passed in 1.03s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 57 passed in 0.35s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_openai_tools_probe.py
# exit 0; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
# exit 0; elapsed_ms_mean=456.50608045980334, descriptor_as_openai_tool_calls_mean=0.0, isolated_payload_calls_mean=50000.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Local Linux registered probe comparison: old_mean=467.4363755621016 ms, new_mean=456.50608045980334 ms, delta_ms=-10.93029510229826, speedup=1.02394x (2.34% faster).
- Best candidate local implementation probe during development: new_mean=452.0637028850615 ms, delta_ms=-15.3726726770401, speedup=1.03401x (3.29% faster).
- CI PR-scoped performance workflow is required for the final registered probe report before merge.

## Known Gaps
- Local validation is Linux-only; this is a Python-only slice and does not claim Swift runtime effects.
- Final merge is gated on GitHub Actions, including the registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
