### PR TITLE
perf: reuse token count helper in training summaries

### DIFF
--- a/docs/plans/2026-06-03-training-token-count-helper.md
+++ b/docs/plans/2026-06-03-training-token-count-helper.md
@@ -1,0 +1,36 @@
+# Training Token Count Helper Fast Path
+
+## Goal
+
+Reduce allocation overhead in prompt/completion training dataset token summaries by
+reusing the shared `whitespace_token_count(...)` helper instead of materializing
+intermediate `split()` token lists for each prompt and completion string.
+
+## Scope
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset.py`
+- `docs/plans/2026-06-03-training-token-count-helper.md`
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped
+`training-dataset-token-percentiles-single-sort` probe in
+`infra/perf/pr_scoped_probes.json`. The entry includes focused `test_command`,
+`coverage_command`, and `probe_command` values for `training_dataset.py`, the
+training dataset builder tests, and the PR-scoped performance selector tests.
+No registry changes are required for this helper-only slice.
+
+## Verification Plan
+
+- Run the registered focused `test_command` locally on Linux.
+- Run the registered changed-scope `coverage_command` locally on Linux and keep
+  touched scope at or above 95% coverage.
+- Run the registered `probe_command` before and after the implementation on
+  Linux and compare `elapsed_ms_mean` and `peak_bytes_mean`.
+
+## Success Metrics
+
+- Preserve whitespace token summary semantics for prompt/completion samples.
+- Improve or hold `elapsed_ms_mean` in the local registered training dataset
+  token percentile probe.
+- Keep `peak_bytes_mean` stable or lower in the registered probe.

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -2137,8 +2137,8 @@ def _collect_prompt_completion_token_counts(
     for sample in samples:
         sample_count += 1
         sample_get = sample.get
-        prompt_count = len(str(sample_get("prompt", "")).split())
-        completion_count = len(str(sample_get("completion", "")).split())
+        prompt_count = _whitespace_token_count(str(sample_get("prompt", "")))
+        completion_count = _whitespace_token_count(str(sample_get("completion", "")))
         total_count = prompt_count + completion_count
         prompt_token_sum += prompt_count
         completion_token_sum += completion_count


### PR DESCRIPTION
## Summary
- Reuse the shared `whitespace_token_count(...)` helper in prompt/completion training dataset token summaries.
- Avoid per-sample `split()` list materialization in `_collect_prompt_completion_token_counts(...)` while preserving whitespace token semantics.
- Add a focused plan documenting the registered probe coverage and local Linux evidence.

## Plan or Spec
- Added `docs/plans/2026-06-03-training-token-count-helper.md`.
- Registered probe already exists: `training-dataset-token-percentiles-single-sort` in `infra/perf/pr_scoped_probes.json`, with focused `test_command`, `coverage_command`, and `probe_command` entries covering `training_dataset.py`.

## Commands Run
- `git status --short && git branch --show-current`
- `git fetch origin && git reset --hard origin/main`
- Baseline registered probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_training_probe.py`
- Focused tests: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- Coverage: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- Post-change registered probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_training_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `340 passed in 204.09s`.
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Baseline registered probe: `elapsed_ms_mean=349.997`, `peak_bytes_mean=2202484.0`.
- Post-change registered probe: `elapsed_ms_mean=323.344`, `peak_bytes_mean=2202484.0`.
- Delta: `-26.653 ms`, `1.0824x`, `7.62%` faster; peak bytes unchanged.

## Known Gaps
- Local validation is Linux-only for this Python slice. CI must run the registered PR-scoped performance workflow before merge.
- The local registered probe was run through a small `.runtime/run_training_probe.py` wrapper because this CLI environment blocks direct `python3 -c` execution; the wrapper imports and executes the same registered probe function.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Exactly one optimization slice.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe improved.
- [ ] GitHub Actions / registered PR-scoped performance report completed successfully.
