### PR TITLE
fix: validate custom training templates

### DIFF
--- a/docs/plans/2026-06-07-issue-1528-training-template-admission.md
+++ b/docs/plans/2026-06-07-issue-1528-training-template-admission.md
@@ -1,0 +1,67 @@
+# Issue 1528 Training Template Admission Implementation Plan
+
+## Goal
+
+Add admission-time validation for custom SFT training templates so missing prompt,
+completion, or assistant-generation markers fail with typed operator errors
+before backend training starts.
+
+## Architecture
+
+The Python worker will treat custom local conversion templates as resolved
+training controls. Template validation belongs in `training_config.py` because
+`normalize_training_config` already owns typed 422-style admission failures and
+is shared by CLI, API, and desktop requests through the model-operation surface.
+The resulting receipt will be copied into the normalized dataset snapshot and
+the final adapter manifest so accepted template paths are visible with the rest
+of the resolved-control evidence.
+
+## Scope Boundaries
+
+- Include: `custom_training_template`, `training_template_receipt`,
+  `template_path`, `template_source`, `required_placeholders`,
+  `assistant_marker_policy`, and typed `invalid_training_template` failures.
+- Include: `{INPUT}` and `{OUTPUT}` placeholder validation for custom prompt
+  templates.
+- Include: assistant marker validation for response-only SFT templates.
+- Include: two-example custom templates requiring prompt, completion, and
+  assistant marker paths.
+- Exclude: replacing builtin `alpaca`, `sharegpt`, or chat template rendering.
+- Exclude: multimodal processor template transformation owned by later #1531
+  watch-log slices.
+
+## Files
+
+- Modify: `services/mlx-worker-python/worker/model_ops/training_config.py`
+  - Add a compact receipt field to `LoRATrainingConfig`.
+  - Validate custom template controls after response-only defaults resolve.
+- Modify: `services/mlx-worker-python/worker/model_ops/training_receipts.py`
+  - Add a helper that normalizes accepted template receipt fields and raises
+    typed 422-style failures for invalid custom template inputs.
+- Modify: `services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py`
+  - Copy the receipt into normalized dataset manifest overrides and adapter
+    manifests.
+- Add: `services/mlx-worker-python/tests/test_training_template_admission.py`
+  - Add service-level tests for invalid template placeholders, response-only
+    assistant markers, two-example separators, and accepted template receipts.
+  - Add helper-level tests for builtin, requested-marker, inferred-marker, and
+    marker-drift receipt behavior.
+- Modify: `docs/runbooks/phase-8-lora-adapter-workflow.md`
+  - Document the custom template ext keys and typed preflight behavior.
+
+## Test Plan
+
+1. Add failing service-level tests in `test_training_template_admission.py`.
+2. Run the new tests and verify they fail for missing validation/receipt fields.
+3. Implement the minimal receipt helper and config wiring.
+4. Re-run the focused tests.
+5. Run the broader focused LoRA receipt/admission tests.
+6. Run `git diff --check`.
+
+## Performance Probes And Metrics
+
+The new check is string-only admission work over operator-provided template
+fields and runs once per training request. The changed scope has no meaningful
+runtime performance probe beyond the existing PR-scoped worker test selection.
+Success metric: invalid templates fail before runner invocation, and accepted
+templates add stable receipt fields without changing backend execution.

--- a/docs/runbooks/phase-8-lora-adapter-workflow.md
+++ b/docs/runbooks/phase-8-lora-adapter-workflow.md
@@ -163,7 +163,9 @@ Use the following `ext` keys as the stable operator-facing inputs:
   "response_only": "true",
   "gradient_checkpointing": "false",
   "mask_prompt": "true",
-  "max_seq_length": "2048"
+  "max_seq_length": "2048",
+  "custom_training_template": "User: {INPUT}\n<|assistant|>{OUTPUT}",
+  "assistant_generation_marker": "<|assistant|>"
 }
 ```
 
@@ -225,6 +227,18 @@ Expected training behavior:
   `training_objective` overrides fail before backend execution
 - adapter receipts keep the source trace count in `dataset_sample_count` and
   record expanded trainer rows in `trainer_dataset_sample_count`
+- custom SFT training templates must pass worker admission before backend
+  execution. `custom_training_template` must include `{INPUT}` and `{OUTPUT}`.
+  Response-only templates must also include either the configured
+  `assistant_generation_marker` or a supported assistant marker such as
+  `<|assistant|>`, `<|assistant_start|>`, or
+  `<|start_header_id|>assistant<|end_header_id|>`. Requests with
+  `template_example_count=2` must include a recoverable example separator such
+  as `{EXAMPLE_SEPARATOR}` or a visible `---` separator. Invalid templates fail
+  with `invalid_training_template` and typed 422-style details before training
+  starts.
+- accepted template controls are copied into `training_template_receipt` in the
+  normalized dataset manifest and final adapter manifest.
 - Hugging Face dataset materialization is cached under `<jobs_root>/datasets/<cache-key>`
 - Melix supports `lora`, `qlora`, `dora`, `dpo`, `orpo`, and `cpt` through the same `train_lora` surface
 - `dora` records `adapter_algorithm=dora` and `dora_enabled=true` in the adapter manifest

--- a/services/mlx-worker-python/tests/test_training_template_admission.py
+++ b/services/mlx-worker-python/tests/test_training_template_admission.py
@@ -182,6 +182,9 @@ def test_train_lora_rejects_two_example_custom_template_without_separator(
     assert events[-1].failed.error.details["field"] == "template_example_separator"
     assert events[-1].failed.error.details["reason"] == "missing_two_example_separator"
     assert events[-1].failed.error.details["required_placeholders"] == "{INPUT},{OUTPUT}"
+    assert events[-1].failed.error.details["required_separators"] == (
+        "{EXAMPLE_SEPARATOR},\\n---\\n,\\n\\n---\\n\\n,\\n### Example 2"
+    )
     assert events[-1].failed.error.details["http_status"] == "422"
 
 
@@ -262,6 +265,7 @@ def test_training_template_receipt_accepts_custom_template_and_rejects_marker_dr
     assert marker_error.value.code == "invalid_training_template"
     assert marker_error.value.details["field"] == "assistant_generation_marker"
     assert marker_error.value.details["reason"] == "marker_not_found_in_template"
+    assert "required_markers" not in marker_error.value.details
     assert marker_error.value.details["http_status"] == "422"
 
 

--- a/services/mlx-worker-python/tests/test_training_template_admission.py
+++ b/services/mlx-worker-python/tests/test_training_template_admission.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from packages.protocol.python.worker.v1 import maintenance_pb2
+
+from worker.engine.maintenance_core import MaintenanceCore
+from worker.grpc_server import WorkerMaintenanceService
+from worker.model_ops.adapter_activation_pipeline import AdapterActivationPipeline
+from worker.model_ops.deterministic_lora_runner import DeterministicLoRARunner
+from worker.model_ops.errors import ModelOperationError
+from worker.model_ops.lora_training_pipeline import LoRATrainingPipeline
+from worker.model_ops.mlx_lm_runner import TrainingRequest, TrainingResult
+from worker.model_ops import training_receipts as training_receipts_module
+from worker.model_registry.catalog import WorkerModelCatalog
+from worker.registry import WorkerRegistry
+
+
+class CountingRunner(DeterministicLoRARunner):
+    def __init__(self) -> None:
+        super().__init__()
+        self.native_train_calls = 0
+
+    def train_native(self, request: TrainingRequest) -> TrainingResult:
+        self.native_train_calls += 1
+        return super().train_native(request)
+
+
+def _write_dataset_package(
+    root: Path,
+    *,
+    format: str = "chat_messages",
+    samples: list[dict],
+) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "melix-template-admission",
+                "format": format,
+                "sample_count": len(samples),
+                "version": "1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    with (root / "samples.jsonl").open("w", encoding="utf-8") as handle:
+        for sample in samples:
+            handle.write(json.dumps(sample) + "\n")
+    return root
+
+
+def _build_service(tmp_path: Path, runner: DeterministicLoRARunner) -> WorkerMaintenanceService:
+    registry = WorkerRegistry(model_catalog=WorkerModelCatalog())
+    service = WorkerMaintenanceService(registry, jobs_root=tmp_path / "model-ops")
+    service._core = MaintenanceCore(
+        registry,
+        jobs_root=tmp_path / "model-ops",
+        lora_training_pipeline=LoRATrainingPipeline(runner=runner),
+        adapter_activation_pipeline=AdapterActivationPipeline(runner=runner),
+    )
+    return service
+
+
+def _prompt_completion_dataset(tmp_path: Path, name: str) -> Path:
+    return _write_dataset_package(
+        tmp_path / name,
+        format="prompt_completion",
+        samples=[{"prompt": "Say hi.", "completion": "Hi."}],
+    )
+
+
+def _chat_dataset(tmp_path: Path, name: str) -> Path:
+    return _write_dataset_package(
+        tmp_path / name,
+        samples=[
+            {
+                "messages": [
+                    {"role": "user", "content": "Say hi."},
+                    {"role": "assistant", "content": "Hi."},
+                ]
+            }
+        ],
+    )
+
+
+def test_train_lora_rejects_custom_template_missing_input_placeholder(tmp_path: Path) -> None:
+    dataset_dir = _prompt_completion_dataset(tmp_path, "dataset-template-missing-input")
+    service = _build_service(tmp_path, DeterministicLoRARunner())
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train-template-missing-input"),
+                ext={
+                    "operation": "train_lora",
+                    "adapter_name": "melix-template-adapter",
+                    "dataset_uri": str(dataset_dir),
+                    "custom_training_template": "Assistant: {OUTPUT}",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "invalid_training_template"
+    assert events[-1].failed.error.details["field"] == "custom_training_template"
+    assert events[-1].failed.error.details["reason"] == "missing_required_placeholder"
+    assert events[-1].failed.error.details["missing_placeholders"] == "{INPUT}"
+    assert events[-1].failed.error.details["http_status"] == "422"
+
+
+def test_train_lora_rejects_response_only_custom_template_missing_assistant_marker(
+    tmp_path: Path,
+) -> None:
+    dataset_dir = _chat_dataset(tmp_path, "dataset-template-missing-marker")
+    runner = CountingRunner()
+    service = _build_service(tmp_path, runner)
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train-template-missing-marker"),
+                ext={
+                    "operation": "train_lora",
+                    "adapter_name": "melix-template-adapter",
+                    "dataset_uri": str(dataset_dir),
+                    "custom_training_template": "User: {INPUT}\nAssistant: {OUTPUT}",
+                    "response_only": "true",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert runner.native_train_calls == 0
+    assert events[-1].failed.error.code == "invalid_training_template"
+    assert events[-1].failed.error.details["field"] == "assistant_generation_marker"
+    assert events[-1].failed.error.details["reason"] == "missing_assistant_generation_marker"
+    assert (
+        events[-1].failed.error.details["required_markers"]
+        == "<|assistant|>,<|assistant_start|>,<|start_header_id|>assistant<|end_header_id|>"
+    )
+    assert events[-1].failed.error.details["http_status"] == "422"
+
+
+def test_train_lora_rejects_two_example_custom_template_without_separator(
+    tmp_path: Path,
+) -> None:
+    dataset_dir = _prompt_completion_dataset(tmp_path, "dataset-template-two-example")
+    service = _build_service(tmp_path, DeterministicLoRARunner())
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train-template-two-example"),
+                ext={
+                    "operation": "train_lora",
+                    "adapter_name": "melix-template-adapter",
+                    "dataset_uri": str(dataset_dir),
+                    "custom_training_template": (
+                        "Example 1 {INPUT} <|assistant|>{OUTPUT}\n"
+                        "Example 2 {INPUT} <|assistant|>{OUTPUT}"
+                    ),
+                    "assistant_generation_marker": "<|assistant|>",
+                    "template_example_count": "2",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "invalid_training_template"
+    assert events[-1].failed.error.details["field"] == "template_example_separator"
+    assert events[-1].failed.error.details["reason"] == "missing_two_example_separator"
+    assert events[-1].failed.error.details["required_placeholders"] == "{INPUT},{OUTPUT}"
+    assert events[-1].failed.error.details["http_status"] == "422"
+
+
+def test_train_lora_records_accepted_custom_template_receipt(tmp_path: Path) -> None:
+    dataset_dir = _prompt_completion_dataset(tmp_path, "dataset-template-accepted")
+    runner = CountingRunner()
+    service = _build_service(tmp_path, runner)
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train-template-accepted"),
+                generate_manifest=True,
+                ext={
+                    "operation": "train_lora",
+                    "adapter_name": "melix-template-adapter",
+                    "dataset_uri": str(dataset_dir),
+                    "custom_training_template": "User: {INPUT}\n<|assistant|>{OUTPUT}",
+                    "assistant_generation_marker": "<|assistant|>",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    payload = json.loads(next(event.manifest for event in events if event.HasField("manifest")).manifest_json)
+    assert runner.native_train_calls == 1
+    assert payload["training_template_receipt"] == {
+        "template_source": "request",
+        "template_path": "custom_training_template",
+        "template_kind": "custom_prompt_completion",
+        "required_placeholders": ["{INPUT}", "{OUTPUT}"],
+        "assistant_marker_policy": {
+            "required": False,
+            "marker": "<|assistant|>",
+            "source": "request",
+        },
+    }
+    normalized_manifest = json.loads(
+        Path(payload["normalized_dataset_manifest_path"]).read_text(encoding="utf-8")
+    )
+    assert normalized_manifest["training_template_receipt"] == payload["training_template_receipt"]
+
+
+def test_training_template_receipt_accepts_custom_template_and_rejects_marker_drift() -> None:
+    receipt = training_receipts_module.training_template_receipt(
+        {
+            "custom_training_template": "Prompt: {INPUT}\n<|assistant|>{OUTPUT}",
+            "assistant_generation_marker": "<|assistant|>",
+        },
+        dataset_format="prompt_completion",
+        response_only=False,
+    )
+
+    assert receipt == {
+        "template_source": "request",
+        "template_path": "custom_training_template",
+        "template_kind": "custom_prompt_completion",
+        "required_placeholders": ["{INPUT}", "{OUTPUT}"],
+        "assistant_marker_policy": {
+            "required": False,
+            "marker": "<|assistant|>",
+            "source": "request",
+        },
+    }
+
+    with pytest.raises(ModelOperationError) as marker_error:
+        training_receipts_module.training_template_receipt(
+            {
+                "custom_training_template": "Prompt: {INPUT}\nAssistant: {OUTPUT}",
+                "assistant_generation_marker": "<|assistant|>",
+            },
+            dataset_format="prompt_completion",
+            response_only=False,
+        )
+
+    assert marker_error.value.code == "invalid_training_template"
+    assert marker_error.value.details["field"] == "assistant_generation_marker"
+    assert marker_error.value.details["reason"] == "marker_not_found_in_template"
+    assert marker_error.value.details["http_status"] == "422"
+
+
+def test_training_template_receipt_accepts_inferred_marker_and_two_example_separator() -> None:
+    assert training_receipts_module.training_template_receipt(
+        {},
+        dataset_format="chat_messages",
+        response_only=False,
+    ) == {
+        "template_source": "builtin",
+        "template_path": "",
+        "template_kind": "chat_messages",
+        "required_placeholders": [],
+        "assistant_marker_policy": {
+            "required": False,
+            "marker": "",
+            "source": "builtin",
+        },
+    }
+
+    receipt = training_receipts_module.training_template_receipt(
+        {
+            "custom_training_template": (
+                "Example 1\nPrompt: {INPUT}\n<|assistant_start|>{OUTPUT}"
+                "\n{EXAMPLE_SEPARATOR}\n"
+                "Example 2\nPrompt: {INPUT}\n<|assistant_start|>{OUTPUT}"
+            ),
+            "template_example_count": "2",
+        },
+        dataset_format="prompt_completion",
+        response_only=True,
+    )
+
+    assert receipt["assistant_marker_policy"] == {
+        "required": True,
+        "marker": "<|assistant_start|>",
+        "source": "template",
+    }

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -140,6 +140,7 @@ class LoRATrainingPipeline:
         normalized_manifest_overrides: dict[str, Any] = {
             "validation_strategy": config.validation_strategy,
             "validation_sample_count": config.validation_sample_count,
+            "training_template_receipt": dict(config.training_template_receipt),
         }
         if config.validation_split:
             normalized_manifest_overrides["hf_valid_split"] = config.validation_split
@@ -294,6 +295,7 @@ class LoRATrainingPipeline:
             "grad_clip_policy": dict(config.grad_clip_policy),
             "eval_batch_size": dict(config.eval_batch_size),
             "scheduler_kwargs_omitted": dict(config.scheduler_kwargs_omitted),
+            "training_template_receipt": dict(config.training_template_receipt),
             "training_mode": config.training_mode,
             "training_objective": config.training_objective,
             "adapter_algorithm": config.adapter_algorithm,

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -27,6 +27,7 @@ from worker.model_ops.training_receipts import (
     grad_clip_policy_receipt,
     resolved_bounds_receipt,
     scheduler_kwargs_omitted_receipt,
+    training_template_receipt,
     typed_validation_details,
     format_bound_value,
 )
@@ -90,6 +91,7 @@ class LoRATrainingConfig:
     grad_clip_policy: dict[str, object] = field(default_factory=dict)
     eval_batch_size: dict[str, object] = field(default_factory=dict)
     scheduler_kwargs_omitted: dict[str, object] = field(default_factory=dict)
+    training_template_receipt: dict[str, object] = field(default_factory=dict)
     training_planner_receipt: dict[str, object] = field(default_factory=dict)
     training_objective: str = "supervised_finetuning"
     adapter_algorithm: str = "lora"
@@ -676,6 +678,11 @@ def normalize_training_config(
         ),
     )
     scheduler_kwargs_omitted = scheduler_kwargs_omitted_receipt(ext)
+    resolved_training_template_receipt = training_template_receipt(
+        ext,
+        dataset_format=dataset_format,
+        response_only=response_only,
+    )
     training_planner_receipt = build_training_planner_receipt(
         source_model=source_model,
         ext=ext,
@@ -748,6 +755,7 @@ def normalize_training_config(
         grad_clip_policy=grad_clip_policy,
         eval_batch_size=eval_batch_size,
         scheduler_kwargs_omitted=scheduler_kwargs_omitted,
+        training_template_receipt=resolved_training_template_receipt,
         training_planner_receipt=training_planner_receipt,
         training_objective=mode_contract["training_objective"],
         adapter_algorithm=adapter_record.adapter_algorithm,

--- a/services/mlx-worker-python/worker/model_ops/training_receipts.py
+++ b/services/mlx-worker-python/worker/model_ops/training_receipts.py
@@ -312,6 +312,143 @@ def scheduler_kwargs_omitted_receipt(ext: dict[str, str]) -> dict[str, object]:
     }
 
 
+_INPUT_PLACEHOLDER = "{INPUT}"
+_OUTPUT_PLACEHOLDER = "{OUTPUT}"
+_ASSISTANT_MARKERS = (
+    "<|assistant|>",
+    "<|assistant_start|>",
+    "<|start_header_id|>assistant<|end_header_id|>",
+)
+_TWO_EXAMPLE_SEPARATORS = (
+    "{EXAMPLE_SEPARATOR}",
+    "\n---\n",
+    "\n\n---\n\n",
+    "\n### Example 2",
+)
+
+
+def training_template_receipt(
+    ext: dict[str, str],
+    *,
+    dataset_format: str,
+    response_only: bool,
+) -> dict[str, object]:
+    template = ext.get("custom_training_template", "").strip()
+    if not template:
+        return {
+            "template_source": "builtin",
+            "template_path": "",
+            "template_kind": dataset_format,
+            "required_placeholders": [],
+            "assistant_marker_policy": {
+                "required": False,
+                "marker": "",
+                "source": "builtin",
+            },
+        }
+
+    missing_placeholders = [
+        placeholder
+        for placeholder in (_INPUT_PLACEHOLDER, _OUTPUT_PLACEHOLDER)
+        if placeholder not in template
+    ]
+    if missing_placeholders:
+        _raise_invalid_training_template(
+            field="custom_training_template",
+            reason="missing_required_placeholder",
+            received=template,
+            details={
+                "required_placeholders": ",".join((_INPUT_PLACEHOLDER, _OUTPUT_PLACEHOLDER)),
+                "missing_placeholders": ",".join(missing_placeholders),
+            },
+        )
+
+    marker = _resolve_assistant_marker(ext, template)
+    marker_required = response_only
+    if marker_required and not marker:
+        _raise_invalid_training_template(
+            field="assistant_generation_marker",
+            reason="missing_assistant_generation_marker",
+            received=template,
+            details={
+                "required_markers": ",".join(_ASSISTANT_MARKERS),
+            },
+        )
+    _validate_two_example_template(ext, template)
+
+    return {
+        "template_source": "request",
+        "template_path": "custom_training_template",
+        "template_kind": "custom_prompt_completion",
+        "required_placeholders": [_INPUT_PLACEHOLDER, _OUTPUT_PLACEHOLDER],
+        "assistant_marker_policy": {
+            "required": marker_required,
+            "marker": marker,
+            "source": "request" if ext.get("assistant_generation_marker", "").strip() else (
+                "template" if marker else ""
+            ),
+        },
+    }
+
+
+def _validate_two_example_template(ext: dict[str, str], template: str) -> None:
+    raw_example_count = ext.get("template_example_count", "").strip()
+    if raw_example_count != "2":
+        return
+    if any(separator in template for separator in _TWO_EXAMPLE_SEPARATORS):
+        return
+    _raise_invalid_training_template(
+        field="template_example_separator",
+        reason="missing_two_example_separator",
+        received=template,
+        details={
+            "required_placeholders": ",".join((_INPUT_PLACEHOLDER, _OUTPUT_PLACEHOLDER)),
+            "required_separators": ",".join(_TWO_EXAMPLE_SEPARATORS),
+        },
+    )
+
+
+def _resolve_assistant_marker(ext: dict[str, str], template: str) -> str:
+    requested_marker = ext.get("assistant_generation_marker", "").strip()
+    if requested_marker:
+        if requested_marker not in template:
+            _raise_invalid_training_template(
+                field="assistant_generation_marker",
+                reason="marker_not_found_in_template",
+                received=requested_marker,
+                details={
+                    "required_markers": ",".join(_ASSISTANT_MARKERS),
+                },
+            )
+        return requested_marker
+    for marker in _ASSISTANT_MARKERS:
+        if marker in template:
+            return marker
+    return ""
+
+
+def _raise_invalid_training_template(
+    *,
+    field: str,
+    reason: str,
+    received: str,
+    details: dict[str, str],
+) -> None:
+    from worker.model_ops.errors import ModelOperationError
+
+    raise ModelOperationError(
+        code="invalid_training_template",
+        message=f"Invalid training template: {reason}.",
+        details={
+            "field": field,
+            "reason": reason,
+            "received": received,
+            "http_status": "422",
+            **details,
+        },
+    )
+
+
 def capability_gate_receipt(
     *,
     config: Any,

--- a/services/mlx-worker-python/worker/model_ops/training_receipts.py
+++ b/services/mlx-worker-python/worker/model_ops/training_receipts.py
@@ -403,7 +403,9 @@ def _validate_two_example_template(ext: dict[str, str], template: str) -> None:
         received=template,
         details={
             "required_placeholders": ",".join((_INPUT_PLACEHOLDER, _OUTPUT_PLACEHOLDER)),
-            "required_separators": ",".join(_TWO_EXAMPLE_SEPARATORS),
+            "required_separators": ",".join(
+                separator.replace("\n", "\\n") for separator in _TWO_EXAMPLE_SEPARATORS
+            ),
         },
     )
 
@@ -416,9 +418,7 @@ def _resolve_assistant_marker(ext: dict[str, str], template: str) -> str:
                 field="assistant_generation_marker",
                 reason="marker_not_found_in_template",
                 received=requested_marker,
-                details={
-                    "required_markers": ",".join(_ASSISTANT_MARKERS),
-                },
+                details={},
             )
         return requested_marker
     for marker in _ASSISTANT_MARKERS:


### PR DESCRIPTION
## Summary
- Add worker admission validation for custom SFT training templates before backend LoRA training starts.
- Record accepted custom template controls in `training_template_receipt` on normalized dataset and adapter manifests.
- Document custom template ext keys and typed `invalid_training_template` failures in the Phase 8 LoRA runbook.

## Plan or Spec
- `docs/plans/2026-06-07-issue-1528-training-template-admission.md`
- Follow-up slice for #1528.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_training_template_admission.py
# 6 passed in 0.33s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_training_template_admission.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o .runtime/template-admission-post-merge-coverage.json
python3 scripts/changed_scope_coverage.py equivalent against origin/main...HEAD
# TOTAL 129 0 100%

git diff --check
# exit 0

make py-test
# 3630 passed, 14 skipped, 2 warnings in 192.54s (0:03:12)

git commit -m "fix: validate custom training templates"
# pre-commit hook ran make swift-test, make py-test, make integration-test, and PR-scoped performance report
# make swift-test: completed rc=0 elapsed=723.4s
# make py-test: 3630 passed, 14 skipped, 2 warnings in 170.80s (0:02:50)
# make integration-test: 117 passed, 1 skipped in 792.65s (0:13:12)
# PR-scoped performance report: Status ok, regressions 0, context regressions 0, verification failures 0

git merge origin/main --no-edit
# exit 0, no conflicts

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_training_template_admission.py
# 6 passed in 0.53s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report
root = Path.cwd()
changed = subprocess.check_output(['git', 'diff', '--name-only', 'origin/main...HEAD'], text=True).splitlines()
outcome = run_performance_report(root, changed, base_ref='origin/main')
print({'status': outcome.status, 'report_dir': str(outcome.report_dir), 'selected_probe_count': outcome.selected_probe_count})
raise SystemExit(0 if outcome.status == 'ok' else 1)
PY
# {'status': 'ok', 'report_dir': '.runtime/pre-commit-performance/20260607-122655-624596a1/report', 'selected_probe_count': 2}
```

## Coverage and Metrics
- Changed-scope coverage after merging latest `origin/main`: `TOTAL 129 0 100%`.
- PR-scoped performance report after merging latest `origin/main`: `.runtime/pre-commit-performance/20260607-122655-624596a1/report/report.md`.
- Performance status: `ok`; selected probes: 2; regressions: 0; context regressions: 0; verification failures: 0.
- Observability mode: `off` for runtime telemetry changes; this adds manifest receipt evidence only. Probe overhead: `N/A`, no new runtime probe or debug instrumentation was added.

## Known Gaps
- Does not implement #1531 multimodal processor training-template transformations.
- Does not replace builtin Alpaca, ShareGPT, or chat template rendering.
- No live MLX training run was executed; service-level deterministic LoRA runner coverage verifies admission and manifest behavior.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
