### PR TITLE
perf: defer dataset preview path construction

### DIFF
--- a/docs/plans/2026-06-03-dataset-preview-deferred-path-construction.md
+++ b/docs/plans/2026-06-03-dataset-preview-deferred-path-construction.md
@@ -1,0 +1,27 @@
+# Dataset preview deferred path construction
+
+## Scope
+
+This Python performance slice is limited to the dataset registry first-preview scan path in `services/mlx-worker-python/worker/dataset_registry/catalog.py`.
+
+## Motivation
+
+`read_hf_dataset_snapshot_rows(..., limit=1)` uses `_first_supported_dataset_file(...)` to find the first readable dataset file without materializing the full snapshot file list. `_next_supported_scan_entry(...)` previously constructed a `Path` object every time a better lexical candidate was found while scanning a directory. Snapshots with many ignored sidecar files before the first data file can therefore spend extra allocations on candidates that are discarded within the same scan.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped performance probe `dataset-registry-preview-limit-short-circuit` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` values. This slice keeps the same probe and extends its synthetic snapshot with ignored sidecar files so the scan-candidate allocation path is represented.
+
+## Plan
+
+1. Add regression coverage that counts `Path` construction in `_next_supported_scan_entry(...)` when multiple candidate names are superseded during a first-preview scan.
+2. Store the winning raw entry path during the scan and construct a single `Path` only for the final selected entry.
+3. Extend `scripts/dataset_registry_preview_limit_probe.py` with configurable ignored sidecar files and report `sidecar_count`.
+4. Run focused pytest, changed-scope coverage, and the registered probe locally on Linux.
+
+## Success criteria
+
+- Focused dataset registry and PR-scoped performance tests pass.
+- Changed-scope coverage for the touched files is at least 95%.
+- The registered `dataset-registry-preview-limit-short-circuit` probe reports lower preview elapsed time or a clearly bounded allocation-path improvement.
+- PR-scoped performance CI completes successfully before merge.

--- a/scripts/dataset_registry_preview_limit_probe.py
+++ b/scripts/dataset_registry_preview_limit_probe.py
@@ -24,22 +24,29 @@ def _int_env(name: str, default: int) -> int:
     return int(raw_value)
 
 
-def _build_snapshot(root: Path, *, row_count: int) -> Path:
-    snapshot_dir = root / "snapshot" / "data"
-    snapshot_dir.mkdir(parents=True)
+def _build_snapshot(root: Path, *, row_count: int, sidecar_count: int) -> Path:
+    snapshot_root = root / "snapshot"
+    snapshot_root.mkdir(parents=True)
+    for index in range(sidecar_count, 0, -1):
+        (snapshot_root / f"sidecar-{index:05d}.txt").write_text("ignored\n", encoding="utf-8")
+    snapshot_dir = snapshot_root / "data"
+    snapshot_dir.mkdir()
     rows = [{"prompt": f"prompt-{index}", "answer": f"answer-{index}"} for index in range(row_count)]
     (snapshot_dir / "train.json").write_text(json.dumps({"rows": rows}), encoding="utf-8")
-    (root / "snapshot" / "README.md").write_text("# Synthetic dataset\n", encoding="utf-8")
-    return root / "snapshot"
+    (snapshot_root / "README.md").write_text("# Synthetic dataset\n", encoding="utf-8")
+    return snapshot_root
 
 
 def main() -> int:
     row_count = _int_env("MELIX_DATASET_PREVIEW_PROBE_FILES", 50_000)
+    sidecar_count = _int_env("MELIX_DATASET_PREVIEW_PROBE_SIDECARS", 1_000)
     sample_count = _int_env("MELIX_DATASET_PREVIEW_PROBE_SAMPLES", 7)
     elapsed_samples: list[float] = []
     peak_samples: list[float] = []
     with tempfile.TemporaryDirectory(prefix="melix-dataset-preview-probe-") as temp_dir:
-        snapshot_dir = _build_snapshot(Path(temp_dir), row_count=row_count)
+        snapshot_dir = _build_snapshot(
+            Path(temp_dir), row_count=row_count, sidecar_count=sidecar_count
+        )
         expected = [{"prompt": "prompt-0", "answer": "answer-0"}]
         zero_limit_elapsed_samples: list[float] = []
         zero_limit_peak_samples: list[float] = []
@@ -74,6 +81,7 @@ def main() -> int:
                 "zero_limit_elapsed_ms_mean": round(statistics.fmean(zero_limit_elapsed_samples), 6),
                 "zero_limit_peak_bytes_mean": round(statistics.fmean(zero_limit_peak_samples), 3),
                 "file_count": float(row_count),
+                "sidecar_count": float(sidecar_count),
                 "rows_returned": 1.0,
                 "zero_limit_rows_returned": 0.0,
                 "sample_count": float(sample_count),

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -5,7 +5,7 @@ import sys
 import types
 from dataclasses import FrozenInstanceError
 from pathlib import Path
-from typing import Iterator
+from typing import Any, Iterator
 
 import pytest
 
@@ -342,6 +342,35 @@ def test_dataset_catalog_first_preview_scan_skips_readme_without_rescan(tmp_path
     assert first_entry is not None
     assert first_entry[1] == data_dir
     assert catalog._first_supported_dataset_file(snapshot_dir) == train_path
+
+
+def test_dataset_catalog_first_preview_scan_defers_path_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_dir.mkdir()
+    for index in range(25, 0, -1):
+        (snapshot_dir / f"sidecar-{index:02d}.txt").write_text("ignored\n", encoding="utf-8")
+    winner = snapshot_dir / "data.json"
+    winner.write_text('{"rows":[{"prompt":"first"}]}', encoding="utf-8")
+
+    real_path = catalog.Path
+    constructor_calls = 0
+
+    def counting_path(*args: Any, **kwargs: Any) -> Path:
+        nonlocal constructor_calls
+        constructor_calls += 1
+        return real_path(*args, **kwargs)
+
+    monkeypatch.setattr(catalog, "Path", counting_path)
+
+    first_entry = catalog._next_supported_scan_entry(snapshot_dir, after="")
+
+    assert first_entry is not None
+    assert first_entry[0] == "data.json"
+    assert first_entry[1] == winner
+    assert constructor_calls == 1
 
 
 def test_dataset_catalog_json_row_reader_limit_uses_incremental_decode(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2868,6 +2868,7 @@ def test_dataset_registry_preview_limit_probe_script_emits_metrics(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.setenv("MELIX_DATASET_PREVIEW_PROBE_FILES", "4")
+    monkeypatch.setenv("MELIX_DATASET_PREVIEW_PROBE_SIDECARS", "3")
     monkeypatch.setenv("MELIX_DATASET_PREVIEW_PROBE_SAMPLES", "1")
 
     with pytest.raises(SystemExit) as exc_info:
@@ -2876,6 +2877,7 @@ def test_dataset_registry_preview_limit_probe_script_emits_metrics(
     assert exc_info.value.code == 0
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["file_count"] == 4.0
+    assert metrics["sidecar_count"] == 3.0
     assert metrics["rows_returned"] == 1.0
     assert metrics["zero_limit_rows_returned"] == 0.0
     assert metrics["elapsed_ms_mean"] >= 0

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -488,7 +488,7 @@ def _first_supported_dataset_file(directory: Path) -> Path | None:
 
 def _next_supported_scan_entry(directory: Path, *, after: str) -> tuple[str, Path, bool, bool] | None:
     best_name = ""
-    best_path: Path | None = None
+    best_path_raw = ""
     best_is_dir = False
     best_is_file = False
     try:
@@ -507,14 +507,14 @@ def _next_supported_scan_entry(directory: Path, *, after: str) -> tuple[str, Pat
                 if is_file and name in _README_NAMES:
                     continue
                 best_name = name
-                best_path = Path(entry.path)
+                best_path_raw = entry.path
                 best_is_dir = is_dir
                 best_is_file = is_file
     except OSError:
         return None
-    if best_path is None:
+    if not best_path_raw:
         return None
-    return best_name, best_path, best_is_dir, best_is_file
+    return best_name, Path(best_path_raw), best_is_dir, best_is_file
 
 
 def _selected_dataset_files(snapshot_path: Path, *, split: str) -> tuple[Path, ...]:


### PR DESCRIPTION
## Summary
- Defer `Path` construction in the dataset registry first-preview directory scan until the winning scan entry is known.
- Add a regression test that counts path-constructor calls for superseded preview-scan candidates.
- Extend the registered preview-limit probe fixture with ignored sidecar files so this allocation path is measured.

## Plan or Spec
- Updated `docs/plans/2026-06-03-dataset-preview-deferred-path-construction.md`.
- Registered probe: `dataset-registry-preview-limit-short-circuit`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_first_preview_scan_defers_path_construction services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_preview_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_preview_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_preview_limit_probe.py`
- Baseline probe with updated probe fixture on `origin/main`: `MELIX_DATASET_PREVIEW_PROBE_REPO_ROOT="$PWD" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/dataset_registry_preview_limit_probe_20260603.py`
- Head probe: `MELIX_DATASET_PREVIEW_PROBE_REPO_ROOT="$PWD" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 2 passed.
- Registered focused tests: 54 passed.
- Changed-scope coverage: 100% (`TOTAL 36 0 100%`).
- Local registered probe comparison with `sidecar_count=1000`, `file_count=50000`, `sample_count=7`:
  - baseline `elapsed_ms_mean=2.469512`, `elapsed_ms_min=2.330437`
  - head `elapsed_ms_mean=2.197507`, `elapsed_ms_min=2.114199`
  - delta `-0.272005 ms` mean, about `11.0%` faster
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed.
- The probe fixture changed to include ignored sidecar files, so the local comparison used the updated probe script against both `origin/main` and this branch.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally with before/after metrics.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
