### PR TITLE
perf: skip empty report evidence probe phase normalization

### DIFF
--- a/docs/plans/2026-06-05-report-evidence-probe-phase-empty-fastpath.md
+++ b/docs/plans/2026-06-05-report-evidence-probe-phase-empty-fastpath.md
@@ -1,0 +1,22 @@
+# Report Evidence Probe Phase Empty Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.productization.report_evidence_gate._rule_matches_report`.
+Most release evidence matrix rules match through run kinds, metric prefixes, or target fields and do not declare `probe_phases`; the fallback probe-phase check should not normalize an empty default rule on those non-match paths.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` values and runs `scripts/report_evidence_gate_run_kind_probe.py`.
+
+## Plan
+
+1. Preserve existing release evidence matrix matching semantics for run-kind, metric-prefix, target-field, and non-empty probe-phase rules.
+2. Add a focused regression test proving empty or absent probe-phase rules skip set normalization.
+3. Implement the fast path by returning `False` before `_string_frozenset` when the probe-phase rule is empty.
+4. Verify with focused pytest, changed-scope coverage, and the registered probe locally on Linux; use PR-scoped performance CI as the merge gate.
+
+## Metrics
+
+Success is measured by `elapsed_ms_mean` and the component timings from `scripts/report_evidence_gate_run_kind_probe.py`; behavior parity is measured by focused report-evidence gate tests and changed-scope coverage for the touched module and tests.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -430,6 +430,30 @@ def test_report_evidence_gate_probe_phase_list_rules_reflect_mutation() -> None:
     )
 
 
+def test_report_evidence_gate_empty_probe_phase_rules_skip_normalization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_string_frozenset(values: object) -> frozenset[str]:  # pragma: no cover
+        raise AssertionError("empty probe phase rules should skip set normalization")
+
+    monkeypatch.setattr(report_evidence_gate_module, "_string_frozenset", fail_string_frozenset)
+
+    assert not report_evidence_gate_module._rule_matches_report(
+        rule={},
+        runs=[],
+        targets=[],
+        metrics=[],
+        probe_phases={"runtime_prepare"},
+    )
+    assert not report_evidence_gate_module._rule_matches_report(
+        rule={"probe_phases": ()},
+        runs=[],
+        targets=[],
+        metrics=[],
+        probe_phases={"runtime_prepare"},
+    )
+
+
 def test_report_evidence_gate_run_kind_list_rules_reflect_mutation() -> None:
     run_kinds = ["evaluation"]
     rule = {"run_kinds": run_kinds}

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -351,8 +351,10 @@ def _rule_matches_report(
                         return True
                 elif str(value).strip():
                     return True
-    required_probe_phases = _string_frozenset(rule.get("probe_phases", ()))
-    return bool(required_probe_phases and required_probe_phases.issubset(probe_phases))
+    required_probe_phases = rule.get("probe_phases", ())
+    if not required_probe_phases:
+        return False
+    return _string_frozenset(required_probe_phases).issubset(probe_phases)
 
 
 @lru_cache(maxsize=128)


### PR DESCRIPTION
## Summary
- Skip `_string_frozenset` normalization when report-evidence gate rules have no `probe_phases` entry or an empty probe-phase tuple.
- Add a regression test for the empty probe-phase path and document the performance slice.

## Plan or Spec
- `docs/plans/2026-06-05-report-evidence-probe-phase-empty-fastpath.md`

## Commands Run
```text
# Baseline probe on origin/main (f397f1e4), 4 samples of the registered probe command:
PYTHONPATH="$base:$base/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_RUN_KIND_ITERATIONS=50000 MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES=5 uv run --project "$base/services/mlx-worker-python" python3 "$base/scripts/report_evidence_gate_run_kind_probe.py"
# exit 0; elapsed_ms_mean samples: 884.4545, 887.1721, 885.1362, 896.5896

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_empty_probe_phase_rules_skip_normalization services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_probe_phase_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_probe_phase_list_rules_reflect_mutation services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# exit 0; 6 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_fast_reject_preserves_empty_prefix services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_sparse_match_scans_row_items services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_preserves_stringified_presence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_empty_probe_phase_rules_skip_normalization services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_dedupes_evidence_ids services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_single_role_keeps_stringified_evidence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_ignores_invalid_cached_roles services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# exit 0; 18 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o /tmp/report_evidence_probe_phase_coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json /tmp/report_evidence_probe_phase_coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py
# exit 0; TOTAL 8 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_RUN_KIND_ITERATIONS=50000 MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# exit 0; elapsed_ms_mean samples: 891.6276, 882.5381, 891.5281, 881.8911

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-line coverage: `100%` (`8/8` measurable changed lines).
- Registered local probe: `report-evidence-gate-run-kind-set-membership` via `scripts/report_evidence_gate_run_kind_probe.py`.
- Baseline mean: `888.3381 ms`; head mean: `886.8962 ms`; delta: `-1.4419 ms`; speedup: `1.0016x`.
- Component metrics are noisy on Linux; PR-scoped performance CI is the merge validation source.

## Known Gaps
- Linux local probe only validates the Python path; PR-scoped performance CI must complete before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
