### PR TITLE
perf: dispatch hub size hint units directly

### DIFF
--- a/docs/plans/2026-06-05-hub-size-direct-unit-dispatch.md
+++ b/docs/plans/2026-06-05-hub-size-direct-unit-dispatch.md
@@ -39,3 +39,11 @@ The affected path is covered by the existing registered PR-scoped probe
 
 This is a Python-only slice and is locally verifiable on Linux. No Swift runtime
 effect is claimed.
+
+## Slice Result
+
+Implemented by checking the trailing unit bytes before slicing the numeric
+prefix, preserving the generic split fallback for unusual unit casing and
+invalid units. Local Linux probe results against the same worktree baseline:
+`elapsed_ms_mean` 1489.547 -> 1486.842 ms, `size_hint_calls_mean` unchanged at
+40000, and `payload_compatibility_elapsed_ms_mean` 211.760 -> 210.237 ms.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -207,8 +207,11 @@ def test_direct_size_hint_rejects_extra_tokens_without_full_split() -> None:
     assert _direct_size_hint_from_text("12 gb") == 12 * 1024 * 1024 * 1024
     assert _direct_size_hint_from_text("12\tGB") == 12 * 1024 * 1024 * 1024
     assert _direct_size_hint_from_text("12 GB\n") == 12 * 1024 * 1024 * 1024
+    assert _direct_size_hint_from_text("1.5 GB") == int(1.5 * 1024 * 1024 * 1024)
     assert _direct_size_hint_from_text("9 mb") == 9 * 1024 * 1024
     assert _direct_size_hint_from_text("512 kb") == 512 * 1024
+    assert _direct_size_hint_from_text("12 Mb") == 12 * 1024 * 1024
+    assert _direct_size_hint_from_text("12 XB") == 0
 
 
 def test_direct_card_size_hint_preserves_case_insensitive_label_prefix() -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -660,23 +660,25 @@ def _size_hint_bytes(payload: dict[str, Any], *, card_data: dict[str, Any] | Non
 
 def _direct_size_hint_from_text(text: str) -> int:
     if len(text) >= 4 and text[-3].isspace():
-        value_text = text[:-3]
-        unit_text = text[-2:]
-        if unit_text == "MB" or unit_text == "mb":
-            multiplier = _SIZE_HINT_MB
-        elif unit_text == "GB" or unit_text == "gb":
-            multiplier = _SIZE_HINT_GB
-        elif unit_text == "KB" or unit_text == "kb":
-            multiplier = _SIZE_HINT_KB
-        else:
-            multiplier = 0
-        if multiplier:
-            if value_text.isdecimal():
-                return int(value_text) * multiplier
-            try:
-                return int(float(value_text) * multiplier)
-            except ValueError:
-                return 0
+        unit_suffix = ord(text[-1])
+        if unit_suffix == 66 or unit_suffix == 98:  # B or b
+            unit_initial = ord(text[-2])
+            if unit_initial == 77 or unit_initial == 109:  # M or m
+                multiplier = _SIZE_HINT_MB
+            elif unit_initial == 71 or unit_initial == 103:  # G or g
+                multiplier = _SIZE_HINT_GB
+            elif unit_initial == 75 or unit_initial == 107:  # K or k
+                multiplier = _SIZE_HINT_KB
+            else:
+                multiplier = 0
+            if multiplier:
+                value_text = text[:-3]
+                if value_text.isdecimal():
+                    return int(value_text) * multiplier
+                try:
+                    return int(float(value_text) * multiplier)
+                except ValueError:
+                    return 0
 
     parts = text.split(maxsplit=2)
     if len(parts) != 2:


### PR DESCRIPTION
## Summary
- Optimizes the Hub catalog direct size-hint parser by dispatching on trailing unit characters before slicing the numeric prefix.
- Preserves the generic split fallback for mixed-case or unusual unit forms.
- Extends direct parser regression coverage for fractional, mixed-case, and invalid units.

## Plan or Spec
- `docs/plans/2026-06-05-hub-size-direct-unit-dispatch.md`

## Commands Run
```text
# Baseline probe on origin/main worktree before the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
exit 0; elapsed_ms_mean=1489.5473344251513; size_hint_calls_mean=40000.0; payload_compatibility_elapsed_ms_mean=211.76029136404395

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
exit 0; 69 passed in 0.26s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
exit 0; 69 passed in 0.41s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
exit 0; Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
exit 0; TOTAL 19 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
exit 0; elapsed_ms_mean=1486.8424961343408; size_hint_calls_mean=40000.0; payload_compatibility_elapsed_ms_mean=210.23734007030725

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 19 0 100%`.
- Registered probe: `hub-catalog-size-hint-regex-precompile` covers `services/mlx-worker-python/worker/model_ops/hub_catalog.py`, focused tests, and `scripts/hub_catalog_size_hint_probe.py`.
- Local Linux probe delta: `elapsed_ms_mean` 1489.547 -> 1486.842 ms (about 0.18% faster); `payload_compatibility_elapsed_ms_mean` 211.760 -> 210.237 ms; `size_hint_calls_mean` unchanged at 40000.0.
- CI PR-scoped performance is required as the registered-probe merge gate.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this Python slice used the registered focused test, changed-scope coverage, and registered probe. GitHub Actions is the merge gate.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
