### PR TITLE
perf: cache raw tool config selections

### DIFF
--- a/docs/plans/2026-06-03-tool-registry-raw-selection-config-cache.md
+++ b/docs/plans/2026-06-03-tool-registry-raw-selection-config-cache.md
@@ -1,0 +1,37 @@
+# Tool Registry Raw Selection Config Cache Slice
+
+## Scope
+
+This Python performance slice is limited to the built-in agentic tool config
+selection path in `services/mlx-worker-python/worker/runtime/tool_registry.py`.
+It preserves tool selection semantics, protobuf schemas, and copy-on-return
+isolation while reducing repeated normalized-selection work for raw selection
+inputs that differ from their canonical registry names only by whitespace.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+That entry has focused `test_command`, `coverage_command`, and `probe_command`
+commands and watches `tool_registry.py`, `test_tool_registry.py`, and
+`scripts/tool_registry_select_probe.py`.
+
+This slice extends the probe script with a raw single-name config selection
+metric so CI and local Linux validation measure the path optimized here.
+
+## Implementation Plan
+
+1. Add a regression test proving repeated raw built-in config selections cache
+   the serialized selection under both the raw and normalized keys without
+   weakening copy isolation.
+2. Store the raw requested-name tuple as an alias when `built_in_tool_config()`
+   normalizes a selection through the registry.
+3. Extend `scripts/tool_registry_select_probe.py` with
+   `raw_single_config_elapsed_ms_mean`.
+4. Run focused tests, changed-scope coverage, and the registered probe locally.
+
+## Success Metrics
+
+- `raw_single_config_elapsed_ms_mean` decreases on the local Linux probe.
+- Existing `tool-registry-select-name-index-cache` metrics remain stable.
+- Changed-scope coverage for touched Python paths remains at least 95%.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4255,6 +4255,12 @@
         "warn_pct": 5.0
       },
       {
+        "key": "raw_single_config_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
         "key": "missing_selection_elapsed_ms_mean",
         "unit": "ms",
         "direction": "lower_is_better",

--- a/scripts/tool_registry_select_probe.py
+++ b/scripts/tool_registry_select_probe.py
@@ -33,6 +33,7 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     full_list_self_samples: list[float] = []
     full_config_template_elapsed_samples: list[float] = []
     full_config_template_samples: list[float] = []
+    raw_single_config_elapsed_samples: list[float] = []
     missing_selection_elapsed_samples: list[float] = []
     missing_selection_error_samples: list[float] = []
     checksum = 0
@@ -63,6 +64,14 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         )
         full_config_template_samples.append(float(full_config_template_count))
 
+        raw_single_config_started = time.perf_counter()
+        for _index in range(full_config_iterations):
+            config = built_in_tool_config((" image_crop ",))
+            checksum += len(config.tools)
+        raw_single_config_elapsed_samples.append(
+            (time.perf_counter() - raw_single_config_started) * 1000.0
+        )
+
         missing_selection_started = time.perf_counter()
         missing_selection_count = 0
         for index in range(full_config_iterations):
@@ -84,6 +93,9 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
             full_config_template_elapsed_samples
         ),
         "full_config_template_hits_mean": statistics.fmean(full_config_template_samples),
+        "raw_single_config_elapsed_ms_mean": statistics.fmean(
+            raw_single_config_elapsed_samples
+        ),
         "missing_selection_elapsed_ms_mean": statistics.fmean(
             missing_selection_elapsed_samples
         ),

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -507,6 +507,32 @@ def test_built_in_tool_config_partial_selection_reuses_serialized_selection_cach
     assert built_in_tool_config(["image_crop", "local_compute"]).tools[0].name == "image_crop"
 
 
+def test_built_in_tool_config_caches_raw_normalized_selection_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw_selection = (" image_crop ",)
+    expected_config = built_in_tool_config(raw_selection)
+
+    selection_templates = tool_registry_module._BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES
+
+    assert selection_templates[raw_selection] == expected_config
+    assert selection_templates[("image_crop",)] == expected_config
+
+    def fail_select(self: ToolRegistry, names: list[str] | tuple[str, ...]) -> ToolRegistry:
+        raise AssertionError(  # pragma: no cover
+            "cached raw built_in_tool_config() selection should skip registry selection"
+        )
+
+    monkeypatch.setattr(ToolRegistry, "select", fail_select)
+
+    config = built_in_tool_config(raw_selection)
+
+    assert config == expected_config
+    assert config is not expected_config
+    config.tools[0].name = "mutated"
+    assert built_in_tool_config(raw_selection).tools[0].name == "image_crop"
+
+
 def test_tool_registry_worker_tool_config_reuses_cached_serialized_snapshot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -404,12 +404,16 @@ def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> co
         if names == _BUILTIN_TOOL_CONFIG_NAMES_LIST:
             return _copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
         requested_names = tuple(names)
+    raw_requested_names = requested_names
     cached_config = _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES.get(requested_names)
     if cached_config is not None:
         return _copy_tool_config(cached_config)
     registry = _BUILTIN_TOOL_CONFIG_REGISTRY.select(requested_names)
     config = registry.as_worker_tool_config()
-    _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES[registry.names()] = config
+    normalized_names = registry.names()
+    _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES[normalized_names] = config
+    if raw_requested_names != normalized_names:
+        _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES[raw_requested_names] = config
     return _copy_tool_config(config)
 
 


### PR DESCRIPTION
## Summary
- Cache raw built-in tool config selection aliases after registry normalization so repeated whitespace-normalized selections skip registry selection.
- Extend the registered tool-registry select probe with `raw_single_config_elapsed_ms_mean` for this path.
- Add a focused plan and regression test for raw/normalized selection cache aliasing and copy isolation.

## Plan or Spec
- `docs/plans/2026-06-03-tool-registry-raw-selection-config-cache.md`

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
58 passed in 0.91s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
58 passed in 0.37s
TOTAL 24 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
{"checksum": 1760000.0, "elapsed_ms_mean": 24.926292710006237, "full_config_template_elapsed_ms_mean": 25.243996363133192, "full_config_template_hits_mean": 16000.0, "full_list_self_hits_mean": 16000.0, "iterations": 80000.0, "missing_selection_elapsed_ms_mean": 14.238169603049755, "missing_selection_errors_mean": 16000.0, "raw_single_config_elapsed_ms_mean": 14.747611619532108, "sample_count": 5.0, "select_calls_mean": 80000.0, "selection_case_count": 5.0}

$ git diff --check
passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 24 0 100%`).
- Registered local probe: `tool-registry-select-name-index-cache` via `scripts/tool_registry_select_probe.py`.
- Raw single config micro-check on Linux: old mean `225.7116 ms` -> new mean `158.0041 ms` over 100,000 calls x 5 samples (`delta=-67.7075 ms`, speedup `1.43x`).
- New registered metric: `raw_single_config_elapsed_ms_mean=14.7476 ms` for 16,000 calls/sample in the probe run.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally; this PR is limited to a focused Python runtime slice and GitHub Actions should run the broader gates.
- No protocol or dependency changes; generated protobuf outputs and lockfiles are unchanged.
- Observability mode: PR-scoped performance probe evidence only. Probe overhead: N/A, no runtime observability added.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
