### PR TITLE
perf: fast path stream delta token counts

### DIFF
--- a/docs/plans/2026-06-07-stream-assembler-delta-token-count-fastpath.md
+++ b/docs/plans/2026-06-07-stream-assembler-delta-token-count-fastpath.md
@@ -1,0 +1,62 @@
+# Stream Assembler Delta Token Count Fast Path
+
+This Python performance slice is limited to delta token-count estimation in
+`services/mlx-worker-python/worker/runtime/stream_assembler.py`.
+
+## Scope
+
+`RequestStreamAssembler._annotate_token_counts(...)` estimates per-delta token
+weights for multi-delta streaming fragments. The current implementation uses
+`len(text.split())` for content and reasoning deltas, which materializes a list
+for normalized ASCII text emitted by common token streams.
+
+This slice adds a narrow long normalized-ASCII whitespace count helper and keeps
+Python `split()` semantics for short deltas, leading/trailing spaces, repeated
+spaces, ASCII control whitespace, and non-ASCII text.
+
+## Registered probe
+
+The affected path is covered by the existing registered PR-scoped probe:
+
+- `stream-assembler-token-byte-fast-decode`
+
+This slice extends that probe's metrics with a base-vs-head delta token-count
+micro-workload:
+
+- `delta_token_count_old_ms_mean`
+- `delta_token_count_new_ms_mean`
+- `delta_token_count_delta_ms`
+- `delta_token_count_speedup`
+- `delta_token_count_text_count`
+
+## Verification plan
+
+Run from the repository root on Linux:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_stream_assembler.py::test_estimated_delta_token_count_matches_split_semantics_without_ascii_allocation \
+  services/mlx-worker-python/tests/test_stream_assembler.py::test_delta_token_annotation_uses_ascii_count_fast_path \
+  services/mlx-worker-python/tests/test_stream_assembler.py::test_plain_token_metadata_keeps_fast_path_and_metrics \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_stream_assembler.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics \
+  && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json \
+  && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+    services/mlx-worker-python/worker/runtime/stream_assembler.py \
+    services/mlx-worker-python/tests/test_stream_assembler.py \
+    services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+    scripts/stream_assembler_token_bytes_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py \
+  --registry infra/perf/pr_scoped_probes.json \
+  --probe-id stream-assembler-token-byte-fast-decode \
+  --base-repo /root/.hermes/profiles/coder/workspace/melix \
+  --head-repo "$PWD" \
+  --output .runtime/stream-assembler-token-byte-fast-decode-report.json
+```
+
+PR-scoped performance CI remains the final registered probe validation source
+before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -599,7 +599,7 @@
       "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
       "scripts/stream_assembler_token_bytes_probe.py"
     ],
-    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_plain_token_metadata_keeps_fast_path_and_metrics services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_ascii_without_incremental_decoder services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_multibyte_without_incremental_decoder services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_preserves_split_multibyte_sequence services/mlx-worker-python/tests/test_stream_assembler.py::test_standard_qwen_pipe_tool_parser_keeps_rescue_parser_off services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics",
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_plain_token_metadata_keeps_fast_path_and_metrics services/mlx-worker-python/tests/test_stream_assembler.py::test_estimated_delta_token_count_matches_split_semantics_without_ascii_allocation services/mlx-worker-python/tests/test_stream_assembler.py::test_delta_token_annotation_uses_ascii_count_fast_path services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_ascii_without_incremental_decoder services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_multibyte_without_incremental_decoder services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_preserves_split_multibyte_sequence services/mlx-worker-python/tests/test_stream_assembler.py::test_standard_qwen_pipe_tool_parser_keeps_rescue_parser_off services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics",
     "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_token_bytes_probe.py",
     "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/stream_assembler_token_bytes_probe.py ]; then python3 scripts/stream_assembler_token_bytes_probe.py; else python3 - <<\"PYPROBE\"\nfrom __future__ import annotations\nimport json, os, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd()\nsys.path.insert(0, str(repo_root))\nsys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.runtime.stream_assembler import RequestStreamAssembler, StreamFragment\nsample_count = int(os.environ.get(\"MELIX_STREAM_ASSEMBLER_TOKEN_BYTES_SAMPLES\", \"5\"))\ntoken_event_count = int(os.environ.get(\"MELIX_STREAM_ASSEMBLER_TOKEN_BYTES_EVENTS\", \"80000\"))\ntoken_payloads = tuple(f\"token-{index % 97} \".encode(\"utf-8\") for index in range(token_event_count))\nexpected_text = b\"\".join(token_payloads).decode(\"utf-8\")\nelapsed = []\npeaks = []\ngenerated_tokens = []\nchecksum = 0\nfor _ in range(sample_count):\n    assembler = RequestStreamAssembler(\"token-bytes-probe\", False, \"\", \"\")\n    tracemalloc.start()\n    started = time.perf_counter()\n    emitted_chars = 0\n    for payload in token_payloads:\n        for delta in assembler.accept(StreamFragment(token_bytes=payload)):\n            emitted_chars += len(delta.content_text)\n    completed = assembler.completed()\n    elapsed_ms = (time.perf_counter() - started) * 1000.0\n    _, peak = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    if completed.assistant_text != expected_text:\n        raise SystemExit(\"assembled token-byte text did not match expected text\")\n    if emitted_chars != len(expected_text):\n        raise SystemExit(\"unexpected emitted character count\")\n    if completed.metrics[\"byte_fallback_decode_error_count\"] != 0:\n        raise SystemExit(\"unexpected decode errors for ASCII token bytes\")\n    elapsed.append(elapsed_ms)\n    peaks.append(float(peak))\n    generated_tokens.append(float(completed.metrics[\"generated_token_count\"]))\n    checksum += len(completed.assistant_text)\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed), \"peak_bytes_mean\": statistics.fmean(peaks), \"generated_token_count_mean\": statistics.fmean(generated_tokens), \"token_event_count\": float(token_event_count), \"checksum\": float(checksum), \"sample_count\": float(sample_count)}, sort_keys=True))\nPYPROBE\nfi'",
     "probe_impl": "command_json",
@@ -621,6 +621,35 @@
         "key": "generated_token_count_mean",
         "unit": "tokens",
         "direction": "informational"
+      },
+      {
+        "key": "delta_token_count_old_ms_mean",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "delta_token_count_new_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "delta_token_count_delta_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "delta_token_count_speedup",
+        "unit": "x",
+        "direction": "higher_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "delta_token_count_text_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
       }
     ]
   },

--- a/scripts/stream_assembler_token_bytes_probe.py
+++ b/scripts/stream_assembler_token_bytes_probe.py
@@ -12,7 +12,44 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
-from worker.runtime.stream_assembler import RequestStreamAssembler, StreamFragment
+from worker.runtime.stream_assembler import (
+    RequestStreamAssembler,
+    StreamFragment,
+    _whitespace_token_count,
+)
+
+
+def _measure_delta_token_count(sample_count: int) -> dict[str, float]:
+    token_texts = tuple(
+        " ".join(f"token{(index + offset) % 257}" for offset in range(128))
+        for index in range(4096)
+    )
+    old_elapsed: list[float] = []
+    new_elapsed: list[float] = []
+    checksum = 0
+
+    for _ in range(sample_count):
+        started = time.perf_counter()
+        old_counts = [len(text.split()) for text in token_texts]
+        old_elapsed.append((time.perf_counter() - started) * 1000.0)
+
+        started = time.perf_counter()
+        new_counts = [_whitespace_token_count(text) for text in token_texts]
+        new_elapsed.append((time.perf_counter() - started) * 1000.0)
+        if new_counts != old_counts:
+            raise SystemExit("delta token count fast path diverged from split() semantics")
+        checksum += sum(new_counts)
+
+    old_mean = statistics.fmean(old_elapsed)
+    new_mean = statistics.fmean(new_elapsed)
+    return {
+        "delta_token_count_old_ms_mean": old_mean,
+        "delta_token_count_new_ms_mean": new_mean,
+        "delta_token_count_delta_ms": new_mean - old_mean,
+        "delta_token_count_speedup": old_mean / new_mean if new_mean else 0.0,
+        "delta_token_count_text_count": float(len(token_texts)),
+        "delta_token_count_checksum": float(checksum),
+    }
 
 
 def _measure(sample_count: int | None = None, token_event_count: int | None = None) -> dict[str, float]:
@@ -54,7 +91,7 @@ def _measure(sample_count: int | None = None, token_event_count: int | None = No
         generated_tokens.append(float(completed.metrics["generated_token_count"]))
         checksum += len(completed.assistant_text)
 
-    return {
+    metrics = {
         "elapsed_ms_mean": statistics.fmean(elapsed),
         "peak_bytes_mean": statistics.fmean(peaks),
         "generated_token_count_mean": statistics.fmean(generated_tokens),
@@ -62,6 +99,8 @@ def _measure(sample_count: int | None = None, token_event_count: int | None = No
         "checksum": float(checksum),
         "sample_count": float(sample_count),
     }
+    metrics.update(_measure_delta_token_count(sample_count))
+    return metrics
 
 
 if __name__ == "__main__":

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2692,6 +2692,11 @@ def test_stream_assembler_token_bytes_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0
     assert metrics["peak_bytes_mean"] > 0
     assert metrics["checksum"] > 0
+    assert metrics["delta_token_count_old_ms_mean"] >= 0
+    assert metrics["delta_token_count_new_ms_mean"] >= 0
+    assert metrics["delta_token_count_speedup"] > 0
+    assert metrics["delta_token_count_text_count"] == 4096.0
+    assert metrics["delta_token_count_checksum"] > 0
 
 
 def test_runtime_utils_kwarg_cache_probe_script_emits_metrics(

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -934,6 +934,54 @@ def test_plain_token_metadata_keeps_fast_path_and_metrics(monkeypatch) -> None:
     assert completed.metrics["stream_short_reply_flush_count"] == 0
 
 
+def test_estimated_delta_token_count_matches_split_semantics_without_ascii_allocation() -> None:
+    samples = (
+        "plain ascii chunk",
+        "single",
+        " leading space",
+        "trailing space ",
+        "double  space",
+        "tab\tseparated",
+        "newline\nseparated",
+        "unicode\u2003space",
+        "emoji 😀 token",
+    )
+
+    for sample in samples:
+        assert stream_assembler._whitespace_token_count(sample) == len(sample.split())
+
+    assert RequestStreamAssembler._estimated_delta_token_count(
+        AssemblyDelta(content_text="plain ascii chunk")
+    ) == 3
+    assert RequestStreamAssembler._estimated_delta_token_count(
+        AssemblyDelta(reasoning_text="unicode\u2003space")
+    ) == 2
+
+
+def test_delta_token_annotation_uses_ascii_count_fast_path(monkeypatch) -> None:
+    calls: list[str] = []
+    original_count = stream_assembler._whitespace_token_count
+
+    def tracked_count(text: str) -> int:
+        calls.append(text)
+        return original_count(text)
+
+    monkeypatch.setattr(stream_assembler, "_whitespace_token_count", tracked_count)
+    assembler = RequestStreamAssembler("req-delta-count-fast-path", True, "", "qwen")
+
+    annotated = assembler._annotate_token_counts(
+        [
+            AssemblyDelta(content_text="visible plain text"),
+            AssemblyDelta(reasoning_text="hidden reasoning text"),
+            AssemblyDelta(tool_call=AssembledToolCall("call-fast", "search", "{}", 1, "qwen")),
+        ],
+        7,
+    )
+
+    assert [delta.token_count for delta in annotated] == [3, 3, 1]
+    assert calls == ["visible plain text", "hidden reasoning text"]
+
+
 def test_token_byte_delta_decodes_complete_ascii_without_incremental_decoder(monkeypatch) -> None:
     assembler = RequestStreamAssembler(
         request_id="req-token-byte-fast-path",

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -12,6 +12,20 @@ from worker.runtime import tool_call_rescue
 logger = logging.getLogger(__name__)
 _UTF8_INCREMENTAL_DECODER = codecs.getincrementaldecoder("utf-8")
 _COMPACT_SORTED_JSON_ENCODER = json.JSONEncoder(separators=(",", ":"), sort_keys=True)
+_ASCII_TOKEN_COUNT_DISQUALIFIERS = ("  ", "\t", "\n", "\r", "\v", "\f")
+_ASCII_TOKEN_COUNT_FAST_PATH_MIN_CHARS = 256
+
+
+def _whitespace_token_count(text: str) -> int:
+    if (
+        len(text) >= _ASCII_TOKEN_COUNT_FAST_PATH_MIN_CHARS
+        and text.isascii()
+        and text[0] != " "
+        and text[-1] != " "
+        and not any(disqualifier in text for disqualifier in _ASCII_TOKEN_COUNT_DISQUALIFIERS)
+    ):
+        return text.count(" ") + 1
+    return len(text.split())
 
 
 @lru_cache(maxsize=32)
@@ -970,9 +984,9 @@ class RequestStreamAssembler:
     @staticmethod
     def _estimated_delta_token_count(delta: AssemblyDelta) -> int:
         if delta.content_text:
-            return max(1, len(delta.content_text.split()))
+            return max(1, _whitespace_token_count(delta.content_text))
         if delta.reasoning_text:
-            return max(1, len(delta.reasoning_text.split()))
+            return max(1, _whitespace_token_count(delta.reasoning_text))
         return 1
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Add a long normalized-ASCII whitespace token-count fast path for stream assembler delta weighting.
- Keep Python `split()` semantics for short text, non-ASCII text, repeated spaces, and control whitespace.
- Extend the registered `stream-assembler-token-byte-fast-decode` probe with delta token-count metrics.

## Plan or Spec
- `docs/plans/2026-06-07-stream-assembler-delta-token-count-fastpath.md`

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_estimated_delta_token_count_matches_split_semantics_without_ascii_allocation services/mlx-worker-python/tests/test_stream_assembler.py::test_delta_token_annotation_uses_ascii_count_fast_path services/mlx-worker-python/tests/test_stream_assembler.py::test_plain_token_metadata_keeps_fast_path_and_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics
4 passed in 0.24s

$ bash /tmp/stream_token_coverage_cmd.sh
90 passed in 0.88s
TOTAL 52 1 98%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id stream-assembler-token-byte-fast-decode --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output .runtime/stream-assembler-token-byte-fast-decode-report.json
head verification ok; base probe ok; head probe ok

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics
1 passed in 0.20s

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 52 1 98%`.
- Registered local probe: `stream-assembler-token-byte-fast-decode`.
- Existing token-byte probe metric stayed within tolerance: `elapsed_ms_mean` base `749.708 ms`, head `753.629 ms` (+0.52%).
- New delta token-count metric improved: old `14.843 ms`, new `6.523 ms`, delta `-8.320 ms`, speedup `2.275x` over 4,096 long normalized-ASCII texts.
- PR-scoped performance CI is still required as the final registered probe validation source before merge.

## Known Gaps
- Linux-local Python validation only; no Swift/macOS runtime behavior is changed in this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
