### PR TITLE
perf: remove changed-scope overlap varargs

### DIFF
--- a/docs/plans/2026-06-03-changed-scope-overlap-no-varargs.md
+++ b/docs/plans/2026-06-03-changed-scope-overlap-no-varargs.md
@@ -1,0 +1,34 @@
+# Changed-scope coverage overlap helper no-varargs slice
+
+## Scope
+
+This Python-only performance slice targets `scripts/changed_scope_coverage.py`.
+The affected path is covered by the registered PR-scoped probe
+`changed-scope-coverage-measured-set-filter` in `infra/perf/pr_scoped_probes.json`.
+The probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries and is locally verifiable on Linux.
+
+## Hypothesis
+
+`_measurable_changed_lines()` calls `_line_ranges_may_overlap()` once per
+candidate path during changed-scope coverage checks. The helper always receives
+the same two measured line groups (`executed_lines` and `missing_lines`), but the
+current helper accepts `*measured_line_groups`, allocating a short varargs tuple
+on every path. Replacing that helper with an explicit two-group signature keeps
+behavior identical while removing repeated tuple allocation from the measured-set
+filter hot path.
+
+## Verification
+
+- Focused pytest for changed-scope coverage behavior and PR-scoped registry tests.
+- Changed-scope coverage for `scripts/changed_scope_coverage.py`,
+  `tests/test_changed_scope_coverage.py`, `services/mlx-worker-python/tests/test_pr_scoped_performance.py`,
+  and `scripts/changed_scope_coverage_measured_probe.py`.
+- Registered local probe:
+  `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage_measured_probe.py`.
+- CI must run the registered PR-scoped performance probe before merge.
+
+## Linux Boundary
+
+This slice touches a repository script and Python tests only. It is locally
+validated on Linux; no Swift runtime effect is claimed.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -131,19 +131,29 @@ def _filter_coverage_paths(paths: list[str], allowlist: frozenset[str] | None) -
     return [path for path in paths if path in allowlist]
 
 
-def _line_ranges_may_overlap(changed: set[int], *measured_line_groups: list[int]) -> bool:
+def _line_ranges_may_overlap(
+    changed: set[int],
+    executed_lines: list[int],
+    missing_lines: list[int],
+) -> bool:
     if not changed:
         return False
     min_changed = min(changed)
     max_changed = max(changed)
-    for line_group in measured_line_groups:
-        if not line_group:
-            continue
-        first_line = line_group[0]
-        last_line = line_group[-1]
+    if executed_lines:
+        first_line = executed_lines[0]
+        last_line = executed_lines[-1]
         if first_line > last_line:
-            first_line = min(line_group)
-            last_line = max(line_group)
+            first_line = min(executed_lines)
+            last_line = max(executed_lines)
+        if first_line <= max_changed and last_line >= min_changed:
+            return True
+    if missing_lines:
+        first_line = missing_lines[0]
+        last_line = missing_lines[-1]
+        if first_line > last_line:
+            first_line = min(missing_lines)
+            last_line = max(missing_lines)
         if first_line <= max_changed and last_line >= min_changed:
             return True
     return False

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -373,6 +373,7 @@ def test_line_ranges_may_overlap_rejects_disjoint_changed_bounds() -> None:
     assert changed_scope_coverage._line_ranges_may_overlap({1, 4}, [2], [3]) is True
     assert changed_scope_coverage._line_ranges_may_overlap({5}, [], [4, 6]) is True
     assert changed_scope_coverage._line_ranges_may_overlap({5}, [9, 1], []) is True
+    assert changed_scope_coverage._line_ranges_may_overlap({5}, [], [9, 1]) is True
 
 
 def test_measurable_changed_lines_skips_source_read_when_no_changed_lines(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Remove the per-call varargs tuple allocation from the changed-scope coverage overlap helper by accepting the two measured line groups explicitly.
- Add regression coverage for the unsorted `missing_lines` fallback branch that the duplicated fast path now handles directly.
- Document the Python-only performance slice and validation plan.

## Plan or Spec
- `docs/plans/2026-06-03-changed-scope-overlap-no-varargs.md`
- Registered probe: `changed-scope-coverage-measured-set-filter` in `infra/perf/pr_scoped_probes.json` already covers `scripts/changed_scope_coverage.py` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-measured-set-filter --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/changed_scope_overlap_probe.json`

## Coverage and Metrics
- Focused tests: 34 passed.
- Changed-scope coverage: `TOTAL 15 0 100%`.
- Registered local probe runner: base `elapsed_ms_mean=0.27184554242662023`, head `elapsed_ms_mean=0.25197617443544523`, delta `-0.019869367991175`, speedup approximately `1.079x`; `source_read_calls_mean` stayed `0.0`.
- CI PR-scoped performance workflow is required as the merge gate.

## Known Gaps
- Linux-local validation only; this slice is Python/script-only and does not claim Swift runtime effects.
- Micro-benchmark timings are small and can be noisy; the registered CI probe remains authoritative before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage passed at >=95%.
- [x] Registered local probe showed a lower head mean than base.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
