### PR TITLE
perf: map dataset source path materialization

### DIFF
--- a/docs/plans/2026-06-03-dataset-source-path-map.md
+++ b/docs/plans/2026-06-03-dataset-source-path-map.md
@@ -1,0 +1,27 @@
+# Dataset source path materialization map slice
+
+## Scope
+
+This Python-only performance slice targets `worker.productization.dataset_preparation._iter_source_file_paths` after the scandir traversal has collected and sorted file path strings. The behavior remains unchanged: return a sorted `list[Path]` for regular files under the ingest source root while preserving the existing scandir error handling and symlink policy.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped probe `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The registered entry has focused `test_command`, `coverage_command`, and `probe_command` entries and watches:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_source_records_probe.py`
+
+## Implementation plan
+
+1. Keep the scandir traversal, sorting, and filtering logic unchanged.
+2. Replace the terminal list comprehension that materializes `Path` instances with `list(map(Path, file_paths))` to move the per-item call loop into the built-in map iterator.
+3. Verify with the registered focused tests, changed-scope coverage, and the registered base-vs-head probe on Linux.
+
+## Success criteria
+
+- Focused dataset ingest and PR-scoped performance tests pass.
+- Changed-scope coverage remains at 100% for the changed line.
+- The registered probe reports lower `elapsed_ms_mean` on the head repository versus the base repository.
+- PR-scoped performance CI selects and completes `dataset-source-records-scandir` successfully.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -557,7 +557,7 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
         except OSError:
             continue
     file_paths.sort()
-    return [Path(path) for path in file_paths]
+    return list(map(Path, file_paths))
 
 
 def _source_kind(path: Path) -> str | None:


### PR DESCRIPTION
## Summary
- Replace the final dataset source path materialization comprehension with `list(map(Path, file_paths))` after the existing scandir traversal and sort.
- Keep filtering, ordering, and error handling unchanged for dataset ingest source file discovery.

## Plan or Spec
- `docs/plans/2026-06-03-dataset-source-path-map.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 10 passed in 0.15s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused selection>
# 10 passed in 0.31s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-dataset-source-kind-endswith-binding-20260603 --head-repo "$PWD" --output /tmp/dataset-source-records-map-path-probe.json
# test_ok=True coverage_ok=True; base/head probes ok

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 1 0 100%`).
- Registered PR-scoped probe: `dataset-source-records-scandir`.
- Local Linux base-vs-head metrics:
  - `elapsed_ms_mean`: base `11.90736550571663`, head `11.259775941393205`, delta `-0.6475895643234253 ms` (`5.44%` lower).
  - `elapsed_ms_p95`: base `12.64470024034381`, head `12.073378078639507`, delta `-0.5713221617043018 ms` (`4.52%` lower).
  - `source_kind_elapsed_ms_mean`: base `16.789627594075032`, head `16.348414522196567`, delta `-0.441213071878465 ms`.
- CI must still run the registered PR-scoped performance workflow and publish the official report for this PR.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice.
- No Swift runtime validation is involved in this Python-only path.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no new probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
