### PR TITLE
perf: hoist code eval JSON digit ordinal

### DIFF
--- a/docs/plans/2026-06-03-code-eval-json-int-ord-constant.md
+++ b/docs/plans/2026-06-03-code-eval-json-int-ord-constant.md
@@ -1,0 +1,30 @@
+# Code evaluation JSON integer ord constant
+
+This Python-only performance slice is limited to the code-evaluation payload JSON
+fast path in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+The payload parser repeatedly scans integer fields such as `tests_passed` and
+`tests_total` from UTF-8 JSON bytes. The digit scanner previously called
+`ord("0")` inside the per-byte loop. This slice hoists that constant to module
+scope so the hot loop subtracts a precomputed byte value while preserving the
+existing byte-oriented parsing behavior and malformed-payload fallbacks.
+
+Registered PR-scoped probe: `code-eval-payload-json-bytes` in
+`infra/perf/pr_scoped_probes.json`. The entry already declares focused
+`test_command`, `coverage_command`, and `probe_command` values for this path and
+runs on `ubuntu-latest`.
+
+Verification scope:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_required_field_check_preserves_fast_path_gate services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-payload-json-bytes --base-repo <origin-main-worktree> --head-repo "$PWD" --output /tmp/code-eval-json-int-ord-probe.json
+```
+
+Acceptance criteria:
+
+- Focused code-eval payload tests pass.
+- Changed-scope coverage for touched lines remains at least 95%.
+- The registered probe preserves payload byte size and peak memory while showing
+  no regression in the JSON payload parse loop.
+- PR-scoped performance CI completes the registered probe before merge.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -22,6 +22,7 @@ _PYTHON_SPLITLINE_BOUNDARIES = "\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029"
 _ASCII_SPLITLINE_BOUNDARIES = "\n\r\v\f\x1c\x1d\x1e"
 _ASCII_NON_LINE_WHITESPACE = " \t\x1f"
 _COUNT_TESTS_SPLITLINES_MAX_CHARS = 500_000
+_ORD_ZERO = ord("0")
 
 
 @dataclass(frozen=True, slots=True)
@@ -565,7 +566,7 @@ def _extract_json_int_field_value_and_end(
     value = 0
     digit_count = 0
     while cursor < payload_length:
-        digit = payload_bytes[cursor] - ord("0")
+        digit = payload_bytes[cursor] - _ORD_ZERO
         if digit < 0 or digit > 9:
             break
         value = (value * 10) + digit


### PR DESCRIPTION
## Summary
- Hoist the JSON integer digit baseline from `ord("0")` calls to a module-level `_ORD_ZERO` constant in the code-eval payload byte parser.
- Keep the existing malformed-payload fallback and byte-oriented fast path unchanged.
- Document this Python performance slice and its registered probe evidence.

## Plan or Spec
- Plan: `docs/plans/2026-06-03-code-eval-json-int-ord-constant.md`
- Registered probe: `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_required_field_check_preserves_fast_path_gate services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-payload-json-bytes --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-startup-version-first-char-binding-20260603-base --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-startup-version-first-char-binding-20260603 --output /tmp/code-eval-json-int-ord-probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: 9 passed in 0.89s.
- Registered probe head verification: 9 passed in 5.87s; changed-line coverage 100% (`2/2` measurable changed lines covered).
- Local Linux probe (`code-eval-payload-json-bytes`, 7 samples x 1200 iterations):
  - base `elapsed_ms_mean=90.90025390365294`
  - head `elapsed_ms_mean=90.316416695714`
  - delta `-0.583837 ms`, speedup `0.6464%`
  - base/head `peak_bytes_mean=60425.0`, payload bytes `55474.0`
- CI PR-scoped performance report is required before merge.

## Known Gaps
- This is a very small Python micro-optimization; the elapsed improvement is modest and should be treated as a no-regression/slight-improvement slice.
- Swift runtime effects are not applicable to this slice.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed on Linux.
- [x] Changed-scope coverage passed locally on Linux.
- [x] Registered local probe completed with comparable base/head metrics.
- [ ] GitHub Actions completed successfully, including PR-scoped performance validation.
