### PR TITLE
perf: short-circuit single-line coverage membership

### DIFF
--- a/docs/plans/2026-06-05-changed-scope-single-line-before-range.md
+++ b/docs/plans/2026-06-05-changed-scope-single-line-before-range.md
@@ -1,0 +1,35 @@
+# Changed-scope single-line membership fast path
+
+## Scope
+
+This Python-only performance slice is limited to `scripts/changed_scope_coverage.py`.
+When a coverage entry exposes exactly one executed line and one missing line,
+`_measurable_changed_lines` can decide disjoint changed-line sets with direct
+membership checks before computing broader min/max range overlap.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`changed-scope-coverage-empty-path-short-circuit` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` values and runs
+`scripts/changed_scope_coverage_probe.py`.
+
+## Plan
+
+1. Preserve existing changed-line coverage behavior for empty changes, single-line
+   coverage entries, and multi-line coverage entries.
+2. Add a focused regression test proving single-line coverage entries do not call
+   the broad range-overlap helper when direct membership already proves no
+   measurable line can exist.
+3. Move the existing singleton membership fast path ahead of the range-overlap
+   guard, leaving the range guard for multi-line coverage entries.
+4. Verify with the registered focused tests, changed-scope coverage command, and
+   the registered local Linux probe before using PR-scoped performance CI as the
+   merge gate.
+
+## Metrics
+
+Success is measured by the registered probe's `elapsed_ms_mean` while preserving
+`source_read_calls_mean == 0.0`. This slice is Linux-verifiable and does not
+claim any Swift runtime effect.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -171,8 +171,6 @@ def _measurable_changed_lines(
     entry = coverage_payload["files"][rel_path]
     executed_lines = entry["executed_lines"]
     missing_lines = entry["missing_lines"]
-    if not _line_ranges_may_overlap(changed, executed_lines, missing_lines):
-        return [], [], []
     if len(executed_lines) == 1 and len(missing_lines) == 1:
         executed_line = executed_lines[0]
         missing_line = missing_lines[0]
@@ -186,6 +184,8 @@ def _measurable_changed_lines(
         executed_lookup = (executed_line,)
         missing_lookup = (missing_line,)
     else:
+        if not _line_ranges_may_overlap(changed, executed_lines, missing_lines):
+            return [], [], []
         executed = set(executed_lines)
         missing = set(missing_lines)
         measured_changed = [

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -407,6 +407,36 @@ def test_measurable_changed_lines_skips_source_read_when_no_changed_lines(monkey
     assert read_calls == []
 
 
+def test_measurable_changed_lines_checks_singletons_before_range_overlap(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    coverage_payload = {
+        "files": {
+            "foo.py": {
+                "executed_lines": [1],
+                "missing_lines": [2],
+            }
+        }
+    }
+
+    def fail_range_overlap(*args: object, **kwargs: object) -> bool:  # pragma: no cover
+        raise AssertionError("single-line coverage entries should use direct membership checks")
+
+    monkeypatch.setattr(changed_scope_coverage, "_line_ranges_may_overlap", fail_range_overlap)
+
+    measurable, covered, missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        {3, 4},
+    )
+
+    assert measurable == []
+    assert covered == []
+    assert missed == []
+
+
 def test_measurable_changed_lines_skips_empty_measured_lines(monkeypatch, tmp_path: Path) -> None:
     coverage_payload = {"files": {"foo.py": {"executed_lines": [], "missing_lines": []}}}
 


### PR DESCRIPTION
## Summary
- Move changed-scope single-line executed/missing membership checks before broad range-overlap evaluation.
- Add a regression test that proves singleton coverage entries bypass `_line_ranges_may_overlap` when the changed set is disjoint.
- Document the slice and its registered PR-scoped probe.

## Plan or Spec
- `docs/plans/2026-06-05-changed-scope-single-line-before-range.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py::test_measurable_changed_lines_checks_singletons_before_range_overlap tests/test_changed_scope_coverage.py::test_measurable_changed_lines_skips_source_read_when_no_changed_lines
# 2 passed in 0.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 35 passed in 0.98s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 35 passed in 0.55s; TOTAL 9 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage_probe.py
# {"elapsed_ms_mean": 0.11807746653045927, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-empty-path-short-circuit --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/melix_changed_scope_single_line_pr_probe.json
# ok; base elapsed_ms_mean=0.2778855019382068, head elapsed_ms_mean=0.11673130627189364, source_read_calls_mean=0.0 on both
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%`.
- Registered probe: `changed-scope-coverage-empty-path-short-circuit`.
- Local PR-scoped probe result: `base elapsed_ms_mean=0.2778855019382068`, `head elapsed_ms_mean=0.11673130627189364`, `delta_ms=-0.161154195666`, `speedup=2.380557x`, `improvement=57.99%`.
- Structural metric preserved: `source_read_calls_mean=0.0` on base and head.
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- None. This is a Python-only slice verified locally on Linux; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
