### PR TITLE
perf: fast-path zero-offset event JSON fences

### DIFF
--- a/docs/plans/2026-06-02-event-response-json-prefix-zero-fastpath.md
+++ b/docs/plans/2026-06-02-event-response-json-prefix-zero-fastpath.md
@@ -1,0 +1,35 @@
+# Event response JSON zero-offset fence fast path
+
+This Python-only performance slice targets fenced event-extraction response parsing in `services/mlx-worker-python/worker/productization/event_extraction.py`.
+
+## Scope
+
+LLM event-extraction responses commonly start directly with the canonical JSON fence prefix string (three backticks, `json`, then a newline) and have no leading whitespace. The existing parser always entered the leading-whitespace scan before checking the canonical fence. This slice adds a zero-offset canonical-fence fast path while preserving the existing fallback for leading whitespace, generic fences, unfenced JSON, and trailing-fence validation.
+
+## Registered Probe
+
+Affected path coverage uses the existing registered PR-scoped probe `event-extraction-response-json-fence-trim` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/productization/event_extraction.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+- `scripts/event_extraction_response_json_probe.py`
+- PR-scoped performance registry tests
+
+## Verification Plan
+
+Run the registered probe's focused test command, changed-scope coverage command, and local Linux registered probe runner:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_leading_whitespace_before_fence services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_generic_fence_after_fast_json_prefix services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_unfenced_json_without_pretrim_copy services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_trailing_text_after_fenced_json services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_fenced_non_object_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_leading_whitespace_before_fence services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_generic_fence_after_fast_json_prefix services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_unfenced_json_without_pretrim_copy services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_trailing_text_after_fenced_json services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_fenced_non_object_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_response_json_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id event-extraction-response-json-fence-trim --base-repo <baseline-worktree> --head-repo "$PWD" --output /tmp/event_response_json_prefix_zero_probe.json
+```
+
+## Acceptance Criteria
+
+- Focused behavior and registry tests pass.
+- Changed-scope coverage remains at or above 95% for the touched Python scope.
+- Registered local probe preserves checksum/event-count metrics and improves or stays within acceptable noise for `elapsed_ms_mean` and `peak_bytes_mean`.
+- PR-scoped performance CI completes the registered probe successfully before merge.

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2850,8 +2850,19 @@ def _coerce_string_list(value: object) -> list[str]:
 
 
 def _parse_response_json(response_text: str) -> dict[str, object]:
-    response_start = 0
     response_length = len(response_text)
+    if response_text.startswith(_JSON_FENCE_PREFIX):
+        parsed, end_index = _JSON_DECODER.raw_decode(
+            response_text,
+            _JSON_FENCE_PREFIX_LENGTH,
+        )
+        if not _has_only_optional_closing_fence(response_text, end_index, response_length):
+            raise json.JSONDecodeError("Extra data", response_text, end_index)
+        if not isinstance(parsed, dict):
+            raise ValueError("LLM response must be a JSON object")
+        return parsed
+
+    response_start = 0
     while response_start < response_length and response_text[response_start].isspace():
         response_start += 1
 


### PR DESCRIPTION
## Summary
- Add a zero-offset canonical JSON fence fast path in event-extraction response parsing.
- Preserve leading-whitespace, generic-fence, unfenced JSON, and trailing-fence validation behavior.

## Plan or Spec
- `docs/plans/2026-06-02-event-response-json-prefix-zero-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_leading_whitespace_before_fence services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_generic_fence_after_fast_json_prefix services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_unfenced_json_without_pretrim_copy services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_trailing_text_after_fenced_json services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_fenced_non_object_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics
# 10 passed in 1.74s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_leading_whitespace_before_fence services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_generic_fence_after_fast_json_prefix services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_unfenced_json_without_pretrim_copy services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_trailing_text_after_fenced_json services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_fenced_non_object_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_response_json_probe.py
# 10 passed in 0.58s; changed-scope coverage TOTAL 8 0 100%

git diff --check
# exit 0

MELIX_EVENT_RESPONSE_JSON_PROBE_EVENT_COUNT=800 MELIX_EVENT_RESPONSE_JSON_PROBE_ITERATIONS=40 MELIX_EVENT_RESPONSE_JSON_PROBE_SAMPLES=3 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id event-extraction-response-json-fence-trim --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/event_response_json_prefix_zero_probe.json
# head verification ok, base probe ok, head probe ok
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 8 0 100%`).
- Registered local Linux probe (reduced-size deterministic run of `event-extraction-response-json-fence-trim`):
  - `elapsed_ms_mean`: base `332.1620902667443`, head `315.0676206375162`, delta `-17.094469629228115 ms`, speedup `5.146424029154056%`.
  - `peak_bytes_mean`: base `1498370.6666666667`, head `1498386.6666666667`, delta `+16 bytes` (noise-level).
  - `checksum`: base/head `96000.0`; `event_count`: base/head `800.0`.
- CI PR-scoped performance workflow is required for the full registered probe validation before merge.

## Known Gaps
- Local Linux validation uses a reduced probe size to keep the scheduled job bounded; CI remains the source of truth for the full registered PR-scoped probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead change: N/A, no probe implementation change.
- [x] Deferred work and known gaps are stated explicitly.
