### PR TITLE
perf: chain dataset quality output lengths

### DIFF
--- a/docs/plans/2026-06-02-dataset-quality-lengths-chain.md
+++ b/docs/plans/2026-06-02-dataset-quality-lengths-chain.md
@@ -1,0 +1,22 @@
+# Dataset quality output length chain
+
+## Scope
+
+This Python performance slice is limited to dataset quality summary output-length aggregation in `services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+
+## Probe registration
+
+The slice adds a PR-scoped performance probe for `scripts/dataset_quality_lengths_probe.py` before claiming performance validation. The probe exercises `_quality_summary(...)` with a large synthetic train/validation row set and reports elapsed latency plus row/output-length sanity metrics.
+
+## Behavior contract
+
+- Dataset quality summary schema and quality metrics remain unchanged.
+- `mean_output_length` and `p95_output_length` must match the existing deterministic row-length semantics for prompt/completion and chat-message rows.
+- The optimization must avoid unrelated dataset ingest/listing behavior changes.
+
+## Verification plan
+
+- Focused dataset versioning tests for quality summary behavior.
+- PR-scoped performance registry tests for probe selection and metric emission.
+- Changed-scope coverage for the touched Python module, tests, registry, and probe script.
+- Registered probe locally on Linux, then PR-scoped performance CI before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4451,6 +4451,56 @@
     ]
   },
   {
+    "id": "dataset-quality-lengths-chain",
+    "name": "Dataset quality output length chain",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/dataset_preparation.py",
+      "services/mlx-worker-python/tests/test_dataset_preparation_versioning.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/dataset_quality_lengths_probe.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/dataset_quality_lengths_probe.py\"; for CANDIDATE in \"${MELIX_PR_SCOPED_PERFORMANCE_HEAD_REPO:-}/$SCRIPT\" \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better"
+      },
+      {
+        "key": "elapsed_ms_p95",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "row_count",
+        "unit": "items",
+        "direction": "informational"
+      },
+      {
+        "key": "mean_output_length",
+        "unit": "chars",
+        "direction": "informational"
+      },
+      {
+        "key": "p95_output_length",
+        "unit": "chars",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "dataset-source-records-scandir",
     "name": "Dataset source records scandir",
     "runner": "ubuntu-latest",

--- a/scripts/dataset_quality_lengths_probe.py
+++ b/scripts/dataset_quality_lengths_probe.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "services/mlx-worker-python"))
+
+from worker.productization.dataset_preparation import DatasetVersionRequest, _quality_summary  # noqa: E402
+
+
+def _row(index: int, *, messages: bool) -> dict[str, Any]:
+    if messages:
+        return {
+            "source_segment_id": f"segment-{index:05d}",
+            "messages": [
+                {"role": "user", "content": f"Question {index} " + "x" * 24},
+                {"role": "assistant", "content": f"Answer {index} " + "y" * 48},
+            ],
+        }
+    return {
+        "source_segment_id": f"segment-{index:05d}",
+        "prompt": f"Prompt {index}",
+        "completion": "z" * (32 + (index % 17)),
+    }
+
+
+def measure(*, train_count: int, validation_count: int, samples: int) -> dict[str, float]:
+    train_rows = [_row(index, messages=False) for index in range(train_count)]
+    validation_rows = [_row(train_count + index, messages=True) for index in range(validation_count)]
+    request = DatasetVersionRequest(
+        workspace_manifest_path=Path("workspace-manifest.json"),
+        ingest_receipt_path=Path("ingest-receipt.json"),
+        output_root=Path("datasets"),
+        dataset_id="support-chat",
+        version_id="support-chat-v1",
+    )
+    ingest_receipt = {
+        "quality_control_summary": {
+            "source_record_count": train_count + validation_count,
+            "exact_dedup_count": 0,
+            "fuzzy_dedup_count": 0,
+            "pii_mask_count": 0,
+        }
+    }
+
+    elapsed_samples: list[float] = []
+    summary: dict[str, Any] | None = None
+    for _ in range(samples):
+        started = time.perf_counter()
+        summary = _quality_summary(
+            request=request,
+            ingest_receipt=ingest_receipt,
+            version_id="support-chat-v1",
+            train_rows=train_rows,
+            validation_rows=validation_rows,
+            failed_count=0,
+            latency_ms=0.0,
+        )
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+
+    if summary is None:
+        raise AssertionError("quality summary was not measured")
+    row_count = train_count + validation_count
+    if summary["metrics"]["generated_sample_count"] != row_count:
+        raise AssertionError(
+            f"expected {row_count} generated samples, got {summary['metrics']['generated_sample_count']}"
+        )
+    if summary["mean_output_length"] <= 0:
+        raise AssertionError("expected positive mean output length")
+    if summary["p95_output_length"] <= 0:
+        raise AssertionError("expected positive p95 output length")
+
+    return {
+        "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+        "elapsed_ms_min": round(min(elapsed_samples), 6),
+        "elapsed_ms_p95": round(sorted(elapsed_samples)[int(0.95 * (len(elapsed_samples) - 1))], 6),
+        "sample_count": float(samples),
+        "train_row_count": float(train_count),
+        "validation_row_count": float(validation_count),
+        "row_count": float(row_count),
+        "mean_output_length": float(summary["mean_output_length"]),
+        "p95_output_length": float(summary["p95_output_length"]),
+    }
+
+
+def main() -> int:
+    train_count = int(os.environ.get("MELIX_DATASET_QUALITY_LENGTHS_TRAIN_ROWS", "12000"))
+    validation_count = int(os.environ.get("MELIX_DATASET_QUALITY_LENGTHS_VALIDATION_ROWS", "3000"))
+    samples = int(os.environ.get("MELIX_DATASET_QUALITY_LENGTHS_SAMPLES", "7"))
+    print(json.dumps(measure(train_count=train_count, validation_count=validation_count, samples=samples), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -218,6 +218,7 @@ def test_scope_report_selects_dataset_version_listing_probe() -> None:
 
     selected_ids = _selected_probe_ids(scope)
     assert "dataset-version-listing-scandir" in selected_ids
+    assert "dataset-quality-lengths-chain" in selected_ids
     assert "dataset-source-records-scandir" in selected_ids
 
 
@@ -354,6 +355,28 @@ def test_dataset_version_listing_probe_script_emits_metrics(
     assert metrics["elapsed_ms_p95"] >= 0.0
     assert metrics["sample_count"] == 1.0
     assert metrics["version_count"] == 5.0
+
+
+def test_dataset_quality_lengths_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_DATASET_QUALITY_LENGTHS_TRAIN_ROWS", "5")
+    monkeypatch.setenv("MELIX_DATASET_QUALITY_LENGTHS_VALIDATION_ROWS", "2")
+    monkeypatch.setenv("MELIX_DATASET_QUALITY_LENGTHS_SAMPLES", "1")
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/dataset_quality_lengths_probe.py"))
+
+    assert probe_script["main"]() == 0
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] >= 0.0
+    assert metrics["elapsed_ms_p95"] >= 0.0
+    assert metrics["sample_count"] == 1.0
+    assert metrics["train_row_count"] == 5.0
+    assert metrics["validation_row_count"] == 2.0
+    assert metrics["row_count"] == 7.0
+    assert metrics["mean_output_length"] > 0.0
+    assert metrics["p95_output_length"] > 0.0
 
 
 def test_dataset_source_records_probe_script_emits_metrics(
@@ -3053,6 +3076,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "trajectory-manifest-json-load",
         "dataset-registry-preview-limit-short-circuit",
         "dataset-version-listing-scandir",
+        "dataset-quality-lengths-chain",
         "dataset-source-records-scandir",
         "maintenance-bench-report-readback",
         "maintenance-percentile-vector-reuse",

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import csv
 from datetime import datetime, timezone
 import hashlib
+from itertools import chain
 import json
 import os
 import re
@@ -960,7 +961,7 @@ def _quality_summary(
     total_count = success_count + failed_count
     success_rate = success_count / total_count if total_count else 0.0
     score = round(success_rate, 6)
-    lengths = [_sample_output_length(row) for row in [*train_rows, *validation_rows]]
+    lengths = [_sample_output_length(row) for row in chain(train_rows, validation_rows)]
     quality_controls = ingest_receipt.get("quality_control_summary", {})
     source_record_count = float(quality_controls.get("source_record_count", 0) or 0)
     exact_dedup_count = float(quality_controls.get("exact_dedup_count", 0) or 0)


### PR DESCRIPTION
## Summary
- Register a PR-scoped dataset quality output-length performance probe.
- Avoid materializing an intermediate concatenated train/validation row list while computing dataset quality output length metrics.
- Add a focused plan note for this Python performance slice.

## Plan or Spec
- `docs/plans/2026-06-02-dataset-quality-lengths-chain.md`

## Commands Run
- `git fetch origin && git status --short && git rev-parse HEAD origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 5 passed.
- Changed-scope coverage: 100.00% (18/18 measurable changed lines).
- Local Linux probe baseline (pre-optimization, 3 runs): means 3.812050 ms, 3.344875 ms, 3.985101 ms; average 3.714009 ms.
- Local Linux probe after optimization (3 runs): means 3.322563 ms, 3.256277 ms, 3.405602 ms; average 3.328147 ms.
- Delta: -0.385861 ms mean, 10.39% faster on the local synthetic 15k-row dataset quality probe.

## Known Gaps
- Local validation is Linux/Python only. CI must run the registered PR-scoped performance workflow before merge.
- The exact registry `probe_command` uses the same Python script; the local tool sandbox required running the script directly instead of via the registry's nested `bash -c` wrapper.

## Evidence Checklist
- [x] Branch started from `origin/main` (`f1c56ee71516896d28942c740129af711d4f2b59`).
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Local Python probe shows improvement.
- [ ] GitHub Actions and PR-scoped performance probe completed successfully.
