### PR TITLE
perf: avoid hub library lowercase allocation

### DIFF
--- a/docs/plans/2026-06-08-hub-catalog-library-mlx-atom.md
+++ b/docs/plans/2026-06-08-hub-catalog-library-mlx-atom.md
@@ -1,0 +1,28 @@
+# Hub Catalog MLX Library Atom Fast Path
+
+## Scope
+
+This performance slice keeps the Hub catalog compatibility path behaviorally identical while removing a per-record lowercase allocation from the exact `library_name == MLX` check in `services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+
+## Probe Coverage
+
+The affected path is already covered by the registered PR-scoped probe `Hub catalog size hint regex precompile` in `infra/perf/pr_scoped_probes.json`.
+
+Registered commands include:
+
+- focused test command for `services/mlx-worker-python/tests/test_hub_catalog.py` and PR-scoped probe selection tests;
+- changed-scope coverage command over `hub_catalog.py`, `test_hub_catalog.py`, PR-scoped performance tests, and `scripts/hub_catalog_size_hint_probe.py`;
+- local probe command through `scripts/hub_catalog_size_hint_probe.py`, which reports both size-hint and MLX compatibility metrics.
+
+## Implementation Plan
+
+1. Add a regression assertion for mixed-case `library_name` atom detection.
+2. Replace `library_name.lower() == "mlx"` in `_is_mlx_compatible` with the existing allocation-free `_is_mlx_atom` helper.
+3. Run focused tests, changed-scope coverage, and the registered probe locally on Linux.
+4. Compare the registered probe against an `origin/main` baseline worktree before PR creation.
+
+## Success Criteria
+
+- Behavior remains unchanged for mixed-case `MLX` library metadata.
+- Changed-scope coverage remains at or above 95%.
+- Registered probe shows a positive direction for `payload_compatibility_elapsed_ms_mean`.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -106,6 +106,16 @@ def test_bytes_per_parameter_preserves_quantization_priority_without_joining_tag
     assert _bytes_per_parameter(["adapter", "2bit-mlx"], lowered_tags=None) == 0.25
 
 
+def test_mlx_library_atom_detection_preserves_mixed_case_without_lowercase_copy() -> None:
+    assert _is_mlx_compatible(
+        repo_id="plain/model",
+        tags=["Text-Generation"],
+        library_name="MlX",
+        card_data={},
+        lowered_tags={"text-generation"},
+    ) is True
+
+
 class FakeHTTPResponse:
     def __init__(self, payload: object):
         self._payload = json.dumps(payload).encode("utf-8")

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -510,7 +510,7 @@ def _is_mlx_compatible(
     lowered_tags = _normalized_lowered_tags(tags, lowered_tags)
     if "mlx" in lowered_tags:
         return True
-    if library_name.lower() == "mlx":
+    if _is_mlx_atom(library_name):
         return True
     lowered_repo_id = repo_id.lower()
     if "mlx" in lowered_repo_id:


### PR DESCRIPTION
## Summary
- Replace the Hub catalog `library_name.lower() == "mlx"` compatibility branch with the existing allocation-free `_is_mlx_atom` helper.
- Add a focused mixed-case `MlX` regression assertion for `_is_mlx_compatible`.
- Record the governing plan for this small Python performance slice.

## Plan or Spec
- `docs/plans/2026-06-08-hub-catalog-library-mlx-atom.md`
- Registered PR-scoped probe: `Hub catalog size hint regex precompile` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics` → 76 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py` → TOTAL 3 0 100%
- Baseline probe on detached `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_COMPATIBILITY_ITERATIONS=400000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=9 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- Head probe on this branch: same command and environment as baseline
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 3 0 100%`).
- Baseline registered probe (`origin/main`, 9 samples): `payload_compatibility_elapsed_ms_mean=431.25561216018264`, `elapsed_ms_mean=1503.965578869813`.
- Head registered probe (9 samples): `payload_compatibility_elapsed_ms_mean=417.78997590558396`, `elapsed_ms_mean=1474.265217160185`.
- Compatibility delta: `-13.46562625459868 ms` over 400k compatibility calls, about `3.12%` faster for the probe's compatibility metric.

## Known Gaps
- Linux local validation covers the Python Hub catalog path only; no Swift runtime effect is claimed.
- CI PR-scoped performance workflow is required as the registered probe validation source before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before creating the branch.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe was run locally against baseline and head.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
