### PR TITLE
perf: short-circuit dataset split mismatches

### DIFF
--- a/docs/plans/2026-06-05-dataset-split-lowercase-fastpath.md
+++ b/docs/plans/2026-06-05-dataset-split-lowercase-fastpath.md
@@ -1,0 +1,29 @@
+# Dataset split lowercase fast path
+
+This Python-only performance slice narrows the registered dataset registry split
+matching hot path in `worker.dataset_registry.catalog._path_part_matches_split`.
+
+The common Hugging Face cache path uses lowercase split names such as
+`validation-00000.jsonl`. The prior implementation lowercased every candidate
+path part before checking exact/prefix and stem matches. This slice first checks
+whether the path part can match the requested split by its first character,
+returns early for obvious non-matches, then uses the existing lowercase fallback
+for mixed-case filenames and directories.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped probe
+`dataset-registry-limited-read-streaming` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries over:
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_split_match_probe.py`
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage, and local Linux probe.
+Compare the direct probe against an `origin/main` baseline worktree before
+opening the PR; GitHub Actions PR-scoped performance remains the merge gate.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -311,6 +311,11 @@ def test_dataset_catalog_path_match_checks_filename_before_parent_parts() -> Non
         catalog._path_matches_split(Path("custom/train-00000.jsonl"), "validation")
         is False
     )
+    assert (
+        catalog._path_matches_split(Path("Custom/Validation-00000.jsonl"), "validation")
+        is True
+    )
+    assert catalog._path_part_matches_split("", "validation", "validation-", "validation_") is False
 
 
 def test_dataset_catalog_row_reader_respects_limit(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -995,6 +995,29 @@ def _path_part_matches_split(
     split_dash_prefix: str,
     split_underscore_prefix: str,
 ) -> bool:
+    if not part or not normalized_split:
+        return False
+    first_char = part[0]
+    split_first_char = normalized_split[0]
+    if first_char != split_first_char and first_char.lower() != split_first_char:
+        return False
+    if (
+        part == normalized_split
+        or part.startswith(split_dash_prefix)
+        or part.startswith(split_underscore_prefix)
+    ):
+        return True
+    dot_index = part.rfind(".")
+    if dot_index > 0 and dot_index < len(part) - 1:
+        stem = part[:dot_index]
+        if (
+            stem == normalized_split
+            or stem.startswith(split_dash_prefix)
+            or stem.startswith(split_underscore_prefix)
+        ):
+            return True
+    if first_char == split_first_char:
+        return False
     lowered = part.lower()
     if (
         lowered == normalized_split


### PR DESCRIPTION
## Summary
- Short-circuit dataset split part matching when the candidate path part cannot start with the requested split.
- Preserve mixed-case fallback behavior for filenames/directories such as `Validation-00000.jsonl`.
- Add a small plan note for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-05-dataset-split-lowercase-fastpath.md`

## Commands Run
```text
# focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_path_split_matching_avoids_temporary_path_construction services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_split_match_tokens_are_cached_per_split services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_string_stem_matches_pathlib_for_split_names services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_selected_split_filters_during_iteration services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_path_match_checks_filename_before_parent_parts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_split_match_probe_script_emits_metrics
Result: 8 passed in 0.26s

# changed-scope coverage via registered coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_split_match_probe.py
Result: 8 passed in 0.23s; TOTAL 17 0 100%

# local registered probe, direct head run
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_split_match_probe.py
Result: {"elapsed_ms_mean": 35.10775314643979, "file_count": 20000.0, "matched_files_mean": 5000.0, "path_constructor_calls_mean": 0.0, "peak_bytes_mean": 42026.6, "sample_count": 5.0}

# local PR-scoped base-vs-head runner
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-registry-limited-read-streaming --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-dataset-split-lowercase-fastpath-20260605 --head-repo "$PWD" --output /tmp/dataset_split_lowercase_fastpath_report.json
Result: passed; base elapsed_ms_mean=56.44173547625542, head elapsed_ms_mean=37.532805651426315
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 17 0 100%`.
- Registered probe: `dataset-registry-limited-read-streaming`.
- Local base-vs-head probe: `elapsed_ms_mean` improved from `56.44173547625542` ms to `37.532805651426315` ms (`-18.9089298248291` ms, about `33.5%` faster).
- Structural guardrails: `matched_files_mean=5000.0` unchanged; `path_constructor_calls_mean=0.0` unchanged.
- PR-scoped performance CI is required as the final registered probe validation source before merge.

## Known Gaps
- Full repository gates were not run locally; this slice used the registered focused Python test/coverage/probe commands on Linux.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A (no observability change); probe overhead: registered PR-scoped probe only.
- [x] Deferred work and known gaps are stated explicitly.
