### PR TITLE
perf: bind code-eval splitline boundaries

### DIFF
--- a/docs/plans/2026-06-03-code-eval-nonblank-splitline-binding.md
+++ b/docs/plans/2026-06-03-code-eval-nonblank-splitline-binding.md
@@ -1,0 +1,26 @@
+# Code-eval nonblank splitline binding
+
+## Scope
+
+This Python-only performance slice touches `services/mlx-worker-python/worker/engine/code_eval_runner.py` for the large-test fallback in `_count_nonblank_test_lines()`.
+
+## Hypothesis
+
+The registered `code-eval-test-count-nonblank-streaming` probe exercises a large generated test body that uses the streaming nonblank-line counter rather than the small-input `splitlines()` path. The hot loop currently resolves the module-level splitline boundary string on every character and combines the `line_has_content` guard with the whitespace test in one expression. Binding the boundary string once and nesting the whitespace check under the false `line_has_content` branch should reduce repeated global lookup and avoid calling `isspace()` after a line has already been counted, while preserving full Python splitline compatibility.
+
+## Registered probe coverage
+
+`infra/perf/pr_scoped_probes.json` already registers `code-eval-test-count-nonblank-streaming` for `code_eval_runner.py` with focused `test_command`, `coverage_command`, and `probe_command` entries. No registry change is needed for this slice.
+
+## Verification plan
+
+- Run the registered focused test command for `code-eval-test-count-nonblank-streaming`.
+- Run the registered changed-scope coverage command for the same probe.
+- Run `scripts/code_eval_test_count_probe.py` locally on Linux and compare base vs head with `scripts/pr_scoped_performance_run.py`.
+- Run `git diff --check` before committing.
+
+## Success criteria
+
+- Existing nonblank counting semantics remain identical for normal and uncommon splitline boundaries.
+- Changed-scope coverage is at least 95% for the touched files.
+- Local and CI registered probes show a directionally clear elapsed-time improvement.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -302,12 +302,14 @@ def _count_nonblank_test_lines(test_code: str) -> int:
         return sum(1 for line in test_code.splitlines() if line.strip())
     count = 0
     line_has_content = False
+    splitline_boundaries = _PYTHON_SPLITLINE_BOUNDARIES
     for character in test_code:
-        if character in _PYTHON_SPLITLINE_BOUNDARIES:
+        if character in splitline_boundaries:
             line_has_content = False
-        elif not line_has_content and not character.isspace():
-            count += 1
-            line_has_content = True
+        elif not line_has_content:
+            if not character.isspace():
+                count += 1
+                line_has_content = True
     return count
 
 


### PR DESCRIPTION
## Summary
- Bind the code-eval streaming nonblank counter's splitline boundary table once before the hot character loop.
- Nest the `isspace()` check behind the `line_has_content` guard so counted lines skip whitespace checks until the next splitline boundary.

## Plan or Spec
- Added `docs/plans/2026-06-03-code-eval-nonblank-splitline-binding.md`.
- Registered probe: `code-eval-test-count-nonblank-streaming` already covers `services/mlx-worker-python/worker/engine/code_eval_runner.py` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_syntax_error_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_count_nonblank_lines_streams_without_filtered_list services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics` *(correct executed path used `services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list`; 9 passed)*
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...` *(same registered focused selection; 9 passed)*
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_test_count_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-test-count-nonblank-streaming --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/code_eval_nonblank_newline_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 9 passed.
- Changed-scope coverage: 100.00% (`6/6` measurable changed lines covered).
- Local registered probe (`code-eval-test-count-nonblank-streaming`):
  - base `elapsed_ms_mean=67.24054679008466`
  - head `elapsed_ms_mean=60.134818378303734`
  - delta `-7.105728411080924 ms` (~10.57% faster)
  - `peak_bytes_mean` unchanged at `112.0`

## Known Gaps
- This is a Linux-local Python slice. CI must run the registered PR-scoped performance workflow before merge.
- The probe marks elapsed time as informational, but the local base/head run shows a clear improvement.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered local base/head probe completed.
- [ ] GitHub Actions PR-scoped performance run completed.
