### PR TITLE
perf: bind runtime weight entry scanner

### DIFF
--- a/docs/plans/2026-06-03-runtime-utils-weight-entry-binding.md
+++ b/docs/plans/2026-06-03-runtime-utils-weight-entry-binding.md
@@ -1,0 +1,26 @@
+# Runtime Utils Top-level Weight Entry Binding Slice
+
+## Scope
+
+This Python-only performance slice is limited to `services/mlx-worker-python/worker/runtime/runtime_utils.py`, specifically the top-level model weight file scan used by `estimate_model_weight_resident_bytes()` when no valid safetensors index is available.
+
+## Probe Coverage
+
+The affected path is covered by the registered PR-scoped probe `runtime-utils-top-level-weight-streaming` in `infra/perf/pr_scoped_probes.json`. The registry already includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/runtime_utils.py`
+- `services/mlx-worker-python/tests/test_runtime_utils.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/runtime_utils_top_level_weights_probe.py`
+
+## Implementation Plan
+
+1. Keep the existing `os.scandir()` streaming behavior and suffix semantics unchanged.
+2. Bind `_weight_dir_entry_file_size` once before the scan loop to avoid repeated global lookup on large top-level model bundles.
+3. Reuse existing focused tests for indexed fallback, top-level scanning, error handling, and PR-scoped probe registration.
+4. Run focused pytest, changed-scope coverage, and the registered local probe on Linux before opening the PR.
+5. Use GitHub Actions PR-scoped performance output as the merge gate.
+
+## Linux Validation Boundary
+
+This slice changes Python worker code only and is locally verifiable on Linux. Swift runtime effects are not involved.

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -175,9 +175,10 @@ def _top_level_weight_file_bytes(model_dir: Path) -> int:
         entries = os.scandir(model_dir)
     except OSError:
         return 0
+    entry_file_size = _weight_dir_entry_file_size
     with entries:
         for entry in entries:
-            total += _weight_dir_entry_file_size(entry)
+            total += entry_file_size(entry)
     return total
 
 


### PR DESCRIPTION
## Summary
- Bind the top-level weight scan helper once before the `os.scandir()` loop in `runtime_utils.py`.
- Keep weight suffix filtering, top-level-only semantics, and OSError handling unchanged.
- Add a slice plan documenting the registered probe coverage and Linux validation boundary.

## Plan or Spec
- `docs/plans/2026-06-03-runtime-utils-weight-entry-binding.md`
- Registered PR-scoped probe: `runtime-utils-top-level-weight-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```bash
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_top_level_weights_probe.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-utils-top-level-weight-streaming --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/runtime_utils_weight_probe.json
```

## Coverage and Metrics
- Focused pytest: 20 passed.
- Changed-scope coverage: 100.00% (`TOTAL 2 0 100%`).
- Local registered probe (`runtime-utils-top-level-weight-streaming`): base `elapsed_ms_mean=170.0037`, head `elapsed_ms_mean=167.8650`, delta `-2.1387 ms` (~1.26% faster); `peak_bytes_mean` unchanged at `2040.8` bytes.

## Known Gaps
- Python-only slice; Swift runtime validation is not applicable.
- Local probe results are Linux measurements. GitHub Actions PR-scoped performance must complete successfully before merge.

## Evidence Checklist
- [x] Registered probe covers the changed path and includes focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows directionally positive elapsed-time movement.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
