### PR TITLE
perf: fast path code eval stdio tail limits

### DIFF
--- a/docs/plans/2026-06-02-code-eval-stdio-read-limit.md
+++ b/docs/plans/2026-06-02-code-eval-stdio-read-limit.md
@@ -1,0 +1,42 @@
+# Code eval stdio read-limit fast path
+
+## Scope
+
+This Python-only performance slice is limited to the code-evaluation stdio tail
+reader in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+The optimization preserves existing subprocess stdout/stderr tail semantics while
+removing per-call `int(...)`/`max(...)` helper overhead from `_read_limited_stdio`
+for the registered positive integer `stdout_limit_bytes` path. Negative or zero
+limits still clamp to zero bytes.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`code-eval-stdio-tail-single-stat` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry already provides focused `test_command`, `coverage_command`,
+and `probe_command` entries for the touched worker path. This slice keeps the
+probe registry stable and uses the registered local/CI probe as the performance
+gate.
+
+## Plan
+
+1. Keep the existing stdio race/error tests as the behavior parity guard.
+2. Replace `max(int(byte_limit), 0)` with a direct positive-integer branch,
+   collapse the read-size selection to a single expression, and return early for
+   zero-byte reads.
+3. Run the focused code-eval pytest targets, changed-scope coverage, and the
+   registered `code_eval_stdio_probe.py` on Linux before opening the PR.
+4. Use GitHub Actions and the registered PR-scoped performance report as the
+   merge gate.
+
+## Verification
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_text_handles_missing_and_oversized_files services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_handles_open_race services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_ignores_close_errors services/mlx-worker-python/tests/test_code_eval_runner.py::test_output_limit_reuses_limited_stdio_sizes services/mlx-worker-python/tests/test_code_eval_runner.py::test_timeout_and_output_limit_failure_details_include_stdio_when_present services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_stdio_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_text_handles_missing_and_oversized_files services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_handles_open_race services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_ignores_close_errors services/mlx-worker-python/tests/test_code_eval_runner.py::test_output_limit_reuses_limited_stdio_sizes services/mlx-worker-python/tests/test_code_eval_runner.py::test_timeout_and_output_limit_failure_details_include_stdio_when_present services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_stdio_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_stdio_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_stdio_probe.py
+```

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -537,11 +537,16 @@ def test_read_limited_text_handles_missing_and_oversized_files(tmp_path: Path) -
     assert code_eval_runner._read_limited_text(missing_path, 8) == ""
     assert code_eval_runner._read_limited_stdio(missing_path, 8) == ("", 0)
 
+    empty_path = tmp_path / "empty.txt"
+    empty_path.write_text("", encoding="utf-8")
+    assert code_eval_runner._read_limited_stdio(empty_path, 4) == ("", 0)
+
     output_path = tmp_path / "output.txt"
     output_path.write_text("0123456789abcdef", encoding="utf-8")
 
     assert code_eval_runner._read_limited_text(output_path, 4) == "cdef"
     assert code_eval_runner._read_limited_stdio(output_path, 4) == ("cdef", 16)
+    assert code_eval_runner._read_limited_stdio(output_path, 0) == ("", 16)
 
     directory_path = tmp_path / "directory"
     directory_path.mkdir()

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -556,12 +556,12 @@ def _read_limited_stdio(path: Path, byte_limit: int) -> tuple[str, int]:
 
     try:
         size = os.fstat(fd).st_size
-        read_limit = max(int(byte_limit), 0)
+        read_limit = byte_limit if byte_limit > 0 else 0
+        read_size = read_limit if size > read_limit else size
+        if read_size == 0:
+            return "", size
         if size > read_limit:
             os.lseek(fd, -read_limit, os.SEEK_END)
-            read_size = read_limit
-        else:
-            read_size = size
         return os.read(fd, read_size).decode("utf-8", errors="replace").strip(), size
     except OSError:
         return "", 0


### PR DESCRIPTION
## Summary
- Fast-path `_read_limited_stdio()` for the normal positive integer stdio limit path by avoiding per-call `int(...)`/`max(...)` helper overhead.
- Collapse read-size selection while preserving missing file, open race, oversized tail, and close-error behavior.
- Add a focused governing plan for this performance slice.

## Plan or Spec
- `docs/plans/2026-06-02-code-eval-stdio-read-limit.md`
- Registered probe: `code-eval-stdio-tail-single-stat` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_text_handles_missing_and_oversized_files services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_handles_open_race services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_ignores_close_errors services/mlx-worker-python/tests/test_code_eval_runner.py::test_output_limit_reuses_limited_stdio_sizes services/mlx-worker-python/tests/test_code_eval_runner.py::test_timeout_and_output_limit_failure_details_include_stdio_when_present services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_stdio_probe_script_emits_metrics` → 8 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...same focused targets...` → 8 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_stdio_probe.py` → TOTAL 2/2 changed lines covered, 100%
- Baseline probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_stdio_probe.py` x3
- Candidate probe on this branch: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_stdio_probe.py` x3
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`services/mlx-worker-python/worker/engine/code_eval_runner.py` changed lines 559-560 covered).
- Registered local probe (`code_eval_stdio_probe.py`, `elapsed_ms_mean`, lower is better):
  - Baseline samples: 29.9298 ms, 29.1364 ms, 27.3823 ms; mean 28.8162 ms.
  - Candidate samples: 25.7395 ms, 28.3103 ms, 25.7461 ms; mean 26.5986 ms.
  - Delta: -2.2175 ms (-7.70%); speedup 1.083x.
- Probe invariants unchanged: `stdio_stat_calls_mean=6000.0`, `tail_chars_mean=5119.0`, `output_limit_exceeded_mean=1.0`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime effect is claimed.
- The optimization targets the common registered positive integer limit path; zero/negative limits preserve the existing zero-byte clamp behavior.

## Evidence Checklist
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% for touched Python lines.
- [x] Registered local performance probe shows improvement.
- [x] Governing plan/spec is updated under `docs/plans/`.
- [ ] GitHub Actions complete successfully.
- [ ] PR-scoped performance workflow completes successfully and reports the registered probe.
