### PR TITLE
perf: bind dataset source path traversal helpers

### DIFF
--- a/docs/plans/2026-06-08-dataset-source-file-path-local-bindings.md
+++ b/docs/plans/2026-06-08-dataset-source-file-path-local-bindings.md
@@ -1,0 +1,17 @@
+# Dataset source file-path local bindings
+
+## Slice
+
+This Python performance slice is limited to the dataset ingest source-file discovery helper in `services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped probe `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries and reports source file discovery latency plus source-kind classification latency.
+
+## Change
+
+Keep the existing `os.scandir()` traversal semantics, sorted output ordering, non-followed directory symlink handling, and `OSError` skip behavior. Bind hot loop helpers (`append`, `pop`, `os.scandir`, and `Path`) to locals before walking the tree so repeated directory-entry loops avoid repeated attribute lookups.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage command, and registered probe locally on Linux before opening the PR. The PR-scoped performance workflow is the CI validation source for this registered probe.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -564,23 +564,28 @@ def _iter_source_records(
 
 def _iter_source_file_paths(input_path: Path) -> list[Path]:
     file_paths: list[str] = []
+    file_paths_append = file_paths.append
     stack = [os.fspath(input_path)]
+    stack_append = stack.append
+    stack_pop = stack.pop
+    scandir = os.scandir
+    path_cls = Path
     while stack:
-        directory = stack.pop()
+        directory = stack_pop()
         try:
-            with os.scandir(directory) as entries:
+            with scandir(directory) as entries:
                 for entry in entries:
                     try:
                         if entry.is_dir(follow_symlinks=False):
-                            stack.append(entry.path)
+                            stack_append(entry.path)
                         elif entry.is_file(follow_symlinks=False):
-                            file_paths.append(entry.path)
+                            file_paths_append(entry.path)
                     except OSError:
                         continue
         except OSError:
             continue
     file_paths.sort()
-    return [Path(file_path) for file_path in file_paths]
+    return [path_cls(file_path) for file_path in file_paths]
 
 
 def _source_kind(path: Path) -> str | None:


### PR DESCRIPTION
## Summary
- Bound hot-loop helpers in dataset source file discovery (`append`, `pop`, `os.scandir`, and `Path`) to local variables.
- Kept existing `os.scandir()` traversal, sorted path output, non-followed symlinks, and `OSError` skip behavior unchanged.

## Plan or Spec
- `docs/plans/2026-06-08-dataset-source-file-path-local-bindings.md`
- Registered probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 10 passed in 0.94s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# 10 passed in 0.32s; TOTAL 10 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/dataset_source_records_probe.py"; for CANDIDATE in "../head/$SCRIPT" "${GITHUB_WORKSPACE:-}/head/$SCRIPT" "$SCRIPT"; do if [ -f "$CANDIDATE" ]; then MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2'
# Latest local runs after the change:
# elapsed_ms_mean: 10.9596, 10.8785, 10.9110 ms
# source_kind_elapsed_ms_mean: 15.5180, 15.6207, 16.6245 ms

PYTHONPATH="$PWD/services/mlx-worker-python" python3 - <<'PY'
# Manual same-process old-vs-new helper comparison on 6,000 files.
# old mean 20.7365 ms; new mean 18.5623 ms; speedup 1.117x; delta -2.1742 ms
PY
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%` for the registered coverage command.
- Registered local probe latest `elapsed_ms_mean`: `10.9596`, `10.8785`, `10.9110` ms across three runs after the change.
- Same-process old-vs-new helper comparison: old_mean=`20.7365 ms`, new_mean=`18.5623 ms`, speedup=`1.117x`, delta=`-2.1742 ms`.
- CI PR-scoped performance report is required for the registered probe validation before merge.

## Known Gaps
- Linux local validation only; no Swift runtime behavior is touched.
- CI must complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
