### PR TITLE
perf: add ASCII fast path for code eval line counting

### DIFF
--- a/docs/plans/2026-05-11-code-eval-nonblank-line-counter.md
+++ b/docs/plans/2026-05-11-code-eval-nonblank-line-counter.md
@@ -30,3 +30,13 @@ review follow-up. Local Linux base-vs-head probe evidence showed the streaming
 counter kept `nonblank_line_count_mean=48000` while reducing `peak_bytes_mean`
 from `2117.0` to `112.0` bytes; `elapsed_ms_mean` increased from `45.36` to
 `77.21` ms and remains informational for this allocation-focused slice.
+
+## 2026-06-03 ASCII Fast Path Follow-up
+
+This follow-up keeps the same registered probe and narrows the implementation to
+the large-payload `_count_nonblank_test_lines` fallback. Common executable-code
+evaluation test payloads are ASCII, so the counter now detects ASCII payloads and
+uses ASCII-only splitline and whitespace membership checks. Non-ASCII payloads
+continue through the existing Unicode splitline-compatible path, preserving the
+documented LF, CR/CRLF, VT, FF, file/group/record separator, NEL, LS, and PS
+semantics.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -461,6 +461,7 @@ def test_count_nonblank_test_lines_matches_splitlines_semantics() -> None:
     samples = [
         "\n assert one\r\n\t\rassert two\n   \nassert three",
         "\r\n\t\r\nassert one\rassert two\n\u2003assert three\n",
+        "case one\x1fcontinued\n\t\x1fcase two\x1ccase three",
         "case one\vcase two\fcase three\x1ccase four\x1dcase five\x1ecase six\x85case seven\u2028case eight\u2029case nine",
         "   \n\t\r\n\r",
     ]

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -19,6 +19,8 @@ _JSON_DECODE_ERROR = json.JSONDecodeError
 _PYTHON_CODE_BLOCK_TAG = "python"
 _PYTHON_CODE_BLOCK_TAG_LENGTH = len(_PYTHON_CODE_BLOCK_TAG)
 _PYTHON_SPLITLINE_BOUNDARIES = "\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029"
+_ASCII_SPLITLINE_BOUNDARIES = "\n\r\v\f\x1c\x1d\x1e"
+_ASCII_NON_LINE_WHITESPACE = " \t\x1f"
 _COUNT_TESTS_SPLITLINES_MAX_CHARS = 500_000
 
 
@@ -302,6 +304,16 @@ def _count_nonblank_test_lines(test_code: str) -> int:
         return sum(1 for line in test_code.splitlines() if line.strip())
     count = 0
     line_has_content = False
+    if test_code.isascii():
+        splitline_boundaries = _ASCII_SPLITLINE_BOUNDARIES
+        non_line_whitespace = _ASCII_NON_LINE_WHITESPACE
+        for character in test_code:
+            if character in splitline_boundaries:
+                line_has_content = False
+            elif not line_has_content and character not in non_line_whitespace:
+                count += 1
+                line_has_content = True
+        return count
     splitline_boundaries = _PYTHON_SPLITLINE_BOUNDARIES
     for character in test_code:
         if character in splitline_boundaries:


### PR DESCRIPTION
## Summary
- Add an ASCII-only fast path for large `_count_nonblank_test_lines` fallback payloads in code evaluation.
- Preserve the existing Unicode splitline-compatible path for non-ASCII payloads.
- Extend the splitlines semantics regression coverage for ASCII `\x1f` whitespace and document the follow-up slice.

## Plan or Spec
- `docs/plans/2026-05-11-code-eval-nonblank-line-counter.md`
- Registered PR-scoped probe: `code-eval-test-count-nonblank-streaming` in `infra/perf/pr_scoped_probes.json` (already has focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# baseline local probe on origin/main worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_test_count_probe.py
# exit 0; {"elapsed_ms_mean": 70.675910250949, "line_count": 60000.0, "nonblank_line_count_mean": 48000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0}

# focused registered test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_syntax_error_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics
# exit 0; 9 passed in 1.42s

# changed-scope coverage via registered coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_syntax_error_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_test_count_probe.py
# exit 0; 9 passed in 42.84s; TOTAL 12 0 100%

# direct head probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_test_count_probe.py
# exit 0; {"elapsed_ms_mean": 57.15598851176245, "line_count": 60000.0, "nonblank_line_count_mean": 48000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0}

# registered base-vs-head probe runner
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-test-count-nonblank-streaming --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/code_eval_nonblank_ascii_probe.json
# exit 0; base elapsed_ms_mean=69.39141751666155; head elapsed_ms_mean=54.787054990551304; nonblank_line_count_mean=48000.0 both; peak_bytes_mean=112.0 both

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Local registered probe (`code-eval-test-count-nonblank-streaming`):
  - `elapsed_ms_mean`: base `69.39141751666155` ms → head `54.787054990551304` ms (`-14.604362526110243` ms, `21.046352774971915%` lower; ~`26.656593475646662%` speedup vs head time).
  - `nonblank_line_count_mean`: `48000.0` → `48000.0`.
  - `peak_bytes_mean`: `112.0` → `112.0`.
- CI PR-scoped performance report is still required as the merge gate.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this Python-only slice used the registered focused Linux test/coverage/probe commands.
- No Swift runtime validation is applicable for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
