### PR TITLE
perf: scan hub catalog MLX tags once

### DIFF
--- a/docs/plans/2026-06-04-hub-catalog-tag-payload-single-pass.md
+++ b/docs/plans/2026-06-04-hub-catalog-tag-payload-single-pass.md
@@ -1,0 +1,21 @@
+# Hub Catalog Tag Payload Single-Pass Probe Slice
+
+## Scope
+
+Optimize one small Python hot path in `services/mlx-worker-python/worker/model_ops/hub_catalog.py`: `_tag_payload_contains_mlx(...)` currently performs list membership checks before a fallback loop for MLX tag detection. This slice keeps behavior unchanged while collapsing list payload detection into a single pass.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped `hub-catalog-size-hint-regex-precompile` command-json probe in `infra/perf/pr_scoped_probes.json`. That probe watches `hub_catalog.py`, has focused `test_command`, `coverage_command`, and `probe_command` entries, and reports both size-hint and payload-compatibility timing metrics.
+
+## Verification Plan
+
+- Run the focused Hub catalog test command from the registered probe.
+- Run the registered changed-scope coverage command from the probe.
+- Run `scripts/hub_catalog_size_hint_probe.py` locally on Linux before and after the change and compare `payload_compatibility_elapsed_ms_mean` plus the overall `elapsed_ms_mean` metrics.
+
+## Success Criteria
+
+- Behavior remains identical for list, string, and non-string tag payloads.
+- Changed-scope coverage remains at or above 95 percent.
+- The registered probe shows an improvement in payload compatibility timing without a meaningful regression in the size-hint path.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -367,6 +367,23 @@ def test_card_data_tag_mlx_check_avoids_string_list_materialization(monkeypatch:
     ) is False
 
 
+def test_tag_payload_mlx_list_detection_uses_single_iteration_pass() -> None:
+    class CountingTagList(list):
+        contains_calls = 0
+
+        def __contains__(self, value: object) -> bool:  # pragma: no cover
+            self.contains_calls += 1
+            return super().__contains__(value)
+
+    matching_tags = CountingTagList(["Text-Generation", "MLX", object()])
+    non_matching_tags = CountingTagList(["Text-Generation", object()])
+
+    assert hub_catalog_module._tag_payload_contains_mlx(matching_tags) is True
+    assert hub_catalog_module._tag_payload_contains_mlx(non_matching_tags) is False
+    assert matching_tags.contains_calls == 0
+    assert non_matching_tags.contains_calls == 0
+
+
 def test_get_model_card_raises_invalid_argument_for_blank_repo_id() -> None:
     catalog = HubCatalog()
 

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -346,10 +346,10 @@ def _is_mlx_atom(value: str) -> bool:
 
 def _tag_payload_contains_mlx(value: Any) -> bool:
     if isinstance(value, list):
-        if "MLX" in value or "mlx" in value:
-            return True
         for item in value:
-            if isinstance(item, str) and _is_mlx_atom(item):
+            if item == "MLX" or item == "mlx" or (
+                isinstance(item, str) and len(item) == 3 and _is_mlx_atom(item)
+            ):
                 return True
         return False
     if isinstance(value, str):


### PR DESCRIPTION
## Summary
- Collapse Hub catalog MLX tag payload detection into a single list iteration.
- Add a regression test proving list containment probes are not used for exact/non-matching list payloads.
- Add a scoped plan for the registered performance slice.

## Plan or Spec
- `docs/plans/2026-06-04-hub-catalog-tag-payload-single-pass.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# baseline on origin/main: exit 0; elapsed_ms_mean=1483.6109700612724; payload_compatibility_elapsed_ms_mean=216.8710040859878

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# exit 0; 69 passed in 0.37s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# exit 0; TOTAL 10 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# exit 0; elapsed_ms_mean=1422.5951788015664; payload_compatibility_elapsed_ms_mean=206.8478947505355

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Registered local probe: `hub-catalog-size-hint-regex-precompile` via `scripts/hub_catalog_size_hint_probe.py`.
- Baseline vs candidate:
  - `elapsed_ms_mean`: 1483.6109700612724 ms -> 1422.5951788015664 ms (delta -61.01579125970602 ms; ~4.11% faster).
  - `payload_compatibility_elapsed_ms_mean`: 216.8710040859878 ms -> 206.8478947505355 ms (delta -10.023109335452318 ms; ~4.62% faster).
  - `size_hint_calls_mean`: 40000.0 -> 40000.0.
  - `payload_compatibility_calls_mean`: 200000.0 -> 200000.0.

## Known Gaps
- Linux local verification covers this Python slice. CI is still required for the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
