### PR TITLE
perf: speed trajectory provenance scalar copy checks

### DIFF
--- a/docs/plans/2026-06-04-trajectory-copy-local-bindings.md
+++ b/docs/plans/2026-06-04-trajectory-copy-local-bindings.md
@@ -13,8 +13,15 @@ covers the affected path with focused `test_command`, `coverage_command`, and
 
 Keep trajectory provenance normalization semantics unchanged while reducing
 container-dispatch overhead in `normalize_trajectory_provenance(...)`. The common
-built-in `dict` and `list` values now use direct `type(...) is ...` checks before
-falling back to the existing subclass-safe `isinstance(...)` path.
+built-in `dict` and `list` values already use direct `type(...) is ...` checks
+before falling back to the existing subclass-safe `isinstance(...)` path.
+
+This follow-up micro-slice keeps the same registered probe and narrows the next
+hot path inside `_copy_trajectory_provenance_value(...)`: keep the existing exact
+`type(...) is ...` dispatch order, but use a precomputed frozenset for exact JSON
+scalar type membership before falling back to subclass-safe `isinstance(...)` and
+`copy.deepcopy(...)` handling. This targets the leaf-heavy recursive copy path
+without changing container isolation semantics.
 
 ## Verification
 

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -373,7 +373,21 @@ def test_copy_trajectory_provenance_value_falls_back_for_custom_mutables() -> No
         def __init__(self, value: int) -> None:
             self.value = value
 
-    original = {"items": [CustomMutable(1)], "tuple": (CustomMutable(2),)}
+    class DictSubclass(dict):
+        pass
+
+    class ListSubclass(list):
+        pass
+
+    class TupleSubclass(tuple):
+        pass
+
+    original = {
+        "items": ListSubclass([CustomMutable(1)]),
+        "tuple": TupleSubclass((CustomMutable(2),)),
+        "plain_tuple": (CustomMutable(4),),
+        "mapping": DictSubclass({"nested": CustomMutable(3)}),
+    }
 
     copied = _copy_trajectory_provenance_value(original)
 
@@ -384,6 +398,12 @@ def test_copy_trajectory_provenance_value_falls_back_for_custom_mutables() -> No
     assert copied["tuple"] is not original["tuple"]
     assert copied["tuple"][0] is not original["tuple"][0]
     assert copied["tuple"][0].value == 2
+    assert copied["plain_tuple"] is not original["plain_tuple"]
+    assert copied["plain_tuple"][0] is not original["plain_tuple"][0]
+    assert copied["plain_tuple"][0].value == 4
+    assert copied["mapping"] is not original["mapping"]
+    assert copied["mapping"]["nested"] is not original["mapping"]["nested"]
+    assert copied["mapping"]["nested"].value == 3
 
 
 def test_train_lora_records_agentic_trajectory_provenance_in_adapter_manifest(

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -30,6 +30,7 @@ TRAJECTORY_PROVENANCE_FIELDS = (
 TRAJECTORY_PROVENANCE_CSV_FIELDS = TRAJECTORY_PROVENANCE_FIELDS
 
 _JSON_IMMUTABLE_TYPES = (str, int, float, bool, type(None))
+_JSON_IMMUTABLE_TYPE_SET = frozenset(_JSON_IMMUTABLE_TYPES)
 _TRAJECTORY_MANIFEST_OPTIONAL_FIELD_MAP = (
     ("trajectory_toolset_version", "trajectory_toolset_version"),
     ("trajectory_registry_schema_version", "trajectory_registry_schema_version"),
@@ -49,7 +50,7 @@ def _copy_trajectory_provenance_value(value: Any) -> Any:
         return [_copy_trajectory_provenance_value(item) for item in value]
     if value_type is tuple:
         return tuple(_copy_trajectory_provenance_value(item) for item in value)
-    if value_type in _JSON_IMMUTABLE_TYPES:
+    if value_type in _JSON_IMMUTABLE_TYPE_SET:
         return value
     if isinstance(value, dict):
         return {key: _copy_trajectory_provenance_value(item) for key, item in value.items()}


### PR DESCRIPTION
## Summary
- Speeds up the trajectory provenance recursive JSON copy helper by using a precomputed exact-type set for immutable JSON scalar dispatch.
- Expands the focused copy test to cover built-in tuple plus dict/list/tuple subclass containers so the fallback copy paths remain covered.

## Plan or Spec
- `docs/plans/2026-06-04-trajectory-copy-local-bindings.md`
- Registered PR-scoped performance probe: `trajectory-provenance-copy-elision` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_provenance_copy_elision_probe_script_emits_metrics
# 5 passed in 0.43s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names
uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
# changed_line_coverage=100.00%; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 scripts/trajectory_provenance_copy_elision_probe.py
# {"baseline_elapsed_ms_mean": 1486.0049505718052, "optimized_elapsed_ms_mean": 478.2898535951972, "delta_ms": -1007.715096976608, "speedup": 3.1069129721273416, "peak_bytes_mean": 19040.0, "component_count": 64.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% for `services/mlx-worker-python/worker/trajectory_provenance.py`.
- Registered local probe (`trajectory-provenance-copy-elision`): `optimized_elapsed_ms_mean=478.2898535951972 ms`, `baseline_elapsed_ms_mean=1486.0049505718052 ms`, `delta_ms=-1007.715096976608`, `speedup=3.1069129721273416x`, `peak_bytes_mean=19040.0`.
- CI PR-scoped performance report is required as the merge validation source for the registered probe.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice and CI is the broader gate.
- No Swift runtime effect is claimed or required for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
