### PR TITLE
perf: fast-path lowercase hub size units

### DIFF
--- a/docs/plans/2026-06-03-hub-catalog-uppercase-model-size-label-fastpath.md
+++ b/docs/plans/2026-06-03-hub-catalog-uppercase-model-size-label-fastpath.md
@@ -18,6 +18,12 @@ The affected path is covered by `hub-catalog-size-hint-regex-precompile` in `inf
 
 Add a narrow exact-prefix branch for uppercase `MODEL SIZE:` and `MODEL SIZE|` direct card-size labels before falling back to the generic case-insensitive character-by-character label scanner. This keeps existing accepted label formats intact while avoiding the generic scanner for the synthetic and common uppercase direct-label form.
 
+Follow-up within the same registered probe path: add exact lowercase unit suffix
+branches in `_direct_size_hint_from_text(...)` for integer `kb`/`mb`/`gb` direct
+card-size values. This preserves the decimal/fallback parser for fractional and
+unusual values while avoiding `split(...)`, `lower()`, and `float(...)` on common
+lowercase integer unit labels such as `MODEL SIZE:7 kb`.
+
 ## Verification Plan
 
 - Run the registered focused test command for the Hub catalog probe.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -204,6 +204,9 @@ def test_repo_id_mlx_substring_match_preserves_ascii_case_insensitivity() -> Non
 def test_direct_size_hint_rejects_extra_tokens_without_full_split() -> None:
     assert _direct_size_hint_from_text("12 GB extra") == 0
     assert _direct_size_hint_from_text("12 GB") == 12 * 1024 * 1024 * 1024
+    assert _direct_size_hint_from_text("12 gb") == 12 * 1024 * 1024 * 1024
+    assert _direct_size_hint_from_text("9 mb") == 9 * 1024 * 1024
+    assert _direct_size_hint_from_text("512 kb") == 512 * 1024
 
 
 def test_direct_card_size_hint_preserves_case_insensitive_label_prefix() -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -652,11 +652,23 @@ def _direct_size_hint_from_text(text: str) -> int:
         value_text = text[:-3]
         if value_text.isdecimal():
             return int(value_text) * _SIZE_HINT_MB
+    if text.endswith(" mb"):
+        value_text = text[:-3]
+        if value_text.isdecimal():
+            return int(value_text) * _SIZE_HINT_MB
     if text.endswith(" GB"):
         value_text = text[:-3]
         if value_text.isdecimal():
             return int(value_text) * _SIZE_HINT_GB
+    if text.endswith(" gb"):
+        value_text = text[:-3]
+        if value_text.isdecimal():
+            return int(value_text) * _SIZE_HINT_GB
     if text.endswith(" KB"):
+        value_text = text[:-3]
+        if value_text.isdecimal():
+            return int(value_text) * _SIZE_HINT_KB
+    if text.endswith(" kb"):
         value_text = text[:-3]
         if value_text.isdecimal():
             return int(value_text) * _SIZE_HINT_KB


### PR DESCRIPTION
## Summary
- Add integer lowercase `kb`/`mb`/`gb` suffix fast paths for direct Hub catalog size hints.
- Extend focused Hub catalog tests for lowercase direct size units.
- Update the active Hub catalog size-hint plan with this follow-up slice.

## Plan or Spec
- `docs/plans/2026-06-03-hub-catalog-uppercase-model-size-label-fastpath.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=100000 MELIX_HUB_CATALOG_COMPATIBILITY_ITERATIONS=100000 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py` (baseline on `origin/main`)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=100000 MELIX_HUB_CATALOG_COMPATIBILITY_ITERATIONS=100000 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py` (branch)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 66 passed.
- Changed-scope coverage: 100% (15/15 measurable changed lines).
- Short local probe baseline (`origin/main`, 100k iterations): `elapsed_ms_mean=742.2369780950248`, `payload_compatibility_elapsed_ms_mean=110.36793971434236`, `size_hint_calls_mean=20000.0`.
- Short local probe branch (100k iterations): `elapsed_ms_mean=725.5410268902779`, `payload_compatibility_elapsed_ms_mean=106.12236969172955`, `size_hint_calls_mean=20000.0`.
- Full local registered probe baseline (`origin/main`): `elapsed_ms_mean=1458.8666741736233`, `payload_compatibility_elapsed_ms_mean=225.325577147305`, `size_hint_calls_mean=40000.0`.
- Full local registered probe branch: `elapsed_ms_mean=1458.2744753919542`, `payload_compatibility_elapsed_ms_mean=206.7322633229196`, `size_hint_calls_mean=40000.0`.
- CI PR-scoped performance must run the registered `hub-catalog-size-hint-regex-precompile` probe before merge.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime effect is claimed or needed for this Python-only slice.
- The performance delta is intentionally small because this only narrows one direct integer lowercase-unit path.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met the 95% requirement.
- [x] Registered probe ran locally on Linux.
- [ ] PR-scoped performance CI completed successfully.
- [ ] All required PR checks completed successfully.
