### PR TITLE
perf: reuse report evidence run-kind set

### DIFF
--- a/docs/plans/2026-06-07-report-evidence-run-kind-set.md
+++ b/docs/plans/2026-06-07-report-evidence-run-kind-set.md
@@ -1,0 +1,28 @@
+# Report Evidence Gate Run-Kind Set Reuse
+
+## Summary
+
+This Python performance slice narrows the report evidence gate release-matrix
+role lookup. Run-kind-only matrix rules now reuse one normalized set of observed
+report run kinds instead of scanning the same `runs` rows once per role.
+
+## Scope
+
+- Affected production path: `services/mlx-worker-python/worker/productization/report_evidence_gate.py`
+- Focused tests: `services/mlx-worker-python/tests/test_report_evidence_gate.py`
+- Registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership`
+
+## Probe Contract
+
+The registered probe already covers the affected path in
+`infra/perf/pr_scoped_probes.json` and includes focused `test_command`,
+`coverage_command`, and `probe_command` entries. This slice uses the existing
+probe because it measures `_report_matrix_roles()` and `_rule_matches_report()`
+with large synthetic run-kind, metric-prefix, target-field, release-matrix, and
+slowest-phase inputs.
+
+## Verification Plan
+
+Run the registered focused pytest command, changed-scope coverage command, and
+probe locally on Linux before pushing. The GitHub PR-scoped performance workflow
+remains the merge gate and must complete successfully before squash merge.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -556,6 +556,36 @@ def test_report_matrix_roles_skip_probe_phase_scan_without_phase_rules(
     assert roles == ["serving"]
 
 
+def test_report_matrix_roles_reuses_run_kind_value_set_for_run_kind_only_rules(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+    original_report_run_kind_values = report_evidence_gate_module._report_run_kind_values
+
+    def count_report_run_kind_values(runs: list[dict[str, object]]) -> frozenset[str]:
+        nonlocal calls
+        calls += 1
+        return original_report_run_kind_values(runs)
+
+    monkeypatch.setattr(
+        report_evidence_gate_module,
+        "_report_run_kind_values",
+        count_report_run_kind_values,
+    )
+
+    roles = report_evidence_gate_module._report_matrix_roles(
+        {"runs": [{"run_kind": 42}, {"run_kind": "serving_benchmark"}]},
+        {
+            "serving": {"run_kinds": ("serving_benchmark",)},
+            "numeric": {"run_kinds": ("42",)},
+            "missing": {"run_kinds": ("evaluation",)},
+        },
+    )
+
+    assert roles == ["serving", "numeric"]
+    assert calls == 1
+
+
 def test_report_matrix_roles_scans_probe_phases_once_for_phase_rules(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -289,8 +289,15 @@ def _report_matrix_roles(
     runs = _dict_list(report.get("runs"))
     targets = _dict_list(report.get("targets"))
     metrics = _dict_list(report.get("metrics"))
+    run_kind_values: frozenset[str] | None = None
     probe_phases: set[str] | None = None
     for role, rule in matrix.items():
+        if _run_kind_only_rule(rule):
+            if run_kind_values is None:
+                run_kind_values = _report_run_kind_values(runs)
+            if _string_frozenset(rule.get("run_kinds", ())) & run_kind_values:
+                roles.append(role)
+            continue
         if rule.get("probe_phases") and probe_phases is None:
             probe_phases = _probe_phases(report)
         if _rule_matches_report(
@@ -302,6 +309,19 @@ def _report_matrix_roles(
         ):
             roles.append(role)
     return roles
+
+
+def _run_kind_only_rule(rule: dict[str, object]) -> bool:
+    return bool(rule.get("run_kinds")) and not (
+        rule.get("metric_prefixes")
+        or rule.get("target_fields")
+        or rule.get("probe_phases")
+    )
+
+
+def _report_run_kind_values(runs: list[dict[str, object]]) -> frozenset[str]:
+    run_kind_key = "run_kind"
+    return frozenset(str(run.get(run_kind_key, "")) for run in runs)
 
 
 def _rule_matches_report(


### PR DESCRIPTION
## Summary
- Reuse a single normalized report run-kind set across run-kind-only release-matrix rules in `report_evidence_gate`.
- Add a regression test proving the run-kind value set is built once while preserving stringified non-string run-kind matching.
- Document the slice and registered probe contract under `docs/plans/2026-06-07-report-evidence-run-kind-set.md`.

## Plan or Spec
- `docs/plans/2026-06-07-report-evidence-run-kind-set.md`
- Registered probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py` (baseline before patch)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_matrix_roles_reuses_run_kind_value_set_for_run_kind_only_rules`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py` (candidate after patch)
- Registered focused pytest command for `report-evidence-gate-run-kind-set-membership`: 22 tests passed.
- Registered changed-scope coverage command for `report-evidence-gate-run-kind-set-membership`: TOTAL 22 0 100%.
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100.00% (22/22 measurable changed lines).
- Local registered probe metric of interest: `matrix_roles_elapsed_ms_mean` improved from `9.592215` ms to `5.179034` ms (`-4.413182` ms, `1.852125x`, `46.01%`).
- Full local probe elapsed mean changed from `917.390201` ms to `911.319403` ms.
- CI PR-scoped performance workflow is required as the final registered probe validation source before merge.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime effect is claimed for this slice.
- Probe timings are synthetic and can be noisy, so the PR-scoped performance CI report remains the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% for touched Python lines.
- [x] Local registered probe shows a clear improvement for the targeted metric.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
