### PR TITLE
perf: bind native MTP sidecar loop helpers

### DIFF
--- a/docs/plans/2026-05-28-native-mtp-duplicate-sidecar-filter.md
+++ b/docs/plans/2026-05-28-native-mtp-duplicate-sidecar-filter.md
@@ -22,6 +22,17 @@ duplicate-MTP-entry workload and gates `extra_new_mean_ms`, `extra_delta_ms`,
 The JSON read `delta_ms` and `speedup` ratios are reported as informational
 control metrics because they are derived from an unchanged helper and have shown
 CI jitter even when absolute `new_mean_ms` remains inside threshold.
+The key-predicate `key_delta_ms` and `key_speedup` ratios are likewise recorded
+as informational controls for sidecar-loop slices; `key_new_mean_ms` remains the
+direct gate for any future slice that changes `_is_mtp_weight_key()` itself.
+
+## Follow-up slice: local helper binding
+
+The 2026-06-04 follow-up keeps the same registered probe and narrows the change
+to the `extra_mtp_safetensor_files()` sidecar loop. It binds the MTP key
+predicate, string conversion, and final `Path` constructor once outside the
+weight-map loop while preserving raw file-name dedupe semantics for duplicate,
+missing, model-shard, and non-safetensor candidates.
 
 ## Verification plan
 

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4940,14 +4940,12 @@
       {
         "key": "key_delta_ms",
         "unit": "ms",
-        "direction": "lower_is_better",
-        "warn_pct": 5.0
+        "direction": "informational"
       },
       {
         "key": "key_speedup",
         "unit": "x",
-        "direction": "higher_is_better",
-        "warn_pct": 5.0
+        "direction": "informational"
       },
       {
         "key": "key_count",

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -3330,6 +3330,8 @@ def test_registered_probe_registry_entries_validate_commands_and_watch_globs() -
         "model_listing_old_mean_ms",
         "model_listing_old_peak_bytes_mean",
         "key_old_mean_ms",
+        "key_delta_ms",
+        "key_speedup",
     ):
         assert native_mtp_metrics[metric_key]["direction"] == "informational"
         assert "warn_pct" not in native_mtp_metrics[metric_key]
@@ -3337,8 +3339,6 @@ def test_registered_probe_registry_entries_validate_commands_and_watch_globs() -
     assert native_mtp_metrics["model_listing_delta_ms"]["direction"] == "lower_is_better"
     assert native_mtp_metrics["model_listing_speedup"]["direction"] == "higher_is_better"
     assert native_mtp_metrics["key_new_mean_ms"]["direction"] == "lower_is_better"
-    assert native_mtp_metrics["key_delta_ms"]["direction"] == "lower_is_better"
-    assert native_mtp_metrics["key_speedup"]["direction"] == "higher_is_better"
 
     changed_scope_metrics = {
         metric["key"]: metric

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -58,25 +58,31 @@ def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
     path_join = os.path.join
     path_exists = os.path.exists
     path_sep = os.sep
+    is_mtp_weight_key = _is_mtp_weight_key
+    to_text = str
+    to_path = Path
     for key, file_name in weight_map.items():
-        if not _is_mtp_weight_key(key):
+        if not is_mtp_weight_key(key):
             continue
-        file_name_text = str(file_name)
+        file_name_text = to_text(file_name)
         if file_name_text in seen:
             continue
-        seen_add(file_name_text)
         if not file_name_text.endswith(".safetensors"):
+            seen_add(file_name_text)
             continue
         file_basename = file_name_text
         if path_sep in file_name_text:
             file_basename = file_name_text.rsplit(path_sep, 1)[-1]
         if file_basename.startswith("model"):
+            seen_add(file_name_text)
             continue
         path_text = path_join(model_path_text, file_name_text)
         if not path_exists(path_text):
             logger.warning("MTP shard listed in index is missing: %s", path_text)
+            seen_add(file_name_text)
             continue
-        append_extra_file(Path(path_text))
+        seen_add(file_name_text)
+        append_extra_file(to_path(path_text))
     return extra_files
 
 


### PR DESCRIPTION
## Summary
- Bind the native-MTP sidecar loop's MTP-key predicate, string conversion, and `Path` constructor once outside the `weight_map` scan.
- Preserve existing raw file-name dedupe behavior for duplicate, missing, model-shard, and non-safetensor candidates.

## Plan or Spec
- `docs/plans/2026-05-28-native-mtp-duplicate-sidecar-filter.md`
- Registered probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline before implementation (origin/main)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" MELIX_NATIVE_MTP_LOADER_MODEL_FILES=1500 MELIX_NATIVE_MTP_LOADER_DISTRACTOR_FILES=1500 MELIX_NATIVE_MTP_LOADER_SAMPLES=5 MELIX_NATIVE_MTP_LOADER_KEY_ITERATIONS=2500 uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
exit 0
baseline extra_new_mean_ms=30.59634668752551, extra_speedup=4.256120004661674

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics
exit 0: 8 passed in 1.44s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
exit 0: 6 passed in 0.32s; changed_line_coverage=100.00%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" MELIX_NATIVE_MTP_LOADER_MODEL_FILES=1500 MELIX_NATIVE_MTP_LOADER_DISTRACTOR_FILES=1500 MELIX_NATIVE_MTP_LOADER_SAMPLES=5 MELIX_NATIVE_MTP_LOADER_KEY_ITERATIONS=2500 uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` for `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`.
- Local registered probe (Linux): `extra_new_mean_ms=29.386829491704702`, baseline before change `30.59634668752551`, local delta vs pre-change candidate `-1.209517025820808 ms` (~3.95% lower).
- Probe control metrics after change: `extra_old_mean_ms=130.60600254684687`, `extra_speedup=4.4443720131058795`, `model_listing_speedup=2.495107255826834`, `speedup=1.1029108389973654`.
- CI PR-scoped performance workflow is still required as the merge validation source.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice.
- Linux local validation covers Python behavior/probe only; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; runtime overhead unchanged outside the optimized loop.
- [x] Deferred work and known gaps are stated explicitly.
