### PR TITLE
perf: avoid lower allocations for MLX tag checks

### DIFF
--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -340,11 +340,14 @@ def _is_mlx_atom(value: str) -> bool:
 
 
 def _tag_payload_contains_mlx(value: Any) -> bool:
-    if isinstance(value, str):
-        return value.lower() == "mlx"
-    if not isinstance(value, list):
+    if isinstance(value, list):
+        for item in value:
+            if isinstance(item, str) and _is_mlx_atom(item):
+                return True
         return False
-    return any(item.lower() == "mlx" for item in value if isinstance(item, str))
+    if isinstance(value, str):
+        return _is_mlx_atom(value)
+    return False
 
 
 def _normalized_lowered_tags(tags: list[str], lowered_tags: set[str] | None = None) -> set[str]:


### PR DESCRIPTION
## Summary
- Replace per-tag `str.lower()` MLX tag checks with the existing three-character atom predicate.
- Check list tag payloads first on the hot compatibility path, then preserve scalar string support.
- Keep exact atom semantics (`MLX`, `mLx`, etc. match; longer strings such as `mlx-compatible` do not) while avoiding lowercase string allocation.

## Plan or Spec
- N/A: this is a scoped internal performance slice for the already registered `hub-catalog-size-hint-regex-precompile` PR-scoped probe. No external behavior or workflow changed.

## Commands Run
```text
git fetch origin main && git reset --hard origin/main && git worktree add -b perf/hub-catalog-mlx-tag-atom-20260602 ... origin/main -> exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_COMPATIBILITY_ITERATIONS=200000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py (baseline) -> exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_COMPATIBILITY_ITERATIONS=200000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py (candidate after list-first review follow-up) -> exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics -> 65 passed, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics -> 65 passed, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json -> exit 0
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py -> TOTAL 5 0 100%, exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Registered probe: `hub-catalog-size-hint-regex-precompile` covers `services/mlx-worker-python/worker/model_ops/hub_catalog.py` and includes focused `test_command`, `coverage_command`, and `probe_command`.
- Local Linux baseline probe: `payload_compatibility_elapsed_ms_mean=281.8629113957286`, `elapsed_ms_mean=1543.017579894513`, `sample_count=5.0`.
- Local Linux candidate probe after list-first follow-up: `payload_compatibility_elapsed_ms_mean=225.225661508739`, `elapsed_ms_mean=1542.923580110073`, `sample_count=5.0`.
- Delta: compatibility path `-56.6372498869896 ms` (about `1.251x` faster); overall registered probe `-0.093999784440 ms` (neutral/about `1.000x`).
- Prior candidate probe before list-first follow-up also improved compatibility: `payload_compatibility_elapsed_ms_mean=237.4930770136416`.

## Known Gaps
- Full repository gates were not run locally; this PR uses the registered focused Python probe/test/coverage slice.
- CI PR-scoped performance workflow is required as the merge validation source.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or marked N/A because behavior is unchanged.
- [x] Protocol changes include regenerated generated artifacts, or marked N/A because no protocol changed.
- [x] Dependency changes include updated lockfiles, or marked N/A because dependencies did not change.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
