### PR TITLE
perf: avoid lower allocation in dataset split match

### DIFF
--- a/docs/plans/2026-06-08-dataset-split-first-char-ord.md
+++ b/docs/plans/2026-06-08-dataset-split-first-char-ord.md
@@ -1,0 +1,25 @@
+# Dataset split first-character match fast path
+
+## Scope
+
+Optimize one Python hot path in `services/mlx-worker-python/worker/dataset_registry/catalog.py`: split matching for dataset file and parent path parts. The previous first-character guard used `first_char.lower()` when the incoming path part started with an uppercase letter, allocating a lowercased one-character string on mismatch checks. This slice replaces that guard with an ASCII ordinal comparison helper while preserving mixed-case split matching.
+
+## Registered probe coverage
+
+The affected path is covered by the registered PR-scoped `dataset-registry-limited-read-streaming` command-json probe in `infra/perf/pr_scoped_probes.json`. The probe watches `catalog.py`, `test_dataset_registry.py`, `test_pr_scoped_performance.py`, and `scripts/dataset_registry_split_match_probe.py`, and includes focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+The probe reports `elapsed_ms_mean`, `path_constructor_calls_mean`, and `peak_bytes_mean` for `_path_matches_split()` across a synthetic dataset path set. This slice uses `elapsed_ms_mean` as the primary Linux performance signal and keeps `path_constructor_calls_mean` at zero.
+
+## Implementation plan
+
+1. Add a small ASCII helper that compares an arbitrary one-character string with an already-normalized lowercase split first character without calling `.lower()`.
+2. Use the helper in `_path_part_matches_split()` only for the existing first-character rejection guard.
+3. Add focused regression assertions for uppercase, lowercase, and non-matching first-character behavior.
+4. Run the registered focused test command, changed-scope coverage command, and registered probe locally on Linux before pushing.
+5. Use the PR-scoped performance GitHub Actions report as the final registered probe validation source before merge.
+
+## Success metrics
+
+- Behavior parity: focused dataset registry and PR-scoped performance tests pass.
+- Changed-scope coverage: registered coverage command remains at or above 95%.
+- Performance: `dataset_registry_split_match_probe.py` improves `elapsed_ms_mean` versus same-branch pre-change baseline while keeping `path_constructor_calls_mean=0`.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -315,6 +315,9 @@ def test_dataset_catalog_path_match_checks_filename_before_parent_parts() -> Non
         catalog._path_matches_split(Path("Custom/Validation-00000.jsonl"), "validation")
         is True
     )
+    assert catalog._ascii_char_matches_lowercase("V", "v") is True
+    assert catalog._ascii_char_matches_lowercase("v", "v") is True
+    assert catalog._ascii_char_matches_lowercase("T", "v") is False
     assert catalog._path_part_matches_split("", "validation", "validation-", "validation_") is False
 
 

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -989,6 +989,13 @@ def _split_match_tokens(split: str) -> tuple[str, str, str]:
     return normalized_split, f"{normalized_split}-", f"{normalized_split}_"
 
 
+def _ascii_char_matches_lowercase(character: str, lowercase_character: str) -> bool:
+    character_code = ord(character)
+    if 65 <= character_code <= 90:
+        character_code += 32
+    return character_code == ord(lowercase_character)
+
+
 def _path_part_matches_split(
     part: str,
     normalized_split: str,
@@ -999,7 +1006,7 @@ def _path_part_matches_split(
         return False
     first_char = part[0]
     split_first_char = normalized_split[0]
-    if first_char != split_first_char and first_char.lower() != split_first_char:
+    if first_char != split_first_char and not _ascii_char_matches_lowercase(first_char, split_first_char):
         return False
     if (
         part == normalized_split


### PR DESCRIPTION
## Summary
- Avoid allocating `first_char.lower()` in dataset split path matching by using an ASCII ordinal comparison helper.
- Add regression assertions for uppercase, lowercase, and non-matching first-character split checks.
- Document the slice and registered probe coverage in `docs/plans/2026-06-08-dataset-split-first-char-ord.md`.

## Plan or Spec
- `docs/plans/2026-06-08-dataset-split-first-char-ord.md`
- Registered PR-scoped probe: `dataset-registry-limited-read-streaming`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SPLIT_MATCH_PROBE_FILE_COUNT=20000 MELIX_DATASET_SPLIT_MATCH_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/dataset_registry_split_match_probe.py` (pre-change baseline)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_path_split_matching_avoids_temporary_path_construction services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_split_match_tokens_are_cached_per_split services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_string_stem_matches_pathlib_for_split_names services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_selected_split_filters_during_iteration services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_path_match_checks_filename_before_parent_parts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_split_match_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_path_split_matching_avoids_temporary_path_construction services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_split_match_tokens_are_cached_per_split services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_string_stem_matches_pathlib_for_split_names services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_selected_split_filters_during_iteration services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_path_match_checks_filename_before_parent_parts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_split_match_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_split_match_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SPLIT_MATCH_PROBE_FILE_COUNT=20000 MELIX_DATASET_SPLIT_MATCH_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/dataset_registry_split_match_probe.py` (post-change)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 8 passed.
- Changed-scope coverage: 100% (`TOTAL 9 0 100%`).
- Local Linux registered probe baseline: `elapsed_ms_mean=36.10574025660753`, `path_constructor_calls_mean=0.0`, `peak_bytes_mean=42026.6`.
- Local Linux registered probe after change: `elapsed_ms_mean=27.4835966527462`, `path_constructor_calls_mean=0.0`, `peak_bytes_mean=41984.6`.
- Local delta: `-8.62214360386133 ms` mean, about `23.88%` faster for the registered split-match probe.

## Known Gaps
- Local validation is Linux-only for this Python slice.
- Final registered probe validation is expected from the PR-scoped performance GitHub Actions workflow.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally before and after the change with an improving metric.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
