### PR TITLE
perf: elide lora quantized kind strip

### DIFF
--- a/docs/plans/2026-06-03-lora-quantized-kind-strip-elision.md
+++ b/docs/plans/2026-06-03-lora-quantized-kind-strip-elision.md
@@ -1,0 +1,35 @@
+# LoRA quantized kind strip elision slice
+
+This Python-only performance slice is limited to the quantized-base kind parser in `services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py`.
+
+## Registered probe coverage
+
+The affected path is covered by the registered PR-scoped performance probe `lora-aux-modules-scandir` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py`
+- `services/mlx-worker-python/tests/test_lora_training_receipts.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/lora_aux_modules_scandir_probe.py`
+
+No registry change is required for this slice.
+
+## Optimization slice
+
+`_quantized_kind_from_text()` lowercases and scans candidate model identity text for quantization markers such as `q4`, `4bit`, and `optiq`. The compiled boundary regex already treats leading and trailing whitespace as non-alphanumeric delimiters, so this slice removes the redundant full-string `strip()` before `lower()`.
+
+The behavior remains unchanged for whitespace-padded values and embedded suffix false positives; the focused regression test now asserts a whitespace-padded `q8` marker still resolves correctly.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage command, and the registered local probe on Linux before opening the PR. The PR-scoped performance workflow remains the merge gate for the registered probe result in CI.
+
+## Expected metrics
+
+The registered probe reports quantized-kind parser metrics:
+
+- `quantized_kind_baseline_elapsed_ms_mean`
+- `quantized_kind_optimized_elapsed_ms_mean`
+- `quantized_kind_delta_ms`
+- `quantized_kind_iteration_count`
+
+The slice is accepted only if local probe and CI evidence show no regression and preferably a lower optimized quantized-kind elapsed mean.

--- a/services/mlx-worker-python/tests/test_lora_training_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_receipts.py
@@ -618,6 +618,7 @@ def test_lora_quantized_kind_detection_uses_precompiled_patterns(
     monkeypatch.setattr(lora_runtime_metadata_module.re, "search", fail_re_search)
 
     assert lora_runtime_metadata_module._quantized_kind_from_text("mlx q4 adapter") == "q4"
+    assert lora_runtime_metadata_module._quantized_kind_from_text(" \tq8\n") == "q8"
     assert lora_runtime_metadata_module._quantized_kind_from_text("not-a-q4suffix") == "unknown"
 
 

--- a/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
@@ -410,7 +410,10 @@ def _str_value(raw_value: Any) -> str:
 
 
 def _quantized_kind_from_text(raw_value: str) -> str:
-    normalized = raw_value.strip().lower()
+    # The boundary regex already treats leading/trailing whitespace as a
+    # non-alphanumeric delimiter, so avoid an extra full-string strip in this
+    # hot parser loop.
+    normalized = raw_value.lower()
     for kind, pattern in _QUANTIZED_KIND_PATTERNS:
         if kind in normalized and pattern.search(normalized):
             return kind


### PR DESCRIPTION
## Summary
- Elide the redundant `strip()` in the LoRA quantized-kind parser before lowercasing/scanning model identity text.
- Add a regression assertion that whitespace-padded quantized markers still match through the existing boundary regex.
- Document the slice and registered probe coverage in `docs/plans/2026-06-03-lora-quantized-kind-strip-elision.md`.

## Plan or Spec
- `docs/plans/2026-06-03-lora-quantized-kind-strip-elision.md`
- Registered PR-scoped probe: `lora-aux-modules-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git status --short && git branch --show-current && git fetch origin && git reset --hard origin/main && git status --short && git rev-parse --short HEAD`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_uses_os_path_isfile_with_precedence services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_fallback_precedence services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_returns_missing_without_resume_assets services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_uses_precompiled_patterns services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_skips_regex_without_substring services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_processor_resume_probe_baseline_modes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` (14 passed)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_aux_modules_scandir_probe.py` (100% changed-line coverage)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LORA_RUNTIME_METADATA_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/lora_aux_modules_scandir_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id lora-aux-modules-scandir --base-repo /tmp/melix-lora-strip-base --head-repo "$PWD" --output /tmp/lora-quantized-kind-strip-elision-probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: 14 passed.
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Registered local probe (`lora-aux-modules-scandir`):
  - base `quantized_kind_optimized_elapsed_ms_mean=8.182591359530177`
  - head `quantized_kind_optimized_elapsed_ms_mean=6.479564388947828`
  - delta vs base optimized mean: `-1.703026970582349 ms` (~20.8% lower)
  - head `quantized_kind_delta_ms=-53.48174606582948`
  - head `quantized_kind_iteration_count=12000.0`
- CI PR-scoped performance workflow is required as the final registered-probe validation source before merge.

## Known Gaps
- Linux local validation covers the Python parser and registered probe only; no Swift runtime path is changed.
- Probe timing has normal host noise, so merge is gated on the GitHub Actions PR-scoped performance report as well.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before the slice.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe ran with base/head comparison.
- [ ] GitHub Actions, including PR-scoped performance, completed successfully.
