### PR TITLE
perf: bind trajectory manifest getter

### DIFF
--- a/docs/plans/2026-06-02-trajectory-manifest-get-binding.md
+++ b/docs/plans/2026-06-02-trajectory-manifest-get-binding.md
@@ -1,0 +1,34 @@
+# Trajectory manifest get binding
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.trajectory_provenance._trajectory_provenance_from_snapshot_manifest()`.
+The manifest loader already avoids text decoding and nested copy work on the
+registered hot path; this slice reduces repeated mapping method lookup overhead
+while preserving the same field selection, defaults, and optional provenance
+handling.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`. The
+registry defines focused `test_command`, `coverage_command`, and `probe_command`
+entries for the trajectory provenance loader path.
+
+## Implementation Plan
+
+1. Keep the existing JSON byte-loading and `copy_nested=False` behavior.
+2. Bind `manifest.get` once in the manifest-to-provenance helper and reuse that
+   binding for the initial agentic-manifest guard plus required and optional
+   field extraction.
+3. Preserve the public return shape and the existing behavior for non-agentic or
+   empty manifests.
+4. Run the registered focused tests, changed-scope coverage, and registered
+   local probe on Linux. PR-scoped performance CI remains the merge gate.
+
+## Expected Metrics Direction
+
+The registered probe should keep `component_count` stable and reduce
+`new_mean_ms` / improve `speedup` for `trajectory-manifest-json-load` without
+increasing `new_peak_bytes_mean`.

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -107,36 +107,37 @@ def _trajectory_provenance_from_snapshot_manifest(
     snapshot_manifest_path: Path | str | None = None,
     copy_nested: bool,
 ) -> dict[str, Any]:
+    manifest_get = manifest.get
     if (
-        str(manifest.get("format", "")).strip() != "agentic_tool_trace"
-        and not str(manifest.get("trajectory_trace_digest", "")).strip()
+        str(manifest_get("format", "")).strip() != "agentic_tool_trace"
+        and not str(manifest_get("trajectory_trace_digest", "")).strip()
     ):
         return {}
 
     provenance: dict[str, Any] = {}
     dataset_id = str(
-        manifest.get("source_dataset_id") or manifest.get("dataset_id") or ""
+        manifest_get("source_dataset_id") or manifest_get("dataset_id") or ""
     ).strip()
     if dataset_id:
         provenance["trajectory_dataset_id"] = dataset_id
-    dataset_version = str(manifest.get("version") or "").strip()
+    dataset_version = str(manifest_get("version") or "").strip()
     if dataset_version:
         provenance["trajectory_dataset_version"] = dataset_version
     schema_version = str(
-        manifest.get("trajectory_schema_version") or "melix.agentic_tool_trace.v1"
+        manifest_get("trajectory_schema_version") or "melix.agentic_tool_trace.v1"
     ).strip()
     if schema_version:
         provenance["trajectory_schema_version"] = schema_version
-    split = str(manifest.get("trajectory_split") or "train").strip()
+    split = str(manifest_get("trajectory_split") or "train").strip()
     if split:
         provenance["trajectory_split"] = split
-    trace_digest = str(manifest.get("trajectory_trace_digest") or "").strip()
+    trace_digest = str(manifest_get("trajectory_trace_digest") or "").strip()
     if trace_digest:
         provenance["trajectory_trace_digest"] = trace_digest
     if snapshot_manifest_path is not None:
         provenance["trajectory_snapshot_manifest_path"] = str(snapshot_manifest_path)
     for source_field, output_field in _TRAJECTORY_MANIFEST_OPTIONAL_FIELD_MAP:
-        value = manifest.get(source_field)
+        value = manifest_get(source_field)
         if value in ("", None):
             continue
         provenance[output_field] = value


### PR DESCRIPTION
## Summary
- Bind `manifest.get` once in trajectory manifest provenance extraction to reduce repeated mapping method lookups on the registered manifest JSON load path.
- Add a focused plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-02-trajectory-manifest-get-binding.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 7 passed in 1.75s; exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
# 7 passed in 0.79s; changed_line_coverage=100.00%; exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/trajectory_manifest_json_load_probe.py"; if [ -f "$SCRIPT" ]; then python3 "$SCRIPT"; else for CANDIDATE in "../head/$SCRIPT" "${GITHUB_WORKSPACE:-}/head/$SCRIPT"; do if [ -f "$CANDIDATE" ]; then python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2; fi'
# {"component_count": 64.0, "delta_ms": -700.4602261818945, "elapsed_ms_mean": 695.4200221225619, "iteration_count": 2000.0, "new_mean_ms": 695.4200221225619, "new_peak_bytes_mean": 49580.0, "old_mean_ms": 1395.8802483044565, "old_peak_bytes_mean": 97375.6, "peak_bytes_mean": 49580.0, "sample_count": 5.0, "speedup": 2.0072477120286942}; exit 0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%` for `services/mlx-worker-python/worker/trajectory_provenance.py`.
- Registered local probe: `trajectory-manifest-json-load` completed on Linux with `old_mean_ms=1395.8802483044565`, `new_mean_ms=695.4200221225619`, `delta_ms=-700.4602261818945`, `speedup=2.0072477120286942`, `new_peak_bytes_mean=49580.0`.
- Additional longer local comparison against `origin/main` was used for slice decision: origin/main `new_mean_ms=2138.4229294822685`; head `new_mean_ms=2110.1393838013923` for 6000 iterations / 7 samples.
- CI PR-scoped performance remains the final registered probe validation source.

## Known Gaps
- None. This is a Python-only slice validated locally on Linux; CI is required for the registered PR-scoped performance report before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no new observability overhead.
- [x] Deferred work and known gaps are stated explicitly.
