### PR TITLE
perf: aggregate benchmark matrix tool summaries in one pass

### DIFF
--- a/docs/plans/2026-06-07-benchmark-store-tool-summary-single-pass.md
+++ b/docs/plans/2026-06-07-benchmark-store-tool-summary-single-pass.md
@@ -1,0 +1,21 @@
+# Benchmark Store Tool Summary Single-Pass Aggregation
+
+## Scope
+
+This Python-only performance slice is limited to `BenchmarkStore._attach_matrix_tool_turn_summary_fields(...)` in `services/mlx-worker-python/worker/productization/benchmark_store.py`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `benchmark-store-matrix-streaming` in `infra/perf/pr_scoped_probes.json`. The registry entry already provides focused `test_command`, `coverage_command`, and `probe_command` entries for the benchmark store implementation, focused tests, and `scripts/benchmark_store_probe.py`.
+
+## Plan
+
+1. Keep behavior unchanged for empty rows, wrong row types, pre-populated summary rows, and unmatched summary cells.
+2. Collapse the separate request-row type check, tool-field presence scan, and aggregate pass into one request-row pass.
+3. Run the registered focused tests, changed-scope coverage, `git diff --check`, and the registered local Linux probe before opening the PR.
+4. Use GitHub Actions and the registered PR-scoped performance report as the merge gate.
+
+## Metrics
+
+Primary metric: lower `elapsed_ms_mean` from `benchmark-store-matrix-streaming`.
+Secondary metric: lower or stable `peak_bytes_mean`; emitted row counts must remain unchanged.

--- a/services/mlx-worker-python/worker/productization/benchmark_store.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_store.py
@@ -642,25 +642,23 @@ class BenchmarkStore:
             return summary_rows
         if not all(isinstance(row, BenchmarkMatrixSummaryRow) for row in summary_rows):
             return summary_rows
-        if not all(isinstance(row, BenchmarkMatrixRequestRow) for row in request_rows):
-            return summary_rows
-
-        has_tool_turn_fields = any(
-            row.tool_call_count
-            or row.tool_latency_ms
-            or row.observation_bytes
-            or row.fatal_rate
-            or row.turn_count
-            for row in request_rows
-        )
-        if not has_tool_turn_fields:
-            return summary_rows
 
         aggregates_by_cell_key: dict[
             tuple[str, int, int, int, str, str, str, int],
             tuple[int, int, float, int, int, int],
         ] = {}
+        has_tool_turn_fields = False
         for row in request_rows:
+            if not isinstance(row, BenchmarkMatrixRequestRow):
+                return summary_rows
+            row_has_tool_turn_fields = (
+                row.tool_call_count
+                or row.tool_latency_ms
+                or row.observation_bytes
+                or row.fatal_rate
+                or row.turn_count
+            )
+            has_tool_turn_fields = has_tool_turn_fields or bool(row_has_tool_turn_fields)
             key = (
                 row.suite_id,
                 row.context_length,
@@ -687,6 +685,8 @@ class BenchmarkStore:
                 fatal_count + (1 if row.fatal_rate > 0.0 else 0),
                 turn_count + row.turn_count,
             )
+        if not has_tool_turn_fields:
+            return summary_rows
 
         hydrated_rows: list[BenchmarkMatrixSummaryRow] = []
         for row in summary_rows:


### PR DESCRIPTION
## Summary
- Collapse benchmark matrix request-row type validation, tool-field detection, and aggregate construction into a single request-row pass.
- Add a governing plan for the benchmark store tool-summary single-pass slice.

## Plan or Spec
- docs/plans/2026-06-07-benchmark-store-tool-summary-single-pass.md
- Registered probe: `benchmark-store-matrix-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_counts_lines_without_read_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_counts_lines_without_read_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_store.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/benchmark_store_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-store-matrix-streaming --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-benchmark-store-tool-summary-single-pass-20260607 --head-repo "$PWD" --output /tmp/benchmark-store-tool-summary-single-pass-probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 28 passed.
- Changed-scope coverage: 100.00% (7/7 measurable changed lines).
- Local registered probe `benchmark-store-matrix-streaming`:
  - base `elapsed_ms_mean=1478.052313`, head `elapsed_ms_mean=1389.294126`, delta `-88.758187 ms` (~6.00% faster).
  - base `peak_bytes_mean=179799.3`, head `peak_bytes_mean=181502.0`, delta `+1702.7 bytes` (~0.95%, within threshold).
  - row count parity: `summary_row_count=750`, `request_row_count=6000`, `request_csv_line_count=6001` for both base/head.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- This is a Python-only slice validated locally on Linux; no Swift runtime behavior is changed.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the changed path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows elapsed-time improvement with output parity.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
