### PR TITLE
perf: use ascii lower in evaluation normalization

### DIFF
--- a/docs/plans/2026-06-01-evaluation-answer-ascii-lower.md
+++ b/docs/plans/2026-06-01-evaluation-answer-ascii-lower.md
@@ -1,0 +1,36 @@
+# Evaluation answer ASCII lower fast path
+
+## Scope
+
+This performance slice narrows the registered evaluation answer-normalization
+hot path to a single local optimization in
+`worker.engine.evaluation_core.EvaluationCore._normalized_answer`.
+
+## Registered probe
+
+The affected path is covered by `evaluation-answer-normalization-fast-path` in
+`infra/perf/pr_scoped_probes.json`.
+
+- `test_command`: focused evaluation normalization tests plus PR-scoped probe
+  registry tests.
+- `coverage_command`: changed-scope coverage for the same focused test set.
+- `probe_command`: command-json probe that repeatedly normalizes free-text,
+  numeric, and option answers and reports elapsed time plus extractor-call
+  counts.
+
+## Implementation plan
+
+1. Preserve the existing wrapping, numeric, option, and whitespace-normalization
+   behavior.
+2. Use `str.lower()` for normalized answers that are already ASCII, where it is
+   semantically equivalent to `str.casefold()` and avoids the broader Unicode
+   folding path.
+3. Keep `str.casefold()` for non-ASCII answers so Unicode equivalence behavior is
+   unchanged.
+4. Validate locally on Linux with the registered focused tests, coverage command,
+   and probe command before opening the PR.
+
+## Validation boundary
+
+This slice only touches Python worker code and is locally verifiable on Linux.
+Swift runtime validation is not involved.

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -3361,6 +3361,8 @@ def test_normalized_answer_skips_extractors_for_free_text(monkeypatch: pytest.Mo
     assert EvaluationCore._normalized_answer("+9.00") == "9"
     assert EvaluationCore._normalized_answer("b") == "B"
     assert EvaluationCore._normalized_answer("Option C is correct") == "option c is correct"
+    assert EvaluationCore._normalized_answer("STRASSE") == "strasse"
+    assert EvaluationCore._normalized_answer("Straße") == "strasse"
 
     assert numeric_calls == 0
     assert option_calls == 0

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -3953,6 +3953,8 @@ class EvaluationCore:
             )
         ):
             stripped = " ".join(stripped.split())
+        if stripped.isascii():
+            return stripped.lower()
         return stripped.casefold()
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Add an ASCII-only `str.lower()` fast path in `EvaluationCore._normalized_answer` while keeping `str.casefold()` for non-ASCII answers.
- Add focused regression coverage proving ASCII and non-ASCII normalization stay equivalent.

## Plan or Spec
- `docs/plans/2026-06-01-evaluation-answer-ascii-lower.md`
- Registered probe: `evaluation-answer-normalization-fast-path` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_helpers_cover_numeric_option_and_normalization_paths services/mlx-worker-python/tests/test_evaluation_core.py::test_normalized_answer_skips_extractors_for_free_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_answer_normalization_probe_command_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_persists_agentic_tool_evidence
# 17 passed in 4.35s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_helpers_cover_numeric_option_and_normalization_paths services/mlx-worker-python/tests/test_evaluation_core.py::test_normalized_answer_skips_extractors_for_free_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_answer_normalization_probe_command_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_persists_agentic_tool_evidence && uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --base origin/main --head HEAD --coverage-json coverage.json
# 17 passed in 3.16s; changed_line_coverage=100.00% (4/4)

# Registered probe, baseline origin/main detached worktree:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PYPROBE' ...
# {"elapsed_ms_mean": 184.30173, "normalization_checksum": 7724000.0, "numeric_extract_calls_mean": 0.0, "option_extract_calls_mean": 0.0, ...}

# Registered probe, head:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PYPROBE' ...
# {"elapsed_ms_mean": 182.183705, "normalization_checksum": 7724000.0, "numeric_extract_calls_mean": 0.0, "option_extract_calls_mean": 0.0, ...}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (4/4 measurable changed lines).
- Local registered probe (`evaluation-answer-normalization-fast-path`, Linux): old_mean=184.301730 ms, new_mean=182.183705 ms, delta_ms=-2.118025, speedup=1.011626x.
- Probe parity: `normalization_checksum=7724000.0`, `numeric_extract_calls_mean=0.0`, `option_extract_calls_mean=0.0` for both baseline and head.
- CI PR-scoped performance report is required as the repository validation source before merge.

## Known Gaps
- None for the Python path. Swift runtime validation is not involved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
