### PR TITLE
perf: fast-path trajectory manifest strings

### DIFF
--- a/docs/plans/2026-06-07-trajectory-manifest-string-fastpath.md
+++ b/docs/plans/2026-06-07-trajectory-manifest-string-fastpath.md
@@ -1,0 +1,33 @@
+# Trajectory Manifest String Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.trajectory_provenance._trajectory_provenance_from_snapshot_manifest()` and its JSON-load caller. The slice keeps the manifest provenance contract unchanged while reducing repeated `str(...).strip()` work for the common normalized manifest case where string fields are already plain, non-empty, and whitespace-free.
+
+## Registered Probe
+
+The affected path is covered by the existing registered PR-scoped probe `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`. That probe already declares focused `test_command`, `coverage_command`, and `probe_command` entries, and watches:
+
+- `services/mlx-worker-python/worker/trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/trajectory_manifest_json_load_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Plan
+
+1. Add a narrow regression assertion that whitespace-padded manifest strings are still trimmed.
+2. Introduce a small string normalization fast path that returns already-clean exact `str` values without allocating a stripped copy.
+3. Use the helper only inside snapshot manifest provenance extraction and keep nested provenance copy behavior unchanged.
+4. Run focused pytest, changed-scope coverage, and the registered probe locally on Linux.
+5. Use GitHub Actions plus the registered PR-scoped performance report as the merge gate.
+
+## Metrics
+
+Local Linux verification uses the registered command-json probe:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/trajectory_manifest_json_load_probe.py"; if [ -f "$SCRIPT" ]; then python3 "$SCRIPT"; else for CANDIDATE in "../head/$SCRIPT" "${GITHUB_WORKSPACE:-}/head/$SCRIPT"; do if [ -f "$CANDIDATE" ]; then python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2; fi'
+```
+
+CI remains the authoritative base-vs-head validation source for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -240,6 +240,33 @@ def test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes(
     }
 
 
+def test_load_trajectory_provenance_from_snapshot_manifest_trims_string_fields(
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_bytes(
+        json.dumps(
+            {
+                "format": " agentic_tool_trace ",
+                "source_dataset_id": " agentic-snapshot ",
+                "version": " 2026-05-25 ",
+                "trajectory_schema_version": " melix.agentic_tool_trace.v1 ",
+                "trajectory_split": " train ",
+                "trajectory_trace_digest": " abc123 ",
+            }
+        ).encode("utf-8")
+    )
+
+    assert load_trajectory_provenance_from_snapshot_manifest(manifest_path) == {
+        "trajectory_dataset_id": "agentic-snapshot",
+        "trajectory_dataset_version": "2026-05-25",
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "trajectory_snapshot_manifest_path": str(manifest_path),
+        "trajectory_split": "train",
+        "trajectory_trace_digest": "abc123",
+    }
+
+
 def test_load_trajectory_provenance_from_snapshot_manifest_accepts_dict_subclass(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -296,6 +323,32 @@ def test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs(
     ) == {
         "trajectory_schema_version": "melix.agentic_tool_trace.v1",
         "trajectory_split": "train",
+        "trajectory_trace_digest": "abc123",
+    }
+    assert trajectory_provenance_from_snapshot_manifest(
+        {
+            "format": 0,
+            "trajectory_trace_digest": 123,
+        }
+    ) == {
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "trajectory_split": "train",
+        "trajectory_trace_digest": "123",
+    }
+    assert trajectory_provenance_from_snapshot_manifest(
+        {
+            "format": "agentic_tool_trace",
+            "source_dataset_id": 123,
+            "version": 456,
+            "trajectory_schema_version": 789,
+            "trajectory_split": 10,
+            "trajectory_trace_digest": "abc123",
+        }
+    ) == {
+        "trajectory_dataset_id": "123",
+        "trajectory_dataset_version": "456",
+        "trajectory_schema_version": "789",
+        "trajectory_split": "10",
         "trajectory_trace_digest": "abc123",
     }
     assert (

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -111,30 +111,76 @@ def _trajectory_provenance_from_snapshot_manifest(
 ) -> dict[str, Any]:
     manifest_get = manifest.get
     to_str = _STR
-    if (
-        to_str(manifest_get("format", "")).strip() != "agentic_tool_trace"
-        and not to_str(manifest_get("trajectory_trace_digest", "")).strip()
-    ):
-        return {}
+    format_value = manifest_get("format", "")
+    if format_value != "agentic_tool_trace":
+        if (
+            to_str(format_value).strip() != "agentic_tool_trace"
+            and not to_str(manifest_get("trajectory_trace_digest", "")).strip()
+        ):
+            return {}
 
     provenance: dict[str, Any] = {}
-    dataset_id = to_str(
-        manifest_get("source_dataset_id") or manifest_get("dataset_id") or ""
-    ).strip()
+    dataset_id_value = manifest_get("source_dataset_id") or manifest_get("dataset_id") or ""
+    if type(dataset_id_value) is str:
+        dataset_id = (
+            dataset_id_value
+            if dataset_id_value
+            and dataset_id_value[0] > " "
+            and dataset_id_value[-1] > " "
+            else dataset_id_value.strip()
+        )
+    else:
+        dataset_id = to_str(dataset_id_value).strip()
     if dataset_id:
         provenance["trajectory_dataset_id"] = dataset_id
-    dataset_version = to_str(manifest_get("version") or "").strip()
+    dataset_version_value = manifest_get("version") or ""
+    if type(dataset_version_value) is str:
+        dataset_version = (
+            dataset_version_value
+            if dataset_version_value
+            and dataset_version_value[0] > " "
+            and dataset_version_value[-1] > " "
+            else dataset_version_value.strip()
+        )
+    else:
+        dataset_version = to_str(dataset_version_value).strip()
     if dataset_version:
         provenance["trajectory_dataset_version"] = dataset_version
-    schema_version = to_str(
-        manifest_get("trajectory_schema_version") or "melix.agentic_tool_trace.v1"
-    ).strip()
+    schema_version_value = manifest_get("trajectory_schema_version") or "melix.agentic_tool_trace.v1"
+    if type(schema_version_value) is str:
+        schema_version = (
+            schema_version_value
+            if schema_version_value
+            and schema_version_value[0] > " "
+            and schema_version_value[-1] > " "
+            else schema_version_value.strip()
+        )
+    else:
+        schema_version = to_str(schema_version_value).strip()
     if schema_version:
         provenance["trajectory_schema_version"] = schema_version
-    split = to_str(manifest_get("trajectory_split") or "train").strip()
+    split_value = manifest_get("trajectory_split") or "train"
+    if type(split_value) is str:
+        split = (
+            split_value
+            if split_value and split_value[0] > " " and split_value[-1] > " "
+            else split_value.strip()
+        )
+    else:
+        split = to_str(split_value).strip()
     if split:
         provenance["trajectory_split"] = split
-    trace_digest = to_str(manifest_get("trajectory_trace_digest") or "").strip()
+    trace_digest_value = manifest_get("trajectory_trace_digest") or ""
+    if type(trace_digest_value) is str:
+        trace_digest = (
+            trace_digest_value
+            if trace_digest_value
+            and trace_digest_value[0] > " "
+            and trace_digest_value[-1] > " "
+            else trace_digest_value.strip()
+        )
+    else:
+        trace_digest = to_str(trace_digest_value).strip()
     if trace_digest:
         provenance["trajectory_trace_digest"] = trace_digest
     if snapshot_manifest_path is not None:


### PR DESCRIPTION
## Summary
- Fast-path already-clean `agentic_tool_trace` manifest format strings before falling back to trimmed coercion.
- Avoid `str(...).strip()` on common normalized string manifest fields while preserving whitespace trimming and non-string coercion behavior.
- Add regression coverage for padded strings and non-string manifest values.

## Plan or Spec
- Updated `docs/plans/2026-06-07-trajectory-manifest-string-fastpath.md` with the slice scope, registered probe, and validation plan.
- Registered probe coverage: `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json` already has focused `test_command`, `coverage_command`, and `probe_command` entries for this path.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_trims_string_fields services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_accepts_dict_subclass services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py`
- Base comparison from `origin/main`: same probe with `MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_SAMPLES=9`.
- Head comparison: same probe with `MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_SAMPLES=9`.
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `9 passed`.
- Changed-scope coverage: `TOTAL 24 0 100%` for `services/mlx-worker-python/worker/trajectory_provenance.py`.
- Registered local probe (head, 5 samples): `old_mean_ms=1397.7142956107855`, `new_mean_ms=711.8989295326173`, `delta_ms=-685.8153660781682`, `speedup=1.9633605805931273`, `new_peak_bytes_mean=49580.0`.
- Local base-vs-head smoke using 9-sample registered probe output:
  - base `origin/main`: `new_mean_ms=703.3416212846836`, `speedup=1.9965480102801463`
  - head: `new_mean_ms=695.0790244154632`, `speedup=2.0293400431927973`
  - local head delta vs base: `-8.262596869220375 ms` (`~1.17%` lower)
- CI PR-scoped performance report is required as the authoritative registered probe validation before merge.

## Known Gaps
- This is a Python-only slice verified locally on Linux; no Swift runtime effects are claimed.
- Local timing is synthetic and can be noisy, so merge is gated on the registered PR-scoped performance workflow.

## Evidence Checklist
- [x] Main synced from `origin/main` before branch creation.
- [x] Affected path has registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
