### PR TITLE
perf: tighten trajectory provenance normalization dispatch

### DIFF
--- a/docs/plans/2026-06-06-trajectory-provenance-normalize-dispatch.md
+++ b/docs/plans/2026-06-06-trajectory-provenance-normalize-dispatch.md
@@ -1,0 +1,26 @@
+# Trajectory Provenance Normalize Dispatch Slice
+
+## Scope
+
+This Python-only performance slice is limited to `normalize_trajectory_provenance()` in `services/mlx-worker-python/worker/trajectory_provenance.py`.
+
+## Registered Probe
+
+The affected path is already covered by registered PR-scoped probe `trajectory-provenance-copy-elision` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` fields and watches:
+
+- `services/mlx-worker-python/worker/trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/trajectory_provenance_copy_elision_probe.py`
+
+## Optimization Plan
+
+Keep behavior equivalent while reducing per-field normalization overhead:
+
+1. Bind the provenance getter and nested copy helper once per normalization call.
+2. Dispatch by exact value type before checking the empty-string sentinel so dict/list values do not pay container-to-string equality work.
+3. Preserve nested container copy isolation for JSON-like dict/list provenance values and keep the fallback for custom mutable values in `_copy_trajectory_provenance_value()`.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and registered probe locally on Linux. GitHub Actions PR-scoped performance remains the final merge gate for the base-vs-head registered report.

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -368,6 +368,46 @@ def test_normalize_trajectory_provenance_copies_nested_json_containers() -> None
     assert copied_quality["components"][0]["score"] == 1.0
 
 
+def test_normalize_trajectory_provenance_copies_containers_without_empty_string_compare() -> None:
+    class DictSubclass(dict):
+        def __eq__(self, other: object) -> bool:
+            raise AssertionError("container values should not be compared to empty strings")
+
+    source = {
+        "trajectory_quality_metrics": DictSubclass(
+            {"reward_coverage_count": 1, "components": [{"name": "format"}]}
+        )
+    }
+
+    normalized = normalize_trajectory_provenance(source)
+
+    assert normalized["trajectory_quality_metrics"] == {
+        "reward_coverage_count": 1,
+        "components": [{"name": "format"}],
+    }
+    assert normalized["trajectory_quality_metrics"] is not source["trajectory_quality_metrics"]
+
+
+def test_normalize_trajectory_provenance_keeps_scalars_and_skips_empty_values() -> None:
+    class EmptySentinel:
+        def __eq__(self, other: object) -> bool:
+            return other == ""
+
+    source = {
+        "trajectory_dataset_id": "agentic-snapshot",
+        "trajectory_dataset_version": "",
+        "trajectory_toolset_version": 3,
+        "trajectory_registry_schema_version": EmptySentinel(),
+    }
+
+    normalized = normalize_trajectory_provenance(source)
+
+    assert normalized == {
+        "trajectory_dataset_id": "agentic-snapshot",
+        "trajectory_toolset_version": 3,
+    }
+
+
 def test_copy_trajectory_provenance_value_falls_back_for_custom_mutables() -> None:
     class CustomMutable:
         def __init__(self, value: int) -> None:

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -58,15 +58,23 @@ def normalize_trajectory_provenance(
     if not provenance:
         return {}
     normalized: dict[str, Any] = {}
+    provenance_get = provenance.get
+    copy_value = _copy_trajectory_provenance_value
     for field in TRAJECTORY_PROVENANCE_FIELDS:
-        value = provenance.get(field)
-        if value in ("", None):
+        value = provenance_get(field)
+        if value is None:
             continue
         value_type = type(value)
-        if value_type is dict or value_type is list:
-            normalized[field] = _copy_trajectory_provenance_value(value)
+        if value_type is str:
+            if value == "":
+                continue
+            normalized[field] = value
+        elif value_type is dict or value_type is list:
+            normalized[field] = copy_value(value)
         elif isinstance(value, (dict, list)):
-            normalized[field] = _copy_trajectory_provenance_value(value)
+            normalized[field] = copy_value(value)
+        elif value == "":
+            continue
         else:
             normalized[field] = value
     return normalized


### PR DESCRIPTION
## Summary
- Tighten `normalize_trajectory_provenance()` dispatch by binding the provenance getter/copy helper once per call.
- Dispatch exact strings before container copy paths so dict/list provenance values avoid empty-string equality work while preserving nested-copy isolation.
- Add regression coverage for container equality avoidance plus scalar/empty sentinel handling.

## Plan or Spec
- `docs/plans/2026-06-06-trajectory-provenance-normalize-dispatch.md`
- Registered PR-scoped probe: `trajectory-provenance-copy-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_containers_without_empty_string_compare services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_keeps_scalars_and_skips_empty_values services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_provenance_copy_elision_probe_script_emits_metrics
# 7 passed in 0.51s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_containers_without_empty_string_compare services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_keeps_scalars_and_skips_empty_values services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
# 5 passed in 0.61s; changed_line_coverage=100.00%; TOTAL 13 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 scripts/trajectory_provenance_copy_elision_probe.py
# baseline_elapsed_ms_mean=1524.9578814022243; optimized_elapsed_ms_mean=486.609426420182; delta_ms=-1038.3484549820423; speedup=3.133843691892314; peak_bytes_mean=19112.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` for `services/mlx-worker-python/worker/trajectory_provenance.py` changed lines (`TOTAL 13 0 100%`).
- Local registered probe: `trajectory_provenance_copy_elision_probe.py` reported `baseline_elapsed_ms_mean=1524.9579`, `optimized_elapsed_ms_mean=486.6094`, `delta_ms=-1038.3485`, `speedup=3.1338x`, `optimized_peak_bytes_mean=19112.0`.
- CI is required for the registered PR-scoped base-vs-head performance report before merge.

## Known Gaps
- None for local Python verification.
- No Swift runtime effects are claimed in this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode changes; probe overhead is the registered local/CI performance probe.
- [x] Deferred work and known gaps are stated explicitly.
