### PR TITLE
perf: stream native MTP weight shard loading

### DIFF
--- a/docs/plans/2026-06-07-native-mtp-weight-load-loops.md
+++ b/docs/plans/2026-06-07-native-mtp-weight-load-loops.md
@@ -1,0 +1,33 @@
+# Native MTP weight shard load loop slice
+
+This Python-only performance slice is limited to `worker.runtime.native_mtp.mlx_lm_loader`.
+The native-MTP patched `load_model` path previously built one combined list from the
+base `model*.safetensors` paths plus sidecar MTP shard paths before loading each
+shard. Large models can have many base and sidecar shards, so this adds an
+explicit streaming helper that loads base shards and sidecar shards in two loops
+without materializing the combined path list.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.
+This slice extends that probe with weight-load-loop metrics while retaining the
+existing index JSON, top-level safetensor listing, sidecar filtering, and key
+predicate metrics. The probe has focused `test_command`, `coverage_command`, and
+`probe_command` entries and runs on `ubuntu-latest`.
+
+## Implementation plan
+
+1. Add a small helper that loads base and native-MTP sidecar weight shards without
+   building a combined path list.
+2. Route the patched native-MTP `load_model` path through the helper.
+3. Add a focused unit guard for load order and merged weight contents.
+4. Extend the registered probe output and registry metrics for weight-load-loop
+   timing and peak allocation.
+5. Run focused tests, changed-scope coverage, and the registered probe locally on
+   Linux before opening the PR.
+
+## Verification boundary
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime
+effect is claimed.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4978,8 +4978,8 @@
   },
   {
     "id": "native-mtp-loader-safetensor-scandir",
-    "name": "Native MTP loader sidecar filter fast path",
-    "description": "Filter native-MTP sidecar shard index names before Path joins while preserving index JSON byte loading and scandir shard listing guards.",
+    "name": "Native MTP loader shard load loops",
+    "description": "Load native-MTP base and sidecar shard weights without materializing a combined path list while preserving index JSON byte loading and scandir shard listing guards.",
     "watch_globs": [
       "services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py",
       "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py",
@@ -4987,8 +4987,8 @@
       "scripts/native_mtp_loader_safetensor_scandir_probe.py",
       "infra/perf/pr_scoped_probes.json"
     ],
-    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics",
-    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py",
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py",
     "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_NATIVE_MTP_LOADER_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/native_mtp_loader_safetensor_scandir_probe.py\"; for CANDIDATE in \"${MELIX_NATIVE_MTP_LOADER_PROBE_SCRIPT:-}\" \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -n \"$CANDIDATE\" ] && [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
@@ -5112,6 +5112,51 @@
         "warn_pct": 0.0
       },
       {
+        "key": "weight_load_old_mean_ms",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "weight_load_new_mean_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "weight_load_delta_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "weight_load_speedup",
+        "unit": "x",
+        "direction": "higher_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "weight_load_old_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      },
+      {
+        "key": "weight_load_new_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "weight_load_result_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "weight_load_iterations",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
         "key": "key_old_mean_ms",
         "unit": "ms",
         "direction": "informational"
@@ -5137,7 +5182,8 @@
         "unit": "count",
         "direction": "informational"
       }
-    ]
+    ],
+    "runner": "ubuntu-latest"
   },
   {
     "id": "same-cohort-batching-probe-evidence",

--- a/scripts/native_mtp_loader_safetensor_scandir_probe.py
+++ b/scripts/native_mtp_loader_safetensor_scandir_probe.py
@@ -20,6 +20,7 @@ try:
     from worker.runtime.native_mtp.mlx_lm_loader import (
         _is_mtp_weight_key,
         _load_json_payload,
+        _load_weight_shards,
         _model_safetensor_files,
         extra_mtp_safetensor_files,
     )
@@ -27,6 +28,7 @@ except ImportError:  # Base revisions before this slice do not expose the helper
     extra_mtp_safetensor_files = None
     _is_mtp_weight_key = None
     _load_json_payload = None
+    _load_weight_shards = None
     _model_safetensor_files = None
 
 
@@ -143,11 +145,67 @@ def _measure_key_predicate(
     return elapsed_ms, expected_true_count
 
 
+def _baseline_load_weight_shards(
+    load: Callable[[str], dict[str, str]],
+    weight_files: list[str],
+    extra_files: list[Path],
+) -> dict[str, str]:
+    weights: dict[str, str] = {}
+    for wf in [*weight_files, *(str(path) for path in extra_files)]:
+        weights.update(load(wf))
+    return weights
+
+
+def _candidate_load_weight_shards(
+    load: Callable[[str], dict[str, str]],
+    weight_files: list[str],
+    extra_files: list[Path],
+) -> dict[str, str]:
+    if _load_weight_shards is None:
+        return _baseline_load_weight_shards(load, weight_files, extra_files)
+    return _load_weight_shards(load, weight_files, extra_files)
+
+
+def _fake_weight_load(path: str) -> dict[str, str]:
+    return {path: path}
+
+
+def _measure_weight_loading(
+    callback: Callable[[Callable[[str], dict[str, str]], list[str], list[Path]], dict[str, str]],
+    weight_files: list[str],
+    extra_files: list[Path],
+    *,
+    samples: int,
+    iterations: int,
+) -> tuple[list[float], list[float], int]:
+    elapsed_ms: list[float] = []
+    peaks: list[float] = []
+    result_count = 0
+    expected_count = len(weight_files) + len(extra_files)
+    for _ in range(samples):
+        tracemalloc.start()
+        start = time.perf_counter()
+        try:
+            result: dict[str, str] = {}
+            for _ in range(iterations):
+                result = callback(_fake_weight_load, weight_files, extra_files)
+        finally:
+            _, peak = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+        elapsed_ms.append((time.perf_counter() - start) * 1000.0)
+        peaks.append(float(peak))
+        result_count = len(result)
+        if result_count != expected_count:
+            raise RuntimeError("candidate native-MTP weight loading differs from baseline")
+    return elapsed_ms, peaks, result_count
+
+
 def run_probe() -> dict[str, float | int | str]:
     model_files = int(os.environ.get("MELIX_NATIVE_MTP_LOADER_MODEL_FILES", "1500"))
     distractor_files = int(os.environ.get("MELIX_NATIVE_MTP_LOADER_DISTRACTOR_FILES", "1500"))
     samples = int(os.environ.get("MELIX_NATIVE_MTP_LOADER_SAMPLES", "5"))
     key_iterations = int(os.environ.get("MELIX_NATIVE_MTP_LOADER_KEY_ITERATIONS", "2500"))
+    weight_load_iterations = int(os.environ.get("MELIX_NATIVE_MTP_LOADER_WEIGHT_LOAD_ITERATIONS", "500"))
     with tempfile.TemporaryDirectory() as tmp:
         model_dir = Path(tmp) / "model"
         _populate_model_dir(
@@ -224,12 +282,28 @@ def run_probe() -> dict[str, float | int | str]:
             samples=samples,
             iterations=key_iterations,
         )
+        weight_load_old_ms, weight_load_old_peaks, weight_load_result_count = _measure_weight_loading(
+            _baseline_load_weight_shards,
+            list(candidate),
+            candidate_extra,
+            samples=samples,
+            iterations=weight_load_iterations,
+        )
+        weight_load_new_ms, weight_load_new_peaks, _ = _measure_weight_loading(
+            _candidate_load_weight_shards,
+            list(candidate),
+            candidate_extra,
+            samples=samples,
+            iterations=weight_load_iterations,
+        )
     old_mean = statistics.mean(old_ms)
     new_mean = statistics.mean(new_ms)
     extra_old_mean = statistics.mean(extra_old_ms)
     extra_new_mean = statistics.mean(extra_new_ms)
     key_old_mean = statistics.mean(key_old_ms)
     key_new_mean = statistics.mean(key_new_ms)
+    weight_load_old_mean = statistics.mean(weight_load_old_ms)
+    weight_load_new_mean = statistics.mean(weight_load_new_ms)
     model_listing_old_mean = statistics.mean(model_listing_old_ms)
     model_listing_new_mean = statistics.mean(model_listing_new_ms)
     return {
@@ -241,8 +315,16 @@ def run_probe() -> dict[str, float | int | str]:
         "duplicate_mtp_entries": distractor_files,
         "samples": samples,
         "key_iterations": key_iterations,
+        "weight_load_iterations": weight_load_iterations,
         "key_count": len(key_candidates),
         "key_true_count": key_true_count,
+        "weight_load_result_count": weight_load_result_count,
+        "weight_load_old_mean_ms": weight_load_old_mean,
+        "weight_load_new_mean_ms": weight_load_new_mean,
+        "weight_load_delta_ms": weight_load_new_mean - weight_load_old_mean,
+        "weight_load_speedup": weight_load_old_mean / weight_load_new_mean if weight_load_new_mean else 0.0,
+        "weight_load_old_peak_bytes_mean": statistics.mean(weight_load_old_peaks),
+        "weight_load_new_peak_bytes_mean": statistics.mean(weight_load_new_peaks),
         "key_old_mean_ms": key_old_mean,
         "key_new_mean_ms": key_new_mean,
         "key_delta_ms": key_new_mean - key_old_mean,

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -48,6 +48,7 @@ from worker.runtime.mlx_executor import MLXRuntimeExecutor
 from worker.runtime.native_mtp.mlx_lm_loader import (
     _is_mtp_weight_key,
     _load_json_payload,
+    _load_weight_shards,
     _model_safetensor_files,
     extra_mtp_safetensor_files,
 )
@@ -1653,6 +1654,21 @@ def test_native_mtp_extra_safetensor_files_filters_names_before_path_join(
         "mtp-00002.safetensors",
     ]
     assert basename_candidate_names == []
+
+
+def test_native_mtp_load_weight_shards_streams_base_and_extra_paths() -> None:
+    base_paths = ["model-a.safetensors", "model-b.safetensors"]
+    extra_paths = [Path("mtp-a.safetensors"), Path("nested/mtp-b.safetensors")]
+    loaded_paths: list[str] = []
+
+    def load(path: str) -> dict[str, str]:
+        loaded_paths.append(path)
+        return {path: path}
+
+    weights = _load_weight_shards(load, base_paths, extra_paths)
+
+    assert loaded_paths == [*base_paths, *(str(path) for path in extra_paths)]
+    assert weights == {path: path for path in loaded_paths}
 
 
 def test_native_mtp_patched_loader_uses_scandir_model_weight_listing(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -371,6 +371,7 @@ def test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics(
     monkeypatch.setenv("MELIX_NATIVE_MTP_LOADER_DISTRACTOR_FILES", "8")
     monkeypatch.setenv("MELIX_NATIVE_MTP_LOADER_SAMPLES", "1")
     monkeypatch.setenv("MELIX_NATIVE_MTP_LOADER_KEY_ITERATIONS", "2")
+    monkeypatch.setenv("MELIX_NATIVE_MTP_LOADER_WEIGHT_LOAD_ITERATIONS", "2")
     probe_script = runpy.run_path(
         str(REPO_ROOT / "scripts/native_mtp_loader_safetensor_scandir_probe.py")
     )
@@ -390,6 +391,10 @@ def test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics(
     assert metrics["key_count"] == 26
     assert metrics["key_true_count"] == 17
     assert metrics["key_iterations"] == 2
+    assert metrics["weight_load_iterations"] == 2
+    assert metrics["weight_load_result_count"] == 18
+    assert metrics["weight_load_old_mean_ms"] >= 0.0
+    assert metrics["weight_load_new_mean_ms"] >= 0.0
     assert metrics["key_old_mean_ms"] >= 0.0
     assert metrics["key_new_mean_ms"] >= 0.0
 

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -46,6 +46,19 @@ def _model_safetensor_files(model_path: Path) -> list[str]:
     return weight_files
 
 
+def _load_weight_shards(load: Callable[[str], dict], weight_files: list[str], extra_files: list[Path]) -> dict:
+    """Load base and native-MTP sidecar shards without combining path lists."""
+
+    weights = {}
+    weights_update = weights.update
+    to_text = str
+    for path in weight_files:
+        weights_update(load(path))
+    for path in extra_files:
+        weights_update(load(to_text(path)))
+    return weights
+
+
 def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
     index_payload = _load_json_payload(model_path / "model.safetensors.index.json")
     weight_map = index_payload.get("weight_map")
@@ -135,9 +148,7 @@ def apply() -> bool:
         if not weight_files and strict:
             raise FileNotFoundError(f"No safetensors found in {model_path}")
 
-        weights = {}
-        for wf in [*weight_files, *(str(path) for path in extra_files)]:
-            weights.update(mx.load(wf))
+        weights = _load_weight_shards(mx.load, weight_files, extra_files)
 
         if (model_file := config.get("model_file")) is not None:
             spec = importlib.util.spec_from_file_location(


### PR DESCRIPTION
## Summary
- Stream native-MTP base and sidecar safetensor shard loading through a helper instead of materializing one combined path list.
- Add a focused regression test for load order and merged weights.
- Extend the registered `native-mtp-loader-safetensor-scandir` PR-scoped probe with weight-load-loop timing/allocation metrics.

## Plan or Spec
- `docs/plans/2026-06-07-native-mtp-weight-load-loops.md`

## Commands Run
```text
git fetch origin main
# origin/main and HEAD were both 0b82a46868b5ae4bc73b2c327aad07feba227b3e before edits.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics
# 10 passed in 0.34s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && \
uv run --project services/mlx-worker-python coverage json -o coverage.json && \
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
# 8 passed in 0.31s
# changed_line_coverage=100.00%; TOTAL 10 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" \
  uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
# exited 0; see Coverage and Metrics for selected metrics

git diff --check
# exited 0
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` = 100.00% (10/10 changed measurable lines).
- Registered probe: `native-mtp-loader-safetensor-scandir` (command_json, runner `ubuntu-latest`) covers this path with focused `test_command`, `coverage_command`, and `probe_command` entries.
- Local Linux probe metrics from `scripts/native_mtp_loader_safetensor_scandir_probe.py`:
  - `weight_load_old_mean_ms=473.52857850492`
  - `weight_load_new_mean_ms=460.26636455208063`
  - `weight_load_delta_ms=-13.262213952839375`
  - `weight_load_speedup=1.0288142149291004`
  - `weight_load_old_peak_bytes_mean=286427.2`
  - `weight_load_new_peak_bytes_mean=259819.2`
  - `weight_load_result_count=3002`
- The PR-scoped performance GitHub Actions report is still required as the registered CI validation source before merge.

## Known Gaps
- Local verification is Linux/Python-only; no Swift runtime effect is claimed.
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this focused Python performance slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
