### PR TITLE
perf: fast path uppercase hub size labels

### DIFF
--- a/docs/plans/2026-06-03-hub-catalog-uppercase-model-size-label-fastpath.md
+++ b/docs/plans/2026-06-03-hub-catalog-uppercase-model-size-label-fastpath.md
@@ -1,0 +1,31 @@
+# Hub Catalog Uppercase Model-Size Label Fast Path
+
+## Goal
+
+Reduce hot-path string scanning in `worker.model_ops.hub_catalog._strip_model_size_label(...)` for the common uppercase `cardData.model_size` label shapes emitted by the registered size-hint probe, such as `MODEL SIZE:128 MB`.
+
+## Scope
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- Existing registered probe: `hub-catalog-size-hint-regex-precompile`
+
+## Registered Probe
+
+The affected path is covered by `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`. The registry entry already includes focused `test_command`, `coverage_command`, and `probe_command` entries for Hub catalog size-hint parsing and the synthetic probe script.
+
+## Slice
+
+Add a narrow exact-prefix branch for uppercase `MODEL SIZE:` and `MODEL SIZE|` direct card-size labels before falling back to the generic case-insensitive character-by-character label scanner. This keeps existing accepted label formats intact while avoiding the generic scanner for the synthetic and common uppercase direct-label form.
+
+## Verification Plan
+
+- Run the registered focused test command for the Hub catalog probe.
+- Run the registered changed-scope coverage command and require at least 95% coverage for touched executable scope.
+- Run the registered `scripts/hub_catalog_size_hint_probe.py` locally on Linux before and after the change and compare `elapsed_ms_mean`, `size_hint_calls_mean`, and peak memory.
+
+## Success Metrics
+
+- Preserve direct card model-size behavior for mixed-case labels, uppercase labels, colon/pipe separators, and invalid `model-size` text.
+- Keep `_size_hint_from_text(...)` fallback call counts unchanged.
+- Improve or hold steady `elapsed_ms_mean` in the local registered probe and rely on PR-scoped CI as the merge gate.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -210,6 +210,7 @@ def test_direct_card_size_hint_preserves_case_insensitive_label_prefix() -> None
     assert hub_catalog_module._direct_card_size_hint_from_text("Model size: 12 MB") == 12 * MB
     assert hub_catalog_module._direct_card_size_hint_from_text("MODEL SIZE | 7 kb") == 7 * KB
     assert hub_catalog_module._direct_card_size_hint_from_text("MODEL SIZE:7 kb") == 7 * KB
+    assert hub_catalog_module._direct_card_size_hint_from_text("MODEL SIZE|7 kb") == 7 * KB
     assert hub_catalog_module._direct_card_size_hint_from_text("model size 2 GB") == 2 * GB
     assert hub_catalog_module._direct_card_size_hint_from_text("model-size: 2 GB") == 0
 

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -683,6 +683,8 @@ def _direct_card_size_hint_from_text(text: str) -> int:
 def _strip_model_size_label(text: str) -> str:
     if text.startswith("Model size: "):
         return text[12:]
+    if text.startswith("MODEL SIZE:") or text.startswith("MODEL SIZE|"):
+        return text[11:]
     if not _starts_with_model_size_label(text):
         return ""
     cursor = 10


### PR DESCRIPTION
## Summary
- Add an exact uppercase `MODEL SIZE:` / `MODEL SIZE|` fast path before the generic model-size label scanner.
- Extend Hub catalog parser coverage for the no-space uppercase pipe separator.
- Document the Python performance slice and registered probe gate.

## Plan or Spec
- `docs/plans/2026-06-03-hub-catalog-uppercase-model-size-label-fastpath.md`

## Commands Run
```text
# Baseline probe on origin/main before editing (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
{"checksum": 3424780288.0, "elapsed_ms_mean": 1510.7268596068025, "matched_hint_count": 80000.0, "payload_compatibility_calls_mean": 200000.0, "payload_compatibility_elapsed_ms_mean": 214.4926014356315, "payload_compatibility_matched_count": 160000.0, "peak_bytes_mean": 1833.0, "sample_count": 5.0, "size_hint_calls_mean": 40000.0}

# Registered focused test command (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
66 passed in 1.07s

# Registered changed-scope coverage command (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
TOTAL 3 0 100%

# Head probe after editing (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
{"checksum": 3424780288.0, "elapsed_ms_mean": 1436.201150715351, "matched_hint_count": 80000.0, "payload_compatibility_calls_mean": 200000.0, "payload_compatibility_elapsed_ms_mean": 221.80265933275223, "payload_compatibility_matched_count": 160000.0, "peak_bytes_mean": 1833.0, "sample_count": 5.0, "size_hint_calls_mean": 40000.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Registered probe: `hub-catalog-size-hint-regex-precompile` (CI PR-scoped performance remains the merge gate).
- Local Linux probe delta: `elapsed_ms_mean` 1510.7269 ms -> 1436.2012 ms (`-74.5257 ms`, `+4.9331%`, `1.0519x` speedup).
- `size_hint_calls_mean`: 40000.0 -> 40000.0 (unchanged fallback call count).
- `peak_bytes_mean`: 1833.0 -> 1833.0 (unchanged).

## Known Gaps
- Full Swift/macOS runtime effects are not applicable to this Python-only slice.
- GitHub Actions PR-scoped performance report is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
