### PR TITLE
perf: single pass tool registry selection lookup

### DIFF
--- a/docs/plans/2026-06-02-tool-registry-select-single-pass.md
+++ b/docs/plans/2026-06-02-tool-registry-select-single-pass.md
@@ -1,0 +1,50 @@
+# Tool registry select single-pass normalized lookup
+
+## Summary
+
+This Python-only performance slice keeps `ToolRegistry.select()` behavior unchanged
+while reducing work on uncached multi-name selections. The current path first
+normalizes and deduplicates requested names, then performs a second pass over the
+normalized tuple to look up descriptors and collect missing names. This slice
+combines normalization, deduplication, descriptor lookup, and missing-name
+collection into one pass while preserving the normalized tuple cache key and
+existing raw tuple cache aliases.
+
+## Registered PR-scoped probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+The entry already includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_select_probe.py`
+
+No probe registry change is required for this slice.
+
+## Optimization slice
+
+Scope is limited to `ToolRegistry.select()` multi-name misses before a selected
+registry is cached:
+
+- keep exact tuple and exact full-list fast paths unchanged;
+- keep single-name handling unchanged;
+- build `requested_names`, `selected`, and `missing_names` during the same loop;
+- preserve duplicate-name elision, blank-name elision, missing-name errors,
+  selected registry ordering, and cache population semantics.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and the
+registered probe locally on Linux. The PR-scoped performance workflow remains the
+merge gate for base-vs-head validation.
+
+## Success criteria
+
+- Focused Python tests pass.
+- Changed-scope coverage for touched files remains at or above 95%.
+- Registered probe shows a non-regressing or improved `elapsed_ms_mean` and no
+  semantic metric regressions.
+- GitHub Actions and the PR-scoped performance workflow are green before merge.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -286,28 +286,28 @@ class ToolRegistry:
                 return selection
 
         requested_names_list: list[str] = []
+        selected: list[ToolDescriptor] = []
+        missing_names: list[str] = []
         seen_names: set[str] = set()
+        tool_by_name = self._tool_by_name
+        missing_tool_sentinel = _MISSING_TOOL_SENTINEL
         for name in names:
             normalized_name = name.strip()
             if not normalized_name or normalized_name in seen_names:
                 continue
             seen_names.add(normalized_name)
             requested_names_list.append(normalized_name)
+            tool = tool_by_name.get(normalized_name, missing_tool_sentinel)
+            if tool is missing_tool_sentinel:
+                missing_names.append(normalized_name)
+            else:
+                selected.append(cast(ToolDescriptor, tool))
         requested_names = tuple(requested_names_list)
         if requested_names == self._tool_names:
             return self
         cached_selection = self._selection_cache.get(requested_names)
         if cached_selection is not None:
             return cached_selection
-        tool_by_name = self._tool_by_name
-        selected: list[ToolDescriptor] = []
-        missing_names: list[str] = []
-        for name in requested_names:
-            tool = tool_by_name.get(name, _MISSING_TOOL_SENTINEL)
-            if tool is _MISSING_TOOL_SENTINEL:
-                missing_names.append(name)
-            else:
-                selected.append(tool)
         if missing_names:
             joined = ", ".join(missing_names)
             raise ToolRegistryError(f"Unknown tool registry entry requested: {joined}")


### PR DESCRIPTION
## Summary
- Optimize the Python `ToolRegistry.select()` multi-name miss path by combining normalization, deduplication, descriptor lookup, and missing-name collection into one loop.
- Keep exact tuple/full-list fast paths, single-name handling, ordering, duplicate elision, missing-name errors, and selection-cache population semantics unchanged.

## Plan or Spec
- `docs/plans/2026-06-02-tool-registry-select-single-pass.md`
- Registered PR-scoped probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Focused tests (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
57 passed in 1.03s

# Changed-scope coverage (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
57 passed in 0.49s; TOTAL 8 0 100%

# Registered local base-vs-head probe (exit 0, repeated twice)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-select-name-index-cache --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-tool-registry-select-name-tuple-base-20260602 --head-repo "$PWD" --output /tmp/tool_registry_select_single_pass_probe.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-select-name-index-cache --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-tool-registry-select-name-tuple-base-20260602 --head-repo "$PWD" --output /tmp/tool_registry_select_single_pass_probe_2.json

# Whitespace check (exit 0)
git diff --check
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%` for `tool_registry.py` changed lines and registered probe/test paths.
- Local registered probe run 1:
  - `elapsed_ms_mean`: base `20.9342`, head `21.0741` (`+0.67%`, within 5% warn threshold)
  - `full_config_template_elapsed_ms_mean`: base `22.9652`, head `21.7361` (`-5.35%`)
  - `missing_selection_elapsed_ms_mean`: base `14.5086`, head `14.0023` (`-3.49%`)
- Local registered probe run 2:
  - `elapsed_ms_mean`: base `23.0621`, head `21.1030` (`-8.49%`)
  - `full_config_template_elapsed_ms_mean`: base `27.3934`, head `21.9551` (`-19.85%`)
  - `missing_selection_elapsed_ms_mean`: base `17.9227`, head `13.9692` (`-22.06%`)
- CI PR-scoped performance remains the merge gate for the registered base-vs-head report.

## Known Gaps
- Linux local validation covers this Python-only slice. No Swift runtime effect is claimed.
- Probe run 1 showed a small `elapsed_ms_mean` variance regression inside the warn threshold; run 2 showed improvement. CI registered probe is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe evidence; probe overhead changes N/A because no observability code changed.
- [x] Deferred work and known gaps are stated explicitly.
