### PR TITLE
perf: use manual response boundary slots

### DIFF
--- a/docs/plans/2026-06-07-response-boundary-manual-slots.md
+++ b/docs/plans/2026-06-07-response-boundary-manual-slots.md
@@ -1,0 +1,46 @@
+# Response Boundary Manual Slots Slice
+
+## Scope
+
+This Python-only performance slice is limited to `ResponseOnlyBoundary` record
+construction in `worker.model_ops.response_only_boundary`. The goal is to keep
+the response-only boundary record slotted and immutable while trimming the
+per-record dataclass construction overhead in large dataset summarization probes.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`response-only-boundary-slotted-records` in `infra/perf/pr_scoped_probes.json`.
+That registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/response_only_boundary.py`
+- `services/mlx-worker-python/tests/test_response_only_boundary.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/response_only_boundary_slots_probe.py`
+
+## Plan
+
+1. Replace the frozen slotted dataclass wrapper with an explicit slotted record
+   that preserves no-`__dict__`, equality, repr, and assignment blocking for the
+   persisted manifest boundary fields.
+2. Keep aggregate behavior unchanged.
+3. Run the focused response-only boundary tests, changed-scope coverage, and the
+   registered local probe on Linux.
+4. Use PR-scoped performance CI as the base-vs-head merge gate.
+
+## Local Evidence
+
+Initial local probe on `origin/main` with 50k boundaries and 7 samples:
+
+- `construction_elapsed_ms_mean`: `116.496`
+- `aggregation_elapsed_ms_mean`: `257.139`
+- `peak_bytes_mean`: `3422115.429`
+
+Initial local probe on this slice with the same settings:
+
+- `construction_elapsed_ms_mean`: `115.182`
+- `aggregation_elapsed_ms_mean`: `244.501`
+- `peak_bytes_mean`: `3422115.429`
+
+The registered CI probe remains the authoritative base-vs-head validation source.

--- a/services/mlx-worker-python/tests/test_response_only_boundary.py
+++ b/services/mlx-worker-python/tests/test_response_only_boundary.py
@@ -370,6 +370,11 @@ def test_response_only_boundary_records_are_slotted() -> None:
 
     assert not hasattr(boundary, "__dict__")
     assert not hasattr(aggregate, "__dict__")
+    assert boundary == ResponseOnlyBoundary(assistant_offset=8, total_tokens=10)
+    assert boundary != object()
+    assert repr(boundary) == "ResponseOnlyBoundary(assistant_offset=8, total_tokens=10)"
+    with pytest.raises(AttributeError):
+        boundary.assistant_offset = 9
     assert boundary.response_tokens == 2
     assert aggregate.trainable_response_token_count == 2
     assert over_offset_aggregate.response_tokens_max == 0

--- a/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
+++ b/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
@@ -43,9 +43,10 @@ class _ChatTemplateTokenizer(Protocol):
         ...
 
 
-@dataclass(frozen=True, slots=True, init=False)
 class ResponseOnlyBoundary:
     """Per-sample response-only boundary record persisted in the manifest."""
+
+    __slots__ = ("assistant_offset", "total_tokens")
 
     assistant_offset: int
     total_tokens: int
@@ -58,6 +59,23 @@ class ResponseOnlyBoundary:
     ) -> None:
         _set_attr(self, "assistant_offset", assistant_offset)
         _set_attr(self, "total_tokens", total_tokens)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise AttributeError("cannot assign to field " + repr(name))
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, ResponseOnlyBoundary):
+            return (
+                self.assistant_offset == other.assistant_offset
+                and self.total_tokens == other.total_tokens
+            )
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        return (
+            "ResponseOnlyBoundary(assistant_offset="
+            f"{self.assistant_offset!r}, total_tokens={self.total_tokens!r})"
+        )
 
     @property
     def response_tokens(self) -> int:


### PR DESCRIPTION
## Summary
- Replace the frozen slotted dataclass wrapper for `ResponseOnlyBoundary` with an explicit slotted immutable record.
- Preserve no-`__dict__`, equality, repr, and assignment-blocking behavior while trimming repeated construction overhead in dataset boundary summarization.
- Add regression assertions for the preserved record semantics.

## Plan or Spec
- `docs/plans/2026-06-07-response-boundary-manual-slots.md`
- Registered PR-scoped probe: `response-only-boundary-slotted-records` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline local probe on origin/main
PYTHONPATH="/root/.hermes/profiles/coder/workspace/melix:/root/.hermes/profiles/coder/workspace/melix/services/mlx-worker-python" MELIX_RESPONSE_BOUNDARY_SLOT_PROBE_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/response_only_boundary_slots_probe.py
# exit 0; construction_elapsed_ms_mean=116.4962916768023; aggregation_elapsed_ms_mean=257.1390458116574; peak_bytes_mean=3422115.4285714286

# Head local probe on this branch
PYTHONPATH="/root/.hermes/profiles/coder/workspace/worktrees/melix-response-boundary-truncated-seed-20260607:/root/.hermes/profiles/coder/workspace/worktrees/melix-response-boundary-truncated-seed-20260607/services/mlx-worker-python" MELIX_RESPONSE_BOUNDARY_SLOT_PROBE_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/response_only_boundary_slots_probe.py
# exit 0; construction_elapsed_ms_mean=115.1824484446219; aggregation_elapsed_ms_mean=244.50086110404558; peak_bytes_mean=3422115.4285714286

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_without_limit_updates_running_bounds services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 9 passed, 1 skipped

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_without_limit_updates_running_bounds services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/response_only_boundary.py services/mlx-worker-python/tests/test_response_only_boundary.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/response_only_boundary_slots_probe.py
# exit 0; TOTAL 14 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/response_only_boundary_slots_probe.py"; if [ -f "$SCRIPT" ]; then python3 "$SCRIPT"; else for CANDIDATE in "../head/$SCRIPT" "${GITHUB_WORKSPACE:-}/head/$SCRIPT"; do if [ -f "$CANDIDATE" ]; then python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2; fi'
# exit 0; construction_elapsed_ms_mean=116.63682581856847; aggregation_elapsed_ms_mean=244.6143539622426; peak_bytes_mean=3422112.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Local 7-sample probe delta: construction `116.496ms -> 115.182ms` (`-1.314ms`, ~`1.13%` faster); aggregation `257.139ms -> 244.501ms` (`-12.638ms`, ~`4.92%` faster); peak bytes unchanged.
- Registered PR-scoped performance CI is required as the authoritative base-vs-head validation source before merge.

## Known Gaps
- Full repository test gates were not run locally; this slice used the focused registered probe commands on Linux.
- CI must complete the registered PR-scoped performance report before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; probe overhead is existing bounded synthetic probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
