### PR TITLE
perf: filter native mtp sidecar suffix before dedupe

### DIFF
--- a/docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md
+++ b/docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md
@@ -10,6 +10,8 @@ The prior helper used a list comprehension that read `entry.name` twice for ever
 
 The probe is extended to measure the model safetensor listing path directly against the historical `glob.glob(str(model_dir / "model*.safetensors"))` baseline, while preserving the existing index JSON, sidecar shard, and key predicate metrics.
 
+2026-06-07 follow-up slice: the same registered probe now also seeds duplicate native-MTP metadata entries that do not end in `.safetensors`. The loader filters those names before the duplicate-set lookup, keeping missing-path warnings and `os.path.exists()` checks limited to candidate sidecar shard paths while reducing set churn on noisy index maps.
+
 ## Verification plan
 
 ```bash

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5141,6 +5141,11 @@
         "warn_pct": 0.0
       },
       {
+        "key": "irrelevant_mtp_entries",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
         "key": "weight_load_old_mean_ms",
         "unit": "ms",
         "direction": "informational"

--- a/scripts/native_mtp_loader_safetensor_scandir_probe.py
+++ b/scripts/native_mtp_loader_safetensor_scandir_probe.py
@@ -46,6 +46,8 @@ def _populate_model_dir(model_dir: Path, *, model_files: int, distractor_files: 
         (model_dir / f"model-{index:05d}.bin").write_bytes(b"0")
         weight_map[f"language_model.mtp.layers.{index}.weight"] = mtp_name
         weight_map[f"language_model.mtp.layers.{index}.duplicate_weight"] = mtp_name
+        weight_map[f"language_model.mtp.layers.{index}.metadata"] = f"mtp-{index:05d}.json"
+        weight_map[f"language_model.mtp.layers.{index}.metadata_duplicate"] = f"mtp-{index:05d}.json"
     (model_dir / "model-nested.safetensors").mkdir()
     (model_dir / "model.safetensors.index.json").write_text(
         json.dumps({"weight_map": weight_map}, sort_keys=True),
@@ -313,6 +315,7 @@ def run_probe() -> dict[str, float | int | str]:
         "model_files": model_files,
         "distractor_files": distractor_files,
         "duplicate_mtp_entries": distractor_files,
+        "irrelevant_mtp_entries": distractor_files * 2,
         "samples": samples,
         "key_iterations": key_iterations,
         "weight_load_iterations": weight_load_iterations,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -380,7 +380,7 @@ def test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics(
 
     assert metrics["old_mean_ms"] >= 0.0
     assert metrics["new_mean_ms"] >= 0.0
-    assert metrics["result_count"] == 24
+    assert metrics["result_count"] == 40
     assert metrics["model_listing_old_mean_ms"] >= 0.0
     assert metrics["model_listing_new_mean_ms"] >= 0.0
     assert metrics["model_listing_result_count"] == 10
@@ -388,8 +388,9 @@ def test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics(
     assert metrics["model_files"] == 8
     assert metrics["distractor_files"] == 8
     assert metrics["duplicate_mtp_entries"] == 8
-    assert metrics["key_count"] == 26
-    assert metrics["key_true_count"] == 17
+    assert metrics["irrelevant_mtp_entries"] == 16
+    assert metrics["key_count"] == 42
+    assert metrics["key_true_count"] == 33
     assert metrics["key_iterations"] == 2
     assert metrics["weight_load_iterations"] == 2
     assert metrics["weight_load_result_count"] == 18

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -83,9 +83,6 @@ def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
             file_name_text = file_name
         else:
             file_name_text = to_text(file_name)
-        if file_name_text in seen:
-            continue
-        seen_add(file_name_text)
         if not file_name_text.endswith(".safetensors"):
             continue
         file_basename = file_name_text
@@ -93,6 +90,9 @@ def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
             file_basename = file_name_text.rsplit(path_sep, 1)[-1]
         if file_basename.startswith("model"):
             continue
+        if file_name_text in seen:
+            continue
+        seen_add(file_name_text)
         path_text = path_join(model_path_text, file_name_text)
         if not path_exists(path_text):
             logger.warning("MTP shard listed in index is missing: %s", path_text)


### PR DESCRIPTION
## Summary
- Filters native-MTP index entries by `.safetensors` suffix before touching the sidecar duplicate set.
- Extends the registered native-MTP PR-scoped probe with duplicate non-safetensor metadata entries and an informational `irrelevant_mtp_entries` metric.
- Updates the native-MTP performance slice plan with the follow-up measurement shape.

## Plan or Spec
- Updated `docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md`.
- Registered probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin && git reset --hard origin/main` from the main Melix checkout before creating this worktree.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` — 12 passed.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q ... && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` — 8 passed, changed-scope coverage 100%.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" MELIX_NATIVE_MTP_LOADER_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py`.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_SAMPLES=3 MELIX_NATIVE_MTP_LOADER_MODEL_FILES=500 MELIX_NATIVE_MTP_LOADER_DISTRACTOR_FILES=500 uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id native-mtp-loader-safetensor-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-native-mtp-extra-suffix-before-seen-20260607 --head-repo "$PWD" --output /tmp/native_mtp_extra_pr_probe.json` — local registered runner completed successfully.

## Coverage and Metrics
- Changed-scope coverage: 100% for `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`.
- Local direct registered probe (5 samples, 1500 model files, 1500 distractors): `extra_old_mean_ms=194.424839`, `extra_new_mean_ms=33.463141`, `extra_delta_ms=-160.961698`, `extra_speedup=5.810119`, `irrelevant_mtp_entries=3000`.
- Additional direct probe metrics: `model_listing_old_mean_ms=22.179559`, `model_listing_new_mean_ms=9.234401`; `weight_load_old_mean_ms=466.434925`, `weight_load_new_mean_ms=440.422988`.
- CI PR-scoped performance report is required as the final registered probe validation source before merge.

## Known Gaps
- This is a Python-only slice verified locally on Linux; no Swift runtime effect is claimed.
- The local `pr_scoped_performance_run.py` smoke used reduced probe dimensions for runtime, while the direct local probe used the default larger dimensions.

## Evidence Checklist
- [x] Synced from `origin/main` before branch creation.
- [x] Affected path has registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage measured at >= 95%.
- [x] Local registered probe emitted metrics.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
