### PR TITLE
perf: unroll trajectory manifest optional fields

### DIFF
--- a/docs/plans/2026-06-04-trajectory-manifest-local-bindings.md
+++ b/docs/plans/2026-06-04-trajectory-manifest-local-bindings.md
@@ -1,0 +1,18 @@
+# Trajectory Manifest Local Bindings
+
+## Scope
+
+This Python-only performance slice is limited to `load_trajectory_provenance_from_snapshot_manifest()` and its manifest-to-provenance helper in `services/mlx-worker-python/worker/trajectory_provenance.py`.
+
+The hot path repeatedly reads trajectory snapshot manifests during dataset and LoRA provenance propagation. The existing registered probe `trajectory-manifest-json-load` already covers the affected path in `infra/perf/pr_scoped_probes.json` and includes focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Plan
+
+1. Preserve behavior with the existing trajectory provenance tests and PR-scoped probe smoke test.
+2. Keep the optimization minimal: reduce repeated global/member lookups in manifest extraction by binding optional field metadata and provenance assignment locally while leaving copy semantics unchanged.
+3. Run the registered focused test command, changed-scope coverage command, and local registered probe on Linux.
+4. Use the PR-scoped performance GitHub Actions report as the merge gate after push.
+
+## Verification Notes
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -31,17 +31,6 @@ TRAJECTORY_PROVENANCE_CSV_FIELDS = TRAJECTORY_PROVENANCE_FIELDS
 
 _JSON_IMMUTABLE_TYPES = (str, int, float, bool, type(None))
 _JSON_IMMUTABLE_TYPE_SET = frozenset(_JSON_IMMUTABLE_TYPES)
-_TRAJECTORY_MANIFEST_OPTIONAL_FIELD_MAP = (
-    ("trajectory_toolset_version", "trajectory_toolset_version"),
-    ("trajectory_registry_schema_version", "trajectory_registry_schema_version"),
-    ("trajectory_reward_policy_id", "trajectory_reward_policy_id"),
-    ("trajectory_leakage_policy_id", "trajectory_leakage_policy_id"),
-    ("source_package_path", "trajectory_package_path"),
-    ("trajectory_quality_metrics", "trajectory_quality_metrics"),
-    ("agentic_sft_token_metrics", "agentic_sft_token_metrics"),
-)
-
-
 def _copy_trajectory_provenance_value(value: Any) -> Any:
     value_type = type(value)
     if value_type is dict:
@@ -142,11 +131,30 @@ def _trajectory_provenance_from_snapshot_manifest(
         provenance["trajectory_trace_digest"] = trace_digest
     if snapshot_manifest_path is not None:
         provenance["trajectory_snapshot_manifest_path"] = str(snapshot_manifest_path)
-    for source_field, output_field in _TRAJECTORY_MANIFEST_OPTIONAL_FIELD_MAP:
-        value = manifest_get(source_field)
-        if value is None or value == "":
-            continue
-        provenance[output_field] = value
+    trajectory_toolset_version = manifest_get("trajectory_toolset_version")
+    if trajectory_toolset_version is not None and trajectory_toolset_version != "":
+        provenance["trajectory_toolset_version"] = trajectory_toolset_version
+    trajectory_registry_schema_version = manifest_get("trajectory_registry_schema_version")
+    if (
+        trajectory_registry_schema_version is not None
+        and trajectory_registry_schema_version != ""
+    ):
+        provenance["trajectory_registry_schema_version"] = trajectory_registry_schema_version
+    trajectory_reward_policy_id = manifest_get("trajectory_reward_policy_id")
+    if trajectory_reward_policy_id is not None and trajectory_reward_policy_id != "":
+        provenance["trajectory_reward_policy_id"] = trajectory_reward_policy_id
+    trajectory_leakage_policy_id = manifest_get("trajectory_leakage_policy_id")
+    if trajectory_leakage_policy_id is not None and trajectory_leakage_policy_id != "":
+        provenance["trajectory_leakage_policy_id"] = trajectory_leakage_policy_id
+    source_package_path = manifest_get("source_package_path")
+    if source_package_path is not None and source_package_path != "":
+        provenance["trajectory_package_path"] = source_package_path
+    trajectory_quality_metrics = manifest_get("trajectory_quality_metrics")
+    if trajectory_quality_metrics is not None and trajectory_quality_metrics != "":
+        provenance["trajectory_quality_metrics"] = trajectory_quality_metrics
+    agentic_sft_token_metrics = manifest_get("agentic_sft_token_metrics")
+    if agentic_sft_token_metrics is not None and agentic_sft_token_metrics != "":
+        provenance["agentic_sft_token_metrics"] = agentic_sft_token_metrics
     if copy_nested:
         return normalize_trajectory_provenance(provenance)
     return provenance


### PR DESCRIPTION
## Summary
- Unroll trajectory manifest optional-field extraction in `worker.trajectory_provenance` to avoid per-call tuple iteration on the manifest JSON load hot path.
- Add a scoped plan for the Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-04-trajectory-manifest-local-bindings.md`
- Registered probe: `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json` (existing focused test, coverage, and probe commands).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id trajectory-manifest-json-load --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/trajectory_manifest_local_bindings_probe.json`

## Coverage and Metrics
- Focused pytest: `7 passed`.
- Changed-scope coverage: `95.24%` for `services/mlx-worker-python/worker/trajectory_provenance.py` changed lines.
- Local registered PR-scoped probe comparison:
  - base `new_mean_ms=714.6101482212543`
  - head `new_mean_ms=694.0165619365871`
  - delta vs base head metric: `-20.593586284667254 ms` (~2.88% lower)
  - head probe internal speedup vs script baseline: `2.0383802172623633x`

## Known Gaps
- Python-only slice validated locally on Linux. No Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance report is still required as the merge gate.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe was run against base and head.
- [ ] PR-scoped performance CI completed successfully.
- [ ] All required PR checks are green.
