### PR TITLE
perf: streamline dataset quality length collection

### DIFF
--- a/docs/plans/2026-06-02-dataset-quality-length-direct-loop.md
+++ b/docs/plans/2026-06-02-dataset-quality-length-direct-loop.md
@@ -1,0 +1,29 @@
+# Dataset quality output length direct loop
+
+## Scope
+
+Optimize one Python hot path in dataset quality summary construction: output-length collection for generated dataset samples in `worker.productization.dataset_preparation._quality_summary`.
+
+## Registered probe
+
+The affected path is already covered by the PR-scoped registered probe `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused test, changed-scope coverage, and probe commands for:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_versioning.py`
+- `scripts/dataset_quality_lengths_probe.py`
+
+## Implementation plan
+
+- Preserve completion and chat-message output length semantics.
+- Replace the `chain(...)` + per-row helper call in the quality-summary hot path with a direct two-list loop that binds `append` once and inlines the existing length rules.
+- Cover the batched helper directly with mixed completion, message, and malformed-message rows.
+
+## Verification
+
+- Run the registered probe locally on Linux before and after the change.
+- Run the probe registry's focused test command.
+- Run the probe registry's changed-scope coverage command and require at least 95% coverage.
+
+## Boundary
+
+This is a Python-only Linux-validated slice. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -10,6 +10,7 @@ from worker.productization.dataset_preparation import (
     DatasetIngestRequest,
     DatasetRetryFailedRequest,
     DatasetVersionRequest,
+    _sample_output_lengths,
     list_dataset_versions,
     prepare_dataset_ingest,
     prepare_dataset_version,
@@ -109,6 +110,19 @@ def test_dataset_version_writes_schema_backed_package_and_quality_summary(
     assert quality["pii_mask_count"] == 1
     assert quality["dedup_ratio"] == 0
     assert quality["metrics"]["quality_scoring_latency_ms"] >= 0
+
+
+def test_dataset_quality_output_lengths_preserve_completion_and_message_semantics() -> None:
+    train_rows = [
+        {"completion": "abc"},
+        {"completion": 12345},
+    ]
+    validation_rows = [
+        {"messages": [{"content": "hello"}, {"content": "world"}, {"role": "tool"}]},
+        {"messages": "not-a-list"},
+    ]
+
+    assert _sample_output_lengths(train_rows, validation_rows) == [3, 5, 10, 0]
 
 
 def test_dataset_version_rejects_blocked_workspace_preflight_receipt_before_reading_segments(

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 import csv
 from datetime import datetime, timezone
 import hashlib
-from itertools import chain
 import json
 import os
 import re
@@ -961,7 +960,7 @@ def _quality_summary(
     total_count = success_count + failed_count
     success_rate = success_count / total_count if total_count else 0.0
     score = round(success_rate, 6)
-    lengths = [_sample_output_length(row) for row in chain(train_rows, validation_rows)]
+    lengths = _sample_output_lengths(train_rows, validation_rows)
     quality_controls = ingest_receipt.get("quality_control_summary", {})
     source_record_count = float(quality_controls.get("source_record_count", 0) or 0)
     exact_dedup_count = float(quality_controls.get("exact_dedup_count", 0) or 0)
@@ -1004,13 +1003,27 @@ def _quality_grade(score: float) -> str:
     return "F"
 
 
-def _sample_output_length(row: dict[str, Any]) -> int:
-    if "completion" in row:
-        return len(str(row["completion"]))
-    messages = row.get("messages", [])
-    if isinstance(messages, list):
-        return sum(len(str(item.get("content", ""))) for item in messages if isinstance(item, dict))
-    return 0
+def _sample_output_lengths(
+    train_rows: list[dict[str, Any]],
+    validation_rows: list[dict[str, Any]],
+) -> list[int]:
+    lengths: list[int] = []
+    append = lengths.append
+    for rows in (train_rows, validation_rows):
+        for row in rows:
+            if "completion" in row:
+                append(len(str(row["completion"])))
+                continue
+            messages = row.get("messages", [])
+            if not isinstance(messages, list):
+                append(0)
+                continue
+            total = 0
+            for item in messages:
+                if isinstance(item, dict):
+                    total += len(str(item.get("content", "")))
+            append(total)
+    return lengths
 
 
 def _p95(values: list[int]) -> int:


### PR DESCRIPTION
## Summary
- Replace dataset quality output-length collection with a direct two-list loop that binds append once and inlines the existing completion/message length rules.
- Add focused regression coverage for completion, message, and malformed-message length semantics.
- Document the slice plan and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-06-02-dataset-quality-length-direct-loop.md`
- Registered PR-scoped probe: `dataset-quality-lengths-chain`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_output_lengths_preserve_completion_and_message_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_output_lengths_preserve_completion_and_message_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 6 passed.
- Changed-scope coverage: `TOTAL 23 0 100%`.
- Local registered probe baseline from `origin/main`: `elapsed_ms_mean=5.169114`, `elapsed_ms_min=4.591494`, `elapsed_ms_p95=5.453483`.
- Local registered probe candidate: `elapsed_ms_mean=2.566602`, `elapsed_ms_min=2.344341`, `elapsed_ms_p95=2.989905`.
- Delta: `-2.602512 ms` mean, speedup `2.014x` on the 15k-row synthetic probe.

## Known Gaps
- This is a Python-only Linux-validated slice; no Swift runtime effect is claimed.
- CI PR-scoped performance workflow is required for repository registered-probe validation before merge.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the changed path.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe was run locally on Linux.
- [ ] GitHub Actions and PR-scoped performance report are green.
