### PR TITLE
perf: streamline PR scope command summaries

### DIFF
--- a/docs/plans/2026-06-06-prscope-command-summary-lstrip.md
+++ b/docs/plans/2026-06-06-prscope-command-summary-lstrip.md
@@ -1,0 +1,43 @@
+# PR-scoped performance command-summary lstrip fast path
+
+## Scope
+
+This Python-only performance slice is limited to `_summarize_command` in
+`services/mlx-worker-python/worker/productization/pr_scoped_performance.py`.
+
+The slice keeps command-summary semantics unchanged while replacing the manual
+line-by-line scan with a direct `lstrip`/first-newline path. The hot path used by
+PR-scoped probe command reporting normally has leading whitespace, a first command
+line, and additional body lines; it only needs the first non-empty command line
+plus an ellipsis marker.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `pr-scoped-performance-scope-matcher` in
+`infra/perf/pr_scoped_probes.json`.
+
+The registered entry includes focused:
+
+- `test_command` for scope selection, glob matching, command-summary behavior, and probe dispatch.
+- `coverage_command` for changed-scope coverage on `pr_scoped_performance.py` and its tests.
+- `probe_command` that reports `build_scope_report_ms_*` and `command_summary_ms_mean`.
+
+## Verification plan
+
+Run on Linux before pushing:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_exact_force_all_skips_wildcard_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_pr_scope_script_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_changed_paths_force_all_wildcards_handles_empty_matchers services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_changed_paths_force_all_wildcards_short_circuits_on_match services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_matches_any_glob_uses_explicit_short_circuit services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_coverage_paths_for_probe_uses_explicit_glob_matcher services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_empty_direct_paths_skips_probe_matching services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_exact_only_intersects_changed_paths services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_reuses_cached_frozenset_without_copying services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_glob_matching_exact_path_skips_regex_compile services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_matching_preserves_prefix_short_circuit services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_json_probe_rejects_missing_command_and_non_numeric_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_exact_force_all_skips_wildcard_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_pr_scope_script_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_changed_paths_force_all_wildcards_handles_empty_matchers services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_changed_paths_force_all_wildcards_short_circuits_on_match services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_matches_any_glob_uses_explicit_short_circuit services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_coverage_paths_for_probe_uses_explicit_glob_matcher services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_empty_direct_paths_skips_probe_matching services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_exact_only_intersects_changed_paths services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_reuses_cached_frozenset_without_copying services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_glob_matching_exact_path_skips_regex_compile services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_matching_preserves_prefix_short_circuit services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_json_probe_rejects_missing_command_and_non_numeric_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_pr_scoped_scope_matcher as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
+```
+
+GitHub Actions PR-scoped performance remains the final merge gate.
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage is at or above the repository threshold for the touched scope.
+- Local registered probe shows lower `command_summary_ms_mean` with unchanged scope-selection counts.
+- PR-scoped performance CI completes successfully before merge.

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -74,25 +74,17 @@ def _log_progress(message: str) -> None:
 
 
 def _summarize_command(command: str, *, max_length: int = 180) -> str:
-    summary = ""
-    has_more_lines = False
-    line_start = 0
-    command_length = len(command)
-    while line_start <= command_length:
-        line_end = command.find("\n", line_start)
-        if line_end == -1:
-            line_end = command_length
-        line = command[line_start:line_end].strip()
-        if line:
-            if summary:
-                has_more_lines = True
-                break
-            summary = line
-        if line_end == command_length:
-            break
-        line_start = line_end + 1
-    if not summary:
+    command = command.lstrip()
+    if not command:
         return "<empty command>"
+
+    line_end = command.find("\n")
+    if line_end == -1:
+        summary = command.rstrip()
+        has_more_lines = False
+    else:
+        summary = command[:line_end].rstrip()
+        has_more_lines = bool(command[line_end + 1 :].lstrip())
 
     if has_more_lines:
         summary = f"{summary} ..."


### PR DESCRIPTION
## Summary
- Streamline PR-scoped performance command summaries by trimming leading whitespace once and reading the first command line directly.
- Keep the compact heartbeat behavior and ellipsis marker semantics for multi-line commands.
- Document the Python performance slice and registered probe evidence plan.

## Plan or Spec
- `docs/plans/2026-06-06-prscope-command-summary-lstrip.md`
- Registered probe: `pr-scoped-performance-scope-matcher`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change ... test_command from pr-scoped-performance-scope-matcher` — 20 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py ...` — 100% changed-scope coverage
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_pr_scoped_scope_matcher as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%` for `services/mlx-worker-python/worker/productization/pr_scoped_performance.py` and `services/mlx-worker-python/tests/test_pr_scoped_performance.py`.
- Local registered probe (single head run): `command_summary_ms_mean=14.328779`, `build_scope_report_ms_mean=2.031284`, `selected_probe_count_mean=7.0`, `force_all_selected_mean=0.0`.
- Local base-vs-head repeated probe (3 runs each, same Linux worktree/env): `base_command_summary_ms_mean=16.76324166666667`, `head_command_summary_ms_mean=14.754469`, `delta_ms=-2.008772666666669`, `speedup=1.136146727250345`; `selected_probe_count_mean=7.0`, `force_all_selected_mean=0.0` unchanged.
- CI PR-scoped performance is required as the final registered-probe validation source before merge.

## Known Gaps
- This is a Python-only slice locally verified on Linux.
- Local probe timing is synthetic and noisy; GitHub Actions PR-scoped performance remains the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally with base-vs-head improvement evidence.
- [ ] PR-scoped performance workflow completed successfully in CI.
