### PR TITLE
perf: cache text family bool literals

### DIFF
--- a/docs/plans/2026-06-07-text-family-bool-literal-cache.md
+++ b/docs/plans/2026-06-07-text-family-bool-literal-cache.md
@@ -1,0 +1,29 @@
+# Text Family Bool Literal Cache
+
+## Scope
+
+This Python-only performance slice is limited to `text_family_adapters._bool_from_any()` during repeated text-family config resolution.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `text-family-config-copy-elision` in `infra/perf/pr_scoped_probes.json`. The registered entry includes focused `test_command`, `coverage_command`, and `probe_command` values for:
+
+- `services/mlx-worker-python/worker/runtime/text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/text_family_config_probe.py`
+
+## Change
+
+Hoist the truthy and falsy string literal sets used by `_bool_from_any()` to module-level frozensets. This preserves the accepted string variants while avoiding per-call set construction on the repeated config-resolution path.
+
+## Verification plan
+
+1. Run the registered focused pytest command for `text-family-config-copy-elision` locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run `scripts/text_family_config_probe.py` against the `origin/main` baseline and this branch and compare `elapsed_ms_mean`, `peak_bytes_mean`, and `config_copy_calls_mean`.
+4. Use the PR-scoped performance workflow as the final CI merge gate before squash merging.
+
+## Metrics
+
+Success is measured by a lower or non-regressing `elapsed_ms_mean` in `scripts/text_family_config_probe.py` with unchanged `config_copy_calls_mean == 0`. This slice has no Swift runtime effect.

--- a/services/mlx-worker-python/tests/test_text_family_adapters.py
+++ b/services/mlx-worker-python/tests/test_text_family_adapters.py
@@ -9,6 +9,7 @@ from worker.runtime.text_family_adapters import (
     ResolvedTextFamilyConfig,
     TextFamilyDescriptor,
     TextFamilyDetection,
+    _bool_from_any,
     _inferred_attention_profile,
     _inferred_expert_count,
     _inferred_rope_profile,
@@ -262,6 +263,14 @@ def test_resolve_text_family_config_covers_fallback_parsing_and_bool_variants() 
     assert interleaved.tool_parser_xml_fallback is False
     assert mla.attention_profile == "mla"
     assert mla.moe_gate_dequant is True
+
+
+def test_bool_from_any_preserves_literal_string_variants() -> None:
+    assert _bool_from_any("on") is True
+    assert _bool_from_any(" YES ") is True
+    assert _bool_from_any("off") is False
+    assert _bool_from_any(" NO ") is False
+    assert _bool_from_any("maybe") is False
 
 
 def test_resolve_text_family_config_marks_family_default_expert_count_source() -> None:

--- a/services/mlx-worker-python/worker/runtime/text_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/text_family_adapters.py
@@ -90,6 +90,8 @@ class ResolvedTextFamilyConfig:
 
 _DEFAULT_TEXT_FAMILY_ID = "llama"
 _EMPTY_CONFIG_PAYLOAD: Mapping[str, Any] = {}
+_TRUE_BOOL_LITERALS = frozenset(("1", "true", "yes", "on"))
+_FALSE_BOOL_LITERALS = frozenset(("0", "false", "no", "off"))
 _TEXT_FAMILY_ADAPTERS: dict[str, TextFamilyDescriptor] = {
     "llama": TextFamilyDescriptor(
         family_id="llama",
@@ -470,9 +472,9 @@ def _bool_from_any(value: Any) -> bool:
         return bool(value)
     if isinstance(value, str):
         normalized = value.strip().lower()
-        if normalized in {"1", "true", "yes", "on"}:
+        if normalized in _TRUE_BOOL_LITERALS:
             return True
-        if normalized in {"0", "false", "no", "off"}:
+        if normalized in _FALSE_BOOL_LITERALS:
             return False
     return False
 


### PR DESCRIPTION
## Summary
- Hoist `_bool_from_any()` truthy/falsy string literal sets to module-level frozensets on the text-family config hot path.
- Add a focused regression test for accepted boolean string variants.

## Plan or Spec
- `docs/plans/2026-06-07-text-family-bool-literal-cache.md`
- Registered probe: `text-family-config-copy-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/text_family_adapters.py services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/text_family_config_probe.py`
- Baseline: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py` from `origin/main` worktree.
- Candidate: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py` from this branch.
- `git diff --check`

## Coverage and Metrics
- Focused tests: `21 passed in 1.87s`.
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Local Linux registered probe comparison:
  - baseline `elapsed_ms_mean=267.3620763234794`, `peak_bytes_mean=1274.6`, `config_copy_calls_mean=0.0`
  - candidate `elapsed_ms_mean=265.108654089272`, `peak_bytes_mean=1274.6`, `config_copy_calls_mean=0.0`
  - delta `-2.253422 ms`, speedup `0.843%`
- CI PR-scoped performance report is required as the final registered probe validation before merge.

## Known Gaps
- Python-only slice; no Swift runtime effect is claimed.
- Local metrics are Linux-only and synthetic; the registered PR-scoped performance workflow remains the merge gate.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Confirmed affected path has registered PR-scoped probe commands.
- [x] Added/updated governing plan under `docs/plans/`.
- [x] Ran focused tests locally.
- [x] Ran changed-scope coverage locally.
- [x] Ran local registered probe against baseline and candidate.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
