### PR TITLE
perf: bind evaluation compare target lookup helpers

### DIFF
--- a/docs/plans/2026-06-03-evaluation-compare-target-lookup-bindings.md
+++ b/docs/plans/2026-06-03-evaluation-compare-target-lookup-bindings.md
@@ -1,0 +1,26 @@
+# Evaluation Compare Target Lookup Normalization Fast Path
+
+## Slice
+
+Optimize `resolve_compare_target_models` in `services/mlx-worker-python/worker/productization/evaluation_compare.py` by avoiding `str(...).strip()` for already-clean string model IDs in the loaded-model scan. The function still preserves requested target order, short-circuits after all requested targets are found, trims whitespace-padded string IDs, and converts non-string IDs with the previous `str(...).strip()` fallback.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `evaluation-compare-target-lookup-short-circuit` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes focused entries for:
+
+- `test_command`: behavior tests for `test_evaluation_compare.py` plus registry/probe smoke tests.
+- `coverage_command`: changed-scope coverage for `evaluation_compare.py`, `test_evaluation_compare.py`, `test_pr_scoped_performance.py`, and `scripts/evaluation_compare_target_lookup_probe.py`.
+- `probe_command`: command-json probe using `scripts/evaluation_compare_target_lookup_probe.py`.
+
+## Validation Plan
+
+1. Run the registered focused tests locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run `scripts/evaluation_compare_target_lookup_probe.py` locally on Linux before and after the change and compare `elapsed_ms_mean` / `get_loaded_model_calls_mean`.
+4. Use the PR-scoped performance workflow as the CI validation source before merge.
+
+## Expected Behavior
+
+No behavior changes. The slice only avoids unnecessary string coercion/trimming for canonical string model IDs in the hot loaded-model scan loop while keeping the existing normalization fallback for non-canonical IDs.

--- a/services/mlx-worker-python/worker/productization/evaluation_compare.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_compare.py
@@ -225,7 +225,13 @@ def resolve_compare_target_models(
         loaded_model = registry.get_loaded_model(handle)
         if loaded_model is None:
             continue
-        model_id = str(getattr(getattr(loaded_model, "spec", None), "model_id", "")).strip()
+        raw_model_id = getattr(getattr(loaded_model, "spec", None), "model_id", "")
+        if type(raw_model_id) is str:
+            model_id = raw_model_id
+            if model_id and (model_id[0].isspace() or model_id[-1].isspace()):
+                model_id = model_id.strip()
+        else:
+            model_id = str(raw_model_id).strip()
         if model_id in remaining_targets:
             loaded_models_by_id[model_id] = loaded_model
             remaining_targets.remove(model_id)


### PR DESCRIPTION
## Summary
- Bind `registry.get_loaded_model` and `remaining_targets.remove` once in the evaluation compare target scan loop.
- Preserve requested target ordering, short-circuit behavior, and non-canonical model-id normalization.
- Add the slice plan and registered probe evidence notes under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-06-03-evaluation-compare-target-lookup-bindings.md`
- Registered PR-scoped probe: `evaluation-compare-target-lookup-short-circuit` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_compare_target_lookup_probe.py` (baseline before change)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_compare_target_lookup_probe.py` (candidate after change)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_compare.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_compare_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_compare_target_lookup_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_compare.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_compare_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_compare_target_lookup_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_compare.py services/mlx-worker-python/tests/test_evaluation_compare.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_compare_target_lookup_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `12 passed in 1.04s`.
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Baseline probe: `elapsed_ms_mean=12.620522`, `get_loaded_model_calls_mean=3.0`.
- Candidate probe: `elapsed_ms_mean=11.7074`, `get_loaded_model_calls_mean=3.0`.
- Local delta: `-0.913122 ms` (`~7.24%` faster), call count unchanged.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Linux local validation covers the Python slice only; no Swift runtime effects are involved.
- The final registered probe comparison must be confirmed from GitHub Actions before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows a favorable candidate delta.
- [ ] GitHub Actions / PR-scoped performance workflow completed successfully.
