### PR TITLE
Optimize Swift long-text prefill step

### DIFF
--- a/docs/plans/2026-06-04-swift-prefill-step-optimization.md
+++ b/docs/plans/2026-06-04-swift-prefill-step-optimization.md
@@ -1,0 +1,198 @@
+# Swift Text Prefill Step Optimization Plan
+
+## Context
+
+The June 4, 2026 128k serving comparison showed Melix TTFT dominated by Swift
+text worker prefill rather than gateway or scheduler overhead:
+
+- Client TTFT p50 was about 34.1 seconds.
+- `swift_text.prefill_ms` was about 33.7 seconds.
+- `swift_text.decode_ttft_ms` was about 0.57 seconds.
+- Gateway shaping and route resolution were sub-millisecond, and scheduler
+  admission/queue delay was about 27 ms.
+
+The scheduler progress chunk target and the worker model prefill step are
+separate values. `scheduler.prefill_chunk_target_tokens=16` is progress
+accounting; the Swift text worker receives `prefillStepSize` and uses it as the
+MLXLMCommon prompt prepare step. Before this plan, all non-vision text requests
+used a fixed worker prefill step of 512 tokens.
+
+## Goal
+
+Reduce long-context text TTFT by widening the Swift text worker prefill step for
+large text-only prompts while preserving the existing short-prompt and vision
+paths.
+
+## Scope
+
+- Keep text-only prompts below 32k estimated tokens on the existing 512-token
+  worker prefill step.
+- Use a 1024-token worker prefill step for text-only prompts at or above 32k
+  estimated tokens.
+- Preserve the 16-token scheduler progress chunk target and progress metrics.
+- Preserve the vision-bearing request path, which uses boundary-safe progress
+  chunks rather than the text worker window.
+- Verify with focused control-plane tests and a real 128k Gemma E4B serving
+  benchmark before making a performance claim.
+
+Out of scope:
+
+- Changing MLXLMCommon or vendored Gemma4 cache semantics.
+- Changing scheduler progress event granularity.
+- Changing acceleration profile selection.
+- Changing protobuf schemas.
+
+## Design
+
+MLXLMCommon's default `LLMModel.prepare` interprets the `windowSize` parameter
+as the prompt prefill step size and defaults to 512. Gemma4's model attention
+sliding window is read separately from model config (`sliding_window=512`) and
+is not replaced by this worker step.
+
+This slice changes the control-plane request policy only:
+
+- `estimatedPromptTokens < 32_768`: request `prefillStepSize=512`.
+- `estimatedPromptTokens >= 32_768`: request `prefillStepSize=1024`.
+- Vision-bearing prompts: keep the existing boundary-safe step target.
+
+## Performance Probes And Success Metrics
+
+Primary 128k probes:
+
+- `http.ttfd_ms`
+- `swift_text.prefill_ms`
+- `swift_text.decode_ttft_ms`
+- `swift_text.worker_prefill_requested_step_tokens`
+- `swift_text.worker_prefill_effective_window_tokens`
+- `swift_text.prefill_prompt_tokens`
+- `swift_text.peak_resident_bytes`
+- `swift_text.active_memory_bytes`
+- `scheduler.prefill_chunk_target_tokens`
+- scenario TTFT, total latency, decode tok/s, aggregate tok/s, and errors
+
+Success criteria for keeping the change:
+
+- 128k Melix requests remain `2/2` successful with no context, memory, quadratic
+  guard, or RPC errors.
+- `swift_text.worker_prefill_requested_step_tokens` and
+  `swift_text.worker_prefill_effective_window_tokens` report 1024 in the 128k
+  scenario.
+- TTFT and `swift_text.prefill_ms` improve versus the current-origin baseline
+  without a material decode tok/s regression.
+- Peak resident memory remains within the current host envelope.
+
+Rollback criteria:
+
+- Any long-context correctness failure or worker crash.
+- Material decode throughput regression.
+- Memory pressure or peak RSS increase large enough to make the 128k path less
+  reliable than the 512-token baseline.
+
+## Verification
+
+Focused local verification:
+
+```bash
+swift test --package-path services/control-plane-swift --filter 'RequestCoordinatorTests/chunkedPrefillsEmitProgressEventsAndSchedulerMetricsForLongPrompts|RequestCoordinatorTests/longTextPrefillsWidenWorkerPrefillStepWithoutChangingSchedulerProgressChunks|RequestCoordinatorTests/longTextWorkerPrefillStepThresholdIsInclusiveAt32768EstimatedTokens'
+```
+
+Performance verification:
+
+- Run the 128k Gemma E4B serving scenario from this branch with the same model,
+  prompt target, output target, ports, warmup, repeats, memory snapshots, and
+  acceleration evidence as the June 4 comparison.
+- Compare against a current `origin/main` baseline built in release mode from
+  the same host state.
+- Use the runtime-only helper at
+  `.runtime/serving-comparison/swift-prefill-step-ab/scripts/run_melix_prefill_ab.py`
+  to run the baseline and optimized Melix stacks sequentially. The helper
+  refuses to run formal measurements when another Melix runtime, OMLX, SwiftLM,
+  or heavy Swift build/test process is active, unless the operator explicitly
+  asks for contaminated diagnostic numbers.
+
+## Measurement Log
+
+### 1024-token worker step pilot
+
+Run:
+
+`/Users/chenyu/Documents/github/melix/.runtime/worktrees/swift-prefill-optimization-20260604/.runtime/serving-comparison/swift-prefill-step-ab/runs/20260604T185637+0900-melix-prefill-step-ab`
+
+Notes:
+
+- This was run before the branch was synced from `041e82f6` to `4df62095`.
+  The intervening `origin/main` change touched the macOS menu bar and window UI
+  plan, not the Swift control-plane request path.
+- Host guard was clean for local serving resources; only remote semantic judge
+  wrapper processes were present as advisories.
+- Scenario was 128k prompt target, 512 output cap, one warmup, two formal
+  repeats, concurrency 1, cold-unique saturating prompts.
+
+Results:
+
+- Baseline and optimized both completed `2/2` requests with no context, memory,
+  quadratic guard, or RPC errors.
+- Baseline worker step was 512 tokens; optimized worker step was 1024 tokens.
+- Client TTFT p50 improved from `34.02s` to `32.83s`, a `1.19s` or `3.50%`
+  reduction.
+- Total latency p50 improved from `47.38s` to `46.20s`, a `1.18s` or `2.49%`
+  reduction.
+- Client decode throughput was effectively unchanged: `38.34` tok/s baseline
+  versus `38.32` tok/s optimized.
+- Worker prefill time improved from `33.19s` to `31.30s`; worker prefill chunks
+  dropped from 129 to 65.
+- Peak resident memory was flat: about `8.316 GB` baseline versus `8.315 GB`
+  optimized.
+
+Conclusion:
+
+- 1024 is a viable long-text step candidate. Because the 1024 result improved
+  TTFT without a client-visible decode regression or memory increase, run one
+  additional 2048-token experiment on current `origin/main` before selecting the
+  final policy.
+
+### 2048-token worker step experiment
+
+Run:
+
+`/Users/chenyu/Documents/github/melix/.runtime/worktrees/swift-prefill-optimization-20260604/.runtime/serving-comparison/swift-prefill-step-ab/runs/20260604T191050+0900-melix-prefill-step-ab`
+
+Notes:
+
+- This run used current `origin/main` at `4df62095` for both the baseline and
+  optimized worktrees.
+- Host guard passed before measurement. A separate worktree started lightweight
+  pre-commit integration-test worker processes after the guard passed, so this
+  run is useful for directional comparison but should not override a cleaner
+  1024 result unless the benefit is clear.
+- Scenario matched the 1024 pilot: 128k prompt target, 512 output cap, one
+  warmup, two formal repeats, concurrency 1, cold-unique saturating prompts.
+
+Results:
+
+- Baseline and optimized both completed `2/2` requests with no context, memory,
+  quadratic guard, or RPC errors.
+- Baseline worker step was 512 tokens; optimized worker step was 2048 tokens.
+- Client TTFT p50 improved from `33.70s` to `32.64s`, a `1.06s` or `3.13%`
+  reduction.
+- Total latency p50 improved from `47.06s` to `46.05s`, a `1.01s` or `2.14%`
+  reduction.
+- Client decode throughput moved from `38.33` tok/s baseline to `38.20` tok/s
+  optimized, a `0.35%` reduction.
+- Worker prefill time improved from `32.64s` to `31.09s`; worker prefill chunks
+  dropped from 129 to 33.
+- Worker decode metrics were weaker than baseline (`decode_ttft_ms` 634 to
+  1241; `decode_ms` 14004 to 14627), while peak resident memory stayed within
+  the existing envelope.
+
+Final decision:
+
+- Keep the final long-text worker step at 1024 tokens. The 2048-token experiment
+  reduced worker prefill chunk count further, but it did not improve
+  end-to-end TTFT beyond the 1024 pilot and showed slightly weaker decode-side
+  metrics. 1024 is the better conservative policy for this slice.
+- After the measurements, the worktree was synced to `origin/main` at
+  `1450c8f2`. The new upstream changes touched Python worker native MTP,
+  report-evidence, and macOS app packaging paths, not the Swift control-plane
+  prefill-step policy. The final focused control-plane tests still passed after
+  this sync.

--- a/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
+++ b/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
@@ -321,6 +321,8 @@ private enum CacheRouteClass: String, Sendable {
 
 private let boundarySafePrefillChunkTargetTokens: UInt32 = 16
 private let textWorkerPrefillWindowTargetTokens: UInt32 = 512
+private let longTextWorkerPrefillWindowPromptThresholdTokens: UInt32 = 32_768
+private let longTextWorkerPrefillWindowTargetTokens: UInt32 = 1_024
 private let workerDispatchReadinessCacheTTLSeconds: TimeInterval = 5
 private let defaultActiveKVQuantProfile = "turboquant-q4"
 private let activeKVQuantProfiles: Set<String> = [
@@ -3096,7 +3098,14 @@ private func resolvedWorkerPrefillStepSize(
     if messagesContainVisionInput(messages) {
         return resolvedPrefillProgressChunkTarget(for: messages)
     }
-    return estimatedPromptTokens(for: messages) > 0 ? textWorkerPrefillWindowTargetTokens : 0
+    let estimatedPromptTokens = estimatedPromptTokens(for: messages)
+    guard estimatedPromptTokens > 0 else {
+        return 0
+    }
+    if estimatedPromptTokens >= longTextWorkerPrefillWindowPromptThresholdTokens {
+        return longTextWorkerPrefillWindowTargetTokens
+    }
+    return textWorkerPrefillWindowTargetTokens
 }
 
 private func requestRouteRequest(

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -2531,6 +2531,68 @@ struct RequestCoordinatorTests {
         #expect(metrics.values["scheduler.cache_pressure"] == 0.25)
     }
 
+    @Test("long text prefills widen the worker prefill step without changing scheduler progress chunks")
+    func longTextPrefillsWidenWorkerPrefillStepWithoutChangingSchedulerProgressChunks() async throws {
+        let workerClient = PhaseAwareWorkerClient()
+        let metricsStore = MetricsStore()
+        let schedulerReadModel = SchedulerReadModel(metricsStore: metricsStore)
+        let coordinator = RequestCoordinator(
+            workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+            abortRegistry: AbortRegistry(),
+            schedulerReadModel: schedulerReadModel,
+            metricsStore: metricsStore
+        )
+
+        let longPrompt = (1...32_768).map { "token\($0)" }.joined(separator: " ")
+        let execution = try await coordinator.startChatCompletion(
+            makeTranslatedChatRequest(
+                requestID: "req-long-text-prefill-window",
+                messages: [makeWorkerTextMessage(longPrompt)]
+            )
+        )
+        let consumer = Task {
+            do {
+                for try await _ in execution.stream {}
+            } catch {
+            }
+        }
+        defer { consumer.cancel() }
+
+        let prefillRequest = try #require(await waitForPrefillRequest(workerClient: workerClient))
+        #expect(prefillRequest.prefillStepSize == 1_024)
+
+        _ = try #require(await waitForDecodeRequest(workerClient: workerClient))
+        let prefillProgress = try #require(await waitForProgress(
+            schedulerReadModel: schedulerReadModel,
+            requestID: "req-long-text-prefill-window",
+            phase: .requestPrefilling,
+            lane: "text.prefill.background",
+            attempts: 50,
+            matching: { $0.prefillProcessedTokens == 32_768 }
+        ))
+        await workerClient.emitDecodeStarted(
+            requestID: "req-long-text-prefill-window",
+            decodeHandle: "decode-req-long-text-prefill-window"
+        )
+        await workerClient.emitToken(requestID: "req-long-text-prefill-window", text: "chunked")
+        await workerClient.finishDecode(requestID: "req-long-text-prefill-window")
+
+        let metrics = await metricsStore.snapshot()
+        #expect(prefillProgress.prefillProgressPct == 100)
+        #expect(metrics.values["scheduler.prefill_chunk_target_tokens"] == 16)
+        #expect(metrics.values["scheduler.prefill_chunk_count"] == 2_048)
+        #expect(metrics.values["scheduler.prefill_last_chunk_tokens"] == 32_768)
+    }
+
+    @Test("long text worker prefill step threshold is inclusive at 32768 estimated tokens")
+    func longTextWorkerPrefillStepThresholdIsInclusiveAt32768EstimatedTokens() async throws {
+        let belowThresholdStep = try await workerPrefillStepSizeForTextTokenCount(32_767)
+        let atThresholdStep = try await workerPrefillStepSizeForTextTokenCount(32_768)
+
+        #expect(belowThresholdStep == 512)
+        #expect(atThresholdStep == 1_024)
+    }
+
     @Test("phase-aware text requests join the active continuous batch cohort")
     func phaseAwareTextRequestsJoinTheActiveContinuousBatchCohort() async throws {
         let workerClient = PhaseAwareWorkerClient()
@@ -5413,6 +5475,36 @@ private func makeWorkerTextMessage(_ text: String) -> Melix_Worker_V1_ChatMessag
     part.text = text
     message.parts = [part]
     return message
+}
+
+private func workerPrefillStepSizeForTextTokenCount(
+    _ tokenCount: Int
+) async throws -> UInt32 {
+    let workerClient = PhaseAwareWorkerClient()
+    let metricsStore = MetricsStore()
+    let coordinator = RequestCoordinator(
+        workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+        abortRegistry: AbortRegistry(),
+        schedulerReadModel: SchedulerReadModel(metricsStore: metricsStore),
+        metricsStore: metricsStore
+    )
+    let prompt = (1...tokenCount).map { "token\($0)" }.joined(separator: " ")
+    let execution = try await coordinator.startChatCompletion(
+        makeTranslatedChatRequest(
+            requestID: "req-prefill-step-\(tokenCount)",
+            messages: [makeWorkerTextMessage(prompt)]
+        )
+    )
+    let consumer = Task {
+        do {
+            for try await _ in execution.stream {}
+        } catch {
+        }
+    }
+    defer { consumer.cancel() }
+
+    let prefillRequest = try #require(await waitForPrefillRequest(workerClient: workerClient))
+    return prefillRequest.prefillStepSize
 }
 
 private func makeWorkerVisionMessage(


### PR DESCRIPTION
## Summary
- Widen Swift text-worker prefill steps for text-only prompts at or above 32k estimated tokens from 512 to 1024 tokens.
- Preserve short-prompt behavior, vision boundary-safe behavior, and scheduler progress accounting.
- Add focused `RequestCoordinatorTests` coverage and document the 128k A/B benchmark plus the rejected 2048-token experiment.

## Plan or Spec
- `docs/plans/2026-06-04-swift-prefill-step-optimization.md`

## Commands Run
```text
make bootstrap
# passed; configured .githooks and confirmed the locked Python environment

make proto
# passed; no generated artifact diff

swift test --package-path services/control-plane-swift --filter 'RequestCoordinatorTests/chunkedPrefillsEmitProgressEventsAndSchedulerMetricsForLongPrompts|RequestCoordinatorTests/longTextPrefillsWidenWorkerPrefillStepWithoutChangingSchedulerProgressChunks|RequestCoordinatorTests/longTextWorkerPrefillStepThresholdIsInclusiveAt32768EstimatedTokens'
# passed; 3 tests in 1 suite after 1.073s

git diff --check origin/main...HEAD
# passed

git commit -m "Optimize Swift long-text prefill step"
# pre-commit ran on a 256 GiB macOS host:
# - make swift-test: passed; rc=0, elapsed=594.3s
# - make py-test: passed; 3470 passed, 14 skipped, 2 warnings in 154.62s
# - make integration-test: passed; 117 passed, 1 skipped in 724.23s
# - scoped performance report: ok; regressions=0, context_regressions=0, verification_failures=0
```

## Coverage and Metrics
- Changed-scope coverage: `N/A` for exact Swift changed-line percentage because the local SwiftPM gate does not currently emit changed-line coverage for `RequestCoordinator.swift`; the behavior is covered by focused `RequestCoordinatorTests`, and the pre-commit scoped probe reports targeted tests pass with coverage pass at 100.0% for the selected probe.
- Pre-commit scoped performance report: `.runtime/pre-commit-performance/20260604-113406-1450c8f2/report/report.md`
  - Status: `ok`
  - Changed files: `3`
  - Selected probes: `1`
  - Regressions: `0`
  - Context regressions: `0`
  - Verification failures: `0`
- Direct 128k serving A/B evidence: `.runtime/serving-comparison/swift-prefill-step-ab/runs/20260604T185637+0900-melix-prefill-step-ab`
  - Baseline vs optimized success: `2/2` vs `2/2`
  - Worker prefill step: `512` -> `1024`
  - Worker prefill chunks: `129` -> `65`
  - TTFT p50: `34.02s` -> `32.83s` (`-1.19s`, `-3.50%`)
  - Total latency p50: `47.38s` -> `46.20s` (`-1.18s`, `-2.49%`)
  - Decode throughput p50: `38.34` -> `38.32` tok/s (`-0.06%`)
  - Memory stayed flat: `8.54GB` -> `8.54GB`
  - Guard/error counters: `prefill_context_limit_rejection_count=0`, `prefill_memory_guard_rejection_count=0`, `prefill_quadratic_guard_rejection_count=0`, `rpc_error_count=0`
- Additional 2048-token experiment evidence: `.runtime/serving-comparison/swift-prefill-step-ab/runs/20260604T191050+0900-melix-prefill-step-ab`
  - TTFT improved directionally (`-1.06s`, `-3.13%`) but decode throughput regressed more (`-0.35%`) and external integration-test worker activity appeared after host guard, so the final policy keeps the smaller 1024-token step.
- Observability mode: `evidence`; benchmark helper used isolated sequential Melix stacks and wrote host snapshots, raw metrics, summary JSON/CSV, and markdown reports under `.runtime/serving-comparison`.
- Probe overhead: production path adds no new observability work; benchmark overhead is limited to the evidence harness, and the PR-scoped performance probe is pre-commit only.

## Known Gaps
- The 1024-token A/B was run before later `origin/main` changes; the branch was then synced to `origin/main` at `1450c8f2`, focused `RequestCoordinatorTests` passed, and the full pre-commit gate passed after that sync.
- The 2048-token run is retained only as decision evidence, not as the selected behavior, because of the weaker decode result and host-noise caveat above.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
