### PR TITLE
Add cookbook host probe recommendation

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -2270,6 +2270,40 @@ public struct RecipeInitOptions: Equatable, Sendable {
     }
 }
 
+public struct CookbookRecommendOptions: Equatable, Sendable {
+    public let modelID: String
+    public let workload: String
+    public let serverPlatform: String
+    public let serverArch: String
+    public let operatorPlatform: String
+    public let operatorArch: String
+    public let browserPlatform: String
+    public let browserArch: String
+    public let json: Bool
+
+    public init(
+        modelID: String,
+        workload: String,
+        serverPlatform: String = "",
+        serverArch: String = "",
+        operatorPlatform: String = "",
+        operatorArch: String = "",
+        browserPlatform: String = "",
+        browserArch: String = "",
+        json: Bool = false
+    ) {
+        self.modelID = modelID
+        self.workload = workload
+        self.serverPlatform = serverPlatform
+        self.serverArch = serverArch
+        self.operatorPlatform = operatorPlatform
+        self.operatorArch = operatorArch
+        self.browserPlatform = browserPlatform
+        self.browserArch = browserArch
+        self.json = json
+    }
+}
+
 public enum MelixCLIOutputFormat: String, Equatable, Sendable {
     case legacy
     case jsonV1 = "json-v1"
@@ -2344,6 +2378,7 @@ public enum MelixCLICommand: Equatable, Sendable {
     case recipesPlan(RecipePlanOptions)
     case recipesApply(RecipeApplyOptions)
     case recipesInit(RecipeInitOptions)
+    case cookbookRecommend(CookbookRecommendOptions)
     case modelRootsList(ModelRootsListOptions)
     case modelRootsAdd(ModelRootsMutateOptions)
     case modelRootsRemove(ModelRootsMutateOptions)
@@ -2515,6 +2550,8 @@ public enum MelixCLIParser {
             return try parseURI(tail)
         case "recipes":
             return try parseRecipes(tail)
+        case "cookbook":
+            return try parseCookbook(tail)
         case "server":
             return try parseServer(tail)
         case "remote-server":
@@ -2599,6 +2636,7 @@ public enum MelixCLIParser {
       melix recipes plan RECIPE_ID [--version VERSION] [--set KEY=VALUE ...] [--output PATH] [--json]
       melix recipes apply RECIPE_ID [--version VERSION] [--set KEY=VALUE ...] [--dry-run] [--resume] [--from-step STEP_ID] [--json]
       melix recipes init --from URI --task TASK [--output PATH] [--json]
+      melix cookbook recommend MODEL_ID --workload WORKLOAD [--server-platform PLATFORM] [--server-arch ARCH] [--operator-platform PLATFORM] [--operator-arch ARCH] [--browser-platform PLATFORM] [--browser-arch ARCH] [--json]
       melix model roots list [--json]
       melix model roots add --path PATH [--json]
       melix model roots remove --path PATH [--json]
@@ -3661,6 +3699,42 @@ public enum MelixCLIParser {
                     sourceURI: sourceURI,
                     task: task,
                     outputPath: values.single["--output"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
+        default:
+            throw MelixCLIError.usage(usageText)
+        }
+    }
+
+    private static func parseCookbook(_ arguments: [String]) throws -> MelixCLICommand {
+        guard let action = arguments.first else {
+            throw MelixCLIError.usage(usageText)
+        }
+        var optionArguments = Array(arguments.dropFirst())
+        switch action {
+        case "recommend":
+            let modelID = try extractPositionalValue(
+                from: &optionArguments,
+                label: "MODEL_ID",
+                command: "melix cookbook recommend"
+            )
+            let values = try ArgumentCursor(arguments: optionArguments).parse()
+            guard let workload = values.single["--workload"],
+                  workload.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            else {
+                throw MelixCLIError.missingRequired("--workload is required for melix cookbook recommend.")
+            }
+            return .cookbookRecommend(
+                .init(
+                    modelID: modelID,
+                    workload: workload,
+                    serverPlatform: values.single["--server-platform"] ?? "",
+                    serverArch: values.single["--server-arch"] ?? "",
+                    operatorPlatform: values.single["--operator-platform"] ?? "",
+                    operatorArch: values.single["--operator-arch"] ?? "",
+                    browserPlatform: values.single["--browser-platform"] ?? "",
+                    browserArch: values.single["--browser-arch"] ?? "",
                     json: values.flags.contains("--json")
                 )
             )
@@ -7743,6 +7817,8 @@ public actor MelixCLIRunner {
             return try await runRecipesApply(options)
         case .recipesInit(let options):
             return try runRecipesInit(options)
+        case .cookbookRecommend(let options):
+            return try runCookbookRecommend(options)
         case .pipelineRun(let options):
             return try await runPipeline(options)
         case .batchRun(let options):

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -102,6 +102,8 @@ public enum MelixCLICommandCodec {
             return "recipes.apply"
         case .recipesInit:
             return "recipes.init"
+        case .cookbookRecommend:
+            return "cookbook.recommend"
         case .modelRootsList:
             return "model.roots.list"
         case .modelRootsAdd:
@@ -1047,6 +1049,16 @@ public enum MelixCLICommandCodec {
             appendOption("--from", value: options.sourceURI, into: &arguments)
             appendOption("--task", value: options.task, into: &arguments)
             appendOption("--output", value: options.outputPath, into: &arguments)
+            json = options.json
+        case .cookbookRecommend(let options):
+            arguments = ["cookbook", "recommend", options.modelID]
+            appendOption("--workload", value: options.workload, into: &arguments)
+            appendOption("--server-platform", value: options.serverPlatform, into: &arguments)
+            appendOption("--server-arch", value: options.serverArch, into: &arguments)
+            appendOption("--operator-platform", value: options.operatorPlatform, into: &arguments)
+            appendOption("--operator-arch", value: options.operatorArch, into: &arguments)
+            appendOption("--browser-platform", value: options.browserPlatform, into: &arguments)
+            appendOption("--browser-arch", value: options.browserArch, into: &arguments)
             json = options.json
         case .pipelineRun(let options):
             arguments = ["pipeline", "run"]

--- a/Sources/MelixCLICore/MelixCookbook.swift
+++ b/Sources/MelixCLICore/MelixCookbook.swift
@@ -1,0 +1,169 @@
+import Dispatch
+import Foundation
+
+private enum MelixCookbookHostPlatformSource: String {
+    case hardwareProbe = "hardware_probe"
+    case explicitOperatorSetting = "explicit_operator_setting"
+    case browserFallback = "browser_fallback"
+    case unavailable
+}
+
+private struct MelixCookbookHostSelection {
+    let platform: String
+    let arch: String
+    let source: MelixCookbookHostPlatformSource
+    let warnings: [String]
+}
+
+private struct MelixCookbookBackendRecommendation {
+    let selectedBackend: String
+    let commandFamily: String
+}
+
+private enum MelixCookbookRecommendationPlanner {
+    static let browserFallbackWarning =
+        "Browser platform hints may describe the UI client rather than the Melix serving host."
+    static let unavailableWarning =
+        "No host platform source was available; run a Melix hardware probe before relying on this recommendation."
+
+    static func makePayload(options: CookbookRecommendOptions, planMS: Double) -> [String: Any] {
+        let host = selectHost(options)
+        let backend = recommendBackend(for: host)
+        return [
+            "schema_version": "melix.cookbook.recommendation.v1",
+            "model_id": trimmedString(options.modelID),
+            "workload": trimmedString(options.workload),
+            "host": [
+                "platform": host.platform,
+                "arch": host.arch,
+                "host_platform_source": host.source.rawValue,
+            ],
+            "recommendation": [
+                "selected_backend": backend.selectedBackend,
+                "command_family": backend.commandFamily,
+            ],
+            "warnings": host.warnings,
+            "probe": [
+                "name": "cookbook.host_source_selection",
+                "cookbook.plan_ms": NSNumber(value: planMS),
+            ],
+        ]
+    }
+
+    static func makeText(options: CookbookRecommendOptions, planMS: Double) -> String {
+        let host = selectHost(options)
+        let backend = recommendBackend(for: host)
+        let hostDisplay = host.platform.isEmpty
+            ? "unavailable (\(host.source.rawValue))"
+            : "\(host.platform)/\(host.arch) (\(host.source.rawValue))"
+        var lines = [
+            "Melix cookbook recommendation",
+            "Model: \(trimmedString(options.modelID))",
+            "Workload: \(trimmedString(options.workload))",
+            "Host: \(hostDisplay)",
+            "Backend: \(backend.selectedBackend)",
+            "Command family: \(backend.commandFamily)",
+        ]
+        for warning in host.warnings {
+            lines.append("Warning: \(warning)")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func selectHost(_ options: CookbookRecommendOptions) -> MelixCookbookHostSelection {
+        if let platform = nonEmpty(options.serverPlatform) {
+            return MelixCookbookHostSelection(
+                platform: normalizePlatform(platform),
+                arch: normalizeArch(options.serverArch),
+                source: .hardwareProbe,
+                warnings: []
+            )
+        }
+        if let platform = nonEmpty(options.operatorPlatform) {
+            return MelixCookbookHostSelection(
+                platform: normalizePlatform(platform),
+                arch: normalizeArch(options.operatorArch),
+                source: .explicitOperatorSetting,
+                warnings: []
+            )
+        }
+        if let platform = nonEmpty(options.browserPlatform) {
+            return MelixCookbookHostSelection(
+                platform: normalizePlatform(platform),
+                arch: normalizeArch(options.browserArch),
+                source: .browserFallback,
+                warnings: [browserFallbackWarning]
+            )
+        }
+        return MelixCookbookHostSelection(
+            platform: "",
+            arch: "",
+            source: .unavailable,
+            warnings: [unavailableWarning]
+        )
+    }
+
+    private static func recommendBackend(for host: MelixCookbookHostSelection) -> MelixCookbookBackendRecommendation {
+        if host.platform == "macos", ["arm64", "arm64e"].contains(host.arch) {
+            return MelixCookbookBackendRecommendation(
+                selectedBackend: "mlx-native",
+                commandFamily: "melix server start"
+            )
+        }
+        if host.platform == "linux" {
+            return MelixCookbookBackendRecommendation(
+                selectedBackend: "python-worker",
+                commandFamily: "melix server start"
+            )
+        }
+        return MelixCookbookBackendRecommendation(
+            selectedBackend: "generic-local-runtime",
+            commandFamily: "melix server start"
+        )
+    }
+
+    private static func normalizePlatform(_ value: String) -> String {
+        switch normalizedString(value) {
+        case "darwin", "mac", "macos", "macosx", "osx":
+            return "macos"
+        case "win", "win32", "windows":
+            return "windows"
+        default:
+            return normalizedString(value)
+        }
+    }
+
+    private static func normalizeArch(_ value: String) -> String {
+        switch normalizedString(value) {
+        case "aarch64":
+            return "arm64"
+        default:
+            return normalizedString(value)
+        }
+    }
+
+    private static func nonEmpty(_ value: String) -> String? {
+        let normalized = normalizedString(value)
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func normalizedString(_ value: String) -> String {
+        trimmedString(value).lowercased()
+    }
+
+    private static func trimmedString(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+extension MelixCLIRunner {
+    func runCookbookRecommend(_ options: CookbookRecommendOptions) throws -> String {
+        let startedAt = DispatchTime.now()
+        let planMS = elapsedMilliseconds(since: startedAt)
+        if options.json {
+            let payload = MelixCookbookRecommendationPlanner.makePayload(options: options, planMS: planMS)
+            return try MelixCLIJSON.prettyString(payload)
+        }
+        return MelixCookbookRecommendationPlanner.makeText(options: options, planMS: planMS)
+    }
+}

--- a/docs/plans/2026-06-08-issue-1762-cookbook-host-probe.md
+++ b/docs/plans/2026-06-08-issue-1762-cookbook-host-probe.md
@@ -1,0 +1,89 @@
+# Issue 1762 Cookbook Host Probe Source Slice
+
+## Goal
+
+Add the first deterministic cookbook recommendation slice for issue #1762:
+when Melix generates a serve/profile recommendation, the host platform must come
+from the server-side hardware/runtime probe first, then an explicit operator
+override, and only then a browser fallback.
+
+## Scope
+
+- Add a focused CLI cookbook recommendation command:
+  `melix cookbook recommend MODEL_ID --workload WORKLOAD [--server-platform PLATFORM] [--server-arch ARCH] [--operator-platform PLATFORM] [--operator-arch ARCH] [--browser-platform PLATFORM] [--browser-arch ARCH] [--json]`.
+- Emit a stable receipt with:
+  - `schema_version = melix.cookbook.recommendation.v1`
+  - `host_platform_source = hardware_probe | explicit_operator_setting | browser_fallback | unavailable`
+  - selected host platform and architecture
+  - selected backend and command family
+  - warnings when Melix falls back to browser hints
+- Keep model ranking, downloads, dependency installation, and benchmark artifact
+  joining out of scope for this slice.
+- Keep the command deterministic and fixture-driven so later cookbook ranking
+  can reuse the receipt contract.
+
+## Design
+
+The Swift CLI owns this first slice because recipe planning and operator-facing
+fit receipts already live there. The implementation adds a small
+`MelixCookbookPlanner` helper in `MelixCLICore`; it does not call the running
+control plane and does not mutate state.
+
+The host-selection policy is fail-closed and deterministic:
+
+1. Use non-empty `server-platform` values as `hardware_probe`.
+2. Otherwise use non-empty `operator-platform` values as
+   `explicit_operator_setting`.
+3. Otherwise use non-empty `browser-platform` values as `browser_fallback` and
+   emit a warning because browser hints may describe the UI client, not the
+   machine serving the model.
+4. If no source exists, emit `unavailable`, select the generic command family,
+   and warn that the recommendation needs a hardware probe.
+
+Backend and command-family selection remains intentionally simple:
+
+- macOS Apple Silicon (`platform = macos`, `arch = arm64 | arm64e`) selects
+  `mlx-native` and `melix server start`.
+- Linux selects `python-worker` and `melix server start`.
+- Other platforms use `generic-local-runtime` and `melix server start`.
+
+## Verification
+
+Focused Swift tests cover:
+
+- contradictory Windows browser hint with macOS server probe still selects the
+  macOS/native path and records `host_platform_source = hardware_probe`;
+- explicit operator setting wins when no server probe exists;
+- browser fallback emits a warning;
+- parser and command codec preserve cookbook recommendation arguments.
+
+Commands:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" \
+swift test --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
+
+python3 scripts/swift_changed_line_coverage.py \
+  --binary .build/arm64-apple-macosx/debug/MelixPackageTests.xctest/Contents/MacOS/MelixPackageTests \
+  --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata \
+  --diff-from origin/main \
+  Sources/MelixCLICore/MelixCLI.swift \
+  Sources/MelixCLICore/MelixCLICommandCodec.swift \
+  Sources/MelixCLICore/MelixCookbook.swift \
+  tests/MelixCLITests/MelixCLIParserTests.swift \
+  tests/MelixCLITests/MelixCLIRunnerTests.swift
+```
+
+## Metrics
+
+- `cookbook.plan_ms` is emitted in each recommendation receipt.
+- No registered PR-scoped performance probe currently watches this new helper;
+  the PR scoped performance report should therefore show zero selected probes
+  unless the registry changes.
+
+## Known Gaps
+
+- This slice does not implement multi-model ranking, benchmark evidence joins,
+  dependency preflight, download readiness, or UI display.
+- Future slices should connect the receipt to hardware probes surfaced by the
+  running server and to benchmark evidence artifacts.

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -1168,6 +1168,7 @@ struct MelixCLIParserTests {
             (.recipesPlan(.init(recipeID: "import.hf-mlx-model", version: "1", values: ["repo_id": "org/model", "model_id": "model"], outputPath: "/tmp/plan.json", json: true)), "recipes.plan"),
             (.recipesApply(.init(recipeID: "benchmark.eval.smoke", version: "1", values: ["model_id": "model"], dryRun: true, resume: true, fromStepID: "benchmark", json: true)), "recipes.apply"),
             (.recipesInit(.init(sourceURI: "hf://model/org/model", task: "import", outputPath: "/tmp/import.recipe.json", json: true)), "recipes.init"),
+            (.cookbookRecommend(.init(modelID: "mlx/qwen", workload: "chat", serverPlatform: "macos", serverArch: "arm64", json: true)), "cookbook.recommend"),
             (.modelRootsList(.init(json: true)), "model.roots.list"),
             (.modelRootsAdd(.init(path: "/models", json: true)), "model.roots.add"),
             (.modelRootsRemove(.init(path: "/models", json: true)), "model.roots.remove"),
@@ -1265,6 +1266,7 @@ struct MelixCLIParserTests {
             .recipesPlan(.init(recipeID: "import.hf-mlx-model", version: "1", values: ["repo_id": "org/model", "model_id": "model"], outputPath: "/tmp/plan.json", json: true)),
             .recipesApply(.init(recipeID: "benchmark.eval.smoke", version: "1", values: ["model_id": "model"], dryRun: true, resume: true, fromStepID: "benchmark", json: true)),
             .recipesInit(.init(sourceURI: "hf://model/org/model", task: "import", outputPath: "/tmp/import.recipe.json", json: true)),
+            .cookbookRecommend(.init(modelID: "mlx/qwen", workload: "chat", serverPlatform: "macos", serverArch: "arm64", json: true)),
             .modelRootsList(.init(json: true)),
             .modelRootsAdd(.init(path: "/models", json: true)),
             .modelRootsRemove(.init(path: "/models", json: true)),
@@ -1915,6 +1917,57 @@ struct MelixCLIParserTests {
         }
         #expect(throws: MelixCLIError.missingRequired("--task is required for melix recipes init.")) {
             try MelixCLIParser.parse(["recipes", "init", "--from", "hf://model/org/repo"])
+        }
+    }
+
+    @Test("parses cookbook recommendation host source options")
+    func parsesCookbookRecommendationHostSourceOptions() throws {
+        let command = try MelixCLIParser.parse([
+            "cookbook",
+            "recommend",
+            "mlx-community/Qwen3.5-9B-MLX-4bit",
+            "--workload", "chat",
+            "--server-platform", "macos",
+            "--server-arch", "arm64",
+            "--operator-platform", "linux",
+            "--operator-arch", "x86_64",
+            "--browser-platform", "windows",
+            "--browser-arch", "x86_64",
+            "--json",
+        ])
+
+        #expect(
+            command ==
+                .cookbookRecommend(
+                    .init(
+                        modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+                        workload: "chat",
+                        serverPlatform: "macos",
+                        serverArch: "arm64",
+                        operatorPlatform: "linux",
+                        operatorArch: "x86_64",
+                        browserPlatform: "windows",
+                        browserArch: "x86_64",
+                        json: true
+                    )
+                )
+        )
+
+        let arguments = try MelixCLICommandCodec.arguments(for: command)
+        #expect(arguments.contains("cookbook"))
+        #expect(arguments.contains("recommend"))
+        #expect(Self.optionValue("--server-platform", in: arguments) == "macos")
+        #expect(Self.optionValue("--browser-platform", in: arguments) == "windows")
+        #expect(arguments.contains("--json"))
+
+        #expect(throws: MelixCLIError.usage(MelixCLIParser.usageText)) {
+            try MelixCLIParser.parse(["cookbook"])
+        }
+        #expect(throws: MelixCLIError.missingRequired("--workload is required for melix cookbook recommend.")) {
+            try MelixCLIParser.parse(["cookbook", "recommend", "mlx-community/Qwen3.5-9B-MLX-4bit"])
+        }
+        #expect(throws: MelixCLIError.usage(MelixCLIParser.usageText)) {
+            try MelixCLIParser.parse(["cookbook", "show", "mlx-community/Qwen3.5-9B-MLX-4bit"])
         }
     }
 

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -4287,6 +4287,130 @@ struct MelixCLIRunnerTests {
         #expect(runDirectories.map(\.lastPathComponent).contains(latestRunRoot.lastPathComponent))
     }
 
+    @Test("cookbook recommendation trusts server hardware probe over browser hint")
+    func cookbookRecommendationTrustsServerHardwareProbeOverBrowserHint() async throws {
+        let runner = MelixCLIRunner(client: StubControlPlaneXPCClient())
+
+        let output = try await runner.run(.cookbookRecommend(.init(
+            modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+            workload: "chat",
+            serverPlatform: "macOS",
+            serverArch: "arm64e",
+            operatorPlatform: "linux",
+            operatorArch: "x86_64",
+            browserPlatform: "windows",
+            browserArch: "x86_64",
+            json: true
+        )))
+        let payload = try #require(parseJSONObject(output))
+        let host = try #require(payload["host"] as? [String: Any])
+        let recommendation = try #require(payload["recommendation"] as? [String: Any])
+        let probe = try #require(payload["probe"] as? [String: Any])
+
+        #expect(payload["schema_version"] as? String == "melix.cookbook.recommendation.v1")
+        #expect(payload["model_id"] as? String == "mlx-community/Qwen3.5-9B-MLX-4bit")
+        #expect(payload["workload"] as? String == "chat")
+        #expect(host["platform"] as? String == "macos")
+        #expect(host["arch"] as? String == "arm64e")
+        #expect(host["host_platform_source"] as? String == "hardware_probe")
+        #expect(recommendation["selected_backend"] as? String == "mlx-native")
+        #expect(recommendation["command_family"] as? String == "melix server start")
+        #expect((payload["warnings"] as? [String])?.isEmpty == true)
+        #expect(probe["name"] as? String == "cookbook.host_source_selection")
+        #expect((probe["cookbook.plan_ms"] as? NSNumber)?.doubleValue ?? -1 >= 0)
+    }
+
+    @Test("cookbook recommendation marks browser platform fallback with warning")
+    func cookbookRecommendationMarksBrowserPlatformFallbackWithWarning() async throws {
+        let runner = MelixCLIRunner(client: StubControlPlaneXPCClient())
+
+        let output = try await runner.run(.cookbookRecommend(.init(
+            modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+            workload: "coding",
+            browserPlatform: "windows",
+            browserArch: "x86_64",
+            json: true
+        )))
+        let payload = try #require(parseJSONObject(output))
+        let host = try #require(payload["host"] as? [String: Any])
+        let warnings = try #require(payload["warnings"] as? [String])
+
+        #expect(host["platform"] as? String == "windows")
+        #expect(host["arch"] as? String == "x86_64")
+        #expect(host["host_platform_source"] as? String == "browser_fallback")
+        #expect(warnings.contains("Browser platform hints may describe the UI client rather than the Melix serving host."))
+    }
+
+    @Test("cookbook recommendation uses explicit operator host when server probe is absent")
+    func cookbookRecommendationUsesExplicitOperatorHostWhenServerProbeIsAbsent() async throws {
+        let runner = MelixCLIRunner(client: StubControlPlaneXPCClient())
+
+        let output = try await runner.run(.cookbookRecommend(.init(
+            modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+            workload: "evaluation",
+            operatorPlatform: "linux",
+            operatorArch: "x86_64",
+            browserPlatform: "windows",
+            browserArch: "x86_64",
+            json: true
+        )))
+        let payload = try #require(parseJSONObject(output))
+        let host = try #require(payload["host"] as? [String: Any])
+        let recommendation = try #require(payload["recommendation"] as? [String: Any])
+
+        #expect(host["platform"] as? String == "linux")
+        #expect(host["arch"] as? String == "x86_64")
+        #expect(host["host_platform_source"] as? String == "explicit_operator_setting")
+        #expect(recommendation["selected_backend"] as? String == "python-worker")
+        #expect((payload["warnings"] as? [String])?.isEmpty == true)
+    }
+
+    @Test("cookbook recommendation normalizes host aliases and renders text")
+    func cookbookRecommendationNormalizesHostAliasesAndRendersText() async throws {
+        let runner = MelixCLIRunner(client: StubControlPlaneXPCClient())
+
+        let output = try await runner.run(.cookbookRecommend(.init(
+            modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+            workload: "chat",
+            serverPlatform: "darwin",
+            serverArch: "aarch64"
+        )))
+
+        #expect(output.contains("Melix cookbook recommendation"))
+        #expect(output.contains("Model: mlx-community/Qwen3.5-9B-MLX-4bit"))
+        #expect(output.contains("Host: macos/arm64 (hardware_probe)"))
+        #expect(output.contains("Backend: mlx-native"))
+        #expect(output.contains("Command family: melix server start"))
+    }
+
+    @Test("cookbook recommendation records unavailable host source")
+    func cookbookRecommendationRecordsUnavailableHostSource() async throws {
+        let runner = MelixCLIRunner(client: StubControlPlaneXPCClient())
+
+        let output = try await runner.run(.cookbookRecommend(.init(
+            modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+            workload: "reasoning",
+            json: true
+        )))
+        let payload = try #require(parseJSONObject(output))
+        let host = try #require(payload["host"] as? [String: Any])
+        let recommendation = try #require(payload["recommendation"] as? [String: Any])
+        let warnings = try #require(payload["warnings"] as? [String])
+
+        #expect(host["platform"] as? String == "")
+        #expect(host["arch"] as? String == "")
+        #expect(host["host_platform_source"] as? String == "unavailable")
+        #expect(recommendation["selected_backend"] as? String == "generic-local-runtime")
+        #expect(warnings.contains("No host platform source was available; run a Melix hardware probe before relying on this recommendation."))
+
+        let textOutput = try await runner.run(.cookbookRecommend(.init(
+            modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+            workload: "reasoning"
+        )))
+        #expect(textOutput.contains("Host: unavailable (unavailable)"))
+        #expect(textOutput.contains("Warning: No host platform source was available; run a Melix hardware probe before relying on this recommendation."))
+    }
+
     @Test("workflow recipe init rejects unmatched tasks")
     func workflowRecipeInitRejectsUnmatchedTasks() async throws {
         let runner = MelixCLIRunner(client: StubControlPlaneXPCClient())


### PR DESCRIPTION
## Summary
- Add `melix cookbook recommend MODEL_ID --workload WORKLOAD` with JSON and text receipts.
- Select the cookbook host source in deterministic priority order: server hardware probe, explicit operator setting, browser fallback, then unavailable.
- Emit warning receipts when relying on browser fallback or when no host source is available.

Refs #1762.

## Plan or Spec
- `docs/plans/2026-06-08-issue-1762-cookbook-host-probe.md`

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --filter 'MelixCLIParserTests/parsesCookbookRecommendationHostSourceOptions|MelixCLIRunnerTests/cookbookRecommendation'
# red phase: failed before the cookbook command/options existed; green phase passed after implementation

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --filter 'MelixCLIRunnerTests/cookbookRecommendationRecordsUnavailableHostSource'
# red phase for review fix: failed with Host: / (unavailable); green phase passed after typed text rendering fix

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
# passed: 342 tests before the final focused additions; later coverage run passed 345 tests

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
# passed: 345 tests

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixCLICommandCodec.swift Sources/MelixCLICore/MelixCookbook.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift
# passed: TOTAL 100.00% 356/356 changed lines covered

git diff --check origin/main
# passed

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id swift-cli-json-envelope-encoding --base-repo "$PWD" --head-repo "$PWD" --coverage-paths-json '["tests/MelixCLITests/MelixCLIRunnerTests.swift"]' --output .runtime/pr-scoped-performance-local/probes/swift-cli-json-envelope-encoding.json
# passed

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_report.py --scope .runtime/pr-scoped-performance-local/artifacts/scope/scope.json --results-dir .runtime/pr-scoped-performance-local/probes --output-dir .runtime/pr-scoped-performance-local/report --format terminal --sticky-comment
# passed: Status ok, Regressions 0, Verification failures 0

make git-hooks-install
# passed: installed .githooks pre-commit

git commit -m "feat: add cookbook host probe recommendation"
# passed pre-commit gate on 256 GiB macOS host:
# - make swift-test: passed
# - make py-test: 3660 passed, 14 skipped
# - make integration-test: 117 passed, 1 skipped
# - PR-scoped performance: Status ok, Regressions 0, Verification failures 0

git commit --amend --no-edit
# passed pre-commit gate on 256 GiB macOS host after review fix:
# - make swift-test: passed
# - make py-test: 3660 passed, 14 skipped
# - make integration-test: 117 passed, 1 skipped
# - PR-scoped performance: Status ok, Regressions 0, Verification failures 0

git merge --no-edit origin/main
# passed: merged current origin/main after #1910, #1911, and #1913 landed

git diff --check origin/main
# passed after merging origin/main

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --filter 'MelixCLIParserTests/parsesCookbookRecommendationHostSourceOptions|MelixCLIRunnerTests/cookbookRecommendation'
# passed after merging origin/main: 6 tests

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
# passed after merging origin/main: 345 tests

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixCLICommandCodec.swift Sources/MelixCLICore/MelixCookbook.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift
# passed after merging origin/main: TOTAL 100.00% 356/356 changed lines covered

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-scoped-performance-after-merge/changed-files.json --output .runtime/pr-scoped-performance-after-merge/artifacts/scope/scope.json
# passed after merging origin/main: selected swift-cli-json-envelope-encoding

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id swift-cli-json-envelope-encoding --base-repo "$PWD" --head-repo "$PWD" --coverage-paths-json '["tests/MelixCLITests/MelixCLIRunnerTests.swift"]' --output .runtime/pr-scoped-performance-after-merge/probes/swift-cli-json-envelope-encoding.json
# passed after merging origin/main

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_report.py --scope .runtime/pr-scoped-performance-after-merge/artifacts/scope/scope.json --results-dir .runtime/pr-scoped-performance-after-merge/probes --output-dir .runtime/pr-scoped-performance-after-merge/report --format terminal --sticky-comment
# passed after merging origin/main: Status ok, Regressions 0, Context regressions 0, Verification failures 0

git merge --no-edit origin/main
# passed: merged current origin/main again after #1915 landed

git diff --check origin/main
# passed after the second origin/main merge

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --filter 'MelixCLIParserTests/parsesCookbookRecommendationHostSourceOptions|MelixCLIRunnerTests/cookbookRecommendation'
# passed after the second origin/main merge: 6 tests

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
# passed after the second origin/main merge: 345 tests

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main Sources/MelixCLICore/MelixCLI.swift Sources/MelixCLICore/MelixCLICommandCodec.swift Sources/MelixCLICore/MelixCookbook.swift tests/MelixCLITests/MelixCLIParserTests.swift tests/MelixCLITests/MelixCLIRunnerTests.swift
# passed after the second origin/main merge: TOTAL 100.00% 356/356 changed lines covered

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-scoped-performance-after-main-2/changed-files.json --output .runtime/pr-scoped-performance-after-main-2/artifacts/scope/scope.json
# passed after the second origin/main merge: selected swift-cli-json-envelope-encoding

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id swift-cli-json-envelope-encoding --base-repo "$PWD" --head-repo "$PWD" --coverage-paths-json '["tests/MelixCLITests/MelixCLIRunnerTests.swift"]' --output .runtime/pr-scoped-performance-after-main-2/probes/swift-cli-json-envelope-encoding.json
# passed after the second origin/main merge

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_report.py --scope .runtime/pr-scoped-performance-after-main-2/artifacts/scope/scope.json --results-dir .runtime/pr-scoped-performance-after-main-2/probes --output-dir .runtime/pr-scoped-performance-after-main-2/report --format terminal --sticky-comment
# passed after the second origin/main merge: Status ok, Regressions 0, Context regressions 0, Verification failures 0
```

## Coverage and Metrics
- Changed-line Swift coverage: `100.00%` (`356/356`) for the changed Swift source and test files.
- Local PR-scoped performance report: `Status: ok`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`.
- Pre-commit PR-scoped performance report: `Status: ok`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`.
- Direct probe: `swift-cli-json-envelope-encoding`; latest local result after merging current `origin/main`: `elapsed_ms_mean` base `6369.287`, head `837.573`, delta `-5531.714 (-86.85%)`, status `improvement`.
- Cookbook receipt metric: `cookbook.plan_ms` records recommendation planning time in the command JSON payload.
- Observability mode: `minimal` command receipt metric and warning fields; no debug artifacts are required.
- Probe overhead: `N/A`; this slice emits one local planning duration in an operator command receipt and does not add a runtime sampling loop.

## Known Gaps
- This is the host-source recommendation slice for #1762; it does not yet implement full model ranking, benchmark receipt joins, download orchestration, or App UI surfacing.
- Browser platform fallback is intentionally treated as lower trust than server-side hardware probe data.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
