### PR TITLE
perf: add changed-scope allowlist string fast path

### DIFF
--- a/docs/plans/2026-06-05-changed-scope-allowlist-single-string.md
+++ b/docs/plans/2026-06-05-changed-scope-allowlist-single-string.md
@@ -1,0 +1,50 @@
+# Changed Scope Coverage Allowlist Single-String Fast Path
+
+## Scope
+
+This Python-only performance slice narrows probe-specific coverage allowlist
+parsing in `scripts/changed_scope_coverage.py`. Registered probes often target a
+single coverage path; allowing `MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON` to carry
+a JSON string for that case avoids list iteration and repeated `str()` coercion
+while preserving the existing JSON-list behavior.
+
+Affected paths:
+
+- `scripts/changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_measured_probe.py`
+- `tests/test_changed_scope_coverage.py`
+- `docs/plans/2026-06-05-changed-scope-allowlist-single-string.md`
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`changed-scope-coverage-measured-set-filter` in
+`infra/perf/pr_scoped_probes.json`. The registry entry already provides focused
+`test_command`, `coverage_command`, and `probe_command` entries for this path.
+This slice extends `scripts/changed_scope_coverage_measured_probe.py` so the
+registered probe script also emits `allowlist_parse_elapsed_ms_mean` and
+`allowlist_parse_count` for the new single-string allowlist path.
+
+## Implementation Plan
+
+1. Add regression coverage for a single JSON string allowlist payload.
+2. Add a minimal parser fast path that returns a one-entry `frozenset` for string
+   payloads before falling back to the existing JSON-list parsing.
+3. Extend the measured changed-scope probe script with a focused repeated
+   single-string allowlist parse metric.
+4. Run the registered focused tests, changed-scope coverage command, and the
+   registered local probe on Linux.
+
+## Success Metrics
+
+- Focused tests pass.
+- Changed-scope coverage for touched Python lines remains at least 95%.
+- The registered probe reports no regression in `elapsed_ms_mean` for the
+  measured changed-scope coverage workload.
+- The new `allowlist_parse_elapsed_ms_mean` metric is emitted for the
+  single-string allowlist path.
+
+## Verification Boundary
+
+This is a Python tooling slice and is locally verifiable on Linux. It does not
+change Swift runtime behavior.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2792,7 +2792,7 @@
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
     "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
-    "probe_command": "python3 -c 'import importlib.util,json,pathlib,statistics,tempfile,time\nrepo=pathlib.Path.cwd()\nspec=importlib.util.spec_from_file_location(\"target\", repo/\"scripts\"/\"changed_scope_coverage.py\")\nmodule=importlib.util.module_from_spec(spec)\nspec.loader.exec_module(module)\npath_count=300; measured_lines_per_path=500; sample_count=7\nelapsed=[]\nwith tempfile.TemporaryDirectory(prefix=\"melix-changed-scope-measured-probe-\") as tmp:\n    root=pathlib.Path(tmp)\n    rel_paths=[f\"pkg/module_{index}.py\" for index in range(path_count)]\n    for rel_path in rel_paths:\n        source_path=root/rel_path; source_path.parent.mkdir(parents=True, exist_ok=True); source_path.write_text(\"covered = 1\\nmissed = 2\\n\", encoding=\"utf-8\")\n    coverage_payload={\"files\": {rel_path: {\"executed_lines\": list(range(1, measured_lines_per_path+1, 2)), \"missing_lines\": list(range(2, measured_lines_per_path+1, 2))} for rel_path in rel_paths}}\n    changed_lines={measured_lines_per_path+1, measured_lines_per_path+2}\n    for _ in range(sample_count):\n        start=time.perf_counter()\n        for rel_path in rel_paths:\n            measurable, covered, missed = module._measurable_changed_lines(root, coverage_payload, rel_path, changed_lines)\n            if measurable or covered or missed: raise RuntimeError(\"empty changed sets must not produce measurable lines\")\n        elapsed.append((time.perf_counter()-start)*1000.0)\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed), \"source_read_calls_mean\": 0.0, \"path_count\": float(path_count), \"measured_lines_per_path\": float(measured_lines_per_path), \"sample_count\": float(sample_count)}, sort_keys=True))'",
+    "probe_command": "python3 scripts/changed_scope_coverage_measured_probe.py",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
     "metrics": [
@@ -2811,6 +2811,18 @@
       },
       {
         "key": "measured_lines_per_path",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
+        "key": "allowlist_parse_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0,
+        "warn_abs": 0.05
+      },
+      {
+        "key": "allowlist_parse_count",
         "unit": "count",
         "direction": "informational"
       }

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -120,6 +120,8 @@ def _coverage_path_allowlist(env: Mapping[str, str]) -> frozenset[str] | None:
         payload = json.loads(raw_value)
     except json.JSONDecodeError as exc:
         raise SystemExit(f"invalid MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON: {exc}") from exc
+    if isinstance(payload, str):
+        return frozenset([payload] if payload else [])
     if not isinstance(payload, list):
         raise SystemExit("MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON must be a JSON list")
     return frozenset(str(path) for path in payload if str(path))

--- a/scripts/changed_scope_coverage_measured_probe.py
+++ b/scripts/changed_scope_coverage_measured_probe.py
@@ -24,11 +24,14 @@ def run_probe(
     *,
     path_count: int = 300,
     measured_lines_per_path: int = 500,
+    allowlist_parse_count: int = 10000,
     samples: int = 7,
 ) -> dict[str, float]:
     module = _load_changed_scope_coverage(repo_root)
     elapsed_samples: list[float] = []
+    allowlist_elapsed_samples: list[float] = []
     read_samples: list[float] = []
+    allowlist_value = json.dumps("pkg/module_0.py")
 
     with tempfile.TemporaryDirectory(prefix="melix-changed-scope-measured-probe-") as tmp:
         root = Path(tmp)
@@ -72,11 +75,22 @@ def run_probe(
                         raise RuntimeError("empty changed sets must not produce measurable lines")
                 elapsed_samples.append((time.perf_counter() - start) * 1000.0)
                 read_samples.append(float(read_calls))
+
+                start = time.perf_counter()
+                for _ in range(allowlist_parse_count):
+                    allowlist = module._coverage_path_allowlist(
+                        {"MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON": allowlist_value}
+                    )
+                    if allowlist != frozenset({"pkg/module_0.py"}):
+                        raise RuntimeError("single-string allowlist parse returned unexpected paths")
+                allowlist_elapsed_samples.append((time.perf_counter() - start) * 1000.0)
         finally:
             module.Path.read_text = original_read_text
 
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "allowlist_parse_elapsed_ms_mean": statistics.fmean(allowlist_elapsed_samples),
+        "allowlist_parse_count": float(allowlist_parse_count),
         "source_read_calls_mean": statistics.fmean(read_samples),
         "path_count": float(path_count),
         "measured_lines_per_path": float(measured_lines_per_path),

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -203,6 +203,12 @@ def test_coverage_path_allowlist_rejects_non_list_payload() -> None:
         )
 
 
+def test_coverage_path_allowlist_accepts_single_string_payload() -> None:
+    assert changed_scope_coverage._coverage_path_allowlist(
+        {"MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON": '"direct.py"'}
+    ) == {"direct.py"}
+
+
 def test_parse_changed_lines_ignores_no_newline_marker_and_keeps_line_numbers() -> None:
     diff_text = "\n".join(
         [
@@ -499,7 +505,44 @@ def test_changed_scope_coverage_measured_probe_emits_large_measured_metrics() ->
     assert metrics["measured_lines_per_path"] == 10.0
     assert metrics["sample_count"] == 2.0
     assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["allowlist_parse_elapsed_ms_mean"] > 0
+    assert metrics["allowlist_parse_count"] == 10000.0
     assert metrics["source_read_calls_mean"] == 0.0
+
+
+def test_changed_scope_coverage_measured_probe_rejects_unexpected_allowlist_parse(
+    monkeypatch, tmp_path: Path
+) -> None:
+    class WrongAllowlistCoverageModule:
+        Path = Path
+
+        @staticmethod
+        def _measurable_changed_lines(
+            repo_root: Path,
+            coverage_payload: dict[str, object],
+            rel_path: str,
+            changed: set[int],
+        ) -> tuple[list[int], list[int], list[int]]:
+            return [], [], []
+
+        @staticmethod
+        def _coverage_path_allowlist(env: dict[str, str]) -> frozenset[str]:
+            return frozenset({"pkg/other.py"})
+
+    monkeypatch.setattr(
+        changed_scope_coverage_measured_probe,
+        "_load_changed_scope_coverage",
+        lambda repo_root: WrongAllowlistCoverageModule,
+    )
+
+    with pytest.raises(RuntimeError, match="single-string allowlist parse"):
+        changed_scope_coverage_measured_probe.run_probe(
+            tmp_path,
+            path_count=1,
+            measured_lines_per_path=2,
+            allowlist_parse_count=1,
+            samples=1,
+        )
 
 
 def test_changed_scope_coverage_probe_counts_unexpected_source_reads(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add a single-string JSON fast path for `MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON` in changed-scope coverage.
- Extend the measured changed-scope probe script and registry metrics to report repeated single-string allowlist parsing.
- Add regression tests for the new parser shape and probe guardrail.

## Plan or Spec
- `docs/plans/2026-06-05-changed-scope-allowlist-single-string.md`
- Registered PR-scoped probe: `changed-scope-coverage-measured-set-filter`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `python3 scripts/changed_scope_coverage_measured_probe.py` (3 samples)
- local comparison microbench for one-path list JSON vs string JSON allowlist parsing
- `git diff --check`

## Coverage and Metrics
- Focused tests: 37 passed.
- Changed-scope coverage: `TOTAL 26 0 100%`.
- Registered local probe samples:
  - sample 1: `elapsed_ms_mean=0.2497`, `allowlist_parse_elapsed_ms_mean=14.3742`, `source_read_calls_mean=0.0`
  - sample 2: `elapsed_ms_mean=0.3232`, `allowlist_parse_elapsed_ms_mean=17.1045`, `source_read_calls_mean=0.0`
  - sample 3: `elapsed_ms_mean=0.3192`, `allowlist_parse_elapsed_ms_mean=14.3521`, `source_read_calls_mean=0.0`
- Local parser comparison (100000 iterations, 7 samples): `list_json_elapsed_ms_mean=170.9072`, `string_json_elapsed_ms_mean=142.4256`, `delta_ms=-28.4815`, `speedup=1.19997x`.
- CI is required for the registered PR-scoped probe validation before merge.

## Known Gaps
- This is a Python tooling slice; it does not change or locally validate Swift runtime behavior.

## Evidence Checklist
- [x] Affected path has registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally on Linux.
- [x] Changed-scope coverage for touched Python lines is >=95%.
- [x] Registered probe ran locally and emitted JSON metrics.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
