### PR TITLE
perf: optimize LoRA processor resume mode

### DIFF
--- a/docs/plans/2026-06-02-lora-processor-resume-stat-fastpath.md
+++ b/docs/plans/2026-06-02-lora-processor-resume-stat-fastpath.md
@@ -1,0 +1,38 @@
+# LoRA processor resume mode stat fast path slice
+
+## Scope
+
+Optimize the LoRA canary receipt `_processor_resume_mode` hot path in
+`services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py`.
+
+The current implementation checks three known resume asset filenames with
+separate `Path` construction and `Path.is_file()` calls. The slice keeps the
+same precedence (`processor_config.json`, then `preprocessor_config.json`, then
+`tokenizer_config.json`) while using a module-level filename table, one
+`os.fspath()` conversion, local `os.path.join`/`os.path.isfile` bindings, and no
+per-check `Path` object construction.
+
+## Registered Probe
+
+Registered PR-scoped probe: `lora-aux-modules-scandir`.
+
+The registry entry covers the affected LoRA runtime metadata module and provides
+focused `test_command`, `coverage_command`, and `probe_command` values. This
+slice extends the probe script and metrics to report processor resume mode
+baseline/optimized latency and `os.path.isfile` call counts alongside the
+existing auxiliary-module and quantized-kind measurements.
+
+## Verification Plan
+
+- Add focused tests for processor resume mode precedence, `os.path.isfile` usage,
+  and missing-asset fallback.
+- Run the registered focused `test_command` locally on Linux.
+- Run the registered changed-scope `coverage_command` locally on Linux.
+- Run the registered `probe_command` locally on Linux and compare before/after
+  processor resume mode metrics.
+
+## Expected Metrics
+
+The probe should preserve behavior and reduce per-call overhead by avoiding
+repeated `Path` object construction while keeping the same bounded three-file
+existence check.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4583,9 +4583,9 @@
       "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
       "scripts/lora_aux_modules_scandir_probe.py"
     ],
-    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_uses_precompiled_patterns services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
-    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_uses_precompiled_patterns services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_aux_modules_scandir_probe.py",
-    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/lora_aux_modules_scandir_probe.py\"; for CANDIDATE in \"${MELIX_PR_SCOPED_PERFORMANCE_HEAD_REPO:-}/$SCRIPT\" \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then MELIX_LORA_RUNTIME_METADATA_REPO_ROOT=\"$PWD\" python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_uses_os_path_isfile_with_precedence services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_fallback_precedence services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_returns_missing_without_resume_assets services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_uses_precompiled_patterns services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_processor_resume_probe_baseline_modes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_uses_os_path_isfile_with_precedence services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_fallback_precedence services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_returns_missing_without_resume_assets services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_uses_precompiled_patterns services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_processor_resume_probe_baseline_modes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_aux_modules_scandir_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/lora_aux_modules_scandir_probe.py\"; CANDIDATES=(); if [ -n \"${MELIX_PR_SCOPED_PERFORMANCE_HEAD_REPO:-}\" ]; then CANDIDATES+=(\"${MELIX_PR_SCOPED_PERFORMANCE_HEAD_REPO}/$SCRIPT\"); fi; if [ \"$(basename \"$PWD\")\" = \"base\" ]; then CANDIDATES+=(\"../head/$SCRIPT\"); fi; CANDIDATES+=(\"$SCRIPT\" \"../head/$SCRIPT\"); if [ -n \"${GITHUB_WORKSPACE:-}\" ]; then CANDIDATES+=(\"${GITHUB_WORKSPACE}/head/$SCRIPT\"); fi; for CANDIDATE in \"${CANDIDATES[@]}\"; do if [ -f \"$CANDIDATE\" ]; then MELIX_LORA_RUNTIME_METADATA_REPO_ROOT=\"$PWD\" python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
     "metrics": [
@@ -4611,6 +4611,30 @@
         "key": "noise_file_count",
         "unit": "count",
         "direction": "higher_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "processor_resume_baseline_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "processor_resume_optimized_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "processor_resume_delta_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "processor_resume_isfile_calls_mean",
+        "unit": "count",
+        "direction": "lower_is_better",
         "warn_pct": 0.0
       },
       {

--- a/scripts/lora_aux_modules_scandir_probe.py
+++ b/scripts/lora_aux_modules_scandir_probe.py
@@ -79,6 +79,66 @@ def _measure(*, noise_count: int, sample_count: int) -> dict[str, float]:
     }
 
 
+def _baseline_processor_resume_mode(base_model_dir: Path) -> str:
+    if (base_model_dir / "processor_config.json").is_file():
+        return "processor_config"
+    if (base_model_dir / "preprocessor_config.json").is_file():
+        return "preprocessor_config"
+    if (base_model_dir / "tokenizer_config.json").is_file():
+        return "tokenizer_only"
+    return "missing"
+
+
+def _measure_processor_resume_mode(*, noise_count: int, sample_count: int) -> dict[str, float]:
+    optimized_elapsed_ms: list[float] = []
+    baseline_elapsed_ms: list[float] = []
+    isfile_calls: list[float] = []
+
+    with tempfile.TemporaryDirectory(prefix="melix-lora-processor-probe-") as temp_dir:
+        base_model_dir = Path(temp_dir) / "base-model"
+        _seed_base_model(base_model_dir, noise_count=noise_count, aux_index=noise_count)
+        (base_model_dir / "tokenizer_config.json").write_text("{}\n", encoding="utf-8")
+        (base_model_dir / "preprocessor_config.json").write_text("{}\n", encoding="utf-8")
+        expected = _baseline_processor_resume_mode(base_model_dir)
+        if expected != "preprocessor_config":
+            raise RuntimeError("unexpected processor resume baseline")  # pragma: no cover
+
+        original_isfile = metadata_module.os.path.isfile
+        for _ in range(sample_count):
+            call_count = 0
+
+            def counting_isfile(path: str | Path):
+                nonlocal call_count
+                call_count += 1
+                return original_isfile(path)
+
+            metadata_module.os.path.isfile = counting_isfile
+            started = time.perf_counter()
+            try:
+                optimized = metadata_module._processor_resume_mode(base_model_dir)
+            finally:
+                optimized_elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+                metadata_module.os.path.isfile = original_isfile
+            if optimized != expected:
+                raise RuntimeError("processor resume mode changed")  # pragma: no cover
+            isfile_calls.append(float(call_count))
+
+            started = time.perf_counter()
+            baseline = _baseline_processor_resume_mode(base_model_dir)
+            baseline_elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+            if baseline != expected:
+                raise RuntimeError("processor resume baseline changed")  # pragma: no cover
+
+    optimized_mean = statistics.fmean(optimized_elapsed_ms)
+    baseline_mean = statistics.fmean(baseline_elapsed_ms)
+    return {
+        "processor_resume_baseline_elapsed_ms_mean": baseline_mean,
+        "processor_resume_optimized_elapsed_ms_mean": optimized_mean,
+        "processor_resume_delta_ms": optimized_mean - baseline_mean,
+        "processor_resume_isfile_calls_mean": statistics.fmean(isfile_calls),
+    }
+
+
 def _baseline_quantized_kind_from_text(raw_value: str) -> str:
     normalized = raw_value.strip().lower()
     for kind in _QUANTIZED_KIND_ORDER:
@@ -127,6 +187,7 @@ def main() -> int:
     sample_count = _int_env("MELIX_LORA_AUX_MODULES_PROBE_SAMPLES", 7)
     quantized_iteration_count = _int_env("MELIX_LORA_QUANTIZED_KIND_PROBE_ITERATIONS", 12000)
     metrics = _measure(noise_count=noise_count, sample_count=sample_count)
+    metrics.update(_measure_processor_resume_mode(noise_count=noise_count, sample_count=sample_count))
     metrics.update(
         _measure_quantized_kind(
             iteration_count=quantized_iteration_count,

--- a/services/mlx-worker-python/tests/test_lora_training_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_receipts.py
@@ -554,6 +554,61 @@ def test_lora_canary_aux_module_detection_returns_false_when_scandir_fails(
     assert lora_runtime_metadata_module._aux_modules_restored(base_model_dir) is False
 
 
+def test_lora_processor_resume_mode_uses_os_path_isfile_with_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    base_model_dir = tmp_path / "base-model"
+    base_model_dir.mkdir()
+    (base_model_dir / "tokenizer_config.json").write_text("{}\n", encoding="utf-8")
+    (base_model_dir / "preprocessor_config.json").write_text("{}\n", encoding="utf-8")
+    (base_model_dir / "processor_config.json").write_text("{}\n", encoding="utf-8")
+
+    def fail_path_is_file(self: Path):
+        raise AssertionError("processor resume mode should avoid Path.is_file")  # pragma: no cover
+
+    checked_paths: list[str] = []
+    original_isfile = lora_runtime_metadata_module.os.path.isfile
+
+    def counting_isfile(path: str | Path):
+        checked_paths.append(str(path))
+        return original_isfile(path)
+
+    monkeypatch.setattr(Path, "is_file", fail_path_is_file)
+    monkeypatch.setattr(lora_runtime_metadata_module.os.path, "isfile", counting_isfile)
+
+    assert lora_runtime_metadata_module._processor_resume_mode(base_model_dir) == "processor_config"
+    assert checked_paths == [str(base_model_dir / "processor_config.json")]
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        ("preprocessor_config.json", "preprocessor_config"),
+        ("tokenizer_config.json", "tokenizer_only"),
+    ],
+)
+def test_lora_processor_resume_mode_fallback_precedence(
+    tmp_path: Path,
+    filename: str,
+    expected: str,
+) -> None:
+    base_model_dir = tmp_path / "base-model"
+    base_model_dir.mkdir()
+    (base_model_dir / filename).write_text("{}\n", encoding="utf-8")
+
+    assert lora_runtime_metadata_module._processor_resume_mode(base_model_dir) == expected
+
+
+def test_lora_processor_resume_mode_returns_missing_without_resume_assets(
+    tmp_path: Path,
+) -> None:
+    base_model_dir = tmp_path / "base-model"
+    base_model_dir.mkdir()
+
+    assert lora_runtime_metadata_module._processor_resume_mode(base_model_dir) == "missing"
+
+
 def test_lora_quantized_kind_detection_uses_precompiled_patterns(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -267,9 +267,27 @@ def test_lora_aux_modules_scandir_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0.0
     assert metrics["noise_file_count"] == 5.0
     assert metrics["scandir_calls_mean"] == 1.0
+    assert metrics["processor_resume_baseline_elapsed_ms_mean"] >= 0.0
+    assert metrics["processor_resume_optimized_elapsed_ms_mean"] >= 0.0
+    assert metrics["processor_resume_isfile_calls_mean"] == 2.0
     assert metrics["quantized_kind_baseline_elapsed_ms_mean"] >= 0.0
     assert metrics["quantized_kind_optimized_elapsed_ms_mean"] >= 0.0
     assert metrics["quantized_kind_iteration_count"] == 6.0
+
+
+def test_lora_processor_resume_probe_baseline_modes(tmp_path: Path) -> None:
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/lora_aux_modules_scandir_probe.py"))
+    baseline_processor_resume_mode = probe_script["_baseline_processor_resume_mode"]
+    base_model_dir = tmp_path / "base-model"
+    base_model_dir.mkdir()
+
+    assert baseline_processor_resume_mode(base_model_dir) == "missing"
+    (base_model_dir / "tokenizer_config.json").write_text("{}\n", encoding="utf-8")
+    assert baseline_processor_resume_mode(base_model_dir) == "tokenizer_only"
+    (base_model_dir / "preprocessor_config.json").write_text("{}\n", encoding="utf-8")
+    assert baseline_processor_resume_mode(base_model_dir) == "preprocessor_config"
+    (base_model_dir / "processor_config.json").write_text("{}\n", encoding="utf-8")
+    assert baseline_processor_resume_mode(base_model_dir) == "processor_config"
 
 
 def test_trajectory_provenance_copy_elision_probe_script_emits_metrics(

--- a/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
@@ -33,6 +33,11 @@ _AUXILIARY_MODULE_PATTERNS = (
 _AUXILIARY_MODULE_PREFIXES = tuple(
     pattern.removesuffix("*.py") for pattern in _AUXILIARY_MODULE_PATTERNS
 )
+_PROCESSOR_RESUME_FILENAMES = (
+    ("processor_config.json", "processor_config"),
+    ("preprocessor_config.json", "preprocessor_config"),
+    ("tokenizer_config.json", "tokenizer_only"),
+)
 
 _QUANTIZED_KIND_ORDER = ("4bit", "8bit", "q4", "q8", "optiq")
 _QUANTIZED_KIND_PATTERNS = tuple(
@@ -321,12 +326,12 @@ def _saved_tokenizer_config(
 
 
 def _processor_resume_mode(base_model_dir: Path) -> str:
-    if (base_model_dir / "processor_config.json").is_file():
-        return "processor_config"
-    if (base_model_dir / "preprocessor_config.json").is_file():
-        return "preprocessor_config"
-    if (base_model_dir / "tokenizer_config.json").is_file():
-        return "tokenizer_only"
+    base_model_path = os.fspath(base_model_dir)
+    join = os.path.join
+    isfile = os.path.isfile
+    for filename, resume_mode in _PROCESSOR_RESUME_FILENAMES:
+        if isfile(join(base_model_path, filename)):
+            return resume_mode
     return "missing"
 
 


### PR DESCRIPTION
## Summary
- Optimize LoRA `_processor_resume_mode` by replacing per-check `Path` object construction with a module-level filename table plus local `os.path.join` / `os.path.isfile` bindings.
- Extend the registered `lora-aux-modules-scandir` PR-scoped probe with processor resume mode metrics and focused tests.
- Add a short plan note for the stat fast-path slice.

## Plan or Spec
- `docs/plans/2026-06-02-lora-processor-resume-stat-fastpath.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` via the registered `lora-aux-modules-scandir` `test_command`: 13 passed.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && ... changed_scope_coverage.py ...` via the registered `coverage_command`: 13 passed; changed-line coverage 100%.
- Registered local `probe_command`: emitted processor resume metrics.
- Local PR-scoped probe dry run with temp `base`/`head` worktrees: head verification ok, base probe ok, head probe ok.
- `git diff --check`: passed.

## Coverage and Metrics
- Changed-scope coverage: 89/89 changed measurable lines covered, 100%.
- Registered local probe (direct): `processor_resume_baseline_elapsed_ms_mean=0.0197385837`, `processor_resume_optimized_elapsed_ms_mean=0.0077033016`, `processor_resume_delta_ms=-0.0120352821`, `processor_resume_isfile_calls_mean=2.0`.
- Local PR-scoped dry run: base probe ok, head probe ok; head processor resume metrics: `baseline=0.0205241543 ms`, `optimized=0.0080192196 ms`, `delta=-0.0125049347 ms`, `isfile_calls=2.0`.

## Known Gaps
- Python slice only; locally validated on Linux. CI is still required for the repository registered PR-scoped performance workflow and full PR checks.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused local tests passed.
- [x] Changed-scope coverage passed.
- [x] Registered local probe emitted metrics.
- [x] GitHub Actions / PR-scoped performance report pending after PR creation.
