### PR TITLE
perf: fast-path full tool config selection

### DIFF
--- a/docs/plans/2026-06-05-tool-registry-worker-config-copy-binding.md
+++ b/docs/plans/2026-06-05-tool-registry-worker-config-copy-binding.md
@@ -1,0 +1,35 @@
+# Tool registry worker config full-selection fast path
+
+## Scope
+
+This Python-only performance slice is limited to
+`services/mlx-worker-python/worker/runtime/tool_registry.py`, specifically the
+built-in worker `ToolConfig` copy path used by `built_in_tool_config()`.
+
+## Probe registration
+
+The affected path is covered by the registered PR-scoped probe
+`tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json`. The
+probe includes focused `test_command`, `coverage_command`, and `probe_command`
+entries and tracks `full_selection_tool_config_elapsed_ms_mean` alongside the
+existing schema and partial-selection metrics.
+
+## Change
+
+When callers pass the canonical full built-in tool tuple, return an isolated copy
+of the already-built full template immediately. This preserves protobuf object
+isolation while avoiding the selection-cache dictionary lookup on the hot full
+selection path. The slice also binds the copy helper locally inside
+`built_in_tool_config()` so all return branches reuse the same fast local lookup.
+
+## Verification plan
+
+- Focused tool-registry tests, including full tuple selection copy isolation.
+- Registered changed-scope coverage for the tool-registry probe scope.
+- Registered local probe on Linux, comparing the pre-change and post-change
+  `full_selection_tool_config_elapsed_ms_mean` and adjacent metrics.
+
+## Boundary
+
+This is a Python worker slice and is fully locally verifiable on Linux. No Swift
+runtime effect is claimed.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -78,6 +78,17 @@ def test_built_in_tool_config_returns_isolated_template_copies() -> None:
     assert second_config.schema_version == tool_registry_module.TOOL_REGISTRY_SCHEMA_VERSION
 
 
+def test_built_in_tool_config_full_tuple_selection_returns_full_template_copy() -> None:
+    selected_config = built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES)
+    selected_config.tools.pop()
+    selected_config.schema_version = "mutated"
+
+    next_selected_config = built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES)
+
+    assert [tool.name for tool in next_selected_config.tools] == list(BUILTIN_AGENTIC_TOOL_NAMES)
+    assert next_selected_config.schema_version == tool_registry_module.TOOL_REGISTRY_SCHEMA_VERSION
+
+
 def test_built_in_tool_config_selection_returns_isolated_template_copies() -> None:
     first_config = built_in_tool_config(("image_crop", "local_compute"))
     first_config.tools.pop()

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -393,28 +393,29 @@ def built_in_tool_registry() -> ToolRegistry:
 
 
 def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> common_pb2.ToolConfig:
-    if names is None:
-        return _copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
+    copy_tool_config = _copy_tool_config
+    if names is None or names == BUILTIN_AGENTIC_TOOL_NAMES:
+        return copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
     if isinstance(names, tuple):
         cached_config = _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES.get(names)
         if cached_config is not None:
-            return _copy_tool_config(cached_config)
+            return copy_tool_config(cached_config)
         requested_names = names
     else:
         if names == _BUILTIN_TOOL_CONFIG_NAMES_LIST:
-            return _copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
+            return copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
         requested_names = tuple(names)
     raw_requested_names = requested_names
     cached_config = _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES.get(requested_names)
     if cached_config is not None:
-        return _copy_tool_config(cached_config)
+        return copy_tool_config(cached_config)
     registry = _BUILTIN_TOOL_CONFIG_REGISTRY.select(requested_names)
     config = registry.as_worker_tool_config()
     normalized_names = registry.names()
     _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES[normalized_names] = config
     if raw_requested_names != normalized_names:
         _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES[raw_requested_names] = config
-    return _copy_tool_config(config)
+    return copy_tool_config(config)
 
 
 def _arg(


### PR DESCRIPTION
## Summary
- Fast-path `built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES)` to return an isolated copy of the full built-in template directly.
- Reuse a local copy-helper binding across `built_in_tool_config()` return branches.
- Add regression coverage for full tuple selection copy isolation.

## Plan or Spec
- Added `docs/plans/2026-06-05-tool-registry-worker-config-copy-binding.md`.
- Registered probe coverage: `tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json` already covers `services/mlx-worker-python/worker/runtime/tool_registry.py` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py`

## Coverage and Metrics
- Focused tests: `59 passed in 0.98s`.
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Local registered probe baseline on `origin/main` before the slice: `full_selection_tool_config_elapsed_ms_mean=62.37146519124508`, `built_in_tool_config_elapsed_ms_mean=66.45323392003775`, `partial_selection_tool_config_elapsed_ms_mean=49.941874109208584`.
- Local registered probe after the slice: `full_selection_tool_config_elapsed_ms_mean=56.957351602613926`, `built_in_tool_config_elapsed_ms_mean=55.980682745575905`, `partial_selection_tool_config_elapsed_ms_mean=49.854044523090124`.
- Delta: full selection improved by `-5.414113588631153 ms` (`~8.68%` lower) on the local Linux probe.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- This is a Python worker slice; no Swift runtime effect is claimed.
- Linux local probe results are microbenchmark evidence; final acceptance depends on the registered GitHub Actions PR-scoped performance report.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the changed runtime path.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Local registered probe shows directionally improved full-selection metric.
- [ ] GitHub Actions complete successfully, including PR-scoped performance validation.
