### PR TITLE
perf: bind code eval fence literal

### DIFF
--- a/docs/plans/2026-06-06-code-eval-fence-binding-performance.md
+++ b/docs/plans/2026-06-06-code-eval-fence-binding-performance.md
@@ -1,0 +1,48 @@
+# Code Evaluation Fence Literal Binding Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to `extract_candidate_code(...)` in
+`services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+The parser keeps the existing behavior for empty predictions, plain-text code,
+lowercase and mixed-case Python fenced code blocks, empty fenced blocks,
+unterminated trailing fences, and trailing commentary after the final complete
+code block.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`code-eval-code-block-last-match-streaming` in
+`infra/perf/pr_scoped_probes.json`. The registry entry already includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_code_block_extract_probe.py`
+
+## Change
+
+Bind the Markdown code-fence literal once inside `extract_candidate_code(...)`
+and reuse that local binding for the `rfind()` and fallback `count()` calls.
+This keeps the same last-complete-code-block parsing semantics while avoiding
+repeated literal lookups along the hot extraction path.
+
+## Verification Plan
+
+1. Run the registered focused pytest selection locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run the registered local probe comparing `origin/main` and the candidate
+   branch.
+4. Use GitHub Actions PR-scoped performance as the final registered probe gate
+   before merge.
+
+## Local Probe Result
+
+Local Linux registered probe comparison before PR:
+
+- base `elapsed_ms_mean=0.040521246514150074`, `peak_bytes_mean=245.0`
+- head `elapsed_ms_mean=0.03357989979641778`, `peak_bytes_mean=245.0`
+- elapsed delta `-0.006941346717732291 ms` (~17.13% lower)
+- peak delta `0 bytes`

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -50,18 +50,19 @@ def extract_candidate_code(raw_response: str) -> tuple[str, str]:
     if not normalized:
         return "", "empty_prediction"
 
-    closing = normalized.rfind("```")
+    fence = "```"
+    closing = normalized.rfind(fence)
     if closing >= 0:
-        opening = normalized.rfind("```", 0, closing)
+        opening = normalized.rfind(fence, 0, closing)
         if opening >= 0:
             content_start = _code_block_content_start(normalized, opening + 3)
             candidate = normalized[content_start:closing].strip()
             if candidate:
                 return candidate, "parsed_code_block"
-            if normalized.count("```") % 2 == 0:
+            if normalized.count(fence) % 2 == 0:
                 return candidate, "parsed_code_block"
             closing = opening
-            opening = normalized.rfind("```", 0, closing)
+            opening = normalized.rfind(fence, 0, closing)
             if opening >= 0:
                 content_start = _code_block_content_start(normalized, opening + 3)
                 return normalized[content_start:closing].strip(), "parsed_code_block"


### PR DESCRIPTION
## Summary
- Bind the Markdown code-fence literal once inside `extract_candidate_code(...)` and reuse it for the hot `rfind()`/fallback `count()` calls.
- Keep code-evaluation parsing behavior unchanged for plain text, Python fenced blocks, empty blocks, and trailing incomplete/commentary fences.
- Add a governing performance-slice plan with local probe evidence.

## Plan or Spec
- `docs/plans/2026-06-06-code-eval-fence-binding-performance.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# 4 passed in 0.99s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py
# 4 passed; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-code-block-last-match-streaming --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/code_eval_fence_binding_probe.json
# head verification ok; base/head probes ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%` for `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
- Registered probe: `code-eval-code-block-last-match-streaming`.
- Local Linux probe metrics:
  - base `elapsed_ms_mean=0.040521246514150074`, `peak_bytes_mean=245.0`
  - head `elapsed_ms_mean=0.03357989979641778`, `peak_bytes_mean=245.0`
  - elapsed delta `-0.006941346717732291 ms` (~17.13% lower)
  - peak delta `0 bytes`
- CI PR-scoped performance must complete before merge.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this Python micro-slice.
- Swift/macOS runtime effects are not applicable to this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A, production code has no observability change; probe overhead is limited to registered PR-scoped performance execution.
- [x] Deferred work and known gaps are stated explicitly.
