### PR TITLE
perf: bind token count whitespace helpers

### DIFF
--- a/docs/plans/2026-06-03-token-count-local-bindings.md
+++ b/docs/plans/2026-06-03-token-count-local-bindings.md
@@ -1,0 +1,36 @@
+# Token Count Local Binding Fast Path
+
+## Goal
+
+Reduce overhead in `whitespace_token_count(...)` by binding the ASCII whitespace
+set and Unicode whitespace predicate once in the helper signature. The token
+counting loop and semantics remain unchanged; this only removes repeated local
+setup on the OCR/VLM deterministic runtime token-count hot path.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/token_counting.py`
+- `docs/plans/2026-06-03-token-count-local-bindings.md`
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped
+`deterministic-ocr-token-count-scan` probe in `infra/perf/pr_scoped_probes.json`.
+The entry includes focused `test_command`, `coverage_command`, and
+`probe_command` values for `worker/runtime/token_counting.py`, the OCR runtime,
+focused vision runtime tests, and `scripts/deterministic_ocr_token_count_probe.py`.
+No registry changes are required for this local-binding-only slice.
+
+## Verification Plan
+
+- Run the registered focused `test_command` locally on Linux.
+- Run the registered changed-scope `coverage_command` locally on Linux and keep
+  touched scope at or above 95% coverage.
+- Run the registered `probe_command` before and after the implementation on
+  Linux and compare `elapsed_ms_mean` and `peak_bytes_mean`.
+
+## Success Metrics
+
+- Preserve existing token-count behavior for ASCII and Unicode whitespace cases.
+- Improve `elapsed_ms_mean` in the local registered OCR token-count probe.
+- Keep `peak_bytes_mean` stable within the registered probe tolerance.

--- a/services/mlx-worker-python/worker/runtime/token_counting.py
+++ b/services/mlx-worker-python/worker/runtime/token_counting.py
@@ -6,22 +6,25 @@ _ASCII_WHITESPACE = frozenset(" \t\n\r\v\f")
 
 
 @lru_cache(maxsize=512)
-def whitespace_token_count(text: str) -> int:
+def whitespace_token_count(
+    text: str,
+    *,
+    _ascii_whitespace: frozenset[str] = _ASCII_WHITESPACE,
+    _is_space=str.isspace,
+) -> int:
     token_count = 0
     in_token = False
     if text.isascii():
-        whitespace = _ASCII_WHITESPACE
         for character in text:
-            if character in whitespace:
+            if character in _ascii_whitespace:
                 in_token = False
             elif not in_token:
                 token_count += 1
                 in_token = True
         return token_count
 
-    is_space = str.isspace
     for character in text:
-        if is_space(character):
+        if _is_space(character):
             in_token = False
         elif not in_token:
             token_count += 1


### PR DESCRIPTION
## Summary
- Bind the ASCII whitespace set and Unicode whitespace predicate in `whitespace_token_count(...)` so the hot OCR/VLM token-count loop avoids repeated helper setup.
- Add a focused plan documenting the registered probe coverage and local Linux evidence.

## Plan or Spec
- Added `docs/plans/2026-06-03-token-count-local-bindings.md`.
- Registered probe already exists: `deterministic-ocr-token-count-scan` in `infra/perf/pr_scoped_probes.json`, with focused `test_command`, `coverage_command`, and `probe_command` entries covering `worker/runtime/token_counting.py`.

## Commands Run
- `git status --short && git branch --show-current`
- `git fetch origin && git reset --hard origin/main`
- Baseline probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py`
- Focused tests: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_same_request_cache services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once`
- Coverage: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_ocr_token_count_probe.py`
- Post-change probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `10 passed in 2.17s`.
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Baseline registered probe (`origin/main`): `elapsed_ms_mean=1629.306729`, `peak_bytes_mean=211.2`.
- Post-change registered probe: `elapsed_ms_mean=1300.823652`, `peak_bytes_mean=211.2`.
- Delta: `-328.483077 ms`, `1.252519x`, `20.16%` faster; peak bytes unchanged.

## Known Gaps
- Local validation is Linux-only for this Python slice. CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Exactly one optimization slice.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe improved.
- [ ] GitHub Actions / registered PR-scoped performance report completed successfully.
