### PR TITLE
perf: fast-path default embedding digest projection

### DIFF
--- a/docs/plans/2026-06-05-embedding-project-digest-default-dimension.md
+++ b/docs/plans/2026-06-05-embedding-project-digest-default-dimension.md
@@ -1,0 +1,31 @@
+# Embedding Project Digest Default-Dimension Fast Path
+
+This Python-only performance slice is limited to `worker.runtime.embedding_backends.DeterministicEmbeddingBackend._project_digest()`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json`. The probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+This slice extends the checked-in probe script so the registered probe reports both:
+
+- the existing large 4097-dimension projection workload; and
+- a default 8-dimension projection workload matching the common deterministic embedding family default.
+
+## Slice
+
+The projection helper already builds one normalized 8-value digest block before repeating it across requested dimensions. When the requested dimension is exactly one digest block, returning that freshly built normalized block avoids the extra `normalized_base * 1` list copy while preserving the legacy projection values and list return type.
+
+For other exact multiples of 8, the helper returns `normalized_base * full_repeats` directly. Remainder-bearing dimensions keep the existing append behavior.
+
+## Verification plan
+
+1. Run focused embedding runtime and PR-scoped probe tests on Linux.
+2. Run changed-scope coverage for the changed source, tests, probe, and plan.
+3. Run the registered probe locally on Linux against `origin/main` and this branch.
+4. Use GitHub Actions PR-scoped performance as the final merge gate.
+
+## Success criteria
+
+- Legacy projection parity remains unchanged for dimensions `0, 1, 8, 9, 17, 384, 1536, 4096, 4097`.
+- Local registered probe reports lower default-dimension elapsed time without increasing large-dimension behavior materially.
+- PR-scoped performance CI completes successfully before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2893,7 +2893,7 @@
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke",
     "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py",
-    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 -c 'import gc,json,time,tracemalloc; from worker.runtime.embedding_backends import BERTEmbeddingBackend; b=BERTEmbeddingBackend(); d=4097; n=500; s=3; texts=[f\"bert::synthetic projection row {i % 251}::{i}\" for i in range(n)]; es=[]; ps=[]; c=0.0\nfor _ in range(s):\n gc.collect(); tracemalloc.start(); t=time.perf_counter()\n for text in texts:\n  v=b._project_digest(text,d)\n  if len(v)!=d: raise AssertionError(f\"unexpected vector length: {len(v)}\")\n  c += v[0] + v[-1]\n es.append((time.perf_counter()-t)*1000.0); ps.append(float(tracemalloc.get_traced_memory()[1])); tracemalloc.stop()\nprint(json.dumps({\"elapsed_ms_mean\":round(sum(es)/len(es),6),\"peak_bytes_mean\":round(sum(ps)/len(ps),6),\"sample_count\":float(s),\"vector_count\":float(n),\"dimensions\":float(d),\"checksum\":round(c,6)}, sort_keys=True))'",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_EMBEDDING_PROJECT_DIGEST_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/deterministic_embedding_project_digest_probe.py\"; CANDIDATES=(); if [ \"$(basename \"$PWD\")\" = \"base\" ]; then CANDIDATES+=(\"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"); fi; CANDIDATES+=(\"$SCRIPT\" \"../head/$SCRIPT\"); for CANDIDATE in \"${CANDIDATES[@]}\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
     "metrics": [
@@ -2905,6 +2905,18 @@
       },
       {
         "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "default_dimension_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "default_dimension_peak_bytes_mean",
         "unit": "bytes",
         "direction": "lower_is_better",
         "warn_pct": 5.0

--- a/scripts/deterministic_embedding_project_digest_probe.py
+++ b/scripts/deterministic_embedding_project_digest_probe.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import gc
 import json
+import os
 from pathlib import Path
 import sys
 import time
@@ -10,7 +11,7 @@ import tracemalloc
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[1]
+    return Path(os.environ.get("MELIX_EMBEDDING_PROJECT_DIGEST_REPO_ROOT", Path.cwd())).resolve()
 
 
 def main() -> int:
@@ -22,12 +23,20 @@ def main() -> int:
 
     backend = BERTEmbeddingBackend()
     dimensions = 4097
+    default_dimensions = 8
     vector_count = 500
+    default_vector_count = 5000
     sample_count = 3
     seed_texts = [f"bert::synthetic projection row {index % 251}::{index}" for index in range(vector_count)]
+    default_seed_texts = [
+        f"bert::default projection row {index % 251}::{index}" for index in range(default_vector_count)
+    ]
     elapsed_samples: list[float] = []
     peak_samples: list[float] = []
+    default_elapsed_samples: list[float] = []
+    default_peak_samples: list[float] = []
     checksum = 0.0
+    default_checksum = 0.0
 
     for _ in range(sample_count):
         gc.collect()
@@ -44,13 +53,38 @@ def main() -> int:
         elapsed_samples.append(elapsed_ms)
         peak_samples.append(float(peak_bytes))
 
+        gc.collect()
+        tracemalloc.start()
+        default_started = time.perf_counter()
+        for seed_text in default_seed_texts:
+            vector = backend._project_digest(seed_text, default_dimensions)
+            if len(vector) != default_dimensions:
+                raise AssertionError(f"unexpected default vector length: {len(vector)}")
+            default_checksum += vector[0] + vector[-1]
+        default_elapsed_ms = (time.perf_counter() - default_started) * 1000.0
+        _, default_peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        default_elapsed_samples.append(default_elapsed_ms)
+        default_peak_samples.append(float(default_peak_bytes))
+
     payload = {
         "elapsed_ms_mean": round(sum(elapsed_samples) / len(elapsed_samples), 6),
         "peak_bytes_mean": round(sum(peak_samples) / len(peak_samples), 6),
+        "default_dimension_elapsed_ms_mean": round(
+            sum(default_elapsed_samples) / len(default_elapsed_samples),
+            6,
+        ),
+        "default_dimension_peak_bytes_mean": round(
+            sum(default_peak_samples) / len(default_peak_samples),
+            6,
+        ),
         "sample_count": float(sample_count),
         "vector_count": float(vector_count),
+        "default_dimension_vector_count": float(default_vector_count),
         "dimensions": float(dimensions),
+        "default_dimensions": float(default_dimensions),
         "checksum": round(checksum, 6),
+        "default_dimension_checksum": round(default_checksum, 6),
     }
     print(json.dumps(payload, sort_keys=True))
     return 0

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1529,6 +1529,10 @@ def test_deterministic_embedding_project_digest_probe_script_smoke(capsys: pytes
     assert metrics["sample_count"] == 3.0
     assert metrics["vector_count"] == 500.0
     assert metrics["dimensions"] == 4097.0
+    assert metrics["default_dimension_elapsed_ms_mean"] > 0
+    assert metrics["default_dimension_peak_bytes_mean"] > 0
+    assert metrics["default_dimension_vector_count"] == 5000.0
+    assert metrics["default_dimensions"] == 8.0
 
 
 def test_scope_report_selects_deterministic_image_edit_digest_probe() -> None:

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -64,6 +64,10 @@ class DeterministicEmbeddingBackend:
             return [0.0] * dimensions
         inverse_l2_norm = 1.0 / l2_norm
         normalized_base = [round(value * inverse_l2_norm, 6) for value in base_values]
+        if remainder == 0:
+            if full_repeats == 1:
+                return normalized_base
+            return normalized_base * full_repeats
         result = normalized_base * full_repeats
         if remainder == 1:
             result.append(normalized_base[0])


### PR DESCRIPTION
## Summary
- Fast-path deterministic embedding projection when the requested dimension is exactly one normalized digest block (8 dimensions), avoiding the extra `normalized_base * 1` list copy.
- Extend the registered PR-scoped embedding projection probe to report the default 8-dimension workload alongside the existing 4097-dimension workload.
- Add a focused plan documenting the slice, probe, Linux validation scope, and merge gate.

## Plan or Spec
- `docs/plans/2026-06-05-embedding-project-digest-default-dimension.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
# 18 passed in 15.03s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
# 18 passed in 50.90s; TOTAL 29 1 97%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-project-digest-allocation --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-embedding-project-digest-compare-20260605/base --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-embedding-project-digest-extend-20260605 --output /tmp/embedding-project-digest-probe-2.json
# probe ok; head verification ok; base/head probe ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 29 1 97%`.
- Registered local probe `deterministic-embedding-project-digest-allocation` (run 2):
  - `default_dimension_elapsed_ms_mean`: base `162.562863 ms`, head `158.348921 ms`, delta `-4.213942 ms` (`-2.59%`).
  - `default_dimension_peak_bytes_mean`: base `1408.0 bytes`, head `1352.0 bytes`, delta `-56 bytes` (`-3.98%`).
  - Existing 4097-dimension metric: base `18.442931 ms`, head `18.146121 ms`, delta `-0.296810 ms` (`-1.61%`); peak bytes unchanged at `74906.666667`.
- CI PR-scoped performance is still required as the merge gate for the registered probe.

## Known Gaps
- Local validation was Linux-only. No Swift runtime behavior is changed in this slice.
- Full `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run locally; this PR uses focused Python tests, changed-scope coverage, the registered probe, and GitHub Actions as the broader gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
