### PR TITLE
perf: simplify OpenAI tool payload copies

### DIFF
--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -329,34 +329,37 @@ class ToolRegistry:
     def as_openai_tools(self) -> list[dict[str, Any]]:
         copy_dict = _COPY_DICT
         copy_list = _COPY_LIST
-        return [
-            {
-                "type": "function",
-                "function": {
-                    "name": name,
-                    "description": description,
-                    "parameters": {
-                        "type": "object",
-                        "additionalProperties": False,
-                        "properties": {
-                            argument_name: copy_dict(schema)
-                            for argument_name, schema in schema_properties
+        tools: list[dict[str, Any]] = []
+        append_tool = tools.append
+        for (
+            name,
+            description,
+            tool_kind,
+            observation_kind,
+            schema_properties,
+            required_arguments,
+        ) in self._openai_tool_templates:
+            properties: dict[str, Any] = {}
+            for argument_name, schema in schema_properties:
+                properties[argument_name] = copy_dict(schema)
+            append_tool(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "description": description,
+                        "parameters": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": properties,
+                            "required": copy_list(required_arguments),
                         },
-                        "required": copy_list(required_arguments),
                     },
-                },
-                "x-melix-tool-kind": tool_kind,
-                "x-melix-observation-kind": observation_kind,
-            }
-            for (
-                name,
-                description,
-                tool_kind,
-                observation_kind,
-                schema_properties,
-                required_arguments,
-            ) in self._openai_tool_templates
-        ]
+                    "x-melix-tool-kind": tool_kind,
+                    "x-melix-observation-kind": observation_kind,
+                }
+            )
+        return tools
 
     def as_worker_tool_config(self) -> common_pb2.ToolConfig:
         if self._worker_tool_config_bytes:


### PR DESCRIPTION
## Summary
- Replaces the inner `as_openai_tools()` schema-property dictionary comprehension with a direct copy loop over cached OpenAI tool templates.
- Preserves per-call payload isolation for returned property dictionaries and `required` lists while avoiding the comprehension frame on the repeated materialization hot path.

## Plan or Spec
- `docs/plans/2026-05-24-tool-registry-openai-template-loop.md`
- Registered PR-scoped probe: `tool-registry-openai-tools-template-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
$ git fetch origin && git reset --hard origin/main
HEAD is now at 480a655b perf: elide lora quantized kind strip (#1778)

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
57 passed in 1.03s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_openai_tools_probe.py
57 passed in 0.38s
TOTAL 8 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
{"checksum": 1500000.0, "descriptor_as_openai_tool_calls_mean": 0.0, "elapsed_ms_mean": 452.8598510660231, "isolated_payload_calls_mean": 50000.0, "iterations": 50000.0, "sample_count": 5.0}

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-openai-tools-template-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/tool_registry_openai_loop_probe.json
base elapsed_ms_mean=456.48164581507444; head elapsed_ms_mean=455.9235915541649; coverage=100.0%; test_ok=true; coverage_ok=true

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`8/8` measurable changed lines covered) for `services/mlx-worker-python/worker/runtime/tool_registry.py`.
- Registered local probe (`tool-registry-openai-tools-template-cache`):
  - `elapsed_ms_mean`: base `456.48164581507444` ms, head `455.9235915541649` ms, delta `-0.5580542609095573` ms (`~0.12%` faster).
  - `descriptor_as_openai_tool_calls_mean`: base `0.0`, head `0.0`.
  - `isolated_payload_calls_mean`: base `50000.0`, head `50000.0`.
- CI PR-scoped performance is required before merge and should rerun the same registered probe from the workflow.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime behavior is touched.
- Performance delta is intentionally small and must be confirmed by the registered CI probe before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
