### PR TITLE
perf: bind trajectory manifest string coercion

### DIFF
--- a/docs/plans/2026-06-03-trajectory-manifest-str-binding.md
+++ b/docs/plans/2026-06-03-trajectory-manifest-str-binding.md
@@ -1,0 +1,34 @@
+# Trajectory manifest str binding
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.trajectory_provenance._trajectory_provenance_from_snapshot_manifest()`.
+The manifest loader already reads JSON as bytes, skips nested copy work on the
+registered load path, and binds `manifest.get`; this slice reduces repeated
+built-in lookup overhead for required string coercions while preserving field
+selection and default behavior.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`. The
+registry entry already has focused `test_command`, `coverage_command`, and
+`probe_command` entries for this trajectory provenance loader path, so no probe
+registry change is required.
+
+## Implementation Plan
+
+1. Keep the existing JSON byte-loading and `copy_nested=False` hot-path behavior.
+2. Bind `str` at module import and localize it inside the manifest-to-provenance
+   helper before the repeated manifest string coercions.
+3. Preserve all public return shapes, optional fields, default values, and
+   non-agentic manifest handling.
+4. Run the registered focused tests, changed-scope coverage, and registered
+   local probe on Linux. PR-scoped performance CI remains the merge gate.
+
+## Expected Metrics Direction
+
+The registered probe should keep `component_count` stable and reduce
+`new_mean_ms` for `trajectory-manifest-json-load` without increasing
+`new_peak_bytes_mean`.

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -8,6 +8,7 @@ from typing import Any
 
 _JSON_LOADS = json.loads
 _PATH_READ_BYTES = Path.read_bytes
+_STR = str
 
 
 TRAJECTORY_PROVENANCE_FIELDS = (
@@ -108,30 +109,31 @@ def _trajectory_provenance_from_snapshot_manifest(
     copy_nested: bool,
 ) -> dict[str, Any]:
     manifest_get = manifest.get
+    to_str = _STR
     if (
-        str(manifest_get("format", "")).strip() != "agentic_tool_trace"
-        and not str(manifest_get("trajectory_trace_digest", "")).strip()
+        to_str(manifest_get("format", "")).strip() != "agentic_tool_trace"
+        and not to_str(manifest_get("trajectory_trace_digest", "")).strip()
     ):
         return {}
 
     provenance: dict[str, Any] = {}
-    dataset_id = str(
+    dataset_id = to_str(
         manifest_get("source_dataset_id") or manifest_get("dataset_id") or ""
     ).strip()
     if dataset_id:
         provenance["trajectory_dataset_id"] = dataset_id
-    dataset_version = str(manifest_get("version") or "").strip()
+    dataset_version = to_str(manifest_get("version") or "").strip()
     if dataset_version:
         provenance["trajectory_dataset_version"] = dataset_version
-    schema_version = str(
+    schema_version = to_str(
         manifest_get("trajectory_schema_version") or "melix.agentic_tool_trace.v1"
     ).strip()
     if schema_version:
         provenance["trajectory_schema_version"] = schema_version
-    split = str(manifest_get("trajectory_split") or "train").strip()
+    split = to_str(manifest_get("trajectory_split") or "train").strip()
     if split:
         provenance["trajectory_split"] = split
-    trace_digest = str(manifest_get("trajectory_trace_digest") or "").strip()
+    trace_digest = to_str(manifest_get("trajectory_trace_digest") or "").strip()
     if trace_digest:
         provenance["trajectory_trace_digest"] = trace_digest
     if snapshot_manifest_path is not None:


### PR DESCRIPTION
## Summary
- Bind `str` once for the trajectory snapshot manifest provenance helper and reuse the local binding across repeated required-field coercions.
- Preserve the existing byte-loading, `copy_nested=False` hot path, provenance field names, defaults, and non-agentic manifest behavior.

## Plan or Spec
- `docs/plans/2026-06-03-trajectory-manifest-str-binding.md`
- Registered probe: `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 7 passed in 1.81s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
# 7 passed in 0.76s; changed_line_coverage=100.00%; TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_SAMPLES=7 MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_ITERATIONS=3000 uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
# before change on origin/main: new_mean_ms=1090.379525, old_mean_ms=2170.424798, speedup=1.990522, new_peak_bytes_mean=49580.0
# after change: new_mean_ms=1067.404278, old_mean_ms=2142.596860, speedup=2.007296, new_peak_bytes_mean=49580.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
# old_mean_ms=1427.779572; new_mean_ms=738.553317; delta_ms=-689.226255; speedup=1.933211; new_peak_bytes_mean=49580.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/trajectory_provenance.py` changed lines 7/7 covered, `100.00%`.
- Local registered probe (`trajectory-manifest-json-load`, 7 samples x 3000 iterations): prior head `new_mean_ms=1090.379525`; optimized `new_mean_ms=1067.404278`; delta vs prior head `-22.975247 ms` (`~2.11%` faster), peak bytes unchanged at `49580.0`.
- Default local registered probe after change: `old_mean_ms=1427.779572`, `new_mean_ms=738.553317`, `delta_ms=-689.226255`, `speedup=1.933211`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- None for the Python/Linux slice. Swift runtime effects are not part of this PR.
- CI must validate the registered PR-scoped probe before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
