### PR TITLE
perf: bind report evidence source id stringifier

### DIFF
--- a/docs/plans/2026-06-05-report-evidence-source-str-binding.md
+++ b/docs/plans/2026-06-05-report-evidence-source-str-binding.md
@@ -1,0 +1,29 @@
+# Report Evidence Source ID String Binding Performance Slice
+
+## Scope
+
+This Python-only slice is limited to `_release_matrix_rows(...)` in
+`services/mlx-worker-python/worker/productization/report_evidence_gate.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`report-evidence-gate-run-kind-set-membership` in
+`infra/perf/pr_scoped_probes.json`. The probe entry already includes focused
+`test_command`, `coverage_command`, and `probe_command` values and runs
+`scripts/report_evidence_gate_run_kind_probe.py`, which emits
+`release_matrix_elapsed_ms_mean` along with the aggregate gate timings.
+
+## Optimization hypothesis
+
+Release-matrix row construction stringifies every source evidence id while
+accumulating evidence sets. Binding `str` once in `_release_matrix_rows(...)`
+removes repeated global lookups in the single-role and multi-role accumulation
+paths while preserving the existing set de-duplication and sorted output.
+
+## Verification plan
+
+Run the registered focused test command, registered changed-scope coverage
+command, the registered probe locally on Linux, and a local `origin/main` versus
+head probe comparison before pushing. CI remains the merge gate for the
+registered PR-scoped performance report.

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -241,6 +241,7 @@ def _release_matrix_rows(
 ) -> list[dict[str, object]]:
     evidence_by_role: dict[str, set[str]] = {}
     matrix_roles = set(matrix)
+    to_string = str
     for report in reports:
         roles = report.get("release_matrix_roles")
         source_evidence_ids = report.get("source_evidence_ids", [])
@@ -255,9 +256,9 @@ def _release_matrix_rows(
             if role in matrix_roles:
                 evidence_ids_for_role = evidence_by_role.setdefault(role, set())
                 for evidence_id in source_evidence_ids:
-                    evidence_ids_for_role.add(str(evidence_id))
+                    evidence_ids_for_role.add(to_string(evidence_id))
             continue
-        evidence_ids = tuple(str(item) for item in source_evidence_ids)
+        evidence_ids = tuple(to_string(item) for item in source_evidence_ids)
         for role in roles:
             if role not in matrix_roles:
                 continue


### PR DESCRIPTION
## Summary
- Bind `str` once inside `_release_matrix_rows(...)` so release-matrix source evidence IDs avoid repeated global lookups during accumulation.
- Add the governing performance-slice plan for the report-evidence source ID stringification path.

## Plan or Spec
- `docs/plans/2026-06-05-report-evidence-source-str-binding.md`

## Commands Run
```text
# Baseline from origin/main (c42df011)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# exit 0; release_matrix_elapsed_ms_mean=34.61525999009609; elapsed_ms_mean=873.1450662016869

# Candidate quick probe before full validation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" MELIX_REPORT_EVIDENCE_RUN_KIND_ITERATIONS=10000 MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# exit 0; release_matrix_elapsed_ms_mean=6.2016296821335954; elapsed_ms_mean=170.50650886570412

# Registered focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_fast_reject_preserves_empty_prefix services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_sparse_match_scans_row_items services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_preserves_stringified_presence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_dedupes_evidence_ids services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_single_role_keeps_stringified_evidence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_ignores_invalid_cached_roles services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# exit 0; 17 passed in 1.04s

# Registered changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused nodes> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
# exit 0; 17 passed in 0.35s; TOTAL 3 0 100%

# Registered local probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/report_evidence_gate_run_kind_probe.py"; if [ -f "$SCRIPT" ]; then python3 "$SCRIPT"; else for CANDIDATE in "../head/$SCRIPT" "${GITHUB_WORKSPACE:-}/head/$SCRIPT"; do if [ -f "$CANDIDATE" ]; then python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2; fi'
# exit 0; release_matrix_elapsed_ms_mean=29.540688078850508; elapsed_ms_mean=900.6283206865191

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for `report_evidence_gate.py` changed lines.
- Registered probe: `report-evidence-gate-run-kind-set-membership` selected by the changed path.
- Local baseline (`origin/main` c42df011): `release_matrix_elapsed_ms_mean=34.61525999009609`, `elapsed_ms_mean=873.1450662016869`.
- Local candidate: `release_matrix_elapsed_ms_mean=29.540688078850508`, `elapsed_ms_mean=900.6283206865191`.
- Targeted release-matrix delta: `-5.074571911245582 ms` (`~14.66%` faster). Aggregate gate elapsed was `+27.48325448483217 ms` (`~3.15%` slower), below the registered 5% warning threshold and outside the targeted release-matrix submetric noise-sensitive slice.

## Known Gaps
- Local validation is Linux-only. GitHub Actions PR-scoped performance must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no new probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
