### PR TITLE
Fix long-context admission from model config windows

### DIFF
--- a/docs/control-plane-protocol.md
+++ b/docs/control-plane-protocol.md
@@ -719,6 +719,14 @@ must return a typed `invalid_generation_bounds` response before worker
 generation starts. Stop strings are normalized into the worker sampling contract
 for both streaming and buffered responses.
 
+Prompt-budget admission uses the selected catalog model context window after
+registry discovery has applied model-artifact context evidence such as
+`config.json` `max_position_embeddings` or nested text config equivalents.
+The gateway may reject clearly over-budget prompts before worker generation
+using its local prompt-token estimate, but that estimate is a pre-worker guard
+and must be reported with source metadata when it drives a typed
+`prompt_budget_exceeded` response.
+
 The translated worker request records a request-local generation receipt under
 `execution.ext` with the `melix.generation.` prefix on these field names:
 `max_tokens_requested`, `max_tokens_effective`,

--- a/docs/plans/2026-06-04-config-derived-long-context-admission.md
+++ b/docs/plans/2026-06-04-config-derived-long-context-admission.md
@@ -1,0 +1,45 @@
+# Config-Derived Long-Context Admission
+
+## Problem
+
+Gemma E4B MLX checkpoints can declare a 128k text context window through
+`config.json` (`text_config.max_position_embeddings`), but Melix registry
+discovery currently publishes raw local and Hugging Face cache models with an
+8192-token `max_context`. The OpenAI-compatible gateway uses the catalog
+`ModelSummary.maxContext` for prompt-budget admission before worker dispatch, so
+long-context requests are rejected before the Swift text runtime can apply its
+own config-derived context.
+
+## Goal
+
+Make text request admission use model-artifact context evidence instead of a
+hard-coded discovery default, while preserving pre-worker budget protection for
+clearly over-budget requests.
+
+## Scope
+
+- Infer discovered model `max_context` from model config files when available.
+- Support top-level and nested text config fields used by local MLX, VLM, and
+  MoE-style checkpoints.
+- Preserve the existing 8192 fallback only when no usable context declaration is
+  present.
+- Keep prompt-budget admission typed and pre-worker for clearly excessive
+  prompts.
+- Record prompt estimate source in rejection metadata so near-boundary
+  admission decisions remain auditable.
+
+## Out Of Scope
+
+- Changing Swift text KV-cache strategy, chunking, or decode throughput.
+- Adding a cross-process tokenizer-count RPC.
+- Claiming 128k runtime performance parity; this slice only removes the
+  incorrect admission/catalog cap.
+
+## Verification
+
+- Python registry tests prove raw discovered models publish config-derived
+  `max_context`, including nested `text_config.max_position_embeddings`.
+- Swift gateway tests prove a 128k-capable text companion can reach worker
+  dispatch instead of being rejected under the old 8192 catalog cap.
+- Focused Swift prompt-budget tests continue to reject clearly over-budget
+  requests before worker generation.

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Dispatch
 import MelixControlPlaneProtocol
 import MelixWorkerProtocol
 import OSLog
@@ -19,6 +20,51 @@ public struct RichOutputSanitizationResult: Equatable, Sendable {
         self.didSanitize = didSanitize
         self.blockedHTMLFragmentCount = blockedHTMLFragmentCount
         self.unsafeURIRejectionCount = unsafeURIRejectionCount
+    }
+}
+
+private struct TextContextWindowInference: Sendable {
+    let tokens: UInt32
+    let source: String
+}
+
+private actor TextContextWindowInferenceCache {
+    private enum Entry {
+        case loading(Task<TextContextWindowInference?, Never>)
+        case loaded(TextContextWindowInference?)
+    }
+
+    private let queue = DispatchQueue(
+        label: "dev.melix.openai.text-context-window-inference",
+        qos: .utility
+    )
+    private var entries: [String: Entry] = [:]
+
+    func value(
+        for modelPath: String,
+        load: @escaping @Sendable () -> TextContextWindowInference?
+    ) async -> TextContextWindowInference? {
+        if let entry = entries[modelPath] {
+            switch entry {
+            case .loading(let task):
+                return await task.value
+            case .loaded(let value):
+                return value
+            }
+        }
+
+        let queue = queue
+        let task = Task(priority: .utility) {
+            await withCheckedContinuation { continuation in
+                queue.async {
+                    continuation.resume(returning: load())
+                }
+            }
+        }
+        entries[modelPath] = .loading(task)
+        let value = await task.value
+        entries[modelPath] = .loaded(value)
+        return value
     }
 }
 
@@ -543,6 +589,7 @@ public struct OpenAIHandler: Sendable {
     private let decoder: JSONDecoder
     private let encoder: JSONEncoder
     private let idleSweepScheduler: ModelIdleSweepScheduler
+    private let textContextWindowInferenceCache: TextContextWindowInferenceCache
 
     public init(
         modelCatalog: ModelCatalog,
@@ -604,6 +651,7 @@ public struct OpenAIHandler: Sendable {
             minimumIntervalSeconds: Self.modelIdleSweepDebounceSeconds,
             now: now
         )
+        self.textContextWindowInferenceCache = TextContextWindowInferenceCache()
     }
 
     private static func transientGatewayConfigStore(environment: [String: String]) -> GatewayConfigStore {
@@ -2605,8 +2653,9 @@ public struct OpenAIHandler: Sendable {
 
         let companionID = textCompanionModelID(for: servedModelID)
         if await modelCatalog.model(id: companionID) == nil {
+            let companionModel = await makeTextCompanionModel(from: model, companionID: companionID)
             await modelCatalog.registerModel(
-                makeTextCompanionModel(from: model, companionID: companionID),
+                companionModel,
                 reason: "text_companion_registered"
             )
         }
@@ -2755,7 +2804,7 @@ public struct OpenAIHandler: Sendable {
     private func makeTextCompanionModel(
         from source: Melix_Controlplane_V1_ModelSummary,
         companionID: String
-    ) -> Melix_Controlplane_V1_ModelSummary {
+    ) async -> Melix_Controlplane_V1_ModelSummary {
         var companion = source
         companion.modelID = companionID
         companion.kind = "text"
@@ -2766,7 +2815,7 @@ public struct OpenAIHandler: Sendable {
         companion.capabilityClass = .modelCapabilityText
         companion.routeClass = .workerRouteSwiftText
         companion.features = source.features.contains("chat") ? source.features : source.features + ["chat"]
-        if let inferredContext = inferredTextMaxContext(fromModelPath: source.settings.ext["melix.model_path"]) {
+        if let inferredContext = await inferredTextMaxContext(fromModelPath: source.settings.ext["melix.model_path"]) {
             let inferredMaxContext = inferredContext.tokens
             companion.maxContext = max(companion.maxContext, inferredMaxContext)
             companion.settings.ext["melix.context_window.source"] = inferredContext.source
@@ -3108,12 +3157,18 @@ public struct OpenAIHandler: Sendable {
         return overflow ? UInt32.max : value
     }
 
-    private func inferredTextMaxContext(fromModelPath modelPath: String?) -> (tokens: UInt32, source: String)? {
+    private func inferredTextMaxContext(fromModelPath modelPath: String?) async -> TextContextWindowInference? {
         let trimmedPath = modelPath?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard trimmedPath.isEmpty == false else {
             return nil
         }
-        let configURL = URL(fileURLWithPath: trimmedPath, isDirectory: true)
+        return await textContextWindowInferenceCache.value(for: trimmedPath) {
+            Self.loadInferredTextMaxContext(fromModelPath: trimmedPath)
+        }
+    }
+
+    private static func loadInferredTextMaxContext(fromModelPath modelPath: String) -> TextContextWindowInference? {
+        let configURL = URL(fileURLWithPath: modelPath, isDirectory: true)
             .appendingPathComponent("config.json")
         guard let data = try? Data(contentsOf: configURL),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
@@ -3121,28 +3176,28 @@ public struct OpenAIHandler: Sendable {
         }
         let contextKeys = ["max_position_embeddings", "max_seq_len", "max_seq_length", "seq_length", "n_positions"]
         for key in contextKeys {
-            if let value = uint32ConfigValue(root[key]) {
-                return (value, "config.\(key)")
+            if let value = Self.uint32ConfigValue(root[key]) {
+                return TextContextWindowInference(tokens: value, source: "config.\(key)")
             }
         }
         for nestedKey in ["text_config", "language_config", "llm_config"] {
             for key in contextKeys {
-                if let value = nestedUInt32ConfigValue(root[nestedKey], key: key) {
-                    return (value, "config.\(nestedKey).\(key)")
+                if let value = Self.nestedUInt32ConfigValue(root[nestedKey], key: key) {
+                    return TextContextWindowInference(tokens: value, source: "config.\(nestedKey).\(key)")
                 }
             }
         }
         return nil
     }
 
-    private func nestedUInt32ConfigValue(_ value: Any?, key: String) -> UInt32? {
+    private static func nestedUInt32ConfigValue(_ value: Any?, key: String) -> UInt32? {
         guard let object = value as? [String: Any] else {
             return nil
         }
-        return uint32ConfigValue(object[key])
+        return Self.uint32ConfigValue(object[key])
     }
 
-    private func uint32ConfigValue(_ value: Any?) -> UInt32? {
+    private static func uint32ConfigValue(_ value: Any?) -> UInt32? {
         switch value {
         case let number as NSNumber:
             let intValue = number.uint64Value

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -2766,6 +2766,11 @@ public struct OpenAIHandler: Sendable {
         companion.capabilityClass = .modelCapabilityText
         companion.routeClass = .workerRouteSwiftText
         companion.features = source.features.contains("chat") ? source.features : source.features + ["chat"]
+        if let inferredContext = inferredTextMaxContext(fromModelPath: source.settings.ext["melix.model_path"]) {
+            let inferredMaxContext = inferredContext.tokens
+            companion.maxContext = max(companion.maxContext, inferredMaxContext)
+            companion.settings.ext["melix.context_window.source"] = inferredContext.source
+        }
         companion.supportedModalities = ["text"]
         companion.supportedTasks = ["generate"]
         companion.settings.alias = source.settings.alias.isEmpty
@@ -3039,13 +3044,18 @@ public struct OpenAIHandler: Sendable {
             ? contextWindowTokens - outputCapTokens
             : 0
         let promptTokensEstimated = estimatedPromptTokens(for: normalized.messages)
-        guard promptTokensEstimated > maxPromptTokens else {
+        let estimateSlackTokens = promptBudgetEstimateSlackTokens(contextWindowTokens: contextWindowTokens)
+        let rejectThreshold = addingClamped(maxPromptTokens, estimateSlackTokens)
+        guard promptTokensEstimated > rejectThreshold else {
             return nil
         }
         let metadata: [String: Any] = [
             "max_prompt_tokens_requested": Int(maxPromptTokens),
             "max_prompt_tokens_effective": Int(maxPromptTokens),
             "prompt_tokens_estimated": Int(promptTokensEstimated),
+            "prompt_tokens_estimate_source": "control_plane_heuristic_utf8_whitespace",
+            "prompt_tokens_estimate_slack": Int(estimateSlackTokens),
+            "prompt_tokens_reject_threshold": Int(rejectThreshold),
             "context_window_tokens": Int(contextWindowTokens),
             "output_cap_tokens": Int(outputCapTokens),
             "admission_phase": "prompt_budget",
@@ -3084,6 +3094,67 @@ public struct OpenAIHandler: Sendable {
             ?? gatewayServingDefaults?.maxTokens
             ?? GatewayServingDefaultsStore.defaultMaxTokens
         return fallbackOutputCapTokens >= contextWindowTokens ? 0 : fallbackOutputCapTokens
+    }
+
+    private func promptBudgetEstimateSlackTokens(contextWindowTokens: UInt32) -> UInt32 {
+        guard contextWindowTokens >= 32_768 else {
+            return 0
+        }
+        return max(1_024, contextWindowTokens / 64)
+    }
+
+    private func addingClamped(_ lhs: UInt32, _ rhs: UInt32) -> UInt32 {
+        let (value, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? UInt32.max : value
+    }
+
+    private func inferredTextMaxContext(fromModelPath modelPath: String?) -> (tokens: UInt32, source: String)? {
+        let trimmedPath = modelPath?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard trimmedPath.isEmpty == false else {
+            return nil
+        }
+        let configURL = URL(fileURLWithPath: trimmedPath, isDirectory: true)
+            .appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        let contextKeys = ["max_position_embeddings", "max_seq_len", "max_seq_length", "seq_length", "n_positions"]
+        for key in contextKeys {
+            if let value = uint32ConfigValue(root[key]) {
+                return (value, "config.\(key)")
+            }
+        }
+        for nestedKey in ["text_config", "language_config", "llm_config"] {
+            for key in contextKeys {
+                if let value = nestedUInt32ConfigValue(root[nestedKey], key: key) {
+                    return (value, "config.\(nestedKey).\(key)")
+                }
+            }
+        }
+        return nil
+    }
+
+    private func nestedUInt32ConfigValue(_ value: Any?, key: String) -> UInt32? {
+        guard let object = value as? [String: Any] else {
+            return nil
+        }
+        return uint32ConfigValue(object[key])
+    }
+
+    private func uint32ConfigValue(_ value: Any?) -> UInt32? {
+        switch value {
+        case let number as NSNumber:
+            let intValue = number.uint64Value
+            guard intValue > 0, intValue <= UInt64(UInt32.max) else {
+                return nil
+            }
+            return UInt32(intValue)
+        case let string as String:
+            return UInt32(string.trimmingCharacters(in: .whitespacesAndNewlines))
+        default:
+            return nil
+        }
     }
 
     private func estimatedPromptTokens(

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -2819,6 +2819,111 @@ struct OpenAIHandlerTests {
         #expect(await harness.vlmClient.lastGenerateRequest == nil)
     }
 
+    @Test("POST /v1/chat/completions caches Gemma4 text companion context inference by model path")
+    func postChatCompletionsCachesGemma4TextCompanionContextInferenceByModelPath() async throws {
+        let modelDirectory = try makeModelConfigDirectory(
+            config: """
+            {
+              "model_type": "gemma4",
+              "text_config": {
+                "model_type": "gemma4_text",
+                "max_position_embeddings": 131072
+              }
+            }
+            """
+        )
+        let harness = makeGemma4VLMOpenAIHandler(
+            requestID: "req-http-gemma4-vlm-text-companion-context-cache",
+            textEvents: [
+                makeCompletedEvent(
+                    requestID: "req-http-gemma4-vlm-text-companion-context-cache",
+                    seq: 1,
+                    finishReason: "stop",
+                    assistantText: "ok"
+                ),
+            ],
+            textLoadModelHandle: "melix-dev-vlm#text::swift",
+            configureModel: { model in
+                model.maxContext = 8_192
+                model.settings.ext["melix.vlm.execution_mode"] = "multimodal"
+                model.settings.ext["melix.vlm.text_only_batch_generator"] = "true"
+                model.settings.ext.removeValue(forKey: "melix.vlm.text_companion.enabled")
+                model.settings.ext["melix.model_path"] = modelDirectory.path
+                model.settings.ext["melix.model_revision"] = "dev"
+                model.settings.ext["melix.tokenizer_hash"] = "tok-dev"
+            }
+        )
+        let firstBody = try #require(
+            """
+            {
+              "model": "melix-dev-vlm",
+              "stream": false,
+              "messages": [
+                { "role": "user", "content": "Reply briefly." }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+        let firstResponse = try await harness.handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: firstBody
+            )
+        )
+        _ = try await collectBody(firstResponse.body)
+        let firstCompanion = try #require(await harness.catalog.model(id: "melix-dev-vlm#text"))
+
+        #expect(firstResponse.statusCode == 200)
+        #expect(firstCompanion.maxContext == 131_072)
+
+        try """
+        {
+          "model_type": "gemma4",
+          "text_config": {
+            "model_type": "gemma4_text",
+            "max_position_embeddings": 8192
+          }
+        }
+        """.write(
+            to: modelDirectory.appendingPathComponent("config.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        var secondModel = try #require(await harness.catalog.model(id: "melix-dev-vlm"))
+        secondModel.modelID = "melix-dev-vlm-alt"
+        secondModel.settings.alias = "Melix Vision Alt"
+        secondModel.maxContext = 8_192
+        await harness.catalog.registerModel(secondModel, reason: "test_model_registered")
+
+        let secondBody = try #require(
+            """
+            {
+              "model": "melix-dev-vlm-alt",
+              "stream": false,
+              "messages": [
+                { "role": "user", "content": "Reply briefly." }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+        let secondResponse = try await harness.handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: secondBody
+            )
+        )
+        _ = try await collectBody(secondResponse.body)
+        let secondCompanion = try #require(await harness.catalog.model(id: "melix-dev-vlm-alt#text"))
+
+        #expect(secondResponse.statusCode == 200)
+        #expect(secondCompanion.maxContext == 131_072)
+        #expect(secondCompanion.settings.ext["melix.context_window.source"] == "config.text_config.max_position_embeddings")
+    }
+
     @Test("POST /v1/chat/completions keeps Gemma4 VLM media requests on the Swift vision route")
     func postChatCompletionsKeepsGemma4VLMMediaRequestsOnSwiftVisionRoute() async throws {
         let harness = makeGemma4VLMOpenAIHandler(

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -2745,10 +2745,78 @@ struct OpenAIHandlerTests {
         )
 
         let loadRequest = try #require(await harness.textClient.lastLoadModelRequest)
+        let companion = try #require(await harness.catalog.model(id: "melix-dev-vlm#text"))
 
         #expect(response.statusCode == 200)
         #expect(loadRequest.model.modelID == "melix-dev-vlm#text")
         #expect(loadRequest.model.maxContext == 262_144)
+        #expect(companion.maxContext == 262_144)
+        #expect(companion.settings.ext["melix.context_window.source"] == "config.text_config.max_position_embeddings")
+    }
+
+    @Test("POST /v1/chat/completions lets 128k text companions reach worker admission")
+    func postChatCompletionsLets128KTextCompanionsReachWorkerAdmission() async throws {
+        let modelDirectory = try makeModelConfigDirectory(
+            config: """
+            {
+              "model_type": "gemma4",
+              "text_config": {
+                "model_type": "gemma4_text",
+                "max_position_embeddings": 131072
+              }
+            }
+            """
+        )
+        let harness = makeGemma4VLMOpenAIHandler(
+            requestID: "req-http-gemma4-vlm-text-companion-128k",
+            textEvents: [
+                makeCompletedEvent(
+                    requestID: "req-http-gemma4-vlm-text-companion-128k",
+                    seq: 1,
+                    finishReason: "stop",
+                    assistantText: "ok"
+                ),
+            ],
+            textLoadModelHandle: "melix-dev-vlm#text::swift",
+            configureModel: { model in
+                model.maxContext = 8_192
+                model.settings.ext["melix.vlm.execution_mode"] = "multimodal"
+                model.settings.ext["melix.vlm.text_only_batch_generator"] = "true"
+                model.settings.ext.removeValue(forKey: "melix.vlm.text_companion.enabled")
+                model.settings.ext["melix.model_path"] = modelDirectory.path
+                model.settings.ext["melix.model_revision"] = "dev"
+                model.settings.ext["melix.tokenizer_hash"] = "tok-dev"
+            }
+        )
+        let densePrompt = String(repeating: "a", count: 524_288)
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-vlm",
+              "stream": false,
+              "max_tokens": 512,
+              "messages": [
+                { "role": "user", "content": "\(densePrompt)" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await harness.handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+
+        #expect(response.statusCode == 200)
+        let companion = try #require(await harness.catalog.model(id: "melix-dev-vlm#text"))
+        #expect(companion.maxContext == 131_072)
+        #expect(companion.settings.ext["melix.context_window.source"] == "config.text_config.max_position_embeddings")
+        #expect(await harness.textClient.lastGenerateRequest != nil)
+        #expect(await harness.vlmClient.lastGenerateRequest == nil)
     }
 
     @Test("POST /v1/chat/completions keeps Gemma4 VLM media requests on the Swift vision route")
@@ -11278,6 +11346,50 @@ struct OpenAIHandlerTests {
         #expect(response.statusCode == 200)
         #expect(message["content"] as? String == "ok")
         #expect(await workerClient.lastGenerateRequest != nil)
+    }
+
+    @Test("long context admission still rejects prompts beyond estimate slack")
+    func longContextAdmissionStillRejectsPromptsBeyondEstimateSlack() async throws {
+        let workerClient = ScriptedWorkerClient(events: [])
+        var model = warmModel()
+        model.maxContext = 131_072
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [model]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-long-context-over-budget" })
+        )
+        let densePrompt = String(repeating: "a", count: 540_000)
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": false,
+              "max_tokens": 512,
+              "messages": [
+                { "role": "user", "content": "\(densePrompt)" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(method: .post, path: "/v1/chat/completions", headers: [:], body: body)
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let error = try #require(payload["error"] as? [String: Any])
+        let metadata = try #require(error["prompt_token_metadata"] as? [String: Any])
+
+        #expect(response.statusCode == 400)
+        #expect(error["code"] as? String == "prompt_budget_exceeded")
+        #expect(metadata["context_window_tokens"] as? Int == 131_072)
+        #expect(metadata["max_prompt_tokens_effective"] as? Int == 130_560)
+        #expect(metadata["prompt_tokens_estimate_source"] as? String == "control_plane_heuristic_utf8_whitespace")
+        #expect(metadata["prompt_tokens_estimate_slack"] as? Int == 2_048)
+        #expect(metadata["prompt_tokens_reject_threshold"] as? Int == 132_608)
+        #expect(await workerClient.lastGenerateRequest == nil)
     }
 
     @Test("chat requests return 409 when the model is not ready")

--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -1030,8 +1030,11 @@ def test_registry_root_tree_records_plain_local_weight_presence_during_single_sc
 
     assert manifest_paths == ()
     assert hf_cache_repo_dirs == ()
-    assert [(scan.model_dir, scan.has_model_weight_files, scan.has_generation_config) for scan in plain_scans] == [
-        (config_dir.resolve(), True, False)
+    assert [
+        (scan.model_dir, scan.has_model_weight_files, scan.has_generation_config, scan.has_tokenizer_config)
+        for scan in plain_scans
+    ] == [
+        (config_dir.resolve(), True, False, False)
     ]
     assert not hasattr(plain_scans[0], "__dict__")
 
@@ -1222,6 +1225,70 @@ def test_raw_model_spec_loads_config_payload_when_not_supplied(
     assert model.ext["melix.model_path"] == str(model_dir.resolve())
     assert config_load_count == 1
 
+    nested_model_dir = tmp_path / "nested-context-model"
+    _write_model_config(
+        nested_model_dir,
+        {
+            "model_type": "gemma4",
+            "text_config": {
+                "model_type": "gemma4_text",
+                "max_position_embeddings": 131_072,
+            },
+        },
+    )
+    _write_weights(nested_model_dir)
+    nested_model = catalog._raw_model_spec(
+        model_id="nested-context-model",
+        model_dir=nested_model_dir.resolve(),
+        revision="local",
+        source_kind="local_mlx_directory",
+        metadata={},
+    )
+
+    assert nested_model.max_context == 131_072
+    assert nested_model.ext["melix.context_window.source"] == "config.text_config.max_position_embeddings"
+
+    top_level_model_dir = tmp_path / "top-level-context-model"
+    _write_model_config(
+        top_level_model_dir,
+        {
+            "model_type": "qwen3",
+            "max_position_embeddings": 262_144,
+        },
+    )
+    (top_level_model_dir / "tokenizer_config.json").write_text(
+        json.dumps({"model_max_length": 1000000000000000019884624838656}) + "\n",
+        encoding="utf-8",
+    )
+    _write_weights(top_level_model_dir)
+    top_level_model = catalog._raw_model_spec(
+        model_id="top-level-context-model",
+        model_dir=top_level_model_dir.resolve(),
+        revision="local",
+        source_kind="local_mlx_directory",
+        metadata={},
+    )
+
+    assert top_level_model.max_context == 262_144
+    assert top_level_model.ext["melix.context_window.source"] == "config.max_position_embeddings"
+
+    tokenizer_model_dir = tmp_path / "tokenizer-context-model"
+    _write_model_config(tokenizer_model_dir, {"model_type": "custom"})
+    (tokenizer_model_dir / "tokenizer_config.json").write_text(
+        json.dumps({"model_max_length": 65_536}) + "\n",
+        encoding="utf-8",
+    )
+    _write_weights(tokenizer_model_dir)
+    tokenizer_model = catalog._raw_model_spec(
+        model_id="tokenizer-context-model",
+        model_dir=tokenizer_model_dir.resolve(),
+        revision="local",
+        source_kind="local_mlx_directory",
+        metadata={},
+    )
+
+    assert tokenizer_model.max_context == 65_536
+    assert tokenizer_model.ext["melix.context_window.source"] == "tokenizer_config.model_max_length"
 
 
 def test_registry_snapshot_does_not_stat_plain_local_manifest_after_tree_scan(
@@ -1269,6 +1336,7 @@ def test_registry_snapshot_does_not_stat_missing_plain_local_generation_config_a
     root = tmp_path / "root"
     model_dir = root / "plain-model"
     generation_probe = (model_dir / "generation_config.json").resolve()
+    tokenizer_probe = (model_dir / "tokenizer_config.json").resolve()
     _write_model_config(
         model_dir,
         {
@@ -1281,11 +1349,14 @@ def test_registry_snapshot_does_not_stat_missing_plain_local_generation_config_a
 
     original_stat = Path.stat
     generation_probe_calls = 0
+    tokenizer_probe_calls = 0
 
     def tracking_stat(self: Path, *args: object, **kwargs: object) -> os.stat_result:
-        nonlocal generation_probe_calls
+        nonlocal generation_probe_calls, tokenizer_probe_calls
         if os.fspath(self) == os.fspath(generation_probe):
             generation_probe_calls += 1
+        if os.fspath(self) == os.fspath(tokenizer_probe):
+            tokenizer_probe_calls += 1
         return original_stat(self, *args, **kwargs)
 
     try:
@@ -1293,7 +1364,13 @@ def test_registry_snapshot_does_not_stat_missing_plain_local_generation_config_a
     except FileNotFoundError:
         pass
     assert generation_probe_calls == 1
+    try:
+        tracking_stat(tokenizer_probe)
+    except FileNotFoundError:
+        pass
+    assert tokenizer_probe_calls == 1
     generation_probe_calls = 0
+    tokenizer_probe_calls = 0
     monkeypatch.setattr(Path, "stat", tracking_stat)
 
     catalog = WorkerModelCatalog(environment={"MELIX_MODEL_ROOTS": str(root), "HOME": str(tmp_path / "home")})
@@ -1301,6 +1378,7 @@ def test_registry_snapshot_does_not_stat_missing_plain_local_generation_config_a
 
     assert [model.model_id for model in snapshot.models] == ["plain-model"]
     assert generation_probe_calls == 0
+    assert tokenizer_probe_calls == 0
 
 
 

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -79,6 +79,7 @@ class _PlainLocalModelScan:
     model_dir: Path
     has_model_weight_files: bool
     has_generation_config: bool
+    has_tokenizer_config: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -190,6 +191,65 @@ def _load_model_config_payload(
 ) -> dict[str, object]:
     config_path = model_dir / "config.json"
     return _load_json_dict_file(config_path, json_cache=json_cache)
+
+
+_CONTEXT_WINDOW_KEYS = (
+    "max_position_embeddings",
+    "max_seq_len",
+    "max_seq_length",
+    "seq_length",
+    "n_positions",
+)
+_TEXT_CONTEXT_CONFIG_KEYS = ("text_config", "language_config", "llm_config")
+_TOKENIZER_MAX_LENGTH_SENTINEL = 10**18
+
+
+def _config_context_window(config_payload: Mapping[str, object] | None) -> tuple[int, str]:
+    if not isinstance(config_payload, Mapping):
+        return 0, ""
+
+    for key in _CONTEXT_WINDOW_KEYS:
+        value = _positive_int_value(config_payload.get(key))
+        if value > 0:
+            return value, f"config.{key}"
+
+    for config_key in _TEXT_CONTEXT_CONFIG_KEYS:
+        nested = config_payload.get(config_key)
+        if not isinstance(nested, Mapping):
+            continue
+        for key in _CONTEXT_WINDOW_KEYS:
+            value = _positive_int_value(nested.get(key))
+            if value > 0:
+                return value, f"config.{config_key}.{key}"
+
+    return 0, ""
+
+
+def _tokenizer_context_window(
+    model_dir: Path,
+    *,
+    json_cache: dict[Path, tuple[int, int, dict[str, object]]] | None = None,
+) -> tuple[int, str]:
+    tokenizer_payload = _load_json_dict_file(model_dir / "tokenizer_config.json", json_cache=json_cache)
+    value = _positive_int_value(tokenizer_payload.get("model_max_length"))
+    if 0 < value < _TOKENIZER_MAX_LENGTH_SENTINEL:
+        return value, "tokenizer_config.model_max_length"
+    return 0, ""
+
+
+def _model_context_window(
+    model_dir: Path,
+    config_payload: Mapping[str, object] | None,
+    *,
+    json_cache: dict[Path, tuple[int, int, dict[str, object]]] | None = None,
+    has_tokenizer_config: bool | None = None,
+) -> tuple[int, str]:
+    config_value, config_source = _config_context_window(config_payload)
+    if config_value > 0:
+        return config_value, config_source
+    if has_tokenizer_config is False:
+        return 0, ""
+    return _tokenizer_context_window(model_dir, json_cache=json_cache)
 
 
 def _load_tensor_index_payload(
@@ -2011,6 +2071,7 @@ class WorkerModelCatalog:
                 metadata={},
                 config_payload=config_payload,
                 has_generation_config=plain_local_model.has_generation_config,
+                has_tokenizer_config=plain_local_model.has_tokenizer_config,
             )
             self._apply_root_metadata(
                 model,
@@ -2097,6 +2158,7 @@ class WorkerModelCatalog:
                     has_manifest = False
                     has_config = False
                     has_generation_config = False
+                    has_tokenizer_config = False
                     has_model_weight_files = False
                     for entry in entries:
                         entry_name = entry.name
@@ -2109,6 +2171,9 @@ class WorkerModelCatalog:
                                 continue
                             if entry_name == "generation_config.json" and entry.is_file():
                                 has_generation_config = True
+                                continue
+                            if entry_name == "tokenizer_config.json" and entry.is_file():
+                                has_tokenizer_config = True
                                 continue
                             if entry_name == "model.safetensors.index.json" and entry.is_file():
                                 has_model_weight_files = True
@@ -2136,6 +2201,7 @@ class WorkerModelCatalog:
                         model_dir=current,
                         has_model_weight_files=has_model_weight_files,
                         has_generation_config=has_generation_config,
+                        has_tokenizer_config=has_tokenizer_config,
                     )
                 )
                 continue
@@ -2177,6 +2243,7 @@ class WorkerModelCatalog:
         metadata: dict[str, str],
         config_payload: Mapping[str, object] | None = None,
         has_generation_config: bool | None = None,
+        has_tokenizer_config: bool | None = None,
     ) -> common_pb2.ModelSpec:
         json_cache = getattr(self, "_json_file_cache", None)
         if json_cache is None:
@@ -2190,6 +2257,16 @@ class WorkerModelCatalog:
         }
         if config_payload is None:
             config_payload = _load_model_config_payload(model_dir, json_cache=json_cache)
+        max_context, max_context_source = _model_context_window(
+            model_dir,
+            config_payload,
+            json_cache=json_cache,
+            has_tokenizer_config=has_tokenizer_config,
+        )
+        if max_context <= 0:
+            max_context = 8192
+            max_context_source = "default.8192"
+        ext["melix.context_window.source"] = max_context_source
         ext.update(dflash_draft_metadata(config_payload))
         model_kind = "vlm" if _is_gemma4_vlm_config(config_payload) else "text"
         if model_kind == "text":
@@ -2235,7 +2312,7 @@ class WorkerModelCatalog:
             quant_profile_id="",
             parser_mode="text",
             reasoning_mode="off",
-            max_context=8192,
+            max_context=max_context,
             ext=ext,
         )
 


### PR DESCRIPTION
## Summary
- Derive local MLX model context windows from `config.json` and finite `tokenizer_config.json` evidence instead of publishing the 8192-token fallback for every raw local directory.
- Let OpenAI text companions infer nested text context windows before prompt-budget admission, so Gemma 4 text routes can reach worker admission at 128k.
- Keep pre-worker rejection for clearly excessive prompts, record prompt-estimate source/slack metadata, and avoid extra missing sidecar stats during plain-local registry scans.

## Plan or Spec
- `docs/plans/2026-06-04-config-derived-long-context-admission.md`
- `docs/control-plane-protocol.md`

## Commands Run
```text
git diff --check -> pass
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q -> pass
swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(postChatCompletionsGivesGemma4TextCompanionsNestedTextContextLimit|postChatCompletionsLets128KTextCompanionsReachWorkerAdmission|nonStreamChatRejectsOverBudgetPromptsBeforeWorkerGeneration|streamChatRejectsOverBudgetPromptsBeforeFirstSSEDataChunk|maxCompletionTokensRemainsAnOutputCapInPromptBudgetAdmission|defaultOutputCapDoesNotExhaustPromptBudgetForShortPrompts|longContextAdmissionStillRejectsPromptsBeyondEstimateSlack)' -> 7 tests passed
swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(postChatCompletionsGivesGemma4TextCompanionsNestedTextContextLimit|postChatCompletionsLets128KTextCompanionsReachWorkerAdmission|postChatCompletionsCachesGemma4TextCompanionContextInferenceByModelPath|longContextAdmissionStillRejectsPromptsBeyondEstimateSlack)' -> 4 tests passed
swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(postChatCompletionsRoutesGemma4TextOnlyVLMThroughSwiftTextCompanion|postChatCompletionsKeepsGemma4VLMMediaRequestsOnSwiftVisionRoute|postChatCompletionsRefusesOpenAIToolsOnMediaBearingRequests)' -> 3 tests passed
swift test --package-path services/control-plane-swift --filter 'PythonBridgeWorkerClientTests|ModelCatalogTests' -> 103 tests passed
Focused registry changed-scope coverage command -> 19 passed; changed-line coverage 100%
git commit -m "fix: derive long context windows from model configs" -> pre-commit full gate passed: make swift-test, make py-test, make integration-test, PR scoped performance Status ok
git merge --no-commit --no-ff origin/main && git commit --no-edit -> pre-commit full gate passed again after updating to origin/main: make swift-test, make py-test, make integration-test, PR scoped performance Status ok
git commit -m "fix: cache text companion context inference" -> pre-commit full gate passed: make swift-test, make py-test, make integration-test, PR scoped performance Status ok
128k comparison rerun -> /Users/chenyu/Documents/github/melix/.runtime/serving-comparison/20260604T115034+0900-melix-omlx-swiftml-128k-fix-context/report.zh.md
```

## Coverage and Metrics
- Changed-scope coverage: model registry focused probe reported 99.0% on the final pre-commit run, above the 95% gate.
- PR scoped performance report: `/Users/chenyu/Documents/github/melix/.runtime/worktrees/fix-128k-context-admission/.runtime/pre-commit-performance/20260604-043355-cf96cddd/report/report.md`
- Performance status: `ok`; model registry plain-local probe elapsed mean changed from `53.729ms` to `53.617ms` (`-0.21%`), with no generation-config stat, manifest stat, config load, or manifest parse regressions.
- Review-fix PR scoped performance report: `/Users/chenyu/Documents/github/melix/.runtime/worktrees/fix-128k-context-admission/.runtime/pre-commit-performance/20260604-050839-4b33b6f5/report/report.md`
- Review-fix performance status: `ok`; changed files `2`, selected probes `0`, regressions `0`, verification failures `0`.
- Full local gate: the versioned pre-commit hook ran `make swift-test`, `make py-test`, and `make integration-test` on this 256 GiB macOS host for the feature commit, merge-to-latest-main commit, and review-fix commit.
- 128k serving comparison:
  - Melix vs OMLX: Melix 2/2, TTFT p50 `34.17s`, total p50 `47.76s`, decode p50 `37.7 tok/s`; OMLX 2/2, TTFT p50 `32.01s`, total p50 `47.33s`, decode p50 `33.4 tok/s`.
  - Melix vs SwiftLM: Melix 2/2, TTFT p50 `38.68s`, total p50 `52.28s`, decode p50 `37.7 tok/s`; SwiftLM 0/2 because the server exited during 128k prefill and formal requests hit connection refused.
- Observability mode: evidence. The change adds normal admission metadata and uses benchmark artifacts under `.runtime`; no opt-in debug probe was added.
- Probe overhead: `N/A`: no new runtime debug probe or production sampling path was introduced.

## Known Gaps
- SwiftLM 128k result is recorded as an observed failure, not a fair speed comparison, because the host was under high load and low free-page pressure during that pair.
- Protocol schema changes: N/A, no protobuf schema changed.
- Dependency or lockfile changes: N/A, no dependency changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
