### PR TITLE
perf: strip maintenance capability values once

### DIFF
--- a/docs/plans/2026-06-04-maintenance-capability-split-single-strip-performance.md
+++ b/docs/plans/2026-06-04-maintenance-capability-split-single-strip-performance.md
@@ -1,0 +1,19 @@
+# Maintenance capability split single-strip performance
+
+## Scope
+
+This slice targets capability metadata parsing in `services/mlx-worker-python/worker/engine/maintenance_core.py`, specifically `_split_capability_values()` used by model-info capability lists.
+
+## Probe coverage
+
+`infra/perf/pr_scoped_probes.json` registers `maintenance-capability-split-single-strip` for the touched maintenance-core path. The entry includes focused `test_command`, `coverage_command`, and `probe_command` values, with `scripts/maintenance_capability_split_probe.py` measuring baseline list-comprehension splitting against the current implementation.
+
+## Implementation plan
+
+- Preserve comma-separated capability parsing semantics: trim whitespace, drop empty segments, keep order.
+- Replace the list comprehension that calls `strip()` in both the expression and filter with a small loop that strips each segment once.
+- Validate locally on Linux with the registered focused tests, changed-scope coverage, and the registered Python probe.
+
+## Validation boundary
+
+This is a Python-only Linux-verifiable slice. No Swift runtime effect is claimed.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1579,6 +1579,47 @@
     ]
   },
   {
+    "id": "maintenance-capability-split-single-strip",
+    "name": "Maintenance capability split single strip",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/maintenance_core.py",
+      "services/mlx-worker-python/tests/test_maintenance_service.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/maintenance_capability_split_probe.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_split_capability_values_strips_once_and_drops_empty_segments services/mlx-worker-python/tests/test_maintenance_service.py::test_get_model_info_appends_tool_parser_when_capability_parser_metadata_is_absent services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_capability_split_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_capability_split_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_split_capability_values_strips_once_and_drops_empty_segments services/mlx-worker-python/tests/test_maintenance_service.py::test_get_model_info_appends_tool_parser_when_capability_parser_metadata_is_absent services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_capability_split_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_capability_split_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/maintenance_capability_split_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/maintenance_capability_split_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for PREFIX in \"${MELIX_MAINTENANCE_CAPABILITY_SPLIT_HEAD_REPO:-}\" \"../head\" \"${GITHUB_WORKSPACE:-}/head\"; do CANDIDATE=\"$PREFIX/$SCRIPT\"; if [ -n \"$PREFIX\" ] && [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "delta_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_abs": 0.02
+      },
+      {
+        "key": "speedup",
+        "unit": "ratio",
+        "direction": "higher_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "upload-receipt-published-files-scandir",
     "name": "Upload receipt published-files scandir",
     "runner": "ubuntu-latest",

--- a/scripts/maintenance_capability_split_probe.py
+++ b/scripts/maintenance_capability_split_probe.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.engine.maintenance_core import _split_capability_values
+
+
+def _baseline_split(raw_value: str) -> list[str]:
+    return [
+        part.strip()
+        for part in raw_value.split(",")
+        if part.strip()
+    ]
+
+
+def _payload(segment_count: int) -> str:
+    values = (" text ", " image", "", " qwen ", " tool\t", "\n")
+    return ",".join(values[index % len(values)] for index in range(segment_count))
+
+
+def _run_split(splitter, raw_value: str, iterations: int) -> tuple[float, int, int]:
+    checksum = 0
+    segment_count = 0
+    started = time.perf_counter()
+    for _ in range(iterations):
+        values = splitter(raw_value)
+        if values[:5] != ["text", "image", "qwen", "tool", "text"]:
+            raise SystemExit(f"unexpected split prefix: {values[:5]!r}")
+        checksum += sum(len(value) for value in values)
+        segment_count += len(values)
+    return (time.perf_counter() - started) * 1000.0, checksum, segment_count
+
+
+def main() -> int:
+    iterations = int(os.environ.get("MELIX_MAINTENANCE_CAPABILITY_SPLIT_ITERATIONS", "50000"))
+    sample_count = int(os.environ.get("MELIX_MAINTENANCE_CAPABILITY_SPLIT_SAMPLES", "5"))
+    value_segments = int(os.environ.get("MELIX_MAINTENANCE_CAPABILITY_SPLIT_SEGMENTS", "72"))
+    raw_value = _payload(value_segments)
+
+    expected = _baseline_split(raw_value)
+    observed = _split_capability_values(raw_value)
+    if observed != expected:
+        raise SystemExit(f"split output drifted: {observed!r} != {expected!r}")
+
+    baseline_elapsed: list[float] = []
+    optimized_elapsed: list[float] = []
+    peak_bytes: list[float] = []
+    checksum = 0
+    segment_total = 0
+    for _ in range(sample_count):
+        elapsed_ms, checksum, segment_total = _run_split(
+            _baseline_split,
+            raw_value,
+            iterations,
+        )
+        baseline_elapsed.append(elapsed_ms)
+
+        elapsed_ms, checksum, segment_total = _run_split(
+            _split_capability_values,
+            raw_value,
+            iterations,
+        )
+        optimized_elapsed.append(elapsed_ms)
+
+        tracemalloc.start()
+        _run_split(
+            _split_capability_values,
+            raw_value,
+            1,
+        )
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_bytes.append(float(peak))
+
+    baseline_mean = statistics.fmean(baseline_elapsed)
+    optimized_mean = statistics.fmean(optimized_elapsed)
+    metrics = {
+        "baseline_elapsed_ms_mean": baseline_mean,
+        "optimized_elapsed_ms_mean": optimized_mean,
+        "elapsed_ms_mean": optimized_mean,
+        "delta_ms_mean": optimized_mean - baseline_mean,
+        "speedup": baseline_mean / optimized_mean if optimized_mean > 0 else 0.0,
+        "peak_bytes_mean": statistics.fmean(peak_bytes),
+        "segment_count": float(value_segments),
+        "iteration_count": float(iterations),
+        "sample_count": float(sample_count),
+        "split_values_per_sample": float(segment_total),
+        "checksum": float(checksum),
+    }
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -4871,6 +4871,12 @@ def test_get_model_info_uses_kind_fallbacks_for_audio_and_image_models(tmp_path:
     assert image.detected_identity_source == "default"
 
 
+def test_split_capability_values_strips_once_and_drops_empty_segments() -> None:
+    assert maintenance_core_module._split_capability_values(
+        " text, image ,, qwen ,\ttool\n, "
+    ) == ["text", "image", "qwen", "tool"]
+
+
 def test_get_model_info_appends_tool_parser_when_capability_parser_metadata_is_absent(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1810,6 +1810,16 @@ def test_scope_report_selects_maintenance_parameter_normalization_probe() -> Non
     assert "maintenance-benchmark-parameter-normalization-single-convert" in probe_ids
 
 
+def test_scope_report_selects_maintenance_capability_split_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/engine/maintenance_core.py"],
+    )
+
+    probe_ids = {probe["id"] for probe in scope["selected_probes"]}
+    assert "maintenance-capability-split-single-strip" in probe_ids
+
+
 def test_scope_report_selects_upload_receipt_published_files_probe() -> None:
     scope = build_scope_report(
         registry_path=REGISTRY_PATH,
@@ -2797,6 +2807,34 @@ def test_maintenance_parameter_normalization_probe_script_emits_metrics(
     assert metrics["peak_bytes_mean"] > 0
 
 
+def test_maintenance_capability_split_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_MAINTENANCE_CAPABILITY_SPLIT_SEGMENTS", "12")
+    monkeypatch.setenv("MELIX_MAINTENANCE_CAPABILITY_SPLIT_ITERATIONS", "4")
+    monkeypatch.setenv("MELIX_MAINTENANCE_CAPABILITY_SPLIT_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/maintenance_capability_split_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["sample_count"] == 1.0
+    assert metrics["iteration_count"] == 4.0
+    assert metrics["segment_count"] == 12.0
+    assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["baseline_elapsed_ms_mean"] >= 0
+    assert metrics["optimized_elapsed_ms_mean"] == metrics["elapsed_ms_mean"]
+    assert metrics["speedup"] > 0.0
+    assert metrics["split_values_per_sample"] == 32.0
+    assert metrics["checksum"] > 0.0
+    assert metrics["peak_bytes_mean"] > 0
+
+
 def test_mlx_audio_wav_streaming_probe_script_emits_metrics(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -3196,6 +3234,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "maintenance-percentile-vector-reuse",
         "maintenance-prompt-shape-vector-repeat",
         "maintenance-benchmark-parameter-normalization-single-convert",
+        "maintenance-capability-split-single-strip",
         "phase8-metrics-closure-audit-reuse",
         "pr-scoped-performance-registry-cache",
         "real-model-support-hf-cache-latest-snapshot",

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -203,9 +203,9 @@ class BenchmarkLoadedModelResolution:
 
 def _split_capability_values(raw_value: str) -> list[str]:
     return [
-        part.strip()
+        stripped
         for part in raw_value.split(",")
-        if part.strip()
+        if (stripped := part.strip())
     ]
 
 


### PR DESCRIPTION
## Summary
- Register `maintenance-capability-split-single-strip` as a PR-scoped command-json performance probe.
- Strip comma-separated maintenance capability values once per segment with assignment-expression filtering.
- Add focused regression/probe tests and a governing plan for the slice.

## Plan or Spec
- `docs/plans/2026-06-04-maintenance-capability-split-single-strip-performance.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_split_capability_values_strips_once_and_drops_empty_segments services/mlx-worker-python/tests/test_maintenance_service.py::test_get_model_info_appends_tool_parser_when_capability_parser_metadata_is_absent services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_capability_split_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_capability_split_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` → 5 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...` → 5 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/maintenance_capability_split_probe.py` → TOTAL 24 0 100%
- `MELIX_MAINTENANCE_CAPABILITY_SPLIT_HEAD_REPO="$PWD" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id maintenance-capability-split-single-strip --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/maintenance_capability_probe_trial2.json`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (24 measurable changed lines, 0 missed).
- Local registered probe: base `elapsed_ms_mean=353.7621205672622`, head `elapsed_ms_mean=349.8897345736623`, delta `-3.8723859935998713 ms` (lower is better).
- Probe-internal single-strip comparison on head: `baseline_elapsed_ms_mean=397.4119513295591`, `optimized_elapsed_ms_mean=349.8897345736623`, `delta_ms_mean=-47.52221675589681`, `speedup=1.1358205516197903`.

## Known Gaps
- Python-only slice verified locally on Linux; no Swift runtime effect is claimed.
- CI PR-scoped performance remains the merge gate for the registered probe.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance completed successfully.
