### PR TITLE
perf: streamline text family attention hint lookup

### DIFF
--- a/docs/plans/2026-06-06-text-family-attention-hint-fastpath.md
+++ b/docs/plans/2026-06-06-text-family-attention-hint-fastpath.md
@@ -1,0 +1,34 @@
+# Text Family Attention Hint Lookup Fast Path
+
+## Scope
+
+Optimize `text_family_adapters._inferred_attention_profile()` for repeated text-family
+config resolution.
+
+## Probe Coverage
+
+The affected path is already registered in `infra/perf/pr_scoped_probes.json` as
+`text-family-config-copy-elision`, with focused `test_command`, `coverage_command`,
+and `probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/runtime/text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_text_family_adapters.py`
+- `scripts/text_family_config_probe.py`
+
+## Change
+
+Use direct mapping lookups with `KeyError` handling for optional attention hint keys
+instead of repeated `Mapping.get()` calls followed by `_string(...).lower()` on
+missing values. This preserves MLA string hint detection and the existing `use_mla`
+boolean fallback while reducing repeated optional-key overhead in the registered
+config-resolution probe.
+
+## Verification Plan
+
+1. Run focused text-family tests and PR-scoped performance registry tests.
+2. Run changed-scope coverage through the registered probe command.
+3. Run `scripts/text_family_config_probe.py` on `origin/main` and this branch, at
+   least three times each, and compare `elapsed_ms_mean`, `peak_bytes_mean`, and
+   `config_copy_calls_mean`.
+4. Accept the slice only if the registered probe shows a clear non-regressing
+   direction and behavior coverage stays at 95%+ for changed lines.

--- a/services/mlx-worker-python/tests/test_text_family_adapters.py
+++ b/services/mlx-worker-python/tests/test_text_family_adapters.py
@@ -9,6 +9,7 @@ from worker.runtime.text_family_adapters import (
     ResolvedTextFamilyConfig,
     TextFamilyDescriptor,
     TextFamilyDetection,
+    _inferred_attention_profile,
     _inferred_expert_count,
     _split_csv,
     detect_text_family_identity,
@@ -70,6 +71,18 @@ def test_split_csv_short_circuits_empty_values_without_split() -> None:
 
     assert _split_csv(NoSplitEmpty("")) == []
     assert _split_csv(" text, qwen ,, tools ") == ["text", "qwen", "tools"]
+
+
+def test_inferred_attention_profile_skips_non_string_hints_and_preserves_use_mla_fallback() -> None:
+    assert (
+        _inferred_attention_profile(
+            {"attention_type": 0, "attn_type": None, "attention_impl": [], "use_mla": True},
+            default="gqa",
+        )
+        == "mla"
+    )
+    assert _inferred_attention_profile({"attention_impl": "flash-mla"}, default="gqa") == "mla"
+    assert _inferred_attention_profile({"attention_impl": 0}, default="gqa") == "gqa"
 
 
 def test_detect_text_family_identity_prefers_explicit_supported_override() -> None:

--- a/services/mlx-worker-python/worker/runtime/text_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/text_family_adapters.py
@@ -325,10 +325,17 @@ def _model_type(config_payload: Mapping[str, Any] | None) -> str:
 def _inferred_attention_profile(config_payload: Mapping[str, Any] | None, *, default: str) -> str:
     config_payload = _config_mapping(config_payload)
     for key in ("attention_type", "attn_type", "attention_impl", "attn_impl"):
-        value = _string(config_payload.get(key)).lower()
-        if "mla" in value:
+        try:
+            value = config_payload[key]
+        except KeyError:
+            continue
+        if isinstance(value, str) and "mla" in value.lower():
             return "mla"
-    if _bool_from_any(config_payload.get("use_mla")):
+    try:
+        use_mla = config_payload["use_mla"]
+    except KeyError:
+        return default
+    if _bool_from_any(use_mla):
         return "mla"
     return default
 


### PR DESCRIPTION
## Summary
- Streamline optional attention hint lookup in text family config resolution by replacing repeated `Mapping.get()`/empty-string lowering with direct mapping lookups and `KeyError` fallback.
- Add focused coverage for non-string hint handling and the existing `use_mla` fallback.

## Plan or Spec
- `docs/plans/2026-06-06-text-family-attention-hint-fastpath.md`
- Registered PR-scoped probe: `text-family-config-copy-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py
# 3 runs: 300.459578 ms, 294.022952 ms, 287.575004 ms; mean 294.019 ms

# Branch verification
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics
# 19 passed in 1.80s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/text_family_adapters.py services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/text_family_config_probe.py
# 19 passed in 17.88s; TOTAL 14 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py
# 3 runs: 266.812376 ms, 268.061177 ms, 282.191891 ms; mean 272.355 ms

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (14 measurable changed lines, 14 covered, 0 missed).
- Registered local probe (`text-family-config-copy-elision` / `scripts/text_family_config_probe.py`):
  - old_mean=294.019 ms
  - new_mean=272.355 ms
  - delta_ms=-21.664 ms
  - speedup=1.0795x
  - improvement=7.37%
  - `config_copy_calls_mean` unchanged at 0.0; `peak_bytes_mean` unchanged at 1274.6 bytes.
- CI PR-scoped performance workflow is required for repository-side registered probe validation before merge.

## Known Gaps
- Local verification is Linux/Python-only; no Swift runtime effect is claimed for this Python slice.
- CI registered probe report must pass before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
