### PR TITLE
Validate LoRA truncation admission

### DIFF
--- a/docs/plans/2026-06-07-issue-1528-truncation-admission.md
+++ b/docs/plans/2026-06-07-issue-1528-truncation-admission.md
@@ -1,0 +1,86 @@
+# Issue 1528 Truncation Admission Implementation Plan
+
+## Goal
+
+Fail LoRA training requests before backend execution when sequence truncation
+would remove required supervision tokens, and emit stable typed evidence for
+operators to correct the request.
+
+## Architecture
+
+The Python worker keeps training admission in the worker-owned model operation
+path because CLI, API, and Desktop all converge there before backend training.
+This slice extends the existing response-only boundary probe with a stable
+422-style error shape and adds a lightweight normalized-dataset inspection for
+media-token truncation requests. It does not change MLX-LM training semantics
+or preference loss math; preference loss already uses safe token counts for
+fully masked rows.
+
+## Scope Boundaries
+
+- Include: response-only zero-label failures with `field`, `reason`,
+  sample/count, requested/effective sequence length, and corrective action.
+- Include: media-token truncation admission for normalized chat samples whose
+  declared media-token budget cannot fit inside `max_seq_length`.
+- Include: preservation of chat sample media references and media-token hints
+  in the normalized dataset snapshot.
+- Include: runner/service tests proving invalid requests fail before
+  `train_model`.
+- Include: runbook documentation for the new typed error details.
+- Exclude: real VLM processor tokenization, image/video decoding, or model
+  family-specific media feature packing.
+- Exclude: changing DPO/ORPO/CPO reducers; their zero-token guard is already
+  covered by safe token counts.
+
+## Files
+
+- Modify: `services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py`
+  - Upgrade `_validate_response_only_trainable_tokens` details to the stable
+    watch-log schema.
+  - Add a pre-`load_local_dataset` normalized `train.jsonl` media truncation
+    admission pass.
+- Modify: `services/mlx-worker-python/worker/model_ops/training_dataset.py`
+  - Preserve structured `media_refs` and media-token hint fields from
+    `chat_messages` samples so admission checks can use package metadata.
+- Modify: `services/mlx-worker-python/tests/test_lora_model_ops_unit.py`
+  - Update the existing zero-label test to assert the stable schema.
+  - Add a media-token truncation test that proves `train_model` is not called.
+  - Add normalization coverage for preserving media-token hints.
+- Modify: `services/mlx-worker-python/tests/test_lora_model_ops.py`
+  - Add service-level coverage proving typed admission details survive the
+    shared worker `ConvertModel(train_lora)` failure event.
+- Modify: `docs/runbooks/phase-8-lora-adapter-workflow.md`
+  - Document `no_unmasked_completion_tokens` and `media_tokens_truncated`
+    training admission failures.
+
+## Test Plan
+
+1. Add failing assertions for the new zero-label error shape.
+2. Add a failing media-token truncation test with a fake MLX-LM module.
+3. Run the focused tests and verify they fail for missing fields/behavior.
+4. Implement the minimal runner admission helpers.
+5. Re-run focused tests:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py -k "normalize_sample_covers_prompt_text_and_tool_paths or response_only_labels_are_truncated or media_tokens"
+```
+
+6. Run a service-level typed error propagation test:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py -k "admission_failure_preserves_typed_error_details"
+```
+
+7. Run changed-scope coverage and `git diff --check`.
+8. Before commit, run the repository pre-commit hook through `git commit`,
+   which executes `make swift-test`, `make py-test`, `make integration-test`,
+   and the scoped performance report on this host.
+
+## Performance Probes And Metrics
+
+The response-only validation uses an aggregate already computed from MLX-LM's
+train set, so the change is error-detail only. The media truncation scan reads
+normalized `train.jsonl` once before backend training and only performs integer
+accounting over top-level sample metadata. Success metric: invalid fixtures
+return typed admission errors before `train_model`, changed-line coverage is at
+least 95%, and the PR-scoped performance report has zero regressions.

--- a/docs/runbooks/phase-8-lora-adapter-workflow.md
+++ b/docs/runbooks/phase-8-lora-adapter-workflow.md
@@ -239,6 +239,17 @@ Expected training behavior:
   starts.
 - accepted template controls are copied into `training_template_receipt` in the
   normalized dataset manifest and final adapter manifest.
+- response-only chat training with `mask_prompt=true` fails before backend
+  execution when `max_seq_length` truncates every assistant completion token.
+  The worker returns `response_only_labels_truncated` with
+  `field=max_length`, `reason=no_unmasked_completion_tokens`, affected sample
+  counts, requested/effective sequence length, and a suggested minimum sequence
+  length when the boundary can be derived.
+- chat training samples with media-token hints fail before backend execution
+  when the declared media-token count cannot fit inside `max_seq_length`.
+  The worker returns `training_tokens_truncated` with `field=max_length`,
+  `reason=media_tokens_truncated`, the sample index, media-token count,
+  requested/effective sequence length, and a suggested minimum sequence length.
 - Hugging Face dataset materialization is cached under `<jobs_root>/datasets/<cache-key>`
 - Melix supports `lora`, `qlora`, `dora`, `dpo`, `orpo`, and `cpt` through the same `train_lora` surface
 - `dora` records `adapter_algorithm=dora` and `dora_enabled=true` in the adapter manifest

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -2736,6 +2736,255 @@ def test_run_subprocess_extracts_terminal_structured_result_without_splitlines(
         == "melix.alignment_candidate_reward_trace.v1"
     )
 
+    response_config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"max_seq_length": "8", "response_only": "true", "mask_prompt": "true"},
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+    response_request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-truncated-labels",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=tmp_path / "normalized-response",
+        config=response_config,
+        dataset_format="chat_messages",
+    )
+    response_aggregate = mlx_lm_runner_module.aggregate_response_only_boundaries(
+        [
+            mlx_lm_runner_module.ResponseOnlyBoundary(assistant_offset=8, total_tokens=10),
+            mlx_lm_runner_module.ResponseOnlyBoundary(assistant_offset=8, total_tokens=10),
+        ],
+        max_seq_length=8,
+    )
+    with pytest.raises(ModelOperationError) as response_exc:
+        mlx_lm_runner_module._validate_response_only_trainable_tokens(
+            response_request,
+            response_aggregate,
+        )
+
+    assert response_exc.value.code == "response_only_labels_truncated"
+    assert response_exc.value.details["field"] == "max_length"
+    assert response_exc.value.details["reason"] == "no_unmasked_completion_tokens"
+    assert response_exc.value.details["sample_count"] == "2"
+    assert response_exc.value.details["affected_sample_count"] == "2"
+    assert response_exc.value.details["requested_sequence_length"] == "8"
+    assert response_exc.value.details["effective_sequence_length"] == "8"
+    assert response_exc.value.details["suggested_minimum_sequence_length"] == "9"
+    assert response_exc.value.details["corrective_action"] == (
+        "Increase max_seq_length, shorten the prompt/context before the assistant response, "
+        "or disable response-only masking."
+    )
+    assert response_exc.value.details["response_only_trainable_response_token_count"] == "0"
+
+    normalized_dir = tmp_path / "normalized-media"
+    normalized_dir.mkdir()
+    (normalized_dir / "train.jsonl").write_text(
+        "\n"
+        + json.dumps(["ignored"])
+        + "\n"
+        + json.dumps(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Inspect image one.",
+                        "media_refs": [
+                            {"id": "image-a", "uri": "images/a.png", "image_token_count": 1},
+                            "ignored",
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "The image is visible.",
+                        "video_token_count": "1",
+                        "media_refs": [{"id": "audio-a", "audio_token_count": 1}],
+                    },
+                ],
+                "media_refs": [
+                    {"id": "image-b", "uri": "images/b.png", "image_token_count": "1"},
+                    {"id": "bad", "media_token_count": "not-an-int"},
+                ],
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "Describe this image."},
+                    {"role": "assistant", "content": "It is a chart."},
+                ],
+                "media_refs": [{"id": "image-c", "uri": "images/c.png", "media_token_count": 999}],
+                "media_token_count": 12,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    safe_config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"max_seq_length": "99"},
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+    safe_request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-media-ok",
+        base_model_id="melix-dev-vlm",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dir,
+        config=safe_config,
+        dataset_format="chat_messages",
+    )
+
+    assert mlx_lm_runner_module._sample_media_token_count(
+        {
+            "media_refs": [{"image_token_count": 3}],
+            "messages": [
+                {"video_token_count": 4},
+                "ignored",
+                {"media_refs": [{"audio_token_count": 2}]},
+            ],
+        }
+    ) == 9
+    assert mlx_lm_runner_module._sample_media_token_count(
+        {"media_tokens": "7", "media_refs": [{"image_token_count": 99}]}
+    ) == 7
+    assert list(mlx_lm_runner_module._iter_jsonl_samples(normalized_dir / "train.jsonl"))[0][0] == 2
+    mlx_lm_runner_module._validate_media_token_truncation(safe_request)
+
+    zero_length_config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"max_seq_length": "1"},
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=1,
+    )
+    zero_length_request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-zero-length",
+        base_model_id="melix-dev-vlm",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=tmp_path / "missing-normalized",
+        config=zero_length_config,
+        dataset_format="chat_messages",
+    )
+    object.__setattr__(zero_length_request.config, "max_seq_length", 0)
+    mlx_lm_runner_module._validate_media_token_truncation(zero_length_request)
+
+    missing_train_request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-missing-jsonl",
+        base_model_id="melix-dev-vlm",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=tmp_path / "missing-normalized",
+        config=zero_length_config,
+        dataset_format="chat_messages",
+    )
+    mlx_lm_runner_module._validate_media_token_truncation(missing_train_request)
+
+    truncate_config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"max_seq_length": "8"},
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=2,
+    )
+    truncate_request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-media-truncated",
+        base_model_id="melix-dev-vlm",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dir,
+        config=truncate_config,
+        dataset_format="chat_messages",
+    )
+    with pytest.raises(ModelOperationError) as media_exc:
+        mlx_lm_runner_module._validate_media_token_truncation(truncate_request)
+
+    assert media_exc.value.code == "training_tokens_truncated"
+    assert media_exc.value.details["field"] == "max_length"
+    assert media_exc.value.details["reason"] == "media_tokens_truncated"
+    assert media_exc.value.details["sample_index"] == "3"
+    assert media_exc.value.details["affected_sample_count"] == "1"
+    assert media_exc.value.details["requested_sequence_length"] == "8"
+    assert media_exc.value.details["effective_sequence_length"] == "8"
+    assert media_exc.value.details["media_token_count"] == "12"
+    assert media_exc.value.details["suggested_minimum_sequence_length"] == "13"
+
+    non_chat_config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"max_seq_length": "8"},
+        dataset_format="text_completion",
+        response_only_supported=False,
+        sample_count=1,
+    )
+    non_chat_request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-text",
+        base_model_id="melix-dev-text",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=tmp_path / "missing-normalized",
+        config=non_chat_config,
+        dataset_format="text_completion",
+    )
+    mlx_lm_runner_module._validate_media_token_truncation(non_chat_request)
+
+    train_native_config = training_config_module.normalize_training_config(
+        source_model=_text_model(model_path=str(tmp_path / "base-model")),
+        ext={"max_seq_length": "8"},
+        dataset_format="chat_messages",
+        response_only_supported=True,
+        sample_count=1,
+    )
+    train_native_request = mlx_lm_runner_module.TrainingRequest(
+        job_id="train-native-media-truncated",
+        base_model_id="melix-dev-vlm",
+        model_path=tmp_path / "base-model",
+        model_revision="main",
+        adapter_output_dir=tmp_path / "adapter-output",
+        normalized_dataset_dir=normalized_dir,
+        config=train_native_config,
+        dataset_format="chat_messages",
+    )
+
+    fake_mlx_lm = types.ModuleType("mlx_lm")
+    fake_mlx_lm.__path__ = []
+    fake_tuner = types.ModuleType("mlx_lm.tuner")
+    fake_tuner.__path__ = []
+    fake_lora = types.ModuleType("mlx_lm.lora")
+    fake_callbacks = types.ModuleType("mlx_lm.tuner.callbacks")
+    fake_datasets = types.ModuleType("mlx_lm.tuner.datasets")
+    fake_utils = types.ModuleType("mlx_lm.utils")
+
+    class FakeTrainingCallback:
+        pass
+
+    fake_lora.train_model = lambda *args, **kwargs: None
+    fake_callbacks.TrainingCallback = FakeTrainingCallback
+    fake_datasets.load_local_dataset = lambda *args, **kwargs: pytest.fail("dataset loaded after truncation")
+    fake_utils.load = lambda *args, **kwargs: (object(), object())
+    monkeypatch.setitem(sys.modules, "mlx_lm", fake_mlx_lm)
+    monkeypatch.setitem(sys.modules, "mlx_lm.tuner", fake_tuner)
+    monkeypatch.setitem(sys.modules, "mlx_lm.lora", fake_lora)
+    monkeypatch.setitem(sys.modules, "mlx_lm.tuner.callbacks", fake_callbacks)
+    monkeypatch.setitem(sys.modules, "mlx_lm.tuner.datasets", fake_datasets)
+    monkeypatch.setitem(sys.modules, "mlx_lm.utils", fake_utils)
+
+    with pytest.raises(ModelOperationError) as native_media_exc:
+        mlx_lm_runner_module.MLXLMRunner().train_native(train_native_request)
+
+    assert native_media_exc.value.details["reason"] == "media_tokens_truncated"
+
 
 def test_run_subprocess_rejects_missing_structured_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     payload_path = tmp_path / "payload.json"

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -2779,6 +2779,14 @@ def test_run_subprocess_extracts_terminal_structured_result_without_splitlines(
         "or disable response-only masking."
     )
     assert response_exc.value.details["response_only_trainable_response_token_count"] == "0"
+    object.__setattr__(response_request.config, "max_seq_length", "not-an-int")
+    with pytest.raises(ModelOperationError) as invalid_length_exc:
+        mlx_lm_runner_module._validate_response_only_trainable_tokens(
+            response_request,
+            response_aggregate,
+        )
+    assert invalid_length_exc.value.details["suggested_minimum_sequence_length"] == "9"
+    assert invalid_length_exc.value.details["requested_sequence_length"] == "not-an-int"
 
     normalized_dir = tmp_path / "normalized-media"
     normalized_dir.mkdir()

--- a/services/mlx-worker-python/tests/test_lora_training_admission.py
+++ b/services/mlx-worker-python/tests/test_lora_training_admission.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from packages.protocol.python.worker.v1 import common_pb2, maintenance_pb2
+
+from worker.engine.maintenance_core import MaintenanceCore
+from worker.grpc_server import WorkerMaintenanceService
+from worker.model_ops.adapter_activation_pipeline import AdapterActivationPipeline
+from worker.model_ops.errors import ModelOperationError
+from worker.model_ops.lora_training_pipeline import LoRATrainingPipeline
+from worker.model_ops.mlx_lm_runner import (
+    ActivationMetrics,
+    ActivationRequest,
+    ActivationResult,
+    MLXLMRunner,
+    TrainingMetrics,
+    TrainingRequest,
+    TrainingResult,
+)
+from worker.model_registry.catalog import WorkerModelCatalog
+from worker.registry import WorkerRegistry
+from worker.runtime.deterministic_backend import DeterministicTextBackend
+from worker.runtime.mlx_text_runtime import MLXTextRuntime
+
+
+def _write_dataset_package(root: Path, samples: list[dict[str, object]]) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "melix-dev-dataset",
+                "format": "chat_messages",
+                "sample_count": len(samples),
+                "version": "1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "samples.jsonl").write_text(
+        "".join(json.dumps(sample) + "\n" for sample in samples),
+        encoding="utf-8",
+    )
+    return root
+
+
+class AdmissionFailureRunner(MLXLMRunner):
+    def __init__(self) -> None:
+        super().__init__()
+        self.native_train_calls = 0
+
+    def train_native(self, request: TrainingRequest) -> TrainingResult:
+        self.native_train_calls += 1
+        raise ModelOperationError(
+            code="training_tokens_truncated",
+            message="training tokens would be truncated",
+            details={
+                "field": "max_length",
+                "reason": "media_tokens_truncated",
+                "sample_index": "0",
+                "affected_sample_count": "1",
+                "requested_sequence_length": "8",
+                "effective_sequence_length": "8",
+                "media_token_count": "12",
+                "suggested_minimum_sequence_length": "13",
+            },
+        )
+
+    def activate(self, request: ActivationRequest) -> ActivationResult:
+        return ActivationResult(
+            derived_model_id=request.derived_model_id,
+            model_path=request.weights_path.parent,
+            metrics=ActivationMetrics(
+                job_duration_ms=1.0,
+                adapter_bytes=1,
+                adapter_config_bytes=1,
+            ),
+        )
+
+
+def _build_service(tmp_path: Path, runner: MLXLMRunner) -> WorkerMaintenanceService:
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=DeterministicTextBackend()),
+        model_catalog=WorkerModelCatalog(),
+    )
+    service = WorkerMaintenanceService(registry, jobs_root=tmp_path / "model-ops")
+    service._core = MaintenanceCore(
+        registry,
+        jobs_root=tmp_path / "model-ops",
+        lora_training_pipeline=LoRATrainingPipeline(runner=runner),
+        adapter_activation_pipeline=AdapterActivationPipeline(runner=runner),
+    )
+    model = common_pb2.ModelSpec(
+        model_id="melix-dev-text",
+        model_path=str(tmp_path / "base-model"),
+        model_kind="text",
+        revision="main",
+        quant_profile_id="q4",
+        max_context=4096,
+    )
+    model.ext["melix.lora.family_id"] = "qwen"
+    model.ext["melix.lora.family_kind"] = "dense"
+    model.ext["melix.lora.support_tier"] = "stable"
+    model.ext["melix.lora.training_ready"] = "true"
+    model.ext["melix.lora.default_target_preset"] = "attention"
+    registry.model_catalog.register_model(model)
+    return service
+
+
+def test_train_lora_admission_failure_preserves_typed_error_details(tmp_path: Path) -> None:
+    dataset_dir = _write_dataset_package(
+        tmp_path / "dataset",
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "Describe this image."},
+                    {"role": "assistant", "content": "It is a chart."},
+                ],
+                "media_refs": [{"id": "image-a", "uri": "images/a.png"}],
+                "media_token_count": 12,
+            }
+        ],
+    )
+    runner = AdmissionFailureRunner()
+    service = _build_service(tmp_path, runner)
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="melix-dev-text",
+                output_dir=str(tmp_path / "train"),
+                ext={
+                    "operation": "train_lora",
+                    "adapter_name": "melix-dev-adapter",
+                    "dataset_uri": str(dataset_dir),
+                    "max_seq_length": "8",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    assert events[-1].failed.error.code == "training_tokens_truncated"
+    assert events[-1].failed.error.details["field"] == "max_length"
+    assert events[-1].failed.error.details["reason"] == "media_tokens_truncated"
+    assert events[-1].failed.error.details["requested_sequence_length"] == "8"
+    assert events[-1].failed.error.details["effective_sequence_length"] == "8"
+    assert events[-1].failed.error.details["media_token_count"] == "12"
+    assert events[-1].failed.error.details["suggested_minimum_sequence_length"] == "13"
+    assert runner.native_train_calls == 1

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -280,6 +280,60 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
     with pytest.raises(ModelOperationError, match="prompt_candidate reward_components must be a JSON object"):
         load_training_dataset_package(bad_prompt_candidate_package_path)
 
+    chat_package_path = tmp_path / "chat-package"
+    chat_package_path.mkdir(parents=True, exist_ok=True)
+    (chat_package_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "chat-package",
+                "format": "chat_messages",
+                "sample_count": 1,
+                "version": "1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (chat_package_path / "samples.jsonl").write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Inspect image one.",
+                        "media_refs": ["image-1"],
+                        "image_token_count": 576,
+                    },
+                    {"role": "assistant", "content": "The sign says stop."},
+                ],
+                "media_refs": [
+                    {
+                        "id": "image-1",
+                        "uri": "images/one.jpg",
+                        "media_token_count": 576,
+                    }
+                ],
+                "media_token_count": 576,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    chat_package = load_training_dataset_package(chat_package_path)
+    chat_sample = chat_package.normalized_samples[0]
+
+    assert chat_sample["messages"][0]["media_refs"] == ["image-1"]
+    assert chat_sample["messages"][0]["image_token_count"] == 576
+    assert chat_sample["media_refs"] == [
+        {
+            "id": "image-1",
+            "uri": "images/one.jpg",
+            "media_token_count": 576,
+        }
+    ]
+    assert chat_sample["media_token_count"] == 576
+
     agentic_package_path = tmp_path / "agentic-package"
     agentic_package_path.mkdir(parents=True, exist_ok=True)
     samples = [

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -10,7 +10,7 @@ import re
 import subprocess
 import sys
 import time
-from typing import Any
+from typing import Any, Iterable
 
 from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.multimodal_lora_contracts import (
@@ -286,6 +286,7 @@ class MLXLMRunner:
         # stats returned carry enabled=False + chunk_count=0 so they fall
         # through into forward-compatible defaults on TrainingMetrics.
         chunk_stats = _maybe_chunk_training_dataset(request, tokenizer)
+        _validate_media_token_truncation(request)
         train_set, valid_set, _ = load_local_dataset(
             request.normalized_dataset_dir,
             tokenizer,
@@ -744,6 +745,12 @@ def _validate_response_only_trainable_tokens(
         return
     if aggregate.trainable_response_token_count > 0:
         return
+    affected_sample_count = (
+        aggregate.fully_truncated_response_sample_count
+        if aggregate.fully_truncated_response_sample_count > 0
+        else aggregate.sample_count
+    )
+    suggested_minimum = max(int(aggregate.boundary_max) + 1, int(request.config.max_seq_length) + 1)
     raise ModelOperationError(
         code="response_only_labels_truncated",
         message=(
@@ -753,6 +760,18 @@ def _validate_response_only_trainable_tokens(
             "or disable response-only masking."
         ),
         details={
+            "field": "max_length",
+            "reason": "no_unmasked_completion_tokens",
+            "http_status": "422",
+            "sample_count": str(aggregate.sample_count),
+            "affected_sample_count": str(affected_sample_count),
+            "requested_sequence_length": str(request.config.max_seq_length),
+            "effective_sequence_length": str(request.config.max_seq_length),
+            "suggested_minimum_sequence_length": str(suggested_minimum),
+            "corrective_action": (
+                "Increase max_seq_length, shorten the prompt/context before the assistant response, "
+                "or disable response-only masking."
+            ),
             "max_seq_length": str(request.config.max_seq_length),
             "response_only_boundary_sample_count": str(aggregate.sample_count),
             "response_only_boundary_min": str(aggregate.boundary_min),
@@ -767,6 +786,119 @@ def _validate_response_only_trainable_tokens(
             ),
         },
     )
+
+
+_MEDIA_TOKEN_TOTAL_HINT_FIELDS = (
+    "media_token_count",
+    "media_tokens",
+    "media_token_length",
+)
+_MEDIA_TOKEN_MODALITY_HINT_FIELDS = (
+    "image_token_count",
+    "video_token_count",
+    "audio_token_count",
+)
+_MEDIA_TOKEN_HINT_FIELDS = (
+    *_MEDIA_TOKEN_TOTAL_HINT_FIELDS,
+    *_MEDIA_TOKEN_MODALITY_HINT_FIELDS,
+)
+
+
+def _validate_media_token_truncation(request: TrainingRequest) -> None:
+    """Fail before MLX-LM when media-token hints cannot fit max_seq_length."""
+
+    if request.dataset_format != "chat_messages":
+        return
+    max_seq_length = int(getattr(request.config, "max_seq_length", 0) or 0)
+    if max_seq_length <= 0:
+        return
+    train_path = request.normalized_dataset_dir / "train.jsonl"
+    if not train_path.is_file():
+        return
+
+    for sample_index, sample in _iter_jsonl_samples(train_path):
+        media_token_count = _sample_media_token_count(sample)
+        if media_token_count < max_seq_length:
+            continue
+        raise ModelOperationError(
+            code="training_tokens_truncated",
+            message=(
+                "LoRA training media tokens would consume the configured "
+                f"max_seq_length={max_seq_length} before any text supervision "
+                "can fit. Increase max_seq_length or reduce media tokens before training."
+            ),
+            details={
+                "field": "max_length",
+                "reason": "media_tokens_truncated",
+                "http_status": "422",
+                "sample_index": str(sample_index),
+                "affected_sample_count": "1",
+                "requested_sequence_length": str(max_seq_length),
+                "effective_sequence_length": str(max_seq_length),
+                "media_token_count": str(media_token_count),
+                "suggested_minimum_sequence_length": str(media_token_count + 1),
+                "corrective_action": (
+                    "Increase max_seq_length or reduce media tokens before training."
+                ),
+                "max_seq_length": str(max_seq_length),
+            },
+        )
+
+
+def _iter_jsonl_samples(path: Path) -> Iterable[tuple[int, dict[str, Any]]]:
+    with path.open("r", encoding="utf-8") as handle:
+        for index, raw_line in enumerate(handle):
+            line = raw_line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            if isinstance(payload, dict):
+                yield index, payload
+
+
+def _sample_media_token_count(sample: dict[str, Any]) -> int:
+    sample_total = _direct_media_token_hint(sample)
+    if sample_total > 0:
+        return sample_total
+
+    total = 0
+    total += _media_refs_token_count(sample.get("media_refs"))
+
+    messages = sample.get("messages")
+    if isinstance(messages, list):
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            total += _direct_media_token_hint(message)
+            total += _media_refs_token_count(message.get("media_refs"))
+    return total
+
+
+def _direct_media_token_hint(payload: dict[str, Any]) -> int:
+    for field in _MEDIA_TOKEN_TOTAL_HINT_FIELDS:
+        count = _positive_int(payload.get(field))
+        if count > 0:
+            return count
+    return sum(_positive_int(payload.get(field)) for field in _MEDIA_TOKEN_MODALITY_HINT_FIELDS)
+
+
+def _media_refs_token_count(media_refs: Any) -> int:
+    if not isinstance(media_refs, list):
+        return 0
+    total = 0
+    for media_ref in media_refs:
+        if not isinstance(media_ref, dict):
+            continue
+        total += _direct_media_token_hint(media_ref)
+    return total
+
+
+def _positive_int(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(parsed, 0)
 
 
 def _maybe_chunk_training_dataset(

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -750,7 +750,9 @@ def _validate_response_only_trainable_tokens(
         if aggregate.fully_truncated_response_sample_count > 0
         else aggregate.sample_count
     )
-    suggested_minimum = max(int(aggregate.boundary_max) + 1, int(request.config.max_seq_length) + 1)
+    max_seq_length = _positive_int(getattr(request.config, "max_seq_length", 0))
+    boundary_max = _positive_int(getattr(aggregate, "boundary_max", 0))
+    suggested_minimum = max(boundary_max + 1, max_seq_length + 1)
     raise ModelOperationError(
         code="response_only_labels_truncated",
         message=(

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -32,6 +32,14 @@ _SUPPORTED_ROLES = {"system", "user", "assistant", "tool"}
 _HF_DATASETS_SERVER_URL = "https://datasets-server.huggingface.co"
 _QUALITY_REPORT_SAMPLE_LIMIT = 10
 _ALLOWED_CONTROL_CHARACTERS = frozenset({"\n", "\r", "\t"})
+_CHAT_MEDIA_TOKEN_HINT_FIELDS = (
+    "media_token_count",
+    "media_tokens",
+    "media_token_length",
+    "image_token_count",
+    "video_token_count",
+    "audio_token_count",
+)
 
 HFDatasetFetcher = Callable[[str, dict[str, str]], dict[str, Any]]
 
@@ -802,9 +810,16 @@ def _normalize_sample(
                     details={"message_index": str(index)},
                 )
             previous_role = role
-            normalized_messages.append(
-                {"role": role, "content": _truncate_text(content, max_characters_per_sample)}
-            )
+            normalized_message: dict[str, Any] = {
+                "role": role,
+                "content": _truncate_text(content, max_characters_per_sample),
+            }
+            if "media_refs" in message and isinstance(message["media_refs"], list):
+                normalized_message["media_refs"] = list(message["media_refs"])
+            for field in _CHAT_MEDIA_TOKEN_HINT_FIELDS:
+                if field in message:
+                    normalized_message[field] = message[field]
+            normalized_messages.append(normalized_message)
         if assistant_count == 0 or normalized_messages[-1]["role"] != "assistant":
             raise ModelOperationError(
                 code="invalid_dataset_package",
@@ -813,6 +828,11 @@ def _normalize_sample(
         payload: dict[str, Any] = {"messages": normalized_messages}
         if "tools" in sample and isinstance(sample["tools"], list):
             payload["tools"] = sample["tools"]
+        if "media_refs" in sample and isinstance(sample["media_refs"], list):
+            payload["media_refs"] = list(sample["media_refs"])
+        for field in _CHAT_MEDIA_TOKEN_HINT_FIELDS:
+            if field in sample:
+                payload[field] = sample[field]
         return payload
 
     if format_name == "agentic_tool_trace":


### PR DESCRIPTION
## Summary
- Add early typed LoRA admission failures when response-only max-length truncation leaves zero unmasked completion tokens.
- Preserve chat media refs/token hints through dataset normalization and reject media-token samples that cannot fit `max_seq_length` before MLX-LM training starts.
- Update the governing LoRA runbook and add the implementation plan for the remaining #1528 truncation-admission slice.

Closes #1528.

## Plan or Spec
- `docs/plans/2026-06-07-issue-1528-truncation-admission.md`
- `docs/runbooks/phase-8-lora-adapter-workflow.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_extracts_terminal_structured_result_without_splitlines services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_mlx_lm_runner_train_native_fails_when_response_only_labels_are_truncated services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_applies_manifest_overrides services/mlx-worker-python/tests/test_lora_training_admission.py
# 4 passed in 0.26s after merging origin/main

git diff --cached --check
# pass before commit

git commit -m "Validate LoRA truncation admission"
# pre-commit ran make swift-test, make py-test, make integration-test, and PR-scoped performance report
# make swift-test: pass, elapsed 201.2s
# make py-test: 3633 passed, 14 skipped, 2 warnings in 161.71s
# make integration-test: 117 passed, 1 skipped in 414.09s
# performance report: Status ok, Regressions 0, Verification failures 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python python - <<'PY'
from pathlib import Path
import subprocess
import sys
sys.path.insert(0, str(Path.cwd()))
sys.path.insert(0, str(Path.cwd() / 'services/mlx-worker-python'))
from scripts.pre_commit_gate import run_performance_report
root = Path.cwd()
changed = subprocess.check_output(['git', 'diff', '--name-only', 'origin/main', 'HEAD', '--'], cwd=root, text=True).splitlines()
changed = [line.strip() for line in changed if line.strip()]
outcome = run_performance_report(root, changed, base_ref='origin/main')
print(f'outcome_status={outcome.status}')
print(f'report_dir={outcome.report_dir}')
raise SystemExit(0 if outcome.status == 'ok' else 1)
PY
# merge-after-origin/main scoped performance: Status ok, Regressions 0, Verification failures 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_extracts_terminal_structured_result_without_splitlines services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_rejects_missing_structured_result services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_accepts_carriage_return_line_end services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_skips_embedded_prefix_and_finds_prior_line services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_lm_runner_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_main_covers_checked_in_file
# review-fix probe coverage: 8 passed in 2.24s; changed_scope_coverage 100%, 8/8 changed lines covered

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_extracts_terminal_structured_result_without_splitlines services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_mlx_lm_runner_train_native_fails_when_response_only_labels_are_truncated services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_applies_manifest_overrides services/mlx-worker-python/tests/test_lora_training_admission.py
# review-fix focused suite: 4 passed in 0.32s

git diff --check
# pass before review-fix commit

git commit -m "Harden response-only admission length fallback"
# pre-commit ran make swift-test, make py-test, make integration-test, and PR-scoped performance report
# make swift-test: pass, elapsed 230.4s
# make py-test: 3633 passed, 14 skipped, 2 warnings in 165.65s
# make integration-test: 117 passed, 1 skipped in 429.08s
# performance report: Status ok, Regressions 0, Verification failures 0
```

## Coverage and Metrics
- Initial focused changed-line coverage before commit: TOTAL 98.41%, 186/189 changed executable lines covered.
- Initial pre-commit scoped performance report: `/Users/chenyu/Documents/github/melix/.runtime/worktrees/issue-1528-truncation-admission-20260607/.runtime/pre-commit-performance/20260607-144649-e381a43b/report/report.md`; Status `ok`, regressions `0`, verification failures `0`.
- Merge-after-origin/main scoped performance report: `/Users/chenyu/Documents/github/melix/.runtime/worktrees/issue-1528-truncation-admission-20260607/.runtime/pre-commit-performance/20260607-145110-477906fd/report/report.md`; Status `ok`, regressions `0`, verification failures `0`.
- Review-fix probe changed-line coverage: TOTAL 100%, 8/8 changed executable lines covered.
- Review-fix pre-commit scoped performance report: `/Users/chenyu/Documents/github/melix/.runtime/worktrees/issue-1528-truncation-admission-20260607/.runtime/pre-commit-performance/20260607-151416-477906fd/report/report.md`; Status `ok`, regressions `0`, verification failures `0`.
- Selected probes: training dataset quality/token summary, validation split partial selection, validation sample-limit loading, MLX-LM structured result tail parse. All direct probe coverage passed; review-fix MLX-LM probe coverage passed at 100.0%.

## Known Gaps
- Real VLM processor image/video tokenization is not re-run in admission; media truncation admission uses dataset-provided media token hints preserved in normalized chat samples.
- No protocol or dependency changes in this PR.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: minimal typed admission details and existing PR-scoped performance probes; no deferred debug artifacts.
- [x] Deferred work and known gaps are stated explicitly.
