### PR TITLE
perf: fast-path numeric report phase durations

### DIFF
--- a/docs/plans/2026-06-07-report-evidence-slowest-stream.md
+++ b/docs/plans/2026-06-07-report-evidence-slowest-stream.md
@@ -1,0 +1,24 @@
+# Report Evidence Slowest Probe Phase Duration Parsing
+
+## Slice
+
+Optimize one registered Python hot path in `worker.productization.report_evidence_gate`: `_slowest_probe_phases()`.
+
+The registered `report-evidence-gate-run-kind-set-membership` probe measures `slowest_probe_phase_elapsed_ms_mean` with numeric probe durations. This slice preserves the existing top-five selection strategy while avoiding redundant `float()` conversion for duration values that are already concrete `float` objects.
+
+## Probe Coverage
+
+Registered probe: `report-evidence-gate-run-kind-set-membership`
+
+The registry entry already contains focused commands for:
+
+- tests: report evidence gate unit coverage plus PR-scoped probe selection tests
+- coverage: changed-scope coverage for `report_evidence_gate.py`
+- probe: `scripts/report_evidence_gate_run_kind_probe.py`
+
+## Acceptance
+
+- Preserve top-five ordering and tie semantics for slowest probe phases.
+- Keep the slice limited to the report evidence gate hot path, its focused test, and this plan.
+- Run focused local tests, changed-scope coverage, and the registered probe on Linux.
+- Use the registered PR-scoped performance workflow as the CI validation source before merge.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -166,6 +166,35 @@ def test_report_evidence_gate_slowest_probe_phases_keeps_top_five_order() -> Non
     assert {row["side"] for row in rows} == {"candidate"}
 
 
+def test_report_evidence_gate_slowest_probe_phases_preserves_tie_order() -> None:
+    report: dict[str, object] = {
+        "probe_summary": {
+            "baseline": {
+                "slowest_phases": [
+                    {"phase": f"baseline-{index}", "duration_ms": 10.0}
+                    for index in range(4)
+                ]
+            },
+            "candidate": {
+                "slowest_phases": [
+                    {"phase": f"candidate-{index}", "duration_ms": 10.0}
+                    for index in range(4)
+                ]
+            },
+        }
+    }
+
+    rows = report_evidence_gate_module._slowest_probe_phases(report)
+
+    assert [row["phase"] for row in rows] == [
+        "baseline-0",
+        "baseline-1",
+        "baseline-2",
+        "baseline-3",
+        "candidate-0",
+    ]
+
+
 def test_report_evidence_gate_slowest_probe_phases_accepts_typed_durations() -> None:
     report: dict[str, object] = {
         "probe_summary": {

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -443,7 +443,11 @@ def _slowest_probe_phases(report: dict[str, object]) -> list[dict[str, object]]:
             continue
         for row in dict_list(side_summary.get("slowest_phases")):
             duration = row.get("duration_ms")
-            if isinstance(duration, (float, int, str)):
+            if type(duration) is float:
+                duration_ms = duration
+            elif type(duration) is int:
+                duration_ms = float(duration)
+            elif isinstance(duration, str):
                 duration_ms = float(duration or 0.0)
             else:
                 duration_ms = 0.0


### PR DESCRIPTION
## Summary
- Fast-path `_slowest_probe_phases()` duration parsing when `duration_ms` is already a `float`, avoiding redundant conversion in the numeric probe hot path.
- Add a tie-order regression test so the top-five selection continues to preserve the existing first-seen ordering for equal durations.
- Document the slice and registered probe coverage in `docs/plans/2026-06-07-report-evidence-slowest-stream.md`.

## Plan or Spec
- Plan: `docs/plans/2026-06-07-report-evidence-slowest-stream.md`
- Registered probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- Baseline probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py`
- Focused tests: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_keeps_top_five_order services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_preserves_tie_order services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_accepts_typed_durations`
- Changed-scope coverage: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py`
- Candidate probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 3 passed.
- Registered focused/coverage test set: 22 passed.
- Changed-scope coverage: 100.00% aggregate changed-line coverage (`TOTAL 8 0 100%`).
- Baseline probe (`origin/main`, 5 samples): `elapsed_ms_mean=922.3333518020809`, `slowest_probe_phase_elapsed_ms_mean=47.872405126690865`.
- Candidate probe (5 samples): `elapsed_ms_mean=935.8043836429715`, `slowest_probe_phase_elapsed_ms_mean=38.61417267471552`.
- Targeted delta: `slowest_probe_phase_elapsed_ms_mean -9.258232451975345 ms` (~19.34% faster). Overall probe elapsed was noisy (`+13.471031840890646 ms`) because unrelated sub-metrics varied upward locally.
- The registered PR-scoped performance CI report is required before merge.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime path is changed in this slice.
- Overall local aggregate probe timing is noisy; the targeted registered sub-metric is the acceptance signal for this slice, with CI required for final validation.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally with baseline/candidate metrics.
- [ ] GitHub Actions and PR-scoped performance workflow completed successfully.
