### PR TITLE
ci: schedule main app packaging

### DIFF
--- a/.github/workflows/package-self-contained-app.yml
+++ b/.github/workflows/package-self-contained-app.yml
@@ -8,6 +8,8 @@ on:
         required: true
         default: "main"
         type: string
+  schedule:
+    - cron: "0 0 * * *"
   pull_request:
     types:
       - opened
@@ -44,12 +46,104 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: package-self-contained-app-${{ github.ref }}
+  group: package-self-contained-app-${{ github.event_name == 'schedule' && 'schedule-' || '' }}${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  detect-main-update:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      should_package: ${{ steps.detect-main-update.outputs.should_package }}
+
+    steps:
+      - name: Checkout scheduled main source
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Detect scheduled main update
+        id: detect-main-update
+        uses: actions/github-script@v9
+        env:
+          CURRENT_SHA: ${{ github.sha }}
+        with:
+          script: |
+            const fs = require('fs');
+            const currentSha = process.env.CURRENT_SHA || context.sha;
+            const { owner, repo } = context.repo;
+            const workflow_id = 'package-self-contained-app.yml';
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner,
+              repo,
+              workflow_id,
+              branch: 'main',
+              event: 'schedule',
+              status: 'success',
+              per_page: 30,
+            });
+
+            let matchedRun = null;
+            let matchedArtifact = null;
+            for (const run of runs) {
+              if (run.id === context.runId) {
+                continue;
+              }
+              const artifactResponse = await github.rest.actions.listWorkflowRunArtifacts({
+                owner,
+                repo,
+                run_id: run.id,
+                per_page: 100,
+              });
+              const artifact = artifactResponse.data.artifacts.find((entry) => (
+                entry.name.startsWith('Melix-main-') && !entry.expired
+              ));
+              if (artifact) {
+                matchedRun = run;
+                matchedArtifact = artifact;
+                break;
+              }
+            }
+
+            const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+            if (matchedRun && matchedRun.head_sha === currentSha) {
+              core.setOutput('should_package', 'false');
+              const body = [
+                '## No package needed',
+                '',
+                `- Current main SHA: ${currentSha}`,
+                `- Last successful scheduled app package SHA: ${matchedRun.head_sha}`,
+                `- Last app artifact: ${matchedArtifact.name}`,
+                `- Last package workflow run: ${matchedRun.html_url}`,
+                '',
+              ].join('\n');
+              if (summaryPath) {
+                fs.appendFileSync(summaryPath, body, 'utf8');
+              }
+              return;
+            }
+
+            core.setOutput('should_package', 'true');
+            const body = [
+              '## Package scheduled Melix.app',
+              '',
+              `- Current main SHA: ${currentSha}`,
+              `- Last successful scheduled app package SHA: ${matchedRun ? matchedRun.head_sha : 'none'}`,
+              matchedArtifact ? `- Last app artifact: ${matchedArtifact.name}` : '- Last app artifact: none',
+              '- Decision: package current main because it has not been covered by a successful scheduled app artifact.',
+              '',
+            ].join('\n');
+            if (summaryPath) {
+              fs.appendFileSync(summaryPath, body, 'utf8');
+            }
+
   package-app:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'package-app')
+    needs:
+      - detect-main-update
+    if: |
+      always() &&
+      (github.event_name != 'schedule' || needs.detect-main-update.outputs.should_package == 'true') &&
+      (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'package-app'))
     runs-on: macos-15
     outputs:
       artifact_name: ${{ steps.compute-build-metadata.outputs.artifact_name }}
@@ -61,8 +155,14 @@ jobs:
         with:
           ref: ${{ inputs.source_ref }}
 
+      - name: Checkout scheduled main source
+        if: github.event_name == 'schedule'
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
       - name: Checkout event source
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
         uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
@@ -179,6 +279,7 @@ jobs:
           name: ${{ steps.compute-build-metadata.outputs.artifact_name }}
           path: ${{ runner.temp }}/${{ steps.compute-build-metadata.outputs.artifact_name }}.zip
           if-no-files-found: error
+          retention-days: 14
 
       - name: Publish app artifact download summary
         if: github.event_name != 'pull_request' && success()

--- a/docs/plans/2026-06-03-daily-main-app-packaging-ci.md
+++ b/docs/plans/2026-06-03-daily-main-app-packaging-ci.md
@@ -1,0 +1,52 @@
+# Daily Main App Packaging CI Plan
+
+## Goal
+
+Run the existing self-contained Melix app packaging workflow every day at 00:00 UTC on `main`, and package the app only when `main` has changed since the last successful scheduled app artifact.
+
+## Architecture
+
+Extend `.github/workflows/package-self-contained-app.yml` rather than creating a second packaging workflow. A scheduled-only preflight job queries previous successful scheduled runs of the same workflow, verifies that a matching Melix app artifact exists, and compares that run's `head_sha` with the current scheduled `main` SHA. The existing packaging job runs unchanged for manual, push, tag, and labeled PR events, while scheduled runs enter the packaging path only when the preflight reports a new `main` commit.
+
+Scheduled runs use an event-scoped concurrency key so a daily archive cannot cancel an in-progress `main` push package for the same ref.
+
+## Scope
+
+- Add a daily `schedule` trigger with `cron: "0 0 * * *"`.
+- Add scheduled preflight summary output for both package and no-package decisions.
+- Keep current manual, push, tag, and PR label behavior intact.
+- Isolate scheduled concurrency from push and manual package runs on the same ref.
+- Upload nightly-style app artifacts with `retention-days: 14`.
+- Add focused workflow regression tests.
+
+## Files
+
+- Modify `.github/workflows/package-self-contained-app.yml`.
+- Modify `services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py`.
+
+## Verification
+
+- Focused pytest:
+  `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py -q`
+- Workflow lint when available:
+  `actionlint .github/workflows/package-self-contained-app.yml`
+- Whitespace check:
+  `git diff --check`
+
+## Coverage and Metrics
+
+Changed scope is GitHub Actions YAML plus Python workflow text tests. Runtime performance probes are `N/A` because the change does not alter Melix runtime, worker, Swift app, or packaging implementation code paths; it only changes when an existing CI packaging path runs and how long artifacts are retained.
+
+- Coverage: `N/A` for production code because no production Python, Swift, or generated protocol code changes.
+- Metrics: `N/A` because there is no runtime execution path or performance-sensitive code path change.
+- Observability mode: minimal CI summary output for scheduled package or skip decisions.
+- Probe overhead: `N/A`; no runtime probes are added.
+
+## Implementation Steps
+
+1. Add failing workflow tests for the daily trigger, scheduled preflight, scheduled skip summary, package job gate, and artifact retention.
+2. Run the focused pytest and confirm those tests fail against the current workflow.
+3. Update the workflow with the schedule trigger, preflight job, package job condition, needs wiring, summary text, and retention.
+4. Run the focused pytest until it passes.
+5. Run `actionlint` if installed and `git diff --check`.
+6. Review the final diff against the user-approved design.

--- a/docs/runbooks/platform-packaging-targets.md
+++ b/docs/runbooks/platform-packaging-targets.md
@@ -92,6 +92,18 @@ needs a fresh downloadable `Melix.app` archive from the repository `main` branch
 The manual archive uses the same self-contained app-bundle packaging path as push and tag runs.
 GitHub authentication may be required to download workflow artifacts.
 
+## Daily App Archive From `main`
+
+The same `package-self-contained-app` workflow also runs every day at 00:00 UTC on the repository
+`main` branch. Before building, the workflow compares the current `main` commit with the last
+successful scheduled app artifact. If that prior artifact already covers the current commit, the run
+finishes successfully without packaging and records the skipped decision in the workflow summary.
+
+When `main` has changed since the last successful scheduled app artifact, the workflow packages the
+self-contained `Melix.app` archive and uploads it as a workflow artifact. These scheduled artifacts
+are retained for 14 days. Release assets attached to version tags use the GitHub Release path and are
+not governed by the scheduled artifact retention period.
+
 ## Deterministic Validation
 
 Run the repository-owned smoke command to verify the shared packaging target matrix across all

--- a/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
+++ b/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
@@ -36,6 +36,16 @@ def find_workflow_step(workflow: str, name: str) -> str:
     return match.group(0)
 
 
+def find_workflow_job(workflow: str, job_name: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(job_name)}:[ \t]*\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:[ \t]*$|\Z)",
+        workflow,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"Workflow job not found: {job_name}"
+    return match.group(0)
+
+
 def find_run_workflow_step(workflow: str, name: str, command: str) -> re.Match[str]:
     match = re.search(
         rf"^[ \t]*-[ \t]+name:[ \t]+{re.escape(name)}[ \t]*\n"
@@ -348,6 +358,27 @@ jobs:
     assert "next-step" not in step
 
 
+def test_find_workflow_job_stops_before_any_next_job() -> None:
+    workflow = """
+jobs:
+  detect-main-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide
+        run: echo decide
+  unrelated-job:
+    runs-on: ubuntu-latest
+  package-app:
+    runs-on: macos-26
+"""
+
+    job = find_workflow_job(workflow, "detect-main-update")
+
+    assert "run: echo decide" in job
+    assert "unrelated-job:" not in job
+    assert "package-app:" not in job
+
+
 def test_package_workflow_manual_dispatch_defaults_to_main_checkout() -> None:
     workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
 
@@ -420,7 +451,7 @@ def test_package_workflow_detects_scheduled_main_updates_before_packaging() -> N
 
     assert re.search(r"^[ \t]+detect-main-update:[ \t]*$", workflow, flags=re.MULTILINE)
     assert "should_package: ${{ steps.detect-main-update.outputs.should_package }}" in workflow
-    preflight_job = workflow.split("detect-main-update:", maxsplit=1)[1].split("\n  package-app:", maxsplit=1)[0]
+    preflight_job = find_workflow_job(workflow, "detect-main-update")
     assert "if: github.event_name == 'schedule'" in preflight_job
     assert "actions/checkout@v6" in preflight_job
     assert "ref: main" in preflight_job
@@ -435,7 +466,7 @@ def test_package_workflow_detects_scheduled_main_updates_before_packaging() -> N
 def test_package_workflow_successfully_skips_scheduled_run_without_main_changes() -> None:
     workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
 
-    preflight_job = workflow.split("detect-main-update:", maxsplit=1)[1].split("\n  package-app:", maxsplit=1)[0]
+    preflight_job = find_workflow_job(workflow, "detect-main-update")
     assert "No package needed" in preflight_job
     assert "Current main SHA:" in preflight_job
     assert "Last successful scheduled app package SHA:" in preflight_job
@@ -456,7 +487,7 @@ def test_package_workflow_gates_package_job_only_for_scheduled_skip_and_pr_label
         workflow,
         flags=re.MULTILINE,
     )
-    package_app_job = workflow.split("package-app:", maxsplit=1)[1].split("\n  attach-release-artifact:", maxsplit=1)[0]
+    package_app_job = find_workflow_job(workflow, "package-app")
     assert "github.event_name != 'schedule' || needs.detect-main-update.outputs.should_package == 'true'" in package_app_job
     assert "github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'package-app')" in package_app_job
     assert "startsWith(github.ref, 'refs/tags/v')" in workflow

--- a/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
+++ b/services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py
@@ -12,6 +12,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MODULE_PATH = REPO_ROOT / "scripts" / "package_macos_menubar_app.py"
 PACKAGE_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "package-self-contained-app.yml"
+PACKAGING_RUNBOOK_PATH = REPO_ROOT / "docs" / "runbooks" / "platform-packaging-targets.md"
 
 
 def find_named_workflow_step(workflow: str, name: str) -> re.Match[str]:
@@ -401,6 +402,80 @@ def test_package_workflow_publishes_download_summary_for_uploaded_app_artifact()
     assert "Download:" in summary_step
     assert "Workflow run:" in summary_step
     assert "artifacts/${artifact.id}" in summary_step
+
+
+def test_package_workflow_runs_daily_at_midnight_utc() -> None:
+    workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert re.search(r"^[ \t]*schedule:[ \t]*$", workflow, flags=re.MULTILINE)
+    assert re.search(
+        r"^[ \t]*-[ \t]+cron:[ \t]+\"0 0 \* \* \*\"[ \t]*$",
+        workflow,
+        flags=re.MULTILINE,
+    )
+
+
+def test_package_workflow_detects_scheduled_main_updates_before_packaging() -> None:
+    workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert re.search(r"^[ \t]+detect-main-update:[ \t]*$", workflow, flags=re.MULTILINE)
+    assert "should_package: ${{ steps.detect-main-update.outputs.should_package }}" in workflow
+    preflight_job = workflow.split("detect-main-update:", maxsplit=1)[1].split("\n  package-app:", maxsplit=1)[0]
+    assert "if: github.event_name == 'schedule'" in preflight_job
+    assert "actions/checkout@v6" in preflight_job
+    assert "ref: main" in preflight_job
+    assert "github.rest.actions.listWorkflowRuns" in preflight_job
+    assert "event: 'schedule'" in preflight_job
+    assert "status: 'success'" in preflight_job
+    assert "github.rest.actions.listWorkflowRunArtifacts" in preflight_job
+    assert ".name.startsWith('Melix-main-')" in preflight_job
+    assert "matchedRun.head_sha === currentSha" in preflight_job
+
+
+def test_package_workflow_successfully_skips_scheduled_run_without_main_changes() -> None:
+    workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    preflight_job = workflow.split("detect-main-update:", maxsplit=1)[1].split("\n  package-app:", maxsplit=1)[0]
+    assert "No package needed" in preflight_job
+    assert "Current main SHA:" in preflight_job
+    assert "Last successful scheduled app package SHA:" in preflight_job
+    assert "core.setOutput('should_package', 'false')" in preflight_job
+
+
+def test_package_workflow_isolates_scheduled_concurrency_from_push_runs() -> None:
+    workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "package-self-contained-app-${{ github.event_name == 'schedule' && 'schedule-' || '' }}${{ github.ref }}" in workflow
+
+
+def test_package_workflow_gates_package_job_only_for_scheduled_skip_and_pr_label() -> None:
+    workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert re.search(
+        r"^[ \t]+package-app:[ \t]*\n[ \t]+needs:[ \t]*\n[ \t]+-[ \t]+detect-main-update",
+        workflow,
+        flags=re.MULTILINE,
+    )
+    package_app_job = workflow.split("package-app:", maxsplit=1)[1].split("\n  attach-release-artifact:", maxsplit=1)[0]
+    assert "github.event_name != 'schedule' || needs.detect-main-update.outputs.should_package == 'true'" in package_app_job
+    assert "github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'package-app')" in package_app_job
+    assert "startsWith(github.ref, 'refs/tags/v')" in workflow
+
+
+def test_package_workflow_sets_nightly_artifact_retention() -> None:
+    workflow = PACKAGE_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    upload_step = find_workflow_step(workflow, "Upload app artifact")
+    assert "retention-days: 14" in upload_step
+
+
+def test_packaging_runbook_documents_daily_main_app_archive() -> None:
+    runbook = PACKAGING_RUNBOOK_PATH.read_text(encoding="utf-8")
+
+    assert "Daily App Archive From `main`" in runbook
+    assert "00:00 UTC" in runbook
+    assert "last successful scheduled app artifact" in runbook
+    assert "14 days" in runbook
 
 
 def test_main_resolves_default_build_outputs_and_prints_app_path(


### PR DESCRIPTION
## Summary
- Schedule the existing self-contained app packaging workflow to run from `main` at `00:00 UTC` every day.
- Add a scheduled preflight that finds the last successful scheduled run with a `Melix-main-*` app artifact and skips packaging when its `head_sha` already matches current `main`.
- Document the daily app archive behavior and add workflow/runbook tests for schedule, skip semantics, artifact retention, and concurrency isolation.

## Plan or Spec
- Governing plan: `docs/plans/2026-06-03-daily-main-app-packaging-ci.md`.
- Behavior documentation: `docs/runbooks/platform-packaging-targets.md`.

## Commands Run
```text
make bootstrap
# PASS: configured .githooks and uv sync completed.

make proto
# PASS: proto generation completed; no tracked diff afterwards.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_package_macos_menubar_app_script.py -q
# RED before implementation: 5 failed, 18 passed.
# RED for runbook coverage before docs update: 1 failed, 23 passed.
# RED for schedule concurrency isolation before workflow fix: 1 failed, 24 passed.
# PASS after implementation and after latest origin/main rebase: 25 passed in 0.04s.
# PASS after review parser hardening: 26 passed in 0.07s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_release_distribution.py -q
# PASS after latest origin/main rebase: 18 passed in 0.04s.

ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml parse ok"' .github/workflows/package-self-contained-app.yml
# PASS: yaml parse ok.

git diff --check origin/main...HEAD
# PASS: no whitespace errors.

git merge-base --is-ancestor origin/main HEAD && printf 'origin/main ancestor of HEAD\n'
# PASS: origin/main ancestor of HEAD.

git commit -m "ci: schedule main app packaging"
# PASS: pre-commit hook enforced on 256 GiB macOS host.
# PASS: make swift-test completed rc=0 elapsed=366.2s.
# PASS: make py-test completed rc=0 elapsed=134.5s; 3444 passed, 14 skipped, 2 warnings.
# PASS: make integration-test completed rc=0 elapsed=542.4s; 117 passed, 1 skipped in 542.21s.
# PASS: PR-scoped performance report status ok.

MELIX_PRE_COMMIT_ALLOW_PERF_REGRESSION=1 MELIX_PRE_COMMIT_PERF_REGRESSION_REASON="Test-only workflow parser hardening; package_macos_menubar_app.py is unchanged; repeated focused performance probes show sub-millisecond noise while targeted coverage remains 100 percent." git commit -m "test: harden package workflow job parsing"
# PASS: pre-commit hook enforced on 256 GiB macOS host.
# PASS: make swift-test completed rc=0 elapsed=242.2s.
# PASS: make py-test completed rc=0 elapsed=147.9s; 3445 passed, 14 skipped, 2 warnings.
# PASS: make integration-test completed rc=0 elapsed=460.4s; 117 passed, 1 skipped in 460.10s.
# PASS: PR-scoped performance report status ok; regressions 0; verification failures 0.
```

## Coverage and Metrics
- Changed-line coverage: `100.00%` (`46/46`) from the pre-commit PR-scoped performance report.
- Performance report: `.runtime/pre-commit-performance/20260603-080619-e91cc46c/report/report.md`.
- Selected probe: `package-macos-resolve-fallback-scandir`; status `ok`; regressions `0`; verification failures `0`.
- Review-fix changed-line coverage: `100.00%` (`13/13`) from `.runtime/pre-commit-performance/20260603-085101-5e3c5672/report/report.md`.
- Review-fix selected probe: `package-macos-resolve-fallback-scandir`; status `ok`; regressions `0`; verification failures `0`.
- Runtime production metrics: `N/A` because this change only edits GitHub Actions workflow, docs, and tests; no production Swift, Python, or protocol runtime path changed.
- Observability mode: `minimal`; scheduled workflow writes GitHub Actions step summaries for package-vs-skip decisions.
- Probe overhead: `N/A` because no runtime observability probe was added.

## Known Gaps
- `actionlint` was not run locally because neither `actionlint` nor `go` is installed in this environment; workflow YAML was parsed with Ruby and covered by focused tests.
- Scheduled workflow behavior will execute on `main` only after this PR merges.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
