### PR TITLE
perf: short-circuit exact MLX tag payloads

### DIFF
--- a/docs/plans/2026-06-04-hub-catalog-exact-mlx-tag-membership.md
+++ b/docs/plans/2026-06-04-hub-catalog-exact-mlx-tag-membership.md
@@ -1,0 +1,20 @@
+# Hub Catalog Exact MLX Tag Membership Slice
+
+## Scope
+
+This Python-only performance slice targets `services/mlx-worker-python/worker/model_ops/hub_catalog.py`, specifically the hot tag-payload compatibility helper used while classifying Hugging Face Hub catalog payloads.
+
+## Probe Coverage
+
+The affected path is covered by the registered PR-scoped probe `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`. That entry has focused `test_command`, `coverage_command`, and `probe_command` fields and reports `payload_compatibility_elapsed_ms_mean` for this exact helper path alongside the size-hint metrics.
+
+## Implementation Plan
+
+1. Preserve the existing mixed-case `_is_mlx_atom` fallback for broad compatibility.
+2. Add a narrow exact-list membership fast path for common `"MLX"` / `"mlx"` Hub tag payloads before falling back to per-item atom checks.
+3. Add a focused regression test proving exact `"MLX"` list membership short-circuits the atom helper.
+4. Run focused pytest, changed-scope coverage, and the registered PR-scoped performance probe locally on Linux.
+
+## Validation Boundary
+
+This slice is Python-only and locally verifiable on Linux. CI remains the source of truth for the registered PR-scoped performance workflow before merge.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -1093,6 +1093,16 @@ def test_search_models_counts_fp32_parameters_as_four_bytes_for_local_fit() -> N
     assert model.estimated_resident_bytes > int(64 * 1024 * 1024 * 1024 * 0.60)
 
 
+def test_tag_payload_contains_exact_mlx_without_atom_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    atom_helper = Mock(side_effect=AssertionError("exact MLX list membership should short-circuit"))
+    monkeypatch.setattr(hub_catalog_module, "_is_mlx_atom", atom_helper)
+
+    assert hub_catalog_module._tag_payload_contains_mlx(["Text-Generation", "MLX", object()]) is True
+    atom_helper.assert_not_called()
+
+
 def test_tag_lowering_fallbacks_preserve_direct_helper_compatibility() -> None:
     assert _is_mlx_compatible(
         repo_id="plain/model",

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -341,6 +341,8 @@ def _is_mlx_atom(value: str) -> bool:
 
 def _tag_payload_contains_mlx(value: Any) -> bool:
     if isinstance(value, list):
+        if "MLX" in value or "mlx" in value:
+            return True
         for item in value:
             if isinstance(item, str) and _is_mlx_atom(item):
                 return True


### PR DESCRIPTION
## Summary
- Short-circuit Hub catalog list tag compatibility checks when the payload contains exact `"MLX"` or `"mlx"`.
- Preserve the existing `_is_mlx_atom` fallback for mixed-case strings and broader compatibility forms.
- Add a focused regression test proving exact-list membership avoids per-item atom helper calls.

## Plan or Spec
- `docs/plans/2026-06-04-hub-catalog-exact-mlx-tag-membership.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 67 passed in 0.42s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# 67 passed; TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=7 MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# elapsed_ms_mean=1452.81634280192; payload_compatibility_elapsed_ms_mean=202.14627124369144; sample_count=7

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-hub-size-hint-direct-parser-20260604 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-hub-size-hint-direct-parser-20260604 --output /tmp/hub_catalog_exact_mlx_tag_probe2.json
# exit 0; head verification test_ok=True coverage_ok=True; base/head probe ok=True
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Registered probe: `hub-catalog-size-hint-regex-precompile`.
- PR-scoped runner metrics from `/tmp/hub_catalog_exact_mlx_tag_probe2.json`:
  - `elapsed_ms_mean`: base `1482.108811 ms`, head `1441.148591 ms`, delta `-40.960220 ms` (`2.76%` lower).
  - `payload_compatibility_elapsed_ms_mean`: base `218.256106 ms`, head `199.497984 ms`, delta `-18.758122 ms` (`8.59%` lower).
  - `payload_compatibility_calls_mean`: unchanged at `200000` calls.
  - `sample_count`: `5` in the registered PR-scoped runner.
- Local Linux validation completed; CI PR-scoped performance workflow remains the authoritative registered-probe validation for this PR.

## Known Gaps
- None for the Python slice. Metrics are microbenchmark-sensitive, so the PR-scoped CI probe is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
