### PR TITLE
perf: split dataset quality row loops

### DIFF
--- a/docs/plans/2026-06-03-dataset-quality-row-loop-split.md
+++ b/docs/plans/2026-06-03-dataset-quality-row-loop-split.md
@@ -1,0 +1,39 @@
+# Dataset Quality Row Loop Split Performance Slice
+
+## Scope
+
+Optimize one Python hot path in `worker.productization.dataset_preparation._append_sample_output_lengths(...)`, used by `_quality_summary(...)` while summarizing generated dataset versions.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` values for `services/mlx-worker-python/worker/productization/dataset_preparation.py`, `services/mlx-worker-python/tests/test_dataset_preparation_versioning.py`, `services/mlx-worker-python/tests/test_pr_scoped_performance.py`, and `scripts/dataset_quality_lengths_probe.py`.
+
+## Hypothesis
+
+The quality summary path walks train and validation rows to collect output lengths. The current helper iterates over a temporary `(train_rows, validation_rows)` tuple and enters a nested row loop for both partitions. Splitting that outer partition loop into two direct row loops preserves output ordering and behavior while removing one level of loop dispatch from this frequently replayed summary path.
+
+A rejected pre-slice trial bound `isinstance`, `dict`, `list`, and `len` locally; it raised the 9-sample mean from `2.498558` ms to `2.862005` ms and was not kept.
+
+Baseline local probe on Linux before the accepted row-loop split:
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=21 uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
+{"elapsed_ms_mean": 2.510334, "elapsed_ms_min": 2.265901, "elapsed_ms_p95": 2.875164, "mean_output_length": 51.999, "p95_output_length": 100.0, "row_count": 15000.0, "sample_count": 21.0, "train_row_count": 12000.0, "validation_row_count": 3000.0}
+```
+
+Accepted local probe on Linux after the row-loop split:
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=21 uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
+{"elapsed_ms_mean": 2.260303, "elapsed_ms_min": 2.148971, "elapsed_ms_p95": 2.540818, "mean_output_length": 51.999, "p95_output_length": 100.0, "row_count": 15000.0, "sample_count": 21.0, "train_row_count": 12000.0, "validation_row_count": 3000.0}
+```
+
+Delta: `old_mean=2.510334 ms`, `new_mean=2.260303 ms`, `delta=-0.250031 ms`, `speedup=1.1106x`.
+
+## Verification Plan
+
+1. Keep the registered probe unchanged and scoped to `dataset-quality-lengths-chain`.
+2. Run the focused regression tests from the registered probe.
+3. Run changed-scope coverage for the touched path.
+4. Run the registered probe locally on Linux and compare against the baseline above.
+5. Use GitHub Actions PR-scoped performance as the merge gate after opening the PR.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -117,14 +117,17 @@ def test_dataset_quality_output_lengths_preserve_completion_and_message_semantic
     train_rows = [
         {"completion": "abc"},
         {"completion": 12345},
+        {"messages": [{"content": "hi"}, {"content": "there"}, {"role": "tool"}]},
+        {"messages": "not-a-list"},
     ]
     validation_rows = [
+        {"completion": "done"},
         {"messages": [{"content": "hello"}, {"content": "world"}, {"role": "tool"}]},
         {"messages": "not-a-list"},
     ]
 
-    assert _sample_output_lengths(train_rows, validation_rows) == [3, 5, 10, 0]
-    assert _sample_output_length_stats(train_rows, validation_rows) == (4, 18, 10)
+    assert _sample_output_lengths(train_rows, validation_rows) == [3, 5, 7, 0, 4, 10, 0]
+    assert _sample_output_length_stats(train_rows, validation_rows) == (7, 29, 10)
     assert _sample_output_length_stats([], []) == (0, 0, 0)
 
 

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1037,20 +1037,32 @@ def _append_sample_output_lengths(
 ) -> None:
     append = lengths.append
     str_ = str
-    for rows in (train_rows, validation_rows):
-        for row in rows:
-            if "completion" in row:
-                append(len(str_(row["completion"])))
-                continue
-            messages = row.get("messages", [])
-            if not isinstance(messages, list):
-                append(0)
-                continue
-            total = 0
-            for item in messages:
-                if isinstance(item, dict):
-                    total += len(str_(item.get("content", "")))
-            append(total)
+    for row in train_rows:
+        if "completion" in row:
+            append(len(str_(row["completion"])))
+            continue
+        messages = row.get("messages", [])
+        if not isinstance(messages, list):
+            append(0)
+            continue
+        total = 0
+        for item in messages:
+            if isinstance(item, dict):
+                total += len(str_(item.get("content", "")))
+        append(total)
+    for row in validation_rows:
+        if "completion" in row:
+            append(len(str_(row["completion"])))
+            continue
+        messages = row.get("messages", [])
+        if not isinstance(messages, list):
+            append(0)
+            continue
+        total = 0
+        for item in messages:
+            if isinstance(item, dict):
+                total += len(str_(item.get("content", "")))
+        append(total)
 
 
 def _p95(values: list[int]) -> int:


### PR DESCRIPTION
## Summary
- Split dataset quality output-length scanning into direct train and validation row loops.
- Expanded regression coverage so both partitions exercise completion, message-list, and non-list message semantics.
- Added the governing performance slice plan with local baseline/probe evidence and the rejected binding trial noted.

## Plan or Spec
- `docs/plans/2026-06-03-dataset-quality-row-loop-split.md`
- Registered PR-scoped probe: `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main, Linux
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=21 uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
{"elapsed_ms_mean": 2.510334, "elapsed_ms_min": 2.265901, "elapsed_ms_p95": 2.875164, "mean_output_length": 51.999, "p95_output_length": 100.0, "row_count": 15000.0, "sample_count": 21.0, "train_row_count": 12000.0, "validation_row_count": 3000.0}

# Focused tests, Linux
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_output_lengths_preserve_completion_and_message_semantics services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
6 passed in 0.17s

# Changed-scope coverage, Linux
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_output_lengths_preserve_completion_and_message_semantics services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py
TOTAL 28 0 100%

# Registered probe, Linux
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=21 uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
{"elapsed_ms_mean": 2.23633, "elapsed_ms_min": 2.158359, "elapsed_ms_p95": 2.341754, "mean_output_length": 51.999, "p95_output_length": 100.0, "row_count": 15000.0, "sample_count": 21.0, "train_row_count": 12000.0, "validation_row_count": 3000.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 28 0 100%`.
- Local registered probe delta vs same-host origin/main baseline: `old_mean=2.510334 ms`, `new_mean=2.236330 ms`, `delta=-0.274004 ms`, `speedup=1.1225x`.
- Rejected trial: local binding of `isinstance`/`dict`/`list`/`len` raised the 9-sample mean from `2.498558` ms to `2.862005` ms and was reverted before commit.
- CI PR-scoped performance must validate the registered `dataset-quality-lengths-chain` probe before merge.

## Known Gaps
- Linux-local validation only for this Python slice; no Swift runtime effects are in scope.
- CI PR-scoped performance report is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
