### PR TITLE
perf: fast-path empty serving diagnostics metadata

### DIFF
--- a/docs/plans/2026-06-05-serving-diagnostics-empty-stable-json-fastpath.md
+++ b/docs/plans/2026-06-05-serving-diagnostics-empty-stable-json-fastpath.md
@@ -1,0 +1,35 @@
+# Serving diagnostics empty stable JSON fast path
+
+## Scope
+
+This Python-only performance slice targets the serving diagnostics bundle writer
+in `services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+The synthetic debug queue probe repeatedly serializes empty `invocation`,
+`effective_config`, and `model_refs` mappings while writing diagnostics bundles.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`serving-diagnostics-debug-queue-bounds` in
+`infra/perf/pr_scoped_probes.json`. The registry entry already defines focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/serving_diagnostics.py`
+- `services/mlx-worker-python/tests/test_serving_diagnostics.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/serving_diagnostics_queue_probe.py`
+
+## Optimization point
+
+`_stable_json_object()` previously entered the sorted item-comprehension path
+even for empty mappings. This slice adds an empty-mapping fast path so diagnostics
+bundle serialization avoids unnecessary `items()` lookup, `sorted()` setup, and
+comprehension allocation for empty metadata sections while preserving the exact
+JSON output.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage command, and registered
+serving diagnostics queue probe locally on Linux before opening the PR. The PR
+scoped performance workflow must also report the registered probe successfully
+before merge.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import threading
+from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -327,6 +329,18 @@ def test_serving_diagnostics_empty_effective_config_skips_profile_receipt_scan(
 
     effective_config = json.loads(paths["effective_config"].read_text(encoding="utf-8"))
     assert effective_config == {}
+
+
+def test_stable_json_object_empty_mapping_skips_item_iteration() -> None:
+    class EmptyMapping:
+        def __bool__(self) -> bool:
+            return False
+
+        def items(self) -> object:
+            raise AssertionError("empty mappings should not be sorted or iterated")  # pragma: no cover
+
+    payload = cast("Mapping[str, object]", EmptyMapping())
+    assert serving_diagnostics_module._stable_json_object(payload) == {}
 
 
 def test_serving_diagnostics_event_empty_attributes_match_explicit_empty_mapping() -> None:

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -491,6 +491,8 @@ def _safe_artifact_id(value: str) -> str:
 
 
 def _stable_json_object(payload: Mapping[str, object]) -> dict[str, object]:
+    if not payload:
+        return {}
     return {
         str(key): _stable_json_value(value)
         for key, value in sorted(payload.items(), key=lambda item: str(item[0]))


### PR DESCRIPTION
## Summary
- Add an empty-mapping fast path in serving diagnostics stable JSON normalization.
- Add regression coverage proving empty mappings do not enter item iteration.
- Document the Python-only performance slice and its registered probe.

## Plan or Spec
- `docs/plans/2026-06-05-serving-diagnostics-empty-stable-json-fastpath.md`

## Commands Run
```text
# Baseline probe on origin/main before changes, 3 runs
MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
old elapsed_ms_mean samples: 5.683797, 6.416268, 5.642222
old serialization_elapsed_ms_mean samples: 1.005295, 1.031217, 0.993022

# New focused regression test
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py::test_stable_json_object_empty_mapping_skips_item_iteration
1 passed in 0.11s

# Registered focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
50 passed in 0.20s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py
TOTAL 11 0 100%

# Registered local probe on head, 5 runs
MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py
new elapsed_ms_mean samples: 5.778276, 5.456292, 5.808724, 5.292193, 5.408043
new serialization_elapsed_ms_mean samples: 0.959728, 0.907848, 1.021874, 0.886475, 0.950171

git diff --check
passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Registered probe: `serving-diagnostics-debug-queue-bounds`.
- Local Linux probe comparison:
  - `elapsed_ms_mean`: old_mean=5.914096, new_mean=5.548706, delta_ms=-0.365390, speedup=6.178%.
  - `serialization_elapsed_ms_mean`: old_mean=1.009845, new_mean=0.945219, delta_ms=-0.064625, speedup=6.400%.
  - `serialized_bytes`: unchanged at 10944 bytes.

## Known Gaps
- Local verification is Linux-only. GitHub Actions PR-scoped performance must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: debug diagnostics serialization; probe overhead measured by registered PR-scoped performance probe.
- [x] Deferred work and known gaps are stated explicitly.
