### PR TITLE
perf: bind event response raw JSON decode

### DIFF
--- a/docs/plans/2026-06-05-event-response-json-raw-decode-binding.md
+++ b/docs/plans/2026-06-05-event-response-json-raw-decode-binding.md
@@ -1,0 +1,24 @@
+# Event response JSON raw-decode binding
+
+## Scope
+
+This Python-only performance slice targets fenced event-extraction response parsing in `services/mlx-worker-python/worker/productization/event_extraction.py`.
+
+The affected path is covered by the registered PR-scoped performance probe `event-extraction-response-json-fence-trim` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for the event response JSON parser.
+
+## Optimization
+
+Bind `json.JSONDecoder().raw_decode` once at module load time and reuse the bound callable inside `_parse_response_json()`. The parser is called repeatedly for fenced model responses; avoiding repeated descriptor/attribute lookup keeps behavior unchanged while shaving the hot fenced JSON path.
+
+This slice does not alter response validation, closing-fence handling, or unfenced `json.loads()` behavior.
+
+## Verification plan
+
+- Run the registered focused pytest command for `event-extraction-response-json-fence-trim`.
+- Run the registered changed-scope coverage command for the same probe.
+- Run the registered probe locally on Linux against an `origin/main` baseline and this head branch.
+- Use PR-scoped performance CI as the merge gate for the registered probe report.
+
+## Environment boundary
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime behavior is changed.

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -79,6 +79,7 @@ Rules:
 """
 SEMANTIC_JUDGE_PROMPT_HASH = f"sha256:{sha256(SEMANTIC_JUDGE_SYSTEM_PROMPT.encode('utf-8')).hexdigest()}"
 _JSON_DECODER = json.JSONDecoder()
+_JSON_RAW_DECODE = _JSON_DECODER.raw_decode
 _JSON_FENCE_PREFIX = "```json\n"
 _JSON_FENCE_PREFIX_LENGTH = len(_JSON_FENCE_PREFIX)
 _CLOSING_FENCE_WITH_LEADING_NEWLINE = "\n```"
@@ -2855,7 +2856,7 @@ def _coerce_string_list(value: object) -> list[str]:
 def _parse_response_json(response_text: str) -> dict[str, object]:
     response_length = len(response_text)
     if response_text.startswith(_JSON_FENCE_PREFIX):
-        parsed, end_index = _JSON_DECODER.raw_decode(
+        parsed, end_index = _JSON_RAW_DECODE(
             response_text,
             _JSON_FENCE_PREFIX_LENGTH,
         )
@@ -2870,7 +2871,7 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
         response_start += 1
 
     if response_text.startswith(_JSON_FENCE_PREFIX, response_start):
-        parsed, end_index = _JSON_DECODER.raw_decode(
+        parsed, end_index = _JSON_RAW_DECODE(
             response_text,
             response_start + _JSON_FENCE_PREFIX_LENGTH,
         )
@@ -2883,7 +2884,7 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
     if response_text.startswith("```", response_start):
         newline_index = response_text.find("\n", response_start)
         if newline_index >= 0:
-            parsed, end_index = _JSON_DECODER.raw_decode(response_text, newline_index + 1)
+            parsed, end_index = _JSON_RAW_DECODE(response_text, newline_index + 1)
             if not _has_only_optional_closing_fence(response_text, end_index, response_length):
                 raise json.JSONDecodeError("Extra data", response_text, end_index)
             if not isinstance(parsed, dict):


### PR DESCRIPTION
## Summary
- Bind the event-extraction JSON decoder's `raw_decode` callable once at module load time.
- Reuse that bound callable in the fenced response parser hot path without changing closing-fence validation or unfenced parsing behavior.
- Add a slice plan documenting the registered probe and Linux verification boundary.

## Plan or Spec
- `docs/plans/2026-06-05-event-response-json-raw-decode-binding.md`
- Registered probe: `event-extraction-response-json-fence-trim` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_leading_whitespace_before_fence services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_generic_fence_after_fast_json_prefix services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_unfenced_json_without_pretrim_copy services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_trailing_text_after_fenced_json services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_fenced_non_object_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_response_json_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id event-extraction-response-json-fence-trim --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-event-response-json-raw-decode-binding-20260605 --head-repo "$PWD" --output /tmp/event_response_json_raw_decode_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: 10 passed.
- Changed-scope coverage: 100.00% (`TOTAL 4 0 100%`).
- Registered local probe: base `elapsed_ms_mean=1195.963685773313`, head `elapsed_ms_mean=1151.139567606151`, delta `-44.82411816716206 ms` (~3.75% faster); `peak_bytes_mean` unchanged at `2999248.8`.
- PR-scoped performance CI is required for the registered probe validation before merge.

## Known Gaps
- This is a Python-only slice validated locally on Linux; no Swift runtime behavior is changed.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered local base-vs-head probe showed improvement.
- [ ] GitHub Actions / PR-scoped performance CI completed successfully.
