### PR TITLE
perf: fast-path default embedding projection

### DIFF
--- a/docs/plans/2026-06-06-embedding-project-digest-sha-binding.md
+++ b/docs/plans/2026-06-06-embedding-project-digest-sha-binding.md
@@ -1,9 +1,9 @@
-# Embedding project digest SHA binding
+# Embedding project digest default-dimension fast path
 
 ## Scope
 
 This Python-only performance slice is limited to `worker.runtime.embedding_backends.DeterministicEmbeddingBackend._project_digest`.
-The deterministic embedding projection hashes every input seed before expanding the digest into a normalized vector; repeated embeddings should avoid avoidable module attribute lookup overhead on that hot path.
+The deterministic embedding projection hashes every input seed before expanding the digest into a normalized vector; default 8-dimension embeddings should skip the generic repeat/remainder expansion path after the first digest block is normalized.
 
 ## Registered probe
 
@@ -13,7 +13,7 @@ The registry entry includes focused `test_command`, `coverage_command`, and `pro
 ## Plan
 
 1. Preserve deterministic projection values for all supported dimensions.
-2. Bind the SHA-256 constructor at module load and reuse the binding inside `_project_digest`.
+2. Add a direct `dimensions == 8` path that returns the normalized first digest block without running the generic repeat/remainder expansion path.
 3. Verify with focused embedding tests, changed-scope coverage, and the registered probe locally on Linux.
 4. Use PR-scoped performance CI as the merge gate.
 

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -50,6 +50,10 @@ class DeterministicEmbeddingBackend:
             raw * _DIGEST_UINT32_SCALE - 1.0
             for raw in _UNPACK_DIGEST_UINT32(_SHA256(seed_text.encode("utf-8")).digest())
         ]
+        if dimensions == 8:
+            inverse_l2_norm = 1.0 / math.sqrt(sum(value * value for value in base_values))
+            return [round(value * inverse_l2_norm, 6) for value in base_values]
+
         full_repeats, remainder = divmod(dimensions, 8)
         squared_sum = sum(value * value for value in base_values) * full_repeats
         if remainder == 1:


### PR DESCRIPTION
## Summary
- Fast-path the default 8-dimension deterministic embedding projection so it returns the normalized first digest block without the generic repeat/remainder expansion path.
- Update the governing performance-slice plan for the default-dimension focus.

## Plan or Spec
- `docs/plans/2026-06-06-embedding-project-digest-sha-binding.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_PROJECT_DIGEST_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
# origin/main baseline: default_dimension_elapsed_ms_mean=142.276894/147.236633/143.184612 ms; elapsed_ms_mean=18.626513/17.255852/17.366457 ms; default_dimension_peak_bytes_mean=1352.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
# 18 passed in 14.49s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
# 18 passed in 49.62s; TOTAL 13 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_PROJECT_DIGEST_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
# branch: default_dimension_elapsed_ms_mean=113.087593/112.380654/120.050522 ms; elapsed_ms_mean=19.744218/19.344328/22.158688 ms; default_dimension_peak_bytes_mean=1248.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Registered probe: `deterministic-embedding-project-digest-allocation`.
- Default-dimension metric improved from ~144.23 ms mean baseline to ~115.17 ms mean branch across three local runs (about 20.2% faster); default peak bytes improved from 1352.0 to 1248.0.
- The 4097-dimension probe metric is outside this default-dimension fast path and was noisier/slower locally (baseline ~17.75 ms vs branch ~20.42 ms); CI PR-scoped performance is required as the merge gate before accepting the slice.

## Known Gaps
- Linux local validation only; no Swift runtime effect is claimed.
- CI PR-scoped performance report must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
