### PR TITLE
perf: streamline dataset version manifest path checks

### DIFF
--- a/docs/plans/2026-06-06-dataset-version-manifest-path-join.md
+++ b/docs/plans/2026-06-06-dataset-version-manifest-path-join.md
@@ -1,0 +1,26 @@
+# Dataset Version Manifest Path Join Slice
+
+## Scope
+
+This Python-only performance slice is limited to dataset-version manifest path enumeration in `services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+
+## Registered Probe
+
+The affected path is covered by registered PR-scoped probe `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`. The registry entry already provides focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_versioning.py`
+- `scripts/dataset_version_listing_probe.py`
+
+## Optimization
+
+Keep the existing `os.scandir()` directory walk and replace the per-entry `os.path.join(...)` helper dispatch with direct POSIX-style manifest path construction for the repository-supported Linux/macOS runners. Bind `os.path.isfile` once before the loop to avoid repeated module attribute lookup in the hot path.
+
+The behavior remains the same for Melix-supported platforms: only real version directories containing `dataset-version.json` are yielded, non-directories and empty directories remain ignored, and missing roots still return an empty listing.
+
+## Verification Plan
+
+1. Run the registered focused pytest command for `dataset-version-listing-scandir`.
+2. Run the registered changed-scope coverage command.
+3. Run the registered local probe repeatedly on Linux and compare against the `origin/main` baseline collected before the change.
+4. Use the PR-scoped performance workflow as the final CI merge gate.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -489,13 +489,14 @@ def list_dataset_versions(
 
 
 def _iter_dataset_version_manifest_paths(versions_root: Path) -> Iterable[str]:
+    is_file = os.path.isfile
     try:
         with os.scandir(versions_root) as entries:
             for entry in entries:
                 if not entry.is_dir(follow_symlinks=False):
                     continue
-                manifest_path = os.path.join(entry.path, "dataset-version.json")
-                if os.path.isfile(manifest_path):
+                manifest_path = f"{entry.path}/dataset-version.json"
+                if is_file(manifest_path):
                     yield manifest_path
     except OSError:
         return


### PR DESCRIPTION
## Summary
- Streamlines dataset-version manifest path enumeration by avoiding the per-entry `os.path.join(...)` helper dispatch in the registered listing hot path.
- Binds `os.path.isfile` once before the `os.scandir()` loop while preserving non-directory and missing-manifest filtering.

## Plan or Spec
- `docs/plans/2026-06-06-dataset-version-manifest-path-join.md`

## Commands Run
```text
# Baseline on origin/main (three registered probe runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py
# -> elapsed_ms_mean: 45.273009, 45.076716, 48.446509 (mean of means 46.265411 ms)

# Optimized branch (three registered probe runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py
# -> elapsed_ms_mean: 41.762025, 42.935625, 46.714078 (mean of means 43.803909 ms)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# -> 7 passed in 0.90s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py
# -> 7 passed in 0.31s; TOTAL 3 0 100%

git diff --check
# -> passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for the registered dataset-version listing scope.
- Registered local probe (`dataset-version-listing-scandir`): old_mean=46.265411 ms, new_mean=43.803909 ms, speedup=1.056x, delta_ms=-2.461502 (~5.32% lower).
- CI PR-scoped performance report is required as the final registered-probe validation gate before merge.

## Known Gaps
- Full repository test suite was not run locally; this slice used the registered focused tests, changed-scope coverage, and registered probe.
- Local validation is Linux-only; the touched Python path is covered by the Ubuntu registered probe runner.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
