### PR TITLE
perf: scan macos app path size with scandir

### DIFF
--- a/docs/plans/2026-06-07-macos-path-size-scandir.md
+++ b/docs/plans/2026-06-07-macos-path-size-scandir.md
@@ -1,0 +1,24 @@
+# macOS app path-size scandir slice
+
+This Python performance slice is limited to `worker.productization.macos_app_bundle._path_size_bytes`.
+
+## Scope
+
+- Replace the current `os.walk` directory-size pass with an explicit `os.scandir` stack so package-pruning size accounting avoids per-root `Path` and filename joins on large app-bundle trees.
+- Preserve existing semantics: files and symlinks contribute their `lstat`/non-following stat size, directory symlinks are not traversed, metadata errors are ignored, and missing/unreadable roots return zero contribution.
+- Add a registered PR-scoped probe, `macos-app-path-size-scandir`, because the current macOS app bundle probes cover adjacent resource/native/signing scans but do not directly measure `_path_size_bytes`.
+
+## Verification plan
+
+- Focused tests for `_path_size_bytes` metadata-error tolerance and direct `os.scandir` traversal.
+- `test_pr_scoped_performance` registry checks proving the macOS app bundle path selects the new probe and that the probe script emits JSON metrics.
+- Changed-scope coverage via the registered probe `coverage_command`.
+- Local Linux registered probe run for `scripts/macos_app_path_size_probe.py`; CI remains the PR-scoped merge gate.
+
+## Metrics
+
+The probe synthesizes a 2,500-file package tree plus a directory symlink and reports:
+
+- `elapsed_ms_mean` / `elapsed_ms_min` (lower is better)
+- `file_count` (informational)
+- `measured_size_bytes` and sample count for evidence sanity checks

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2218,6 +2218,42 @@
     ]
   },
   {
+    "id": "macos-app-path-size-scandir",
+    "name": "macOS app bundle path-size scandir",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/macos_app_bundle.py",
+      "services/mlx-worker-python/tests/test_macos_app_bundle.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/macos_app_path_size_probe.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_tolerates_scandir_errors services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_tolerates_metadata_errors services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_uses_scandir_without_os_walk services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_tolerates_directory_symlink_metadata_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_path_size_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_tolerates_scandir_errors services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_tolerates_metadata_errors services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_uses_scandir_without_os_walk services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_tolerates_directory_symlink_metadata_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_path_size_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/macos_app_bundle.py services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/macos_app_path_size_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/macos_app_path_size_probe.py\"; for CANDIDATE in \"${MELIX_PR_SCOPED_PERFORMANCE_HEAD_REPO:-}/$SCRIPT\" \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "file_count",
+        "unit": "files",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "macos-app-signing-targets-scandir",
     "name": "macOS app nested Mach-O signing target scandir",
     "runner": "ubuntu-latest",

--- a/scripts/macos_app_path_size_probe.py
+++ b/scripts/macos_app_path_size_probe.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import statistics
+import tempfile
+import time
+from pathlib import Path
+
+from worker.productization.macos_app_bundle import _path_size_bytes
+
+FILE_COUNT = 2500
+SUBDIR_COUNT = 25
+SAMPLE_COUNT = 9
+
+
+def main() -> None:
+    elapsed_samples: list[float] = []
+    expected_size = 0
+    with tempfile.TemporaryDirectory(prefix="melix-macos-path-size-probe-") as temp_dir:
+        base = Path(temp_dir)
+        root = base / "payload"
+        root.mkdir()
+        external = base / "external"
+        external.mkdir()
+        (external / "ignored.txt").write_text("ignored\n", encoding="utf-8")
+        directory_link = root / "linked-dir"
+        directory_link.symlink_to(external, target_is_directory=True)
+        expected_size += directory_link.lstat().st_size
+
+        for directory_index in range(SUBDIR_COUNT):
+            directory = root / f"package_{directory_index:03d}"
+            directory.mkdir()
+            for file_index in range(FILE_COUNT // SUBDIR_COUNT):
+                path = directory / f"module_{file_index:04d}.py"
+                path.write_text(
+                    f"VALUE = {directory_index * file_index}\n",
+                    encoding="utf-8",
+                )
+                expected_size += path.lstat().st_size
+
+        measured_size = 0
+        for _ in range(SAMPLE_COUNT):
+            started = time.perf_counter()
+            measured_size = _path_size_bytes(root)
+            elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+            if measured_size != expected_size:
+                raise AssertionError(f"expected {expected_size} bytes, got {measured_size}")
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.mean(elapsed_samples),
+                "elapsed_ms_min": min(elapsed_samples),
+                "elapsed_ms_p95": sorted(elapsed_samples)[int(len(elapsed_samples) * 0.95) - 1],
+                "file_count": float(FILE_COUNT),
+                "sample_count": float(SAMPLE_COUNT),
+                "measured_size_bytes": float(measured_size),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_macos_app_bundle.py
+++ b/services/mlx-worker-python/tests/test_macos_app_bundle.py
@@ -691,6 +691,23 @@ def test_iter_python_native_binary_candidates_tolerates_scandir_metadata_errors(
     assert _iter_python_native_binary_candidates(runtime, site_packages) == []
 
 
+def test_path_size_bytes_tolerates_scandir_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "tree"
+    directory.mkdir()
+
+    def fail_scandir(path: Path):
+        if path == directory:
+            raise OSError("synthetic scandir failure")
+        return macos_app_bundle_module.os.scandir(path)
+
+    monkeypatch.setattr(macos_app_bundle_module.os, "scandir", fail_scandir)
+
+    assert _path_size_bytes(directory) == 0
+
+
 def test_path_size_bytes_tolerates_metadata_errors(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -704,23 +721,72 @@ def test_path_size_bytes_tolerates_metadata_errors(
     skipped = directory / "skipped.txt"
     skipped.write_text("skipped\n", encoding="utf-8")
     original_is_symlink = Path.is_symlink
-    original_lstat = Path.lstat
+    original_scandir = macos_app_bundle_module.os.scandir
+
+    class FakeScandir:
+        def __init__(self, entries: list[object]) -> None:
+            self.entries = entries
+
+        def __iter__(self):
+            return iter(self.entries)
+
+        def __enter__(self) -> "FakeScandir":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    class FakeFileEntry:
+        def __init__(self, path: Path, *, fail_stat: bool = False) -> None:
+            self.path = str(path)
+            self._path = path
+            self._fail_stat = fail_stat
+
+        def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+            return False
+
+        def stat(self, *, follow_symlinks: bool = True):
+            if self._fail_stat:
+                raise OSError("synthetic file metadata failure")
+            return self._path.lstat()
 
     def fail_is_symlink(self: Path) -> bool:
         if self == broken:
             raise OSError("synthetic symlink metadata failure")
         return original_is_symlink(self)
 
-    def fail_lstat(self: Path):
-        if self == skipped:
-            raise OSError("synthetic file metadata failure")
-        return original_lstat(self)
+    def fake_scandir(path: Path):
+        if path == directory:
+            return FakeScandir([FakeFileEntry(retained), FakeFileEntry(skipped, fail_stat=True)])
+        return original_scandir(path)
 
     monkeypatch.setattr(Path, "is_symlink", fail_is_symlink)
-    monkeypatch.setattr(Path, "lstat", fail_lstat)
+    monkeypatch.setattr(macos_app_bundle_module.os, "scandir", fake_scandir)
 
     assert _path_size_bytes(broken) == 0
     assert _path_size_bytes(directory) == retained.lstat().st_size
+
+
+def test_path_size_bytes_uses_scandir_without_os_walk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / "tree"
+    nested = directory / "nested"
+    nested.mkdir(parents=True)
+    retained = nested / "retained.txt"
+    retained.write_text("kept\n", encoding="utf-8")
+    symlink_target = tmp_path / "linked-target"
+    symlink_target.mkdir()
+    directory_link = directory / "linked"
+    directory_link.symlink_to(symlink_target, target_is_directory=True)
+
+    def fail_os_walk(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("_path_size_bytes should use os.scandir directly")
+
+    monkeypatch.setattr(macos_app_bundle_module.os, "walk", fail_os_walk)
+
+    assert _path_size_bytes(directory) == retained.lstat().st_size + directory_link.lstat().st_size
 
 
 def test_path_size_bytes_tolerates_directory_symlink_metadata_errors(
@@ -735,14 +801,41 @@ def test_path_size_bytes_tolerates_directory_symlink_metadata_errors(
     symlink_target.mkdir()
     broken_link = directory / "linked"
     broken_link.symlink_to(symlink_target, target_is_directory=True)
-    original_lstat = Path.lstat
+    original_scandir = macos_app_bundle_module.os.scandir
 
-    def fail_lstat(self: Path):
-        if self == broken_link:
-            raise OSError("synthetic directory symlink metadata failure")
-        return original_lstat(self)
+    class FakeScandir:
+        def __init__(self, entries: list[object]) -> None:
+            self.entries = entries
 
-    monkeypatch.setattr(Path, "lstat", fail_lstat)
+        def __iter__(self):
+            return iter(self.entries)
+
+        def __enter__(self) -> "FakeScandir":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    class FakeFileEntry:
+        def __init__(self, path: Path, *, fail_stat: bool = False) -> None:
+            self.path = str(path)
+            self._path = path
+            self._fail_stat = fail_stat
+
+        def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+            return False
+
+        def stat(self, *, follow_symlinks: bool = True):
+            if self._fail_stat:
+                raise OSError("synthetic directory symlink metadata failure")
+            return self._path.lstat()
+
+    def fake_scandir(path: Path):
+        if path == directory:
+            return FakeScandir([FakeFileEntry(retained), FakeFileEntry(broken_link, fail_stat=True)])
+        return original_scandir(path)
+
+    monkeypatch.setattr(macos_app_bundle_module.os, "scandir", fake_scandir)
 
     assert _path_size_bytes(directory) == retained.lstat().st_size
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1466,12 +1466,25 @@ def test_scope_report_selects_macos_app_bundle_probes() -> None:
         changed_files=["services/mlx-worker-python/worker/productization/macos_app_bundle.py"],
     )
 
-    assert scope["selected_count"] == 3
+    assert scope["selected_count"] == 4
     assert _selected_probe_ids(scope) == [
         "macos-app-resource-bundle-scandir",
         "macos-app-native-binary-scandir",
+        "macos-app-path-size-scandir",
         "macos-app-signing-targets-scandir",
     ]
+
+
+def test_macos_app_path_size_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runpy.run_path(str(REPO_ROOT / "scripts/macos_app_path_size_probe.py"), run_name="__main__")
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["file_count"] == 2500.0
+    assert metrics["measured_size_bytes"] > 0.0
+    assert metrics["elapsed_ms_mean"] > 0.0
+    assert metrics["sample_count"] == 9.0
 
 
 def test_macos_app_signing_targets_probe_script_emits_metrics(
@@ -3260,6 +3273,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "multimodal-preprocessing-image-uri-single-parse",
         "macos-app-resource-bundle-scandir",
         "macos-app-native-binary-scandir",
+        "macos-app-path-size-scandir",
         "macos-app-signing-targets-scandir",
         "package-macos-resolve-fallback-scandir",
         "melix-metrics-snapshot-runtime-scandir",

--- a/services/mlx-worker-python/worker/productization/macos_app_bundle.py
+++ b/services/mlx-worker-python/worker/productization/macos_app_bundle.py
@@ -344,22 +344,21 @@ def _path_size_bytes(path: Path) -> int:
         return 0
 
     total = 0
-    for root, dirnames, filenames in os.walk(path, followlinks=False):
-        root_path = Path(root)
-        for dirname in list(dirnames):
-            directory = root_path / dirname
-            try:
-                if directory.is_symlink():
-                    total += directory.lstat().st_size
-                    dirnames.remove(dirname)
-            except OSError:
-                continue
-        for filename in filenames:
-            file_path = root_path / filename
-            try:
-                total += file_path.lstat().st_size
-            except OSError:
-                continue
+    stack = [path]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append(Path(entry.path))
+                            continue
+                        total += entry.stat(follow_symlinks=False).st_size
+                    except OSError:
+                        continue
+        except OSError:
+            continue
     return total
 
 


### PR DESCRIPTION
## Summary
- Replace `_path_size_bytes`'s `os.walk` traversal with an explicit `os.scandir` stack so macOS app bundle size accounting avoids per-root `Path`/filename joins.
- Preserve non-following symlink semantics and metadata/scandir error tolerance.
- Register a focused PR-scoped performance probe for the path-size code path.

## Plan or Spec
- `docs/plans/2026-06-07-macos-path-size-scandir.md`

## Commands Run
```text
# focused behavior + registry tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_tolerates_scandir_errors services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_tolerates_metadata_errors services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_uses_scandir_without_os_walk services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_tolerates_directory_symlink_metadata_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_path_size_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 7 passed in 0.36s

# registered coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_tolerates_scandir_errors services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_tolerates_metadata_errors services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_uses_scandir_without_os_walk services/mlx-worker-python/tests/test_macos_app_bundle.py::test_path_size_bytes_tolerates_directory_symlink_metadata_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_path_size_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/macos_app_bundle.py services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/macos_app_path_size_probe.py
# exit 0; 7 passed; aggregate changed-line coverage 96%

# baseline/head probe comparison with the same synthetic 2,500-file tree
# base origin/main: elapsed_ms_mean=28.84795180418425, elapsed_ms_min=25.88375099003315, elapsed_ms_p95=31.588450074195862
# head: elapsed_ms_mean=5.88811913298236, elapsed_ms_min=5.157724022865295, elapsed_ms_p95=6.750771775841713

# registered head probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/macos_app_path_size_probe.py
# exit 0; {"elapsed_ms_mean": 6.082281935960054, "elapsed_ms_min": 5.69900032132864, "elapsed_ms_p95": 6.492148153483868, "file_count": 2500.0, "measured_size_bytes": 29963.0, "sample_count": 9.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: aggregate 96% (98 measurable changed lines, 94 covered).
- `_path_size_bytes` changed lines: 100% covered.
- Registered local probe (Linux): old_mean=28.848 ms, new_mean=5.888 ms, speedup=4.90x, delta=-22.960 ms on a synthetic 2,500-file package tree.
- Registered PR-scoped CI probe `macos-app-path-size-scandir` is required before merge.

## Known Gaps
- Local validation is Linux/Python only; macOS packaging runtime effects remain covered by CI and existing macOS app bundle tests/probes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
