### PR TITLE
perf: bind trajectory manifest load call targets

### DIFF
--- a/docs/plans/2026-05-30-trajectory-manifest-json-load-bindings.md
+++ b/docs/plans/2026-05-30-trajectory-manifest-json-load-bindings.md
@@ -15,8 +15,9 @@ registry entry includes focused `test_command`, `coverage_command`, and
 `load_trajectory_provenance_from_snapshot_manifest()` already reads manifest
 JSON as bytes to avoid text decoding overhead. This slice keeps that behavior,
 binds the hot `json.loads` and `Path.read_bytes` call targets at module import,
-and skips rebuilding `Path` objects when callers already pass a `Path`. Repeated
-manifest provenance loads avoid per-call attribute lookup and an unnecessary
+uses local bindings for the per-call read/parse/extract sequence, and skips
+rebuilding `Path` objects when callers already pass a `Path`. Repeated manifest
+provenance loads avoid per-call global attribute lookup and an unnecessary
 constructor on the registered probe path.
 
 The change does not alter accepted manifest shapes, provenance field names,

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -149,12 +149,15 @@ def _trajectory_provenance_from_snapshot_manifest(
 def load_trajectory_provenance_from_snapshot_manifest(
     manifest_path: Path | str,
 ) -> dict[str, Any]:
+    read_bytes = _PATH_READ_BYTES
+    loads = _JSON_LOADS
+    extract_provenance = _trajectory_provenance_from_snapshot_manifest
     if not isinstance(manifest_path, Path):
         manifest_path = Path(manifest_path)
-    payload = _JSON_LOADS(_PATH_READ_BYTES(manifest_path))
+    payload = loads(read_bytes(manifest_path))
     if not isinstance(payload, dict):
         return {}
-    return _trajectory_provenance_from_snapshot_manifest(
+    return extract_provenance(
         payload,
         snapshot_manifest_path=manifest_path,
         copy_nested=False,


### PR DESCRIPTION
## Summary
- Keeps the trajectory snapshot manifest loader on the registered JSON-bytes hot path.
- Adds per-call local bindings for the read/parse/extract sequence to avoid repeated global lookups in `load_trajectory_provenance_from_snapshot_manifest()`.
- Updates the governing trajectory manifest JSON-load plan with the local-binding detail.

## Plan or Spec
- `docs/plans/2026-05-30-trajectory-manifest-json-load-bindings.md`
- Registered PR-scoped probe: `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: 7 passed.
- Changed-scope coverage: 100.00% for `services/mlx-worker-python/worker/trajectory_provenance.py` changed lines.
- Local registered probe (`trajectory_manifest_json_load_probe.py`): `old_mean_ms=1409.165657684207`, `new_mean_ms=701.7611182294786`, `delta_ms=-707.4045394547284`, `speedup=2.008041798097176`, `old_peak_bytes_mean=103393.6`, `new_peak_bytes_mean=49580.0`.
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- Linux local validation covers the Python path only; no Swift runtime effect is claimed.
- The local probe compares against its built-in text-loading baseline; the registered CI probe report remains the authoritative PR gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered probe has focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage was measured and passed the repository threshold.
- [x] Local registered probe produced a positive speedup.
- [ ] GitHub Actions completed successfully, including PR-scoped performance.
