### PR TITLE
perf: fast-path dataset quality message lengths

### DIFF
--- a/docs/plans/2026-06-05-dataset-quality-message-content-fastpath.md
+++ b/docs/plans/2026-06-05-dataset-quality-message-content-fastpath.md
@@ -1,0 +1,59 @@
+# Dataset Quality Message Content Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to the message-row branch inside
+`worker.productization.dataset_preparation._append_sample_output_lengths(...)`.
+The helper is used by `_quality_summary(...)` when building dataset version
+quality summaries.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`. The
+registry entry already includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_versioning.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_quality_lengths_probe.py`
+
+## Hypothesis
+
+Dataset quality summaries mostly process `completion` rows, but the registered
+probe also includes chat-message validation rows. The current message branch
+checks `isinstance(item, dict)` before every content lookup. The expected hot
+path uses dictionary message items, so reading `item.get(...)` directly and
+falling back only for non-mapping items should preserve semantics while removing
+one common-path type check per message item.
+
+A pre-slice trial that switched completion rows to `try/except KeyError`
+regressed the 31-sample Linux probe from `2.228684 ms` to `2.798706 ms`, so it
+was rejected and reverted.
+
+Baseline local probe on Linux before the accepted message-content fast path:
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=101 uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
+{"elapsed_ms_mean": 2.325885, "elapsed_ms_min": 2.149487, "elapsed_ms_p95": 2.597716, "mean_output_length": 51.999, "p95_output_length": 100.0, "row_count": 15000.0, "sample_count": 101.0, "train_row_count": 12000.0, "validation_row_count": 3000.0}
+```
+
+Accepted local probe on Linux after the message-content fast path:
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=101 uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
+{"elapsed_ms_mean": 2.141221, "elapsed_ms_min": 2.07063, "elapsed_ms_p95": 2.348198, "mean_output_length": 51.999, "p95_output_length": 100.0, "row_count": 15000.0, "sample_count": 101.0, "train_row_count": 12000.0, "validation_row_count": 3000.0}
+```
+
+Delta: `old_mean=2.325885 ms`, `new_mean=2.141221 ms`, `delta=-0.184664 ms`,
+`speedup=1.0862x`.
+
+## Verification Plan
+
+1. Keep the registered `dataset-quality-lengths-chain` probe unchanged.
+2. Extend focused behavior coverage for non-dict message items.
+3. Run the registered focused tests.
+4. Run changed-scope coverage for the touched Python/test/probe paths.
+5. Run the registered probe locally on Linux and use GitHub Actions PR-scoped
+   performance as the merge gate.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -117,12 +117,12 @@ def test_dataset_quality_output_lengths_preserve_completion_and_message_semantic
     train_rows = [
         {"completion": "abc"},
         {"completion": 12345},
-        {"messages": [{"content": "hi"}, {"content": "there"}, {"role": "tool"}]},
+        {"messages": [{"content": "hi"}, {"content": "there"}, {"role": "tool"}, "skip-me"]},
         {"messages": "not-a-list"},
     ]
     validation_rows = [
         {"completion": "done"},
-        {"messages": [{"content": "hello"}, {"content": "world"}, {"role": "tool"}]},
+        {"messages": [{"content": "hello"}, {"content": "world"}, {"role": "tool"}, "skip-too"]},
         {"messages": "not-a-list"},
     ]
 

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1050,8 +1050,11 @@ def _append_sample_output_lengths(
             continue
         total = 0
         for item in messages:
-            if isinstance(item, dict):
-                total += len(str_(item.get("content", "")))
+            try:
+                content = item.get("content", "")
+            except AttributeError:
+                continue
+            total += len(str_(content))
         append(total)
     for row in validation_rows:
         if "completion" in row:
@@ -1063,8 +1066,11 @@ def _append_sample_output_lengths(
             continue
         total = 0
         for item in messages:
-            if isinstance(item, dict):
-                total += len(str_(item.get("content", "")))
+            try:
+                content = item.get("content", "")
+            except AttributeError:
+                continue
+            total += len(str_(content))
         append(total)
 
 


### PR DESCRIPTION
## Summary
- Fast-path dataset quality message output-length collection by calling `item.get(...)` directly on normal dict message rows and falling back only for non-mapping items.
- Extend focused regression coverage so non-dict message items are still ignored.
- Add the governing plan/evidence note for this performance slice.

## Plan or Spec
- `docs/plans/2026-06-05-dataset-quality-message-content-fastpath.md`
- Registered PR-scoped probe: `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_output_lengths_preserve_completion_and_message_semantics
# 6 passed in 0.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_output_lengths_preserve_completion_and_message_semantics
# 6 passed in 0.31s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py
# TOTAL 10 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=101 uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
# head: {"elapsed_ms_mean": 2.141221, "elapsed_ms_min": 2.07063, "elapsed_ms_p95": 2.348198, "mean_output_length": 51.999, "p95_output_length": 100.0, "row_count": 15000.0, "sample_count": 101.0, "train_row_count": 12000.0, "validation_row_count": 3000.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Local Linux registered-probe comparison for `dataset-quality-lengths-chain` with `MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=101`:
  - base `origin/main`: `elapsed_ms_mean=2.325885`, `elapsed_ms_min=2.149487`, `elapsed_ms_p95=2.597716`
  - head: `elapsed_ms_mean=2.141221`, `elapsed_ms_min=2.07063`, `elapsed_ms_p95=2.348198`
  - delta: `-0.184664 ms` mean, `speedup=1.0862x`
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this is a focused Python performance slice. GitHub Actions is expected to run the broader gates.
- No Swift runtime validation applies to this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
