### PR TITLE
perf: cache schema-free evaluation scoring outcomes

### DIFF
--- a/docs/plans/2026-06-04-evaluation-json-schema-free-score-cache.md
+++ b/docs/plans/2026-06-04-evaluation-json-schema-free-score-cache.md
@@ -1,0 +1,34 @@
+# Evaluation JSON schema-free score cache
+
+## Scope
+
+This performance slice targets the schema-free JSON final-result scoring hot path in
+`worker.productization.evaluation_final_result.score_final_result`.
+
+## Registered probe
+
+The affected path is already covered by the PR-scoped probe
+`evaluation-final-result-json-typed-score-aggregate` in
+`infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`,
+`coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/evaluation_final_result.py`
+- `services/mlx-worker-python/tests/test_evaluation_final_result.py`
+- `scripts/evaluation_json_typed_score_probe.py`
+
+## Optimization hypothesis
+
+Repeated schema-free JSON scoring currently caches the parsed payloads and the
+computed float score, but every call still performs cache lookups, rounds the
+score, and constructs a new `ScoringOutcome`. Cache the immutable validated
+`ScoringOutcome` for schema-free scoring so repeated identical evaluation rows
+can reuse the full result object while preserving invalid-target and
+invalid-extracted JSON behavior.
+
+## Verification plan
+
+1. Run the focused evaluation final-result tests from the registered probe.
+2. Run changed-scope coverage from the registered probe and require at least 95%.
+3. Run `scripts/evaluation_json_typed_score_probe.py` locally on Linux before and
+after the implementation and compare `elapsed_ms_mean`.
+4. Let the PR-scoped performance GitHub Action validate the registered probe in CI.

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -317,8 +317,8 @@ def test_score_final_result_reuses_cached_parsed_json_payloads(monkeypatch: pyte
     evaluation_final_result_module._loads_json_payload.cache_clear()
 
 
-def test_score_final_result_reuses_cached_schema_free_json_scores() -> None:
-    evaluation_final_result_module._cached_json_typed_score.cache_clear()
+def test_score_final_result_reuses_cached_schema_free_json_outcomes() -> None:
+    evaluation_final_result_module._cached_schema_free_json_scoring_outcome.cache_clear()
     evaluation_final_result_module._ignored_paths_for_profile.cache_clear()
     target = json.dumps(
         {
@@ -350,9 +350,32 @@ def test_score_final_result_reuses_cached_schema_free_json_scores() -> None:
         typed_score=1.0,
         validation_status="validated",
     )
-    assert evaluation_final_result_module._cached_json_typed_score.cache_info().hits >= 1
-    evaluation_final_result_module._cached_json_typed_score.cache_clear()
+    assert first is second
+    assert evaluation_final_result_module._cached_schema_free_json_scoring_outcome.cache_info().hits >= 1
+    evaluation_final_result_module._cached_schema_free_json_scoring_outcome.cache_clear()
     evaluation_final_result_module._ignored_paths_for_profile.cache_clear()
+
+
+def test_score_final_result_preserves_schema_free_invalid_extracted_json_status() -> None:
+    evaluation_final_result_module._cached_schema_free_json_scoring_outcome.cache_clear()
+    score = score_final_result(
+        extracted_result="{invalid-json",
+        target=json.dumps({"answer": "A"}),
+        profile=EvaluationProfileDefinition(
+            profile_type="final_result",
+            result_kind="json",
+            extraction_mode="strict_full_response",
+            scoring_mode="json_field_match",
+            threshold=1.0,
+        ),
+    )
+
+    assert score == evaluation_final_result_module.ScoringOutcome(
+        typed_score=0.0,
+        validation_status="parse_failed",
+        failure_reason="invalid_json",
+    )
+    evaluation_final_result_module._cached_schema_free_json_scoring_outcome.cache_clear()
 
 
 def test_score_final_result_rejects_invalid_json_shape_before_scoring() -> None:

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -315,24 +315,27 @@ def _score_json_result(
     target: str,
     profile: EvaluationProfileDefinition,
 ) -> ScoringOutcome:
+    output_schema = profile.output_schema or {}
+    if not output_schema:
+        try:
+            return _cached_schema_free_json_scoring_outcome(
+                target=target,
+                extracted_result=extracted_result,
+                ignored_paths=profile.ignored_paths,
+            )
+        except json.JSONDecodeError:
+            _loads_json_payload(target)
+            return ScoringOutcome(typed_score=0.0, validation_status="parse_failed", failure_reason="invalid_json")
+
     parsed_target = _loads_json_payload(target)
     try:
         parsed_result = _loads_json_payload(extracted_result)
     except json.JSONDecodeError:
         return ScoringOutcome(typed_score=0.0, validation_status="parse_failed", failure_reason="invalid_json")
 
-    output_schema = profile.output_schema or {}
     validation_error = _validate_json_schema(output_schema, parsed_result)
     if validation_error:
         return ScoringOutcome(typed_score=0.0, validation_status="schema_failed", failure_reason=validation_error)
-
-    if not output_schema:
-        score = _cached_json_typed_score(
-            target=target,
-            extracted_result=extracted_result,
-            ignored_paths=profile.ignored_paths,
-        )
-        return ScoringOutcome(typed_score=round(score, 4), validation_status="validated")
 
     score = _json_typed_score(
         expected=parsed_target,
@@ -353,12 +356,18 @@ def _ignored_paths_for_profile(profile_ignored_paths: tuple[str, ...]) -> frozen
 
 
 @lru_cache(maxsize=128)
-def _cached_json_typed_score(*, target: str, extracted_result: str, ignored_paths: tuple[str, ...]) -> float:
-    return _json_typed_score(
+def _cached_schema_free_json_scoring_outcome(
+    *,
+    target: str,
+    extracted_result: str,
+    ignored_paths: tuple[str, ...],
+) -> ScoringOutcome:
+    score = _json_typed_score(
         expected=_loads_json_payload(target),
         actual=_loads_json_payload(extracted_result),
         ignored_paths=_ignored_paths_for_profile(ignored_paths),
     )
+    return ScoringOutcome(typed_score=round(score, 4), validation_status="validated")
 
 
 def _score_text_result(


### PR DESCRIPTION
## Summary
- Cache immutable schema-free JSON scoring outcomes for repeated final-result evaluation rows.
- Preserve the existing invalid-extracted JSON `parse_failed` behavior and invalid-target JSON propagation.
- Add a focused plan for the registered performance slice.

## Plan or Spec
- `docs/plans/2026-06-04-evaluation-json-schema-free-score-cache.md`
- Registered PR-scoped probe: `evaluation-final-result-json-typed-score-aggregate` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_json_typed_score_probe.py
{"elapsed_ms_mean": 19.575113523751497, "iteration_count": 40.0, "key_count": 2000.0, "peak_bytes_mean": 713838.6, "score_checksum": 35.0}

# Focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
40 passed in 0.57s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_json_typed_score_probe.py
TOTAL 20 0 100%

# Registered local probe after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_json_typed_score_probe.py
{"elapsed_ms_mean": 17.330138478428125, "iteration_count": 40.0, "key_count": 2000.0, "peak_bytes_mean": 713702.6, "score_checksum": 35.0}
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 20 0 100%`).
- Registered local Linux probe: `elapsed_ms_mean` improved from `19.575113523751497` ms to `17.330138478428125` ms (`delta_ms=-2.244975045323372`, about `11.47%` faster); `peak_bytes_mean` changed from `713838.6` to `713702.6` bytes.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Full repository test suite was not run locally; this slice used the focused registered test and coverage commands.
- Local validation is Linux/Python only. The registered CI probe is still required as the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
