### PR TITLE
Implement window route metadata shell slice

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
@@ -285,14 +285,16 @@ struct DesktopShellTabStripView: View {
             return "4"
         case .workflows:
             return "5"
-        case .diagnostics:
+        case .jobs:
             return "6"
-        case .image:
+        case .diagnostics:
             return "7"
         case .api:
             return "8"
-        case .settings:
+        case .image:
             return "9"
+        case .settings:
+            return "0"
         case .tools:
             return "0"
         }

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -57,6 +57,14 @@ struct DesktopWorkspaceShellView: View {
                         showsSidebar: paneVisibilityBinding(.sidebar, for: .workflows),
                         showsInspector: paneVisibilityBinding(.inspector, for: .workflows)
                     )
+                case .jobs:
+                    DesktopDomainWorkspaceView(
+                        domain: .jobs,
+                        viewModel: viewModel,
+                        foundation: foundation,
+                        showsSidebar: paneVisibilityBinding(.sidebar, for: .jobs),
+                        showsInspector: paneVisibilityBinding(.inspector, for: .jobs)
+                    )
                 case .diagnostics:
                     DesktopDomainWorkspaceView(
                         domain: .diagnostics,
@@ -2217,7 +2225,9 @@ private struct DesktopDomainWorkspaceView: View {
         case .models:
             return "Manage local model assets, downloads, compatibility, quantization, and adapters."
         case .workflows:
-            return "Run training, recipes, synthetic data generation, batch jobs, and job review."
+            return "Run training, recipes, synthetic dataset generation, and batch operations."
+        case .jobs:
+            return "Review durable operation state, queue progress, history, and artifact lineage across domains."
         case .diagnostics:
             return "Audit benchmark, matrix, evaluation, and log evidence for runtime behavior."
         case .settings:
@@ -2231,6 +2241,8 @@ private struct DesktopDomainWorkspaceView: View {
             return viewModel.primaryModel?.stateText ?? "No primary model"
         case .workflows:
             return viewModel.lastModelOperation?.stage ?? "No active workflow"
+        case .jobs:
+            return viewModel.runtimeJobsEmptyStateTitle
         case .diagnostics:
             return viewModel.diagnosticsRunMonitor?.statusText ?? "Ready for diagnostics"
         case .settings:
@@ -2244,6 +2256,8 @@ private struct DesktopDomainWorkspaceView: View {
             return viewModel.primaryModel?.memoryText ?? "Model metrics unavailable"
         case .workflows:
             return viewModel.lastModelOperation?.operation ?? "No operation recorded"
+        case .jobs:
+            return "\(viewModel.runtimeJobs.count) jobs tracked"
         case .diagnostics:
             return viewModel.diagnosticsRunMonitor?.primaryMetricText ?? "No recent diagnostic metric"
         case .settings:
@@ -2265,7 +2279,16 @@ private struct DesktopDomainWorkspaceView: View {
         case .workflows:
             return [
                 DesktopInspectorActionRow(title: "Open Jobs", systemImage: "list.bullet.rectangle.portrait") {
-                    viewModel.selectToolSection(.jobs)
+                    viewModel.selectSurface(.jobs)
+                },
+                DesktopInspectorActionRow(title: "Open Diagnostics", systemImage: "stethoscope") {
+                    viewModel.selectToolSection(.diagnostics)
+                },
+            ]
+        case .jobs:
+            return [
+                DesktopInspectorActionRow(title: "Refresh Jobs", systemImage: "arrow.clockwise") {
+                    Task { await viewModel.refreshRuntimeJobs() }
                 },
                 DesktopInspectorActionRow(title: "Open Diagnostics", systemImage: "stethoscope") {
                     viewModel.selectToolSection(.diagnostics)
@@ -2295,6 +2318,13 @@ private struct DesktopDomainWorkspaceView: View {
             return [viewModel.lastModelOperation?.outputPath, viewModel.primaryModel?.modelID].compactMap { $0 }.filter { $0.isEmpty == false }
         case .workflows:
             return [viewModel.lastModelOperation?.outputPath, viewModel.selectedRuntimeJob?.artifactRoot].compactMap { $0 }.filter { $0.isEmpty == false }
+        case .jobs:
+            return [
+                viewModel.selectedRuntimeJob?.artifactRoot,
+                viewModel.selectedRuntimeJobDetail?.logs.path,
+                viewModel.selectedRuntimeJobLogSnapshot?.logPath,
+                viewModel.selectedRuntimeJobArtifactSnapshot?.artifacts.first?.path,
+            ].compactMap { $0 }.filter { $0.isEmpty == false }
         case .diagnostics:
             return [viewModel.diagnosticsRunMonitor?.artifactText, viewModel.diagnosticsRunMonitor?.detailText].compactMap { $0 }.filter { $0.isEmpty == false }
         case .settings:

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -2129,6 +2129,22 @@ extension DesktopInspectorContractView where ExtraContent == EmptyView {
     }
 }
 
+enum DesktopInspectorEvidenceBuilder {
+    static func jobsEvidence(
+        artifactRoot: String?,
+        detailLogPath: String?,
+        logSnapshotPath: String?,
+        artifactPaths: [String]
+    ) -> [String] {
+        let basePaths = [
+            artifactRoot,
+            detailLogPath,
+            logSnapshotPath,
+        ]
+        return (basePaths + artifactPaths.map(Optional.some)).compactMap { $0 }.filter { $0.isEmpty == false }
+    }
+}
+
 private struct DesktopDomainWorkspaceView: View {
     let domain: DesktopSurfaceDomain
     let viewModel: RuntimeViewModel
@@ -2319,12 +2335,12 @@ private struct DesktopDomainWorkspaceView: View {
         case .workflows:
             return [viewModel.lastModelOperation?.outputPath, viewModel.selectedRuntimeJob?.artifactRoot].compactMap { $0 }.filter { $0.isEmpty == false }
         case .jobs:
-            return [
-                viewModel.selectedRuntimeJob?.artifactRoot,
-                viewModel.selectedRuntimeJobDetail?.logs.path,
-                viewModel.selectedRuntimeJobLogSnapshot?.logPath,
-                viewModel.selectedRuntimeJobArtifactSnapshot?.artifacts.first?.path,
-            ].compactMap { $0 }.filter { $0.isEmpty == false }
+            return DesktopInspectorEvidenceBuilder.jobsEvidence(
+                artifactRoot: viewModel.selectedRuntimeJob?.artifactRoot,
+                detailLogPath: viewModel.selectedRuntimeJobDetail?.logs.path,
+                logSnapshotPath: viewModel.selectedRuntimeJobLogSnapshot?.logPath,
+                artifactPaths: viewModel.selectedRuntimeJobArtifactSnapshot?.artifacts.compactMap { $0.path } ?? []
+            )
         case .diagnostics:
             return [viewModel.diagnosticsRunMonitor?.artifactText, viewModel.diagnosticsRunMonitor?.detailText].compactMap { $0 }.filter { $0.isEmpty == false }
         case .settings:

--- a/apps/macos-menubar/Sources/AppMain/Models/DesktopShellState.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/DesktopShellState.swift
@@ -6,9 +6,10 @@ public enum DesktopSurface: String, CaseIterable, Identifiable, Codable, Sendabl
     case chat = "Chat"
     case commandCenter = "Command Center"
     case image = "Image"
-    case server = "Server"
+    case server = "Servers"
     case models = "Models"
     case workflows = "Workflows"
+    case jobs = "Jobs"
     case diagnostics = "Diagnostics"
     case tools = "Tools"
     case api = "API"
@@ -32,6 +33,8 @@ public enum DesktopSurface: String, CaseIterable, Identifiable, Codable, Sendabl
             return "square.stack.3d.up"
         case .workflows:
             return "point.3.connected.trianglepath.dotted"
+        case .jobs:
+            return "list.bullet.rectangle.portrait"
         case .diagnostics:
             return "stethoscope"
         case .tools:
@@ -44,7 +47,34 @@ public enum DesktopSurface: String, CaseIterable, Identifiable, Codable, Sendabl
     }
 
     public static var visibleNavigationCases: [DesktopSurface] {
-        [.chat, .commandCenter, .server, .models, .workflows, .diagnostics, .image, .api, .settings]
+        [.chat, .commandCenter, .server, .models, .workflows, .jobs, .diagnostics, .api, .image, .settings]
+    }
+
+    public var routeDomainID: String {
+        switch self {
+        case .chat:
+            return "chat"
+        case .commandCenter:
+            return "command"
+        case .server:
+            return "servers"
+        case .models:
+            return "models"
+        case .workflows:
+            return "workflows"
+        case .jobs:
+            return "jobs"
+        case .diagnostics:
+            return "diagnostics"
+        case .api:
+            return "api"
+        case .image:
+            return "image"
+        case .settings:
+            return "settings"
+        case .tools:
+            return "tools"
+        }
     }
 }
 
@@ -93,6 +123,7 @@ public enum DesktopToolSection: String, CaseIterable, Identifiable, Codable, Sen
 public enum DesktopToolCategory: String, CaseIterable, Identifiable, Codable, Sendable {
     case models = "Models"
     case workflows = "Workflows"
+    case jobs = "Jobs"
     case diagnostics = "Diagnostics"
     case system = "System"
 
@@ -103,7 +134,9 @@ public enum DesktopToolCategory: String, CaseIterable, Identifiable, Codable, Se
         case .models:
             return [.modelsLibrary, .downloads]
         case .workflows:
-            return [.training, .workflowRecipes, .syntheticDatasets, .batchRuns, .jobs]
+            return [.training, .workflowRecipes, .syntheticDatasets, .batchRuns]
+        case .jobs:
+            return [.jobs]
         case .diagnostics:
             return [.diagnostics, .logs]
         case .system:
@@ -115,6 +148,7 @@ public enum DesktopToolCategory: String, CaseIterable, Identifiable, Codable, Se
 public enum DesktopSurfaceDomain: String, CaseIterable, Identifiable, Sendable {
     case models = "Models"
     case workflows = "Workflows"
+    case jobs = "Jobs"
     case diagnostics = "Diagnostics"
     case settings = "Settings"
 
@@ -126,6 +160,8 @@ public enum DesktopSurfaceDomain: String, CaseIterable, Identifiable, Sendable {
             return .models
         case .workflows:
             return .workflows
+        case .jobs:
+            return .jobs
         case .diagnostics:
             return .diagnostics
         case .settings:
@@ -138,7 +174,9 @@ public enum DesktopSurfaceDomain: String, CaseIterable, Identifiable, Sendable {
         case .models:
             return [.modelsLibrary, .downloads]
         case .workflows:
-            return [.training, .workflowRecipes, .syntheticDatasets, .batchRuns, .jobs]
+            return [.training, .workflowRecipes, .syntheticDatasets, .batchRuns]
+        case .jobs:
+            return [.jobs]
         case .diagnostics:
             return [.diagnostics, .logs]
         case .settings:
@@ -152,8 +190,10 @@ extension DesktopToolSection {
         switch self {
         case .modelsLibrary, .downloads:
             return .models
-        case .training, .workflowRecipes, .syntheticDatasets, .batchRuns, .jobs:
+        case .training, .workflowRecipes, .syntheticDatasets, .batchRuns:
             return .workflows
+        case .jobs:
+            return .jobs
         case .diagnostics, .logs:
             return .diagnostics
         case .settings:
@@ -166,7 +206,7 @@ extension DesktopToolSection {
         case .modelsLibrary:
             return "Library"
         case .syntheticDatasets:
-            return "Synthetic Datasets"
+            return "Dataset Generation"
         default:
             return rawValue
         }
@@ -184,6 +224,8 @@ extension DesktopSurface {
             return .models
         case .workflows:
             return .workflows
+        case .jobs:
+            return .jobs
         case .diagnostics:
             return .diagnostics
         case .settings:
@@ -309,6 +351,550 @@ public struct DesktopRuntimeEndpointState: Equatable, Sendable {
     )
 }
 
+public enum DesktopInspectorModule: String, CaseIterable, Identifiable, Codable, Sendable {
+    case chatRuntime
+    case commandCenter
+    case serverProfile
+    case capabilityReceipt
+    case modelAsset
+    case workflowTemplate
+    case jobLineage
+    case diagnosticsEvidence
+    case apiInboundAuth
+    case apiConsole
+    case imageArtifact
+    case runtimeStorage
+
+    public var id: String { rawValue }
+}
+
+public enum DesktopRouteActionTarget: Equatable, Codable, Sendable {
+    case page(domain: DesktopSurface, pageID: String)
+}
+
+public struct DesktopRouteActionMetadata: Equatable, Codable, Sendable {
+    public let title: String
+    public let target: DesktopRouteActionTarget
+
+    public init(title: String, target: DesktopRouteActionTarget) {
+        self.title = title
+        self.target = target
+    }
+}
+
+public struct DesktopRoutePageMetadata: Identifiable, Equatable, Codable, Sendable {
+    public let id: String
+    public let label: String
+    public let title: String
+    public let subtitle: String
+    public let primaryAction: DesktopRouteActionMetadata?
+    public let secondaryActions: [DesktopRouteActionMetadata]
+    public let inspectorModule: DesktopInspectorModule
+    public let routeDomainID: String
+
+    public var crumb: String { domainLabel }
+    public var routePath: String { "/\(routeDomainID)/\(id)" }
+
+    public let domainLabel: String
+
+    public init(
+        id: String,
+        label: String,
+        title: String,
+        subtitle: String,
+        inspectorModule: DesktopInspectorModule,
+        routeDomainID: String,
+        domainLabel: String,
+        primaryAction: DesktopRouteActionMetadata? = nil,
+        secondaryActions: [DesktopRouteActionMetadata] = []
+    ) {
+        self.id = id
+        self.label = label
+        self.title = title
+        self.subtitle = subtitle
+        self.primaryAction = primaryAction
+        self.secondaryActions = secondaryActions
+        self.inspectorModule = inspectorModule
+        self.routeDomainID = routeDomainID
+        self.domainLabel = domainLabel
+    }
+}
+
+public struct DesktopRouteDomainMetadata: Identifiable, Equatable, Codable, Sendable {
+    public let domain: DesktopSurface
+    public let pages: [DesktopRoutePageMetadata]
+
+    public var id: String { domain.routeDomainID }
+
+    public init(domain: DesktopSurface, pages: [DesktopRoutePageMetadata]) {
+        self.domain = domain
+        self.pages = pages
+    }
+}
+
+public struct DesktopRouteMetadata: Equatable, Codable, Sendable {
+    public let domains: [DesktopRouteDomainMetadata]
+
+    public init(domains: [DesktopRouteDomainMetadata]) {
+        self.domains = domains
+    }
+
+    public func page(domain: DesktopSurface, pageID: String) -> DesktopRoutePageMetadata? {
+        domains.first { $0.domain == domain }?.pages.first { $0.id == pageID }
+    }
+
+    public static let acceptedWindowIA = DesktopRouteMetadata(domains: [
+        .init(
+            domain: .chat,
+            pages: [
+                .page(
+                    domain: .chat,
+                    id: "session",
+                    label: "Session",
+                    title: "Chat",
+                    subtitle: "Chat sessions must bind to an explicit local or remote server before sending.",
+                    inspectorModule: .chatRuntime
+                ),
+                .page(
+                    domain: .chat,
+                    id: "inspector-collapsed",
+                    label: "Inspector Collapsed",
+                    title: "Chat",
+                    subtitle: "Chat remains usable when the runtime Inspector is collapsed.",
+                    inspectorModule: .chatRuntime
+                ),
+            ]
+        ),
+        .init(
+            domain: .commandCenter,
+            pages: [
+                .page(
+                    domain: .commandCenter,
+                    id: "overview",
+                    label: "Overview",
+                    title: "Command Center",
+                    subtitle: "Shows what needs attention now without replacing Diagnostics evidence.",
+                    inspectorModule: .commandCenter,
+                    primaryAction: .init(
+                        title: "Review Eval Drift",
+                        target: .page(domain: .diagnostics, pageID: "evaluation")
+                    ),
+                    secondaryActions: [
+                        .init(title: "Jobs", target: .page(domain: .jobs, pageID: "queue")),
+                    ]
+                ),
+                .page(
+                    domain: .commandCenter,
+                    id: "menu-bar",
+                    label: "Menu Bar Command Center",
+                    title: "Menu Bar Command Center",
+                    subtitle: "Compact command center state for menu bar operator access.",
+                    inspectorModule: .commandCenter
+                ),
+            ]
+        ),
+        .init(
+            domain: .server,
+            pages: [
+                .page(
+                    domain: .server,
+                    id: "overview",
+                    label: "Overview",
+                    title: "Servers",
+                    subtitle: "Manage local and remote server profiles, health, credentials, and capability receipts.",
+                    inspectorModule: .serverProfile,
+                    primaryAction: .init(title: "Create Local Server", target: .page(domain: .server, pageID: "create-local")),
+                    secondaryActions: [
+                        .init(title: "Add Remote Server", target: .page(domain: .server, pageID: "add-remote")),
+                    ]
+                ),
+                .page(
+                    domain: .server,
+                    id: "local",
+                    label: "Local Servers",
+                    title: "Local Servers",
+                    subtitle: "Start, stop, and inspect local runtime profiles.",
+                    inspectorModule: .serverProfile,
+                    primaryAction: .init(title: "Create Local Server", target: .page(domain: .server, pageID: "create-local"))
+                ),
+                .page(
+                    domain: .server,
+                    id: "remote",
+                    label: "Remote Servers",
+                    title: "Remote Servers",
+                    subtitle: "Manage outbound provider targets and credential boundaries.",
+                    inspectorModule: .serverProfile,
+                    primaryAction: .init(title: "Add Remote Server", target: .page(domain: .server, pageID: "add-remote"))
+                ),
+                .page(
+                    domain: .server,
+                    id: "create-local",
+                    label: "Create Local Server",
+                    title: "Create Local Server",
+                    subtitle: "Basic setup first, advanced runtime fields collapsed for first-run creation.",
+                    inspectorModule: .serverProfile,
+                    primaryAction: .init(title: "Create And Start", target: .page(domain: .server, pageID: "local"))
+                ),
+                .page(
+                    domain: .server,
+                    id: "add-remote",
+                    label: "Add Remote Server",
+                    title: "Add Remote Server",
+                    subtitle: "Endpoint, authentication, capability test, and review for outbound provider setup.",
+                    inspectorModule: .capabilityReceipt,
+                    primaryAction: .init(title: "Save Remote Server", target: .page(domain: .server, pageID: "remote"))
+                ),
+                .page(
+                    domain: .server,
+                    id: "receipts",
+                    label: "Capability Receipts",
+                    title: "Capability Receipts",
+                    subtitle: "Evidence for runtime capabilities, unsupported routes, and probe freshness.",
+                    inspectorModule: .capabilityReceipt
+                ),
+            ]
+        ),
+        .init(
+            domain: .models,
+            pages: [
+                .page(
+                    domain: .models,
+                    id: "library",
+                    label: "Library",
+                    title: "Models",
+                    subtitle: "Manage model and adapter assets without treating them as running endpoints.",
+                    inspectorModule: .modelAsset,
+                    primaryAction: .init(title: "Validate", target: .page(domain: .models, pageID: "library"))
+                ),
+                .page(
+                    domain: .models,
+                    id: "downloads-imports",
+                    label: "Downloads & Imports",
+                    title: "Downloads & Imports",
+                    subtitle: "Download, import, validate, and convert model assets.",
+                    inspectorModule: .modelAsset,
+                    primaryAction: .init(title: "Start Download", target: .page(domain: .models, pageID: "downloads-imports"))
+                ),
+            ]
+        ),
+        .init(
+            domain: .workflows,
+            pages: [
+                .page(
+                    domain: .workflows,
+                    id: "training",
+                    label: "Training",
+                    title: "Training",
+                    subtitle: "Configure repeatable training workflows that produce adapter assets and jobs.",
+                    inspectorModule: .workflowTemplate,
+                    primaryAction: .init(title: "Train LoRA", target: .page(domain: .jobs, pageID: "queue"))
+                ),
+                .page(
+                    domain: .workflows,
+                    id: "recipes",
+                    label: "Workflow Recipes",
+                    title: "Workflow Recipes",
+                    subtitle: "Apply reusable operation templates that create workflow drafts or jobs.",
+                    inspectorModule: .workflowTemplate
+                ),
+                .page(
+                    domain: .workflows,
+                    id: "dataset-generation",
+                    label: "Dataset Generation",
+                    title: "Dataset Generation",
+                    subtitle: "Generate durable datasets through repeatable workflow templates.",
+                    inspectorModule: .workflowTemplate,
+                    primaryAction: .init(title: "Create Dataset", target: .page(domain: .jobs, pageID: "queue"))
+                ),
+                .page(
+                    domain: .workflows,
+                    id: "batch-runs",
+                    label: "Batch Runs",
+                    title: "Batch Runs",
+                    subtitle: "Run batch operations that produce durable job outputs.",
+                    inspectorModule: .workflowTemplate,
+                    primaryAction: .init(title: "Start Batch", target: .page(domain: .jobs, pageID: "queue"))
+                ),
+            ]
+        ),
+        .init(
+            domain: .jobs,
+            pages: [
+                .page(
+                    domain: .jobs,
+                    id: "overview",
+                    label: "Overview",
+                    title: "Jobs",
+                    subtitle: "Durable operation state across models, workflows, diagnostics, image, servers, and API.",
+                    inspectorModule: .jobLineage,
+                    primaryAction: .init(title: "Refresh Jobs", target: .page(domain: .jobs, pageID: "overview"))
+                ),
+                .page(
+                    domain: .jobs,
+                    id: "queue",
+                    label: "Queue",
+                    title: "Queue",
+                    subtitle: "Queued and running work with blockers, recovery paths, and evidence links.",
+                    inspectorModule: .jobLineage,
+                    primaryAction: .init(title: "Refresh Jobs", target: .page(domain: .jobs, pageID: "queue"))
+                ),
+                .page(
+                    domain: .jobs,
+                    id: "history",
+                    label: "History",
+                    title: "History",
+                    subtitle: "Completed jobs and artifact lineage across owner domains.",
+                    inspectorModule: .jobLineage
+                ),
+            ]
+        ),
+        .init(
+            domain: .diagnostics,
+            pages: [
+                .page(
+                    domain: .diagnostics,
+                    id: "overview",
+                    label: "Overview",
+                    title: "Diagnostics",
+                    subtitle: "Canonical evidence and debugging workspace for runtime behavior.",
+                    inspectorModule: .diagnosticsEvidence
+                ),
+                .page(
+                    domain: .diagnostics,
+                    id: "benchmark",
+                    label: "Benchmark",
+                    title: "Benchmark",
+                    subtitle: "Measure latency, throughput, memory, and runtime path evidence.",
+                    inspectorModule: .diagnosticsEvidence,
+                    primaryAction: .init(title: "Run Benchmark", target: .page(domain: .jobs, pageID: "queue"))
+                ),
+                .page(
+                    domain: .diagnostics,
+                    id: "matrix",
+                    label: "Matrix",
+                    title: "Matrix",
+                    subtitle: "Compare runtime and model behavior across benchmark axes.",
+                    inspectorModule: .diagnosticsEvidence,
+                    primaryAction: .init(title: "Run Matrix", target: .page(domain: .jobs, pageID: "queue"))
+                ),
+                .page(
+                    domain: .diagnostics,
+                    id: "evaluation",
+                    label: "Evaluation",
+                    title: "Evaluation",
+                    subtitle: "Review eval evidence, semantic metrics, and human review state.",
+                    inspectorModule: .diagnosticsEvidence,
+                    primaryAction: .init(title: "Review Eval Drift", target: .page(domain: .diagnostics, pageID: "evaluation"))
+                ),
+                .page(
+                    domain: .diagnostics,
+                    id: "logs",
+                    label: "Logs",
+                    title: "Logs",
+                    subtitle: "Inspect logs and debug bundles as evidence artifacts.",
+                    inspectorModule: .diagnosticsEvidence
+                ),
+            ]
+        ),
+        .init(
+            domain: .api,
+            pages: [
+                .page(
+                    domain: .api,
+                    id: "overview",
+                    label: "Overview",
+                    title: "API",
+                    subtitle: "Developer integration overview for Melix endpoints and inbound access.",
+                    inspectorModule: .apiConsole
+                ),
+                .page(
+                    domain: .api,
+                    id: "inbound-auth",
+                    label: "Inbound Auth",
+                    title: "Inbound Auth",
+                    subtitle: "Configure credentials for clients calling Melix; remote provider credentials live under Servers.",
+                    inspectorModule: .apiInboundAuth
+                ),
+                .page(
+                    domain: .api,
+                    id: "playground",
+                    label: "Playground",
+                    title: "Playground",
+                    subtitle: "Request, response, headers, auth, latency, and receipt console.",
+                    inspectorModule: .apiConsole,
+                    primaryAction: .init(title: "Send Request", target: .page(domain: .api, pageID: "playground"))
+                ),
+                .page(
+                    domain: .api,
+                    id: "endpoints",
+                    label: "Endpoints",
+                    title: "Endpoints",
+                    subtitle: "Supported routes, compatibility, and endpoint receipts.",
+                    inspectorModule: .apiConsole
+                ),
+            ]
+        ),
+        .init(
+            domain: .image,
+            pages: [
+                .page(
+                    domain: .image,
+                    id: "generate",
+                    label: "Generate",
+                    title: "Image",
+                    subtitle: "Generate image artifacts with runtime and lineage visibility.",
+                    inspectorModule: .imageArtifact,
+                    primaryAction: .init(title: "Generate Image", target: .page(domain: .jobs, pageID: "queue"))
+                ),
+                .page(
+                    domain: .image,
+                    id: "edit",
+                    label: "Edit",
+                    title: "Edit",
+                    subtitle: "Edit image artifacts with source, mask, revision, and lineage context.",
+                    inspectorModule: .imageArtifact,
+                    primaryAction: .init(title: "Apply Edit", target: .page(domain: .jobs, pageID: "queue"))
+                ),
+            ]
+        ),
+        .init(
+            domain: .settings,
+            pages: [
+                .page(
+                    domain: .settings,
+                    id: "runtime-storage",
+                    label: "Runtime & Storage",
+                    title: "Runtime & Storage",
+                    subtitle: "Configure runtime discovery, model roots, storage, and operator preferences.",
+                    inspectorModule: .runtimeStorage
+                ),
+                .page(
+                    domain: .settings,
+                    id: "reserved-ia",
+                    label: "Reserved IA",
+                    title: "Reserved IA",
+                    subtitle: "Reserved settings areas for security, retention, developer mode, logs, updates, and shortcuts.",
+                    inspectorModule: .runtimeStorage
+                ),
+            ]
+        ),
+    ])
+}
+
+private extension DesktopRoutePageMetadata {
+    static func page(
+        domain: DesktopSurface,
+        id: String,
+        label: String,
+        title: String,
+        subtitle: String,
+        inspectorModule: DesktopInspectorModule,
+        primaryAction: DesktopRouteActionMetadata? = nil,
+        secondaryActions: [DesktopRouteActionMetadata] = []
+    ) -> DesktopRoutePageMetadata {
+        DesktopRoutePageMetadata(
+            id: id,
+            label: label,
+            title: title,
+            subtitle: subtitle,
+            inspectorModule: inspectorModule,
+            routeDomainID: domain.routeDomainID,
+            domainLabel: domain.rawValue,
+            primaryAction: primaryAction,
+            secondaryActions: secondaryActions
+        )
+    }
+}
+
+public enum DesktopSelectedObjectKind: String, CaseIterable, Identifiable, Codable, Sendable {
+    case server
+    case model
+    case adapter
+    case job
+    case artifact
+    case receipt
+    case diagnosticReport = "diagnostic-report"
+    case apiToken = "api-token"
+
+    public var id: String { rawValue }
+
+    public init?(routePrefix: String) {
+        switch routePrefix.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "server":
+            self = .server
+        case "model":
+            self = .model
+        case "adapter":
+            self = .adapter
+        case "job":
+            self = .job
+        case "artifact":
+            self = .artifact
+        case "receipt":
+            self = .receipt
+        case "diagnostic-report", "eval":
+            self = .diagnosticReport
+        case "api-token", "token":
+            self = .apiToken
+        default:
+            return nil
+        }
+    }
+
+    public var defaultRoute: DesktopRouteActionTarget {
+        switch self {
+        case .server:
+            return .page(domain: .server, pageID: "overview")
+        case .model, .adapter:
+            return .page(domain: .models, pageID: "library")
+        case .job:
+            return .page(domain: .jobs, pageID: "queue")
+        case .artifact:
+            return .page(domain: .jobs, pageID: "history")
+        case .receipt:
+            return .page(domain: .server, pageID: "receipts")
+        case .diagnosticReport:
+            return .page(domain: .diagnostics, pageID: "evaluation")
+        case .apiToken:
+            return .page(domain: .api, pageID: "inbound-auth")
+        }
+    }
+}
+
+public struct DesktopSelectedObjectRoute: RawRepresentable, Equatable, Codable, Sendable {
+    public let kind: DesktopSelectedObjectKind
+    public let objectID: String
+
+    public var rawValue: String {
+        "\(kind.rawValue):\(objectID)"
+    }
+
+    public var defaultRoute: DesktopRouteActionTarget {
+        kind.defaultRoute
+    }
+
+    public init(kind: DesktopSelectedObjectKind, objectID: String) {
+        self.kind = kind
+        self.objectID = objectID
+    }
+
+    public init?(rawValue: String) {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let delimiterIndex = trimmed.firstIndex(of: ":") else {
+            return nil
+        }
+        let prefix = String(trimmed[..<delimiterIndex])
+        let objectID = String(trimmed[trimmed.index(after: delimiterIndex)...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard objectID.isEmpty == false,
+              let kind = DesktopSelectedObjectKind(routePrefix: prefix)
+        else {
+            return nil
+        }
+        self.init(kind: kind, objectID: objectID)
+    }
+}
+
 extension DesktopSurface {
     init(paneVisibilityID rawValue: String) {
         switch Self.normalizedPaneVisibilityID(rawValue) {
@@ -316,12 +902,14 @@ extension DesktopSurface {
             self = .commandCenter
         case "image":
             self = .image
-        case "server":
+        case "server", "servers":
             self = .server
         case "models":
             self = .models
         case "workflows":
             self = .workflows
+        case "jobs":
+            self = .jobs
         case "diagnostics":
             self = .diagnostics
         case "tools":
@@ -349,6 +937,8 @@ extension DesktopSurface {
             return "models"
         case .workflows:
             return "workflows"
+        case .jobs:
+            return "jobs"
         case .diagnostics:
             return "diagnostics"
         case .tools:

--- a/apps/macos-menubar/Sources/AppMain/Persistence/OperatorSessionStore.swift
+++ b/apps/macos-menubar/Sources/AppMain/Persistence/OperatorSessionStore.swift
@@ -125,13 +125,14 @@ public struct OperatorSessionStore: OperatorSessionStoring {
 
 private extension OperatorSessionState {
     init(sharedState: MelixOperatorSessionState) {
+        let selectedToolSection = DesktopToolSection(operatorSessionID: sharedState.selectedToolSectionID)
         self.init(
             schemaVersion: sharedState.schemaVersion,
             selectedSurface: DesktopSurface(
                 operatorSessionID: sharedState.selectedSurfaceID,
-                selectedToolSection: DesktopToolSection(operatorSessionID: sharedState.selectedToolSectionID)
+                selectedToolSection: selectedToolSection
             ),
-            selectedToolSection: DesktopToolSection(operatorSessionID: sharedState.selectedToolSectionID),
+            selectedToolSection: selectedToolSection,
             selectedServerSessionID: sharedState.selectedServerSessionID,
             selectedRuntimeJobID: sharedState.selectedRuntimeJobID,
             serverSessions: sharedState.serverSessions.map(DesktopServerSessionState.init(sharedState:)),

--- a/apps/macos-menubar/Sources/AppMain/Persistence/OperatorSessionStore.swift
+++ b/apps/macos-menubar/Sources/AppMain/Persistence/OperatorSessionStore.swift
@@ -54,10 +54,11 @@ public struct OperatorSessionState: Codable, Equatable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let selectedSurfaceID = try container.decodeIfPresent(String.self, forKey: .selectedSurface) ?? "chat"
         let selectedToolSectionID = try container.decodeIfPresent(String.self, forKey: .selectedToolSection) ?? "modelsLibrary"
+        let selectedToolSection = DesktopToolSection(operatorSessionID: selectedToolSectionID)
         self.init(
             schemaVersion: try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 4,
-            selectedSurface: DesktopSurface(operatorSessionID: selectedSurfaceID),
-            selectedToolSection: DesktopToolSection(operatorSessionID: selectedToolSectionID),
+            selectedSurface: DesktopSurface(operatorSessionID: selectedSurfaceID, selectedToolSection: selectedToolSection),
+            selectedToolSection: selectedToolSection,
             selectedServerSessionID: try container.decodeIfPresent(String.self, forKey: .selectedServerSessionID) ?? "",
             selectedRuntimeJobID: try container.decodeIfPresent(String.self, forKey: .selectedRuntimeJobID) ?? "",
             serverSessions: try container.decodeIfPresent([DesktopServerSessionState].self, forKey: .serverSessions) ?? [],
@@ -126,7 +127,10 @@ private extension OperatorSessionState {
     init(sharedState: MelixOperatorSessionState) {
         self.init(
             schemaVersion: sharedState.schemaVersion,
-            selectedSurface: DesktopSurface(operatorSessionID: sharedState.selectedSurfaceID),
+            selectedSurface: DesktopSurface(
+                operatorSessionID: sharedState.selectedSurfaceID,
+                selectedToolSection: DesktopToolSection(operatorSessionID: sharedState.selectedToolSectionID)
+            ),
             selectedToolSection: DesktopToolSection(operatorSessionID: sharedState.selectedToolSectionID),
             selectedServerSessionID: sharedState.selectedServerSessionID,
             selectedRuntimeJobID: sharedState.selectedRuntimeJobID,
@@ -354,22 +358,24 @@ private extension DesktopServerSessionLifecycle {
 }
 
 private extension DesktopSurface {
-    init(operatorSessionID rawValue: String) {
+    init(operatorSessionID rawValue: String, selectedToolSection: DesktopToolSection = .modelsLibrary) {
         switch Self.normalizedOperatorSessionID(rawValue) {
         case "commandcenter":
             self = .commandCenter
         case "image":
             self = .image
-        case "server":
+        case "server", "servers":
             self = .server
         case "models":
             self = .models
         case "workflows":
             self = .workflows
+        case "jobs":
+            self = .jobs
         case "diagnostics":
             self = .diagnostics
         case "tools":
-            self = .tools
+            self = selectedToolSection.domain.surface
         case "api":
             self = .api
         case "settings":
@@ -393,6 +399,8 @@ private extension DesktopSurface {
             return "models"
         case .workflows:
             return "workflows"
+        case .jobs:
+            return "jobs"
         case .diagnostics:
             return "diagnostics"
         case .tools:

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -348,7 +348,8 @@ struct DesktopFoundationViewTests {
     @MainActor
     func toolsCategoriesMapSectionsIntoStagedWorkflowGroups() {
         #expect(DesktopToolCategory.models.sections == [.modelsLibrary, .downloads])
-        #expect(DesktopToolCategory.workflows.sections == [.training, .workflowRecipes, .syntheticDatasets, .batchRuns, .jobs])
+        #expect(DesktopToolCategory.workflows.sections == [.training, .workflowRecipes, .syntheticDatasets, .batchRuns])
+        #expect(DesktopToolCategory.jobs.sections == [.jobs])
         #expect(DesktopToolCategory.diagnostics.sections == [.diagnostics, .logs])
         #expect(DesktopToolCategory.system.sections == [.settings])
     }
@@ -376,7 +377,7 @@ struct DesktopFoundationViewTests {
         let viewModel = RuntimeViewModel(client: client)
         await viewModel.start()
 
-        for surface in [DesktopSurface.server, .image, .tools, .api] {
+        for surface in [DesktopSurface.server, .jobs, .image, .tools, .api] {
             viewModel.selectSurface(surface)
             let hosted = hostView(DesktopWorkspaceShellView(viewModel: viewModel))
             let renderedTexts = renderedTextValues(in: hosted)
@@ -2603,6 +2604,9 @@ struct DesktopFoundationViewTests {
         for section in DesktopSurfaceDomain.workflows.sections {
             #expect(section.breadcrumbTitle == "Workflows / \(section.domainTitle)")
         }
+        for section in DesktopSurfaceDomain.jobs.sections {
+            #expect(section.breadcrumbTitle == "Jobs / \(section.domainTitle)")
+        }
     }
 
     @Test("jobs tool section renders navigation list selection and empty state")
@@ -2614,7 +2618,7 @@ struct DesktopFoundationViewTests {
         let emptyView = hostView(DesktopJobsToolSectionView(viewModel: viewModel))
         let emptyTexts = renderedTextValues(in: emptyView)
 
-        #expect(viewModel.selectedSurface == .workflows)
+        #expect(viewModel.selectedSurface == .jobs)
         #expect(viewModel.selectedToolSection == .jobs)
         #expect(DesktopJobsToolSectionView.emptyStateTitle == "No Jobs Yet")
         #expect(emptyTexts.contains(DesktopJobsToolSectionView.emptyStateTitle))

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -2662,6 +2662,31 @@ struct DesktopFoundationViewTests {
         #expect(shellView.subviews.isEmpty == false)
     }
 
+    @Test("jobs inspector evidence maps every fetched artifact path")
+    @MainActor
+    func jobsInspectorEvidenceMapsEveryFetchedArtifactPath() {
+        let evidence = DesktopInspectorEvidenceBuilder.jobsEvidence(
+            artifactRoot: "/tmp/melix/jobs/eval-1808",
+            detailLogPath: "/tmp/melix/jobs/eval-1808/detail.log",
+            logSnapshotPath: "/tmp/melix/jobs/eval-1808/live.log",
+            artifactPaths: [
+                "/tmp/melix/jobs/eval-1808/manifest.json",
+                "/tmp/melix/jobs/eval-1808/metrics.json",
+                "",
+                "/tmp/melix/jobs/eval-1808/report.md",
+            ]
+        )
+
+        #expect(evidence == [
+            "/tmp/melix/jobs/eval-1808",
+            "/tmp/melix/jobs/eval-1808/detail.log",
+            "/tmp/melix/jobs/eval-1808/live.log",
+            "/tmp/melix/jobs/eval-1808/manifest.json",
+            "/tmp/melix/jobs/eval-1808/metrics.json",
+            "/tmp/melix/jobs/eval-1808/report.md",
+        ])
+    }
+
     @Test("batch runs tool section renders model config inputs and validation messages")
     @MainActor
     func batchRunsToolSectionRendersModelConfigInputsAndValidationMessages() throws {

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopShellStateTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopShellStateTests.swift
@@ -5,6 +5,132 @@ import Testing
 
 @Suite("Desktop Shell State", .serialized)
 struct DesktopShellStateTests {
+    @Test("desktop route metadata encodes accepted product IA")
+    func desktopRouteMetadataEncodesAcceptedProductIA() throws {
+        #expect(DesktopSurface.visibleNavigationCases == [
+            .chat,
+            .commandCenter,
+            .server,
+            .models,
+            .workflows,
+            .jobs,
+            .diagnostics,
+            .api,
+            .image,
+            .settings,
+        ])
+        #expect(DesktopSurface.visibleNavigationCases.map(\.rawValue) == [
+            "Chat",
+            "Command Center",
+            "Servers",
+            "Models",
+            "Workflows",
+            "Jobs",
+            "Diagnostics",
+            "API",
+            "Image",
+            "Settings",
+        ])
+
+        let metadata = DesktopRouteMetadata.acceptedWindowIA
+        #expect(metadata.domains.map(\.domain.routeDomainID) == [
+            "chat",
+            "command",
+            "servers",
+            "models",
+            "workflows",
+            "jobs",
+            "diagnostics",
+            "api",
+            "image",
+            "settings",
+        ])
+
+        let chat = try #require(metadata.page(domain: .chat, pageID: "session"))
+        #expect(chat.label == "Session")
+        #expect(chat.title == "Chat")
+        #expect(chat.crumb == "Chat")
+        #expect(chat.routePath == "/chat/session")
+        #expect(chat.inspectorModule == .chatRuntime)
+
+        let command = try #require(metadata.page(domain: .commandCenter, pageID: "overview"))
+        #expect(command.primaryAction?.title == "Review Eval Drift")
+        #expect(command.primaryAction?.target == .page(domain: .diagnostics, pageID: "evaluation"))
+        #expect(command.secondaryActions.map(\.title) == ["Jobs"])
+        #expect(command.secondaryActions.first?.target == .page(domain: .jobs, pageID: "queue"))
+
+        let localServer = try #require(metadata.page(domain: .server, pageID: "create-local"))
+        #expect(localServer.title == "Create Local Server")
+        #expect(localServer.primaryAction?.title == "Create And Start")
+        #expect(localServer.inspectorModule == .serverProfile)
+
+        let remoteServer = try #require(metadata.page(domain: .server, pageID: "add-remote"))
+        #expect(remoteServer.title == "Add Remote Server")
+        #expect(remoteServer.primaryAction?.title == "Save Remote Server")
+        #expect(remoteServer.inspectorModule == .capabilityReceipt)
+
+        let jobsQueue = try #require(metadata.page(domain: .jobs, pageID: "queue"))
+        #expect(jobsQueue.title == "Queue")
+        #expect(jobsQueue.inspectorModule == .jobLineage)
+
+        let inboundAuth = try #require(metadata.page(domain: .api, pageID: "inbound-auth"))
+        #expect(inboundAuth.title == "Inbound Auth")
+        #expect(inboundAuth.inspectorModule == .apiInboundAuth)
+    }
+
+    @Test("selected object routes normalize aliases and encode canonical values")
+    func selectedObjectRoutesNormalizeAliasesAndEncodeCanonicalValues() throws {
+        let server = try #require(DesktopSelectedObjectRoute(rawValue: "server:remote-lab"))
+        #expect(server.kind == .server)
+        #expect(server.objectID == "remote-lab")
+        #expect(server.rawValue == "server:remote-lab")
+        #expect(server.defaultRoute == .page(domain: .server, pageID: "overview"))
+
+        let artifact = try #require(DesktopSelectedObjectRoute(rawValue: "artifact:report/benchmark-matrix-042.json"))
+        #expect(artifact.kind == .artifact)
+        #expect(artifact.objectID == "report/benchmark-matrix-042.json")
+        #expect(artifact.rawValue == "artifact:report/benchmark-matrix-042.json")
+        #expect(artifact.defaultRoute == .page(domain: .jobs, pageID: "history"))
+
+        let evalAlias = try #require(DesktopSelectedObjectRoute(rawValue: "eval:support-dialogue-v23"))
+        #expect(evalAlias.kind == .diagnosticReport)
+        #expect(evalAlias.rawValue == "diagnostic-report:support-dialogue-v23")
+        #expect(evalAlias.defaultRoute == .page(domain: .diagnostics, pageID: "evaluation"))
+
+        let tokenAlias = try #require(DesktopSelectedObjectRoute(rawValue: "token:lan-shared-client"))
+        #expect(tokenAlias.kind == .apiToken)
+        #expect(tokenAlias.rawValue == "api-token:lan-shared-client")
+        #expect(tokenAlias.defaultRoute == .page(domain: .api, pageID: "inbound-auth"))
+
+        #expect(DesktopSelectedObjectRoute(rawValue: "workflow:template-1") == nil)
+        #expect(DesktopSelectedObjectRoute(rawValue: "job:") == nil)
+        #expect(DesktopSelectedObjectRoute(rawValue: "missing-delimiter") == nil)
+    }
+
+    @Test("legacy tools jobs session restores to top-level jobs")
+    func legacyToolsJobsSessionRestoresToTopLevelJobs() throws {
+        let legacyJSON = Data(
+            #"""
+            {
+              "schema_version": 5,
+              "selected_surface": "tools",
+              "selected_tool_section": "jobs",
+              "selected_server_session_id": "",
+              "server_sessions": []
+            }
+            """#.utf8
+        )
+        let legacyState = try JSONDecoder().decode(OperatorSessionState.self, from: legacyJSON)
+        #expect(legacyState.selectedSurface == .jobs)
+        #expect(legacyState.selectedToolSection == .jobs)
+        #expect(legacyState.selectedRuntimeJobID.isEmpty)
+
+        let encoded = try JSONEncoder().encode(legacyState)
+        let payload = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(payload["selected_surface"] as? String == "jobs")
+        #expect(payload["selected_tool_section"] as? String == "jobs")
+    }
+
     @Test("pane visibility defaults keep sidebars visible and chat inspector open")
     func paneVisibilityDefaultsKeepSidebarsVisibleAndChatInspectorOpen() throws {
         for surface in DesktopSurface.allCases {

--- a/apps/macos-menubar/Tests/MenuBarTests/OperatorSessionPersistenceSmokeTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/OperatorSessionPersistenceSmokeTests.swift
@@ -180,7 +180,7 @@ struct OperatorSessionPersistenceSmokeTests {
         encoder.outputFormatting = [.sortedKeys]
         let state = OperatorSessionState(
             schemaVersion: 1,
-            selectedSurface: .tools,
+            selectedSurface: .jobs,
             selectedToolSection: .jobs,
             selectedServerSessionID: "",
             selectedRuntimeJobID: "job-codable-selection",
@@ -190,6 +190,7 @@ struct OperatorSessionPersistenceSmokeTests {
 
         var decodedState = try JSONDecoder().decode(OperatorSessionState.self, from: encoder.encode(state))
         #expect(decodedState.schemaVersion == 6)
+        #expect(decodedState.selectedSurface == .jobs)
         #expect(decodedState.selectedToolSection == .jobs)
         #expect(decodedState.selectedRuntimeJobID == "job-codable-selection")
         #expect(decodedState.paneVisibility.count == DesktopPaneVisibilityState.defaultStates.count)
@@ -212,6 +213,8 @@ struct OperatorSessionPersistenceSmokeTests {
         )
         let legacyState = try JSONDecoder().decode(OperatorSessionState.self, from: legacyJSON)
         #expect(legacyState.schemaVersion == 6)
+        #expect(legacyState.selectedSurface == .jobs)
+        #expect(legacyState.selectedToolSection == .jobs)
         #expect(legacyState.selectedRuntimeJobID.isEmpty)
     }
 

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeJobsStateTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeJobsStateTests.swift
@@ -340,7 +340,7 @@ struct RuntimeJobsStateTests {
         #expect(viewModel.selectedRuntimeJob == nil)
 
         viewModel.selectToolSection(.jobs)
-        #expect(viewModel.selectedSurface == .workflows)
+        #expect(viewModel.selectedSurface == .jobs)
         #expect(viewModel.selectedToolSection == .jobs)
     }
 
@@ -1012,6 +1012,7 @@ struct RuntimeJobsStateTests {
             JSONSerialization.jsonObject(with: Data(contentsOf: melixHome.operatorSessionFileURL)) as? [String: Any]
         )
         #expect(persistedPayload["selected_tool_section"] as? String == "jobs")
+        #expect(persistedPayload["selected_surface"] as? String == "jobs")
         #expect(persistedPayload["selected_runtime_job_id"] as? String == "eval-cli-2")
 
         let restored = RuntimeViewModel(
@@ -1021,6 +1022,7 @@ struct RuntimeJobsStateTests {
         await restored.start()
 
         #expect(restored.selectedToolSection == .jobs)
+        #expect(restored.selectedSurface == .jobs)
         #expect(restored.selectedRuntimeJobID == "eval-cli-2")
         restored.applyRuntimeJobs(jobs)
         #expect(restored.selectedRuntimeJob?.id == "eval-cli-2")

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeSyntheticDatasetStateTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeSyntheticDatasetStateTests.swift
@@ -786,6 +786,8 @@ struct RuntimeSyntheticDatasetStateTests {
     func syntheticDatasetNavigationHasIconCategoryAndSessionPersistenceMapping() throws {
         #expect(DesktopToolSection.syntheticDatasets.symbolName == "sparkles.rectangle.stack")
         #expect(DesktopToolCategory.workflows.sections.contains(.syntheticDatasets))
+        #expect(DesktopToolCategory.workflows.sections.contains(.jobs) == false)
+        #expect(DesktopToolCategory.jobs.sections == [.jobs])
 
         let state = OperatorSessionState(
             selectedSurface: .tools,

--- a/docs/plans/window-ui-information-architecture-refresh.md
+++ b/docs/plans/window-ui-information-architecture-refresh.md
@@ -97,6 +97,10 @@ rewrite.
    - Preserve Context, Health, Metrics, Actions, Evidence order.
    - Add visible detail action when a selected object has a detail route.
 
+   Status: review follow-up for the route metadata shell slice now maps Jobs
+   domain Inspector evidence from the selected job root, logs, and every fetched
+   artifact path so artifact lineage is not truncated to the first artifact.
+
 3. Chat Runtime Contract
    - Keep Chat default.
    - Block send without explicit server binding.

--- a/docs/plans/window-ui-information-architecture-refresh.md
+++ b/docs/plans/window-ui-information-architecture-refresh.md
@@ -84,6 +84,14 @@ rewrite.
      from metadata.
    - Add route state for selected objects.
 
+   Status: initial implementation slice landed. The desktop shell now exposes
+   the accepted 10 top-level domains, treats Jobs as a first-class navigation
+   surface, defines typed route metadata for the accepted domain/page map, and
+   normalizes canonical selected-object route values plus legacy `eval` and
+   `token` aliases. Legacy persisted `Tools / Jobs` session state migrates to
+   the top-level Jobs surface. Follow-up slices still need to make every header,
+   secondary tab, and Inspector panel consume this metadata directly.
+
 2. Inspector Contract
    - Implement page-level and selected-object Inspector modes.
    - Preserve Context, Health, Metrics, Actions, Evidence order.


### PR DESCRIPTION
## Summary
- Implements the first accepted window IA shell slice by making Jobs a first-class desktop surface and keeping the production sidebar domain set aligned to the formal product spec.
- Adds typed route metadata for the accepted window IA, including domain/page IDs, page actions, inspector modules, and selected-object route parsing.
- Addresses review feedback by mapping Jobs Inspector evidence from the selected job root, logs, and every fetched artifact path, and by reusing the restored tool-section value during operator session migration.

## Plan or Spec
- `docs/window-ui-product-spec.md`
- `docs/plans/window-ui-information-architecture-refresh.md`

## Commands Run
```text
git merge --no-edit origin/main
# passed; branch includes origin/main 041e82f6

xcrun swift test --package-path apps/macos-menubar --filter 'DesktopFoundationViewTests/jobsInspectorEvidenceMapsEveryFetchedArtifactPath'
# red before implementation: failed as expected while Jobs evidence used artifacts.first?.path
# green after implementation: 1 test passed

xcrun swift test --package-path apps/macos-menubar --filter 'OperatorSessionPersistenceSmokeTests'
# 5 tests passed

xcrun swift test --package-path apps/macos-menubar
# 783 tests passed across 25 suites

xcrun swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'DesktopFoundationViewTests|OperatorSessionPersistenceSmokeTests'
# 244 tests passed across 3 suites

UV_PYTHON=3.12 uv run --frozen --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Sources/AppMain/Persistence/OperatorSessionStore.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
# TOTAL 100.00% 39/39

git diff --check
# passed

git commit -m "Expand jobs inspector artifact evidence"
# pre-commit ran the full local gate:
# - make swift-test: completed rc=0; macOS menubar package 783 tests passed across 25 suites
# - make py-test: 3459 passed, 14 skipped, 2 warnings
# - make integration-test: 117 passed, 1 skipped
# - scoped performance report: Status ok, 0 regressions, 0 verification failures
```

## Coverage and Metrics
- Changed-line coverage: `100.00%` (`39/39`) for the touched Swift executable/test scope.
- Coverage breakdown:
  - `apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift`: `100.00%` (`14/14`)
  - `apps/macos-menubar/Sources/AppMain/Persistence/OperatorSessionStore.swift`: `100.00%` (`3/3`)
  - `apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift`: `100.00%` (`22/22`)
- Metrics report: `.runtime/pre-commit-performance/20260604-073049-3f64b555/report/report.md`
- Metrics result: `Status: ok`; changed files `4`; selected probes `0`; regressions `0`; context regressions `0`; verification failures `0`.
- Observability mode: `N/A`. This change updates window route metadata, Inspector evidence projection, and session migration readability; it does not add runtime probes, evidence-mode collection, or debug diagnostics.
- Probe overhead: `N/A`. No observability probes were added and no registered PR-scoped performance probes were selected.

## Known Gaps
- This is the first implementation slice from the formal spec, not the full window UI rebuild.
- Follow-up slices still need the production header/tab/inspector rendering paths to consume the new route metadata directly.
- Selected-object deep-link behavior is represented by typed route parsing here; UI-level selected-object inspector routing remains deferred.
- Chat runtime binding states, full server creation split UI, and domain-specific inspector modules remain governed by the product spec and active IA plan.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
