### PR TITLE
perf: scan macOS app signing targets with os.walk

### DIFF
--- a/docs/plans/2026-06-04-macos-app-signing-targets-scandir.md
+++ b/docs/plans/2026-06-04-macos-app-signing-targets-scandir.md
@@ -1,0 +1,31 @@
+# macOS app signing target scandir slice
+
+This Python-only performance slice is limited to nested Mach-O signing target
+discovery in `services/mlx-worker-python/worker/productization/macos_app_bundle.py`.
+The previous implementation uses `Path.rglob("*")`, which allocates a `Path`
+object for every directory and file before filtering to Mach-O files.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped performance probe
+`macos-app-signing-targets-scandir` in `infra/perf/pr_scoped_probes.json`. The
+probe includes focused `test_command`, `coverage_command`, and `probe_command`
+entries and runs locally on Linux with synthetic Mach-O-like fixture files.
+
+## Slice plan
+
+1. Add a regression test that forbids `Path.rglob()` for nested signing target
+   discovery and confirms directory symlinks are not traversed.
+2. Replace the `Path.rglob("*")` scan with `os.walk(..., followlinks=False)` and
+   inspect only filenames for Mach-O magic values.
+3. Register the PR-scoped probe and script so CI compares origin/main and head.
+4. Run focused pytest, changed-scope coverage, and the registered probe locally
+   before opening the PR.
+5. Use GitHub Actions PR-scoped performance as the final merge gate.
+
+## Expected metrics
+
+The probe reports `elapsed_ms_mean`, `elapsed_ms_min`, `discovered_count`, and
+fixture shape counts for a synthetic `.app` with nested helper bundles and noise
+files. The expected direction is lower scan latency while preserving the exact
+number of discovered signing targets.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2148,6 +2148,42 @@
     ]
   },
   {
+    "id": "macos-app-signing-targets-scandir",
+    "name": "macOS app nested Mach-O signing target scandir",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/macos_app_bundle.py",
+      "services/mlx-worker-python/tests/test_macos_app_bundle.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/macos_app_signing_targets_probe.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_iter_nested_macho_signing_targets_uses_os_walk_without_path_rglob services/mlx-worker-python/tests/test_macos_app_bundle.py::test_macho_detection_handles_non_files_and_read_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_signing_targets_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_iter_nested_macho_signing_targets_uses_os_walk_without_path_rglob services/mlx-worker-python/tests/test_macos_app_bundle.py::test_macho_detection_handles_non_files_and_read_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_signing_targets_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/macos_app_bundle.py services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/macos_app_signing_targets_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/macos_app_signing_targets_probe.py\"; for CANDIDATE in \"${MELIX_PR_SCOPED_PERFORMANCE_HEAD_REPO:-}/$SCRIPT\" \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "discovered_count",
+        "unit": "files",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "package-macos-resolve-fallback-scandir",
     "name": "Package macOS fallback build product scandir",
     "runner": "ubuntu-latest",

--- a/scripts/macos_app_signing_targets_probe.py
+++ b/scripts/macos_app_signing_targets_probe.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+def main() -> None:
+    repo_root = Path.cwd()
+    sys.path.insert(0, str(repo_root))
+    sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
+
+    from worker.productization.macos_app_bundle import _iter_nested_macho_signing_targets
+
+    target_count = 900
+    noise_count = 900
+    sample_count = 9
+    elapsed_samples: list[float] = []
+    discovered_count = 0
+
+    with tempfile.TemporaryDirectory(prefix="melix-macos-signing-targets-probe-") as temp_dir:
+        app_path = Path(temp_dir) / "Melix.app"
+        macos_dir = app_path / "Contents/MacOS"
+        resource_root = app_path / "Contents/Resources"
+        macos_dir.mkdir(parents=True)
+        resource_root.mkdir(parents=True)
+
+        (macos_dir / "Melix").write_bytes(b"\xfe\xed\xfa\xcflauncher")
+        for index in range(target_count - 1):
+            helper_dir = resource_root / f"Helper{index:04d}.bundle/Contents/MacOS"
+            helper_dir.mkdir(parents=True)
+            (helper_dir / f"Helper{index:04d}").write_bytes(b"\xfe\xed\xfa\xcfpayload")
+        for index in range(noise_count):
+            noise_dir = resource_root / f"Noise{index:04d}.bundle/Contents/Resources"
+            noise_dir.mkdir(parents=True)
+            (noise_dir / f"plain{index:04d}.txt").write_text("plain\n", encoding="utf-8")
+
+        for _ in range(sample_count):
+            started = time.perf_counter()
+            targets = _iter_nested_macho_signing_targets(app_path)
+            elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+            discovered_count = len(targets)
+
+    if discovered_count != target_count:
+        raise AssertionError(f"expected {target_count} signing targets, got {discovered_count}")
+
+    print(
+        json.dumps(
+            {
+                "discovered_count": float(discovered_count),
+                "elapsed_ms_max": round(max(elapsed_samples), 6),
+                "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+                "elapsed_ms_min": round(min(elapsed_samples), 6),
+                "noise_count": float(noise_count),
+                "sample_count": float(sample_count),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_macos_app_bundle.py
+++ b/services/mlx-worker-python/tests/test_macos_app_bundle.py
@@ -14,6 +14,7 @@ from worker.productization.macos_app_bundle import (
     _reject_external_python_framework_runtime,
     _copy_packaged_script,
     _is_macho_file,
+    _iter_nested_macho_signing_targets,
     _iter_python_native_binary_candidates,
     _path_size_bytes,
     _prune_python_package_baggage,
@@ -919,6 +920,41 @@ def test_macho_detection_handles_non_files_and_read_errors(
 
     monkeypatch.setattr(Path, "open", fail_open)
     assert _is_macho_file(native) is False
+
+
+def test_iter_nested_macho_signing_targets_uses_os_walk_without_path_rglob(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app_path = tmp_path / "Melix.app"
+    macos_dir = app_path / "Contents/MacOS"
+    resources_dir = app_path / "Contents/Resources"
+    nested_dir = resources_dir / "Nested.bundle/Contents/MacOS"
+    macos_dir.mkdir(parents=True)
+    nested_dir.mkdir(parents=True)
+
+    launcher = macos_dir / "Melix"
+    launcher.write_bytes(b"\xfe\xed\xfa\xcflauncher")
+    helper = nested_dir / "Helper"
+    helper.write_bytes(b"\xcf\xfa\xed\xfehelper")
+    plain = resources_dir / "plain.txt"
+    plain.write_text("not native\n", encoding="utf-8")
+
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    (external_dir / "ExternalHelper").write_bytes(b"\xfe\xed\xfa\xcfexternal")
+    linked_dir = resources_dir / "Linked.bundle"
+    linked_dir.symlink_to(external_dir, target_is_directory=True)
+
+    def fail_rglob(self: Path, pattern: str):  # pragma: no cover - regression guard
+        raise AssertionError("_iter_nested_macho_signing_targets() should not allocate Path.rglob() trees")
+
+    monkeypatch.setattr(Path, "rglob", fail_rglob)
+
+    assert _iter_nested_macho_signing_targets(app_path) == [
+        launcher,
+        helper,
+    ]
 
 
 def test_copy_swiftpm_resource_bundles_restores_existing_bundle_on_copy_failure(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1425,11 +1425,23 @@ def test_scope_report_selects_macos_app_bundle_probes() -> None:
         changed_files=["services/mlx-worker-python/worker/productization/macos_app_bundle.py"],
     )
 
-    assert scope["selected_count"] == 2
+    assert scope["selected_count"] == 3
     assert _selected_probe_ids(scope) == [
         "macos-app-resource-bundle-scandir",
         "macos-app-native-binary-scandir",
+        "macos-app-signing-targets-scandir",
     ]
+
+
+def test_macos_app_signing_targets_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runpy.run_path(str(REPO_ROOT / "scripts/macos_app_signing_targets_probe.py"), run_name="__main__")
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["discovered_count"] == 900.0
+    assert metrics["elapsed_ms_mean"] > 0.0
+    assert metrics["sample_count"] == 9.0
 
 
 def test_scope_report_selects_mlx_vlm_runtime_probe() -> None:
@@ -3160,6 +3172,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "multimodal-preprocessing-image-uri-single-parse",
         "macos-app-resource-bundle-scandir",
         "macos-app-native-binary-scandir",
+        "macos-app-signing-targets-scandir",
         "package-macos-resolve-fallback-scandir",
         "melix-metrics-snapshot-runtime-scandir",
         "pr-scoped-performance-scope-json-read-bytes",

--- a/services/mlx-worker-python/worker/productization/macos_app_bundle.py
+++ b/services/mlx-worker-python/worker/productization/macos_app_bundle.py
@@ -539,9 +539,12 @@ def _is_macho_file(path: Path) -> bool:
 
 def _iter_nested_macho_signing_targets(app_path: Path) -> list[Path]:
     targets: list[Path] = []
-    for path in app_path.rglob("*"):
-        if _is_macho_file(path):
-            targets.append(path)
+    for root, _dirnames, filenames in os.walk(app_path, followlinks=False):
+        root_path = Path(root)
+        for filename in filenames:
+            path = root_path / filename
+            if _is_macho_file(path):
+                targets.append(path)
     targets.sort(key=lambda candidate: candidate.as_posix())
     return targets
 


### PR DESCRIPTION
## Summary
- Replace nested Mach-O signing target discovery in the macOS app bundle packager with `os.walk(..., followlinks=False)` so the scan visits filenames directly instead of allocating a full `Path.rglob("*")` tree.
- Add a regression test that forbids `Path.rglob()` for this path and keeps directory symlink traversal disabled.
- Register `macos-app-signing-targets-scandir` as a PR-scoped performance probe with a checked-in synthetic probe script.

## Plan or Spec
- `docs/plans/2026-06-04-macos-app-signing-targets-scandir.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_iter_nested_macho_signing_targets_uses_os_walk_without_path_rglob services/mlx-worker-python/tests/test_macos_app_bundle.py::test_macho_detection_handles_non_files_and_read_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_signing_targets_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 5 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_iter_nested_macho_signing_targets_uses_os_walk_without_path_rglob services/mlx-worker-python/tests/test_macos_app_bundle.py::test_macho_detection_handles_non_files_and_read_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_signing_targets_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/macos_app_bundle.py services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/macos_app_signing_targets_probe.py
# 5 passed; changed-scope coverage 100.00% (33/33)

MELIX_PR_SCOPED_PERFORMANCE_HEAD_REPO="$PWD" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id macos-app-signing-targets-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/macos_app_signing_targets_probe.json
# base_probe ok; head_probe ok
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (33 measurable changed lines, 33 covered, 0 missed).
- Registered local probe `macos-app-signing-targets-scandir`:
  - base `elapsed_ms_mean=183.865502`, `elapsed_ms_min=169.553076`, `discovered_count=900.0`
  - head `elapsed_ms_mean=120.521155`, `elapsed_ms_min=116.063605`, `discovered_count=900.0`
  - delta `elapsed_ms_mean=-63.344347 ms`, speedup `1.525587x`, improvement `34.45%`
- GitHub Actions PR-scoped performance report is required before merge.

## Known Gaps
- Local validation uses Linux synthetic Mach-O-like fixtures; CI PR-scoped performance is still the merge gate for the registered base-vs-head report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
