### PR TITLE
perf: reduce semantic actor alias copy overhead

### DIFF
--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -1738,7 +1738,7 @@ def _semantic_action_match_payload(
 def _semantic_field_values(field_name: str, event: dict[str, object]) -> list[str]:
     value = event.get(field_name)
     if field_name == "actor":
-        return list(_cached_semantic_actor_field_values(_event_field_cache_key(value)))
+        return [*_cached_semantic_actor_field_values(_event_field_cache_key(value))]
     return _normalize_unique_event_field(value)
 
 


### PR DESCRIPTION
## Summary
- Reduce cached semantic actor alias copy overhead by using a list-display copy for cached actor tuples.
- Keep the existing `_semantic_field_values()` list return contract and behavior unchanged.

## Plan or Spec
- Uses the existing registered PR-scoped probe: `event-extraction-group-actor-alias-cache` in `infra/perf/pr_scoped_probes.json`.
- No docs/spec behavior change is required; this is a minimal implementation-only Python performance slice.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EVENT_ACTOR_ALIAS_PROBE_ITERATIONS=500 MELIX_EVENT_ACTOR_ALIAS_PROBE_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/event_extraction_actor_alias_probe.py` (baseline on origin/main)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EVENT_ACTOR_ALIAS_PROBE_ITERATIONS=500 MELIX_EVENT_ACTOR_ALIAS_PROBE_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/event_extraction_actor_alias_probe.py` (after change)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_reuses_cached_group_actor_aliases services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_caches_repeated_group_actor_expansion services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_normalizes_and_deduplicates_in_one_pass services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_expands_group_actor_aliases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_actor_alias_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_actor_alias_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_actor_alias_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 7 passed.
- Changed-scope coverage: 100.00% (`TOTAL 1 0 100%`).
- Local Linux registered probe command (default env): `elapsed_ms_mean=3.440388198941946`, `elapsed_ms_min=3.3564530313014984`, `peak_bytes_mean=5362.0`.
- Local comparison probe with 500 iterations / 7 samples:
  - Before: `elapsed_ms_mean=10.346744475620133`, `elapsed_ms_min=8.467166684567928`, `peak_bytes_mean=5284.857142857143`.
  - After: `elapsed_ms_mean=8.655657659151725`, `elapsed_ms_min=8.306304924190044`, `peak_bytes_mean=4828.857142857143`.
  - Delta: `elapsed_delta_ms=-1.691087`, `elapsed_speedup_pct=16.34%`, `peak_delta_bytes=-456.00`.

## Known Gaps
- Local validation is Linux/Python-only. Final registered PR-scoped performance validation must come from GitHub Actions.
- This slice intentionally avoids changing the public helper return type; it only reduces copy overhead within the existing contract.

## Evidence Checklist
- [x] Branch based on current `origin/main`.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage measured at or above 95%.
- [x] Local registered probe ran and reported metrics.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
