### PR TITLE
Fix README action badges

### DIFF
--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -24,7 +24,7 @@ permissions:
 
 concurrency:
   group: release-gates-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
 
 jobs:
   release-gates:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/Keith-CY/melix/actions/workflows/release-gates.yml"><img src="https://img.shields.io/github/actions/workflow/status/Keith-CY/melix/release-gates.yml?branch=main&label=release%20gates" alt="release gates"></a>
-  <a href="https://github.com/Keith-CY/melix/actions/workflows/package-self-contained-app.yml"><img src="https://img.shields.io/github/actions/workflow/status/Keith-CY/melix/package-self-contained-app.yml?branch=main&label=app%20packaging" alt="app packaging"></a>
+  <a href="https://github.com/Keith-CY/melix/actions/workflows/package-self-contained-app.yml?query=event%3Aschedule+branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/Keith-CY/melix/package-self-contained-app.yml?branch=main&event=schedule&label=app%20packaging" alt="app packaging"></a>
   <img src="https://img.shields.io/badge/platform-Apple%20Silicon-black" alt="platform">
   <img src="https://img.shields.io/badge/macOS-15%2B-000000" alt="macOS">
   <img src="https://img.shields.io/badge/focus-LoRA%20%2B%20Bench%20%2F%20Eval-0F766E" alt="focus">

--- a/docs/plans/2026-06-07-readme-action-badges.md
+++ b/docs/plans/2026-06-07-readme-action-badges.md
@@ -1,0 +1,31 @@
+# README Action Badge Repair Plan
+
+## Goal
+
+Restore the root README action badges so they report meaningful release and app packaging status for `main`.
+
+## Diagnosis
+
+- The `release-gates` workflow was manually disabled in GitHub Actions, leaving the README badge stuck on the latest historical failed or cancelled main run.
+- Main push-triggered `release-gates` runs also cancelled earlier main runs, so a fast merge sequence could leave the branch badge red even when no release gate failed.
+- The `package-self-contained-app` workflow is healthy, but the README badge queries all `main` workflow runs. Frequent push-triggered packaging runs can be cancelled by concurrency when newer main commits land, so the badge can briefly report failure even when the scheduled app artifact path is healthy.
+
+## Scope
+
+- Re-enable the `release-gates` workflow in GitHub Actions and trigger a fresh `main` run.
+- Keep the release-gates README badge on `main` so real gate failures remain visible.
+- Keep main push-triggered `release-gates` runs from cancelling each other, while preserving cancellation for repeated non-main/manual/scheduled runs.
+- Scope the app packaging README badge to the scheduled packaging event, which is the durable public app artifact signal.
+- Add a focused README regression test for the badge URLs.
+
+## Verification
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_readme_action_badges.py -q`
+- `actionlint .github/workflows/release-gates.yml .github/workflows/package-self-contained-app.yml` when available
+- `git diff --check`
+- GitHub Actions status for `release-gates.yml` and `package-self-contained-app.yml`
+
+## Coverage and Metrics
+
+- Coverage: focused README badge URL regression coverage.
+- Metrics: `N/A`; the change is documentation and CI-status presentation only. It does not alter runtime, worker, Swift app, or packaging implementation performance paths.

--- a/services/mlx-worker-python/tests/test_readme_action_badges.py
+++ b/services/mlx-worker-python/tests/test_readme_action_badges.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+README = REPO_ROOT / "README.md"
+RELEASE_GATES_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-gates.yml"
+
+
+def test_release_gates_badge_reports_main_branch_status() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert (
+        "img.shields.io/github/actions/workflow/status/"
+        "Keith-CY/melix/release-gates.yml?branch=main&label=release%20gates"
+    ) in readme
+
+
+def test_app_packaging_badge_reports_scheduled_main_artifact_status() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert (
+        "img.shields.io/github/actions/workflow/status/"
+        "Keith-CY/melix/package-self-contained-app.yml?"
+        "branch=main&event=schedule&label=app%20packaging"
+    ) in readme
+    assert "actions/workflows/package-self-contained-app.yml?query=event%3Aschedule+branch%3Amain" in readme
+
+
+def test_release_gates_main_push_runs_are_not_cancelled_by_later_main_pushes() -> None:
+    workflow = RELEASE_GATES_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "release-gates-${{ github.event_name }}-${{ github.ref }}" in workflow
+    assert "github.event_name != 'push' || github.ref != 'refs/heads/main'" in workflow


### PR DESCRIPTION
## Summary
- Stabilize the README action badges so they report durable `main` release and app packaging status.
- Keep `release-gates` main push runs from cancelling one another and poisoning the branch badge with cancelled conclusions.
- Point the app packaging badge at the scheduled `main` packaging signal, which is the public artifact health path.

## Plan or Spec
- `docs/plans/2026-06-07-readme-action-badges.md`

## Commands Run
```text
# GitHub Actions diagnosis and repair
gh workflow list --repo Keith-CY/melix --all
  - release-gates was disabled_manually; package-self-contained-app was active.
gh workflow enable release-gates.yml --repo Keith-CY/melix
  - release-gates re-enabled.
gh workflow run release-gates.yml --repo Keith-CY/melix --ref main
  - started run 27095870998; Swift tests and Python tests have passed, integration tests are in progress.
gh run list --repo Keith-CY/melix --workflow package-self-contained-app.yml --branch main --limit 5 --json databaseId,status,conclusion,headSha,event,createdAt,updatedAt
  - latest main app packaging run 27095790537 completed success.
curl -fsSL 'https://img.shields.io/github/actions/workflow/status/Keith-CY/melix/package-self-contained-app.yml?branch=main&event=schedule&label=app%20packaging'
  - app packaging badge reports passing.

# Local verification
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_readme_action_badges.py -q
  - 3 passed in 0.02s.
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-gates.yml"); YAML.load_file(".github/workflows/package-self-contained-app.yml")'
  - passed.
git diff --check
  - passed.
.githooks/pre-commit
  - make swift-test: passed.
  - make py-test: 3635 passed, 14 skipped, 2 warnings.
  - make integration-test: 117 passed, 1 skipped.
  - scoped performance report: Status ok, Regressions 0.
```

## Coverage and Metrics
- Coverage: focused regression coverage in `services/mlx-worker-python/tests/test_readme_action_badges.py` for the README badge URLs and release-gates main-push cancellation rule.
- Metrics: `.githooks/pre-commit` generated `.runtime/pre-commit-performance/20260607-152100-523fd7f8/report/report.md` with `Status: ok`, `Regressions: 0`, and no selected probes for this docs/CI-status change set.
- Observability mode: `N/A`; this changes README badge status presentation and workflow concurrency only.
- Probe overhead: `N/A`; no runtime or packaging implementation probes were selected.

## Known Gaps
- Local `actionlint` is not installed in this worktree environment; workflow syntax was checked with Ruby YAML parsing instead.
- The freshly re-enabled `main` release-gates run 27095870998 was still in progress when this PR was opened; it had passed Swift and Python tests and was running integration tests.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.