### PR TITLE
perf: scan slowest probe phases without row copy

### DIFF
--- a/docs/plans/2026-06-07-report-evidence-slowest-phases-direct-list-scan.md
+++ b/docs/plans/2026-06-07-report-evidence-slowest-phases-direct-list-scan.md
@@ -1,0 +1,26 @@
+# Report Evidence Gate Slowest Phases Direct List Scan
+
+This Python-only performance slice is limited to `worker.productization.report_evidence_gate._slowest_probe_phases`.
+
+## Scope
+
+- Preserve the top-five slowest probe phase report ordering, typed duration handling, tie behavior, and malformed-row tolerance.
+- Replace the hot-loop `_dict_list(...)` materialization with direct list iteration plus an inline `dict` guard.
+- Keep the slice local to report evidence gate code, its focused regression coverage, and this governing plan.
+
+## Registered probe
+
+The affected path is covered by the existing `report-evidence-gate-run-kind-set-membership` registered PR-scoped performance probe in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe already provides focused `test_command`, `coverage_command`, and `probe_command` entries for `services/mlx-worker-python/worker/productization/report_evidence_gate.py`, including `slowest_probe_phase_elapsed_ms_mean` in `scripts/report_evidence_gate_run_kind_probe.py`.
+
+## Verification plan
+
+1. Run the focused registered test command locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux and confirm the touched scope remains at or above 95%.
+3. Run the registered probe command locally on Linux and compare against the pre-change baseline from `origin/main`.
+4. Use GitHub Actions PR-scoped performance as the merge gate before merging.
+
+## Expected performance signal
+
+The expected directional improvement is a reduction in `slowest_probe_phase_elapsed_ms_mean` from avoiding allocation of an intermediate filtered row list for each side of the probe summary. Overall `elapsed_ms_mean` may improve slightly; the slowest-phase metric is the primary metric for this slice.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -148,15 +148,16 @@ def _write_report(
 
 
 def test_report_evidence_gate_slowest_probe_phases_keeps_top_five_order() -> None:
-    slowest_phases = [
+    slowest_phases: list[object] = [
         {"phase": f"phase-{index}", "duration_ms": float(index)}
         for index in range(20)
     ]
     slowest_phases.insert(0, {"phase": "missing-duration"})
+    slowest_phases.insert(1, "not-a-phase-row")
     report: dict[str, object] = {
         "probe_summary": {
-            "baseline": {"slowest_phases": slowest_phases[:10]},
-            "candidate": {"slowest_phases": slowest_phases[10:]},
+            "baseline": {"slowest_phases": "not-a-list"},
+            "candidate": {"slowest_phases": slowest_phases},
         }
     }
 

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -456,12 +456,16 @@ def _slowest_probe_phases(report: dict[str, object]) -> list[dict[str, object]]:
     rows: list[tuple[float, int, str, dict[str, object]]] = []
     row_index = 0
     rows_append = rows.append
-    dict_list = _dict_list
     for side in ("baseline", "candidate"):
         side_summary = probe_summary.get(side)
         if not isinstance(side_summary, dict):
             continue
-        for row in dict_list(side_summary.get("slowest_phases")):
+        slowest_phases = side_summary.get("slowest_phases")
+        if not isinstance(slowest_phases, list):
+            continue
+        for row in slowest_phases:
+            if not isinstance(row, dict):
+                continue
             duration = row.get("duration_ms")
             if type(duration) is float:
                 duration_ms = duration


### PR DESCRIPTION
## Summary
- Optimizes `report_evidence_gate._slowest_probe_phases` by iterating the `slowest_phases` lists directly instead of allocating `_dict_list(...)` copies for each side.
- Extends the focused regression test to keep non-list and non-dict malformed input coverage for the direct scan path.

## Plan or Spec
- `docs/plans/2026-06-07-report-evidence-slowest-phases-direct-list-scan.md`
- Registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_keeps_top_five_order services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_preserves_tie_order services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_accepts_typed_durations
# 3 passed in 0.17s

<registered report-evidence-gate-run-kind-set-membership test_command>
# 21 passed in 0.88s

<registered report-evidence-gate-run-kind-set-membership coverage_command>
# 21 passed in 0.46s
# changed-scope coverage: TOTAL 8 0 100%

<registered report-evidence-gate-run-kind-set-membership probe_command> on origin/main baseline
# slowest_probe_phase_elapsed_ms_mean=38.3032395504415, elapsed_ms_mean=931.1459905467927

<registered report-evidence-gate-run-kind-set-membership probe_command> on this branch
# slowest_probe_phase_elapsed_ms_mean=34.25225289538503, elapsed_ms_mean=927.3765623569489

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 8 0 100%`).
- Local Linux registered probe delta:
  - `slowest_probe_phase_elapsed_ms_mean`: 38.3032395504415 ms -> 34.25225289538503 ms (`-4.050986655056477 ms`, `10.57609409178494%` faster).
  - `elapsed_ms_mean`: 931.1459905467927 ms -> 927.3765623569489 ms (`-3.769428189843893 ms`, `0.40481602542587214%` faster).
- CI PR-scoped performance is still required as the merge gate and registered probe validation source.

## Known Gaps
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally; this Python slice used the registered focused test, coverage, and probe commands.
- Swift runtime effects are not applicable for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
