### PR TITLE
perf: precompile LoRA quantized kind patterns

### DIFF
--- a/docs/plans/2026-06-02-lora-quantized-kind-regex-precompile.md
+++ b/docs/plans/2026-06-02-lora-quantized-kind-regex-precompile.md
@@ -1,0 +1,48 @@
+# LoRA Quantized Kind Regex Precompile Slice
+
+## Goal
+
+Reduce repeated regex setup in LoRA runtime metadata quantized-base detection.
+The hot path parses profile IDs, extension values, and model identity text to
+identify quantized base kinds such as `4bit`, `8bit`, `q4`, `q8`, and `optiq`.
+
+## Scope
+
+- Path: `services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py`
+- Replace per-call `re.search(...)` pattern construction in
+  `_quantized_kind_from_text(...)` with module-level compiled regex patterns.
+- Preserve the existing token-boundary behavior for accepted quantized kind
+  strings and false positives such as `not-a-q4suffix`.
+- Extend the existing `lora-aux-modules-scandir` PR-scoped probe because it is
+  already the registered probe for `lora_runtime_metadata.py`.
+
+## Probe
+
+Registered probe: `lora-aux-modules-scandir`
+
+The probe keeps its existing auxiliary-module scandir metrics and adds a
+quantized-kind parser workload:
+
+- `quantized_kind_baseline_elapsed_ms_mean` (dynamic `re.search` baseline)
+- `quantized_kind_optimized_elapsed_ms_mean` (current module implementation)
+- `quantized_kind_delta_ms` (optimized minus baseline; lower is better)
+- `quantized_kind_iteration_count` (input scale)
+
+The probe command runs the head probe script against the current repository root
+when comparing base and head, so the same measurement code can validate both the
+old and optimized implementations.
+
+## Verification Plan
+
+1. Focused regression test proving `_quantized_kind_from_text(...)` no longer
+   calls `re.search(...)` at runtime while preserving positive and negative
+   matching behavior.
+2. Registered focused test command from `infra/perf/pr_scoped_probes.json`.
+3. Registered changed-scope coverage command from the probe entry.
+4. Registered probe locally on Linux before opening the PR.
+5. PR-scoped performance workflow in GitHub Actions before merge.
+
+## Linux Boundary
+
+This slice changes Python worker metadata code and is locally verifiable on
+Linux. No Swift/macOS-only runtime effect is claimed for this slice.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4401,9 +4401,9 @@
       "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
       "scripts/lora_aux_modules_scandir_probe.py"
     ],
-    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
-    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_aux_modules_scandir_probe.py",
-    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/lora_aux_modules_scandir_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_uses_precompiled_patterns services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_uses_precompiled_patterns services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_aux_modules_scandir_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/lora_aux_modules_scandir_probe.py\"; for CANDIDATE in \"${MELIX_PR_SCOPED_PERFORMANCE_HEAD_REPO:-}/$SCRIPT\" \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then MELIX_LORA_RUNTIME_METADATA_REPO_ROOT=\"$PWD\" python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
     "metrics": [
@@ -4430,6 +4430,29 @@
         "unit": "count",
         "direction": "higher_is_better",
         "warn_pct": 0.0
+      },
+      {
+        "key": "quantized_kind_baseline_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "quantized_kind_optimized_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "quantized_kind_delta_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "quantized_kind_iteration_count",
+        "unit": "count",
+        "direction": "informational"
       }
     ]
   },

--- a/scripts/lora_aux_modules_scandir_probe.py
+++ b/scripts/lora_aux_modules_scandir_probe.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import statistics
 import sys
 import tempfile
@@ -10,11 +11,14 @@ import time
 import tracemalloc
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(os.environ.get("MELIX_LORA_RUNTIME_METADATA_REPO_ROOT") or Path(__file__).resolve().parents[1])
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
 from worker.model_ops import lora_runtime_metadata as metadata_module  # noqa: E402
+
+
+_QUANTIZED_KIND_ORDER = ("4bit", "8bit", "q4", "q8", "optiq")
 
 
 def _int_env(name: str, default: int) -> int:
@@ -75,10 +79,61 @@ def _measure(*, noise_count: int, sample_count: int) -> dict[str, float]:
     }
 
 
+def _baseline_quantized_kind_from_text(raw_value: str) -> str:
+    normalized = raw_value.strip().lower()
+    for kind in _QUANTIZED_KIND_ORDER:
+        if re.search(rf"(?<![a-z0-9]){re.escape(kind)}(?![a-z0-9])", normalized):
+            return kind
+    return "unknown"
+
+
+def _measure_quantized_kind(*, iteration_count: int, sample_count: int) -> dict[str, float]:
+    payload = [
+        "profile=mlx-community-q4",
+        "source model 4bit adapter",
+        "profile: optiq calibrated",
+        "plain fused adapter",
+        "8bit base checkpoint",
+        "not-a-q4suffix",
+    ] * max(1, iteration_count // 6)
+    expected = [_baseline_quantized_kind_from_text(value) for value in payload]
+    optimized_elapsed_ms: list[float] = []
+    baseline_elapsed_ms: list[float] = []
+
+    for _ in range(sample_count):
+        started = time.perf_counter()
+        optimized = [metadata_module._quantized_kind_from_text(value) for value in payload]
+        optimized_elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+
+        started = time.perf_counter()
+        baseline = [_baseline_quantized_kind_from_text(value) for value in payload]
+        baseline_elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+
+        if optimized != expected or baseline != expected:
+            raise RuntimeError("quantized kind parser output changed")
+
+    optimized_mean = statistics.fmean(optimized_elapsed_ms)
+    baseline_mean = statistics.fmean(baseline_elapsed_ms)
+    return {
+        "quantized_kind_baseline_elapsed_ms_mean": baseline_mean,
+        "quantized_kind_optimized_elapsed_ms_mean": optimized_mean,
+        "quantized_kind_delta_ms": optimized_mean - baseline_mean,
+        "quantized_kind_iteration_count": float(len(payload)),
+    }
+
+
 def main() -> int:
     noise_count = _int_env("MELIX_LORA_AUX_MODULES_PROBE_NOISE_FILES", 4000)
     sample_count = _int_env("MELIX_LORA_AUX_MODULES_PROBE_SAMPLES", 7)
-    print(json.dumps(_measure(noise_count=noise_count, sample_count=sample_count), sort_keys=True))
+    quantized_iteration_count = _int_env("MELIX_LORA_QUANTIZED_KIND_PROBE_ITERATIONS", 12000)
+    metrics = _measure(noise_count=noise_count, sample_count=sample_count)
+    metrics.update(
+        _measure_quantized_kind(
+            iteration_count=quantized_iteration_count,
+            sample_count=sample_count,
+        )
+    )
+    print(json.dumps(metrics, sort_keys=True))
     return 0
 
 

--- a/services/mlx-worker-python/tests/test_lora_training_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_receipts.py
@@ -554,6 +554,18 @@ def test_lora_canary_aux_module_detection_returns_false_when_scandir_fails(
     assert lora_runtime_metadata_module._aux_modules_restored(base_model_dir) is False
 
 
+def test_lora_quantized_kind_detection_uses_precompiled_patterns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_re_search(*_args: object, **_kwargs: object):
+        raise AssertionError("quantized kind detection should reuse compiled patterns")  # pragma: no cover
+
+    monkeypatch.setattr(lora_runtime_metadata_module.re, "search", fail_re_search)
+
+    assert lora_runtime_metadata_module._quantized_kind_from_text("mlx q4 adapter") == "q4"
+    assert lora_runtime_metadata_module._quantized_kind_from_text("not-a-q4suffix") == "unknown"
+
+
 def test_lora_canary_receipt_detects_missing_checkpoint_resume_assets(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -257,6 +257,7 @@ def test_lora_aux_modules_scandir_probe_script_emits_metrics(
 ) -> None:
     monkeypatch.setenv("MELIX_LORA_AUX_MODULES_PROBE_NOISE_FILES", "5")
     monkeypatch.setenv("MELIX_LORA_AUX_MODULES_PROBE_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_LORA_QUANTIZED_KIND_PROBE_ITERATIONS", "6")
     probe_script = runpy.run_path(str(REPO_ROOT / "scripts/lora_aux_modules_scandir_probe.py"))
 
     assert probe_script["main"]() == 0
@@ -265,6 +266,9 @@ def test_lora_aux_modules_scandir_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0.0
     assert metrics["noise_file_count"] == 5.0
     assert metrics["scandir_calls_mean"] == 1.0
+    assert metrics["quantized_kind_baseline_elapsed_ms_mean"] >= 0.0
+    assert metrics["quantized_kind_optimized_elapsed_ms_mean"] >= 0.0
+    assert metrics["quantized_kind_iteration_count"] == 6.0
 
 
 def test_trajectory_provenance_copy_elision_probe_script_emits_metrics(

--- a/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
@@ -35,6 +35,10 @@ _AUXILIARY_MODULE_PREFIXES = tuple(
 )
 
 _QUANTIZED_KIND_ORDER = ("4bit", "8bit", "q4", "q8", "optiq")
+_QUANTIZED_KIND_PATTERNS = tuple(
+    (kind, re.compile(rf"(?<![a-z0-9]){re.escape(kind)}(?![a-z0-9])"))
+    for kind in _QUANTIZED_KIND_ORDER
+)
 
 
 ADAPTER_RUNTIME_EXT_KEY_MAP: tuple[tuple[str, str], ...] = (
@@ -402,8 +406,8 @@ def _str_value(raw_value: Any) -> str:
 
 def _quantized_kind_from_text(raw_value: str) -> str:
     normalized = raw_value.strip().lower()
-    for kind in _QUANTIZED_KIND_ORDER:
-        if re.search(rf"(?<![a-z0-9]){re.escape(kind)}(?![a-z0-9])", normalized):
+    for kind, pattern in _QUANTIZED_KIND_PATTERNS:
+        if pattern.search(normalized):
             return kind
     return "unknown"
 


### PR DESCRIPTION
## Summary
- Precompile LoRA quantized-kind regex patterns at module import time and reuse the compiled pattern objects in `_quantized_kind_from_text(...)`.
- Extend the registered `lora-aux-modules-scandir` PR-scoped probe with a quantized-kind parser workload and focused regression coverage.
- Add the governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-02-lora-quantized-kind-regex-precompile.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.valid.json
# exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_uses_precompiled_patterns services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 8 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_uses_precompiled_patterns services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_aux_modules_scandir_probe.py
# 8 passed; changed-scope coverage TOTAL 42 1 98%

MELIX_PR_SCOPED_PERFORMANCE_HEAD_REPO="$PWD" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id lora-aux-modules-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-lora-quantized-kind-regex-precompile-20260602-base --head-repo "$PWD" --output /tmp/lora_quantized_probe_final.json
# exit 0; registered probe passed locally

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 42 1 98%`.
- Registered local probe `lora-aux-modules-scandir`:
  - base `quantized_kind_optimized_elapsed_ms_mean=62.693 ms`, `quantized_kind_delta_ms=+2.632 ms`
  - head `quantized_kind_optimized_elapsed_ms_mean=20.963 ms`, `quantized_kind_delta_ms=-40.921 ms`
  - input scale: `quantized_kind_iteration_count=12000.0`
- CI PR-scoped performance is still required as the merge gate for the registered probe report.

## Known Gaps
- Python-only Linux-verifiable slice; no Swift/macOS runtime effect is claimed.
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this focused slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
