### PR TITLE
perf: use tuple prefix check for native MTP keys

### DIFF
--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -23,7 +23,7 @@ def _load_json_payload(path: Path) -> dict[str, Any]:
 
 def _is_mtp_weight_key(key: Any) -> bool:
     if isinstance(key, str):
-        return key.startswith("language_model.mtp.") or key.startswith("mtp.")
+        return key.startswith(_MTP_WEIGHT_KEY_PREFIXES)
     return str(key).startswith(_MTP_WEIGHT_KEY_PREFIXES)
 
 


### PR DESCRIPTION
## Summary
- Switch native-MTP weight-key detection to the cached tuple-prefix fast path for string keys.
- Keep the existing non-string fallback and native-MTP sidecar/listing behavior unchanged.

## Plan or Spec
- Governing path: `AGENTS.md` performance-slice workflow and the registered PR-scoped probe `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.
- No behavior/spec change; this is a local runtime hot-path optimization.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics
3 passed in 1.49s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
6 passed in 0.31s
changed_line_coverage=100.00%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_KEY_ITERATIONS=5000 MELIX_NATIVE_MTP_LOADER_SAMPLES=7 MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% for `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` changed line 26.
- Registered probe: `native-mtp-loader-safetensor-scandir` covers this path with focused `test_command`, `coverage_command`, and `probe_command` entries.
- Local Linux probe metrics (7 samples, 5000 key iterations): `key_old_mean_ms=4617.715950`, `key_new_mean_ms=4278.022113`, `key_delta_ms=-339.693836`, `key_speedup=1.079404x`.
- Other probe dimensions remained favorable in the same run: sidecar extra scan `extra_speedup=4.427984x`, model listing `model_listing_speedup=2.624174x`, JSON load `speedup=1.068744x`.

## Known Gaps
- Full repository gates were not run locally; this slice used the registered focused Python test, coverage, and probe commands on Linux.
- GitHub Actions / PR-scoped performance CI is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A because runtime behavior is unchanged.
- [x] Protocol changes include regenerated generated artifacts, or N/A because there are no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A because there are no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
