### PR TITLE
perf: dispatch hub size hint units once

### DIFF
--- a/docs/plans/2026-06-05-hub-size-direct-unit-dispatch.md
+++ b/docs/plans/2026-06-05-hub-size-direct-unit-dispatch.md
@@ -1,0 +1,41 @@
+# Hub catalog direct size-hint unit dispatch
+
+## Scope
+
+Optimize one Python hot path in Hub catalog size-hint parsing:
+`worker.model_ops.hub_catalog._direct_size_hint_from_text(...)`.
+
+The direct parser runs for common `cardData.model_size` values before the
+generic regular-expression fallback. The current implementation checks each
+uppercase and lowercase unit suffix separately before falling back to
+`split(maxsplit=2)`. This slice replaces those repeated suffix checks with one
+tail-unit dispatch while preserving the whitespace-separated value/unit
+contract and the split fallback for unusual unit casing.
+
+## Registered Probe
+
+The affected path is covered by the existing registered PR-scoped probe
+`hub-catalog-size-hint-regex-precompile` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+
+## Plan
+
+1. Preserve direct parser behavior for uppercase/lowercase KB, MB, GB,
+   fractional values, tab/newline-separated value/unit pairs, invalid units,
+   and extra trailing tokens.
+2. Dispatch the common tail unit once instead of running six separate
+   `endswith(...)` checks.
+3. Run the registered focused test command, changed-scope coverage command, and
+   local registered probe on Linux.
+4. Use GitHub Actions PR-scoped performance output as the merge gate.
+
+## Verification Notes
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime
+effect is claimed.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -205,6 +205,8 @@ def test_direct_size_hint_rejects_extra_tokens_without_full_split() -> None:
     assert _direct_size_hint_from_text("12 GB extra") == 0
     assert _direct_size_hint_from_text("12 GB") == 12 * 1024 * 1024 * 1024
     assert _direct_size_hint_from_text("12 gb") == 12 * 1024 * 1024 * 1024
+    assert _direct_size_hint_from_text("12\tGB") == 12 * 1024 * 1024 * 1024
+    assert _direct_size_hint_from_text("12 GB\n") == 12 * 1024 * 1024 * 1024
     assert _direct_size_hint_from_text("9 mb") == 9 * 1024 * 1024
     assert _direct_size_hint_from_text("512 kb") == 512 * 1024
 

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -659,30 +659,25 @@ def _size_hint_bytes(payload: dict[str, Any], *, card_data: dict[str, Any] | Non
 
 
 def _direct_size_hint_from_text(text: str) -> int:
-    if text.endswith(" MB"):
+    if len(text) >= 4 and text[-3].isspace():
         value_text = text[:-3]
-        if value_text.isdecimal():
-            return int(value_text) * _SIZE_HINT_MB
-    if text.endswith(" mb"):
-        value_text = text[:-3]
-        if value_text.isdecimal():
-            return int(value_text) * _SIZE_HINT_MB
-    if text.endswith(" GB"):
-        value_text = text[:-3]
-        if value_text.isdecimal():
-            return int(value_text) * _SIZE_HINT_GB
-    if text.endswith(" gb"):
-        value_text = text[:-3]
-        if value_text.isdecimal():
-            return int(value_text) * _SIZE_HINT_GB
-    if text.endswith(" KB"):
-        value_text = text[:-3]
-        if value_text.isdecimal():
-            return int(value_text) * _SIZE_HINT_KB
-    if text.endswith(" kb"):
-        value_text = text[:-3]
-        if value_text.isdecimal():
-            return int(value_text) * _SIZE_HINT_KB
+        unit_text = text[-2:]
+        if unit_text == "MB" or unit_text == "mb":
+            multiplier = _SIZE_HINT_MB
+        elif unit_text == "GB" or unit_text == "gb":
+            multiplier = _SIZE_HINT_GB
+        elif unit_text == "KB" or unit_text == "kb":
+            multiplier = _SIZE_HINT_KB
+        else:
+            multiplier = 0
+        if multiplier:
+            if value_text.isdecimal():
+                return int(value_text) * multiplier
+            try:
+                return int(float(value_text) * multiplier)
+            except ValueError:
+                return 0
+
     parts = text.split(maxsplit=2)
     if len(parts) != 2:
         return 0
@@ -690,6 +685,8 @@ def _direct_size_hint_from_text(text: str) -> int:
     multiplier = _SIZE_HINT_MULTIPLIERS.get(unit_text.lower())
     if multiplier is None:
         return 0
+    if value_text.isdecimal():
+        return int(value_text) * multiplier
     try:
         return int(float(value_text) * multiplier)
     except ValueError:


### PR DESCRIPTION
## Summary
- Optimizes the direct Hub catalog `cardData.model_size` parser by dispatching the final size unit once instead of checking six suffix variants.
- Preserves fallback parsing for trailing whitespace, mixed-case units, invalid units, fractional values, and extra trailing tokens.
- Adds a governing performance-slice plan for this Python-only path.

## Plan or Spec
- `docs/plans/2026-06-05-hub-size-direct-unit-dispatch.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# exit 0; baseline on origin/main before changes: elapsed_ms_mean=1498.7914012745023, payload_compatibility_elapsed_ms_mean=212.59886911138892

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# exit 0; 69 passed in 1.10s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# exit 0; 69 passed; changed-scope TOTAL 20 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# exit 0; head: elapsed_ms_mean=1474.1731331683695, payload_compatibility_elapsed_ms_mean=203.55282397940755

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 20 0 100%`).
- Registered local probe: `hub-catalog-size-hint-regex-precompile` via `scripts/hub_catalog_size_hint_probe.py`.
- Local baseline vs head:
  - `elapsed_ms_mean`: 1498.7914012745023 -> 1474.1731331683695 ms (delta -24.618268106132746 ms, ~1.64% faster)
  - `payload_compatibility_elapsed_ms_mean`: 212.59886911138892 -> 203.55282397940755 ms (delta -9.046045131981373 ms; collateral probe metric, no compatibility-path code changed)
  - `size_hint_calls_mean`: 40000.0 -> 40000.0
  - `matched_hint_count`: 80000.0 -> 80000.0
- CI PR-scoped performance is required as the merge validation source for the registered probe report.

## Known Gaps
- No Swift path changed; no Swift runtime effect is claimed.
- Full repository gates were not run locally; this PR uses the focused registered Python test, coverage, and probe commands for the touched path.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
