### PR TITLE
perf: bind startup version part parser

### DIFF
--- a/docs/plans/2026-06-07-startup-version-nextpart-binding.md
+++ b/docs/plans/2026-06-07-startup-version-nextpart-binding.md
@@ -1,0 +1,35 @@
+# Startup Version Part Parser Binding Slice
+
+## Scope
+
+This Python-only performance slice is limited to `worker.productization.startup_signals.compare_versions()`.
+The function already streams normalized version parts without materializing lists; this slice keeps that
+behavior and binds the normalized-part parser once before the comparison loop so repeated non-equivalent
+version comparisons avoid repeated global lookups.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`startup-signals-version-compare-single-pass` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/startup_signals.py`
+- `services/mlx-worker-python/tests/test_startup_signals.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/startup_signals_version_probe.py`
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage command, and local registered probe on Linux before
+opening the PR. GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.
+
+## Expected metrics
+
+The primary metric is `elapsed_ms_mean` from `scripts/startup_signals_version_probe.py` and should move lower
+or remain within the probe threshold. `peak_bytes_mean`, `comparison_total`, and the update-result allocation
+metrics should remain behavior/parity guards.
+
+## Linux boundary
+
+This is pure Python worker/productization code and is locally verifiable on Linux. No Swift runtime effect is
+claimed for this slice.

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -156,9 +156,10 @@ def compare_versions(left: str, right: str) -> int:
             return 0
         if right_index and right_length == left_length + 1 and right_cleaned.startswith(left_cleaned, 1):
             return 0
+    next_normalized_version_part = _next_normalized_version_part
     while True:
-        left_value, left_index, left_done = _next_normalized_version_part(left_cleaned, left_index)
-        right_value, right_index, right_done = _next_normalized_version_part(right_cleaned, right_index)
+        left_value, left_index, left_done = next_normalized_version_part(left_cleaned, left_index)
+        right_value, right_index, right_done = next_normalized_version_part(right_cleaned, right_index)
         if left_done and right_done:
             return 0
         if left_value < right_value:


### PR DESCRIPTION
## Summary
- Bind `compare_versions()` to the normalized version-part parser once before the streaming comparison loop.
- Keep version comparison behavior unchanged while reducing repeated global lookup work in non-equivalent version comparisons.

## Plan or Spec
- `docs/plans/2026-06-07-startup-version-nextpart-binding.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_does_not_allocate_streaming_part_generators services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_raw_values_skip_normalization services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_clean_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_v_prefix_equivalent_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_raw_v_prefix_equivalent_values_skip_stripping services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics
# 11 passed in 2.75s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_does_not_allocate_streaming_part_generators services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_raw_values_skip_normalization services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_clean_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_v_prefix_equivalent_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_raw_v_prefix_equivalent_values_skip_stripping services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_version_probe.py
# 11 passed in 3.96s; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_version_probe.py
# {"elapsed_ms_mean": 12.919563334435225, ...}
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Registered local probe: `startup-signals-version-compare-single-pass` via `scripts/startup_signals_version_probe.py`.
- Baseline probe repeat (`origin/main`, n=3): `elapsed_ms_mean` mean `13.26784657846604` ms.
- Head probe repeat (n=3): `elapsed_ms_mean` mean `13.035365380346775` ms.
- Delta: `-0.23248119811926493` ms (`~1.75%` lower).
- Behavior guard: `comparison_total=-32.0`, `peak_bytes_mean=112.0` remained stable in local probe output.
- CI is required for final registered PR-scoped performance validation.

## Known Gaps
- No Swift runtime effect is claimed; this is a Linux-verifiable Python-only slice.
- Local measurements are micro-probe samples and may vary; the GitHub PR-scoped performance report remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
