### PR TITLE
perf: cache hidden channel strip check

### DIFF
--- a/docs/plans/2026-06-04-stream-hidden-channel-strip-cache.md
+++ b/docs/plans/2026-06-04-stream-hidden-channel-strip-cache.md
@@ -1,0 +1,46 @@
+# Stream assembler hidden-channel strip cache
+
+## Scope
+
+This Python-only performance slice targets hidden Harmony pipe-channel handling in
+`services/mlx-worker-python/worker/runtime/stream_assembler.py`.
+
+`RequestStreamAssembler._hidden_pipe_channel_deltas()` checked `hidden.strip()`
+twice per hidden channel: once for the empty-thinking metric and once before
+emitting or suppressing hidden reasoning. This slice preserves behavior while
+materializing that boolean once per call.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `stream-assembler-parser-mode-cache` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for the stream assembler path, its focused tests, and the
+probe script.
+
+## Implementation Plan
+
+1. Reuse the existing hidden Harmony channel tests and registered probe coverage.
+2. Cache the `hidden.strip()` truthiness in `_hidden_pipe_channel_deltas()` so
+   hidden-channel processing avoids the duplicate strip allocation.
+3. Run the registered focused tests, changed-scope coverage, and registered
+   probe locally on Linux.
+4. Use PR-scoped performance CI as the registered validation source before merge.
+
+## Baseline
+
+Local Linux baseline before implementation:
+
+```json
+{"channel_name_calls_mean": 13.0, "channel_name_checksum": 86.0, "chunk_count": 1200.0, "elapsed_ms_mean": 3.675401327200234, "harmony_channel_count": 13.0, "raw_char_count": 14810.0, "sample_count": 8.0, "tool_call_count": 10.0}
+```
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_parser_mode_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_parser_mode_probe.py
+```

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -1086,10 +1086,11 @@ class RequestStreamAssembler:
         return []
 
     def _hidden_pipe_channel_deltas(self, hidden: str, visible: str = "") -> list[AssemblyDelta]:
-        if not hidden.strip():
+        hidden_has_content = bool(hidden.strip())
+        if not hidden_has_content:
             self._metrics["empty_thinking_sentinel_count"] += 1
         deltas: list[AssemblyDelta] = []
-        if hidden.strip():
+        if hidden_has_content:
             if self._reasoning_enabled:
                 self._reasoning_parts.append(hidden)
                 deltas.append(AssemblyDelta(reasoning_text=hidden, raw_text=hidden))


### PR DESCRIPTION
## Summary
- Cache the hidden-channel `strip()` truthiness in `RequestStreamAssembler._hidden_pipe_channel_deltas()` so hidden Harmony channel processing avoids duplicate strip work.
- Keep behavior unchanged for empty hidden channels, reasoning-enabled emission, and reasoning-disabled suppression metrics.

## Plan or Spec
- `docs/plans/2026-06-04-stream-hidden-channel-strip-cache.md`
- Registered PR-scoped probe: `stream-assembler-parser-mode-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_parser_mode_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_parser_mode_probe.py`
- `MELIX_STREAM_ASSEMBLER_PARSER_MODE_SAMPLES=50 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_parser_mode_probe.py` against base and head worktrees
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id stream-assembler-parser-mode-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/stream_hidden_strip_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: 85 passed.
- Changed-scope coverage: 100.00% (`TOTAL 3 0 100%`).
- Registered local probe runner: base `elapsed_ms_mean=3.537504409905523`, head `elapsed_ms_mean=3.5142453270964324`, delta `-0.023259082809090614 ms` (~0.66% faster); coverage/test verification passed.
- Higher-sample local probe check (`MELIX_STREAM_ASSEMBLER_PARSER_MODE_SAMPLES=50`): base `elapsed_ms_mean=3.554686289280653`, head `elapsed_ms_mean=3.455996671691537`, delta `-0.098689617589116 ms` (~2.78% faster).

## Known Gaps
- This is a Python-only Linux-local slice. No Swift runtime behavior is changed.
- The local probe effect is small; PR-scoped performance CI is still required as the registered validation source before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before starting the slice.
- [x] Confirmed affected path has registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Kept the change to one optimization point.
- [x] Ran focused tests locally.
- [x] Ran changed-scope coverage locally.
- [x] Ran registered local probe comparison.
- [x] PR-scoped performance CI completed successfully.

