### PR TITLE
perf: avoid video reference path split allocation

### DIFF
--- a/docs/plans/2026-06-02-video-reference-path-suffix-fastpath.md
+++ b/docs/plans/2026-06-02-video-reference-path-suffix-fastpath.md
@@ -1,0 +1,28 @@
+# Video reference path suffix fast path
+
+## Goal
+
+Avoid the temporary string/list allocations from `path.rstrip("/").rsplit("/", 1)` while parsing video URI path metadata. `_parse_video_reference()` runs on the video preprocessing hot path and only needs the final path segment plus suffix, so this slice scans the original path string with indexes and slices once for the final path name.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_video_preprocessing.py`
+- `docs/plans/2026-06-02-video-reference-path-suffix-fastpath.md`
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped registered probe `video-preprocessing-uri-byte-length-reuse` in `infra/perf/pr_scoped_probes.json`. The entry has focused `test_command`, `coverage_command`, and `probe_command` values and watches `worker/runtime/video_preprocessing.py`, the focused tests, and `scripts/video_preprocessing_uri_probe.py`.
+
+## Verification plan
+
+Run the registered probe commands locally on Linux:
+
+1. Focused pytest for video preprocessing and probe selection.
+2. Changed-scope coverage using the registered `coverage_command`.
+3. Registered probe comparison from an `origin/main` baseline worktree to the head worktree.
+4. `git diff --check`.
+
+## Success metric
+
+The registered probe should preserve behavior, keep parse calls and byte-length reads at one per prepared URI video call, and reduce mean elapsed time by avoiding path `rstrip`/`rsplit` allocations in the URI parse helper.

--- a/services/mlx-worker-python/tests/test_video_preprocessing.py
+++ b/services/mlx-worker-python/tests/test_video_preprocessing.py
@@ -273,6 +273,8 @@ def test_parse_video_reference_caches_repeated_uri_metadata() -> None:
     [
         ("https://example.com/media/archive.demo.MP4", "archive.demo.MP4", "mp4"),
         ("https://example.com/media/demo.mov/", "demo.mov", "mov"),
+        ("https://example.com/media/demo.mov///", "demo.mov", "mov"),
+        ("/", "", ""),
         ("/tmp/.mp4", ".mp4", ""),
         ("relative/video.", "video.", ""),
     ],

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -162,7 +162,11 @@ def _parse_video_reference(reference: str) -> ParsedVideoReference:
 
 
 def _path_name_and_suffix(path: str) -> tuple[str, str]:
-    path_name = path.rstrip("/").rsplit("/", 1)[-1]
+    end_index = len(path)
+    while end_index > 0 and path[end_index - 1] == "/":
+        end_index -= 1
+    slash_index = path.rfind("/", 0, end_index)
+    path_name = path[slash_index + 1 : end_index]
     dot_index = path_name.rfind(".")
     path_suffix = path_name[dot_index + 1 :].lower() if 0 < dot_index < len(path_name) - 1 else ""
     return path_name, path_suffix


### PR DESCRIPTION
## Summary
- Replaces video reference path `rstrip().rsplit()` metadata extraction with an index-based final-segment scan.
- Adds regression coverage for multiple trailing slashes and root-only paths.
- Adds a focused plan for this Python performance slice.

## Plan or Spec
- `docs/plans/2026-06-02-video-reference-path-suffix-fastpath.md`
- Registered PR-scoped probe: `video-preprocessing-uri-byte-length-reuse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py::test_validate_video_uri_accepts_parsed_and_string_remote_references services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/video_preprocessing_uri_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id video-preprocessing-uri-byte-length-reuse --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-video-reference-path-suffix-fastpath-20260602-base --head-repo "$PWD" --output /tmp/video_reference_path_suffix_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: 37 passed.
- Changed-scope coverage: `TOTAL 5 0 100%` for changed executable lines.
- Registered local probe `video-preprocessing-uri-byte-length-reuse`:
  - `elapsed_ms_mean`: base `643.5570382513106`, head `581.2941682524979`, delta `-62.262870 ms`, speedup `1.107111x` / `9.67%` faster.
  - `byte_length_getattrs_per_call`: base `1.0`, head `1.0`.
  - `parse_calls_per_call`: base `1.0`, head `1.0`.

## Known Gaps
- Python-only slice validated locally on Linux. CI must validate the registered PR-scoped performance workflow for the PR.

## Evidence Checklist
- [x] Registered probe covers the changed path and has focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows improved mean elapsed time with behavior counters unchanged.
- [x] `git diff --check` passed.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
