### PR TITLE
perf: fast-path trajectory manifest optional checks

### DIFF
--- a/docs/plans/2026-06-03-trajectory-manifest-optional-empty-check.md
+++ b/docs/plans/2026-06-03-trajectory-manifest-optional-empty-check.md
@@ -1,0 +1,32 @@
+# Trajectory Manifest Optional Empty Check Fast Path
+
+## Scope
+
+Optimize one Python hot path in `services/mlx-worker-python/worker/trajectory_provenance.py`:
+optional manifest field extraction should skip missing and empty-string fields
+without constructing a tuple membership candidate on every optional field.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for `trajectory_provenance.py`,
+`test_trajectory_provenance.py`, `test_pr_scoped_performance.py`, and
+`scripts/trajectory_manifest_json_load_probe.py`.
+
+## Implementation Plan
+
+1. Preserve the existing semantics: skip `None` and empty-string optional fields,
+   retain all other values including `0`, `False`, containers, and non-empty
+   strings.
+2. Replace tuple membership with explicit `is None` / `== ""` checks in the
+   manifest optional-field loop only.
+3. Run focused tests, changed-scope coverage, and the registered manifest JSON
+   load probe locally on Linux.
+4. Use GitHub Actions PR-scoped performance as the CI validation source.
+
+## Verification Notes
+
+Linux local validation is expected for this Python slice. Swift/macOS runtime
+validation is not applicable.

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -140,7 +140,7 @@ def _trajectory_provenance_from_snapshot_manifest(
         provenance["trajectory_snapshot_manifest_path"] = str(snapshot_manifest_path)
     for source_field, output_field in _TRAJECTORY_MANIFEST_OPTIONAL_FIELD_MAP:
         value = manifest_get(source_field)
-        if value in ("", None):
+        if value is None or value == "":
             continue
         provenance[output_field] = value
     if copy_nested:


### PR DESCRIPTION
## Summary
- Fast-path trajectory manifest optional field checks by replacing tuple membership with explicit `None` / empty-string checks.
- Keep semantics unchanged for all other optional values, including `0`, `False`, containers, and non-empty strings.

## Plan or Spec
- Added `docs/plans/2026-06-03-trajectory-manifest-optional-empty-check.md`.
- Registered probe coverage: `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json` already provides focused test, coverage, and probe commands for this path.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` → 7 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q ...` → 7 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py services/mlx-worker-python/tests/test_trajectory_provenance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/trajectory_manifest_json_load_probe.py` → TOTAL 1 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py`

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 1 0 100%`).
- Registered local probe before this slice on `origin/main`: `old_mean_ms=1462.803617`, `new_mean_ms=728.782185`, `speedup=2.007189`, `delta_ms=-734.021432`.
- Registered local probe after this slice: `old_mean_ms=1404.919458`, `new_mean_ms=706.721282`, `speedup=1.987940`, `delta_ms=-698.198175`.
- Slice-local head-path delta versus pre-change local run: `new_mean_ms` improved from `728.782185` to `706.721282` (`delta_ms=-22.060903`, about 3.03% faster). CI PR-scoped performance is required for registered probe validation.

## Known Gaps
- Linux local validation only; no Swift/macOS runtime effect is claimed for this Python-only slice.
- Probe timings are local microbenchmark samples and can vary by runner; CI registered probe report is the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally and showed an improved head-path metric compared with the pre-change local run.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
