### PR TITLE
perf: cache hub catalog card data lookups

### DIFF
--- a/docs/plans/2026-06-04-hub-catalog-card-data-get-cache.md
+++ b/docs/plans/2026-06-04-hub-catalog-card-data-get-cache.md
@@ -1,0 +1,48 @@
+# Hub catalog cardData get cache
+
+## Scope
+
+This Python-only performance slice is limited to Hub catalog summary/card record
+construction in `services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+It preserves existing Hub metadata semantics while avoiding repeated `dict.get`
+lookups for the `cardData` payload and frequently reused payload/card accessors
+inside the per-record hot path.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`hub-catalog-tag-normalization-single-pass` in
+`infra/perf/pr_scoped_probes.json`.
+
+The registry entry already exposes focused `test_command`, `coverage_command`,
+and `probe_command` entries for `hub_catalog.py`, `test_hub_catalog.py`,
+`test_pr_scoped_performance.py`, and `scripts/hub_catalog_tag_normalization_probe.py`.
+This slice keeps the registered probe definition stable and relies on that probe
+locally and in CI for performance validation.
+
+## Plan
+
+1. Add a focused regression test proving `_summary_record()` reads `cardData`
+   once while preserving summary resolution.
+2. Cache `payload.get`, the raw `cardData` value, and `card_data.get` in
+   `_summary_record()` so repeated per-record metadata extraction avoids extra
+   attribute lookup and duplicate `cardData` reads.
+3. Thread the already-normalized `cardData` mapping through local-fit artifact
+   estimation so the size-hint fallback does not re-read `cardData` during
+   summary construction.
+4. Cache the raw `cardData` value in `_card_record()` so card construction also
+   avoids duplicate `cardData` reads.
+5. Run the focused Hub catalog tests, changed-scope coverage, and the registered
+   `hub-catalog-tag-normalization-single-pass` probe locally on Linux.
+6. Use GitHub Actions and the registered PR-scoped performance report as the
+   merge gate.
+
+## Verification
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
+```

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -1278,6 +1278,35 @@ def test_summary_record_reuses_lowered_tags_for_local_fit(monkeypatch: pytest.Mo
     assert calls == 1
 
 
+def test_summary_record_reads_card_data_once() -> None:
+    class CountingPayload(dict[str, object]):
+        card_data_gets = 0
+
+        def get(self, key: str, default: object = None) -> object:
+            if key == "cardData":
+                self.card_data_gets += 1
+            return super().get(key, default)
+
+    payload = CountingPayload(
+        {
+            "id": "mlx-community/card-data-once",
+            "author": "mlx-community",
+            "pipeline_tag": "text-generation",
+            "tags": ["MLX", "4bit"],
+            "library_name": "mlx",
+            "siblings": [{"rfilename": "model.safetensors", "size": 1024}],
+            "safetensors": {"total": 1_000_000},
+            "cardData": {"model_name": "Card Data Once"},
+        }
+    )
+
+    catalog = HubCatalog(local_memory_gb=64.0)
+    record = catalog._summary_record(payload)
+
+    assert record.summary == "Card Data Once"
+    assert payload.card_data_gets == 1
+
+
 def test_get_model_card_includes_local_fit_evidence_from_readme_size_hint() -> None:
     payload = [
         {

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -192,13 +192,16 @@ class HubCatalog:
             raise HubCatalogError("hub_payload_invalid", f"Hub payload could not be decoded: {exc}") from exc
 
     def _summary_record(self, payload: dict[str, Any]) -> HubModelSummaryRecord:
-        card_data = payload.get("cardData") if isinstance(payload.get("cardData"), dict) else {}
-        repo_id = _string(payload.get("id") or payload.get("modelId"))
-        tags = _string_list(payload.get("tags"))
+        payload_get = payload.get
+        raw_card_data = payload_get("cardData")
+        card_data = raw_card_data if isinstance(raw_card_data, dict) else {}
+        card_get = card_data.get
+        repo_id = _string(payload_get("id") or payload_get("modelId"))
+        tags = _string_list(payload_get("tags"))
         lowered_tags = _lowered_tag_set(tags)
-        library_name = _string(payload.get("library_name") or card_data.get("library_name"))
-        pipeline_tag = _string(payload.get("pipeline_tag") or card_data.get("pipeline_tag"))
-        sibling_files = _sibling_files(payload.get("siblings"))
+        library_name = _string(payload_get("library_name") or card_get("library_name"))
+        pipeline_tag = _string(payload_get("pipeline_tag") or card_get("pipeline_tag"))
+        sibling_files = _sibling_files(payload_get("siblings"))
         mlx_compatible = _is_mlx_compatible(
             repo_id=repo_id,
             tags=tags,
@@ -214,20 +217,21 @@ class HubCatalog:
             lowered_tags=lowered_tags,
             mlx_compatible=mlx_compatible,
             local_memory_gb=self._local_memory_gb,
+            card_data=card_data,
         )
         return HubModelSummaryRecord(
             repo_id=repo_id,
             author=_author(payload, repo_id),
             model_name=_model_name(repo_id),
-            summary=_string(card_data.get("model_name") or payload.get("description")),
+            summary=_string(card_get("model_name") or payload_get("description")),
             pipeline_tag=pipeline_tag,
             tags=tags,
-            downloads=_int(payload.get("downloads")),
-            likes=_int(payload.get("likes")),
+            downloads=_int(payload_get("downloads")),
+            likes=_int(payload_get("likes")),
             mlx_compatible=mlx_compatible,
             library_name=library_name,
             sibling_files=sibling_files,
-            last_modified=_string(payload.get("lastModified")),
+            last_modified=_string(payload_get("lastModified")),
             local_fit_status=local_fit["status"],
             local_fit_reasons=local_fit["reasons"],
             estimated_artifact_bytes=local_fit["estimated_artifact_bytes"],
@@ -240,7 +244,8 @@ class HubCatalog:
 
     def _card_record(self, payload: dict[str, Any]) -> HubModelCardRecord:
         summary = self._summary_record(payload)
-        card_data = payload.get("cardData") if isinstance(payload.get("cardData"), dict) else {}
+        raw_card_data = payload.get("cardData")
+        card_data = raw_card_data if isinstance(raw_card_data, dict) else {}
         return HubModelCardRecord(
             repo_id=summary.repo_id,
             author=summary.author,
@@ -452,9 +457,10 @@ def _local_fit_evidence(
     mlx_compatible: bool,
     local_memory_gb: float,
     lowered_tags: set[str] | None = None,
+    card_data: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     lowered_tags = _normalized_lowered_tags(tags, lowered_tags)
-    artifact_bytes = _estimated_artifact_bytes(payload)
+    artifact_bytes = _estimated_artifact_bytes(payload, card_data=card_data)
     parameter_count = _parameter_count(payload.get("safetensors"))
     quantization_summary = _quantization_summary(tags, lowered_tags=lowered_tags)
     estimated_resident_bytes = _estimated_resident_bytes(
@@ -563,7 +569,9 @@ def _local_fit_evidence(
     }
 
 
-def _estimated_artifact_bytes(payload: dict[str, Any]) -> int:
+def _estimated_artifact_bytes(
+    payload: dict[str, Any], *, card_data: dict[str, Any] | None = None
+) -> int:
     for key in ("usedStorage", "used_storage", "storage", "size"):
         value = _int(payload.get(key))
         if value > 0:
@@ -573,7 +581,7 @@ def _estimated_artifact_bytes(payload: dict[str, Any]) -> int:
     if sibling_bytes > 0:
         return sibling_bytes
 
-    hint_bytes = _size_hint_bytes(payload)
+    hint_bytes = _size_hint_bytes(payload, card_data=card_data)
     return hint_bytes
 
 
@@ -601,9 +609,10 @@ def _is_weight_or_config_file(filename: str) -> bool:
     return lowered.endswith(_LOWERCASE_WEIGHT_OR_CONFIG_SUFFIXES)
 
 
-def _size_hint_bytes(payload: dict[str, Any]) -> int:
-    raw_card_data = payload.get("cardData")
-    card_data = raw_card_data if isinstance(raw_card_data, dict) else {}
+def _size_hint_bytes(payload: dict[str, Any], *, card_data: dict[str, Any] | None = None) -> int:
+    if card_data is None:
+        raw_card_data = payload.get("cardData")
+        card_data = raw_card_data if isinstance(raw_card_data, dict) else {}
     direct_card_text = _string(card_data.get("model_size"))
     if direct_card_text:
         direct_card_hint = _direct_card_size_hint_from_text(direct_card_text)


### PR DESCRIPTION
## Summary
- Cache Hub catalog payload/card `get` access in summary record construction.
- Reuse the already-normalized `cardData` mapping for local-fit size hint fallback to avoid re-reading it per record.
- Add a focused regression test proving `_summary_record()` resolves the card summary while reading `cardData` only once.

## Plan or Spec
- `docs/plans/2026-06-04-hub-catalog-card-data-get-cache.md`
- Registered probe: `hub-catalog-tag-normalization-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py` (three local runs: one full verification run plus two repeat samples)
- `git diff --check`

## Coverage and Metrics
- Focused tests: `68 passed`.
- Changed-scope coverage: `TOTAL 30 0 100%`.
- Local registered probe baseline before change: `elapsed_ms_mean=216.02712962776423`, `peak_bytes_mean=9835217.2`, `tag_normalization_calls_mean=5000.0`.
- Local registered probe after change: `elapsed_ms_mean=214.07105904072523`, repeat samples `212.06674687564373` and `212.2895710170269`; `peak_bytes_mean=9835612.4`, `tag_normalization_calls_mean=5000.0`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed.
- The local probe improvement is small; the registered CI probe report is the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally with before/after evidence.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
