### PR TITLE
Add cookbook data-root state receipts

### DIFF
--- a/Sources/MelixCLICore/MelixCookbook.swift
+++ b/Sources/MelixCLICore/MelixCookbook.swift
@@ -20,15 +20,32 @@ private struct MelixCookbookBackendRecommendation {
     let commandFamily: String
 }
 
+private struct MelixCookbookStateReceipt {
+    let dataRoot: String
+    let statePath: String
+    let cacheEnabled: Bool
+    let disabledReason: String
+
+    var payload: [String: Any] {
+        [
+            "data_root": dataRoot,
+            "state_path": statePath,
+            "cache_enabled": cacheEnabled,
+            "disabled_reason": disabledReason,
+        ]
+    }
+}
+
 private enum MelixCookbookRecommendationPlanner {
     static let browserFallbackWarning =
         "Browser platform hints may describe the UI client rather than the Melix serving host."
     static let unavailableWarning =
         "No host platform source was available; run a Melix hardware probe before relying on this recommendation."
 
-    static func makePayload(options: CookbookRecommendOptions, planMS: Double) -> [String: Any] {
+    static func makePayload(options: CookbookRecommendOptions, melixHome: MelixHome, planMS: Double) -> [String: Any] {
         let host = selectHost(options)
         let backend = recommendBackend(for: host)
+        let state = makeStateReceipt(melixHome: melixHome)
         return [
             "schema_version": "melix.cookbook.recommendation.v1",
             "model_id": trimmedString(options.modelID),
@@ -42,6 +59,7 @@ private enum MelixCookbookRecommendationPlanner {
                 "selected_backend": backend.selectedBackend,
                 "command_family": backend.commandFamily,
             ],
+            "state": state.payload,
             "warnings": host.warnings,
             "probe": [
                 "name": "cookbook.host_source_selection",
@@ -50,9 +68,10 @@ private enum MelixCookbookRecommendationPlanner {
         ]
     }
 
-    static func makeText(options: CookbookRecommendOptions, planMS: Double) -> String {
+    static func makeText(options: CookbookRecommendOptions, melixHome: MelixHome, planMS: Double) -> String {
         let host = selectHost(options)
         let backend = recommendBackend(for: host)
+        let state = makeStateReceipt(melixHome: melixHome)
         let hostDisplay = host.platform.isEmpty
             ? "unavailable (\(host.source.rawValue))"
             : "\(host.platform)/\(host.arch) (\(host.source.rawValue))"
@@ -63,11 +82,41 @@ private enum MelixCookbookRecommendationPlanner {
             "Host: \(hostDisplay)",
             "Backend: \(backend.selectedBackend)",
             "Command family: \(backend.commandFamily)",
+            "Data root: \(state.dataRoot)",
+            "State path: \(state.statePath)",
+            "Cache enabled: \(state.cacheEnabled)",
         ]
+        if state.disabledReason.isEmpty == false {
+            lines.append("Cache disabled reason: \(state.disabledReason)")
+        }
         for warning in host.warnings {
             lines.append("Warning: \(warning)")
         }
         return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func makeStateReceipt(melixHome: MelixHome) -> MelixCookbookStateReceipt {
+        let statePath = melixHome.stateDirectoryURL
+            .appendingPathComponent("cookbook", isDirectory: true)
+            .appendingPathComponent("recommendations.json")
+        var isDirectory = ObjCBool(false)
+        let exists = FileManager.default.fileExists(atPath: melixHome.stateDirectoryURL.path, isDirectory: &isDirectory)
+        let disabledReason: String
+        if exists == false {
+            disabledReason = "state_root_missing"
+        } else if isDirectory.boolValue == false {
+            disabledReason = "state_root_not_directory"
+        } else if FileManager.default.isWritableFile(atPath: melixHome.stateDirectoryURL.path) == false {
+            disabledReason = "state_root_not_writable"
+        } else {
+            disabledReason = ""
+        }
+        return MelixCookbookStateReceipt(
+            dataRoot: melixHome.rootURL.path,
+            statePath: statePath.path,
+            cacheEnabled: disabledReason.isEmpty,
+            disabledReason: disabledReason
+        )
     }
 
     private static func selectHost(_ options: CookbookRecommendOptions) -> MelixCookbookHostSelection {
@@ -159,11 +208,16 @@ private enum MelixCookbookRecommendationPlanner {
 extension MelixCLIRunner {
     func runCookbookRecommend(_ options: CookbookRecommendOptions) throws -> String {
         let startedAt = DispatchTime.now()
+        let melixHome = MelixHome(environment: environment)
         let planMS = elapsedMilliseconds(since: startedAt)
         if options.json {
-            let payload = MelixCookbookRecommendationPlanner.makePayload(options: options, planMS: planMS)
+            let payload = MelixCookbookRecommendationPlanner.makePayload(
+                options: options,
+                melixHome: melixHome,
+                planMS: planMS
+            )
             return try MelixCLIJSON.prettyString(payload)
         }
-        return MelixCookbookRecommendationPlanner.makeText(options: options, planMS: planMS)
+        return MelixCookbookRecommendationPlanner.makeText(options: options, melixHome: melixHome, planMS: planMS)
     }
 }

--- a/Sources/MelixCLICore/MelixCookbook.swift
+++ b/Sources/MelixCLICore/MelixCookbook.swift
@@ -96,9 +96,8 @@ private enum MelixCookbookRecommendationPlanner {
     }
 
     private static func makeStateReceipt(melixHome: MelixHome) -> MelixCookbookStateReceipt {
-        let statePath = melixHome.stateDirectoryURL
-            .appendingPathComponent("cookbook", isDirectory: true)
-            .appendingPathComponent("recommendations.json")
+        let cookbookURL = melixHome.stateDirectoryURL.appendingPathComponent("cookbook", isDirectory: true)
+        let statePath = cookbookURL.appendingPathComponent("recommendations.json")
         var isDirectory = ObjCBool(false)
         let exists = FileManager.default.fileExists(atPath: melixHome.stateDirectoryURL.path, isDirectory: &isDirectory)
         let disabledReason: String
@@ -109,7 +108,17 @@ private enum MelixCookbookRecommendationPlanner {
         } else if FileManager.default.isWritableFile(atPath: melixHome.stateDirectoryURL.path) == false {
             disabledReason = "state_root_not_writable"
         } else {
-            disabledReason = ""
+            var cookbookIsDirectory = ObjCBool(false)
+            let cookbookExists = FileManager.default.fileExists(atPath: cookbookURL.path, isDirectory: &cookbookIsDirectory)
+            if cookbookExists == false {
+                disabledReason = ""
+            } else if cookbookIsDirectory.boolValue == false {
+                disabledReason = "state_path_not_directory"
+            } else if FileManager.default.isWritableFile(atPath: cookbookURL.path) == false {
+                disabledReason = "state_path_not_writable"
+            } else {
+                disabledReason = ""
+            }
         }
         return MelixCookbookStateReceipt(
             dataRoot: melixHome.rootURL.path,

--- a/docs/plans/2026-06-08-issue-1762-cookbook-data-root.md
+++ b/docs/plans/2026-06-08-issue-1762-cookbook-data-root.md
@@ -14,7 +14,8 @@ runs.
   - `state_path`: absolute cookbook state path under the Melix state directory.
   - `cache_enabled`: whether cookbook cache/state paths are usable.
   - `disabled_reason`: empty when enabled; a stable reason when the state root is
-    missing, not a directory, or not writable.
+    missing, not a directory, or not writable, or when an existing cookbook state
+    path is not a directory or not writable.
 - Render the same state/cache status in text output.
 - Keep this slice read-only. The recommendation command probes path usability
   but does not create directories or write state.
@@ -35,9 +36,10 @@ derives a `state` receipt with:
 - `data_root = melixHome.rootURL.path`
 - `state_path = melixHome.stateDirectoryURL/cookbook/recommendations.json`
 - `cache_enabled = true` only when the state directory exists, is a directory,
-  and is writable
+  is writable, and any existing `state/cookbook` path is a writable directory
 - `disabled_reason = state_root_missing | state_root_not_directory |
-  state_root_not_writable | ""`
+  state_root_not_writable | state_path_not_directory | state_path_not_writable |
+  ""`
 
 The command remains fail-soft because this receipt is advisory. If the path is
 unusable, the recommendation still emits host/backend guidance and records why
@@ -51,6 +53,9 @@ Focused Swift tests cover:
   empty `disabled_reason` when `MELIX_HOME/state` is writable.
 - JSON output records `cache_enabled = false` and
   `disabled_reason = state_root_missing` when the state directory is absent.
+- JSON output records `cache_enabled = false` and
+  `disabled_reason = state_path_not_directory` when `state/cookbook` already
+  exists as a non-directory path.
 - Text output renders the data root and cache status.
 
 Commands:
@@ -74,8 +79,9 @@ scripts/swift_changed_line_coverage.py \
 ## Metrics
 
 - `cookbook.plan_ms` remains the command planning duration.
-- This slice adds no background sampling loop. Probe overhead is one
-  filesystem metadata check against the Melix state directory per recommendation.
+- This slice adds no background sampling loop. Probe overhead is bounded to
+  filesystem metadata checks against the Melix state directory and an existing
+  cookbook state path per recommendation.
 
 ## Known Gaps
 

--- a/docs/plans/2026-06-08-issue-1762-cookbook-data-root.md
+++ b/docs/plans/2026-06-08-issue-1762-cookbook-data-root.md
@@ -1,0 +1,84 @@
+# Issue 1762 Cookbook Data Root Receipt Slice
+
+## Goal
+
+Add a deterministic cookbook state receipt that resolves cookbook/profile/cache
+paths through the same Melix data root on native, container, and remote-shell
+runs.
+
+## Scope
+
+- Extend `melix cookbook recommend MODEL_ID --workload WORKLOAD` receipts with a
+  `state` object:
+  - `data_root`: absolute `MelixHome.rootURL` path.
+  - `state_path`: absolute cookbook state path under the Melix state directory.
+  - `cache_enabled`: whether cookbook cache/state paths are usable.
+  - `disabled_reason`: empty when enabled; a stable reason when the state root is
+    missing, not a directory, or not writable.
+- Render the same state/cache status in text output.
+- Keep this slice read-only. The recommendation command probes path usability
+  but does not create directories or write state.
+- Keep model ranking, download orchestration, profile cache storage, and App UI
+  surfacing out of scope.
+
+## Design
+
+The Swift CLI already owns the first cookbook receipt slice and already resolves
+operator state through `MelixHome`, which delegates to `MelixPathLayout`. This
+slice reuses that path contract instead of introducing cookbook-specific path
+rules.
+
+`MelixCLIRunner.runCookbookRecommend` constructs `MelixHome(environment:)` from
+the runner environment and passes it to the cookbook planner. The planner
+derives a `state` receipt with:
+
+- `data_root = melixHome.rootURL.path`
+- `state_path = melixHome.stateDirectoryURL/cookbook/recommendations.json`
+- `cache_enabled = true` only when the state directory exists, is a directory,
+  and is writable
+- `disabled_reason = state_root_missing | state_root_not_directory |
+  state_root_not_writable | ""`
+
+The command remains fail-soft because this receipt is advisory. If the path is
+unusable, the recommendation still emits host/backend guidance and records why
+cache/state persistence is disabled.
+
+## Verification
+
+Focused Swift tests cover:
+
+- JSON output records `data_root`, `state_path`, `cache_enabled = true`, and an
+  empty `disabled_reason` when `MELIX_HOME/state` is writable.
+- JSON output records `cache_enabled = false` and
+  `disabled_reason = state_root_missing` when the state directory is absent.
+- Text output renders the data root and cache status.
+
+Commands:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" \
+swift test --filter 'MelixCLIRunnerTests/cookbookRecommendation'
+
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" \
+swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
+
+UV_PYTHON=3.12 uv run --project services/mlx-worker-python python \
+scripts/swift_changed_line_coverage.py \
+  --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests \
+  --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata \
+  --diff-from origin/main \
+  Sources/MelixCLICore/MelixCookbook.swift \
+  tests/MelixCLITests/MelixCLIRunnerTests.swift
+```
+
+## Metrics
+
+- `cookbook.plan_ms` remains the command planning duration.
+- This slice adds no background sampling loop. Probe overhead is one
+  filesystem metadata check against the Melix state directory per recommendation.
+
+## Known Gaps
+
+- This slice does not persist cookbook state or cache files.
+- This slice does not audit every existing profile/cache call site. It creates
+  the receipt contract those call sites should use in later slices.

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -4368,9 +4368,9 @@ struct MelixCLIRunnerTests {
     @Test("cookbook recommendation records writable data root state receipt")
     func cookbookRecommendationRecordsWritableDataRootStateReceipt() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
         let stateRoot = root.appendingPathComponent("state", isDirectory: true)
         try FileManager.default.createDirectory(at: stateRoot, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: root) }
         let runner = MelixCLIRunner(
             client: StubControlPlaneXPCClient(),
             environment: ["MELIX_HOME": root.path]
@@ -4398,8 +4398,8 @@ struct MelixCLIRunnerTests {
     @Test("cookbook recommendation disables cache when data root state is missing")
     func cookbookRecommendationDisablesCacheWhenDataRootStateIsMissing() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         let runner = MelixCLIRunner(
             client: StubControlPlaneXPCClient(),
             environment: ["MELIX_HOME": root.path]
@@ -4418,14 +4418,50 @@ struct MelixCLIRunnerTests {
         #expect(state["data_root"] as? String == root.path)
         #expect(state["cache_enabled"] as? Bool == false)
         #expect(state["disabled_reason"] as? String == "state_root_missing")
+
+        let textOutput = try await runner.run(.cookbookRecommend(.init(
+            modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+            workload: "chat",
+            serverPlatform: "macos",
+            serverArch: "arm64"
+        )))
+        #expect(textOutput.contains("Cache enabled: false"))
+        #expect(textOutput.contains("Cache disabled reason: state_root_missing"))
+    }
+
+    @Test("cookbook recommendation disables cache when cookbook state path is not a directory")
+    func cookbookRecommendationDisablesCacheWhenCookbookStatePathIsNotDirectory() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let stateRoot = root.appendingPathComponent("state", isDirectory: true)
+        try FileManager.default.createDirectory(at: stateRoot, withIntermediateDirectories: true)
+        let cookbookPath = stateRoot.appendingPathComponent("cookbook", isDirectory: true)
+        try Data("not-a-directory".utf8).write(to: cookbookPath)
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: ["MELIX_HOME": root.path]
+        )
+
+        let output = try await runner.run(.cookbookRecommend(.init(
+            modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+            workload: "chat",
+            serverPlatform: "macos",
+            serverArch: "arm64",
+            json: true
+        )))
+        let payload = try #require(parseJSONObject(output))
+        let state = try #require(payload["state"] as? [String: Any])
+
+        #expect(state["cache_enabled"] as? Bool == false)
+        #expect(state["disabled_reason"] as? String == "state_path_not_directory")
     }
 
     @Test("cookbook recommendation normalizes host aliases and renders text")
     func cookbookRecommendationNormalizesHostAliasesAndRendersText() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
         let stateRoot = root.appendingPathComponent("state", isDirectory: true)
         try FileManager.default.createDirectory(at: stateRoot, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: root) }
         let runner = MelixCLIRunner(
             client: StubControlPlaneXPCClient(),
             environment: ["MELIX_HOME": root.path]

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -4365,9 +4365,71 @@ struct MelixCLIRunnerTests {
         #expect((payload["warnings"] as? [String])?.isEmpty == true)
     }
 
+    @Test("cookbook recommendation records writable data root state receipt")
+    func cookbookRecommendationRecordsWritableDataRootStateReceipt() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let stateRoot = root.appendingPathComponent("state", isDirectory: true)
+        try FileManager.default.createDirectory(at: stateRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: ["MELIX_HOME": root.path]
+        )
+
+        let output = try await runner.run(.cookbookRecommend(.init(
+            modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+            workload: "chat",
+            serverPlatform: "macos",
+            serverArch: "arm64",
+            json: true
+        )))
+        let payload = try #require(parseJSONObject(output))
+        let state = try #require(payload["state"] as? [String: Any])
+
+        #expect(state["data_root"] as? String == root.path)
+        #expect(state["state_path"] as? String == stateRoot
+            .appendingPathComponent("cookbook", isDirectory: true)
+            .appendingPathComponent("recommendations.json")
+            .path)
+        #expect(state["cache_enabled"] as? Bool == true)
+        #expect(state["disabled_reason"] as? String == "")
+    }
+
+    @Test("cookbook recommendation disables cache when data root state is missing")
+    func cookbookRecommendationDisablesCacheWhenDataRootStateIsMissing() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: ["MELIX_HOME": root.path]
+        )
+
+        let output = try await runner.run(.cookbookRecommend(.init(
+            modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+            workload: "chat",
+            serverPlatform: "macos",
+            serverArch: "arm64",
+            json: true
+        )))
+        let payload = try #require(parseJSONObject(output))
+        let state = try #require(payload["state"] as? [String: Any])
+
+        #expect(state["data_root"] as? String == root.path)
+        #expect(state["cache_enabled"] as? Bool == false)
+        #expect(state["disabled_reason"] as? String == "state_root_missing")
+    }
+
     @Test("cookbook recommendation normalizes host aliases and renders text")
     func cookbookRecommendationNormalizesHostAliasesAndRendersText() async throws {
-        let runner = MelixCLIRunner(client: StubControlPlaneXPCClient())
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let stateRoot = root.appendingPathComponent("state", isDirectory: true)
+        try FileManager.default.createDirectory(at: stateRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: ["MELIX_HOME": root.path]
+        )
 
         let output = try await runner.run(.cookbookRecommend(.init(
             modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
@@ -4381,6 +4443,9 @@ struct MelixCLIRunnerTests {
         #expect(output.contains("Host: macos/arm64 (hardware_probe)"))
         #expect(output.contains("Backend: mlx-native"))
         #expect(output.contains("Command family: melix server start"))
+        #expect(output.contains("Data root: \(root.path)"))
+        #expect(output.contains("State path: \(stateRoot.path)/cookbook/recommendations.json"))
+        #expect(output.contains("Cache enabled: true"))
     }
 
     @Test("cookbook recommendation records unavailable host source")


### PR DESCRIPTION
## Summary
- Add a read-only cookbook state receipt so `melix cookbook recommend` reports the active `MELIX_HOME` data root, cookbook state path, cache availability, and cache disabled reason.
- Render the same state contract in text output, with tests for writable, missing state-root, and invalid intermediate cookbook state-path cases.
- Document the issue #1762 data-root/state contract slice in `docs/plans/2026-06-08-issue-1762-cookbook-data-root.md`.

## Plan or Spec
- `docs/plans/2026-06-08-issue-1762-cookbook-data-root.md`
- GitHub issue: #1762

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --filter 'MelixCLIRunnerTests/cookbookRecommendation'
# Passed: 8 tests in 1 suite.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
# Passed: 348 tests in 3 suites.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
# Passed: 348 tests in 3 suites.

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main Sources/MelixCLICore/MelixCookbook.swift tests/MelixCLITests/MelixCLIRunnerTests.swift
# Passed changed-line threshold: TOTAL 96.10% (148/154).

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-scoped-performance/changed-files.json --output .runtime/pr-scoped-performance/artifacts/scope/scope.json
UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id swift-cli-json-envelope-encoding --base-repo "$PWD" --head-repo "$PWD" --coverage-paths-json '["tests/MelixCLITests/MelixCLIRunnerTests.swift"]' --output .runtime/pr-scoped-performance/probes/swift-cli-json-envelope-encoding.json
UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/pr_scoped_performance_report.py --scope .runtime/pr-scoped-performance/artifacts/scope/scope.json --results-dir .runtime/pr-scoped-performance/probes --output-dir .runtime/pr-scoped-performance/report --format terminal --sticky-comment
# Passed: Status ok, 0 regressions, 0 context regressions, 0 verification failures.

git diff --check origin/main
# Passed: no whitespace errors.

git commit -m "fix: harden cookbook state path receipt"
# Passed pre-commit gate: make swift-test, make py-test, make integration-test, and pre-commit PR-scoped performance report.
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 96.10% (148/154)`.
  - `Sources/MelixCLICore/MelixCookbook.swift`: 89.66% (52/58)
  - `tests/MelixCLITests/MelixCLIRunnerTests.swift`: 100.00% (96/96)
- PR-scoped performance after merging `origin/main`:
  - Status: `ok`
  - Regressions: `0`
  - Context regressions: `0`
  - Verification failures: `0`
  - Probe `swift-cli-json-envelope-encoding`: `elapsed_ms_mean` base=8191.045 ms, head=793.048 ms, delta=-7397.997 ms (-90.32%), status=`improvement`.
- Pre-commit performance report also passed with Status `ok`, 0 regressions, 0 context regressions, 0 verification failures.
  - Probe `swift-cli-json-envelope-encoding`: `elapsed_ms_mean` base=111533.627 ms, head=18934.079 ms, delta=-92599.548 ms (-83.02%), status=`improvement`.
- Observability mode: `minimal`; this slice adds receipt fields only and does not add production metrics or debug probes.
- Probe overhead: `N/A`; no new observability probe was added. Existing PR-scoped probe selected by changed CLI test coverage.

## Known Gaps
- Cookbook cache remains read-only in this slice. It reports the data root and intended state path but does not create directories, write recommendations, or rank/download models.
- No protocol or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
