### PR TITLE
perf: bind changed-scope hunk parser hot path

### DIFF
--- a/docs/plans/2026-06-05-changed-scope-hunk-parser-local-binding.md
+++ b/docs/plans/2026-06-05-changed-scope-hunk-parser-local-binding.md
@@ -1,0 +1,24 @@
+# Changed-scope hunk parser local binding slice
+
+## Scope
+
+This Python-only performance slice is limited to `scripts/changed_scope_coverage.py`, specifically the unified-diff hunk-start parser used by changed-scope coverage.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`. The registry entry already includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `scripts/changed_scope_coverage.py`
+- `tests/test_changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_parse_probe.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Optimization
+
+`_parse_changed_lines()` calls the hunk-start digit parser once for each hunk header in the zero-context diff. This slice keeps the existing parsing semantics but binds `_parse_hunk_new_start_from_digit` into a local variable before the hot loop and switches the digit scan from a `range(...)` iterator to a direct index loop with a local `ord` binding.
+
+The change avoids repeated global helper lookup and a small iterator allocation on every parsed hunk header while preserving malformed-header behavior and all changed-line outputs.
+
+## Verification
+
+Run the registered focused tests, registered changed-scope coverage command, `git diff --check`, and the registered `changed-scope-coverage-diff-parser` probe locally on Linux. PR-scoped performance CI remains the merge gate after the pull request opens.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -34,15 +34,17 @@ def _parse_diff_header_new_path(line: str) -> str | None:
 
 def _parse_hunk_new_start_from_digit(line: str, digit_index: int) -> int | None:
     value = 0
-    digit_seen = False
-    for index in range(digit_index, len(line)):
-        character_code = ord(line[index])
+    index = digit_index
+    line_length = len(line)
+    ord_char = ord
+    while index < line_length:
+        character_code = ord_char(line[index])
         if _ASCII_ZERO <= character_code <= _ASCII_NINE:
             value = value * 10 + (character_code - _ASCII_ZERO)
-            digit_seen = True
+            index += 1
             continue
         if character_code == _ASCII_COMMA or character_code == _ASCII_SPACE:
-            return value if digit_seen else None
+            return value if index > digit_index else None
         return None
     return None
 
@@ -61,6 +63,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     header_separator = _DIFF_HEADER_SEPARATOR
     header_prefix_len = len(header_prefix)
     header_separator_len = len(header_separator)
+    parse_hunk_new_start_from_digit = _parse_hunk_new_start_from_digit
     add_changed_line = None
     new_line: int | None = None
     for line in diff_text.splitlines():
@@ -82,7 +85,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
             if new_range_index < 0:
                 new_line = None
                 continue
-            new_line = _parse_hunk_new_start_from_digit(line, new_range_index + 2)
+            new_line = parse_hunk_new_start_from_digit(line, new_range_index + 2)
             continue
         if add_changed_line is None or new_line is None:
             continue


### PR DESCRIPTION
## Summary
- Optimize the changed-scope coverage diff-parser hot path by binding the hunk digit parser locally inside `_parse_changed_lines`.
- Switch the hunk digit scan to a direct index loop with a local `ord` binding while preserving malformed-header behavior.
- Add the governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-05-changed-scope-hunk-parser-local-binding.md`
- Registered probe: `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `python3 scripts/changed_scope_coverage_parse_probe.py`
- `python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-diff-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-slice-20260605222948-base --head-repo "$PWD" --output /tmp/changed_scope_hunk_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 37 passed.
- Changed-scope coverage: `TOTAL 9 0 100%`.
- Local registered probe comparison:
  - base `elapsed_ms_mean=3.790789283812046`
  - head `elapsed_ms_mean=3.0305659165605903`
  - delta `-0.760223367251456 ms` (~20.05% faster)
  - guard rails unchanged: `file_count=240`, `changed_line_count=7680`, `line_count=16080`

## Known Gaps
- This is a Python-only parser slice verified locally on Linux.
- GitHub Actions PR-scoped performance remains the required merge gate for the registered probe report.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered focused tests passed locally.
- [x] Registered changed-scope coverage passed locally.
- [x] Registered probe ran locally with base-vs-head metrics.
- [x] `git diff --check` passed.
- [ ] GitHub Actions PR-scoped performance completed successfully.
