### PR TITLE
Elide startup version prefix guard checks

### DIFF
--- a/docs/plans/2026-06-04-startup-version-raw-prefix-guard-elision.md
+++ b/docs/plans/2026-06-04-startup-version-raw-prefix-guard-elision.md
@@ -1,0 +1,23 @@
+# Startup Version Raw Prefix Guard Elision
+
+## Scope
+
+This slice is limited to the Python startup version comparison hot path in `services/mlx-worker-python/worker/productization/startup_signals.py`. The raw `v`-prefix equivalence fast path already proves the longer string is non-empty through the length check, so this slice removes redundant truthiness checks before inspecting the first character.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `startup-signals-version-compare-single-pass` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` values. This is a Python-only slice and is locally verifiable on Linux.
+
+## Verification Plan
+
+1. Run the focused registered test command for `startup-signals-version-compare-single-pass`.
+2. Run the registered changed-scope coverage command.
+3. Run the registered local probe on Linux and compare baseline vs optimized `elapsed_ms_mean` for version comparison.
+4. Use GitHub Actions and the registered PR-scoped performance report as the final merge gate.
+
+## Acceptance
+
+- Focused tests pass.
+- Changed-scope coverage is at least 95% for the changed scope.
+- The registered probe shows a non-regressing version comparison path.
+- The change remains limited to raw `v`-prefix guard elision.

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -139,9 +139,9 @@ def compare_versions(left: str, right: str) -> int:
         return 0
     left_length = len(left)
     right_length = len(right)
-    if left_length == right_length + 1 and left and left[0] == "v" and left.startswith(right, 1):
+    if left_length == right_length + 1 and left[0] == "v" and left.startswith(right, 1):
         return 0
-    if right_length == left_length + 1 and right and right[0] == "v" and right.startswith(left, 1):
+    if right_length == left_length + 1 and right[0] == "v" and right.startswith(left, 1):
         return 0
     left_cleaned = left.strip()
     right_cleaned = right.strip()


### PR DESCRIPTION
## Summary
- Elides redundant truthiness checks in the startup version raw `v`-prefix equivalence fast path.
- Keeps the slice limited to `compare_versions(...)` and documents the registered probe plan.

## Plan or Spec
- `docs/plans/2026-06-04-startup-version-raw-prefix-guard-elision.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_does_not_allocate_streaming_part_generators services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_raw_values_skip_normalization services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_clean_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_v_prefix_equivalent_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_raw_v_prefix_equivalent_values_skip_stripping services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics
# 11 passed in 2.76s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_does_not_allocate_streaming_part_generators services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_raw_values_skip_normalization services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_clean_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_v_prefix_equivalent_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_raw_v_prefix_equivalent_values_skip_stripping services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_startup_signals_version_probe_script_emits_metrics
# 11 passed in 3.92s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_version_probe.py
# TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_version_probe.py
# {"comparison_total": -32.0, "elapsed_ms_mean": 12.995136236505848, "pair_count": 12000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0, "update_result_available_count": 12500.0, "update_result_elapsed_ms_mean": 109.17147022805044, "update_result_iterations": 25000.0, "update_result_peak_bytes_mean": 560.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Registered probe: `startup-signals-version-compare-single-pass`.
- Baseline local probe (origin/main before change): `elapsed_ms_mean=13.78352999953287`, `update_result_elapsed_ms_mean=109.90546470774072`.
- Optimized local probe (final run): `elapsed_ms_mean=12.995136236505848`, `update_result_elapsed_ms_mean=109.17147022805044`.
- Local comparison metric delta: `elapsed_ms_mean` improved by `0.788393763027022 ms` (`5.72%` lower). CI PR-scoped performance remains the merge gate for registered probe validation.

## Known Gaps
- Full repository `make` gates were not run locally; this is a Python-only focused performance slice.
- No Swift runtime validation applies.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability-mode change; existing registered synthetic probe was used.
- [x] Deferred work and known gaps are stated explicitly.
