### PR TITLE
Fix Swift route contract review findings

### DIFF
--- a/services/control-plane-swift/Sources/Requests/JSONLReceiptWriter.swift
+++ b/services/control-plane-swift/Sources/Requests/JSONLReceiptWriter.swift
@@ -1,5 +1,7 @@
+import Darwin
 import Foundation
 
+// NOTE: Keep this in sync with services/mlx-text-worker-swift/Sources/Core/JSONLReceiptWriter.swift.
 final class JSONLReceiptWriter: @unchecked Sendable {
     private let url: URL
     private let queue: DispatchQueue
@@ -22,15 +24,35 @@ private func appendLine(_ data: Data, to url: URL) {
             at: url.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        if !FileManager.default.fileExists(atPath: url.path) {
-            FileManager.default.createFile(atPath: url.path, contents: nil)
-        }
-        let handle = try FileHandle(forWritingTo: url)
-        defer { try? handle.close() }
-        try handle.seekToEnd()
-        try handle.write(contentsOf: data)
-        try handle.write(contentsOf: Data("\n".utf8))
     } catch {
         return
+    }
+    let fd = open(url.path, O_WRONLY | O_CREAT | O_APPEND, 0o644)
+    guard fd >= 0 else {
+        return
+    }
+    defer {
+        close(fd)
+    }
+    var line = data
+    line.append(0x0A)
+    line.withUnsafeBytes { buffer in
+        guard let baseAddress = buffer.baseAddress else {
+            return
+        }
+        var offset = 0
+        while true {
+            let written = Darwin.write(fd, baseAddress.advanced(by: offset), buffer.count - offset)
+            if written > 0 {
+                offset += written
+            }
+            if offset == buffer.count {
+                return
+            }
+            if written < 0, errno == EINTR {
+                continue
+            }
+            return
+        }
     }
 }

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -650,6 +650,25 @@ struct RequestCoordinatorTests {
         #expect(metrics.values["scheduler.route_selection_receipt_emitted", default: 0] == 1)
     }
 
+    @Test("JSONL receipt writer preserves first writes from independent writers")
+    func jsonlReceiptWriterPreservesFirstWritesFromIndependentWriters() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-route-receipt-concurrent-\(UUID().uuidString)", isDirectory: true)
+        let receiptPath = directory.appendingPathComponent("route-selection.jsonl").path
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        let count = 48
+        let writers = (0..<count).map { _ in JSONLReceiptWriter(path: receiptPath) }
+        for index in 0..<count {
+            writers[index].append(Data(#"{"request_id":"req-\#(index)"}"#.utf8))
+        }
+
+        let payloads = try #require(await waitForJSONLLines(atPath: receiptPath, expectedCount: count))
+        #expect(Set(payloads.compactMap { $0["request_id"] as? String }) == Set((0..<count).map { "req-\($0)" }))
+    }
+
     @Test("python text compatibility sessions use generate instead of phase-aware prefill")
     func pythonTextCompatibilitySessionsUseGenerateInsteadOfPhaseAwarePrefill() async throws {
         let workerClient = PhaseAwareWorkerClient()
@@ -4349,6 +4368,40 @@ private func waitForFileContents(
         try? await Task.sleep(nanoseconds: 10_000_000)
     }
     return try? String(contentsOfFile: path, encoding: .utf8)
+}
+
+private func waitForJSONLLines(
+    atPath path: String,
+    expectedCount: Int,
+    attempts: Int = 100
+) async -> [[String: Any]]? {
+    let effectiveAttempts = attempts * waitAttemptsMultiplier
+    for _ in 0..<effectiveAttempts {
+        if let contents = try? String(contentsOfFile: path, encoding: .utf8) {
+            let lines = contents.split(separator: "\n")
+            if lines.count == expectedCount,
+               let payloads = parseJSONLLines(lines),
+               payloads.count == expectedCount {
+                return payloads
+            }
+        }
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+        return nil
+    }
+    return parseJSONLLines(contents.split(separator: "\n"))
+}
+
+private func parseJSONLLines(_ lines: [Substring]) -> [[String: Any]]? {
+    var payloads: [[String: Any]] = []
+    for line in lines {
+        guard let payload = try? JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any] else {
+            return nil
+        }
+        payloads.append(payload)
+    }
+    return payloads
 }
 
 private actor BlockingWorkerClient: WorkerRoutingClient {

--- a/services/mlx-text-worker-swift/Sources/Core/JSONLReceiptWriter.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/JSONLReceiptWriter.swift
@@ -1,5 +1,7 @@
+import Darwin
 import Foundation
 
+// NOTE: Keep this in sync with services/control-plane-swift/Sources/Requests/JSONLReceiptWriter.swift.
 final class JSONLReceiptWriter: @unchecked Sendable {
     private let url: URL
     private let queue: DispatchQueue
@@ -22,15 +24,35 @@ private func appendLine(_ data: Data, to url: URL) {
             at: url.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        if !FileManager.default.fileExists(atPath: url.path) {
-            FileManager.default.createFile(atPath: url.path, contents: nil)
-        }
-        let handle = try FileHandle(forWritingTo: url)
-        defer { try? handle.close() }
-        try handle.seekToEnd()
-        try handle.write(contentsOf: data)
-        try handle.write(contentsOf: Data("\n".utf8))
     } catch {
         return
+    }
+    let fd = open(url.path, O_WRONLY | O_CREAT | O_APPEND, 0o644)
+    guard fd >= 0 else {
+        return
+    }
+    defer {
+        close(fd)
+    }
+    var line = data
+    line.append(0x0A)
+    line.withUnsafeBytes { buffer in
+        guard let baseAddress = buffer.baseAddress else {
+            return
+        }
+        var offset = 0
+        while true {
+            let written = Darwin.write(fd, baseAddress.advanced(by: offset), buffer.count - offset)
+            if written > 0 {
+                offset += written
+            }
+            if offset == buffer.count {
+                return
+            }
+            if written < 0, errno == EINTR {
+                continue
+            }
+            return
+        }
     }
 }

--- a/services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicVisionBackend.swift
+++ b/services/mlx-text-worker-swift/Sources/Core/Runtime/DeterministicVisionBackend.swift
@@ -394,7 +394,7 @@ private struct DeterministicVisionVideo: Sendable {
             resolvedURL = URL(fileURLWithPath: trimmed)
             defaultFilename = resolvedURL.lastPathComponent
         }
-        let bytes = (try? Data(contentsOf: resolvedURL)) ?? Data()
+        let bytes = (try? Data(contentsOf: resolvedURL, options: .mappedIfSafe)) ?? Data()
         try self.init(
             bytes: bytes,
             reference: trimmed,

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -1537,9 +1537,9 @@ final class WorkerScaffoldTests: XCTestCase {
         sampling.topP = 1
         sampling.maxOutputTokens = 3
 
-        let longPromptTokens = MLXArray(Array(repeating: 2, count: 300), [1, 300])
         let events = try await withTemporaryDefaultMetallib {
             try await Device.withDefaultDevice(.cpu) {
+                let longPromptTokens = MLXArray(Array(repeating: 2, count: 300), [1, 300])
                 let model = LoadedTextModel(
                     storage: makeBatchCacheIdentityModelContainer(recorder: recorder)
                 )
@@ -2881,6 +2881,28 @@ final class WorkerScaffoldTests: XCTestCase {
         XCTAssertEqual(payload["request_id"] as? String, "req-vision-payload-receipt")
         XCTAssertEqual(payload["worker_family"] as? String, "vision")
         XCTAssertEqual(mediaParts.map { $0["kind"] as? String }, ["image", "video"])
+    }
+
+    func testJSONLReceiptWriterPreservesFirstWritesFromIndependentWriters() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-vision-payload-receipt-concurrent-\(UUID().uuidString)", isDirectory: true)
+        let receiptPath = directory.appendingPathComponent("vision-payload.jsonl").path
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        let count = 48
+        let writers = (0..<count).map { _ in JSONLReceiptWriter(path: receiptPath) }
+        for index in 0..<count {
+            writers[index].append(Data(#"{"request_id":"req-\#(index)"}"#.utf8))
+        }
+
+        let maybePayloads = await waitForJSONLLines(atPath: receiptPath, expectedCount: count)
+        let payloads = try XCTUnwrap(maybePayloads)
+        XCTAssertEqual(
+            Set(payloads.compactMap { $0["request_id"] as? String }),
+            Set((0..<count).map { "req-\($0)" })
+        )
     }
 
     func testRuntimeRegistryTracksBusyStateAndGenerateEventsForLoadedModel() async throws {
@@ -11450,6 +11472,41 @@ private func waitForFileContents(
         try? await Task.sleep(nanoseconds: 10_000_000)
     }
     return try? String(contentsOfFile: path, encoding: .utf8)
+}
+
+@available(macOS 15.0, *)
+private func waitForJSONLLines(
+    atPath path: String,
+    expectedCount: Int,
+    attempts: Int = 100
+) async -> [[String: Any]]? {
+    for _ in 0..<attempts {
+        if let contents = try? String(contentsOfFile: path, encoding: .utf8) {
+            let lines = contents.split(separator: "\n")
+            if lines.count == expectedCount,
+               let payloads = parseJSONLLines(lines),
+               payloads.count == expectedCount {
+                return payloads
+            }
+        }
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+        return nil
+    }
+    return parseJSONLLines(contents.split(separator: "\n"))
+}
+
+@available(macOS 15.0, *)
+private func parseJSONLLines(_ lines: [Substring]) -> [[String: Any]]? {
+    var payloads: [[String: Any]] = []
+    for line in lines {
+        guard let payload = try? JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any] else {
+            return nil
+        }
+        payloads.append(payload)
+    }
+    return payloads
 }
 
 @available(macOS 15.0, *)


### PR DESCRIPTION
## Summary
- Fixes the JSONL receipt writer race called out in #1739 by using POSIX `open(..., O_APPEND)` and a single record write loop for both Swift writer copies.
- Adds same-path, independent-writer regression tests in the control-plane and Swift text-worker packages.
- Uses `.mappedIfSafe` for local video URI reads in the deterministic Swift vision backend.
- Applies the #1782 review follow-up by scaling the control-plane JSONL polling helper with `waitAttemptsMultiplier`.
- Hardens the Swift MLX long-prompt test so CI runners without a local `mlx.metallib` do not instantiate `MLXArray` before the skip guard.

## Plan or Spec
- `docs/plans/2026-06-01-swift-vision-parity-fixtures.md`
- Follow-up to review comments on #1739 after that PR merged before these fixes landed.

## Commands Run
```text
xcrun swift test --package-path services/control-plane-swift --filter 'RequestCoordinatorTests/jsonlReceiptWriterPreservesFirstWritesFromIndependentWriters' => passed
xcrun swift test --package-path services/mlx-text-worker-swift --filter 'WorkerScaffoldTests/testJSONLReceiptWriterPreservesFirstWritesFromIndependentWriters' => passed
xcrun swift test --package-path services/mlx-text-worker-swift --filter 'WorkerScaffoldTests/testDeterministicVisionBackendNormalizesLocalVideoURI' => passed
xcrun swift test --package-path services/mlx-text-worker-swift --filter 'WorkerScaffoldTests/testAutoSwiftMLXBackendKeepsLongPromptBatchDecodeOnSynchronousTokenPath' => passed
make swift-test-text-worker => passed, 241 tests, 0 failures
git diff --check => passed
UV_PYTHON=3.12 git commit --amend --no-edit => pre-commit hook passed
  make swift-test => passed, elapsed 202.0s
  make py-test => 3437 passed, 14 skipped, 2 warnings in 134.74s
  make integration-test => 117 passed, 1 skipped in 424.66s
  scoped performance hook => Status ok, 1 selected probe, 0 regressions
```

## Coverage and Metrics
- Latest head commit: `a8302fcb`
- Latest pre-commit performance report: `.runtime/pre-commit-performance/20260603-091348-74d79c35/report/report.md`
- Status: `ok`
- Changed files in latest hook scope: `1`
- Selected probes: `1` (`same-cohort-batching-probe-evidence`)
- Direct/gated probes: `1`
- Regressions: `0`
- Context regressions: `0`
- Verification failures: `0`
- Probe coverage: `pass` (`100.0%`)
- Earlier scoped reports covered the initial five-file follow-up diff and the #1782 wait-helper review follow-up: `.runtime/pre-commit-performance/20260603-080052-36ae09e7/report/report.md` and `.runtime/pre-commit-performance/20260603-083835-36ae09e7/report/report.md`, both Status `ok`, Regressions `0`.
- Observability mode: `minimal`; this only changes receipt persistence behavior, local video read options, and test guard placement, with no new runtime metrics or debug artifacts.
- Probe overhead: `N/A`; no new observability probe was added.

## Known Gaps
- The two JSONL writer copies remain package-local because the current Swift package graph does not expose a shared utility target. This PR adds reciprocal sync notes and updates both implementations/tests together.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
