### PR TITLE
perf: defer hub catalog cardData compatibility checks

### DIFF
--- a/docs/plans/2026-06-02-hub-catalog-mlx-substring-fastpath.md
+++ b/docs/plans/2026-06-02-hub-catalog-mlx-substring-fastpath.md
@@ -1,0 +1,42 @@
+# Hub catalog MLX repo-id substring fast path
+
+## Scope
+
+This Python-only performance slice is limited to MLX compatibility checks in
+`services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+
+The optimization preserves existing Hub catalog semantics while deferring
+`cardData` normalization until the top-level library, tags, and repo-id checks
+have failed in `_payload_is_mlx_compatible()`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`Hub catalog size hint regex precompile` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry already provides focused `test_command`, `coverage_command`,
+and `probe_command` entries for `hub_catalog.py`, its focused tests, and the
+Hub catalog probe script. This slice keeps the registered probe definition
+stable and relies on its `payload_compatibility_elapsed_ms_mean` metric for the
+MLX compatibility hot path.
+
+## Plan
+
+1. Add a regression test that exercises every ASCII case variant of the `mlx`
+   substring in repo ids across both compatibility entry points.
+2. Defer `cardData` dict extraction in `_payload_is_mlx_compatible()` until
+   earlier top-level compatibility checks miss.
+3. Run the focused Hub catalog tests, changed-scope coverage, and the registered
+   Hub catalog probe locally on Linux.
+4. Use GitHub Actions and the registered PR-scoped performance report as the
+   merge gate.
+
+## Verification
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
+```

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -176,6 +176,31 @@ def test_payload_mlx_tag_match_stays_exact_and_case_insensitive() -> None:
     assert _payload_is_mlx_compatible({"tags": ["ammlx"], "cardData": {}}) is False
 
 
+def test_repo_id_mlx_substring_match_preserves_ascii_case_insensitivity() -> None:
+    for repo_id in (
+        "owner/model-mlx",
+        "owner/model-MLX",
+        "owner/model-Mlx",
+        "owner/model-MlX",
+        "owner/model-mLX",
+        "owner/model-mLx",
+        "owner/model-mlX",
+        "owner/model-MLx",
+    ):
+        assert _payload_is_mlx_compatible({"id": repo_id, "tags": [], "cardData": {}}) is True
+        assert _is_mlx_compatible(
+            repo_id=repo_id,
+            tags=[],
+            library_name="transformers",
+            card_data={},
+        ) is True
+    assert _payload_is_mlx_compatible({"id": "owner/model", "tags": [], "cardData": {}}) is False
+    assert _payload_is_mlx_compatible({"id": "owner/model", "tags": [], "cardData": None}) is False
+    assert _payload_is_mlx_compatible(
+        {"id": "owner/model", "tags": [], "cardData": {"library_name": "MLX"}}
+    ) is True
+
+
 def test_direct_size_hint_rejects_extra_tokens_without_full_split() -> None:
     assert _direct_size_hint_from_text("12 GB extra") == 0
     assert _direct_size_hint_from_text("12 GB") == 12 * 1024 * 1024 * 1024

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -400,14 +400,18 @@ def _base_models(value: Any) -> list[str]:
 
 
 def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:
-    card_data = payload.get("cardData") if isinstance(payload.get("cardData"), dict) else {}
-    library_name = _string(payload.get("library_name") or card_data.get("library_name"))
+    library_name = _string(payload.get("library_name"))
     if library_name and _is_mlx_atom(library_name):
         return True
     if _tag_payload_contains_mlx(payload.get("tags")):
         return True
     repo_id = _string(payload.get("id") or payload.get("modelId"))
     if "mlx" in repo_id.lower():
+        return True
+    card_data = payload.get("cardData")
+    if not isinstance(card_data, dict):
+        return False
+    if not library_name and _is_mlx_atom(_string(card_data.get("library_name"))):
         return True
     card_tags = card_data.get("tags")
     if not card_tags:


### PR DESCRIPTION
## Summary
- Defers `cardData` extraction in `_payload_is_mlx_compatible()` until top-level library, tag, and repo-id checks miss.
- Adds regression coverage for case-insensitive `mlx` repo-id compatibility and delayed `cardData` fallback behavior.

## Plan or Spec
- `docs/plans/2026-06-02-hub-catalog-mlx-substring-fastpath.md`
- Registered PR-scoped probe: `Hub catalog size hint regex precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 66 passed.
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Local registered probe comparison on Linux:
  - Base: `payload_compatibility_elapsed_ms_mean=229.84552094712853`, `elapsed_ms_mean=1513.8671894557774`.
  - Head: `payload_compatibility_elapsed_ms_mean=212.75197146460414`, `elapsed_ms_mean=1520.2170989476144`.
  - Targeted compatibility delta: `-17.093549482524395 ms` (~7.44% faster) over 200,000 compatibility calls.
  - Full probe elapsed is effectively noisy/slightly worse because this slice only targets the compatibility submetric; CI registered probe report remains the merge gate.

## Known Gaps
- Python-only slice validated locally on Linux; no Swift runtime effect is claimed.
- The registered CI PR-scoped performance workflow is required before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe was run locally and reports the targeted metric delta.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
