### PR TITLE
perf: fast-path hub tag list normalization

### DIFF
--- a/docs/plans/2026-06-06-hub-string-list-exact-list.md
+++ b/docs/plans/2026-06-06-hub-string-list-exact-list.md
@@ -1,0 +1,29 @@
+# Hub catalog exact-list string normalization slice
+
+This Python-only performance slice is limited to `worker.model_ops.hub_catalog._string_list`.
+
+## Scope
+
+Hub catalog summary construction normalizes Hub payload tag arrays through `_string_list` for each record before deriving MLX compatibility and local fit evidence. The hot path receives exact `list` instances from decoded JSON payloads; list subclasses remain supported for compatibility but are not the common case.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `hub-catalog-tag-normalization-single-pass` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` values for:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_tag_normalization_probe.py`
+
+## Implementation plan
+
+1. Add focused regression coverage proving exact `list`, list subclass, and scalar string inputs preserve `_string_list` behavior.
+2. Fast-path exact `list` inputs before the generic `isinstance(value, list)` fallback.
+3. Verify with the registered focused tests, changed-scope coverage, and local registered probe on Linux.
+4. Use PR-scoped performance CI as the merge gate.
+
+## Metrics
+
+Target metric: lower `elapsed_ms_mean` in `hub-catalog-tag-normalization-single-pass` with unchanged `tag_normalization_calls_mean` and record count.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -22,6 +22,7 @@ from worker.model_ops.hub_catalog import (
     _payload_is_mlx_compatible,
     _quantization_summary,
     _size_hint_from_text,
+    _string_list,
 )
 
 
@@ -85,6 +86,15 @@ def test_quantization_summary_preserves_alias_order_from_lowered_tags() -> None:
         _quantization_summary(["2-bit", "3bit", "8-bit", "float32", "bf16"])
         == "2-bit, 3-bit, 8-bit, fp32, bf16"
     )
+
+
+def test_string_list_preserves_exact_list_and_list_subclass_inputs() -> None:
+    class TagList(list[str]):
+        pass
+
+    assert _string_list(["mlx", 7, "safetensors"]) == ["mlx", "safetensors"]
+    assert _string_list(TagList(["mlx", "4-bit"])) == ["mlx", "4-bit"]
+    assert _string_list("mlx") == ["mlx"]
 
 
 def test_bytes_per_parameter_preserves_quantization_priority_without_joining_tags() -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -329,6 +329,8 @@ def _int(value: Any) -> int:
 
 
 def _string_list(value: Any) -> list[str]:
+    if type(value) is list:
+        return [item for item in value if isinstance(item, str)]
     if isinstance(value, list):
         return [item for item in value if isinstance(item, str)]
     if isinstance(value, str) and value:


### PR DESCRIPTION
## Summary
- Fast-path exact `list` inputs in Hub catalog `_string_list` before the generic list-subclass fallback.
- Add regression coverage for exact lists, list subclasses, and scalar string tag payloads.

## Plan or Spec
- `docs/plans/2026-06-06-hub-string-list-exact-list.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
# 67 passed before adding the focused regression; registered command below ran 70 passed after the test addition.

# Registered focused test command from infra/perf/pr_scoped_probes.json: hub-catalog-tag-normalization-single-pass
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
# 70 passed in 0.37s

# Registered coverage command from infra/perf/pr_scoped_probes.json: hub-catalog-tag-normalization-single-pass
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py
# 70 passed in 0.42s; changed-scope coverage 100% (8/8)

# Registered probe command from infra/perf/pr_scoped_probes.json: hub-catalog-tag-normalization-single-pass
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
# {"elapsed_ms_mean": 229.8596117645502, "peak_bytes_mean": 9835660.4, "record_count": 5000.0, "sample_count": 5.0, "tag_normalization_calls_mean": 5000.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (8/8 measurable changed lines).
- Local base-vs-head probe comparison, 7 samples, `MELIX_HUB_CATALOG_TAG_PROBE_SAMPLES=7`:
  - base `elapsed_ms_mean=216.19011095858045`
  - head `elapsed_ms_mean=209.05674554939782`
  - `delta_ms=-7.13336540918263`
  - `speedup=1.0341216706040088`
  - `tag_normalization_calls_mean=5000.0` unchanged
- Registered PR-scoped performance CI is still required as the merge gate.
- Observability mode: N/A (no runtime observability change). Probe overhead: N/A (uses existing PR-scoped probe only).

## Known Gaps
- Linux local validation only; no Swift/runtime effect is claimed.
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this small Python-only slice; GitHub Actions is the broader gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
