### PR TITLE
Harden agentic corpus fixture boundaries

### DIFF
--- a/docs/plans/2026-06-08-issue-1761-corpus-boundaries.md
+++ b/docs/plans/2026-06-08-issue-1761-corpus-boundaries.md
@@ -1,0 +1,81 @@
+# Issue 1761 Corpus Boundary Plan
+
+## Goal
+
+Extend the deterministic agentic tool untrusted-context boundary so malformed
+retrieved text and image corpus containers or rows fail closed with typed
+observations instead of being silently treated as empty retrieval results.
+
+## Scope
+
+This slice covers the Python worker deterministic agentic tool runtime:
+
+- `text_search` fixture corpus container selection
+- `image_search` fixture corpus container selection
+- malformed retrieved corpus rows inside selected text and image corpora
+- the governing agentic tool runtime contract
+
+This slice does not cover owner-scoped retrieval, workspace path resolution,
+prompt assembly wrappers, skill or memory entrypoints, or background-job
+continuations. Those remain follow-up work under #1761.
+
+## Architecture
+
+The end-state boundary is a shared untrusted-value validation layer for every
+retrieved segment before it can participate in tool execution or prompt
+assembly. This slice keeps the boundary local to `_context_list(...)`, the
+single helper used by deterministic text and image retrieval fixtures.
+
+Malformed corpus state must fail closed and preserve evidence:
+
+- reject non-list selected corpus containers
+- reject non-object rows inside selected corpus lists
+- emit `reason = invalid_untrusted_input_type`
+- include `field`, `source_type`, `source_id`, `expected_type`,
+  `actual_type`, and `corrective_action`
+- preserve current successful retrieval behavior for valid corpus lists
+
+## Performance Probes And Metrics
+
+The changed path runs once per deterministic `text_search` or `image_search`
+tool call. The overhead is bounded to `isinstance` checks over fixture rows
+that are already iterated by the search adapters.
+
+Verification will include:
+
+- focused pytest for the new fail-closed corpus paths
+- full `test_agentic_tools.py`
+- changed-line coverage for modified Python files with a target of at least
+  95 percent
+- local PR-scoped performance report with `Status: ok`, regressions `0`, and
+  verification failures `0`
+
+If no registered PR-scoped performance probe is selected, the metrics report
+will record that explicitly.
+
+## Implementation Steps
+
+1. Add failing tests in `services/mlx-worker-python/tests/test_agentic_tools.py`
+   for:
+   - a selected text corpus reference whose container is not a list
+   - a selected image corpus row that is not a JSON object
+2. Update `_context_list(...)` in
+   `services/mlx-worker-python/worker/runtime/agentic_tools.py` to raise
+   `AgenticToolRuntimeError` with typed invalid-untrusted details for those
+   cases.
+3. Keep successful `text_search` and `image_search` behavior unchanged for
+   valid top-level lists and corpus-ref mappings.
+4. Update `docs/unified-agentic-tool-runtime-contract.md` to state that corpus
+   containers and rows fail closed.
+5. Run focused tests, changed-line coverage, scoped performance, and PR gates
+   before opening the PR.
+
+## Success Criteria
+
+- Non-list selected text or image corpus containers produce failed
+  observations, not empty search results.
+- Non-object text or image corpus rows produce failed observations, not
+  silently filtered rows.
+- Failed observations use the same typed `invalid_untrusted_input_type` receipt
+  shape introduced by PR #1905.
+- Existing valid retrieval fixture tests still pass.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -146,6 +146,10 @@ assembly. It must not coerce unexpected containers or scalar values into
 strings because that can hide prompt-injection payloads inside trusted-looking
 tool evidence.
 
+Selected retrieved corpus containers and their rows are part of the same
+boundary. A selected text or image corpus must be a JSON list, and each corpus
+row must be a JSON object, before adapter filtering or result projection runs.
+
 When an unexpected untrusted value type is encountered, the runtime must fail
 closed with a failed observation rather than executing the adapter. The failed
 observation payload must include:

--- a/services/mlx-worker-python/tests/test_agentic_tools.py
+++ b/services/mlx-worker-python/tests/test_agentic_tools.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from worker.runtime.agentic_tools import AgenticToolRuntimeError, execute_agentic_tool_calls
+from worker.runtime.agentic_tools import AgenticToolRuntimeError, _context_list, execute_agentic_tool_calls
 from worker.runtime.tool_observation import ToolObservationPolicy
 
 
@@ -391,3 +391,8 @@ def test_agentic_tool_runtime_fails_closed_for_invalid_corpus_containers_and_row
     assert observation["payload"]["source_id"] == expected_source_id
     assert observation["payload"]["expected_type"] == expected_type
     assert observation["payload"]["actual_type"] == actual_type
+
+
+def test_agentic_tool_runtime_rejects_unknown_corpus_keys_before_defaulting_source_metadata() -> None:
+    with pytest.raises(AgenticToolRuntimeError, match="Unsupported retrieved corpus key: audio_corpus"):
+        _context_list({"audio_corpus": [{"id": "clip-1"}]}, "audio_corpus", "default")

--- a/services/mlx-worker-python/tests/test_agentic_tools.py
+++ b/services/mlx-worker-python/tests/test_agentic_tools.py
@@ -339,3 +339,55 @@ def test_agentic_tool_runtime_fails_closed_for_invalid_layout_and_crop_payloads(
     assert observation["payload"]["source_id"] == expected_source_id
     assert observation["payload"]["expected_type"] == expected_type
     assert observation["payload"]["actual_type"] == actual_type
+
+
+@pytest.mark.parametrize(
+    (
+        "tool_call",
+        "fixture_context",
+        "expected_field",
+        "expected_source_type",
+        "expected_source_id",
+        "expected_type",
+        "actual_type",
+    ),
+    [
+        (
+            {"id": "text-corpus-container", "name": "text_search", "arguments": {"query": "melix"}},
+            {"text_corpus": {"default": {"not": "a corpus list"}}},
+            "text_corpus",
+            "retrieved_corpus",
+            "default",
+            "list",
+            "dict",
+        ),
+        (
+            {"id": "image-corpus-row", "name": "image_search", "arguments": {"query": "receipt"}},
+            {"image_corpus": [{"id": "image-1", "media_ref": "img-1", "caption": "receipt"}, ["not", "row"]]},
+            "image_corpus.item",
+            "retrieved_image",
+            "image-2",
+            "object",
+            "list",
+        ),
+    ],
+)
+def test_agentic_tool_runtime_fails_closed_for_invalid_corpus_containers_and_rows(
+    tool_call: dict[str, object],
+    fixture_context: dict[str, object],
+    expected_field: str,
+    expected_source_type: str,
+    expected_source_id: str,
+    expected_type: str,
+    actual_type: str,
+) -> None:
+    run = execute_agentic_tool_calls([tool_call], fixture_context=fixture_context)
+
+    observation = run.observations[0]
+    assert observation["status"] == "failed"
+    assert observation["payload"]["reason"] == "invalid_untrusted_input_type"
+    assert observation["payload"]["field"] == expected_field
+    assert observation["payload"]["source_type"] == expected_source_type
+    assert observation["payload"]["source_id"] == expected_source_id
+    assert observation["payload"]["expected_type"] == expected_type
+    assert observation["payload"]["actual_type"] == actual_type

--- a/services/mlx-worker-python/worker/runtime/agentic_tools.py
+++ b/services/mlx-worker-python/worker/runtime/agentic_tools.py
@@ -525,8 +525,28 @@ def _context_list(fixture_context: dict[str, Any], key: str, corpus_ref: str) ->
     if isinstance(value, dict):
         value = value.get(corpus_ref, [])
     if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, dict)]
+        raise _invalid_untrusted_value_type(
+            field=key,
+            source_type="retrieved_corpus",
+            source_id=corpus_ref,
+            expected_type="list",
+            actual_type=type(value).__name__,
+        )
+
+    item_source_type = "retrieved_image" if key == "image_corpus" else "retrieved_document"
+    item_source_id_prefix = "image" if key == "image_corpus" else "doc"
+    context_items: list[dict[str, Any]] = []
+    for index, item in enumerate(value, start=1):
+        if not isinstance(item, dict):
+            raise _invalid_untrusted_value_type(
+                field=f"{key}.item",
+                source_type=item_source_type,
+                source_id=f"{item_source_id_prefix}-{index}",
+                expected_type="object",
+                actual_type=type(item).__name__,
+            )
+        context_items.append(item)
+    return context_items
 
 
 def _tool_argument_text(arguments: dict[str, Any], name: str, *, tool_call_id: str) -> str:

--- a/services/mlx-worker-python/worker/runtime/agentic_tools.py
+++ b/services/mlx-worker-python/worker/runtime/agentic_tools.py
@@ -521,6 +521,15 @@ def _context_mapping(fixture_context: dict[str, Any], key: str) -> dict[str, Any
 
 
 def _context_list(fixture_context: dict[str, Any], key: str, corpus_ref: str) -> list[dict[str, Any]]:
+    if key == "image_corpus":
+        item_source_type = "retrieved_image"
+        item_source_id_prefix = "image"
+    elif key == "text_corpus":
+        item_source_type = "retrieved_document"
+        item_source_id_prefix = "doc"
+    else:
+        raise AgenticToolRuntimeError(f"Unsupported retrieved corpus key: {key}.")
+
     value = fixture_context.get(key, [])
     if isinstance(value, dict):
         value = value.get(corpus_ref, [])
@@ -533,8 +542,6 @@ def _context_list(fixture_context: dict[str, Any], key: str, corpus_ref: str) ->
             actual_type=type(value).__name__,
         )
 
-    item_source_type = "retrieved_image" if key == "image_corpus" else "retrieved_document"
-    item_source_id_prefix = "image" if key == "image_corpus" else "doc"
     context_items: list[dict[str, Any]] = []
     for index, item in enumerate(value, start=1):
         if not isinstance(item, dict):


### PR DESCRIPTION
## Summary
- Harden deterministic text/image corpus fixture loading so non-list selected corpora and non-object rows fail closed with `invalid_untrusted_input_type` observations.
- Reject unsupported retrieved corpus keys before assigning default source metadata.
- Document the corpus container/row boundary and add the #1761 slice plan.

## Plan or Spec
- `docs/plans/2026-06-08-issue-1761-corpus-boundaries.md`
- `docs/unified-agentic-tool-runtime-contract.md`
- Refs #1761

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_fails_closed_for_invalid_corpus_containers_and_rows
# 2 passed in 0.03s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 40 passed in 0.16s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file=.runtime/coverage/issue1761-corpus.coverage -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 40 passed in 0.09s

UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file=.runtime/coverage/issue1761-corpus.coverage -o .runtime/coverage/issue1761-corpus.json
# Wrote JSON report to .runtime/coverage/issue1761-corpus.json

UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json .runtime/coverage/issue1761-corpus.json services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
# TOTAL 100.00% 20/20

git diff --check
# pass

UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/perf/issue1761-corpus/scope/changed-files.json --output .runtime/perf/issue1761-corpus/scope/scope.json
# pass

UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/perf/issue1761-corpus/scope/scope.json --results-dir .runtime/perf/issue1761-corpus/probes --output-dir .runtime/perf/issue1761-corpus/report --format terminal --sticky-comment
# Status: ok; Changed files: 3; Selected probes: 0; Regressions: 0; Verification failures: 0

git commit -m "Harden agentic corpus fixture boundaries"
# pre-commit ran make swift-test, make py-test, make integration-test, and PR-scoped performance report
# make swift-test: completed rc=0 elapsed=663.5s
# make py-test: 3662 passed, 14 skipped, 2 warnings in 172.94s
# make integration-test: 117 passed, 1 skipped in 765.71s
# pre-commit performance: Status ok; Changed files: 4; Selected probes: 0; Regressions: 0; Verification failures: 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_fails_closed_for_invalid_corpus_containers_and_rows services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_rejects_unknown_corpus_keys_before_defaulting_source_metadata
# 3 passed in 0.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 41 passed in 0.05s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file=.runtime/coverage/issue1761-corpus-review.coverage -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 41 passed in 0.09s

UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file=.runtime/coverage/issue1761-corpus-review.coverage -o .runtime/coverage/issue1761-corpus-review.json
# Wrote JSON report to .runtime/coverage/issue1761-corpus-review.json

UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json .runtime/coverage/issue1761-corpus-review.json services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
# TOTAL 100.00% 29/29

git diff --check
# pass

UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/perf/issue1761-corpus-review/scope/changed-files.json --output .runtime/perf/issue1761-corpus-review/scope/scope.json
# pass

UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/perf/issue1761-corpus-review/scope/scope.json --results-dir .runtime/perf/issue1761-corpus-review/probes --output-dir .runtime/perf/issue1761-corpus-review/report --format terminal --sticky-comment
# Status: ok; Changed files: 4; Selected probes: 0; Regressions: 0; Verification failures: 0

git commit -m "Validate agentic corpus keys"
# pre-commit ran make swift-test, make py-test, make integration-test, and PR-scoped performance report
# make swift-test: completed rc=0 elapsed=328.1s
# make py-test: 3663 passed, 14 skipped, 2 warnings in 163.41s
# make integration-test: 117 passed, 1 skipped in 538.65s
# pre-commit performance: Status ok; Changed files: 2; Selected probes: 0; Regressions: 0; Verification failures: 0

git merge --no-edit origin/main
# merged origin/main at 33a55152; no conflicts

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_fails_closed_for_invalid_corpus_containers_and_rows services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_rejects_unknown_corpus_keys_before_defaulting_source_metadata
# 3 passed in 0.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 41 passed in 0.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file=.runtime/coverage/issue1761-corpus-mainmerge.coverage -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 41 passed in 0.09s

UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file=.runtime/coverage/issue1761-corpus-mainmerge.coverage -o .runtime/coverage/issue1761-corpus-mainmerge.json
# Wrote JSON report to .runtime/coverage/issue1761-corpus-mainmerge.json

UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json .runtime/coverage/issue1761-corpus-mainmerge.json services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
# TOTAL 100.00% 29/29

git diff --check
# pass

make swift-test
# completed rc=0
# protocol package: 1 test passed
# text worker package: 241 tests passed
# control-plane worker clients: 127 tests passed
# macOS menubar package: 796 tests passed

make py-test
# 3664 passed, 14 skipped, 2 warnings in 161.56s

make integration-test
# 117 passed, 1 skipped in 716.57s

UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/perf/issue1761-corpus-final/scope/changed-files.json --output .runtime/perf/issue1761-corpus-final/scope/scope.json
# pass

UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/perf/issue1761-corpus-final/scope/scope.json --results-dir .runtime/perf/issue1761-corpus-final/probes --output-dir .runtime/perf/issue1761-corpus-final/report --format terminal --sticky-comment
# Status: ok; Changed files: 4; Selected probes: 0; Regressions: 0; Verification failures: 0

git merge --no-edit origin/main
# merged origin/main at 8e783ae4; no conflicts

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_fails_closed_for_invalid_corpus_containers_and_rows services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_rejects_unknown_corpus_keys_before_defaulting_source_metadata
# 3 passed in 0.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 41 passed in 0.05s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file .runtime/coverage/issue1761-corpus-mainmerge2.coverage -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 41 passed in 0.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file .runtime/coverage/issue1761-corpus-mainmerge2.coverage -o .runtime/coverage/issue1761-corpus-mainmerge2.json
# Wrote JSON report to .runtime/coverage/issue1761-corpus-mainmerge2.json

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/issue1761-corpus-mainmerge2.json --diff-from origin/main services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
# TOTAL 100.00% 29/29

git diff --check origin/main..HEAD
# pass

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/perf/issue-1761-corpus-mainmerge2/changed-files.json --output .runtime/perf/issue-1761-corpus-mainmerge2/scope.json
# pass

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_report.py --scope .runtime/perf/issue-1761-corpus-mainmerge2/scope.json --results-dir .runtime/perf/issue-1761-corpus-mainmerge2/results --format terminal --output-dir .runtime/perf/issue-1761-corpus-mainmerge2/report --sticky-comment
# Status: ok; Changed files: 4; Selected probes: 0; Regressions: 0; Context regressions: 0; Verification failures: 0

make swift-test
# completed rc=0

make py-test
# 3667 passed, 14 skipped, 2 warnings in 167.78s

make integration-test
# 117 passed, 1 skipped in 425.79s

git merge --no-edit origin/main
# merged origin/main at b831398d; no conflicts

git merge --no-edit origin/main
# merged origin/main at b641167c; no conflicts

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_fails_closed_for_invalid_corpus_containers_and_rows services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_rejects_unknown_corpus_keys_before_defaulting_source_metadata
# 3 passed in 0.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 41 passed in 0.05s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file .runtime/coverage/issue1761-corpus-mainmerge4.coverage -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 41 passed in 0.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file .runtime/coverage/issue1761-corpus-mainmerge4.coverage -o .runtime/coverage/issue1761-corpus-mainmerge4.json
# Wrote JSON report to .runtime/coverage/issue1761-corpus-mainmerge4.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/issue1761-corpus-mainmerge4.json --diff-from origin/main services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
# TOTAL 100.00% 29/29

git diff --check origin/main..HEAD
# pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/perf/issue-1761-corpus-mainmerge4/changed-files.json --output .runtime/perf/issue-1761-corpus-mainmerge4/scope.json
# pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/perf/issue-1761-corpus-mainmerge4/scope.json --results-dir .runtime/perf/issue-1761-corpus-mainmerge4/results --format terminal --output-dir .runtime/perf/issue-1761-corpus-mainmerge4/report --sticky-comment
# Status: ok; Changed files: 4; Selected probes: 0; Regressions: 0; Context regressions: 0; Verification failures: 0

xcrun swift test --package-path apps/macos-menubar --no-parallel -Xswiftc -gnone --filter chatPromptCoalescesRenderCadenceWithoutDroppingStreamTranscriptEvents
# 1 test passed in 0.009s

make py-test
# 3667 passed, 14 skipped, 2 warnings in 192.58s

make integration-test
# 117 passed, 1 skipped in 678.54s

make swift-test
# completed rc=0
# macOS menubar package: 796 tests in 25 suites passed after 29.626s

git merge --no-edit origin/main
# merged origin/main at a85aa0ee; no conflicts

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_fails_closed_for_invalid_corpus_containers_and_rows services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_rejects_unknown_corpus_keys_before_defaulting_source_metadata
# 3 passed in 0.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 41 passed in 0.05s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file .runtime/coverage/issue1761-corpus-mainmerge5.coverage -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 41 passed in 0.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file .runtime/coverage/issue1761-corpus-mainmerge5.coverage -o .runtime/coverage/issue1761-corpus-mainmerge5.json
# Wrote JSON report to .runtime/coverage/issue1761-corpus-mainmerge5.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/issue1761-corpus-mainmerge5.json --diff-from origin/main services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
# TOTAL 100.00% 29/29

git diff --check origin/main..HEAD
# pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/perf/issue-1761-corpus-mainmerge5/changed-files.json --output .runtime/perf/issue-1761-corpus-mainmerge5/scope.json
# pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/perf/issue-1761-corpus-mainmerge5/scope.json --results-dir .runtime/perf/issue-1761-corpus-mainmerge5/results --format terminal --output-dir .runtime/perf/issue-1761-corpus-mainmerge5/report --sticky-comment
# Status: ok; Changed files: 4; Selected probes: 0; Regressions: 0; Context regressions: 0; Verification failures: 0

git merge --no-edit origin/main
# merged origin/main at 279f9581; no conflicts

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_fails_closed_for_invalid_corpus_containers_and_rows services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_rejects_unknown_corpus_keys_before_defaulting_source_metadata
# 3 passed in 0.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 41 passed in 0.07s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file .runtime/coverage/issue1761-corpus-mainmerge6.coverage -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 41 passed in 0.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file .runtime/coverage/issue1761-corpus-mainmerge6.coverage -o .runtime/coverage/issue1761-corpus-mainmerge6.json
# Wrote JSON report to .runtime/coverage/issue1761-corpus-mainmerge6.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/issue1761-corpus-mainmerge6.json --diff-from origin/main services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
# TOTAL 100.00% 29/29

git diff --check origin/main..HEAD
# pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/perf/issue-1761-corpus-mainmerge6/scope/changed-files.json --output .runtime/perf/issue-1761-corpus-mainmerge6/scope/scope.json
# pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/perf/issue-1761-corpus-mainmerge6/scope/scope.json --results-dir .runtime/perf/issue-1761-corpus-mainmerge6/probes --output-dir .runtime/perf/issue-1761-corpus-mainmerge6/report --format terminal --sticky-comment
# Status: ok; Changed files: 4; Selected probes: 0; Regressions: 0; Context regressions: 0; Verification failures: 0
```

## Coverage and Metrics
- Changed-line coverage: `100.00%` (`29/29`) for `services/mlx-worker-python/worker/runtime/agentic_tools.py` and `services/mlx-worker-python/tests/test_agentic_tools.py`.
- PR-scoped performance report: `Status: ok`, changed files `4`, selected probes `0`, regressions `0`, context regressions `0`, verification failures `0`.
- Observability mode: `minimal`; this slice reuses existing failed observation payloads and does not add runtime metrics or debug artifacts.
- Probe overhead: `N/A`; no registered PR-scoped probes were selected for these files.

## Known Gaps
- This is one #1761 slice. Owner-scoped retrieval, workspace path resolution, prompt assembly wrappers, skill or memory entrypoints, and background-job continuations remain follow-up work under #1761.
- No protocol or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
