### PR TITLE
perf: elide hub size label separator set

### DIFF
--- a/docs/plans/2026-05-31-hub-size-label-prefix-fastpath.md
+++ b/docs/plans/2026-05-31-hub-size-label-prefix-fastpath.md
@@ -24,6 +24,18 @@ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_RE
 - Preserve the existing case-insensitive `Model size` / `MODEL SIZE` / `model size` behavior and existing `:` / `|` / whitespace separator handling.
 - Keep the change limited to direct `cardData.model_size` label parsing; regex-based README/description parsing remains unchanged.
 
+## 2026-06-01 Follow-up: Separator Branch Allocation Elision
+
+This follow-up keeps the same registered probe and narrows the remaining hot
+separator branch in `_strip_model_size_label(...)`: after the no-allocation
+ASCII label match, test `:` and `|` with direct character comparisons instead
+of constructing a two-element set for every labeled `cardData.model_size` value.
+The behavior remains unchanged for `Model size: 12 MB`, `MODEL SIZE | 7 kb`,
+and compact separator forms such as `MODEL SIZE:7 kb`. The registered
+`hub-catalog-size-hint-regex-precompile` script now exercises that compact
+separator branch directly so PR-scoped performance validation covers the changed
+path instead of relying only on the exact `Model size: ` shortcut.
+
 ## Success Metrics
 
 - Focused hub catalog tests pass.

--- a/scripts/hub_catalog_size_hint_probe.py
+++ b/scripts/hub_catalog_size_hint_probe.py
@@ -22,7 +22,7 @@ def _payload(index: int) -> tuple[dict[str, Any], int]:
     if mode == 0:
         return {"cardData": {}}, 0
     if mode == 1:
-        return {"cardData": {"model_size": f"Model size: {value} MB"}}, value * 1024 * 1024
+        return {"cardData": {"model_size": f"MODEL SIZE:{value} MB"}}, value * 1024 * 1024
     if mode == 2:
         return {"cardData": {}, "readme": f"README\nMODEL SIZE | {value} kb\nother metadata"}, value * 1024
     if mode == 3:

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -184,6 +184,7 @@ def test_direct_size_hint_rejects_extra_tokens_without_full_split() -> None:
 def test_direct_card_size_hint_preserves_case_insensitive_label_prefix() -> None:
     assert hub_catalog_module._direct_card_size_hint_from_text("Model size: 12 MB") == 12 * MB
     assert hub_catalog_module._direct_card_size_hint_from_text("MODEL SIZE | 7 kb") == 7 * KB
+    assert hub_catalog_module._direct_card_size_hint_from_text("MODEL SIZE:7 kb") == 7 * KB
     assert hub_catalog_module._direct_card_size_hint_from_text("model size 2 GB") == 2 * GB
     assert hub_catalog_module._direct_card_size_hint_from_text("model-size: 2 GB") == 0
 

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -682,7 +682,7 @@ def _strip_model_size_label(text: str) -> str:
     text_length = len(text)
     while cursor < text_length and text[cursor].isspace():
         cursor += 1
-    if cursor < text_length and text[cursor] in {":", "|"}:
+    if cursor < text_length and (text[cursor] == ":" or text[cursor] == "|"):
         cursor += 1
     while cursor < text_length and text[cursor].isspace():
         cursor += 1


### PR DESCRIPTION
## Summary
- Elide the per-call two-element set allocation in the hub catalog `cardData.model_size` label separator branch.
- Extend the registered size-hint probe workload so it exercises compact `MODEL SIZE:<value>` labels directly.
- Add regression coverage for compact `MODEL SIZE:7 kb` labels.

## Plan or Spec
- `docs/plans/2026-05-31-hub-size-label-prefix-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 65 passed in 0.21s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# baseline old separator branch with updated probe: elapsed_ms_mean=1516.8046173639596, size_hint_calls_mean=40000.0
# head: elapsed_ms_mean=1482.0986566133797, size_hint_calls_mean=40000.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Registered local probe: `hub-catalog-size-hint-regex-precompile` via `scripts/hub_catalog_size_hint_probe.py`.
- Probe delta: old_mean=1516.804617 ms, new_mean=1482.098657 ms, delta_ms=-34.705961, speedup=1.023417x, delta_pct=-2.2881%.
- `size_hint_calls_mean` stayed unchanged at 40000.0.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- None for the Python slice. CI remains the source of truth for the registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
