### PR TITLE
perf: bind dataset split match helper

### DIFF
--- a/docs/plans/2026-06-03-dataset-registry-split-helper-binding.md
+++ b/docs/plans/2026-06-03-dataset-registry-split-helper-binding.md
@@ -1,0 +1,37 @@
+# Dataset registry split helper binding
+
+## Scope
+
+This Python-only performance slice is limited to the split matching helper in
+`services/mlx-worker-python/worker/dataset_registry/catalog.py`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`dataset-registry-limited-read-streaming` in `infra/perf/pr_scoped_probes.json`.
+The registry entry has focused `test_command`, `coverage_command`, and
+`probe_command` entries and is locally verifiable on Linux.
+
+## Optimization
+
+`_path_matches_split()` invokes `_path_part_matches_split()` once for the file
+name and then for each parent path part. Bind the helper once per call and reuse
+the local binding through the filename and parent-part checks. This keeps split
+matching behavior unchanged while avoiding repeated global helper lookups in the
+registered split-match probe path.
+
+## Verification Plan
+
+- Run the registered focused tests for `dataset-registry-limited-read-streaming`.
+- Run the registered changed-scope coverage command and require at least 95%
+  coverage for the touched scope.
+- Run the registered local probe on Linux before and after the change and compare
+  `elapsed_ms_mean`, `path_constructor_calls_mean`, and `peak_bytes_mean`.
+- Use PR-scoped performance CI as the merge gate before squash merging.
+
+## Success Criteria
+
+- Existing split matching semantics remain unchanged.
+- Changed-scope coverage remains at or above the repository threshold.
+- The registered probe shows a directionally lower or stable `elapsed_ms_mean`
+  with unchanged `path_constructor_calls_mean`.

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -963,7 +963,8 @@ def _first_split_alias_delimiter(candidate: str) -> int:
 
 def _path_matches_split(relative_path: Path, split: str) -> bool:
     normalized_split, split_dash_prefix, split_underscore_prefix = _split_match_tokens(split)
-    if _path_part_matches_split(
+    part_matches_split = _path_part_matches_split
+    if part_matches_split(
         relative_path.name,
         normalized_split,
         split_dash_prefix,
@@ -972,7 +973,7 @@ def _path_matches_split(relative_path: Path, split: str) -> bool:
         return True
     parts = relative_path.parts
     for part in parts[:-1]:
-        if _path_part_matches_split(
+        if part_matches_split(
             part,
             normalized_split,
             split_dash_prefix,


### PR DESCRIPTION
## Summary
- Bind `_path_part_matches_split` once inside `_path_matches_split` so the split matcher reuses a local helper through filename and parent-part checks.
- Add a focused plan for the dataset registry split helper binding slice.

## Plan or Spec
- `docs/plans/2026-06-03-dataset-registry-split-helper-binding.md`
- Registered probe: `dataset-registry-limited-read-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_path_split_matching_avoids_temporary_path_construction services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_split_match_tokens_are_cached_per_split services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_string_stem_matches_pathlib_for_split_names services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_selected_split_filters_during_iteration services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_path_match_checks_filename_before_parent_parts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_split_match_probe_script_emits_metrics` → 8 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_split_match_probe.py` → TOTAL 3 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_split_match_probe.py`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100.00% for 3 measurable changed lines.
- Local registered probe baseline before change: `elapsed_ms_mean=61.84327267110348`, `path_constructor_calls_mean=0.0`, `peak_bytes_mean=42066.6`.
- Local registered probe after change: `elapsed_ms_mean=58.38183891028166`, `path_constructor_calls_mean=0.0`, `peak_bytes_mean=42066.6`.
- Local delta: `-3.461873760821819 ms` (~5.60% faster) with unchanged constructor calls and peak bytes.
- CI PR-scoped performance must complete the registered `dataset-registry-limited-read-streaming` probe before merge.

## Known Gaps
- Python-only slice validated locally on Linux; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Registered probe exists with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe runs locally with directionally improved elapsed time.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
