### PR TITLE
perf: fast-path text family expert int counts

### DIFF
--- a/docs/plans/2026-06-06-text-family-expert-count-int-fastpath.md
+++ b/docs/plans/2026-06-06-text-family-expert-count-int-fastpath.md
@@ -1,0 +1,29 @@
+# Text Family Expert Count Int Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to `text_family_adapters._expert_count_from_config()` during repeated text-family config resolution.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `text-family-config-copy-elision` in `infra/perf/pr_scoped_probes.json`. The registered entry includes focused `test_command`, `coverage_command`, and `probe_command` values for:
+
+- `services/mlx-worker-python/worker/runtime/text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/text_family_config_probe.py`
+
+## Change
+
+Check the common exact-`int` `num_local_experts` value before the generic `isinstance(..., bool)` / `isinstance(..., int)` chain. Python `bool` remains excluded because the fast path uses `type(value) is int`; existing fallback behavior for bool, float, string, and secondary expert-count keys is preserved.
+
+## Verification plan
+
+1. Run the registered focused pytest command for `text-family-config-copy-elision` locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run `scripts/text_family_config_probe.py` against the `origin/main` baseline and this branch and compare `elapsed_ms_mean`, `peak_bytes_mean`, and `config_copy_calls_mean`.
+4. Use the PR-scoped performance workflow as the final CI merge gate before squash merging.
+
+## Metrics
+
+Success is measured by a lower or non-regressing `elapsed_ms_mean` in `scripts/text_family_config_probe.py` with unchanged `peak_bytes_mean` and `config_copy_calls_mean == 0`. This slice has no Swift runtime effect.

--- a/services/mlx-worker-python/worker/runtime/text_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/text_family_adapters.py
@@ -389,10 +389,10 @@ def _resolved_expert_count(
 def _expert_count_from_config(config_payload: Mapping[str, Any] | None) -> int | None:
     config_payload = _config_mapping(config_payload)
     value = config_payload.get("num_local_experts")
+    if type(value) is int:
+        return max(0, value)
     if isinstance(value, bool):
         pass
-    elif isinstance(value, int):
-        return max(0, value)
     elif isinstance(value, float):
         return max(0, int(value))
     elif isinstance(value, str) and value.strip():


### PR DESCRIPTION
## Summary
- Fast-path exact `int` values for `num_local_experts` in text-family config resolution.
- Preserve bool exclusion and existing float/string/secondary-key fallback behavior.

## Plan or Spec
- `docs/plans/2026-06-06-text-family-expert-count-int-fastpath.md`
- Registered PR-scoped probe: `text-family-config-copy-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe on origin/main worktree (3 runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py
exit 0; elapsed_ms_mean samples: 296.86327325180173, 260.5588066391647, 266.5928930044174

# Branch probe (3 comparison runs before final single registered probe)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py
exit 0; elapsed_ms_mean samples: 266.4874796755612, 274.18334363028407, 275.7636004127562

# Registered focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics
exit 0; 19 passed in 2.57s

# Registered changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/text_family_adapters.py services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/text_family_config_probe.py
exit 0; 19 passed in 17.59s; TOTAL 2 0 100%

# Final local registered probe on branch
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py
exit 0; {"config_copy_calls_mean": 0.0, "elapsed_ms_mean": 263.031224347651, "iterations": 10000, "peak_bytes_mean": 1274.6}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 2 0 100%`).
- Local probe comparison (3-run mean): old_mean=274.672 ms, new_mean=272.145 ms, delta_ms=-2.527, speedup≈0.92%; `peak_bytes_mean` unchanged at 1274.6 bytes; `config_copy_calls_mean` unchanged at 0.0.
- Final branch registered probe: `elapsed_ms_mean=263.031224347651`, `peak_bytes_mean=1274.6`, `config_copy_calls_mean=0.0`.
- CI PR-scoped performance is required as the final registered-probe validation before merge.

## Known Gaps
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally; this is a focused Python hot-path slice on Linux.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead unchanged because no probe code changed.
- [x] Deferred work and known gaps are stated explicitly.
