### PR TITLE
perf: fast-path macOS native binary candidate names

### DIFF
--- a/docs/plans/2026-06-06-macos-app-native-binary-name-check.md
+++ b/docs/plans/2026-06-06-macos-app-native-binary-name-check.md
@@ -1,0 +1,29 @@
+# macOS app native binary candidate name fast path
+
+## Context
+
+The macOS app bundle productization helper walks the packaged Python runtime and
+site-packages trees to collect native binary candidates for stripping. The
+registered PR-scoped probe `macos-app-native-binary-scandir` covers
+`services/mlx-worker-python/worker/productization/macos_app_bundle.py` and
+measures this traversal over a synthetic runtime/site-packages tree.
+
+## Slice
+
+This slice keeps the existing traversal order and candidate semantics while
+removing per-entry `os.path.splitext()` plus parent-directory path parsing from
+`_iter_python_native_binary_candidates()`. The traversal now checks native binary
+suffixes directly against `entry.name` and computes whether the current scanned
+directory is `bin` once per directory.
+
+## Verification
+
+- Focused tests: the `macos-app-native-binary-scandir` registered test command.
+- Coverage: the registered changed-scope coverage command for the same probe.
+- Metrics: the registered `macos-app-native-binary-scandir` probe, run locally on
+  Linux and again in PR-scoped performance CI.
+
+## Boundaries
+
+This is a Python packaging-path optimization and is locally verifiable on Linux.
+It does not change Swift runtime behavior or generated protocol artifacts.

--- a/services/mlx-worker-python/tests/test_macos_app_bundle.py
+++ b/services/mlx-worker-python/tests/test_macos_app_bundle.py
@@ -607,7 +607,11 @@ def test_bundle_slimming_helpers_cover_runtime_edge_cases(
     def fail_rglob(self: Path, pattern: str):  # pragma: no cover - regression guard
         raise AssertionError("_iter_python_native_binary_candidates() should not allocate Path.rglob() trees")
 
+    def fail_splitext(path: str):  # pragma: no cover - regression guard
+        raise AssertionError("_iter_python_native_binary_candidates() should use direct suffix checks")
+
     monkeypatch.setattr(Path, "rglob", fail_rglob)
+    monkeypatch.setattr(macos_app_bundle_module.os.path, "splitext", fail_splitext)
     assert set(_iter_python_native_binary_candidates(runtime, site_packages)) == {
         python_versioned,
         runtime_so,

--- a/services/mlx-worker-python/worker/productization/macos_app_bundle.py
+++ b/services/mlx-worker-python/worker/productization/macos_app_bundle.py
@@ -455,6 +455,7 @@ def _iter_python_native_binary_candidates(
                     entries = sorted(iterator, key=lambda entry: entry.name)
             except OSError:
                 continue
+            include_current_runtime_executables = include_runtime_executables and current.name == "bin"
             for entry in reversed(entries):
                 try:
                     if entry.is_dir(follow_symlinks=False):
@@ -464,11 +465,10 @@ def _iter_python_native_binary_candidates(
                         continue
                 except OSError:
                     continue
-                suffix = os.path.splitext(entry.name)[1]
-                if suffix in _PYTHON_NATIVE_BINARY_SUFFIXES:
+                if entry.name.endswith(_PYTHON_NATIVE_BINARY_SUFFIXES):
                     selected.append(Path(entry.path))
                     continue
-                if not include_runtime_executables or os.path.basename(os.path.dirname(entry.path)) != "bin":
+                if not include_current_runtime_executables:
                     continue
                 if entry.name in _PYTHON_RUNTIME_EXECUTABLE_NAMES or entry.name.startswith("python3."):
                     selected.append(Path(entry.path))


### PR DESCRIPTION
## Summary
- Fast-path macOS app Python native binary candidate filtering by checking `entry.name.endswith(...)` directly.
- Compute whether the current scanned directory is `bin` once per directory instead of parsing each non-native entry path.
- Add a regression guard and a small plan note for the slice.

## Plan or Spec
- `docs/plans/2026-06-06-macos-app-native-binary-name-check.md`
- Registered probe: `macos-app-native-binary-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_bundle_slimming_helpers_cover_runtime_edge_cases services/mlx-worker-python/tests/test_macos_app_bundle.py::test_iter_python_native_binary_candidates_tolerates_scandir_metadata_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/macos_app_bundle.py services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- Registered probe command from `macos-app-native-binary-scandir`, run 3x locally before and after the change.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 4 passed.
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Local Linux registered probe baseline (`elapsed_ms_mean`, 3 runs): `7.567733`, `9.123054`, `7.734253` ms; mean `8.14168` ms.
- Local Linux registered probe head (`elapsed_ms_mean`, 3 runs): `4.980637`, `4.89807`, `4.941525` ms; mean `4.940077` ms.
- Local delta: `-3.201603` ms, about `1.65x` faster (`39.32%` lower mean).
- PR-scoped performance CI is required as the registered probe validation source before merge.

## Known Gaps
- Local validation is Linux-only for this Python packaging path; no Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance report must complete successfully before merging.

## Evidence Checklist
- [x] Affected path is covered by registered PR-scoped probe `macos-app-native-binary-scandir`.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally with before/after metrics.
- [ ] PR-scoped performance CI completed successfully.
- [ ] All required GitHub checks are green.
