### PR TITLE
perf: check provenance immutable leaves first

### DIFF
--- a/docs/plans/2026-06-05-trajectory-provenance-immutable-first.md
+++ b/docs/plans/2026-06-05-trajectory-provenance-immutable-first.md
@@ -1,0 +1,24 @@
+# Trajectory provenance immutable-first copy slice
+
+This Python-only performance slice is limited to `worker.trajectory_provenance._copy_trajectory_provenance_value`.
+
+## Scope
+
+The helper recursively copies JSON-like trajectory provenance containers before they are attached to training, adapter, and evaluation payloads. The hot path is leaf-heavy: most recursive visits are immutable JSON scalars rather than containers.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `trajectory-provenance-copy-elision` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes focused `test_command`, `coverage_command`, and `probe_command` entries. Its command-json probe compares the deep-copy baseline against the optimized provenance copier and reports elapsed time, peak bytes, speedup, and copied component count.
+
+## Implementation plan
+
+1. Preserve the existing dict/list/tuple recursive copy behavior and custom mutable fallback behavior.
+2. Check exact immutable JSON scalar types before exact container types so recursive scalar leaves return before the container comparisons.
+3. Verify with the probe's focused pytest command, changed-scope coverage command, and local registered probe on Linux.
+4. Use PR-scoped performance CI as the merge gate.
+
+## Metrics
+
+Target metric: lower `optimized_elapsed_ms_mean` and positive `speedup` in `trajectory-provenance-copy-elision` while preserving `component_count`.

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -33,14 +33,14 @@ _JSON_IMMUTABLE_TYPES = (str, int, float, bool, type(None))
 _JSON_IMMUTABLE_TYPE_SET = frozenset(_JSON_IMMUTABLE_TYPES)
 def _copy_trajectory_provenance_value(value: Any) -> Any:
     value_type = type(value)
+    if value_type in _JSON_IMMUTABLE_TYPE_SET:
+        return value
     if value_type is dict:
         return {key: _copy_trajectory_provenance_value(item) for key, item in value.items()}
     if value_type is list:
         return [_copy_trajectory_provenance_value(item) for item in value]
     if value_type is tuple:
         return tuple(_copy_trajectory_provenance_value(item) for item in value)
-    if value_type in _JSON_IMMUTABLE_TYPE_SET:
-        return value
     if isinstance(value, dict):
         return {key: _copy_trajectory_provenance_value(item) for key, item in value.items()}
     if isinstance(value, list):


### PR DESCRIPTION
## Summary
- Move exact immutable JSON scalar handling ahead of container checks in the trajectory provenance copier.
- Add a scoped plan for the immutable-first provenance copy performance slice.

## Plan or Spec
- `docs/plans/2026-06-05-trajectory-provenance-immutable-first.md`
- Registered PR-scoped probe: `trajectory-provenance-copy-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_provenance_copy_elision_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/trajectory_provenance_copy_elision_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `5 passed in 1.71s`.
- Changed-scope coverage: `TOTAL 2 0 100%` for `services/mlx-worker-python/worker/trajectory_provenance.py`.
- Local registered probe on this branch: `baseline_elapsed_ms_mean=1646.544`, `optimized_elapsed_ms_mean=379.369`, `delta_ms=-1267.175`, `speedup=4.340x`, `component_count=64`.
- Same local probe on synced `origin/main` before this branch: `optimized_elapsed_ms_mean=401.829`, `speedup=4.173x`; branch delta vs main optimized path: about `-22.460 ms` / `+5.59%` faster.
- CI PR-scoped performance report is required as the merge validation source.

## Known Gaps
- Linux local verification covers this Python-only slice. No Swift runtime validation is applicable.
- Local probe timings are environment-specific; the registered PR-scoped performance workflow remains the merge gate.

## Evidence Checklist
- [x] Synced from `origin/main` before starting the slice.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Behavior-preserving focused tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows a positive direction.
- [ ] GitHub Actions and PR-scoped performance probe completed successfully.
