### PR TITLE
perf: bind statistical category isinstance lookup

### DIFF
--- a/docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md
+++ b/docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md
@@ -25,6 +25,8 @@ This follow-up slice keeps the same category semantics but moves the common non-
 
 The 2026-05-19 slice keeps that direct-key category label path and narrows another hot aggregation step: it replaces `defaultdict(lambda: [0, 0, 0])` with an explicit `dict.get(...)` miss path, avoids calling `str(...)` for already-string category labels, and increments correctness counters only when the row field is truthy. Missing, blank, non-string, sorted-key, and rounding semantics remain unchanged.
 
+The 2026-06-05 follow-up slice keeps the same direct-key and explicit-miss behavior while binding the hot `isinstance` predicate once before the row loop. The probe workload uses string category labels on every row, so this avoids a repeated global lookup without changing the non-string fallback, missing-key skip, blank-label skip, truthiness, or sorted-output semantics.
+
 ## Acceptance Metric
 
 Accept only if the registered category breakdown probe keeps the same checksum/sample counts and improves `elapsed_ms_mean` versus the origin/main baseline in repeated local samples.

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -83,13 +83,14 @@ def build_category_breakdown(
 ) -> dict[str, dict[str, object]]:
     category_totals: dict[str, list[int]] = {}
     category_totals_get = category_totals.get
+    is_instance = isinstance
     string_type = str
     for row in rows:
         try:
             raw_category_label = row["category_label"]
         except KeyError:
             continue
-        if isinstance(raw_category_label, string_type):
+        if is_instance(raw_category_label, string_type):
             category_label = raw_category_label.strip()
         else:
             category_label = string_type(raw_category_label).strip()


### PR DESCRIPTION
## Summary
- Bind the hot `isinstance` predicate once before the statistical category breakdown row loop.
- Preserve direct string category handling, non-string fallback coercion, missing/blank label skips, truthiness semantics, and sorted output.
- Update the governing performance plan with this single-slice rationale.

## Plan or Spec
- `docs/plans/2026-05-07-statistical-category-breakdown-local-bindings.md`
- Registered probe: `statistical-evidence-category-breakdown-single-pass` in `infra/perf/pr_scoped_probes.json` already covers the changed path and includes focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `git status --short && git branch --show-current`
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_statistical_evidence.py::test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_statistical_evidence.py::test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_category_breakdown_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id statistical-evidence-category-breakdown-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-stat-cat-base-20260605 --head-repo "$PWD" --output /tmp/statistical-category-isinstance-probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 6 passed.
- Changed-scope coverage: 100.00% (`TOTAL 2 0 100%`).
- Registered local Linux probe (`statistical-evidence-category-breakdown-single-pass`):
  - base `elapsed_ms_mean=11.942033749073744`, `peak_bytes_mean=17040.0`
  - head `elapsed_ms_mean=10.209691524505615`, `peak_bytes_mean=17040.0`
  - delta `-1.7323422245681286 ms`, about `14.50%` faster; checksum and counts unchanged.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- This is a Python slice locally validated on Linux only.
- The optimization targets the registered probe's common all-string category-label workload; non-string fallback behavior is preserved by existing focused coverage.

## Evidence Checklist
- [x] Synced from `origin/main` before the slice.
- [x] Affected path has a registered PR-scoped performance probe with test, coverage, and probe commands.
- [x] Focused regression tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered local probe showed elapsed-time improvement with unchanged checksum/counts.
- [ ] GitHub Actions completed successfully, including the PR-scoped performance workflow.
