### PR TITLE
perf: hoist image format membership set

### DIFF
--- a/docs/plans/2026-06-06-deterministic-image-format-fastpath.md
+++ b/docs/plans/2026-06-06-deterministic-image-format-fastpath.md
@@ -1,0 +1,19 @@
+# Deterministic Image Format Fast Path
+
+## Context
+
+The deterministic image runtime normalizes response formats for each generated or edited image request. Registered PR-scoped probe `deterministic-image-output-byte-accounting` already covers this path with focused tests, changed-scope coverage, and a command-json probe.
+
+## Slice
+
+This performance slice keeps image format semantics unchanged while moving the supported-format membership container out of `_normalized_format()` and into a module-level constant. The goal is to avoid rebuilding the same set literal on every normalization call.
+
+## Validation
+
+- Focused tests: registered probe `test_command` for deterministic image output byte accounting.
+- Coverage: registered probe `coverage_command` for the deterministic image runtime/test/probe scope.
+- Metrics: registered probe `probe_command`, comparing local baseline against the optimized branch on Linux.
+
+## Boundaries
+
+This is a Python-only slice and is locally verifiable on Linux. It does not change protocol schemas, generated protobuf outputs, or Swift/macOS runtime behavior.

--- a/services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py
@@ -18,6 +18,7 @@ _IMAGE_MIME_TYPES = {
     "jpeg": "image/jpeg",
     "webp": "image/webp",
 }
+_SUPPORTED_IMAGE_FORMATS = frozenset((*_IMAGE_MIME_TYPES, "jpg"))
 
 
 class ImageGenerationCancelled(RuntimeError):
@@ -300,7 +301,7 @@ class DeterministicImageGenerationRuntime(DeterministicProbeMixin[ImageGeneratio
     @staticmethod
     def _normalized_format(response_format: str) -> str:
         normalized = (response_format or "png").strip().lower()
-        if normalized in {"png", "jpeg", "jpg", "webp"}:
+        if normalized in _SUPPORTED_IMAGE_FORMATS:
             return "jpeg" if normalized == "jpg" else normalized
         raise ValueError(f"Unsupported image response format: {response_format}")
 


### PR DESCRIPTION
## Summary
- Hoist deterministic image response-format membership into a module-level constant.
- Avoid rebuilding the same supported-format set on each `_normalized_format()` call while preserving `jpg` -> `jpeg` behavior.

## Plan or Spec
- `docs/plans/2026-06-06-deterministic-image-format-fastpath.md`
- Registered probe: `deterministic-image-output-byte-accounting` in `infra/perf/pr_scoped_probes.json` already covers `services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# Baseline probe on origin/main (3 runs):
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_image_output_bytes_probe.py
elapsed_ms_mean samples: 16.996917594224215, 14.94628768414259, 17.710910737514496

# Focused tests (exit 0):
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_image_runtime.py::test_image_generation_and_edit_probe_bytes_do_not_rescan_images services/mlx-worker-python/tests/test_image_runtime.py::test_image_generation_and_edit_bind_model_id_once_per_loop services/mlx-worker-python/tests/test_image_runtime.py::test_image_edit_binds_strength_once_per_loop services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_output_bytes_probe_script_emits_metrics
6 passed in 1.78s

# Changed-scope coverage (exit 0):
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_image_runtime.py::test_image_generation_and_edit_probe_bytes_do_not_rescan_images services/mlx-worker-python/tests/test_image_runtime.py::test_image_generation_and_edit_bind_model_id_once_per_loop services/mlx-worker-python/tests/test_image_runtime.py::test_image_edit_binds_strength_once_per_loop services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_image_edit_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_image_output_bytes_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_image_generation_runtime.py services/mlx-worker-python/tests/test_image_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_image_output_bytes_probe.py
TOTAL 2 0 100%

# Head probe (3 runs, exit 0):
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_image_output_bytes_probe.py
elapsed_ms_mean samples: 15.384874120354652, 17.28045316413045, 15.129341278225183

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Registered probe: `deterministic-image-output-byte-accounting`.
- Local Linux probe comparison:
  - `old_mean=16.551372 ms`
  - `new_mean=15.931556 ms`
  - `delta_ms=-0.619816 ms`
  - `speedup=1.038905x`
  - `improvement_pct=3.745%`
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux/Python-only; no Swift/macOS runtime behavior is changed.
- The local probe is synthetic and timing has normal VM variance; merge decision should also use the registered CI probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
