### PR TITLE
perf: fast-path dataset source suffix classification

### DIFF
--- a/docs/plans/2026-06-05-dataset-source-kind-dotted-suffix.md
+++ b/docs/plans/2026-06-05-dataset-source-kind-dotted-suffix.md
@@ -1,0 +1,26 @@
+# Dataset source kind dotted suffix fast path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.productization.dataset_preparation._source_kind`.
+The behavior remains unchanged: dataset ingest still classifies text, extracted PDF/DOCX text, markdown,
+code, structured data, and unsupported source file names the same way.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-source-records-scandir` in
+`infra/perf/pr_scoped_probes.json`. The probe already has focused `test_command`, `coverage_command`, and
+`probe_command` entries and measures both source file traversal and `_source_kind` classification latency.
+
+## Plan
+
+1. Keep the existing `os.scandir` traversal unchanged.
+2. For source kind classification, preserve the case-sensitive common lowercase `.txt`/`.text` fast path.
+3. On mixed-case or other suffixes, lower only the final dotted suffix instead of the whole filename; lower the stem only for mixed-case `.txt` extracted PDF/DOCX detection.
+4. Verify with focused pytest, changed-scope coverage, and the registered local Linux probe.
+5. Use PR-scoped performance CI as the merge gate.
+
+## Metrics
+
+Linux-local metrics will be captured with `scripts/dataset_source_records_probe.py`; GitHub Actions PR-scoped
+performance output remains the registered base-vs-head validation source.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -565,30 +565,30 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
 
 def _source_kind(path: Path) -> str | None:
     name = path.name
-    if name.endswith(".txt"):
+    if name[-4:] == ".txt":
         if len(name) >= 8 and name[-8] == "." and name[-7:-4].lower() == "pdf":
             return "pdf"
         if len(name) >= 9 and name[-9] == "." and name[-8:-4].lower() == "docx":
             return "docx"
         return "text"
-    if name.endswith(".text"):
+    if name[-5:] == ".text":
         return "text"
 
     dot_index = name.rfind(".")
     if dot_index < 0:
         return None
 
-    lower_name = name.lower()
-    if lower_name.endswith(".txt"):
-        if len(lower_name) >= 8 and lower_name[-8] == "." and lower_name[-7:-4] == "pdf":
+    dotted_suffix = name[dot_index:].lower()
+    if dotted_suffix == ".txt":
+        lower_stem = name[:dot_index].lower()
+        if lower_stem.endswith(".pdf"):
             return "pdf"
-        if len(lower_name) >= 9 and lower_name[-9] == "." and lower_name[-8:-4] == "docx":
+        if lower_stem.endswith(".docx"):
             return "docx"
         return "text"
-    if lower_name.endswith(".text"):
+    if dotted_suffix == ".text":
         return "text"
 
-    dotted_suffix = lower_name[dot_index:]
     if dotted_suffix in _TEXT_SOURCE_SUFFIXES:
         return "markdown"
     if dotted_suffix in _CODE_SOURCE_SUFFIXES:


### PR DESCRIPTION
## Summary
- Fast-path dataset source suffix classification by checking the common lowercase `.txt` / `.text` cases with fixed suffix slices.
- For mixed-case suffixes, lower only the final dotted suffix and only lower the stem when detecting extracted `.pdf.txt` / `.docx.txt` fixtures.
- Keep dataset source traversal and classification behavior unchanged.

## Plan or Spec
- Added `docs/plans/2026-06-05-dataset-source-kind-dotted-suffix.md` for this Python-only slice.
- Affected path is covered by registered PR-scoped probe `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`, including focused `test_command`, `coverage_command`, and `probe_command`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` → 10 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py` → TOTAL 8 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py`
- `python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-dataset-source-kind-suffix-slice-20260605-base --head-repo "$PWD" --output /tmp/dataset-source-records-slice.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 10 passed.
- Changed-scope coverage: 100.00% (`TOTAL 8 0 100%`).
- Local registered probe result (`dataset-source-records-scandir`, Linux):
  - `elapsed_ms_mean`: base 11.0225 ms → head 10.9151 ms (delta -0.1073 ms, -0.97%).
  - `source_kind_elapsed_ms_mean`: base 15.5914 ms → head 15.3339 ms (delta -0.2575 ms, -1.65%).
  - `source_kind_elapsed_ms_p95`: base 15.7561 ms → head 15.0591 ms (delta -0.6969 ms, -4.42%).
- PR-scoped performance CI is required as the registered base-vs-head merge gate.

## Known Gaps
- This is a Python-only Linux-local slice; no Swift runtime effect is claimed.
- Local probe deltas are small and should be confirmed by the PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Confirmed the affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Added/updated the governing plan under `docs/plans/`.
- [x] Ran focused tests locally.
- [x] Ran changed-scope coverage locally.
- [x] Ran the registered probe locally on Linux.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
