### PR TITLE
perf: trim dataset source compound suffix checks

### DIFF
--- a/docs/plans/2026-06-05-dataset-source-kind-compound-check.md
+++ b/docs/plans/2026-06-05-dataset-source-kind-compound-check.md
@@ -1,0 +1,32 @@
+# Dataset Source Kind Compound Check Fast Path
+
+## Scope
+
+Optimize one Python hot path in dataset ingest: `_source_kind()` classification for `.txt` source files discovered by `worker.productization.dataset_preparation._iter_source_records()`.
+
+The previous suffix fast path already avoided building `Path.suffixes`, but lowercase `.txt` candidates still performed full `.endswith(".pdf.txt")` and `.endswith(".docx.txt")` checks before the direct compound-suffix slice checks. This slice removes those redundant full-suffix checks and keeps the single direct slice checks as the source of truth for `.pdf.txt` and `.docx.txt` classification.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries. The local Linux probe reports:
+
+- `elapsed_ms_mean`
+- `elapsed_ms_min`
+- `elapsed_ms_p95`
+- `source_kind_elapsed_ms_mean`
+- `source_kind_elapsed_ms_min`
+- `source_kind_elapsed_ms_p95`
+- `file_count_mean`
+
+## Plan
+
+1. Keep the existing source-kind behavior coverage for lowercase and mixed-case `.pdf.txt`, `.docx.txt`, `.txt`, `.text`, code, structured-data, and unsupported names.
+2. Remove redundant compound `.endswith(...)` checks from the lowercase `.txt` path and use the already-present direct slice checks instead.
+3. Run the registered focused test command, changed-scope coverage command, and local registered probe on Linux.
+4. Use GitHub Actions PR-scoped performance output as the merge gate.
+
+## Verification Notes
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -566,10 +566,6 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
 def _source_kind(path: Path) -> str | None:
     name = path.name
     if name.endswith(".txt"):
-        if name.endswith(".pdf.txt"):
-            return "pdf"
-        if name.endswith(".docx.txt"):
-            return "docx"
         if len(name) >= 8 and name[-8] == "." and name[-7:-4].lower() == "pdf":
             return "pdf"
         if len(name) >= 9 and name[-9] == "." and name[-8:-4].lower() == "docx":
@@ -584,9 +580,9 @@ def _source_kind(path: Path) -> str | None:
 
     lower_name = name.lower()
     if lower_name.endswith(".txt"):
-        if lower_name.endswith(".pdf.txt"):
+        if len(lower_name) >= 8 and lower_name[-8] == "." and lower_name[-7:-4] == "pdf":
             return "pdf"
-        if lower_name.endswith(".docx.txt"):
+        if len(lower_name) >= 9 and lower_name[-9] == "." and lower_name[-8:-4] == "docx":
             return "docx"
         return "text"
     if lower_name.endswith(".text"):


### PR DESCRIPTION
## Summary
- Trim redundant compound `.endswith(...)` checks from the dataset ingest `_source_kind()` lowercase `.txt` fast path.
- Keep `.pdf.txt`, `.docx.txt`, `.txt`, `.text`, code, structured-data, and unsupported-name classification behavior covered by the existing focused tests.
- Add a focused plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-05-dataset-source-kind-compound-check.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 10 passed in 0.99s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same registered focused selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# 10 passed in 0.33s; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# elapsed_ms_mean=11.004680035901922; source_kind_elapsed_ms_mean=15.50407029156174; file_count_mean=6000.0

MELIX_DATASET_SOURCE_RECORDS_PROBE_DIRS=250 MELIX_DATASET_SOURCE_RECORDS_PROBE_FILES_PER_DIR=80 MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=9 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/dataset_source_kind_compound_probe_large.json
# head verification passed; base/head probe completed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Registered probe: `dataset-source-records-scandir`.
- Local registered base-vs-head probe (larger 20k-file sample to reduce source-kind timing noise):
  - `source_kind_elapsed_ms_mean`: 57.40468488592241 ms -> 55.64114963635802 ms (`-1.7635352495643843 ms`, `-3.07%`).
  - `source_kind_elapsed_ms_p95`: 62.57209973409772 ms -> 59.4644621014595 ms (`-3.107637632638216 ms`, `-4.97%`).
  - `elapsed_ms_mean`: 39.255430818431904 ms -> 39.40348984259698 ms (`+0.14805902416507877 ms`, `+0.38%`, directory listing noise outside the changed `_source_kind()` branch).
  - `elapsed_ms_p95`: 46.63317231461406 ms -> 46.38640908524394 ms (`-0.2467632293701172 ms`, `-0.53%`).
- CI PR-scoped performance report is still required as the merge gate for the registered probe.

## Known Gaps
- Full repository `make` gates were not run locally; this Python slice used the registered focused test, coverage, and probe commands on Linux.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
