### PR TITLE
perf: fast path disjoint coverage bounds

### DIFF
--- a/docs/plans/2026-06-03-changed-scope-coverage-bounds.md
+++ b/docs/plans/2026-06-03-changed-scope-coverage-bounds.md
@@ -1,0 +1,43 @@
+# Changed Scope Coverage Bounds Fast Path
+
+## Scope
+
+This Python-only performance slice narrows the measured-line filtering path in
+`scripts/changed_scope_coverage.py`. When a file has changed lines entirely
+outside the coverage-reported executed/missing line ranges, the tool can return
+an empty changed-line coverage result without materializing per-line lookup sets.
+
+Affected paths:
+
+- `scripts/changed_scope_coverage.py`
+- `tests/test_changed_scope_coverage.py`
+- `docs/plans/2026-06-03-changed-scope-coverage-bounds.md`
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`changed-scope-coverage-measured-set-filter` in
+`infra/perf/pr_scoped_probes.json`. The registry entry already provides focused
+`test_command`, `coverage_command`, and `probe_command` entries for this path.
+
+## Implementation Plan
+
+1. Add an explicit bounds helper that checks whether any coverage measured-line
+   group can overlap the changed-line range.
+2. Use the bounds helper before building executed/missing membership sets in
+   `_measurable_changed_lines()`.
+3. Add focused unit coverage for disjoint and overlapping bounds behavior.
+4. Run the registered focused tests, changed-scope coverage command, and the
+   registered local probe on Linux.
+
+## Success Metrics
+
+- Focused tests pass.
+- Changed-scope coverage for touched Python lines remains at least 95%.
+- The registered probe reports lower `elapsed_ms_mean` for the no-overlap large
+  measured-line workload while preserving zero source reads.
+
+## Verification Boundary
+
+This is a Python tooling slice and is locally verifiable on Linux. It does not
+change Swift runtime behavior.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -131,6 +131,24 @@ def _filter_coverage_paths(paths: list[str], allowlist: frozenset[str] | None) -
     return [path for path in paths if path in allowlist]
 
 
+def _line_ranges_may_overlap(changed: set[int], *measured_line_groups: list[int]) -> bool:
+    if not changed:
+        return False
+    min_changed = min(changed)
+    max_changed = max(changed)
+    for line_group in measured_line_groups:
+        if not line_group:
+            continue
+        first_line = line_group[0]
+        last_line = line_group[-1]
+        if first_line > last_line:
+            first_line = min(line_group)
+            last_line = max(line_group)
+        if first_line <= max_changed and last_line >= min_changed:
+            return True
+    return False
+
+
 def _measurable_changed_lines(
     repo_root: Path,
     coverage_payload: dict[str, object],
@@ -143,6 +161,8 @@ def _measurable_changed_lines(
     entry = coverage_payload["files"][rel_path]
     executed_lines = entry["executed_lines"]
     missing_lines = entry["missing_lines"]
+    if not _line_ranges_may_overlap(changed, executed_lines, missing_lines):
+        return [], [], []
     if len(executed_lines) == 1 and len(missing_lines) == 1:
         executed_line = executed_lines[0]
         missing_line = missing_lines[0]

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -367,6 +367,14 @@ def test_measurable_changed_lines_filters_blank_comment_and_unmeasured_lines(tmp
     assert missed == [5]
 
 
+def test_line_ranges_may_overlap_rejects_disjoint_changed_bounds() -> None:
+    assert changed_scope_coverage._line_ranges_may_overlap(set(), [1], [2]) is False
+    assert changed_scope_coverage._line_ranges_may_overlap({3, 4}, [1], [2]) is False
+    assert changed_scope_coverage._line_ranges_may_overlap({1, 4}, [2], [3]) is True
+    assert changed_scope_coverage._line_ranges_may_overlap({5}, [], [4, 6]) is True
+    assert changed_scope_coverage._line_ranges_may_overlap({5}, [9, 1], []) is True
+
+
 def test_measurable_changed_lines_skips_source_read_when_no_changed_lines(monkeypatch, tmp_path: Path) -> None:
     coverage_payload = {
         "files": {


### PR DESCRIPTION
## Summary
- Add a disjoint line-range fast path to changed-scope coverage measurement.
- Avoid building executed/missing lookup sets when changed lines are completely outside coverage measured-line bounds.
- Cover empty, disjoint, overlapping, and unsorted fallback bounds behavior.

## Plan or Spec
- `docs/plans/2026-06-03-changed-scope-coverage-bounds.md`

## Commands Run
```text
# Baseline on origin/main
python3 scripts/changed_scope_coverage_measured_probe.py
# exit 0; {"elapsed_ms_mean": 1.6745313602898801, "measured_lines_per_path": 500.0, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 34 passed in 0.21s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 24 0 100%

python3 scripts/changed_scope_coverage_measured_probe.py
# exit 0; {"elapsed_ms_mean": 0.23016453321490968, "measured_lines_per_path": 500.0, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}
python3 scripts/changed_scope_coverage_measured_probe.py
# exit 0; {"elapsed_ms_mean": 0.23519573733210564, "measured_lines_per_path": 500.0, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}
python3 scripts/changed_scope_coverage_measured_probe.py
# exit 0; {"elapsed_ms_mean": 0.2273110273693289, "measured_lines_per_path": 500.0, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 24 0 100%`.
- Registered probe: `changed-scope-coverage-measured-set-filter`.
- Local probe baseline: `elapsed_ms_mean=1.6745 ms`, `source_read_calls_mean=0.0`.
- Local probe optimized samples: `elapsed_ms_mean=0.2302 / 0.2352 / 0.2273 ms`, `source_read_calls_mean=0.0`.
- Best stable mean used for delta: `old_mean=1.6745 ms`, `new_mean=0.2302 ms`, `delta_ms=-1.4444 ms`, `speedup=7.27x`.
- CI registered PR-scoped performance report is required before merge.

## Known Gaps
- None. This is a Linux-verifiable Python tooling slice; no Swift runtime behavior is changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
