### PR TITLE
perf: stream rerank response item assembly

### DIFF
--- a/docs/plans/2026-06-06-rerank-response-item-binding-performance.md
+++ b/docs/plans/2026-06-06-rerank-response-item-binding-performance.md
@@ -1,0 +1,31 @@
+# Rerank response incremental assembly performance slice
+
+## Scope
+
+This slice keeps the existing rerank ranking semantics and focuses only on the
+Python rerank response assembly path in
+`services/mlx-worker-python/worker/engine/rerank_core.py`.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped probe
+`rerank-core-top-k-heap-selection` in `infra/perf/pr_scoped_probes.json`.
+That registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` coverage for `RerankCore` and `scripts/rerank_top_k_probe.py`.
+
+## Change
+
+Build `RerankResponse.items` incrementally with the protobuf repeated-field
+`add()` API instead of constructing an intermediate Python list of
+`RerankItem` messages. This avoids the temporary list allocation and keeps the
+existing top-k ranking algorithm and request document passthrough behavior.
+
+## Validation plan
+
+- Run the registered focused test command for `rerank-core-top-k-heap-selection`.
+- Run the registered changed-scope coverage command and remove generated
+  `coverage.json` afterwards.
+- Run `scripts/rerank_top_k_probe.py` locally on Linux and compare against the
+  `origin/main` baseline, focusing on the request-path metric that exercises
+  response assembly.
+- Use GitHub Actions PR-scoped performance workflow as merge validation.

--- a/services/mlx-worker-python/worker/engine/rerank_core.py
+++ b/services/mlx-worker-python/worker/engine/rerank_core.py
@@ -40,12 +40,13 @@ class RerankCore:
 
         ranked = self._rank_scores(scores, top_k=int(request.top_k) if request.top_k else None)
 
-        return inference_pb2.RerankResponse(
-            items=[
-                inference_pb2.RerankItem(index=index, score=score)
-                for index, score in ranked
-            ]
-        )
+        response = inference_pb2.RerankResponse()
+        add_item = response.items.add
+        for index, score in ranked:
+            item = add_item()
+            item.index = index
+            item.score = score
+        return response
 
     @staticmethod
     def _rank_scores(scores: list[float], *, top_k: int | None) -> list[tuple[int, float]]:


### PR DESCRIPTION
## Summary
- Stream rerank response item assembly through the protobuf repeated-field `add()` API.
- Avoid the temporary Python list of `RerankItem` messages while preserving ranking semantics and request document passthrough.
- Document the slice and validation plan under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-06-06-rerank-response-item-binding-performance.md`
- Registered PR-scoped probe: `rerank-core-top-k-heap-selection` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_preserves_sort_contract_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_uses_single_scan_for_top_k_one services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_uses_heap_for_bounded_top_k services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_rank_scores_keeps_full_sort_when_unbounded services/mlx-worker-python/tests/test_rerank_runtime.py::test_rerank_returns_sorted_scores_and_honors_top_k services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_rerank_core_top_k_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_rerank_top_k_probe_script_emits_top_k_one_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/rerank_core.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/rerank_top_k_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RERANK_TOP_K_PROBE_SAMPLES=9 uv run --project services/mlx-worker-python python3 scripts/rerank_top_k_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 8 passed.
- Changed-scope coverage: `TOTAL 7 0 100%` for changed measurable lines.
- Local Linux baseline (`origin/main`, 9 samples): `request_elapsed_ms=581.963561`, `elapsed_ms_mean=2381.165806`, `peak_bytes_mean=705.777778`.
- Local Linux candidate (9 samples): `request_elapsed_ms=571.499354`, `elapsed_ms_mean=2398.516072`, `peak_bytes_mean=705.777778`.
- Request-path delta: `-10.464207 ms` (`~1.80%` faster) on the metric that exercises rerank response assembly. The rank-only metric varies independently because `_rank_scores` is unchanged.
- Registered CI probe validation is required before merge.

## Known Gaps
- Local validation is Linux-only and uses the deterministic Python probe. No Swift runtime effect is claimed.
- CI PR-scoped performance report is the source of truth for registered probe validation.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at 100% for changed measurable lines.
- [x] Registered probe ran locally on Linux with baseline comparison.
- [ ] GitHub Actions and PR-scoped performance workflow completed successfully.
