### PR TITLE
perf: bind dataset version listing loop helpers

### DIFF
--- a/docs/plans/2026-06-05-dataset-version-listing-local-bindings.md
+++ b/docs/plans/2026-06-05-dataset-version-listing-local-bindings.md
@@ -1,0 +1,36 @@
+# Dataset Version Listing Local Bindings
+
+## Scope
+
+This Python-only performance slice is limited to `list_dataset_versions()` in
+`services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+It keeps dataset version listing semantics unchanged while reducing repeated
+attribute/global lookups in the per-version manifest loop.
+
+## Registered performance probe
+
+The affected path is covered by the registered PR-scoped probe
+`dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`. The
+probe declares focused `test_command`, `coverage_command`, and `probe_command`
+entries and reports listing elapsed time plus version count.
+
+## Implementation plan
+
+1. Keep the existing `os.scandir()` manifest discovery behavior unchanged.
+2. Reuse local loop bindings for version append/read operations and avoid a
+   redundant `str()` conversion for manifest paths that are already yielded as
+   strings.
+3. Run the registered focused tests, changed-scope coverage, and the registered
+   probe locally on Linux.
+4. Use GitHub Actions PR-scoped performance as the merge gate after opening the
+   PR.
+
+## Validation
+
+Local Linux validation for this slice:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-version-listing-scandir --base-repo <baseline-worktree> --head-repo "$PWD" --output /tmp/dataset_version_listing_probe.json
+```

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -457,9 +457,11 @@ def list_dataset_versions(
     started = time.perf_counter()
     versions_root = Path(output_root).expanduser() / dataset_id / "versions"
     versions: list[dict[str, Any]] = []
+    versions_append = versions.append
+    read_json_file = _read_json_file
     for manifest_path in _iter_dataset_version_manifest_paths(versions_root):
-        version = _read_json_file(manifest_path)
-        versions.append(
+        version = read_json_file(manifest_path)
+        versions_append(
             {
                 "dataset_id": version.get("dataset_id", ""),
                 "version_id": version.get("version_id", ""),
@@ -469,10 +471,11 @@ def list_dataset_versions(
                 "validation_count": version.get("validation_count", 0),
                 "failed_count": version.get("failed_count", 0),
                 "quality_summary_path": version.get("quality_summary_path", ""),
-                "dataset_version_path": str(manifest_path),
+                "dataset_version_path": manifest_path,
             }
         )
-    versions.sort(key=lambda item: (str(item["created_at"]), str(item["version_id"])))
+    as_str = str
+    versions.sort(key=lambda item: (as_str(item["created_at"]), as_str(item["version_id"])))
     return {
         "schema_version": DATASET_VERSION_LIST_SCHEMA_VERSION,
         "workspace_manifest_path": str(Path(workspace_manifest_path)),


### PR DESCRIPTION
## Summary
- Bind dataset version listing loop helpers locally in `list_dataset_versions()`.
- Keep the existing `os.scandir()` manifest discovery and output semantics unchanged.

## Plan or Spec
- `docs/plans/2026-06-05-dataset-version-listing-local-bindings.md`

## Commands Run
```text
git fetch origin --prune && git worktree add -b perf/next-python-slice-20260605 /root/.hermes/profiles/coder/workspace/worktrees/melix-next-perf-slice-20260605 origin/main
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 7 passed in 1.00s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py
# 7 passed in 0.32s; changed-scope coverage TOTAL 6 0 100%
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-version-listing-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-dataset-version-listing-local-bindings-base-20260605 --head-repo "$PWD" --output /tmp/dataset_version_listing_probe_1780622088.json
# ok; base elapsed_ms_mean=52.969013, head elapsed_ms_mean=45.258693

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`TOTAL 6 0 100%`).
- Registered probe: `dataset-version-listing-scandir`.
- Local Linux probe metrics:
  - `elapsed_ms_mean`: base `52.969013` ms → head `45.258693` ms (`-7.710320` ms, `-14.56%`).
  - `elapsed_ms_min`: base `42.665989` ms → head `42.631825` ms (`-0.034164` ms).
  - `elapsed_ms_p95`: base `60.094572` ms → head `46.133626` ms (`-13.960946` ms).
  - `version_count`: base/head `2500`.
- CI PR-scoped performance is still required as the merge gate.

## Known Gaps
- Swift/runtime effects: N/A; this is a Python-only Linux-verifiable slice.
- CI must run the registered PR-scoped performance report before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; probe overhead is limited to synthetic CI/local evidence execution.
- [x] Deferred work and known gaps are stated explicitly.
