### PR TITLE
perf: fast path changed-scope string allowlists

### DIFF
--- a/docs/plans/2026-06-08-changed-scope-allowlist-string-fastpath.md
+++ b/docs/plans/2026-06-08-changed-scope-allowlist-string-fastpath.md
@@ -1,0 +1,43 @@
+# Changed-scope coverage single-string allowlist fast path
+
+## Scope
+
+This slice optimizes `scripts/changed_scope_coverage.py` when the probe-specific
+`MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON` environment value is a simple JSON
+string such as `"scripts/changed_scope_coverage.py"`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`changed-scope-coverage-measured-set-filter` in `infra/perf/pr_scoped_probes.json`.
+The probe watches `scripts/changed_scope_coverage.py`,
+`scripts/changed_scope_coverage_measured_probe.py`,
+`tests/test_changed_scope_coverage.py`,
+`services/mlx-worker-python/tests/test_pr_scoped_performance.py`, and the probe
+registry. It includes focused `test_command`, `coverage_command`, and
+`probe_command` entries. Its metrics include `allowlist_parse_elapsed_ms_mean`,
+which repeatedly parses the single-string allowlist case used by PR-scoped
+changed-line coverage.
+
+## Plan
+
+1. Add regression coverage proving a plain JSON-string allowlist can bypass the
+   full JSON decoder while escaped JSON strings still use the decoder and keep
+   current semantics.
+2. Add a minimal fast path for unescaped JSON-string allowlists before falling
+   back to `json.loads` for lists, escaped strings, invalid JSON, and other
+   payloads.
+3. Run the focused tests, registered changed-scope coverage command, and local
+   registered probe on Linux.
+4. Use the PR-scoped performance workflow as the merge gate and compare the
+   registered probe metrics against `origin/main`.
+
+## Verification targets
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+python3 scripts/changed_scope_coverage_measured_probe.py
+```

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -119,6 +119,14 @@ def _coverage_path_allowlist(env: Mapping[str, str]) -> frozenset[str] | None:
     raw_value = env.get("MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON", "").strip()
     if not raw_value:
         return None
+    if (
+        len(raw_value) >= 2
+        and raw_value[0] == '"'
+        and raw_value[-1] == '"'
+        and "\\" not in raw_value
+        and '"' not in raw_value[1:-1]
+    ):
+        return frozenset([raw_value[1:-1]] if raw_value[1:-1] else [])
     try:
         payload = json.loads(raw_value)
     except json.JSONDecodeError as exc:

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -209,6 +209,23 @@ def test_coverage_path_allowlist_accepts_single_string_payload() -> None:
     ) == {"direct.py"}
 
 
+def test_coverage_path_allowlist_parses_simple_string_without_json_decoder(monkeypatch) -> None:
+    def fail_loads(*args: object, **kwargs: object) -> object:  # pragma: no cover
+        raise AssertionError("simple single-string allowlists should avoid json.loads")
+
+    monkeypatch.setattr(changed_scope_coverage.json, "loads", fail_loads)
+
+    assert changed_scope_coverage._coverage_path_allowlist(
+        {"MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON": '"pkg/direct.py"'}
+    ) == {"pkg/direct.py"}
+
+
+def test_coverage_path_allowlist_escaped_string_uses_json_decoder() -> None:
+    assert changed_scope_coverage._coverage_path_allowlist(
+        {"MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON": '"pkg/\\u0064irect.py"'}
+    ) == {"pkg/direct.py"}
+
+
 def test_parse_changed_lines_ignores_no_newline_marker_and_keeps_line_numbers() -> None:
     diff_text = "\n".join(
         [


### PR DESCRIPTION
## Summary
- Add a narrow fast path for simple JSON-string `MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON` allowlists in changed-scope coverage.
- Preserve existing JSON decoder behavior for list payloads, escaped strings, invalid JSON, and non-list payloads.
- Add regression tests and a plan for the registered probe slice.

## Plan or Spec
- `docs/plans/2026-06-08-changed-scope-allowlist-string-fastpath.md`
- Registered probe: `changed-scope-coverage-measured-set-filter`

## Commands Run
```text
# Baseline probe on origin/main
python3 scripts/changed_scope_coverage_measured_probe.py
# exit 0; allowlist_parse_elapsed_ms_mean=14.813306142709084, elapsed_ms_mean=0.28501051877226147, source_read_calls_mean=0.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py::test_coverage_path_allowlist_parses_simple_string_without_json_decoder tests/test_changed_scope_coverage.py::test_coverage_path_allowlist_escaped_string_uses_json_decoder tests/test_changed_scope_coverage.py::test_changed_scope_coverage_measured_probe_emits_large_measured_metrics
# exit 0; 3 passed in 0.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 39 passed in 0.91s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 39 passed in 0.61s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# exit 0; Wrote JSON report to coverage.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 7 0 100%

python3 scripts/changed_scope_coverage_measured_probe.py
# exit 0; allowlist_parse_elapsed_ms_mean=6.102871815008776, elapsed_ms_mean=0.22317010111042432, source_read_calls_mean=0.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 7 0 100%`.
- Local registered probe comparison (`changed-scope-coverage-measured-set-filter`):
  - `allowlist_parse_elapsed_ms_mean`: baseline `14.8133 ms`, head `6.1029 ms`, delta `-8.7104 ms` (~58.8% lower).
  - `elapsed_ms_mean`: baseline `0.2850 ms`, head `0.2232 ms`, delta `-0.0618 ms` (~21.7% lower).
  - `source_read_calls_mean`: baseline `0.0`, head `0.0`.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local validation is Linux/Python-only. This slice does not touch Swift.
- The fast path intentionally handles only unescaped JSON-string allowlists; escaped strings and list payloads still use `json.loads`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no runtime observability change; registered probe is evidence-mode CI/local performance evidence.
- [x] Deferred work and known gaps are stated explicitly.
