### PR TITLE
perf: elide native MTP sidecar basename calls

### DIFF
--- a/docs/plans/2026-05-25-native-mtp-sidecar-filter-fast-path.md
+++ b/docs/plans/2026-05-25-native-mtp-sidecar-filter-fast-path.md
@@ -19,6 +19,17 @@ This slice extends that probe and its focused test command to include sidecar sh
 3. Extend `scripts/native_mtp_loader_safetensor_scandir_probe.py` to compare baseline sidecar listing against the optimized helper and emit sidecar-specific timing/peak-memory metrics.
 4. Run the registered focused test command, changed-scope coverage command, and registered probe locally on Linux before PR creation. CI remains the final registered PR-scoped performance gate.
 
+## 2026-06-03 basename-elision follow-up
+
+The follow-up slice keeps the same registered `native-mtp-loader-safetensor-scandir`
+probe and narrows the implementation to one extra allocation cut inside
+`extra_mtp_safetensor_files()`: sidecar candidate filtering now derives the final
+path component with a direct string `rsplit(os.sep, 1)` fast path instead of
+calling `os.path.basename()` for every unique MTP shard candidate. This preserves
+the existing `os.path.join()` behavior for relative and absolute index entries
+while avoiding one helper call per candidate before the filesystem existence
+check.
+
 ## Validation commands
 
 ```bash

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -1582,6 +1582,7 @@ def test_native_mtp_extra_safetensor_files_filters_names_before_path_join(
             "language_model.mtp.layers.2.duplicate_weight": "notes.txt",
             "language_model.mtp.layers.3.weight": "mtp-00001.safetensors",
             "language_model.mtp.layers.4.weight": "mtp-missing.safetensors",
+            "language_model.mtp.layers.5.weight": "nested/mtp-00002.safetensors",
             "language_model.layers.0.weight": "ignored-mtp.safetensors",
         }
     }
@@ -1591,11 +1592,14 @@ def test_native_mtp_extra_safetensor_files_filters_names_before_path_join(
     )
     sidecar_path = model_dir / "mtp-00001.safetensors"
     sidecar_path.write_bytes(b"mtp")
+    nested_sidecar_path = model_dir / "nested" / "mtp-00002.safetensors"
+    nested_sidecar_path.parent.mkdir()
+    nested_sidecar_path.write_bytes(b"nested-mtp")
 
     original_join = Path.__truediv__
     joined_path_names: list[str] = []
     original_basename = native_mtp_loader_module.os.path.basename
-    basename_names: list[str] = []
+    basename_candidate_names: list[str] = []
     original_exists = native_mtp_loader_module.os.path.exists
     exists_names: list[str] = []
 
@@ -1604,8 +1608,8 @@ def test_native_mtp_extra_safetensor_files_filters_names_before_path_join(
         return original_join(self, key)
 
     def tracked_basename(path: str) -> str:
-        if "/" not in path:
-            basename_names.append(path)
+        if path in index_payload["weight_map"].values():
+            basename_candidate_names.append(path)
         return original_basename(path)
 
     def tracked_exists(path: str) -> bool:
@@ -1616,14 +1620,14 @@ def test_native_mtp_extra_safetensor_files_filters_names_before_path_join(
     monkeypatch.setattr(native_mtp_loader_module.os.path, "basename", tracked_basename)
     monkeypatch.setattr(native_mtp_loader_module.os.path, "exists", tracked_exists)
 
-    assert extra_mtp_safetensor_files(model_dir) == [sidecar_path]
+    assert extra_mtp_safetensor_files(model_dir) == [sidecar_path, nested_sidecar_path]
     assert joined_path_names == ["model.safetensors.index.json"]
-    assert exists_names == ["mtp-00001.safetensors", "mtp-missing.safetensors"]
-    assert basename_names == [
-        "model-00001-of-00002.safetensors",
+    assert exists_names == [
         "mtp-00001.safetensors",
         "mtp-missing.safetensors",
+        "mtp-00002.safetensors",
     ]
+    assert basename_candidate_names == []
 
 
 def test_native_mtp_patched_loader_uses_scandir_model_weight_listing(

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -57,7 +57,7 @@ def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
     model_path_text = os.fspath(model_path)
     path_join = os.path.join
     path_exists = os.path.exists
-    path_basename = os.path.basename
+    path_sep = os.sep
     for key, file_name in weight_map.items():
         if not _is_mtp_weight_key(key):
             continue
@@ -65,9 +65,12 @@ def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
         if file_name_text in seen:
             continue
         seen_add(file_name_text)
-        if not file_name_text.endswith(".safetensors") or path_basename(
-            file_name_text
-        ).startswith("model"):
+        if not file_name_text.endswith(".safetensors"):
+            continue
+        file_basename = file_name_text
+        if path_sep in file_name_text:
+            file_basename = file_name_text.rsplit(path_sep, 1)[-1]
+        if file_basename.startswith("model"):
             continue
         path_text = path_join(model_path_text, file_name_text)
         if not path_exists(path_text):


### PR DESCRIPTION
## Summary
- Elides per-candidate `os.path.basename()` calls in native-MTP sidecar shard filtering.
- Keeps the existing suffix check before deriving the final path component, then uses a direct `rsplit(os.sep, 1)` path-component fast path only for names with separators.
- Extends the existing regression test to cover nested sidecar entries without reintroducing basename calls for weight-map candidates.

## Plan or Spec
- Updated `docs/plans/2026-05-25-native-mtp-sidecar-filter-fast-path.md` with the 2026-06-03 basename-elision follow-up.
- Registered PR-scoped probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json` already covers the affected path and has focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `git diff --check`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" MELIX_NATIVE_MTP_LOADER_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py`

## Coverage and Metrics
- Focused tests: 9 passed.
- Changed-scope coverage: `TOTAL 7 0 100%` for `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`.
- Local registered probe, before this slice on the same worktree base: `extra_new_mean_ms=30.38274897262454`, `extra_old_mean_ms=144.8667800053954`, `extra_speedup=4.7680603271258715`.
- Local registered probe, after this slice: `extra_new_mean_ms=27.956041507422924`, `extra_old_mean_ms=137.0620235800743`, `extra_speedup=4.902769354655645`, `extra_delta_ms=-109.10598207265139`.
- Slice-local delta versus the pre-change local probe: `extra_new_mean_ms` improved by `2.426707465201616 ms` (~7.99%).

## Known Gaps
- This is a Python-only Linux-verified slice; no Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused test command passes locally.
- [x] Changed-scope coverage is at least 95% for changed Python lines.
- [x] Registered probe command ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
