### PR TITLE
perf: fast path hub cursor decoding

### DIFF
--- a/docs/plans/2026-06-07-hub-catalog-next-cursor-query-boundary.md
+++ b/docs/plans/2026-06-07-hub-catalog-next-cursor-query-boundary.md
@@ -1,0 +1,24 @@
+# Hub catalog next-cursor query-boundary slice
+
+This Python-only performance slice is limited to `worker.model_ops.hub_catalog._next_cursor_from_link(...)`.
+
+## Scope
+
+The hub catalog scans Hugging Face `Link` headers to extract the `rel="next"` cursor without importing `urlparse`/`parse_qs`. The current implementation first finds the next-link URL bounds and then calls the generic `_cursor_query_value(...)` helper, which performs a second query-marker scan from the start of that URL.
+
+This slice preserves the existing header parsing behavior while reusing the already-known next-link URL boundary to locate the query marker once and parse the `cursor` value directly inside `_next_cursor_from_link(...)`. It also adds an ASCII percent-decoding fast path for the cursor values emitted by the Hub pagination API while retaining the existing `urllib.parse.unquote_plus(...)` fallback for non-ASCII percent escapes.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `hub-catalog-next-cursor-fast-parse` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_next_cursor_probe.py`
+
+The probe reports `elapsed_ms_mean`, `cursor_parse_calls_mean`, and `peak_bytes_mean` for repeated encoded cursor extraction.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage command, and local registered probe on Linux before opening the PR. CI remains the merge gate for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -571,6 +571,14 @@ def test_next_cursor_from_link_accepts_cursor_at_query_start() -> None:
     assert hub_catalog_module._next_cursor_from_link(link_header) == "page/start"
 
 
+def test_next_cursor_from_link_preserves_utf8_and_malformed_percent_decoding() -> None:
+    unicode_header = '<https://huggingface.co/api/models?cursor=page%E2%9C%93+ok>; rel="next"'
+    malformed_header = '<https://huggingface.co/api/models?cursor=page%ZZ+ok>; rel="next"'
+
+    assert hub_catalog_module._next_cursor_from_link(unicode_header) == "page✓ ok"
+    assert hub_catalog_module._next_cursor_from_link(malformed_header) == "page%ZZ ok"
+
+
 def test_next_cursor_from_link_ignores_rel_marker_inside_previous_url() -> None:
     link_header = (
         '<https://huggingface.co/api/models?cursor=prev&note=rel%3D%22next%22>; rel="prev", '

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -27,6 +27,30 @@ _SIZE_HINT_MULTIPLIERS = {
 _BARE_SIZE_HINT_RE = re.compile(r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _EXPLICIT_SIZE_HINT_RE = re.compile(r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _NEXT_LINK_REL_MARKER = 'rel="next"'
+_URL_HEX_DIGITS = {
+    "0": 0,
+    "1": 1,
+    "2": 2,
+    "3": 3,
+    "4": 4,
+    "5": 5,
+    "6": 6,
+    "7": 7,
+    "8": 8,
+    "9": 9,
+    "a": 10,
+    "b": 11,
+    "c": 12,
+    "d": 13,
+    "e": 14,
+    "f": 15,
+    "A": 10,
+    "B": 11,
+    "C": 12,
+    "D": 13,
+    "E": 14,
+    "F": 15,
+}
 _LOWERCASE_WEIGHT_OR_CONFIG_SUFFIXES = (".safetensors", ".npz", ".gguf", "config.json", "tokenizer.json")
 @dataclass(frozen=True, slots=True)
 class HubModelSummaryRecord:
@@ -288,7 +312,24 @@ def _next_cursor_from_link(link_header: str) -> str:
         if url_start < 0:
             search_start = relation_start + marker_len
             continue
-        return _cursor_query_value(link_header, url_start + 1, url_end)
+        query_start = link_header.rfind("?", url_start + 1, url_end)
+        if query_start < 0:
+            return ""
+        query_end = link_header.find("#", query_start + 1, url_end)
+        if query_end < 0:
+            query_end = url_end
+        value_start = query_start + 1
+        if link_header.startswith("cursor=", value_start, query_end):
+            value_start += len("cursor=")
+        else:
+            cursor_start = link_header.find("&cursor=", value_start, query_end)
+            if cursor_start < 0:
+                return ""
+            value_start = cursor_start + len("&cursor=")
+        value_end = link_header.find("&", value_start, query_end)
+        if value_end < 0:
+            value_end = query_end
+        return _unquote_plus_ascii_cursor(link_header[value_start:value_end])
 
 
 def _cursor_query_value(url: str, start: int, end: int) -> str:
@@ -311,7 +352,36 @@ def _cursor_query_value(url: str, start: int, end: int) -> str:
     value_end = url.find("&", value_start, query_end)
     if value_end < 0:
         value_end = query_end
-    return unquote_plus(url[value_start:value_end])
+    return _unquote_plus_ascii_cursor(url[value_start:value_end])
+
+
+def _unquote_plus_ascii_cursor(value: str) -> str:
+    if "%" not in value and "+" not in value:
+        return value
+    hex_digits = _URL_HEX_DIGITS
+    output: list[str] = []
+    append = output.append
+    index = 0
+    value_len = len(value)
+    while index < value_len:
+        char = value[index]
+        if char == "+":
+            append(" ")
+            index += 1
+            continue
+        if char == "%" and index + 2 < value_len:
+            high = hex_digits.get(value[index + 1])
+            low = hex_digits.get(value[index + 2])
+            if high is not None and low is not None:
+                codepoint = (high << 4) + low
+                if codepoint > 0x7F:
+                    return unquote_plus(value)
+                append(chr(codepoint))
+                index += 3
+                continue
+        append(char)
+        index += 1
+    return "".join(output)
 
 
 def _string(value: Any) -> str:


### PR DESCRIPTION
## Summary
- Fast-path Hub next-cursor parsing by reusing the known next-link URL query boundary.
- Add an ASCII `%xx`/`+` decoding fast path for Hub cursor tokens while retaining `unquote_plus` fallback for UTF-8/non-ASCII escapes.
- Document the Python-only slice and registered probe coverage.

## Plan or Spec
- `docs/plans/2026-06-07-hub-catalog-next-cursor-query-boundary.md`
- Registered PR-scoped probe: `hub-catalog-next-cursor-fast-parse` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_next_cursor_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_next_cursor_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-next-cursor-fast-parse --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/hub_cursor_probe_compare.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 71 passed.
- Changed-scope coverage: TOTAL 51 measurable changed lines, 49 covered, 2 missed, 96%.
- Local registered probe: `elapsed_ms_mean=707.9049405641854`, `peak_bytes_mean=832.0`, `cursor_parse_calls_mean=50000.0`.
- Local base-vs-head registered probe: base `elapsed_ms_mean=1351.0672487318516`, head `elapsed_ms_mean=699.1259171627462`, delta `-651.9413315691054 ms` (`-48.25%`); base `peak_bytes_mean=10987.2`, head `peak_bytes_mean=832.0`, delta `-10155.2 bytes` (`-92.43%`).

## Known Gaps
- Python-only slice validated locally on Linux; no Swift runtime effect is claimed.
- PR-scoped performance CI remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Registered PR-scoped probe exists and includes focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage measured above 95%.
- [x] Local registered probe and base-vs-head registered probe showed improvement.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
