### PR TITLE
Add topic membership evaluation scoring mode

### DIFF
--- a/Sources/MelixCLICore/EvaluationPromptStore.swift
+++ b/Sources/MelixCLICore/EvaluationPromptStore.swift
@@ -179,6 +179,13 @@ public struct EvaluationPromptSnapshot: Codable, Equatable, Sendable {
 public struct EvaluationPromptStore: Sendable {
     public static let eventExtractionTaskKind = "event_extraction"
     public static let eventExtractionScoringMode = "event_extraction_weighted_f1"
+    public static let topicMembershipTaskKind = "topic_membership"
+    public static let topicMembershipStrictScoringMode = "topic_membership_strict_micro_f1"
+    public static let topicMembershipSemanticScoringMode = "topic_membership_semantic_micro_f1"
+    public static let topicMembershipScoringModes: Set<String> = [
+        topicMembershipStrictScoringMode,
+        topicMembershipSemanticScoringMode,
+    ]
     public static let builtInBaselinePromptID = "builtin.event-extraction.baseline"
     public static let builtInLegacyBaselineRevisionID = "baseline.v1"
     public static let builtInStage1BaselineRevisionID = "baseline.v2"

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1158,6 +1158,12 @@ public struct EvalCompareOptions: Equatable, Sendable {
     public let fieldMapping: ControlPlaneEvaluationRequest.FieldMapping
     public let profile: ControlPlaneEvaluationRequest.Profile
     public let parameters: [String: String]
+    public let evalPromptID: String
+    public let evalPromptRevisionID: String
+    public let evalPrompt: String
+    public let evalPromptFile: String
+    public let semanticJudgeRemoteServerID: String
+    public let semanticJudgeModelID: String
     public let json: Bool
     public let liveProgress: Bool
 
@@ -1173,6 +1179,12 @@ public struct EvalCompareOptions: Equatable, Sendable {
         fieldMapping: ControlPlaneEvaluationRequest.FieldMapping = .init(),
         profile: ControlPlaneEvaluationRequest.Profile = .init(),
         parameters: [String: String] = [:],
+        evalPromptID: String = "",
+        evalPromptRevisionID: String = "",
+        evalPrompt: String = "",
+        evalPromptFile: String = "",
+        semanticJudgeRemoteServerID: String = "",
+        semanticJudgeModelID: String = "",
         json: Bool = false,
         liveProgress: Bool = true
     ) {
@@ -1187,6 +1199,12 @@ public struct EvalCompareOptions: Equatable, Sendable {
         self.fieldMapping = fieldMapping
         self.profile = profile
         self.parameters = parameters
+        self.evalPromptID = evalPromptID
+        self.evalPromptRevisionID = evalPromptRevisionID
+        self.evalPrompt = evalPrompt
+        self.evalPromptFile = evalPromptFile
+        self.semanticJudgeRemoteServerID = semanticJudgeRemoteServerID.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.semanticJudgeModelID = semanticJudgeModelID.trimmingCharacters(in: .whitespacesAndNewlines)
         self.json = json
         self.liveProgress = liveProgress
     }
@@ -2605,7 +2623,7 @@ public enum MelixCLIParser {
       melix eval prompt update --prompt-id ID --system-prompt-file PATH [--json]
       melix eval prompt freeze --prompt-id ID [--revision-id REV] [--json]
       melix eval prompt archive --prompt-id ID [--json]
-      melix eval compare (--model-id MODEL_ID | --repo-id HF_REPO) (--target-model-id MODEL_ID | --target-adapter ADAPTER_MANIFEST_PATH)... [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--source-csv PATH | --source-jsonl PATH | --hf-dataset-path REPO | --dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-dataset-split SPLIT] [--field-system-path PATH] [--field-input-text-path PATH] [--field-target-path PATH] [--field-sample-id-path PATH] [--profile-type TYPE] [--result-kind KIND] [--extraction-mode MODE] [--scoring-mode MODE] [--threshold N] [--schema PATH | --output-schema-json JSON] [--hints PATH] [--ignored-path PATH ...] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--code-exec-policy MODE] [--no-live] [--json]
+      melix eval compare (--model-id MODEL_ID | --repo-id HF_REPO) (--target-model-id MODEL_ID | --target-adapter ADAPTER_MANIFEST_PATH)... [--suite SUITE ...] [--dataset-id DATASET_ID] [--dataset-root PATH] [--source-csv PATH | --source-jsonl PATH | --hf-dataset-path REPO | --dataset-ref HF_DATASET[@REV]] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-dataset-split SPLIT] [--field-system-path PATH] [--field-input-text-path PATH] [--field-target-path PATH] [--field-sample-id-path PATH] [--profile-type TYPE] [--result-kind KIND] [--extraction-mode MODE] [--scoring-mode MODE] [--threshold N] [--schema PATH | --output-schema-json JSON] [--hints PATH] [--eval-prompt TEXT | --eval-prompt-file PATH | --eval-prompt-id ID [--eval-prompt-revision REV]] [--semantic-judge-remote-server-id ID [--semantic-judge-model MODEL]] [--ignored-path PATH ...] [--sample-size N] [--batch-factor N] [--seed N] [--few-shot N] [--code-exec-policy MODE] [--no-live] [--json]
       melix eval compare export-summary-csv --job-id JOB_ID --output PATH [--json]
       melix eval compare export-samples-csv --job-id JOB_ID --output PATH [--json]
       melix eval compare export-samples-jsonl --job-id JOB_ID --output PATH [--json]
@@ -4851,9 +4869,10 @@ public enum MelixCLIParser {
             }
             let sampleSize = UInt32(values.single["--sample-size"] ?? "") ?? 0
             let scoringMode = sourceConfiguration.profile.scoringMode
-            let suites = (values.multi["--suite"] ?? []).isEmpty && scoringMode == "event_extraction_weighted_f1"
-                ? ["event_extraction"]
-                : (values.multi["--suite"] ?? [])
+            let suites = defaultedEvaluationSuites(
+                explicitSuites: values.multi["--suite"] ?? [],
+                scoringMode: scoringMode
+            )
             try validateEvalPromptOptions(values)
             return .evalRun(
                 EvalRunOptions(
@@ -5029,6 +5048,27 @@ public enum MelixCLIParser {
         return zip(remoteServerIDs, remoteModelIDs).map {
             EvalRemoteTargetOptions(remoteServerID: $0.0, remoteModelID: $0.1)
         }
+    }
+
+    private static func defaultedEvaluationSuites(
+        explicitSuites: [String],
+        scoringMode: String
+    ) -> [String] {
+        guard explicitSuites.isEmpty else {
+            return explicitSuites
+        }
+        if scoringMode == EvaluationPromptStore.eventExtractionScoringMode {
+            return [EvaluationPromptStore.eventExtractionTaskKind]
+        }
+        if EvaluationPromptStore.topicMembershipScoringModes.contains(scoringMode) {
+            return [EvaluationPromptStore.topicMembershipTaskKind]
+        }
+        return []
+    }
+
+    private static func isDedicatedEvaluationScoringMode(_ scoringMode: String) -> Bool {
+        scoringMode == EvaluationPromptStore.eventExtractionScoringMode
+            || EvaluationPromptStore.topicMembershipScoringModes.contains(scoringMode)
     }
 
     private static func parseEvalPrompt(_ arguments: [String]) throws -> MelixCLICommand {
@@ -5228,19 +5268,40 @@ public enum MelixCLIParser {
             values,
             command: "melix eval compare"
         )
+        let scoringMode = sourceConfiguration.profile.scoringMode
+        let suites = defaultedEvaluationSuites(
+            explicitSuites: values.multi["--suite"] ?? [],
+            scoringMode: scoringMode
+        )
+        let semanticJudgeRemoteServerID = values.single["--semantic-judge-remote-server-id"] ?? ""
+        let semanticJudgeModelID = values.single["--semantic-judge-model"] ?? ""
+        if semanticJudgeRemoteServerID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           semanticJudgeModelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        {
+            throw MelixCLIError.missingRequired(
+                "--semantic-judge-remote-server-id is required when using --semantic-judge-model for melix eval compare."
+            )
+        }
+        try validateEvalPromptOptions(values)
         return .evalCompare(
             EvalCompareOptions(
                 modelID: modelID,
                 hfRepoID: hfRepoID,
                 targetModelIDs: targetModelIDs,
                 targetAdapterManifestPaths: targetAdapterManifestPaths,
-                suites: values.multi["--suite"] ?? [],
+                suites: suites,
                 datasetID: values.single["--dataset-id"] ?? "",
                 sampleSize: UInt32(values.single["--sample-size"] ?? "") ?? 0,
                 source: sourceConfiguration.source,
                 fieldMapping: sourceConfiguration.fieldMapping,
                 profile: sourceConfiguration.profile,
                 parameters: try parseEvalParameters(values),
+                evalPromptID: values.single["--eval-prompt-id"] ?? "",
+                evalPromptRevisionID: values.single["--eval-prompt-revision"] ?? "",
+                evalPrompt: values.single["--eval-prompt"] ?? "",
+                evalPromptFile: values.single["--eval-prompt-file"] ?? "",
+                semanticJudgeRemoteServerID: semanticJudgeRemoteServerID,
+                semanticJudgeModelID: semanticJudgeModelID,
                 json: values.flags.contains("--json"),
                 liveProgress: values.flags.contains("--no-live") == false
             )
@@ -5411,7 +5472,7 @@ public enum MelixCLIParser {
             if values.single["--dataset-root"]?.isEmpty == false {
                 throw MelixCLIError.usage("--dataset-root is only supported for builtin evaluation datasets.")
             }
-            if profile.scoringMode == "event_extraction_weighted_f1" {
+            if isDedicatedEvaluationScoringMode(profile.scoringMode) {
                 return (source, fieldMapping, profile)
             }
             guard fieldMapping.inputTextPath.isEmpty == false else {
@@ -5662,7 +5723,7 @@ public enum MelixCLIParser {
             if values.single["--dataset-root"]?.isEmpty == false || values.single["--eval-dataset-root"]?.isEmpty == false {
                 throw MelixCLIError.usage("--dataset-root is only supported for builtin evaluation datasets.")
             }
-            if profile.scoringMode == "event_extraction_weighted_f1" {
+            if isDedicatedEvaluationScoringMode(profile.scoringMode) {
                 return (source, fieldMapping, profile)
             }
             guard fieldMapping.inputTextPath.isEmpty == false else {
@@ -6995,6 +7056,12 @@ public actor MelixCLIRunner {
                 fieldMapping: options.fieldMapping,
                 profile: options.profile,
                 parameters: parameters,
+                evalPromptID: options.evalPromptID,
+                evalPromptRevisionID: options.evalPromptRevisionID,
+                evalPrompt: options.evalPrompt,
+                evalPromptFile: options.evalPromptFile,
+                semanticJudgeRemoteServerID: options.semanticJudgeRemoteServerID,
+                semanticJudgeModelID: options.semanticJudgeModelID,
                 json: options.json,
                 liveProgress: options.liveProgress
             )
@@ -8952,6 +9019,12 @@ public actor MelixCLIRunner {
         appendOption("--scoring-mode", value: options.parameters["scoring_mode"], into: &arguments)
         appendOption("--code-exec-policy", value: options.parameters["code_exec_policy"], into: &arguments)
         appendOption("--hints", value: options.parameters["hints_path"], into: &arguments)
+        appendOption("--eval-prompt-id", value: options.evalPromptID, into: &arguments)
+        appendOption("--eval-prompt-revision", value: options.evalPromptRevisionID, into: &arguments)
+        appendOption("--eval-prompt", value: options.evalPrompt, into: &arguments)
+        appendOption("--eval-prompt-file", value: options.evalPromptFile, into: &arguments)
+        appendOption("--semantic-judge-remote-server-id", value: options.semanticJudgeRemoteServerID, into: &arguments)
+        appendOption("--semantic-judge-model", value: options.semanticJudgeModelID, into: &arguments)
         arguments.append("--json")
         return arguments
     }
@@ -11462,14 +11535,15 @@ public actor MelixCLIRunner {
                 try adHocEvaluationPromptParameters(systemPrompt: adHocPrompt, suiteID: suiteID, options: options)
             ) { _, new in new }
         }
+        let effectiveScoringMode = options.parameters["scoring_mode"]?.isEmpty == false
+            ? options.parameters["scoring_mode"] ?? ""
+            : options.profile.scoringMode
         let usesEventPrompt = suiteID == "event_extraction"
-            || options.profile.scoringMode == EvaluationPromptStore.eventExtractionScoringMode
-            || options.parameters["scoring_mode"] == EvaluationPromptStore.eventExtractionScoringMode
+            || effectiveScoringMode == EvaluationPromptStore.eventExtractionScoringMode
             || options.evalPromptID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
         if usesEventPrompt && adHocPrompt.isEmpty {
             guard suiteID == "event_extraction"
-                || options.profile.scoringMode == EvaluationPromptStore.eventExtractionScoringMode
-                || options.parameters["scoring_mode"] == EvaluationPromptStore.eventExtractionScoringMode
+                || effectiveScoringMode == EvaluationPromptStore.eventExtractionScoringMode
             else {
                 throw MelixCLIError.runtime("Evaluation prompts are only supported for event_extraction_weighted_f1.")
             }
@@ -11482,10 +11556,10 @@ public actor MelixCLIRunner {
         }
         if options.semanticJudgeRemoteServerID.isEmpty == false {
             guard suiteID == "event_extraction"
-                || options.profile.scoringMode == EvaluationPromptStore.eventExtractionScoringMode
-                || options.parameters["scoring_mode"] == EvaluationPromptStore.eventExtractionScoringMode
+                || effectiveScoringMode == EvaluationPromptStore.eventExtractionScoringMode
+                || effectiveScoringMode == EvaluationPromptStore.topicMembershipSemanticScoringMode
             else {
-                throw MelixCLIError.runtime("Semantic judge scoring is only supported for event_extraction_weighted_f1.")
+                throw MelixCLIError.runtime("Semantic judge scoring is only supported for event_extraction_weighted_f1 or topic_membership_semantic_micro_f1.")
             }
             parameters.merge(
                 try semanticJudgeParameters(

--- a/services/mlx-worker-python/tests/test_topic_membership.py
+++ b/services/mlx-worker-python/tests/test_topic_membership.py
@@ -1,0 +1,723 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from packages.protocol.python.worker.v1 import maintenance_pb2
+from worker.engine.evaluation_core import EvaluationCore
+from worker.grpc_server import WorkerMaintenanceService
+from worker.model_registry.catalog import WorkerModelCatalog
+from worker.productization import topic_membership_runner as topic_runner_module
+from worker.productization.evaluation_schemas import EvaluationCompareJob
+from worker.registry import WorkerRegistry
+from worker.runtime.mlx_text_runtime import RuntimeTokenEvent
+from worker.productization.topic_membership import (
+    SEMANTIC_JUDGE_PROMPT_HASH,
+    SEMANTIC_SCORING_MODE,
+    STRICT_SCORING_MODE,
+    TopicMembershipClientResult,
+    evaluate_topic_membership,
+    required_ids,
+    score_dataset,
+)
+
+
+
+class FakeEvaluationRegistry:
+    def __init__(
+        self,
+        *,
+        runtime,
+        model_id: str = "melix-dev-text",
+        runtime_kind: str = "text",
+        ephemeral_runtime: object | None = None,
+    ) -> None:
+        self._primary_model_id = model_id
+        self._loaded_models_by_handle: dict[str, object] = {}
+        self._handles_by_model_id: dict[str, str] = {}
+        self._register_loaded_model(model_id=model_id, runtime=runtime, runtime_kind=runtime_kind)
+        self.started_requests: list[tuple[str, str]] = []
+        self.finished_requests: list[str] = []
+        self.vision_probes: list[tuple[str, object]] = []
+        self.load_model_calls: list[str] = []
+        self.unload_model_calls: list[str] = []
+        self._ephemeral_runtime = ephemeral_runtime or runtime
+
+    @property
+    def handle(self) -> str:
+        return self._handles_by_model_id[self._primary_model_id]
+
+    def _register_loaded_model(self, *, model_id: str, runtime, runtime_kind: str) -> None:
+        handle = f"{model_id}::test"
+        loaded_model = SimpleNamespace(
+            handle=handle,
+            runtime_kind=runtime_kind,
+            runtime_model={"model_id": model_id},
+            spec=SimpleNamespace(model_id=model_id, ext={"melix.source_repo": "test/source"}),
+            runtime=runtime,
+        )
+        self._loaded_models_by_handle[handle] = loaded_model
+        self._handles_by_model_id[model_id] = handle
+
+    def get_loaded_model(self, handle: str):
+        return self._loaded_models_by_handle.get(handle)
+
+    def list_loaded_models(self) -> list[str]:
+        return sorted(self._loaded_models_by_handle)
+
+    def runtime_for_loaded_model(self, loaded_model):
+        return loaded_model.runtime
+
+    def start_request(self, request_id: str, runtime_kind: str = "text"):
+        self.started_requests.append((request_id, runtime_kind))
+        return SimpleNamespace(cancel_event=SimpleNamespace(is_set=lambda: False))
+
+    def finish_request(self, request_id: str) -> None:
+        self.finished_requests.append(request_id)
+
+    def record_vision_probe(self, runtime_kind: str, probe) -> None:
+        self.vision_probes.append((runtime_kind, probe))
+
+    def load_model(self, model_spec):
+        self.load_model_calls.append(str(model_spec.model_id))
+        self._register_loaded_model(
+            model_id=str(model_spec.model_id),
+            runtime=self._ephemeral_runtime,
+            runtime_kind="text",
+        )
+        return self._loaded_models_by_handle[self._handles_by_model_id[str(model_spec.model_id)]]
+
+    def unload_model(self, handle: str) -> bool:
+        self.unload_model_calls.append(handle)
+        loaded = self._loaded_models_by_handle.pop(handle, None)
+        if loaded is None:
+            return False
+        self._handles_by_model_id.pop(loaded.spec.model_id, None)
+        return True
+
+
+class ProbeRuntime:
+    runtime_name = "probe-live-runtime"
+
+    def __init__(self, response: str, probe: object) -> None:
+        self._response = response
+        self._probe = probe
+        self.rendered_prompts: list[str] = []
+
+    def render_prompt(self, messages, loaded_model=None, execution_ext=None, template_kwargs=None):
+        _ = loaded_model
+        _ = execution_ext
+        _ = template_kwargs
+        prompt = "\n".join(part.text for message in messages for part in message.parts)
+        self.rendered_prompts.append(prompt)
+        return prompt
+
+    def generate_tokens(self, loaded_model, prompt: str, sampling, cancel_event, execution_ext=None):
+        _ = loaded_model
+        _ = prompt
+        _ = sampling
+        _ = execution_ext
+        if cancel_event.is_set():
+            return
+        yield RuntimeTokenEvent(text=self._response, completion_tokens=1)
+
+    def last_probe_snapshot(self):
+        return self._probe
+
+
+def _write_adapter_manifest(
+    *,
+    tmp_path: Path,
+    adapter_name: str,
+    source_model_id: str = "melix-dev-text",
+    adapter_set_hash: str = "adapterhash12345678",
+) -> Path:
+    weights_dir = tmp_path / f"weights-{adapter_name}"
+    weights_dir.mkdir(parents=True, exist_ok=True)
+    weights_path = weights_dir / "adapters.safetensors"
+    weights_path.write_text("", encoding="utf-8")
+    manifest_path = tmp_path / f"{adapter_name}.adapter.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.lora_adapter_package.v1",
+                "job_id": f"job-{adapter_name}",
+                "adapter_name": adapter_name,
+                "adapter_set_hash": adapter_set_hash,
+                "weights_path": str(weights_path),
+                "source_model": source_model_id,
+                "source_model_path": f"/tmp/{source_model_id}/model",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+def test_strict_topic_membership_uses_message_jaccard_threshold_exclusively() -> None:
+    gold_cases = [
+        {
+            "source_dialogue_id": "dlg-1",
+            "messages": [],
+            "gold_topics": [
+                {"gold_topic_id": "gold-match", "label": "A", "required_message_ids": ["m1", "m2"]},
+                {"gold_topic_id": "gold-boundary", "label": "B", "required_message_ids": ["g0"]},
+            ],
+        }
+    ]
+    predictions = [
+        {
+            "source_dialogue_id": "dlg-1",
+            "output_json": {
+                "gold_topics": [
+                    {
+                        "topic_id": "pred-match",
+                        "label": "unrelated label is ignored",
+                        "required_message_ids": ["m2", "p1"],
+                    },
+                    {
+                        "topic_id": "pred-boundary",
+                        "label": "same label does not matter",
+                        "required_message_ids": ["g0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9"],
+                    },
+                ]
+            },
+        }
+    ]
+
+    result = score_dataset(gold_cases, predictions, scoring_mode=STRICT_SCORING_MODE)
+
+    assert result["strict_membership"]["true_positive"] == 1
+    assert result["strict_membership"]["false_positive"] == 11
+    assert result["strict_membership"]["false_negative"] == 2
+    assert result["per_case"][0]["matches"] == 1
+
+
+def test_topic_membership_missing_and_parse_errors_fail_closed() -> None:
+    gold_cases = [
+        {
+            "source_dialogue_id": "parse-error",
+            "messages": [],
+            "gold_topics": [{"required_message_ids": ["m1", "m2"]}],
+        },
+        {
+            "source_dialogue_id": "missing",
+            "messages": [],
+            "gold_topics": [{"required_message_ids": ["m3"]}],
+        },
+    ]
+    predictions = [{"source_dialogue_id": "parse-error", "output": "not json"}]
+
+    result = score_dataset(gold_cases, predictions, scoring_mode=STRICT_SCORING_MODE)
+
+    assert result["cases"] == 2
+    assert result["missing_predictions"] == 1
+    assert result["json_valid_rate"] == 0.0
+    assert result["strict_membership"]["true_positive"] == 0
+    assert result["strict_membership"]["false_positive"] == 0
+    assert result["strict_membership"]["false_negative"] == 3
+    assert [row["parse_status"] for row in result["per_case"]] == ["parse_error", "missing_prediction"]
+
+
+def test_required_ids_treats_scalar_message_id_as_one_id() -> None:
+    assert required_ids({"required_message_ids": "m12"}) == {"m12"}
+    assert required_ids({"required_message_ids": 12}) == {"12"}
+
+
+class _FakeTopicJudge:
+    def __init__(self) -> None:
+        self.requests: list[dict[str, object]] = []
+
+    def judge_topic_equivalence(self, request: dict[str, object]) -> dict[str, object]:
+        self.requests.append(request)
+        return {
+            "equivalent": True,
+            "confidence": 0.9,
+            "reason_code": "same_topic",
+            "short_reason": "same plan topic",
+        }
+
+
+def test_semantic_topic_membership_uses_judge_for_topic_alignment_only() -> None:
+    gold_cases = [
+        {
+            "source_dialogue_id": "dlg-semantic",
+            "messages": [
+                {"message_id": "m1", "sender": "speaker_1", "text": "Book the train ticket"},
+                {"message_id": "m2", "sender": "speaker_2", "text": "Confirm the train ticket"},
+            ],
+            "gold_topics": [
+                {
+                    "gold_topic_id": "gold-train",
+                    "label": "train ticket",
+                    "description": "booking train ticket",
+                    "required_message_ids": ["m1"],
+                }
+            ],
+        }
+    ]
+    predictions = [
+        {
+            "source_dialogue_id": "dlg-semantic",
+            "output_json": {
+                "gold_topics": [
+                    {
+                        "topic_id": "pred-train",
+                        "label": "train ticket booking",
+                        "description": "confirm train ticket",
+                        "required_message_ids": ["m2"],
+                    }
+                ]
+            },
+        }
+    ]
+    judge = _FakeTopicJudge()
+
+    result = score_dataset(
+        gold_cases,
+        predictions,
+        scoring_mode=SEMANTIC_SCORING_MODE,
+        judge=judge,
+        judge_remote_server_id="judge",
+        judge_model_id="judge-model",
+    )
+
+    assert result["strict_membership"]["f1"] == 0.0
+    assert result["semantic_membership"]["true_positive"] == 0
+    assert result["semantic_membership"]["false_positive"] == 1
+    assert result["semantic_membership"]["false_negative"] == 1
+    assert result["semantic_membership"]["f1"] == 0.0
+    assert result["per_case"][0]["semantic_matches"] == 1
+    assert result["semantic_judge"]["calls"] == 1
+    assert result["semantic_judge"]["judge_prompt_hash"] == SEMANTIC_JUDGE_PROMPT_HASH
+    assert len(judge.requests) == 1
+
+
+def test_semantic_topic_membership_requires_judge() -> None:
+    with pytest.raises(ValueError, match="requires a semantic judge"):
+        score_dataset([], [], scoring_mode=SEMANTIC_SCORING_MODE)
+
+
+def test_evaluate_topic_membership_writes_semantic_judge_audit(tmp_path: Path) -> None:
+    gold_path = tmp_path / "gold.jsonl"
+    pred_path = tmp_path / "pred.jsonl"
+    summary_path = tmp_path / "summary.json"
+    details_path = tmp_path / "details.jsonl"
+    row_audit_path = tmp_path / "row-audit.jsonl"
+    judge_audit_path = tmp_path / "judge-audit.jsonl"
+    gold_path.write_text(
+        json.dumps(
+            {
+                "source_dialogue_id": "dlg-audit",
+                "messages": [{"message_id": "m1", "text": "train ticket"}],
+                "gold_topics": [
+                    {
+                        "label": "train ticket",
+                        "description": "train ticket",
+                        "required_message_ids": ["m1"],
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    pred_path.write_text(
+        json.dumps(
+            {
+                "source_dialogue_id": "dlg-audit",
+                "output_json": {
+                    "gold_topics": [
+                        {
+                            "label": "train ticket booking",
+                            "description": "train ticket",
+                            "required_message_ids": ["m2"],
+                        }
+                    ]
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = evaluate_topic_membership(
+        gold_jsonl=gold_path,
+        pred_jsonl=pred_path,
+        summary_output=summary_path,
+        details_output=details_path,
+        row_audit_output=row_audit_path,
+        judge_audit_output=judge_audit_path,
+        scoring_mode=SEMANTIC_SCORING_MODE,
+        judge=_FakeTopicJudge(),
+        judge_remote_server_id="judge",
+        judge_model_id="judge-model",
+    )
+
+    audit_rows = [
+        json.loads(line)
+        for line in judge_audit_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert summary["semantic_judge"]["calls"] == 1
+    assert len(audit_rows) == 1
+    assert audit_rows[0]["status"] == "ok"
+    assert audit_rows[0]["equivalent"] is True
+
+def _write_topic_membership_source(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "source_dialogue_id": "dlg-topic-1",
+                "messages": [
+                    {"message_id": "m1", "sender": "speaker_1", "timestamp": "", "text": "Buy train tickets"},
+                    {"message_id": "m2", "sender": "speaker_2", "timestamp": "", "text": "Confirm train tickets"},
+                    {"message_id": "m3", "sender": "speaker_1", "timestamp": "", "text": "Talk about dinner"},
+                ],
+                "gold_topics": [
+                    {
+                        "gold_topic_id": "topic-train",
+                        "label": "train tickets",
+                        "description": "ticket planning",
+                        "required_message_ids": ["m1", "m2"],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_topic_membership_strict_micro_f1_can_use_local_loaded_model(tmp_path: Path) -> None:
+    source_jsonl = tmp_path / "topic-samples.jsonl"
+    _write_topic_membership_source(source_jsonl)
+    registry = FakeEvaluationRegistry(
+        runtime=ProbeRuntime(
+            '{"gold_topics":[{"topic_id":"pred-train","label":"train tickets","required_message_ids":["m1","m2"]}]}',
+            {"images": 0},
+        ),
+        model_id="melix-dev-text",
+    )
+    runner = EvaluationCore(jobs_root=tmp_path / "runs" / "topic", registry=registry)
+
+    run = runner.run_local_suite(
+        model_id="melix-dev-text",
+        model_handle=registry.handle,
+        suite_id="topic_membership",
+        dataset_root=tmp_path,
+        sample_size=1,
+        scoring_mode="topic_membership_strict_micro_f1",
+        parameters={
+            "dataset_id": "local.topic.v1",
+            "topic_membership_source_jsonl": str(source_jsonl),
+            "eval_prompt_system_prompt": "Return topic membership JSON.",
+            "require_live_model": "true",
+        },
+    )
+
+    metrics = {metric.name: metric.value for metric in run.result.metrics}
+    prompt_snapshot = json.loads(Path(run.job.parameters["prompt_snapshot"]).read_text(encoding="utf-8"))
+
+    assert run.job.model_id == "melix-dev-text"
+    assert run.job.task_kind == "text-generation"
+    assert run.job.dataset_id == "local.topic.v1"
+    assert run.job.parameters["runtime_live_model"] == "true"
+    assert run.job.parameters["runtime_model_handle"] == registry.handle
+    assert run.job.parameters["topic_membership_source_jsonl"] == str(source_jsonl.resolve())
+    assert "eval_prompt_system_prompt" not in run.job.parameters
+    assert prompt_snapshot["task_kind"] == "topic_membership"
+    assert prompt_snapshot["system_prompt"] == "Return topic membership JSON."
+    assert registry.started_requests[0][1] == "text"
+    assert registry.finished_requests == [registry.started_requests[0][0]]
+    assert metrics["eval.topic_membership.strict_membership_f1"] == 1.0
+    assert metrics["eval.topic_membership.json_valid_rate"] == 1.0
+    assert run.result.primary_score_name == "strict_membership_f1"
+    assert run.result.primary_score_value == 1.0
+    assert run.samples[0].sample_id == "dlg-topic-1"
+    assert run.samples[0].typed_score == 1.0
+    assert run.samples[0].extraction_status == "extracted"
+    assert "train tickets" in run.samples[0].target
+
+
+def test_topic_membership_parse_errors_fail_closed_in_local_suite(tmp_path: Path) -> None:
+    source_jsonl = tmp_path / "topic-samples.jsonl"
+    _write_topic_membership_source(source_jsonl)
+    registry = FakeEvaluationRegistry(
+        runtime=ProbeRuntime("not json", {"images": 0}),
+        model_id="melix-dev-text",
+    )
+    runner = EvaluationCore(jobs_root=tmp_path / "runs" / "topic", registry=registry)
+
+    run = runner.run_local_suite(
+        model_id="melix-dev-text",
+        model_handle=registry.handle,
+        suite_id="topic_membership",
+        dataset_root=tmp_path,
+        sample_size=1,
+        scoring_mode="topic_membership_strict_micro_f1",
+        parameters={
+            "topic_membership_source_jsonl": str(source_jsonl),
+            "eval_prompt_system_prompt": "Return topic membership JSON.",
+        },
+    )
+
+    metrics = {metric.name: metric.value for metric in run.result.metrics}
+
+    assert run.result.primary_score_value == 0.0
+    assert run.result.failure_count == 1
+    assert metrics["eval.topic_membership.strict_membership_f1"] == 0.0
+    assert metrics["eval.topic_membership.json_valid_rate"] == 0.0
+    assert run.samples[0].typed_score == 0.0
+    assert run.samples[0].extraction_status == "parse_error"
+    assert run.samples[0].parse_status == "parse_error"
+    assert "not json" in run.samples[0].raw_response
+
+
+def test_topic_membership_compare_uses_adapter_target_and_global_micro_f1(
+    tmp_path: Path,
+) -> None:
+    source_jsonl = tmp_path / "topic-samples.jsonl"
+    _write_topic_membership_source(source_jsonl)
+    adapter_manifest = _write_adapter_manifest(
+        tmp_path=tmp_path,
+        adapter_name="topic-alpha",
+        source_model_id="melix-dev-text",
+    )
+    registry = FakeEvaluationRegistry(
+        runtime=ProbeRuntime('{"gold_topics":[]}', {"images": 0}),
+        model_id="melix-dev-text",
+        ephemeral_runtime=ProbeRuntime(
+            '{"gold_topics":[{"topic_id":"pred-train","label":"train tickets","required_message_ids":["m1","m2"]}]}',
+            {"images": 0},
+        ),
+    )
+    runner = EvaluationCore(jobs_root=tmp_path / "runs" / "topic", registry=registry)
+
+    run = runner.run_local_suite(
+        model_id="melix-dev-text",
+        model_handle=registry.handle,
+        suite_id="topic_membership",
+        dataset_root=tmp_path,
+        sample_size=1,
+        scoring_mode="topic_membership_strict_micro_f1",
+        parameters={
+            "dataset_id": "local.topic.v1",
+            "topic_membership_source_jsonl": str(source_jsonl),
+            "eval_prompt_system_prompt": "Return topic membership JSON.",
+            "compare_mode": "base_vs_targets",
+            "compare_target_adapter_manifest_paths": str(adapter_manifest),
+        },
+    )
+
+    assert isinstance(run.job, EvaluationCompareJob)
+    assert len(registry.load_model_calls) == 1
+    assert len(registry.unload_model_calls) == 1
+    ephemeral_id = registry.load_model_calls[0]
+    assert run.results[0].target_model_id == ephemeral_id
+    assert run.results[0].base_accuracy == 0.0
+    assert run.results[0].target_accuracy == 1.0
+    assert run.results[0].delta_accuracy == 1.0
+    metrics = {metric.name: metric.value for metric in run.results[0].metrics}
+    assert metrics["eval.compare.delta_topic_membership_primary_f1"] == 1.0
+    assert metrics["eval.compare.delta_strict_membership_f1"] == 1.0
+    assert run.job.dataset_lineage is not None
+    assert run.job.dataset_lineage.source_path == str(source_jsonl.resolve())
+    assert run.job.dataset_lineage.scoring_mode == "topic_membership_strict_micro_f1"
+    assert run.samples[0].target_typed_score == 1.0
+    assert run.samples[0].base_typed_score == 0.0
+
+
+def test_topic_membership_semantic_mode_uses_dedicated_judge_and_keeps_strict_metric(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_jsonl = tmp_path / "topic-samples.jsonl"
+    source_jsonl.write_text(
+        json.dumps(
+            {
+                "source_dialogue_id": "dlg-topic-semantic",
+                "messages": [
+                    {
+                        "message_id": f"m{index}",
+                        "sender": "speaker_1" if index % 2 else "speaker_2",
+                        "timestamp": "",
+                        "text": f"Train ticket planning message {index}",
+                    }
+                    for index in range(1, 11)
+                ],
+                "gold_topics": [
+                    {
+                        "gold_topic_id": "topic-train",
+                        "label": "train ticket planning",
+                        "description": "all messages plan a train ticket",
+                        "required_message_ids": [f"m{index}" for index in range(1, 11)],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    class FakeTarget:
+        provider_kind = "openai-compatible"
+        base_url = "https://sub2api.example/v1"
+        api_key = "sk-secret"
+        model_id = "remote-topic-model"
+        timeout_seconds = 30
+        rate_limit_per_minute = 0
+
+    class FakeTopicClient:
+        def generate_membership(self, gold_case):
+            _ = gold_case
+            return TopicMembershipClientResult(
+                output_json={
+                    "gold_topics": [
+                        {
+                            "topic_id": "pred-train",
+                            "label": "train ticket planning",
+                            "description": "confirm train ticket planning",
+                            "required_message_ids": ["m1"],
+                        }
+                    ]
+                },
+                raw_response='{"gold_topics":[{"topic_id":"pred-train","label":"train ticket planning","description":"confirm train ticket planning","required_message_ids":["m1"]}]}',
+            )
+
+    class FakeTopicJudge:
+        def __init__(self) -> None:
+            self.requests: list[dict[str, object]] = []
+
+        def judge_topic_equivalence(self, request):
+            self.requests.append(request)
+            return {
+                "equivalent": True,
+                "confidence": 0.9,
+                "reason_code": "same_topic",
+                "short_reason": "same topic",
+            }
+
+    fake_judge = FakeTopicJudge()
+    monkeypatch.setattr(
+        topic_runner_module,
+        "make_topic_membership_client",
+        lambda target, prompt_spec: FakeTopicClient(),
+    )
+    monkeypatch.setattr(
+        topic_runner_module,
+        "make_topic_membership_semantic_judge_client",
+        lambda target: fake_judge,
+    )
+    runner = EvaluationCore(jobs_root=tmp_path / "evals")
+
+    run = runner.run_local_suite(
+        model_id="remote-topic-model",
+        suite_id="topic_membership",
+        dataset_root=tmp_path,
+        sample_size=1,
+        scoring_mode="topic_membership_semantic_micro_f1",
+        parameters={
+            "dataset_id": "local.topic.v1",
+            "topic_membership_source_jsonl": str(source_jsonl),
+            "eval_prompt_system_prompt": "Return topic membership JSON.",
+            "semantic_judge_remote_server_id": "judge",
+            "semantic_judge_provider_kind": "openai-compatible",
+            "semantic_judge_base_url": "https://judge.example/v1",
+            "semantic_judge_api_key": "sk-judge",
+            "semantic_judge_model_id": "judge-model",
+        },
+        remote_target=FakeTarget(),
+    )
+
+    metrics = {metric.name: metric.value for metric in run.result.metrics}
+    summary = json.loads(Path(run.job.parameters["topic_membership_summary"]).read_text(encoding="utf-8"))
+    judge_audit_rows = [
+        json.loads(line)
+        for line in Path(run.job.parameters["topic_membership_judge_audit"]).read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+    assert run.result.primary_score_name == "semantic_membership_f1"
+    assert metrics["eval.topic_membership.strict_membership_f1"] == 0.0
+    assert metrics["eval.topic_membership.semantic_membership_f1"] == pytest.approx(0.181818, abs=1e-6)
+    assert metrics["eval.topic_membership.semantic_judge_calls"] == 1.0
+    assert run.samples[0].typed_score == 0.1818
+    assert summary["semantic_judge"]["judge_remote_server_id"] == "judge"
+    assert summary["semantic_judge"]["judge_model_id"] == "judge-model"
+    assert len(fake_judge.requests) == 1
+    assert len(judge_audit_rows) == 1
+    assert "semantic_judge_api_key" not in run.job.parameters
+    assert "semantic_judge_base_url" not in run.job.parameters
+
+
+def test_worker_maintenance_service_topic_membership_requires_and_maps_source_jsonl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_jsonl = tmp_path / "topic-samples.jsonl"
+    _write_topic_membership_source(source_jsonl)
+
+    class FakeClient:
+        def generate_membership(self, gold_case):
+            assert gold_case["source_dialogue_id"] == "dlg-topic-1"
+            return TopicMembershipClientResult(
+                output_json={
+                    "gold_topics": [
+                        {
+                            "topic_id": "pred-train",
+                            "label": "train tickets",
+                            "required_message_ids": ["m1", "m2"],
+                        }
+                    ]
+                },
+                raw_response='{"gold_topics":[{"topic_id":"pred-train","required_message_ids":["m1","m2"]}]}',
+            )
+
+    monkeypatch.setattr(
+        topic_runner_module,
+        "make_topic_membership_client",
+        lambda target, prompt_spec: FakeClient(),
+    )
+
+    service = WorkerMaintenanceService(
+        WorkerRegistry(model_catalog=WorkerModelCatalog()),
+        jobs_root=tmp_path / "model-ops",
+    )
+    missing_source_request = maintenance_pb2.RunEvaluationRequest(
+        suite_id="topic_membership",
+        sample_size=1,
+        scoring_mode="topic_membership_strict_micro_f1",
+        parameters={"eval_prompt_system_prompt": "Return topic membership JSON."},
+    )
+
+    missing_source_response = service.RunEvaluation(missing_source_request, context=None)
+
+    assert missing_source_response.ok is False
+    assert "--source-jsonl" in missing_source_response.error.message
+
+    request = maintenance_pb2.RunEvaluationRequest(
+        suite_id="topic_membership",
+        sample_size=1,
+        scoring_mode="topic_membership_strict_micro_f1",
+        parameters={"eval_prompt_system_prompt": "Return topic membership JSON."},
+    )
+    request.source.local_jsonl.path = str(source_jsonl)
+    request.remote_target.remote_server_id = "sub2api"
+    request.remote_target.provider_kind = "openai-compatible"
+    request.remote_target.base_url = "https://sub2api.example/v1"
+    request.remote_target.api_key = "sk-test"
+    request.remote_target.model_id = "deepseek-v4-pro"
+
+    response = service.RunEvaluation(request, context=None)
+
+    assert response.ok is True
+    assert response.job.dataset_id == "topic-membership"
+    assert response.job.parameters["topic_membership_source_jsonl"] == str(source_jsonl.resolve())
+    assert response.job.parameters["evaluation_source_kind"] == "jsonl"
+    assert response.results[0].dataset_id == "topic-membership"

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -63,6 +63,10 @@ from worker.productization.event_extraction import (
     prompt_example_dialogue_ids,
     prompt_snapshot_payload,
 )
+from worker.productization.topic_membership import (
+    TOPIC_MEMBERSHIP_SCORING_MODES,
+    TOPIC_MEMBERSHIP_SUITE_ID,
+)
 from worker.productization.evaluation_schemas import (
     EvaluationCompareDatasetLineage,
     EvaluationCompareJob,
@@ -312,6 +316,8 @@ class _LocalEventExtractionClient:
         )
 
 
+
+
 class EvaluationCore:
     def __init__(
         self,
@@ -349,6 +355,35 @@ class EvaluationCore:
                     break
         return samples
 
+    def _run_topic_membership_entrypoint(
+        self,
+        model_id: str,
+        model_handle: str | None,
+        suite_id: str,
+        sample_size: int,
+        requested_scoring_mode: str,
+        parameter_map: dict[str, str],
+        remote_target: Any | None,
+    ) -> EvaluationRun:  # pragma: no cover - delegated runner is covered by topic membership tests.
+        from worker.productization.topic_membership_runner import run_topic_membership_entrypoint
+
+        run = run_topic_membership_entrypoint(
+            core=self,
+            model_id=model_id,
+            model_handle=model_handle,
+            suite_id=suite_id,
+            sample_size=sample_size,
+            scoring_mode=requested_scoring_mode,
+            parameters=dict(parameter_map),
+            remote_target=remote_target,
+        )
+        return EvaluationRun(
+            job=run.job,
+            results=run.results,
+            samples=run.samples,
+            persisted_paths=run.persisted_paths,
+        )
+
     def run_local_suite(
         self,
         *,
@@ -370,6 +405,8 @@ class EvaluationCore:
             if scoring_mode is not None and scoring_mode != ""
             else parameter_map.get("scoring_mode", "")
         )
+        if suite_id == TOPIC_MEMBERSHIP_SUITE_ID or requested_scoring_mode in TOPIC_MEMBERSHIP_SCORING_MODES:
+            return self._run_topic_membership_entrypoint(model_id, model_handle, suite_id, sample_size, requested_scoring_mode, parameter_map, remote_target)  # pragma: no cover
         if suite_id == "event_extraction" or requested_scoring_mode == "event_extraction_weighted_f1":
             loaded_model = self._loaded_model_for_execution(model_handle)
             if str(parameter_map.get("compare_mode", "")).strip():
@@ -3328,6 +3365,7 @@ class EvaluationCore:
                 parameters,
                 "source_path",
                 "evaluation_source_path",
+                "topic_membership_source_jsonl",
                 "event_source_jsonl",
                 "dataset_root",
             ),

--- a/services/mlx-worker-python/worker/grpc_server.py
+++ b/services/mlx-worker-python/worker/grpc_server.py
@@ -368,7 +368,17 @@ class WorkerMaintenanceService(maintenance_pb2_grpc.MaintenanceServiceServicer):
             if request.source_repo:
                 parameters.setdefault("source_repo", request.source_repo)
             scoring_mode = request.scoring_mode or request.profile.scoring_mode
-            if scoring_mode == "event_extraction_weighted_f1":
+            if scoring_mode in {"topic_membership_strict_micro_f1", "topic_membership_semantic_micro_f1"} or request.suite_id == "topic_membership":
+                source_kind = request.source.WhichOneof("kind")
+                if source_kind != "local_jsonl":
+                    raise ValueError("topic_membership scoring requires --source-jsonl.")
+                source_path = request.source.local_jsonl.path
+                parameters.setdefault("topic_membership_source_jsonl", source_path)
+                parameters.setdefault("evaluation_source_kind", "jsonl")
+                parameters.setdefault("evaluation_source_locator", source_path)
+                parameters.setdefault("dataset_id", request.dataset_id or "topic-membership")
+                dataset_root = self._evaluation_materialization_root()
+            elif scoring_mode == "event_extraction_weighted_f1":
                 source_kind = request.source.WhichOneof("kind")
                 if source_kind == "local_jsonl":
                     source_path = request.source.local_jsonl.path

--- a/services/mlx-worker-python/worker/productization/topic_membership.py
+++ b/services/mlx-worker-python/worker/productization/topic_membership.py
@@ -1,0 +1,1295 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+from collections import Counter
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from worker.productization.event_extraction import (
+    RemoteProviderHTTPError,
+    RemoteProviderRequestError,
+    RemoteSemanticJudgeTarget,
+)
+
+
+TOPIC_MEMBERSHIP_SUITE_ID = "topic_membership"
+STRICT_SCORING_MODE = "topic_membership_strict_micro_f1"
+SEMANTIC_SCORING_MODE = "topic_membership_semantic_micro_f1"
+TOPIC_MEMBERSHIP_SCORING_MODES = frozenset({STRICT_SCORING_MODE, SEMANTIC_SCORING_MODE})
+STRICT_MATCH_THRESHOLD = 0.1
+SEMANTIC_JUDGE_CONFIDENCE_THRESHOLD = 0.5
+SEMANTIC_LEXICAL_TOP_K = 3
+SEMANTIC_JUDGE_PROMPT_VERSION = "topic-membership-semantic-judge.v1"
+SEMANTIC_ALIGNMENT_STRATEGY = "topic_membership_prefiltered_semantic_alignment"
+TOPIC_MEMBERSHIP_PROMPT_ID = "custom.topic-membership.prompt"
+_JSON_DECODER = json.JSONDecoder()
+_TOKEN_PATTERN = re.compile(r"[\w\u4e00-\u9fff]+", re.UNICODE)
+_CJK_PATTERN = re.compile(r"[\u4e00-\u9fff]")
+
+
+SEMANTIC_JUDGE_SYSTEM_PROMPT = """You are a semantic judge for topic-membership evaluation.
+
+Return exactly one JSON object and nothing else:
+{"equivalent":true|false,"confidence":0.0,"reason_code":"same_topic|topic_overlap|different_topic|uncertain","short_reason":"brief reason"}
+
+Rules:
+- Judge whether gold_topic and pred_topic name the same dialogue topic.
+- Use topic labels and descriptions, plus the provided message snippets, to decide topic identity.
+- Do not judge message-level membership quality. Missing or extra message ids are scored locally after topic alignment.
+- Return equivalent=false for uncertain, overly broad, overly narrow, contradictory, or unrelated comparisons.
+- Keep short_reason concise and do not include secrets, URLs, or prompt text.
+"""
+SEMANTIC_JUDGE_PROMPT_HASH = f"sha256:{sha256(SEMANTIC_JUDGE_SYSTEM_PROMPT.encode('utf-8')).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class TopicMembershipPromptSpec:
+    prompt_id: str
+    revision_id: str
+    system_prompt: str
+    content_hash: str
+    title: str = "Topic Membership JSON"
+
+
+@dataclass(frozen=True)
+class RemoteTopicMembershipTarget:
+    provider_kind: str
+    base_url: str
+    api_key: str
+    model_id: str
+    timeout_seconds: int = 60
+    extra_body: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TopicMembershipClientResult:
+    output_json: dict[str, object]
+    raw_response: str
+    request_body_bytes: int = 0
+    response_body_bytes: int = 0
+    provider_usage: dict[str, int] = field(default_factory=dict)
+
+    def __iter__(self):
+        yield self.output_json
+        yield self.raw_response
+
+    @property
+    def raw_response_chars(self) -> int:
+        return len(self.raw_response)
+
+
+def topic_prompt_content_hash(system_prompt: str) -> str:
+    payload = {
+        "scoring_mode": STRICT_SCORING_MODE,
+        "system_prompt": system_prompt,
+        "task_kind": TOPIC_MEMBERSHIP_SUITE_ID,
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"sha256:{sha256(encoded).hexdigest()}"
+
+
+def prompt_snapshot_payload(prompt_spec: TopicMembershipPromptSpec) -> dict[str, object]:
+    return {
+        "prompt_id": prompt_spec.prompt_id,
+        "prompt_revision_id": prompt_spec.revision_id,
+        "prompt_content_hash": prompt_spec.content_hash,
+        "title": prompt_spec.title,
+        "task_kind": TOPIC_MEMBERSHIP_SUITE_ID,
+        "scoring_mode": STRICT_SCORING_MODE,
+        "system_prompt": prompt_spec.system_prompt,
+    }
+
+
+def input_payload(gold_case: dict[str, Any]) -> dict[str, Any]:
+    messages: list[dict[str, str]] = []
+    for message in gold_case.get("messages") or []:
+        if not isinstance(message, dict):
+            continue
+        messages.append(
+            {
+                "message_id": str(message.get("message_id") or ""),
+                "sender": str(message.get("sender") or ""),
+                "timestamp": str(message.get("timestamp") or ""),
+                "text": str(message.get("text") or ""),
+            }
+        )
+    return {
+        "source_dialogue_id": str(gold_case.get("source_dialogue_id") or ""),
+        "messages": messages,
+    }
+
+
+def topic_membership_chat_messages(
+    prompt_spec: TopicMembershipPromptSpec,
+    gold_case: dict[str, Any],
+) -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": prompt_spec.system_prompt},
+        {
+            "role": "user",
+            "content": json.dumps(input_payload(gold_case), ensure_ascii=False, sort_keys=True, separators=(",", ":")),
+        },
+    ]
+
+
+def make_topic_membership_client(
+    target: RemoteTopicMembershipTarget,
+    prompt_spec: TopicMembershipPromptSpec,
+):
+    provider_kind = target.provider_kind.strip()
+    if provider_kind == "openai-compatible":
+        return OpenAICompatibleTopicMembershipClient(target, prompt_spec)
+    if provider_kind == "gemini-generative-language":
+        return GeminiGenerativeLanguageTopicMembershipClient(target, prompt_spec)
+    raise ValueError(f"unsupported remote provider kind: {provider_kind}")
+
+
+def make_topic_membership_semantic_judge_client(target: RemoteSemanticJudgeTarget):
+    provider_kind = target.provider_kind.strip()
+    if provider_kind in {"openai-compatible", "gemini-generative-language"}:
+        return RemoteTopicMembershipSemanticJudgeClient(target)
+    raise ValueError(f"unsupported topic membership semantic judge provider kind: {provider_kind}")
+
+
+class OpenAICompatibleTopicMembershipClient:
+    def __init__(self, target: RemoteTopicMembershipTarget, prompt_spec: TopicMembershipPromptSpec) -> None:
+        provider_kind = target.provider_kind.strip()
+        if provider_kind != "openai-compatible":
+            raise ValueError(f"unsupported remote provider kind: {provider_kind}")
+        self._target = target
+        self._prompt = prompt_spec
+
+    def generate_membership(self, gold_case: dict[str, Any]) -> TopicMembershipClientResult:
+        messages = topic_membership_chat_messages(self._prompt, gold_case)
+        payload: dict[str, object] = {
+            "model": self._target.model_id,
+            "messages": messages,
+            "stream": False,
+            "temperature": 0,
+        }
+        for key, value in self._target.extra_body.items():
+            if key in {"model", "messages", "stream"}:
+                continue
+            payload[key] = value
+        response, request_body_bytes, response_body_bytes = self._post_json(payload)
+        content = _assistant_content(response)
+        return TopicMembershipClientResult(
+            output_json=extract_topic_membership_output_json(content),
+            raw_response=content,
+            request_body_bytes=request_body_bytes,
+            response_body_bytes=response_body_bytes,
+            provider_usage=_openai_provider_usage(response),
+        )
+
+    def _post_json(self, payload: dict[str, object]) -> tuple[dict[str, object], int, int]:
+        base_url = self._target.base_url.strip().rstrip("/")
+        if not base_url:
+            raise ValueError("remote provider base_url is empty")
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        request = Request(
+            f"{base_url}/chat/completions",
+            data=body,
+            headers={
+                "Authorization": f"Bearer {self._target.api_key}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "User-Agent": "OpenAI/Python 1.0.0 Melix/0.1",
+            },
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=self._target.timeout_seconds) as response:
+                response_bytes = response.read()
+                response_body = response_bytes.decode("utf-8")
+        except HTTPError as exc:
+            error_body = exc.read().decode("utf-8", errors="replace")
+            raise RemoteProviderHTTPError(status_code=exc.code, response_body=error_body) from exc
+        except URLError as exc:
+            raise RemoteProviderRequestError(reason=exc.reason) from exc
+
+        parsed = json.loads(response_body)
+        if not isinstance(parsed, dict):
+            raise ValueError("remote provider response must be a JSON object")
+        return parsed, len(body), len(response_bytes)
+
+
+class GeminiGenerativeLanguageTopicMembershipClient:
+    def __init__(self, target: RemoteTopicMembershipTarget, prompt_spec: TopicMembershipPromptSpec) -> None:
+        provider_kind = target.provider_kind.strip()
+        if provider_kind != "gemini-generative-language":
+            raise ValueError(f"unsupported remote provider kind: {provider_kind}")
+        self._target = target
+        self._prompt = prompt_spec
+
+    def generate_membership(self, gold_case: dict[str, Any]) -> TopicMembershipClientResult:
+        user_content = json.dumps(input_payload(gold_case), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        payload = {
+            "systemInstruction": {"parts": [{"text": self._prompt.system_prompt}]},
+            "contents": [{"role": "user", "parts": [{"text": user_content}]}],
+            "generationConfig": {"temperature": 0},
+        }
+        response, request_body_bytes, response_body_bytes = self._post_json(payload)
+        content = _gemini_content(response)
+        return TopicMembershipClientResult(
+            output_json=extract_topic_membership_output_json(content),
+            raw_response=content,
+            request_body_bytes=request_body_bytes,
+            response_body_bytes=response_body_bytes,
+            provider_usage=_gemini_provider_usage(response),
+        )
+
+    def _post_json(self, payload: dict[str, object]) -> tuple[dict[str, object], int, int]:
+        base_url = self._target.base_url.strip().rstrip("/")
+        if not base_url:
+            raise ValueError("remote provider base_url is empty")
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        model_path = _gemini_model_path(self._target.model_id)
+        request = Request(
+            f"{base_url}/{model_path}:generateContent?key={quote(self._target.api_key, safe='')}",
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "User-Agent": "OpenAI/Python 1.0.0 Melix/0.1",
+            },
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=self._target.timeout_seconds) as response:
+                response_bytes = response.read()
+                response_body = response_bytes.decode("utf-8")
+        except HTTPError as exc:
+            error_body = exc.read().decode("utf-8", errors="replace")
+            raise RemoteProviderHTTPError(status_code=exc.code, response_body=error_body) from exc
+        except URLError as exc:
+            raise RemoteProviderRequestError(reason=exc.reason) from exc
+
+        parsed = json.loads(response_body)
+        if not isinstance(parsed, dict):
+            raise ValueError("remote provider response must be a JSON object")
+        return parsed, len(body), len(response_bytes)
+
+
+class RemoteTopicMembershipSemanticJudgeClient:
+    def __init__(self, target: RemoteSemanticJudgeTarget) -> None:
+        provider_kind = target.provider_kind.strip()
+        if provider_kind not in {"openai-compatible", "gemini-generative-language"}:
+            raise ValueError(f"unsupported topic membership semantic judge provider kind: {provider_kind}")
+        self._target = target
+        self._last_request_started = 0.0
+
+    def judge_topic_equivalence(self, request: dict[str, object]) -> dict[str, object]:
+        self._throttle_if_needed()
+        payload = self._payload(request)
+        if self._target.provider_kind.strip() == "gemini-generative-language":
+            response = self._post_gemini(payload)
+            content = _gemini_content(response)
+        else:
+            response = self._post_openai(payload)
+            content = _assistant_content(response)
+        return _parse_semantic_judge_response(content)
+
+    def _payload(self, request: dict[str, object]) -> dict[str, object]:
+        user_content = json.dumps(request, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        if self._target.provider_kind.strip() == "gemini-generative-language":
+            return {
+                "systemInstruction": {"parts": [{"text": SEMANTIC_JUDGE_SYSTEM_PROMPT}]},
+                "contents": [{"role": "user", "parts": [{"text": user_content}]}],
+                "generationConfig": {"temperature": 0},
+            }
+        return {
+            "model": self._target.model_id,
+            "messages": [
+                {"role": "system", "content": SEMANTIC_JUDGE_SYSTEM_PROMPT},
+                {"role": "user", "content": user_content},
+            ],
+            "stream": False,
+            "temperature": 0,
+        }
+
+    def _throttle_if_needed(self) -> None:
+        rate_limit_per_minute = int(self._target.rate_limit_per_minute or 0)
+        if rate_limit_per_minute <= 0:
+            return
+        now = time.perf_counter()
+        if self._last_request_started > 0:
+            min_interval_seconds = 60.0 / rate_limit_per_minute
+            elapsed = now - self._last_request_started
+            if elapsed < min_interval_seconds:
+                time.sleep(min_interval_seconds - elapsed)
+                now = time.perf_counter()
+        self._last_request_started = now
+
+    def _post_openai(self, payload: dict[str, object]) -> dict[str, object]:
+        base_url = self._target.base_url.strip().rstrip("/")
+        if not base_url:
+            raise ValueError("topic membership semantic judge base_url is empty")
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        request = Request(
+            f"{base_url}/chat/completions",
+            data=body,
+            headers={
+                "Authorization": f"Bearer {self._target.api_key}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "User-Agent": "OpenAI/Python 1.0.0 Melix/0.1",
+            },
+            method="POST",
+        )
+        return _post_json_request(request, timeout_seconds=self._target.timeout_seconds)
+
+    def _post_gemini(self, payload: dict[str, object]) -> dict[str, object]:
+        base_url = self._target.base_url.strip().rstrip("/")
+        if not base_url:
+            raise ValueError("topic membership semantic judge base_url is empty")
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        model_path = _gemini_model_path(self._target.model_id)
+        request = Request(
+            f"{base_url}/{model_path}:generateContent?key={quote(self._target.api_key, safe='')}",
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "User-Agent": "OpenAI/Python 1.0.0 Melix/0.1",
+            },
+            method="POST",
+        )
+        return _post_json_request(request, timeout_seconds=self._target.timeout_seconds)
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with Path(path).open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if line:
+                row = json.loads(line)
+                if isinstance(row, dict):
+                    rows.append(row)
+    return rows
+
+
+def extract_topic_membership_output_json(response_text: str) -> dict[str, object]:
+    parsed = extract_json_object(response_text)
+    if not isinstance(parsed, dict):
+        raise ValueError("response did not contain a JSON object")
+    return parsed
+
+
+def extract_json_object(response_text: str) -> dict[str, object] | None:
+    stripped = response_text.strip()
+    if stripped.startswith("```json"):
+        stripped = stripped.removeprefix("```json").strip()
+    elif stripped.startswith("```"):
+        stripped = stripped.removeprefix("```").strip()
+    if stripped.endswith("```"):
+        stripped = stripped.removesuffix("```").strip()
+
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        for index, character in enumerate(stripped):
+            if character != "{":
+                continue
+            try:
+                parsed, _end = _JSON_DECODER.raw_decode(stripped[index:])
+                break
+            except json.JSONDecodeError:
+                continue
+        else:
+            return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def required_ids(topic: dict[str, object]) -> set[str]:
+    values = topic.get("required_message_ids") or []
+    if isinstance(values, (str, int, float, bool)):
+        return {str(values)}
+    if not isinstance(values, Iterable):
+        return set()
+    return {str(value) for value in values}
+
+
+def topic_id(topic: dict[str, object], index: int) -> str:
+    return str(topic.get("gold_topic_id") or topic.get("topic_id") or f"topic-{index + 1}")
+
+
+def normalize_output_json(prediction: dict[str, object]) -> tuple[dict[str, object] | None, bool]:
+    output = prediction.get("output_json")
+    if isinstance(output, dict):
+        return output, True
+
+    for key in ("output", "response", "assistant_output"):
+        value = prediction.get(key)
+        if isinstance(value, dict):
+            return value, True
+        if isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError:
+                return None, False
+            if isinstance(parsed, dict):
+                return parsed, True
+            return None, False
+
+    return None, False
+
+
+def prediction_by_dialogue_id(predictions: list[dict[str, object]]) -> dict[str, dict[str, object]]:
+    by_id: dict[str, dict[str, object]] = {}
+    for prediction in predictions:
+        dialogue_id = prediction.get("source_dialogue_id")
+        if dialogue_id:
+            by_id[str(dialogue_id)] = prediction
+    return by_id
+
+
+def jaccard(left: set[str], right: set[str]) -> float:
+    if not left and not right:
+        return 1.0
+    union = left | right
+    if not union:
+        return 0.0
+    return len(left & right) / len(union)
+
+
+def match_topics(
+    gold_topics: list[dict[str, object]],
+    pred_topics: list[dict[str, object]],
+    threshold: float = STRICT_MATCH_THRESHOLD,
+) -> list[tuple[int, int]]:
+    candidates: list[tuple[float, int, int]] = []
+    for gold_index, gold_topic in enumerate(gold_topics):
+        gold_required = required_ids(gold_topic)
+        for pred_index, pred_topic in enumerate(pred_topics):
+            score = jaccard(gold_required, required_ids(pred_topic))
+            if score > threshold:
+                candidates.append((score, gold_index, pred_index))
+
+    matches: list[tuple[int, int]] = []
+    used_gold: set[int] = set()
+    used_pred: set[int] = set()
+    for _score, gold_index, pred_index in sorted(candidates, reverse=True):
+        if gold_index in used_gold or pred_index in used_pred:
+            continue
+        matches.append((gold_index, pred_index))
+        used_gold.add(gold_index)
+        used_pred.add(pred_index)
+    return matches
+
+
+def membership_counts(
+    gold_topics: list[dict[str, object]],
+    pred_topics: list[dict[str, object]],
+    matches: list[tuple[int, int]],
+) -> dict[str, int]:
+    true_positive = 0
+    false_positive = 0
+    false_negative = 0
+
+    matched_gold = {gold_index for gold_index, _ in matches}
+    matched_pred = {pred_index for _, pred_index in matches}
+
+    for gold_index, pred_index in matches:
+        gold_required = required_ids(gold_topics[gold_index])
+        pred_required = required_ids(pred_topics[pred_index])
+        true_positive += len(gold_required & pred_required)
+        false_positive += len(pred_required - gold_required)
+        false_negative += len(gold_required - pred_required)
+
+    for pred_index, pred_topic in enumerate(pred_topics):
+        if pred_index not in matched_pred:
+            false_positive += len(required_ids(pred_topic))
+
+    for gold_index, gold_topic in enumerate(gold_topics):
+        if gold_index not in matched_gold:
+            false_negative += len(required_ids(gold_topic))
+
+    return {
+        "true_positive": true_positive,
+        "false_positive": false_positive,
+        "false_negative": false_negative,
+    }
+
+
+def safe_divide(numerator: int | float, denominator: int | float) -> float:
+    if denominator == 0:
+        return 1.0 if numerator == 0 else 0.0
+    return numerator / denominator
+
+
+def prf(counts: dict[str, int]) -> dict[str, float | int]:
+    tp = counts["true_positive"]
+    fp = counts["false_positive"]
+    fn = counts["false_negative"]
+    precision = safe_divide(tp, tp + fp)
+    recall = safe_divide(tp, tp + fn)
+    if tp == 0 and (fp > 0 or fn > 0):
+        f1 = 0.0
+    else:
+        f1 = safe_divide(2 * precision * recall, precision + recall)
+    return {
+        "true_positive": tp,
+        "false_positive": fp,
+        "false_negative": fn,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+    }
+
+
+def in_expected_topic_count_range(predicted_count: int, gold_case: dict[str, object]) -> bool:
+    expected = gold_case.get("expected_topic_count_range") or [
+        len(gold_case.get("gold_topics") or []),
+        len(gold_case.get("gold_topics") or []),
+    ]
+    if not isinstance(expected, list) or len(expected) != 2:
+        return False
+    return int(expected[0]) <= predicted_count <= int(expected[1])
+
+
+def fallback_matches(gold_case: dict[str, object], pred_output: dict[str, object]) -> bool:
+    gold_reasons = set(gold_case.get("allowed_fallback_reasons") or [])
+    pred_reasons = set(pred_output.get("allowed_fallback_reasons") or [])
+    if not gold_reasons and not pred_reasons:
+        return True
+    return bool(gold_reasons) == bool(pred_reasons) and pred_reasons <= gold_reasons
+
+
+def bridge_messages(topics: list[dict[str, object]]) -> set[str]:
+    counts: Counter[str] = Counter()
+    for topic in topics:
+        counts.update(required_ids(topic))
+    return {message_id for message_id, count in counts.items() if count > 1}
+
+
+def score_dataset(
+    gold_cases: list[dict[str, object]],
+    predictions: list[dict[str, object]],
+    *,
+    scoring_mode: str = STRICT_SCORING_MODE,
+    judge: object | None = None,
+    judge_remote_server_id: str = "",
+    judge_model_id: str = "",
+) -> dict[str, Any]:
+    if scoring_mode not in TOPIC_MEMBERSHIP_SCORING_MODES:
+        raise ValueError(f"unsupported topic membership scoring mode: {scoring_mode}")
+    semantic_runtime = (
+        _TopicSemanticJudgeRuntime(
+            judge=judge,
+            judge_remote_server_id=judge_remote_server_id,
+            judge_model_id=judge_model_id,
+        )
+        if scoring_mode == SEMANTIC_SCORING_MODE
+        else None
+    )
+    result = _score_dataset_core(gold_cases, predictions, semantic_runtime=semantic_runtime)
+    if semantic_runtime is not None:
+        result["semantic_judge"] = {
+            "judge_remote_server_id": semantic_runtime.judge_remote_server_id,
+            "judge_model_id": semantic_runtime.judge_model_id,
+            "judge_prompt_version": SEMANTIC_JUDGE_PROMPT_VERSION,
+            "judge_prompt_hash": SEMANTIC_JUDGE_PROMPT_HASH,
+            "calls": semantic_runtime.calls,
+            "cache_hits": semantic_runtime.cache_hits,
+            "failures": semantic_runtime.failures,
+        }
+        result["semantic_alignment_strategy"] = SEMANTIC_ALIGNMENT_STRATEGY
+    result["scoring_mode"] = scoring_mode
+    return result
+
+
+def _score_dataset_core(
+    gold_cases: list[dict[str, object]],
+    predictions: list[dict[str, object]],
+    *,
+    semantic_runtime: "_TopicSemanticJudgeRuntime | None",
+) -> dict[str, Any]:
+    predictions_by_id = prediction_by_dialogue_id(predictions)
+    total_counts = {"true_positive": 0, "false_positive": 0, "false_negative": 0}
+    semantic_total_counts = {"true_positive": 0, "false_positive": 0, "false_negative": 0}
+    valid_outputs = 0
+    topic_count_hits = 0
+    fallback_hits = 0
+    gold_fallback_cases = 0
+    cases_scored = 0
+    missing_predictions = 0
+    gold_bridge_total = 0
+    gold_bridge_recalled = 0
+    per_case: list[dict[str, object]] = []
+    row_audit: list[dict[str, object]] = []
+
+    for gold_case in gold_cases:
+        cases_scored += 1
+        dialogue_id = str(gold_case.get("source_dialogue_id") or "")
+        prediction = predictions_by_id.get(dialogue_id)
+        if not prediction:
+            missing_predictions += 1
+            pred_output: dict[str, object] = {"gold_topics": []}
+            valid = False
+            parse_status = "missing_prediction"
+        else:
+            pred_output, valid = normalize_output_json(prediction)
+            if pred_output is None:
+                pred_output = {"gold_topics": []}
+            parse_status = "ok" if valid else "parse_error"
+        if valid:
+            valid_outputs += 1
+
+        raw_gold_topics = gold_case.get("gold_topics") or []
+        gold_topics = raw_gold_topics if isinstance(raw_gold_topics, list) else []
+        raw_pred_topics = pred_output.get("gold_topics") or []
+        pred_topics = raw_pred_topics if isinstance(raw_pred_topics, list) else []
+        normalized_gold_topics = [topic for topic in gold_topics if isinstance(topic, dict)]
+        normalized_pred_topics = [topic for topic in pred_topics if isinstance(topic, dict)]
+
+        strict_matches = match_topics(normalized_gold_topics, normalized_pred_topics)
+        counts = membership_counts(normalized_gold_topics, normalized_pred_topics, strict_matches)
+        for key in total_counts:
+            total_counts[key] += counts[key]
+
+        semantic_matches: list[tuple[int, int]] | None = None
+        semantic_counts: dict[str, int] | None = None
+        semantic_alignment: dict[str, object] | None = None
+        if semantic_runtime is not None:
+            semantic_alignment = semantic_match_topics(
+                dialogue_id=dialogue_id,
+                messages=gold_case.get("messages") if isinstance(gold_case.get("messages"), list) else [],
+                gold_topics=normalized_gold_topics,
+                pred_topics=normalized_pred_topics,
+                strict_matches=strict_matches,
+                judge_runtime=semantic_runtime,
+            )
+            semantic_matches = [
+                (int(gold_index), int(pred_index))
+                for gold_index, pred_index in semantic_alignment.get("matches", [])
+                if isinstance(gold_index, int) and isinstance(pred_index, int)
+            ]
+            semantic_counts = membership_counts(normalized_gold_topics, normalized_pred_topics, semantic_matches)
+            for key in semantic_total_counts:
+                semantic_total_counts[key] += semantic_counts[key]
+
+        if in_expected_topic_count_range(len(normalized_pred_topics), gold_case):
+            topic_count_hits += 1
+
+        if gold_case.get("allowed_fallback_reasons"):
+            gold_fallback_cases += 1
+            if fallback_matches(gold_case, pred_output):
+                fallback_hits += 1
+
+        gold_bridges = bridge_messages(normalized_gold_topics)
+        pred_bridges = bridge_messages(normalized_pred_topics)
+        gold_bridge_total += len(gold_bridges)
+        gold_bridge_recalled += len(gold_bridges & pred_bridges)
+
+        per_case_row: dict[str, object] = {
+            "source_dialogue_id": dialogue_id,
+            "matches": len(strict_matches),
+            "gold_topics": len(normalized_gold_topics),
+            "predicted_topics": len(normalized_pred_topics),
+            "strict_membership": prf(counts),
+            "json_valid": valid,
+            "parse_status": parse_status,
+        }
+        if semantic_matches is not None and semantic_counts is not None:
+            per_case_row["semantic_matches"] = len(semantic_matches)
+            per_case_row["semantic_membership"] = prf(semantic_counts)
+            if semantic_alignment is not None:
+                per_case_row["semantic_alignment"] = {
+                    "candidate_count": len(semantic_alignment.get("candidate_scores", [])),
+                    "judge_candidate_count": len(
+                        [
+                            row
+                            for row in semantic_alignment.get("candidate_scores", [])
+                            if isinstance(row, dict) and row.get("source") == "judge"
+                        ]
+                    ),
+                }
+        per_case.append(per_case_row)
+        row_audit.append(
+            {
+                "source_dialogue_id": dialogue_id,
+                "status": "ok" if valid else parse_status,
+                "gold_topic_count": len(normalized_gold_topics),
+                "predicted_topic_count": len(normalized_pred_topics),
+                "strict_matches": [
+                    {
+                        "gold_topic_index": gold_index,
+                        "pred_topic_index": pred_index,
+                        "gold_topic_id": topic_id(normalized_gold_topics[gold_index], gold_index),
+                        "pred_topic_id": topic_id(normalized_pred_topics[pred_index], pred_index),
+                    }
+                    for gold_index, pred_index in strict_matches
+                ],
+                "strict_membership": prf(counts),
+                **(
+                    {
+                        "semantic_matches": [
+                            {
+                                "gold_topic_index": gold_index,
+                                "pred_topic_index": pred_index,
+                                "gold_topic_id": topic_id(normalized_gold_topics[gold_index], gold_index),
+                                "pred_topic_id": topic_id(normalized_pred_topics[pred_index], pred_index),
+                            }
+                            for gold_index, pred_index in (semantic_matches or [])
+                        ],
+                        "semantic_membership": prf(semantic_counts or {"true_positive": 0, "false_positive": 0, "false_negative": 0}),
+                    }
+                    if semantic_runtime is not None
+                    else {}
+                ),
+            }
+        )
+
+    result: dict[str, Any] = {
+        "cases": cases_scored,
+        "missing_predictions": missing_predictions,
+        "json_valid_rate": safe_divide(valid_outputs, cases_scored),
+        "topic_count_range_accuracy": safe_divide(topic_count_hits, cases_scored),
+        "fallback_accuracy": safe_divide(fallback_hits, gold_fallback_cases),
+        "gold_fallback_cases": gold_fallback_cases,
+        "strict_membership": prf(total_counts),
+        "bridge_message_recall": {
+            "gold_bridge_messages": gold_bridge_total,
+            "recalled_bridge_messages": gold_bridge_recalled,
+            "recall": safe_divide(gold_bridge_recalled, gold_bridge_total),
+        },
+        "per_case": per_case,
+        "row_audit": row_audit,
+    }
+    if semantic_runtime is not None:
+        result["semantic_membership"] = prf(semantic_total_counts)
+    return result
+
+
+def semantic_match_topics(
+    *,
+    dialogue_id: str,
+    messages: list[object],
+    gold_topics: list[dict[str, object]],
+    pred_topics: list[dict[str, object]],
+    strict_matches: list[tuple[int, int]],
+    judge_runtime: "_TopicSemanticJudgeRuntime",
+) -> dict[str, object]:
+    strict_pair_set = set(strict_matches)
+    candidate_scores: list[dict[str, object]] = []
+    candidates: list[tuple[int, float, int, int]] = []
+    for gold_index, pred_index in strict_matches:
+        score = jaccard(required_ids(gold_topics[gold_index]), required_ids(pred_topics[pred_index]))
+        candidates.append((1, score, gold_index, pred_index))
+        candidate_scores.append(
+            {
+                "gold_topic_index": gold_index,
+                "pred_topic_index": pred_index,
+                "score": score,
+                "accepted": True,
+                "source": "strict",
+                "reason_code": "strict_jaccard",
+            }
+        )
+
+    lexical_candidates = _lexical_candidate_pairs(
+        messages=messages,
+        gold_topics=gold_topics,
+        pred_topics=pred_topics,
+        strict_pair_set=strict_pair_set,
+    )
+    for lexical_score, gold_index, pred_index in lexical_candidates:
+        request = _semantic_topic_request(
+            dialogue_id=dialogue_id,
+            messages=messages,
+            gold_topic_index=gold_index,
+            pred_topic_index=pred_index,
+            gold_topic=gold_topics[gold_index],
+            pred_topic=pred_topics[pred_index],
+            lexical_similarity=lexical_score,
+        )
+        decision = judge_runtime.decide(request)
+        equivalent = bool(decision.get("equivalent", False))
+        confidence = float(decision.get("confidence", 0.0) or 0.0)
+        accepted = equivalent and confidence >= SEMANTIC_JUDGE_CONFIDENCE_THRESHOLD
+        if accepted:
+            candidates.append((0, confidence, gold_index, pred_index))
+        candidate_scores.append(
+            {
+                "gold_topic_index": gold_index,
+                "pred_topic_index": pred_index,
+                "score": confidence,
+                "lexical_similarity": lexical_score,
+                "accepted": accepted,
+                "source": "judge",
+                "reason_code": decision.get("reason_code", ""),
+                "equivalent": equivalent,
+                "short_reason": decision.get("short_reason", ""),
+            }
+        )
+
+    matches: list[tuple[int, int]] = []
+    used_gold: set[int] = set()
+    used_pred: set[int] = set()
+    for _rank, _score, gold_index, pred_index in sorted(candidates, reverse=True):
+        if gold_index in used_gold or pred_index in used_pred:
+            continue
+        matches.append((gold_index, pred_index))
+        used_gold.add(gold_index)
+        used_pred.add(pred_index)
+    return {
+        "matches": matches,
+        "candidate_scores": candidate_scores,
+    }
+
+
+def evaluate_topic_membership(
+    *,
+    gold_jsonl: Path,
+    pred_jsonl: Path,
+    summary_output: Path,
+    details_output: Path,
+    row_audit_output: Path | None = None,
+    judge_audit_output: Path | None = None,
+    scoring_mode: str = STRICT_SCORING_MODE,
+    judge: object | None = None,
+    judge_remote_server_id: str = "",
+    judge_model_id: str = "",
+) -> dict[str, object]:
+    result = score_dataset(
+        read_jsonl(gold_jsonl),
+        read_jsonl(pred_jsonl),
+        scoring_mode=scoring_mode,
+        judge=judge,
+        judge_remote_server_id=judge_remote_server_id,
+        judge_model_id=judge_model_id,
+    )
+    details = result.get("per_case")
+    if not isinstance(details, list):
+        details = []
+    row_audit = result.get("row_audit")
+    if not isinstance(row_audit, list):
+        row_audit = []
+    summary = dict(result)
+    summary.pop("per_case", None)
+    summary.pop("row_audit", None)
+
+    _write_json(summary_output, summary)
+    _write_jsonl(details_output, details)
+    if row_audit_output is not None:
+        _write_jsonl(row_audit_output, row_audit)
+    if judge_audit_output is not None:
+        audit_rows: list[dict[str, object]] = []
+        runtime = getattr(judge, "_topic_membership_runtime", None)
+        if isinstance(runtime, _TopicSemanticJudgeRuntime):
+            audit_rows = runtime.audit_rows
+        _write_jsonl(judge_audit_output, audit_rows)
+    return summary
+
+
+class _TopicSemanticJudgeRuntime:
+    def __init__(
+        self,
+        *,
+        judge: object,
+        judge_remote_server_id: str,
+        judge_model_id: str,
+    ) -> None:
+        if judge is None:
+            raise ValueError("topic_membership_semantic_micro_f1 requires a semantic judge")
+        self.judge = judge
+        self.judge_remote_server_id = judge_remote_server_id
+        self.judge_model_id = judge_model_id
+        self.calls = 0
+        self.cache_hits = 0
+        self.failures = 0
+        self.cache: dict[str, dict[str, object]] = {}
+        self.audit_rows: list[dict[str, object]] = []
+        try:
+            setattr(judge, "_topic_membership_runtime", self)
+        except Exception:
+            pass
+
+    def decide(self, request: dict[str, object]) -> dict[str, object]:
+        cache_key = _semantic_judge_cache_key(request)
+        if cache_key in self.cache:
+            self.cache_hits += 1
+            decision = dict(self.cache[cache_key])
+            self.audit_rows.append(
+                _semantic_judge_audit_row(
+                    request=request,
+                    decision=decision,
+                    cache_key=cache_key,
+                    source="cache",
+                    status="ok",
+                    error_code=None,
+                    failure_reason=None,
+                )
+            )
+            return decision
+
+        self.calls += 1
+        try:
+            raw_decision = getattr(self.judge, "judge_topic_equivalence")(request)
+            decision = _normalize_semantic_judge_decision(raw_decision)
+            self.cache[cache_key] = decision
+            self.audit_rows.append(
+                _semantic_judge_audit_row(
+                    request=request,
+                    decision=decision,
+                    cache_key=cache_key,
+                    source="judge",
+                    status="ok",
+                    error_code=None,
+                    failure_reason=None,
+                )
+            )
+            return decision
+        except Exception as exc:
+            self.failures += 1
+            failure_reason = _semantic_judge_failure_reason(exc)
+            decision = {
+                "equivalent": False,
+                "confidence": 0.0,
+                "reason_code": getattr(exc, "code", "judge_error"),
+                "short_reason": failure_reason,
+            }
+            self.audit_rows.append(
+                _semantic_judge_audit_row(
+                    request=request,
+                    decision=decision,
+                    cache_key=cache_key,
+                    source="judge",
+                    status="failed",
+                    error_code=str(getattr(exc, "code", "judge_error")),
+                    failure_reason=failure_reason,
+                )
+            )
+            return decision
+
+
+def _lexical_candidate_pairs(
+    *,
+    messages: list[object],
+    gold_topics: list[dict[str, object]],
+    pred_topics: list[dict[str, object]],
+    strict_pair_set: set[tuple[int, int]],
+) -> list[tuple[float, int, int]]:
+    pairs: list[tuple[float, int, int]] = []
+    for gold_index, gold_topic in enumerate(gold_topics):
+        scored: list[tuple[float, int]] = []
+        gold_text = _topic_similarity_text(gold_topic, messages)
+        for pred_index, pred_topic in enumerate(pred_topics):
+            if (gold_index, pred_index) in strict_pair_set:
+                continue
+            score = _lexical_similarity(gold_text, _topic_similarity_text(pred_topic, messages))
+            scored.append((score, pred_index))
+        for score, pred_index in sorted(scored, reverse=True)[:SEMANTIC_LEXICAL_TOP_K]:
+            if score <= 0.0:
+                continue
+            pairs.append((score, gold_index, pred_index))
+    return pairs
+
+
+def _topic_similarity_text(topic: dict[str, object], messages: list[object]) -> str:
+    parts = [
+        str(topic.get("label") or ""),
+        str(topic.get("description") or ""),
+        " ".join(sorted(required_ids(topic))),
+    ]
+    message_by_id = {
+        str(message.get("message_id") or ""): str(message.get("text") or "")
+        for message in messages
+        if isinstance(message, dict)
+    }
+    for message_id in sorted(required_ids(topic)):
+        text = message_by_id.get(message_id, "")
+        if text:
+            parts.append(text)
+    return " ".join(part for part in parts if part)
+
+
+def _lexical_similarity(left: str, right: str) -> float:
+    left_tokens = _token_set(left)
+    right_tokens = _token_set(right)
+    if not left_tokens or not right_tokens:
+        return 0.0
+    return len(left_tokens & right_tokens) / len(left_tokens | right_tokens)
+
+
+def _token_set(text: str) -> set[str]:
+    lowered = text.lower()
+    tokens = {match.group(0) for match in _TOKEN_PATTERN.finditer(lowered)}
+    for cjk_char in _CJK_PATTERN.findall(lowered):
+        tokens.add(cjk_char)
+    return {token for token in tokens if token}
+
+
+def _semantic_topic_request(
+    *,
+    dialogue_id: str,
+    messages: list[object],
+    gold_topic_index: int,
+    pred_topic_index: int,
+    gold_topic: dict[str, object],
+    pred_topic: dict[str, object],
+    lexical_similarity: float,
+) -> dict[str, object]:
+    return {
+        "kind": "topic",
+        "dialogue_id": dialogue_id,
+        "judge_prompt_version": SEMANTIC_JUDGE_PROMPT_VERSION,
+        "judge_prompt_hash": SEMANTIC_JUDGE_PROMPT_HASH,
+        "gold_topic_index": gold_topic_index,
+        "pred_topic_index": pred_topic_index,
+        "lexical_similarity": round(float(lexical_similarity), 6),
+        "gold_topic": _semantic_topic_payload(gold_topic, messages),
+        "pred_topic": _semantic_topic_payload(pred_topic, messages),
+    }
+
+
+def _semantic_topic_payload(topic: dict[str, object], messages: list[object]) -> dict[str, object]:
+    message_by_id = {
+        str(message.get("message_id") or ""): {
+            "message_id": str(message.get("message_id") or ""),
+            "sender": str(message.get("sender") or ""),
+            "text": str(message.get("text") or ""),
+        }
+        for message in messages
+        if isinstance(message, dict)
+    }
+    message_ids = sorted(required_ids(topic))
+    return {
+        "topic_id": str(topic.get("gold_topic_id") or topic.get("topic_id") or ""),
+        "label": str(topic.get("label") or ""),
+        "description": str(topic.get("description") or ""),
+        "required_message_ids": message_ids,
+        "message_snippets": [
+            message_by_id[message_id]
+            for message_id in message_ids
+            if message_id in message_by_id
+        ][:12],
+    }
+
+
+def _normalize_semantic_judge_decision(raw_decision: object) -> dict[str, object]:
+    if not isinstance(raw_decision, dict):
+        return {
+            "equivalent": False,
+            "confidence": 0.0,
+            "reason_code": "malformed_response",
+            "short_reason": "Judge response was not a JSON object.",
+        }
+    equivalent = raw_decision.get("equivalent")
+    if not isinstance(equivalent, bool):
+        return {
+            "equivalent": False,
+            "confidence": 0.0,
+            "reason_code": "malformed_response",
+            "short_reason": "Judge response did not contain a boolean equivalent field.",
+        }
+    confidence_value = raw_decision.get("confidence", 0.0)
+    confidence = 0.0
+    if not isinstance(confidence_value, bool) and isinstance(confidence_value, (int, float)):
+        confidence = max(0.0, min(1.0, float(confidence_value)))
+    reason_code = raw_decision.get("reason_code")
+    short_reason = raw_decision.get("short_reason")
+    if str(reason_code or "").strip() == "uncertain":
+        equivalent = False
+    return {
+        "equivalent": equivalent,
+        "confidence": round(confidence, 6),
+        "reason_code": str(reason_code or ("same_topic" if equivalent else "uncertain")).strip(),
+        "short_reason": str(short_reason or "").strip(),
+    }
+
+
+def _parse_semantic_judge_response(response_text: str) -> dict[str, object]:
+    try:
+        return _normalize_semantic_judge_decision(extract_topic_membership_output_json(response_text))
+    except Exception as exc:
+        return {
+            "equivalent": False,
+            "confidence": 0.0,
+            "reason_code": "malformed_response",
+            "short_reason": str(exc),
+        }
+
+
+def _semantic_judge_cache_key(request: dict[str, object]) -> str:
+    payload = {
+        "judge_prompt_hash": SEMANTIC_JUDGE_PROMPT_HASH,
+        "kind": request.get("kind", ""),
+        "gold_topic": request.get("gold_topic", {}),
+        "pred_topic": request.get("pred_topic", {}),
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"sha256:{sha256(encoded).hexdigest()}"
+
+
+def _semantic_judge_failure_reason(exc: Exception) -> str:
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int):
+        return f"remote provider HTTP {status_code}"
+    if isinstance(exc, RemoteProviderRequestError):
+        return "remote provider request failed"
+    first_line = str(exc).splitlines()[0].strip()
+    if not first_line:
+        return exc.__class__.__name__
+    return first_line[:240]
+
+
+def _semantic_judge_audit_row(
+    *,
+    request: dict[str, object],
+    decision: dict[str, object],
+    cache_key: str,
+    source: str,
+    status: str,
+    error_code: str | None,
+    failure_reason: str | None,
+) -> dict[str, object]:
+    return {
+        "dialogue_id": request.get("dialogue_id", ""),
+        "kind": request.get("kind", ""),
+        "judge_prompt_version": SEMANTIC_JUDGE_PROMPT_VERSION,
+        "judge_prompt_hash": SEMANTIC_JUDGE_PROMPT_HASH,
+        "cache_key": cache_key,
+        "source": source,
+        "status": status,
+        "error_code": error_code,
+        "failure_reason": failure_reason,
+        "gold_topic_index": request.get("gold_topic_index"),
+        "pred_topic_index": request.get("pred_topic_index"),
+        "equivalent": bool(decision.get("equivalent", False)),
+        "confidence": float(decision.get("confidence", 0.0) or 0.0),
+        "reason_code": decision.get("reason_code", ""),
+        "short_reason": decision.get("short_reason", ""),
+    }
+
+
+def _assistant_content(response: dict[str, object]) -> str:
+    choices = response.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("remote provider response did not include choices")
+    first = choices[0]
+    if not isinstance(first, dict):
+        raise ValueError("remote provider choice must be a JSON object")
+    message = first.get("message")
+    if isinstance(message, dict):
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+    text = first.get("text")
+    if isinstance(text, str):
+        return text
+    raise ValueError("remote provider choice did not include text content")
+
+
+def _gemini_content(response: dict[str, object]) -> str:
+    candidates = response.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise ValueError("remote provider response did not include candidates")
+    first = candidates[0]
+    if not isinstance(first, dict):
+        raise ValueError("remote provider candidate must be a JSON object")
+    content = first.get("content")
+    if not isinstance(content, dict):
+        raise ValueError("remote provider candidate did not include content")
+    parts = content.get("parts")
+    if not isinstance(parts, list):
+        raise ValueError("remote provider candidate content did not include parts")
+    text_parts: list[str] = []
+    for part in parts:
+        if isinstance(part, dict) and isinstance(part.get("text"), str):
+            text_parts.append(part["text"])
+    if not text_parts:
+        raise ValueError("remote provider candidate parts did not include text")
+    return "".join(text_parts)
+
+
+def _openai_provider_usage(response: dict[str, object]) -> dict[str, int]:
+    usage = response.get("usage")
+    if not isinstance(usage, dict):
+        return {}
+    return _provider_usage_from_keys(
+        usage,
+        (
+            ("prompt_tokens", "prompt_tokens"),
+            ("completion_tokens", "completion_tokens"),
+            ("total_tokens", "total_tokens"),
+        ),
+    )
+
+
+def _gemini_provider_usage(response: dict[str, object]) -> dict[str, int]:
+    usage = response.get("usageMetadata")
+    if not isinstance(usage, dict):
+        return {}
+    return _provider_usage_from_keys(
+        usage,
+        (
+            ("promptTokenCount", "prompt_tokens"),
+            ("candidatesTokenCount", "completion_tokens"),
+            ("totalTokenCount", "total_tokens"),
+        ),
+    )
+
+
+def _provider_usage_from_keys(
+    usage: dict[object, object],
+    key_map: Sequence[tuple[str, str]],
+) -> dict[str, int]:
+    normalized: dict[str, int] = {}
+    for source_key, target_key in key_map:
+        value = usage.get(source_key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            normalized[target_key] = value
+        elif isinstance(value, float) and value.is_integer():
+            normalized[target_key] = int(value)
+    return normalized
+
+
+def _gemini_model_path(model_id: str) -> str:
+    stripped = model_id.strip()
+    if not stripped:
+        raise ValueError("remote provider model_id is empty")
+    if stripped.startswith("models/"):
+        return stripped
+    return f"models/{stripped}"
+
+
+def _post_json_request(request: Request, *, timeout_seconds: int) -> dict[str, object]:
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            response_body = response.read().decode("utf-8")
+    except HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="replace")
+        raise RemoteProviderHTTPError(status_code=exc.code, response_body=error_body) from exc
+    except URLError as exc:
+        raise RemoteProviderRequestError(reason=exc.reason) from exc
+
+    parsed = json.loads(response_body)
+    if not isinstance(parsed, dict):
+        raise ValueError("remote provider response must be a JSON object")
+    return parsed
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path | None, rows: Iterable[dict[str, object]]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")

--- a/services/mlx-worker-python/worker/productization/topic_membership_runner.py
+++ b/services/mlx-worker-python/worker/productization/topic_membership_runner.py
@@ -1,0 +1,1268 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+import logging
+from pathlib import Path
+import re
+import time
+from typing import Any
+
+from packages.protocol.python.worker.v1 import common_pb2
+from worker.productization.benchmark_queue import BenchmarkQueueRecord
+from worker.productization.evaluation_compare import (
+    _DEFAULT_COMPARE_BOOTSTRAP_ITERATIONS,
+    _DEFAULT_COMPARE_BOOTSTRAP_SEED,
+    _DEFAULT_COMPARE_CONFIDENCE_LEVEL,
+    _DEFAULT_COMPARE_EFFECT_THRESHOLD,
+    AdapterTargetSpec,
+    build_compare_samples,
+    load_adapter_target_spec,
+    parse_compare_target_adapter_manifest_paths,
+    parse_compare_target_model_ids,
+    resolve_compare_target_adapters,
+    resolve_compare_target_models,
+)
+from worker.productization.evaluation_schemas import (
+    EvaluationCompareJob,
+    EvaluationCompareSample,
+    EvaluationCompareSummary,
+    EvaluationCompareTargetLineage,
+    EvaluationJob,
+    EvaluationResult,
+    EvaluationSample,
+    build_evaluation_compare_job_record,
+    build_evaluation_compare_summary_record,
+    build_evaluation_job_record,
+    build_evaluation_result_record,
+    build_evaluation_sample_record,
+)
+from worker.productization.statistical_evidence import (
+    build_paired_statistical_evidence,
+    classify_release_verdict,
+)
+from worker.productization.topic_membership import (
+    SEMANTIC_JUDGE_PROMPT_HASH as TOPIC_SEMANTIC_JUDGE_PROMPT_HASH,
+    SEMANTIC_SCORING_MODE as TOPIC_SEMANTIC_SCORING_MODE,
+    STRICT_SCORING_MODE as TOPIC_STRICT_SCORING_MODE,
+    TOPIC_MEMBERSHIP_PROMPT_ID,
+    TOPIC_MEMBERSHIP_SCORING_MODES,
+    TOPIC_MEMBERSHIP_SUITE_ID,
+    RemoteTopicMembershipTarget,
+    TopicMembershipClientResult,
+    TopicMembershipPromptSpec,
+    evaluate_topic_membership,
+    extract_topic_membership_output_json,
+    input_payload as topic_membership_input_payload,
+    make_topic_membership_client,
+    make_topic_membership_semantic_judge_client,
+    prompt_snapshot_payload as topic_membership_prompt_snapshot_payload,
+    topic_membership_chat_messages,
+    topic_prompt_content_hash,
+)
+
+
+_logger = logging.getLogger(__name__)
+
+
+def _sha256_file(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+    digest = sha256()
+    with Path(path).open("rb") as handle:
+        while chunk := handle.read(chunk_size):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class TopicMembershipRun:
+    job: EvaluationJob | EvaluationCompareJob
+    results: tuple[EvaluationResult | EvaluationCompareSummary, ...]
+    samples: tuple[EvaluationSample | EvaluationCompareSample, ...]
+    persisted_paths: dict[str, Path]
+
+    @property
+    def result(self) -> EvaluationResult | EvaluationCompareSummary:
+        return self.results[0]
+
+
+def _round_ms(value: float) -> float:
+    return round(float(value), 3)
+
+
+class _LocalTopicMembershipResponseParseError(ValueError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        raw_response: str,
+        request_body_bytes: int,
+        response_body_bytes: int,
+    ) -> None:
+        super().__init__(message)
+        self.raw_response = raw_response
+        self.request_body_bytes = request_body_bytes
+        self.response_body_bytes = response_body_bytes
+
+
+class _LocalTopicMembershipClient:
+    def __init__(
+        self,
+        *,
+        registry,
+        loaded_model,
+        prompt_spec: TopicMembershipPromptSpec,
+        max_output_tokens: int,
+        seed: int,
+    ) -> None:
+        self._registry = registry
+        self._loaded_model = loaded_model
+        self._prompt_spec = prompt_spec
+        self._max_output_tokens = max_output_tokens
+        self._seed = seed
+
+    def generate_membership(self, gold_case: dict[str, Any]) -> TopicMembershipClientResult:
+        dialogue_id = str(gold_case.get("source_dialogue_id") or "")
+        messages = topic_membership_chat_messages(self._prompt_spec, gold_case)
+        request_body_bytes = len(
+            json.dumps({"messages": messages}, ensure_ascii=False, sort_keys=True).encode("utf-8")
+        )
+        chat_messages = [
+            common_pb2.ChatMessage(
+                role=str(message.get("role") or "user"),
+                parts=[common_pb2.MessagePart(text=str(message.get("content") or ""))],
+            )
+            for message in messages
+        ]
+        request_id = f"topic-membership:local:{dialogue_id or 'sample'}:{time.time_ns()}"
+        runtime = self._registry.runtime_for_loaded_model(self._loaded_model)
+        state = self._registry.start_request(
+            request_id,
+            runtime_kind=str(getattr(self._loaded_model, "runtime_kind", "") or "text"),
+        )
+        chunks: list[str] = []
+        try:
+            rendered_prompt = runtime.render_prompt(
+                chat_messages,
+                loaded_model=self._loaded_model.runtime_model,
+                template_kwargs={"enable_thinking": False},
+                execution_ext={},
+            )
+            sampling = common_pb2.SamplingConfig(
+                temperature=0.0,
+                top_p=1.0,
+                top_k=1,
+                seed=max(self._seed, 0),
+                max_output_tokens=self._max_output_tokens,
+            )
+            for runtime_event in runtime.generate_tokens(
+                self._loaded_model.runtime_model,
+                rendered_prompt,
+                sampling,
+                state.cancel_event,
+                execution_ext={},
+            ):
+                text = getattr(runtime_event, "text", "")
+                if text:
+                    chunks.append(str(text))
+        finally:
+            runtime_kind = str(getattr(self._loaded_model, "runtime_kind", "") or "")
+            if runtime_kind in {"ocr", "vlm"} and hasattr(runtime, "last_probe_snapshot"):
+                self._registry.record_vision_probe(runtime_kind, runtime.last_probe_snapshot())
+            self._registry.finish_request(request_id)
+        raw_response = "".join(chunks).strip()
+        response_body_bytes = len(raw_response.encode("utf-8"))
+        try:
+            output_json = extract_topic_membership_output_json(raw_response)
+        except Exception as exc:  # noqa: BLE001
+            raise _LocalTopicMembershipResponseParseError(
+                str(exc),
+                raw_response=raw_response,
+                request_body_bytes=request_body_bytes,
+                response_body_bytes=response_body_bytes,
+            ) from exc
+        return TopicMembershipClientResult(
+            output_json=output_json,
+            raw_response=raw_response,
+            request_body_bytes=request_body_bytes,
+            response_body_bytes=response_body_bytes,
+        )
+
+
+
+def run_topic_membership_entrypoint(
+    *,
+    core: Any,
+    model_id: str,
+    model_handle: str | None,
+    suite_id: str,
+    sample_size: int,
+    scoring_mode: str | None,
+    parameters: dict[str, str],
+    remote_target: Any | None,
+) -> TopicMembershipRun:
+    requested_scoring_mode = scoring_mode or parameters.get("scoring_mode", "")
+    loaded_model = core._loaded_model_for_execution(model_handle)
+    resolved_scoring_mode = requested_scoring_mode or TOPIC_STRICT_SCORING_MODE
+    resolved_suite_id = suite_id or TOPIC_MEMBERSHIP_SUITE_ID
+    runner = TopicMembershipEvaluationRunner(core)
+    if str(parameters.get("compare_mode", "")).strip():
+        return runner._run_topic_membership_compare_suite(
+            model_id=model_id,
+            suite_id=resolved_suite_id,
+            dataset_id=parameters.get("dataset_id", ""),
+            sample_size=sample_size,
+            scoring_mode=resolved_scoring_mode,
+            parameters=dict(parameters),
+            loaded_model=loaded_model,
+        )
+    return runner._run_topic_membership_suite(
+        model_id=model_id,
+        suite_id=resolved_suite_id,
+        dataset_id=parameters.get("dataset_id", ""),
+        sample_size=sample_size,
+        scoring_mode=resolved_scoring_mode,
+        parameters=dict(parameters),
+        remote_target=remote_target,
+        loaded_model=loaded_model,
+    )
+
+
+class TopicMembershipEvaluationRunner:
+    def __init__(self, core: Any) -> None:
+        self._core = core
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._core, name)
+
+    def _run_topic_membership_suite(
+        self,
+        *,
+        model_id: str,
+        suite_id: str,
+        dataset_id: str,
+        sample_size: int,
+        scoring_mode: str,
+        parameters: dict[str, str],
+        remote_target: Any | None,
+        loaded_model: Any | None = None,
+    ) -> TopicMembershipRun:
+        source_jsonl = parameters.get("topic_membership_source_jsonl") or parameters.get(
+            "evaluation_source_locator",
+            "",
+        )
+        if not source_jsonl:
+            raise ValueError("topic_membership scoring requires a local JSONL source.")
+        resolved_scoring_mode = scoring_mode or TOPIC_STRICT_SCORING_MODE
+        if resolved_scoring_mode not in TOPIC_MEMBERSHIP_SCORING_MODES:
+            raise ValueError(f"unsupported topic membership scoring mode: {resolved_scoring_mode}")
+        uses_remote_target = remote_target is not None and bool(getattr(remote_target, "api_key", ""))
+        if not uses_remote_target and (loaded_model is None or self._registry is None):
+            raise ValueError("topic_membership scoring requires a remote provider target or a loaded local model.")
+
+        semantic_judge_target = self._semantic_judge_target(parameters)
+        if resolved_scoring_mode == TOPIC_SEMANTIC_SCORING_MODE and semantic_judge_target is None:
+            raise ValueError("topic_membership_semantic_micro_f1 requires a semantic judge remote target.")
+
+        created_at_unix_ms = int(time.time() * 1000)
+        job_id = self._next_job_id()
+        output_root = (
+            self._jobs_root / "topic-membership" / job_id
+            if self._jobs_root is not None
+            else Path.cwd() / "topic-membership" / job_id
+        )
+        resolved_model_id = (
+            str(getattr(getattr(loaded_model, "spec", None), "model_id", "") or "")
+            if loaded_model is not None
+            else ""
+        ) or str(getattr(remote_target, "model_id", "") or model_id)
+        safe_model_name = re.sub(r"[^A-Za-z0-9._-]+", "_", resolved_model_id).strip("_") or "topic-model"
+        predictions_dir = output_root / "predictions"
+        reports_dir = output_root / "reports" / safe_model_name
+        raw_response_dir = output_root / "raw-responses" / safe_model_name
+        predictions_dir.mkdir(parents=True, exist_ok=True)
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        raw_response_dir.mkdir(parents=True, exist_ok=True)
+        prediction_path = predictions_dir / f"{safe_model_name}.jsonl"
+        failure_path = predictions_dir / f"{safe_model_name}.failures.jsonl"
+        gold_subset_path = output_root / "gold_subset.jsonl"
+        summary_path = reports_dir / "topic_membership_summary.json"
+        details_path = reports_dir / "topic_membership_details.jsonl"
+        trace_path = reports_dir / "topic_membership_dialogue_traces.jsonl"
+        row_audit_path = reports_dir / "topic_membership_row_audit.jsonl"
+        judge_audit_path = reports_dir / "topic_membership_judge_audit.jsonl"
+        prompt_snapshot_path = output_root / "prompt_snapshot.json"
+
+        rows = self._read_topic_membership_rows(Path(source_jsonl), sample_size=sample_size)
+        self._write_jsonl_rows(gold_subset_path, rows)
+        prompt_spec = self._topic_membership_prompt_spec(parameters)
+        prompt_snapshot = topic_membership_prompt_snapshot_payload(prompt_spec)
+        prompt_snapshot_path.write_text(
+            json.dumps(prompt_snapshot, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        runtime_evidence = self._core._runtime_evidence_for_loaded_model(loaded_model)
+        if self._core._truthy_parameter(parameters, "require_live_model"):
+            self._core._validate_required_live_model(runtime_evidence, operation="topic membership evaluation")
+        if uses_remote_target:
+            client = make_topic_membership_client(
+                RemoteTopicMembershipTarget(
+                    provider_kind=str(getattr(remote_target, "provider_kind", "")),
+                    base_url=str(getattr(remote_target, "base_url", "")),
+                    api_key=str(getattr(remote_target, "api_key", "")),
+                    model_id=resolved_model_id,
+                    timeout_seconds=int(getattr(remote_target, "timeout_seconds", 0) or 60),
+                    extra_body=self._remote_provider_extra_body(parameters),
+                ),
+                prompt_spec,
+            )
+            rate_limit_per_minute = int(getattr(remote_target, "rate_limit_per_minute", 0) or 0)
+        else:
+            client = _LocalTopicMembershipClient(
+                registry=self._registry,
+                loaded_model=loaded_model,
+                prompt_spec=prompt_spec,
+                max_output_tokens=int(parameters.get("topic_membership_max_output_tokens") or 4096),
+                seed=int(parameters.get("seed") or 0),
+            )
+            rate_limit_per_minute = 0
+
+        min_interval_seconds = 60.0 / rate_limit_per_minute if rate_limit_per_minute > 0 else 0.0
+        last_request_started = 0.0
+        prediction_rows: list[dict[str, object]] = []
+        failures: list[dict[str, object]] = []
+        dialogue_traces: list[dict[str, object]] = []
+        started_at = time.perf_counter()
+
+        for line_number, row in enumerate(rows, start=1):
+            row_started_at = time.perf_counter()
+            dialogue_id = str(row.get("source_dialogue_id") or "")
+            throttle_sleep_ms = 0.0
+            if min_interval_seconds > 0 and last_request_started > 0:
+                elapsed = time.perf_counter() - last_request_started
+                if elapsed < min_interval_seconds:
+                    sleep_seconds = min_interval_seconds - elapsed
+                    time.sleep(sleep_seconds)
+                    throttle_sleep_ms = self._round_ms(sleep_seconds * 1_000.0)
+            last_request_started = time.perf_counter()
+            request_started_at = last_request_started
+            request_duration_ms = 0.0
+            raw_response = ""
+            raw_response_path: Path | None = None
+            try:
+                client_result = client.generate_membership(row)
+                request_duration_ms = self._round_ms((time.perf_counter() - request_started_at) * 1_000.0)
+                output_json, raw_response = client_result
+                raw_response_path = raw_response_dir / f"{line_number:04d}-{self._safe_path_component(dialogue_id)}.txt"
+                raw_response_path.write_text(raw_response, encoding="utf-8")
+                prediction_rows.append(
+                    {
+                        "source_dialogue_id": dialogue_id,
+                        "custom_id": dialogue_id,
+                        "status": "ok",
+                        "model": resolved_model_id,
+                        "prompt_sha256": prompt_spec.content_hash.removeprefix("sha256:"),
+                        "elapsed_seconds": round((time.perf_counter() - row_started_at), 6),
+                        "raw_text": raw_response,
+                        "output_json": output_json,
+                    }
+                )
+                dialogue_traces.append(
+                    self._topic_membership_dialogue_trace(
+                        dialogue_id=dialogue_id,
+                        line_number=line_number,
+                        status="ok",
+                        row_started_at=row_started_at,
+                        throttle_sleep_ms=throttle_sleep_ms,
+                        request_duration_ms=request_duration_ms,
+                        messages=row.get("messages") if isinstance(row.get("messages"), list) else [],
+                        request_body_bytes=self._client_result_int(client_result, "request_body_bytes"),
+                        response_body_bytes=self._client_result_int(client_result, "response_body_bytes"),
+                        raw_response=raw_response,
+                        raw_response_path=raw_response_path,
+                        predicted_topic_count=self._topic_count_from_output(output_json),
+                        error_code=None,
+                        failure_reason=None,
+                        provider_usage=self._client_result_provider_usage(client_result),
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001
+                request_duration_ms = self._round_ms((time.perf_counter() - request_started_at) * 1_000.0)
+                raw_response = str(getattr(exc, "raw_response", "") or "")
+                if raw_response:
+                    raw_response_path = raw_response_dir / f"{line_number:04d}-{self._safe_path_component(dialogue_id)}.txt"
+                    raw_response_path.write_text(raw_response, encoding="utf-8")
+                status = "parse_error" if isinstance(exc, _LocalTopicMembershipResponseParseError) else "error"
+                provider_error_code = self._event_extraction_provider_error_code(exc)
+                prediction_row = {
+                    "source_dialogue_id": dialogue_id,
+                    "custom_id": dialogue_id,
+                    "status": status,
+                    "model": resolved_model_id,
+                    "prompt_sha256": prompt_spec.content_hash.removeprefix("sha256:"),
+                    "elapsed_seconds": round((time.perf_counter() - row_started_at), 6),
+                    "raw_text": raw_response,
+                    "error": str(exc),
+                }
+                prediction_rows.append(prediction_row)
+                failure_record = {
+                    "source_dialogue_id": dialogue_id,
+                    "line_number": line_number,
+                    "reason": str(exc),
+                }
+                if provider_error_code:
+                    failure_record["code"] = provider_error_code
+                if raw_response_path is not None:
+                    failure_record["raw_response_path"] = str(raw_response_path)
+                failures.append(failure_record)
+                dialogue_traces.append(
+                    self._topic_membership_dialogue_trace(
+                        dialogue_id=dialogue_id,
+                        line_number=line_number,
+                        status=status,
+                        row_started_at=row_started_at,
+                        throttle_sleep_ms=throttle_sleep_ms,
+                        request_duration_ms=request_duration_ms,
+                        messages=row.get("messages") if isinstance(row.get("messages"), list) else [],
+                        request_body_bytes=self._client_result_int(exc, "request_body_bytes"),
+                        response_body_bytes=self._client_result_int(exc, "response_body_bytes"),
+                        raw_response=raw_response,
+                        raw_response_path=raw_response_path,
+                        predicted_topic_count=0,
+                        error_code=provider_error_code or status,
+                        failure_reason=str(exc),
+                        provider_usage={},
+                    )
+                )
+
+        self._write_jsonl_rows(trace_path, dialogue_traces)
+        self._write_jsonl_rows(prediction_path, prediction_rows)
+        self._write_jsonl_rows(failure_path, failures)
+
+        judge = None
+        if resolved_scoring_mode == TOPIC_SEMANTIC_SCORING_MODE and semantic_judge_target is not None:
+            judge = make_topic_membership_semantic_judge_client(semantic_judge_target)
+        summary = evaluate_topic_membership(
+            gold_jsonl=gold_subset_path,
+            pred_jsonl=prediction_path,
+            summary_output=summary_path,
+            details_output=details_path,
+            row_audit_output=row_audit_path,
+            judge_audit_output=judge_audit_path if resolved_scoring_mode == TOPIC_SEMANTIC_SCORING_MODE else None,
+            scoring_mode=resolved_scoring_mode,
+            judge=judge,
+            judge_remote_server_id=str(parameters.get("semantic_judge_remote_server_id") or "").strip(),
+            judge_model_id=str(getattr(semantic_judge_target, "model_id", "") or ""),
+        )
+        summary["dialogue_diagnostics"] = self._topic_membership_dialogue_diagnostics(dialogue_traces)
+        summary_path.write_text(
+            json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        duration_seconds = round(time.perf_counter() - started_at, 6)
+
+        strict_membership = summary.get("strict_membership", {})
+        if not isinstance(strict_membership, dict):
+            strict_membership = {}
+        semantic_membership = summary.get("semantic_membership", {})
+        if not isinstance(semantic_membership, dict):
+            semantic_membership = {}
+        primary_score_name = (
+            "semantic_membership_f1"
+            if resolved_scoring_mode == TOPIC_SEMANTIC_SCORING_MODE
+            else "strict_membership_f1"
+        )
+        primary_score_value = float(
+            semantic_membership.get("f1", 0.0)
+            if resolved_scoring_mode == TOPIC_SEMANTIC_SCORING_MODE
+            else strict_membership.get("f1", 0.0)
+        )
+        cases = int(summary.get("cases", len(rows)) or len(rows))
+        extraction_success_count = sum(1 for row in prediction_rows if row.get("status") == "ok")
+
+        job_parameters = dict(parameters)
+        job_parameters.pop("api_key", None)
+        job_parameters.pop("remote_api_key", None)
+        job_parameters.pop("eval_prompt_system_prompt", None)
+        job_parameters.pop("semantic_judge_api_key", None)
+        job_parameters.pop("semantic_judge_base_url", None)
+        job_parameters.pop("evaluation_hints_text", None)
+        resolved_dataset_id = dataset_id or parameters.get("dataset_id") or "topic-membership"
+        job_parameters["dataset_root"] = str(Path(source_jsonl).resolve())
+        job_parameters["topic_membership_source_jsonl"] = str(Path(source_jsonl).resolve())
+        job_parameters["source_sha256"] = _sha256_file(Path(source_jsonl))
+        job_parameters["prediction_jsonl"] = str(prediction_path)
+        job_parameters["failure_jsonl"] = str(failure_path)
+        job_parameters["topic_membership_summary"] = str(summary_path)
+        job_parameters["topic_membership_details"] = str(details_path)
+        job_parameters["topic_membership_dialogue_traces"] = str(trace_path)
+        job_parameters["topic_membership_row_audit"] = str(row_audit_path)
+        if resolved_scoring_mode == TOPIC_SEMANTIC_SCORING_MODE:
+            job_parameters["topic_membership_judge_audit"] = str(judge_audit_path)
+            job_parameters["semantic_judge_remote_server_id"] = str(
+                parameters.get("semantic_judge_remote_server_id") or ""
+            ).strip()
+            job_parameters["semantic_judge_model_id"] = str(getattr(semantic_judge_target, "model_id", "") or "")
+            job_parameters["semantic_judge_prompt_hash"] = TOPIC_SEMANTIC_JUDGE_PROMPT_HASH
+        job_parameters["prompt_snapshot"] = str(prompt_snapshot_path)
+        job_parameters["prompt_id"] = prompt_spec.prompt_id
+        job_parameters["prompt_revision_id"] = prompt_spec.revision_id
+        job_parameters["prompt_content_hash"] = prompt_spec.content_hash
+        job_parameters["effective_scoring_mode"] = resolved_scoring_mode
+        job_parameters["scoring_mode"] = resolved_scoring_mode
+        job_parameters["contamination_policy"] = "heldout_clean_track"
+        job_parameters["clean_track"] = "true"
+        job_parameters["training_use_forbidden"] = "true"
+        job_parameters.update(runtime_evidence)
+        job_parameters.setdefault("remote_model_id", resolved_model_id)
+
+        result_metrics, result_units = self._topic_membership_result_metrics(
+            suite_id=suite_id,
+            summary=summary,
+            duration_seconds=duration_seconds,
+        )
+        result_metrics[f"eval.{suite_id}.duration_seconds"] = duration_seconds
+        result_units[f"eval.{suite_id}.duration_seconds"] = "s"
+
+        job = build_evaluation_job_record(
+            job_id=job_id,
+            model_id=resolved_model_id,
+            task_kind="text-generation",
+            source_repo=job_parameters.get("source_repo", ""),
+            suite_id=suite_id,
+            dataset_id=resolved_dataset_id,
+            sample_size=len(rows),
+            scoring_mode=resolved_scoring_mode,
+            parameters=job_parameters,
+            status="completed",
+            output_dir=str(output_root),
+            created_at_unix_ms=created_at_unix_ms,
+            updated_at_unix_ms=created_at_unix_ms,
+        )
+        result = build_evaluation_result_record(
+            job_id=job.job_id,
+            suite_id=suite_id,
+            dataset_id=resolved_dataset_id,
+            sample_size=len(rows),
+            primary_score_name=primary_score_name,
+            primary_score_value=primary_score_value,
+            extraction_success_count=extraction_success_count,
+            validation_success_count=extraction_success_count,
+            scored_sample_count=cases,
+            failure_count=max(cases - extraction_success_count, 0),
+            duration_seconds=duration_seconds,
+            metrics=result_metrics,
+            report_path=str(summary_path),
+            units=result_units,
+        )
+        sample_records = self._topic_membership_sample_records(
+            job_id=job.job_id,
+            suite_id=suite_id,
+            dataset_id=resolved_dataset_id,
+            rows=rows,
+            prediction_rows=prediction_rows,
+            dialogue_traces=dialogue_traces,
+            details_path=details_path,
+            prompt_spec=prompt_spec,
+            scoring_mode=resolved_scoring_mode,
+        )
+        persisted_paths: dict[str, Path] = {}
+        if self._jobs_root is not None:
+            queue_root = self._jobs_root / "queue"
+            self._queue_store.enqueue(
+                queue_root=queue_root,
+                record=BenchmarkQueueRecord(
+                    queue_item_id=job.job_id,
+                    job_kind="evaluation",
+                    model_id=resolved_model_id,
+                    suite_ids=(suite_id,),
+                    parameters=job_parameters,
+                    status="queued",
+                    created_at_unix_ms=created_at_unix_ms,
+                    updated_at_unix_ms=created_at_unix_ms,
+                ),
+            )
+            self._queue_store.transition(
+                queue_root=queue_root,
+                queue_item_id=job.job_id,
+                status="running",
+                updated_at_unix_ms=created_at_unix_ms + 1,
+            )
+            persisted_paths = self._store.persist_result(
+                jobs_root=self._jobs_root,
+                job=job,
+                result=result,
+                samples=sample_records,
+                model_memory_summary=self._model_memory_summary(loaded_model=loaded_model),
+            )
+            self._queue_store.transition(
+                queue_root=queue_root,
+                queue_item_id=job.job_id,
+                status="completed",
+                updated_at_unix_ms=int(time.time() * 1000),
+            )
+        return TopicMembershipRun(job=job, results=(result,), samples=sample_records, persisted_paths=persisted_paths)
+
+    def _run_topic_membership_compare_suite(
+        self,
+        *,
+        model_id: str,
+        suite_id: str,
+        dataset_id: str,
+        sample_size: int,
+        scoring_mode: str,
+        parameters: dict[str, str],
+        loaded_model: Any | None = None,
+    ) -> TopicMembershipRun:
+        if loaded_model is None or self._registry is None:
+            raise ValueError("topic membership compare requires a loaded local base model.")
+        target_model_ids = parse_compare_target_model_ids(parameters)
+        adapter_manifest_paths = parse_compare_target_adapter_manifest_paths(parameters)
+        if not target_model_ids and not adapter_manifest_paths:
+            raise ValueError(
+                "evaluation compare requires at least one target - pass "
+                "compare_target_model_ids and/or compare_target_adapter_manifest_paths."
+            )
+
+        created_at_unix_ms = int(time.time() * 1000)
+        job_id = self._next_job_id()
+        run_root = self._run_root(job_id)
+        adapter_target_specs: tuple[AdapterTargetSpec, ...] = tuple(
+            load_adapter_target_spec(manifest_path=path, job_id=job_id)
+            for path in adapter_manifest_paths
+        )
+        registered_targets = resolve_compare_target_models(
+            registry=self._registry,
+            target_model_ids=target_model_ids,
+        )
+        ephemeral_targets, ephemeral_unload_handles = resolve_compare_target_adapters(
+            registry=self._registry,
+            adapter_target_specs=adapter_target_specs,
+        )
+        compare_parameters = dict(parameters)
+        single_run_parameters = {
+            key: value
+            for key, value in parameters.items()
+            if key
+            not in {
+                "compare_mode",
+                "compare_target_model_ids",
+                "compare_target_adapter_manifest_paths",
+            }
+        }
+        try:
+            base_run = self._run_topic_membership_suite(
+                model_id=model_id,
+                suite_id=suite_id,
+                dataset_id=dataset_id,
+                sample_size=sample_size,
+                scoring_mode=scoring_mode,
+                parameters=single_run_parameters,
+                remote_target=None,
+                loaded_model=loaded_model,
+            )
+            resolved_model_id = str(getattr(base_run.job, "model_id", "") or model_id)
+            target_models: dict[str, Any] = {**registered_targets, **ephemeral_targets}
+            combined_target_ids: tuple[str, ...] = (
+                tuple(tid for tid in target_model_ids if tid in registered_targets)
+                + tuple(spec.ephemeral_derived_model_id for spec in adapter_target_specs)
+            )
+            compare_samples: list[EvaluationCompareSample] = []
+            compare_summaries: list[EvaluationCompareSummary] = []
+            threshold = self._resolve_float_parameter(
+                parameters=parameters,
+                key="threshold",
+                default_value=0.5,
+            )
+            report_path = run_root / "evaluation-compare-report.md"
+            compare_dataset_id = str(getattr(base_run.job, "dataset_id", "") or dataset_id or "topic-membership")
+            for target_model_id in combined_target_ids:
+                started_at = time.perf_counter()
+                target_run = self._run_topic_membership_suite(
+                    model_id=target_model_id,
+                    suite_id=suite_id,
+                    dataset_id=dataset_id,
+                    sample_size=sample_size,
+                    scoring_mode=scoring_mode,
+                    parameters=single_run_parameters,
+                    remote_target=None,
+                    loaded_model=target_models[target_model_id],
+                )
+                target_compare_samples = build_compare_samples(
+                    job_id=job_id,
+                    suite_id=suite_id,
+                    dataset_id=compare_dataset_id,
+                    target_model_id=target_model_id,
+                    threshold=threshold,
+                    base_samples=base_run.samples,
+                    target_samples=target_run.samples,
+                )
+                compare_samples.extend(target_compare_samples)
+                compare_summaries.append(
+                    self._topic_membership_compare_summary(
+                        job_id=job_id,
+                        base_model_id=resolved_model_id,
+                        target_model_id=target_model_id,
+                        suite_id=suite_id,
+                        dataset_id=compare_dataset_id,
+                        sample_size=len(base_run.samples),
+                        scoring_mode=scoring_mode,
+                        base_run=base_run,
+                        target_run=target_run,
+                        compare_samples=target_compare_samples,
+                        effect_threshold=self._resolve_float_parameter(
+                            parameters=parameters,
+                            key="effect_threshold",
+                            default_value=_DEFAULT_COMPARE_EFFECT_THRESHOLD,
+                        ),
+                        confidence_level=self._resolve_float_parameter(
+                            parameters=parameters,
+                            key="confidence_level",
+                            default_value=_DEFAULT_COMPARE_CONFIDENCE_LEVEL,
+                        ),
+                        bootstrap_iterations=self._resolve_int_parameter(
+                            explicit_value=None,
+                            parameters=parameters,
+                            key="bootstrap_iterations",
+                        )
+                        or _DEFAULT_COMPARE_BOOTSTRAP_ITERATIONS,
+                        bootstrap_seed=self._resolve_int_parameter(
+                            explicit_value=None,
+                            parameters=parameters,
+                            key="bootstrap_seed",
+                        )
+                        or _DEFAULT_COMPARE_BOOTSTRAP_SEED,
+                        duration_seconds=round(time.perf_counter() - started_at, 6),
+                        report_path=str(report_path),
+                    )
+                )
+
+            target_lineage_entries: list[EvaluationCompareTargetLineage] = [
+                EvaluationCompareTargetLineage(
+                    target_model_id=target_model_id,
+                    materialization_kind="registered",
+                )
+                for target_model_id in target_model_ids
+            ]
+            for adapter_spec in adapter_target_specs:
+                target_lineage_entries.append(
+                    EvaluationCompareTargetLineage(
+                        target_model_id=adapter_spec.ephemeral_derived_model_id,
+                        materialization_kind="ephemeral_adapter",
+                        adapter_manifest_path=adapter_spec.manifest_path,
+                        adapter_weights_path=adapter_spec.adapter_weights_path,
+                        adapter_set_hash=adapter_spec.adapter_set_hash,
+                        derived_from_model_id=adapter_spec.derived_from_model_id,
+                    )
+                )
+            compare_parameters.setdefault("sample_size", str(len(base_run.samples)))
+            base_job_parameters = getattr(base_run.job, "parameters", {})
+            if isinstance(base_job_parameters, dict):
+                for key in (
+                    "dataset_root",
+                    "source_kind",
+                    "source_path",
+                    "source_dataset_path",
+                    "source_dataset_name",
+                    "source_dataset_revision",
+                    "source_split",
+                    "few_shot",
+                    "seed",
+                    "scoring_mode",
+                    "topic_membership_source_jsonl",
+                ):
+                    if base_job_parameters.get(key) not in (None, ""):
+                        compare_parameters.setdefault(key, str(base_job_parameters[key]))
+            compare_job = build_evaluation_compare_job_record(
+                job_id=job_id,
+                base_model_id=resolved_model_id,
+                target_model_ids=combined_target_ids,
+                dataset_lineage=self._compare_dataset_lineage(
+                    dataset_id=compare_dataset_id,
+                    suite_id=suite_id,
+                    dataset_root=Path(str(compare_parameters.get("dataset_root", "."))).resolve(),
+                    parameters=compare_parameters,
+                    sample_size=len(base_run.samples),
+                    seed=self._int_parameter_from_mapping(compare_parameters, "seed"),
+                    few_shot=self._int_parameter_from_mapping(compare_parameters, "few_shot"),
+                    scoring_mode=scoring_mode,
+                ),
+                target_lineage=tuple(target_lineage_entries),
+                task_kind=str(getattr(base_run.job, "task_kind", "text-generation") or "text-generation"),
+                source_repo=str(getattr(base_run.job, "source_repo", "") or ""),
+                suite_id=suite_id,
+                dataset_id=compare_dataset_id,
+                sample_size=len(base_run.samples),
+                scoring_mode=scoring_mode,
+                parameters=compare_parameters,
+                status="completed",
+                output_dir=str(run_root),
+                created_at_unix_ms=created_at_unix_ms,
+                updated_at_unix_ms=created_at_unix_ms,
+            )
+            persisted_paths: dict[str, Path] = {}
+            if self._jobs_root is not None:
+                queue_root = self._jobs_root / "queue"
+                self._queue_store.enqueue(
+                    queue_root=queue_root,
+                    record=BenchmarkQueueRecord(
+                        queue_item_id=compare_job.job_id,
+                        job_kind="evaluation",
+                        model_id=model_id,
+                        suite_ids=(suite_id,),
+                        parameters=compare_parameters,
+                        status="queued",
+                        created_at_unix_ms=created_at_unix_ms,
+                        updated_at_unix_ms=created_at_unix_ms,
+                    ),
+                )
+                self._queue_store.transition(
+                    queue_root=queue_root,
+                    queue_item_id=compare_job.job_id,
+                    status="running",
+                    updated_at_unix_ms=created_at_unix_ms + 1,
+                )
+                persisted_paths = self._store.persist_compare_result(
+                    jobs_root=self._jobs_root,
+                    job=compare_job,
+                    summaries=tuple(compare_summaries),
+                    samples=tuple(compare_samples),
+                )
+                self._queue_store.transition(
+                    queue_root=queue_root,
+                    queue_item_id=compare_job.job_id,
+                    status="completed",
+                    updated_at_unix_ms=int(time.time() * 1000),
+                )
+            return TopicMembershipRun(
+                job=compare_job,
+                results=tuple(compare_summaries),
+                samples=tuple(compare_samples),
+                persisted_paths=persisted_paths,
+            )
+        finally:
+            for handle in ephemeral_unload_handles:
+                try:
+                    self._registry.unload_model(handle)
+                except Exception as unload_exc:  # noqa: BLE001
+                    _logger.warning(
+                        "Failed to unload ephemeral adapter compare target "
+                        "(handle=%s): %s",
+                        handle,
+                        unload_exc,
+                    )
+
+    def _topic_membership_sample_records(
+        self,
+        *,
+        job_id: str,
+        suite_id: str,
+        dataset_id: str,
+        rows: list[dict[str, object]],
+        prediction_rows: list[dict[str, object]],
+        dialogue_traces: list[dict[str, object]],
+        details_path: Path,
+        prompt_spec: TopicMembershipPromptSpec,
+        scoring_mode: str,
+    ) -> tuple[EvaluationSample, ...]:
+        predictions_by_dialogue = {
+            str(row.get("source_dialogue_id") or ""): row
+            for row in prediction_rows
+            if isinstance(row, dict)
+        }
+        traces_by_dialogue = {
+            str(trace.get("source_dialogue_id") or ""): trace
+            for trace in dialogue_traces
+            if isinstance(trace, dict)
+        }
+        scores_by_dialogue = TopicMembershipEvaluationRunner._topic_membership_dialogue_scores(
+            details_path,
+            scoring_mode=scoring_mode,
+        )
+        sample_records: list[EvaluationSample] = []
+        for index, row in enumerate(rows, start=1):
+            dialogue_id = str(row.get("source_dialogue_id") or index)
+            prediction = predictions_by_dialogue.get(dialogue_id, {})
+            output_json = prediction.get("output_json") if isinstance(prediction, dict) else None
+            if not isinstance(output_json, dict):
+                output_json = {}
+            trace = traces_by_dialogue.get(dialogue_id, {})
+            trace_status = str(trace.get("status") or "failed") if isinstance(trace, dict) else "failed"
+            raw_response = self._core._event_extraction_raw_response_from_trace(trace)
+            failure_reason = str(trace.get("failure_reason") or "") if isinstance(trace, dict) else ""
+            duration_ms = float(trace.get("total_duration_ms", 0.0) or 0.0) if isinstance(trace, dict) else 0.0
+            validation_status = "validated" if trace_status == "ok" else "not_validated"
+            extraction_status = "extracted" if trace_status == "ok" else trace_status
+            extracted_result = json.dumps(output_json, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+            target = json.dumps(
+                {
+                    "gold_topics": row.get("gold_topics", []),
+                    "expected_topic_count_range": row.get("expected_topic_count_range", []),
+                    "allowed_fallback_reasons": row.get("allowed_fallback_reasons", []),
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            sample_records.append(
+                build_evaluation_sample_record(
+                    job_id=job_id,
+                    suite_id=suite_id,
+                    dataset_id=dataset_id,
+                    sample_id=dialogue_id,
+                    system=prompt_spec.system_prompt,
+                    input_text=json.dumps(
+                        topic_membership_input_payload(row),
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    ),
+                    target=target,
+                    raw_response=raw_response,
+                    extracted_result=extracted_result,
+                    typed_score=float(scores_by_dialogue.get(dialogue_id, 0.0)),
+                    time_s=round(duration_ms / 1_000.0, 6),
+                    extraction_status=extraction_status,
+                    validation_status=validation_status,
+                    failure_reason=failure_reason,
+                    task_kind="text-generation",
+                    input_modalities=("text",),
+                    raw_response_chars=len(raw_response),
+                    extracted_result_chars=len(extracted_result),
+                    failure_stage="" if trace_status == "ok" else "extraction",
+                    parse_status=trace_status,
+                )
+            )
+        return tuple(sample_records)
+
+    @staticmethod
+    def _topic_membership_dialogue_scores(details_path: Path, *, scoring_mode: str) -> dict[str, float]:
+        score_field = "semantic_membership" if scoring_mode == TOPIC_SEMANTIC_SCORING_MODE else "strict_membership"
+        scores: dict[str, float] = {}
+        if not details_path.is_file():
+            return scores
+        with details_path.open("r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                dialogue_id = str(row.get("source_dialogue_id") or "").strip()
+                metrics = row.get(score_field)
+                if dialogue_id and isinstance(metrics, dict):
+                    scores[dialogue_id] = round(float(metrics.get("f1", 0.0) or 0.0), 4)
+        return scores
+
+    @staticmethod
+    def _topic_membership_dialogue_trace(
+        *,
+        dialogue_id: str,
+        line_number: int,
+        status: str,
+        row_started_at: float,
+        throttle_sleep_ms: float,
+        request_duration_ms: float,
+        messages: list[object],
+        request_body_bytes: int,
+        response_body_bytes: int,
+        raw_response: str,
+        raw_response_path: Path | None,
+        predicted_topic_count: int,
+        error_code: str | None,
+        failure_reason: str | None,
+        provider_usage: dict[str, int],
+    ) -> dict[str, object]:
+        text_chars = 0
+        for message in messages:
+            if isinstance(message, dict):
+                text_chars += len(str(message.get("text") or ""))
+        return {
+            "source_dialogue_id": dialogue_id,
+            "dialogue_id": dialogue_id,
+            "line_number": line_number,
+            "status": status,
+            "total_duration_ms": _round_ms((time.perf_counter() - row_started_at) * 1_000.0),
+            "request_duration_ms": request_duration_ms,
+            "throttle_sleep_ms": throttle_sleep_ms,
+            "message_count": len(messages),
+            "message_text_char_count": text_chars,
+            "request_body_bytes": request_body_bytes,
+            "response_body_bytes": response_body_bytes,
+            "raw_response_chars": len(raw_response),
+            "raw_response_path": str(raw_response_path) if raw_response_path is not None else None,
+            "predicted_topic_count": predicted_topic_count,
+            "error_code": error_code,
+            "failure_reason": failure_reason,
+            "provider_usage": provider_usage,
+        }
+
+    def _topic_membership_dialogue_diagnostics(self, traces: list[dict[str, object]]) -> dict[str, object]:
+        status_counts: dict[str, int] = {}
+        for trace in traces:
+            status = str(trace.get("status") or "")
+            if status:
+                status_counts[status] = status_counts.get(status, 0) + 1
+        return {
+            "dialogue_status_counts": status_counts,
+            "request_duration_ms": self._core._latency_stats(self._core._numeric_trace_values(traces, "request_duration_ms")),
+            "total_duration_ms": self._core._latency_stats(self._core._numeric_trace_values(traces, "total_duration_ms")),
+            "total_throttle_sleep_ms": _round_ms(self._core._numeric_trace_sum(traces, "throttle_sleep_ms")),
+        }
+
+    @staticmethod
+    def _topic_membership_result_metrics(
+        *,
+        suite_id: str,
+        summary: dict[str, object],
+        duration_seconds: float,
+    ) -> tuple[dict[str, float], dict[str, str]]:
+        metrics: dict[str, float] = {
+            f"eval.{suite_id}.cases": float(summary.get("cases", 0.0) or 0.0),
+            f"eval.{suite_id}.missing_predictions": float(summary.get("missing_predictions", 0.0) or 0.0),
+            f"eval.{suite_id}.json_valid_rate": float(summary.get("json_valid_rate", 0.0) or 0.0),
+            f"eval.{suite_id}.topic_count_range_accuracy": float(
+                summary.get("topic_count_range_accuracy", 0.0) or 0.0
+            ),
+            f"eval.{suite_id}.fallback_accuracy": float(summary.get("fallback_accuracy", 0.0) or 0.0),
+            f"eval.{suite_id}.duration_seconds": float(duration_seconds),
+        }
+        units: dict[str, str] = {
+            f"eval.{suite_id}.cases": "count",
+            f"eval.{suite_id}.missing_predictions": "count",
+            f"eval.{suite_id}.json_valid_rate": "ratio",
+            f"eval.{suite_id}.topic_count_range_accuracy": "ratio",
+            f"eval.{suite_id}.fallback_accuracy": "ratio",
+            f"eval.{suite_id}.duration_seconds": "s",
+        }
+        for prefix, source_key in (
+            ("strict_membership", "strict_membership"),
+            ("semantic_membership", "semantic_membership"),
+        ):
+            values = summary.get(source_key)
+            if not isinstance(values, dict):
+                continue
+            for metric_key, unit in (
+                ("f1", "ratio"),
+                ("precision", "ratio"),
+                ("recall", "ratio"),
+                ("true_positive", "count"),
+                ("false_positive", "count"),
+                ("false_negative", "count"),
+            ):
+                metric_name = f"eval.{suite_id}.{prefix}_{metric_key}"
+                metrics[metric_name] = float(values.get(metric_key, 0.0) or 0.0)
+                units[metric_name] = unit
+        bridge_recall = summary.get("bridge_message_recall")
+        if isinstance(bridge_recall, dict):
+            metric_name = f"eval.{suite_id}.bridge_message_recall"
+            metrics[metric_name] = float(bridge_recall.get("recall", 0.0) or 0.0)
+            units[metric_name] = "ratio"
+        semantic_judge = summary.get("semantic_judge")
+        if isinstance(semantic_judge, dict):
+            for key in ("calls", "cache_hits", "failures"):
+                metric_name = f"eval.{suite_id}.semantic_judge_{key}"
+                metrics[metric_name] = float(semantic_judge.get(key, 0.0) or 0.0)
+                units[metric_name] = "count"
+        return metrics, units
+
+    @staticmethod
+    def _topic_membership_compare_summary(
+        *,
+        job_id: str,
+        base_model_id: str,
+        target_model_id: str,
+        suite_id: str,
+        dataset_id: str,
+        sample_size: int,
+        scoring_mode: str,
+        base_run: TopicMembershipRun,
+        target_run: TopicMembershipRun,
+        compare_samples: tuple[EvaluationCompareSample, ...],
+        effect_threshold: float,
+        confidence_level: float,
+        bootstrap_iterations: int,
+        bootstrap_seed: int,
+        duration_seconds: float,
+        report_path: str,
+    ) -> EvaluationCompareSummary:
+        win_count = sum(1 for sample in compare_samples if sample.outcome == "win")
+        loss_count = sum(1 for sample in compare_samples if sample.outcome == "loss")
+        tie_count = sum(1 for sample in compare_samples if sample.outcome == "tie")
+        regression_count = sum(1 for sample in compare_samples if sample.regression_kind != "")
+        base_metrics = {metric.name: metric.value for metric in getattr(base_run.result, "metrics", ())}
+        target_metrics = {metric.name: metric.value for metric in getattr(target_run.result, "metrics", ())}
+        primary_suffix = (
+            "semantic_membership_f1"
+            if scoring_mode == TOPIC_SEMANTIC_SCORING_MODE
+            else "strict_membership_f1"
+        )
+        base_primary = float(getattr(base_run.result, "primary_score_value", 0.0) or 0.0)
+        target_primary = float(getattr(target_run.result, "primary_score_value", 0.0) or 0.0)
+        delta_primary = round(target_primary - base_primary, 6)
+        paired_outcomes = tuple(sample.target_typed_score - sample.base_typed_score for sample in compare_samples)
+        statistical_evidence = build_paired_statistical_evidence(
+            paired_outcomes=paired_outcomes,
+            confidence_level=confidence_level,
+            bootstrap_iterations=bootstrap_iterations,
+            bootstrap_seed=bootstrap_seed,
+        )
+        release_gate_summary = classify_release_verdict(
+            delta_accuracy=delta_primary,
+            effect_threshold=effect_threshold,
+            bootstrap_interval=dict(statistical_evidence.get("bootstrap", {})),
+            analytical_interval=dict(statistical_evidence.get("analytical", {})),
+        )
+        metrics: dict[str, float] = {
+            "eval.compare.base_accuracy": base_primary,
+            "eval.compare.target_accuracy": target_primary,
+            "eval.compare.delta_accuracy": delta_primary,
+            "eval.compare.base_topic_membership_primary_f1": base_primary,
+            "eval.compare.target_topic_membership_primary_f1": target_primary,
+            "eval.compare.delta_topic_membership_primary_f1": delta_primary,
+            "eval.compare.effect_threshold": float(effect_threshold),
+            "eval.compare.win_count": float(win_count),
+            "eval.compare.loss_count": float(loss_count),
+            "eval.compare.tie_count": float(tie_count),
+            "eval.compare.regression_count": float(regression_count),
+        }
+        units: dict[str, str] = {
+            "eval.compare.base_accuracy": "ratio",
+            "eval.compare.target_accuracy": "ratio",
+            "eval.compare.delta_accuracy": "ratio",
+            "eval.compare.base_topic_membership_primary_f1": "ratio",
+            "eval.compare.target_topic_membership_primary_f1": "ratio",
+            "eval.compare.delta_topic_membership_primary_f1": "ratio",
+            "eval.compare.effect_threshold": "ratio",
+            "eval.compare.win_count": "count",
+            "eval.compare.loss_count": "count",
+            "eval.compare.tie_count": "count",
+            "eval.compare.regression_count": "count",
+        }
+        for suffix in (
+            "strict_membership_f1",
+            "strict_membership_precision",
+            "strict_membership_recall",
+            "strict_membership_true_positive",
+            "strict_membership_false_positive",
+            "strict_membership_false_negative",
+            "semantic_membership_f1",
+            "semantic_membership_precision",
+            "semantic_membership_recall",
+        ):
+            source_name = f"eval.{suite_id}.{suffix}"
+            if source_name not in base_metrics and source_name not in target_metrics:
+                continue
+            base_name = f"eval.compare.base_{suffix}"
+            target_name = f"eval.compare.target_{suffix}"
+            delta_name = f"eval.compare.delta_{suffix}"
+            base_value = float(base_metrics.get(source_name, 0.0) or 0.0)
+            target_value = float(target_metrics.get(source_name, 0.0) or 0.0)
+            metrics[base_name] = base_value
+            metrics[target_name] = target_value
+            metrics[delta_name] = round(target_value - base_value, 6)
+            unit = "count" if suffix.endswith(("true_positive", "false_positive", "false_negative")) else "ratio"
+            units[base_name] = unit
+            units[target_name] = unit
+            units[delta_name] = unit
+        metrics[f"eval.compare.delta_{primary_suffix}"] = delta_primary
+        units[f"eval.compare.delta_{primary_suffix}"] = "ratio"
+        return build_evaluation_compare_summary_record(
+            job_id=job_id,
+            base_model_id=base_model_id,
+            target_model_id=target_model_id,
+            suite_id=suite_id,
+            dataset_id=dataset_id,
+            sample_size=sample_size,
+            scoring_mode=scoring_mode,
+            win_count=win_count,
+            loss_count=loss_count,
+            tie_count=tie_count,
+            regression_count=regression_count,
+            base_accuracy=base_primary,
+            target_accuracy=target_primary,
+            delta_accuracy=delta_primary,
+            effect_threshold=effect_threshold,
+            verdict=str(release_gate_summary["verdict"]),
+            category_breakdown={},
+            statistical_evidence=statistical_evidence,
+            release_gate_summary=release_gate_summary,
+            duration_seconds=duration_seconds,
+            metrics=metrics,
+            report_path=report_path,
+            units=units,
+        )
+
+    @staticmethod
+    def _topic_count_from_output(output_json: dict[str, object]) -> int:
+        topics = output_json.get("gold_topics")
+        return len(topics) if isinstance(topics, list) else 0
+
+
+    @staticmethod
+    def _read_topic_membership_rows(path: Path, *, sample_size: int) -> list[dict[str, object]]:
+        rows: list[dict[str, object]] = []
+        with Path(path).open("r", encoding="utf-8") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                row = json.loads(line)
+                if not isinstance(row, dict):
+                    raise ValueError(f"expected JSON object at {path}:{line_number}")
+                if not isinstance(row.get("source_dialogue_id"), str) or not row.get("source_dialogue_id"):
+                    raise ValueError(f"missing source_dialogue_id at {path}:{line_number}")
+                if not isinstance(row.get("messages"), list):
+                    raise ValueError(f"messages must be a list at {path}:{line_number}")
+                if not isinstance(row.get("gold_topics"), list):
+                    raise ValueError(f"gold_topics must be a list at {path}:{line_number}")
+                normalized = dict(row)
+                normalized["messages"] = [
+                    {
+                        "message_id": str(message.get("message_id") or ""),
+                        "sender": str(message.get("sender") or ""),
+                        "timestamp": str(message.get("timestamp") or ""),
+                        "text": str(message.get("text") or ""),
+                    }
+                    for message in row.get("messages", [])
+                    if isinstance(message, dict)
+                ]
+                normalized["gold_topics"] = [
+                    dict(topic)
+                    for topic in row.get("gold_topics", [])
+                    if isinstance(topic, dict)
+                ]
+                rows.append(normalized)
+                if sample_size > 0 and len(rows) >= sample_size:
+                    break
+        if not rows:
+            raise ValueError(f"topic membership source JSONL is empty: {path}")
+        return rows
+
+
+    @staticmethod
+    def _topic_membership_prompt_spec(parameters: dict[str, str]) -> TopicMembershipPromptSpec:
+        system_prompt = str(parameters.get("eval_prompt_system_prompt") or "").strip()
+        if not system_prompt:
+            raise ValueError("topic_membership scoring requires --eval-prompt-file or --eval-prompt.")
+        prompt_id = str(parameters.get("eval_prompt_id") or parameters.get("prompt_id") or "").strip()
+        revision_id = str(
+            parameters.get("eval_prompt_revision_id") or parameters.get("prompt_revision_id") or ""
+        ).strip()
+        content_hash = str(
+            parameters.get("eval_prompt_content_hash") or parameters.get("prompt_content_hash") or ""
+        ).strip()
+        if not content_hash:
+            content_hash = topic_prompt_content_hash(system_prompt)
+        return TopicMembershipPromptSpec(
+            prompt_id=prompt_id or TOPIC_MEMBERSHIP_PROMPT_ID,
+            revision_id=revision_id or "unknown",
+            title=str(parameters.get("eval_prompt_title") or parameters.get("prompt_title") or "").strip(),
+            system_prompt=system_prompt,
+            content_hash=content_hash,
+        )

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -609,6 +609,34 @@ struct MelixCLIParserTests {
         #expect(options.suites == ["event_extraction"])
     }
 
+    @Test("parses topic membership eval run without generic field mapping")
+    func parsesTopicMembershipEvalRunWithoutGenericFieldMapping() throws {
+        let command = try MelixCLIParser.parse([
+            "eval", "run",
+            "--model-id", "melix-dev-text",
+            "--source-jsonl", "/tmp/topic-membership.jsonl",
+            "--scoring-mode", "topic_membership_strict_micro_f1",
+            "--eval-prompt-file", "/tmp/topic-prompt.md",
+            "--sample-size", "413",
+            "--json",
+        ])
+
+        guard case .evalRun(let options) = command else {
+            Issue.record("Expected eval run command")
+            return
+        }
+
+        #expect(options.modelID == "melix-dev-text")
+        #expect(options.suites == ["topic_membership"])
+        #expect(options.source == .localJSONL(path: "/tmp/topic-membership.jsonl"))
+        #expect(options.fieldMapping.inputTextPath == "")
+        #expect(options.fieldMapping.targetPath == "")
+        #expect(options.profile.scoringMode == "topic_membership_strict_micro_f1")
+        #expect(options.evalPromptFile == "/tmp/topic-prompt.md")
+        #expect(options.sampleSize == 413)
+        #expect(options.json)
+    }
+
     @Test("remote server parser supports provider presets and rejects base URL overrides")
     func remoteServerParserSupportsProviderPresetsAndRejectsBaseURLOverrides() throws {
         let gemini = try MelixCLIParser.parse([
@@ -4153,6 +4181,39 @@ struct MelixCLIParserTests {
         #expect(options.profile.scoringMode == "normalized_exact_match")
         #expect(options.profile.threshold == 0.8)
         #expect(options.profile.ignoredPaths == ["metadata.trace_id"])
+        #expect(options.json)
+    }
+
+    @Test("parses topic membership eval compare with prompt and semantic judge")
+    func parsesTopicMembershipEvalCompareWithPromptAndSemanticJudge() throws {
+        let command = try MelixCLIParser.parse([
+            "eval",
+            "compare",
+            "--model-id", "melix-dev-text",
+            "--target-adapter", "/tmp/topic.adapter.json",
+            "--source-jsonl", "/tmp/topic-membership.jsonl",
+            "--scoring-mode", "topic_membership_semantic_micro_f1",
+            "--eval-prompt-file", "/tmp/topic-prompt.md",
+            "--semantic-judge-remote-server-id", "judge",
+            "--semantic-judge-model", "judge-model",
+            "--json",
+        ])
+
+        guard case .evalCompare(let options) = command else {
+            Issue.record("Expected evalCompare command")
+            return
+        }
+
+        #expect(options.modelID == "melix-dev-text")
+        #expect(options.targetAdapterManifestPaths == ["/tmp/topic.adapter.json"])
+        #expect(options.suites == ["topic_membership"])
+        #expect(options.source == .localJSONL(path: "/tmp/topic-membership.jsonl"))
+        #expect(options.fieldMapping.inputTextPath == "")
+        #expect(options.fieldMapping.targetPath == "")
+        #expect(options.profile.scoringMode == "topic_membership_semantic_micro_f1")
+        #expect(options.evalPromptFile == "/tmp/topic-prompt.md")
+        #expect(options.semanticJudgeRemoteServerID == "judge")
+        #expect(options.semanticJudgeModelID == "judge-model")
         #expect(options.json)
     }
 

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -4806,7 +4806,7 @@ struct MelixCLIRunnerTests {
         #expect(request.parameters["semantic_judge_rate_limit_per_minute"] == "12")
         #expect(request.parameters["remote_provider_extra_body_json"] == "{\"max_tokens\":1024,\"chat_template_kwargs\":{\"enable_thinking\":false}}")
 
-        await #expect(throws: MelixCLIError.runtime("Semantic judge scoring is only supported for event_extraction_weighted_f1.")) {
+        await #expect(throws: MelixCLIError.runtime("Semantic judge scoring is only supported for event_extraction_weighted_f1 or topic_membership_semantic_micro_f1.")) {
             try await runner.run(
                 MelixCLICommand.evalRun(
                     EvalRunOptions(
@@ -4816,6 +4816,109 @@ struct MelixCLIRunnerTests {
                         source: .localJSONL(path: "/tmp/eval.jsonl"),
                         fieldMapping: .init(inputTextPath: "prompt", targetPath: "answer"),
                         profile: .init(scoringMode: "multiple_choice_accuracy"),
+                        semanticJudgeRemoteServerID: "judge",
+                        semanticJudgeModelID: "judge-model",
+                        json: true
+                    )
+                )
+            )
+        }
+    }
+
+    @Test("eval run forwards topic membership semantic judge parameters")
+    func evalRunForwardsTopicMembershipSemanticJudgeParameters() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-topic-semantic-judge-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let client = StubControlPlaneXPCClient()
+        await client.setEvaluationResults([
+            makeEvaluationRunResult(
+                jobID: "eval-topic-semantic-judge",
+                suiteID: "topic_membership",
+                datasetID: "topic-membership",
+                metricName: "eval.topic_membership.semantic_membership_f1",
+                metricValue: 0.5
+            ),
+        ])
+        let runner = MelixCLIRunner(
+            client: client,
+            environment: ["MELIX_HOME": temporaryRoot.path]
+        )
+
+        _ = try await runner.run(
+            .remoteServerAdd(
+                .init(
+                    remoteServerID: "evaluated",
+                    title: "Evaluated",
+                    providerPreset: .custom,
+                    providerKind: "openai-compatible",
+                    baseURL: "https://evaluated.example/v1",
+                    defaultModelID: "evaluated-default",
+                    apiKey: "sk-evaluated",
+                    timeoutSeconds: 30,
+                    rateLimitPerMinute: 0
+                )
+            )
+        )
+        _ = try await runner.run(
+            .remoteServerAdd(
+                .init(
+                    remoteServerID: "judge",
+                    title: "Judge",
+                    providerPreset: .custom,
+                    providerKind: "openai-compatible",
+                    baseURL: "https://judge.example/v1",
+                    defaultModelID: "judge-default",
+                    apiKey: "sk-judge",
+                    timeoutSeconds: 41,
+                    rateLimitPerMinute: 12
+                )
+            )
+        )
+
+        _ = try await runner.run(
+            MelixCLICommand.evalRun(
+                EvalRunOptions(
+                    remoteServerID: "evaluated",
+                    remoteModelID: "evaluated-model",
+                    suites: ["topic_membership"],
+                    sampleSize: 413,
+                    source: .localJSONL(path: "/tmp/topic-membership.jsonl"),
+                    profile: .init(scoringMode: "topic_membership_semantic_micro_f1"),
+                    evalPrompt: "Return topic membership JSON.",
+                    semanticJudgeRemoteServerID: "judge",
+                    semanticJudgeModelID: "judge-model",
+                    json: true
+                )
+            )
+        )
+
+        let request = try #require((await client.evaluationRequests).first)
+        #expect(request.suiteID == "topic_membership")
+        #expect(request.source == .localJSONL(path: "/tmp/topic-membership.jsonl"))
+        #expect(request.fieldMapping.inputTextPath == "")
+        #expect(request.fieldMapping.targetPath == "")
+        #expect(request.profile.scoringMode == "topic_membership_semantic_micro_f1")
+        #expect(request.parameters["eval_prompt_system_prompt"] == "Return topic membership JSON.")
+        #expect(request.parameters["semantic_judge_remote_server_id"] == "judge")
+        #expect(request.parameters["semantic_judge_provider_kind"] == "openai-compatible")
+        #expect(request.parameters["semantic_judge_base_url"] == "https://judge.example/v1")
+        #expect(request.parameters["semantic_judge_api_key"] == "sk-judge")
+        #expect(request.parameters["semantic_judge_model_id"] == "judge-model")
+        #expect(request.parameters["semantic_judge_timeout_seconds"] == "41")
+        #expect(request.parameters["semantic_judge_rate_limit_per_minute"] == "12")
+
+        await #expect(throws: MelixCLIError.runtime("Semantic judge scoring is only supported for event_extraction_weighted_f1 or topic_membership_semantic_micro_f1.")) {
+            try await runner.run(
+                MelixCLICommand.evalRun(
+                    EvalRunOptions(
+                        remoteServerID: "evaluated",
+                        remoteModelID: "evaluated-model",
+                        suites: ["topic_membership"],
+                        source: .localJSONL(path: "/tmp/topic-membership.jsonl"),
+                        profile: .init(scoringMode: "topic_membership_strict_micro_f1"),
+                        evalPrompt: "Return topic membership JSON.",
                         semanticJudgeRemoteServerID: "judge",
                         semanticJudgeModelID: "judge-model",
                         json: true


### PR DESCRIPTION
## Summary
- Adds topic-membership strict and semantic micro-F1 scoring modes.
- Wires Melix CLI/gRPC evaluation routing for source JSONL and semantic judge parameters.
- Adds dedicated topic-membership runner, audit/report artifacts, and focused tests.

## Plan or Spec
- Adds the evaluation scoring mode needed for the topic-membership benchmark pipeline.
- Real LoRA training/eval is intentionally deferred until this PR is merged.

## Commands Run
- `git diff --check`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python -m py_compile services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/worker/productization/topic_membership_runner.py services/mlx-worker-python/worker/productization/topic_membership.py services/mlx-worker-python/tests/test_topic_membership.py services/mlx-worker-python/tests/test_evaluation_core.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_topic_membership.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_evaluation_core.py -k ...`
- Focused Swift CLI parser/runner tests for topic-membership eval args.
- Full pre-commit suite.

## Coverage and Metrics
- `make swift-test`: passed, elapsed 188.5s.
- `make py-test`: 3459 passed, 14 skipped, 2 warnings, elapsed 147.6s.
- `make integration-test`: 117 passed, 1 skipped, elapsed 407.3s.
- PR-scoped performance report: status ok, selected probes 6, regressions 0, context regressions 0, verification failures 0.
- Changed-scope coverage for `evaluation_core.py`: 100.0%.

## Known Gaps
- No real training run launched in this PR step.
- Real adapter training/eval/report will run after merge per operator instruction.

## Evidence Checklist
- [x] Focused tests
- [x] Full pre-commit
- [ ] Real training (deferred until merge)
