### PR TITLE
perf: trim dataset version listing path overhead

### DIFF
--- a/docs/plans/2026-06-07-dataset-version-workspace-fspath.md
+++ b/docs/plans/2026-06-07-dataset-version-workspace-fspath.md
@@ -1,0 +1,24 @@
+# Dataset version listing workspace path fspath slice
+
+This Python-only performance slice is limited to `list_dataset_versions(...)` in `services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` values for:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_versioning.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_version_listing_probe.py`
+
+## Slice
+
+`list_dataset_versions(...)` already streams version manifests with `os.scandir()`. This slice removes one per-call `Path(...)` construction for the returned `workspace_manifest_path` by using `os.fspath(...)`, and binds `time.perf_counter` locally so the final metrics timestamp avoids a second module attribute lookup.
+
+Behavior remains unchanged for supported `str` and `Path` inputs: the listing preserves the caller-provided manifest path spelling and does not expand or resolve it.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage command, and local registered probe on Linux before opening the PR. Use the PR-scoped performance CI report as the merge gate.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -471,8 +471,10 @@ def list_dataset_versions(
     output_root: Path | str,
     dataset_id: str,
 ) -> dict[str, Any]:
-    started = time.perf_counter()
+    perf_counter = time.perf_counter
+    started = perf_counter()
     versions_root = Path(output_root).expanduser() / dataset_id / "versions"
+    manifest_path_string = os.fspath(workspace_manifest_path)
     versions: list[dict[str, Any]] = []
     versions_append = versions.append
     read_json_file = _read_json_file
@@ -495,11 +497,11 @@ def list_dataset_versions(
     versions.sort(key=lambda item: (as_str(item["created_at"]), as_str(item["version_id"])))
     return {
         "schema_version": DATASET_VERSION_LIST_SCHEMA_VERSION,
-        "workspace_manifest_path": str(Path(workspace_manifest_path)),
+        "workspace_manifest_path": manifest_path_string,
         "dataset_id": dataset_id,
         "versions": versions,
         "metrics": {
-            "dataset_version_listing_latency_ms": (time.perf_counter() - started) * 1000.0,
+            "dataset_version_listing_latency_ms": (perf_counter() - started) * 1000.0,
             "dataset_version_count": len(versions),
         },
     }


### PR DESCRIPTION
## Summary
- Trims `list_dataset_versions(...)` per-call overhead by reusing a local `perf_counter` binding.
- Uses `os.fspath(...)` for the returned workspace manifest path instead of constructing a temporary `Path`.
- Documents the slice and registered probe coverage in `docs/plans/2026-06-07-dataset-version-workspace-fspath.md`.

## Plan or Spec
- Plan: `docs/plans/2026-06-07-dataset-version-workspace-fspath.md`
- Registered probe: `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 7 passed.
- Changed-scope coverage: 100.00% (3/3 measurable changed lines).
- Local registered probe comparison on Linux:
  - base (`origin/main`): `elapsed_ms_mean=44.428595`, `elapsed_ms_min=39.373663`, `elapsed_ms_p95=51.258552`
  - head: `elapsed_ms_mean=41.789184`, `elapsed_ms_min=39.574331`, `elapsed_ms_p95=42.274075`
  - delta: `-2.639411 ms` mean, about `5.94%` faster on this local run.
- PR-scoped performance CI is required as the merge gate for registered probe validation.

## Known Gaps
- Linux local validation only; no Swift runtime effects are touched in this slice.
- The optimization is intentionally small and may be sensitive to filesystem noise; CI registered probe report remains the authoritative base-vs-head gate.

## Evidence Checklist
- [x] Registered PR-scoped probe exists and covers the affected path.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage met the 95%+ requirement locally.
- [x] Registered probe ran locally on Linux with improved mean elapsed time.
- [ ] PR-scoped performance workflow completed successfully in CI.
