### PR TITLE
perf: bind embedding digest sha constructor

### DIFF
--- a/docs/plans/2026-06-06-embedding-project-digest-sha-binding.md
+++ b/docs/plans/2026-06-06-embedding-project-digest-sha-binding.md
@@ -1,0 +1,22 @@
+# Embedding project digest SHA binding
+
+## Scope
+
+This Python-only performance slice is limited to `worker.runtime.embedding_backends.DeterministicEmbeddingBackend._project_digest`.
+The deterministic embedding projection hashes every input seed before expanding the digest into a normalized vector; repeated embeddings should avoid avoidable module attribute lookup overhead on that hot path.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` values and runs `scripts/deterministic_embedding_project_digest_probe.py`.
+
+## Plan
+
+1. Preserve deterministic projection values for all supported dimensions.
+2. Bind the SHA-256 constructor at module load and reuse the binding inside `_project_digest`.
+3. Verify with focused embedding tests, changed-scope coverage, and the registered probe locally on Linux.
+4. Use PR-scoped performance CI as the merge gate.
+
+## Success metrics
+
+Success is measured by the registered probe's `elapsed_ms_mean` and `default_dimension_elapsed_ms_mean` moving lower without changing checksum values. Behavior parity is measured by `test_project_digest_preserves_legacy_projection_values` and the existing embedding runtime tests.

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -6,6 +6,7 @@ import math
 import struct
 import unicodedata
 
+_SHA256 = hashlib.sha256
 _UNPACK_DIGEST_UINT32 = struct.Struct("<8I").unpack
 _DIGEST_UINT32_SCALE = 2.0 / 0xFFFFFFFF
 
@@ -47,7 +48,7 @@ class DeterministicEmbeddingBackend:
     def _project_digest(self, seed_text: str, dimensions: int) -> list[float]:
         base_values = [
             raw * _DIGEST_UINT32_SCALE - 1.0
-            for raw in _UNPACK_DIGEST_UINT32(hashlib.sha256(seed_text.encode("utf-8")).digest())
+            for raw in _UNPACK_DIGEST_UINT32(_SHA256(seed_text.encode("utf-8")).digest())
         ]
         full_repeats, remainder = divmod(dimensions, 8)
         squared_sum = sum(value * value for value in base_values) * full_repeats


### PR DESCRIPTION
## Summary
- Bind the deterministic embedding SHA-256 constructor once at module load.
- Reuse the binding inside `_project_digest` to reduce repeated module attribute lookup overhead while preserving projection parity.

## Plan or Spec
- `docs/plans/2026-06-06-embedding-project-digest-sha-binding.md`
- Registered probe: `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
# 18 passed in 18.02s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
# 18 passed in 53.11s; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_PROJECT_DIGEST_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
# Head sample: {"elapsed_ms_mean": 19.487316, "default_dimension_elapsed_ms_mean": 146.149626, "checksum": 2.775036, "default_dimension_checksum": 71.20083}

# Repeated base/head probe comparison, 3 runs each:
# base elapsed_ms_mean mean=18.668288; head elapsed_ms_mean mean=17.874446; delta=-0.793842 ms (-4.25%)
# base default_dimension_elapsed_ms_mean mean=153.831665; head default_dimension_elapsed_ms_mean mean=148.537337; delta=-5.294328 ms (-3.44%)
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` for the registered changed scope.
- Local registered probe checksums stayed stable: `checksum=2.775036`, `default_dimension_checksum=71.20083`.
- Local 3-run repeated probe comparison showed lower mean elapsed time for both high-dimension and default-dimension projections:
  - `elapsed_ms_mean`: `18.668288 -> 17.874446` ms (`-0.793842` ms, `-4.25%`).
  - `default_dimension_elapsed_ms_mean`: `153.831665 -> 148.537337` ms (`-5.294328` ms, `-3.44%`).
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Linux local verification covers the Python deterministic embedding path only.
- CI must complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
