### PR TITLE
Add workspace path resolver boundary

### DIFF
--- a/docs/plans/2026-06-08-issue-1761-workspace-path-resolver.md
+++ b/docs/plans/2026-06-08-issue-1761-workspace-path-resolver.md
@@ -1,0 +1,80 @@
+# Issue 1761 Workspace Path Resolver Plan
+
+## Goal
+
+Introduce a shared Python worker workspace path resolver so future agent and
+local-job read/write/edit tools have a concrete workspace-root boundary before
+they mutate or inspect filesystem paths.
+
+## Scope
+
+This slice covers the reusable boundary only:
+
+- resolve relative paths inside an active workspace root
+- accept absolute paths only when they resolve inside that root
+- reject `..` traversal and symlink escapes after realpath normalization
+- reject sensitive filenames inside the workspace
+- return machine-readable receipt details for allowed and blocked paths
+- document the boundary in the unified agentic tool runtime contract
+
+This slice does not add a new read/write/edit tool and does not retrofit all
+existing local-job pipelines. Those remain follow-up work under #1761 once the
+shared resolver exists.
+
+## Architecture
+
+The end-state architecture is a single resolver that agent tools, local-job
+operators, and workflow actions can call before any filesystem mutation or
+workspace read. The resolver returns a value object with `workspace_root`,
+`requested_path`, `resolved_path`, `allowed`, and `refusal_reason`, making
+receipts deterministic without forcing each caller to duplicate containment
+logic.
+
+This slice keeps the implementation in
+`worker.runtime.workspace_paths` because it is runtime safety infrastructure,
+not workspace-manifest schema validation. Workspace manifest preflight keeps its
+existing relative-path schema checks; this resolver handles live path requests
+and symlink-aware containment.
+
+## Performance Probes And Metrics
+
+The resolver runs only when a workspace path is requested. The hot path is one
+`Path.resolve(strict=False)` call for the workspace root and requested path plus
+a filename sensitivity check. There is no registered PR-scoped performance
+probe expected for this change; the PR-scoped performance report must still
+show `Status: ok`, regressions `0`, and verification failures `0`.
+
+Verification will include:
+
+- focused pytest for the resolver
+- changed-line coverage for the resolver and tests with a target of at least
+  95 percent
+- local PR-scoped performance report with `Status: ok`
+
+## Implementation Steps
+
+1. Add failing tests in
+   `services/mlx-worker-python/tests/test_workspace_path_resolver.py` for:
+   - relative in-workspace paths
+   - absolute in-workspace paths
+   - `..` traversal escapes
+   - symlink escapes
+   - sensitive filenames such as `.env`
+2. Implement `WorkspacePathResolver` and `WorkspacePathResolution` in
+   `services/mlx-worker-python/worker/runtime/workspace_paths.py`.
+3. Add `receipt_fields()` so callers can attach resolver evidence to local-job
+   and tool receipts.
+4. Update `docs/unified-agentic-tool-runtime-contract.md` to make this resolver
+   the required boundary for future workspace path tools.
+5. Run focused tests, changed-line coverage, scoped performance, and PR gates
+   before opening the PR.
+
+## Success Criteria
+
+- Relative and absolute paths inside the workspace resolve as allowed.
+- Traversal and symlink escapes are blocked before callers can use the target.
+- Sensitive filenames remain blocked even inside the workspace.
+- Resolver receipts include `workspace_root`, `requested_path`,
+  `resolved_path`, `allowed`, and `refusal_reason`.
+- Contract docs identify this as the first shared workspace-path boundary under
+  #1761, with read/write/edit tool integration left for later slices.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -167,6 +167,35 @@ tool runtime. Later retrieval, skill, memory, workspace, and background-job
 entrypoints must reuse the same receipt shape when they introduce their own
 source-specific validators.
 
+### Workspace Path Boundary
+
+Agent and workflow tools that read, write, or edit local files must resolve
+operator-provided paths through the shared Python worker
+`WorkspacePathResolver` before any filesystem access. Relative paths resolve
+inside the active workspace root. Absolute paths are allowed only when their
+realpath-normalized target remains inside that root. Parent traversal and
+symlink escapes must fail closed before a caller opens, writes, renames, or
+deletes the target.
+
+Sensitive filenames remain blocked even when they are physically inside the
+workspace root. The default sensitive set includes common credential files such
+as `.env`, `.npmrc`, `.netrc`, `.pypirc`, and private-key filenames. Callers may
+extend the sensitive filename set for narrower product surfaces, but they must
+not remove the default credential guards.
+
+Workspace path receipts must include:
+
+- `operation`
+- `workspace_root`
+- `requested_path`
+- `resolved_path`
+- `allowed`
+- `refusal_reason`
+
+The v1 workspace resolver slice only introduces the shared boundary primitive.
+Adding concrete read/write/edit tools, local-job mutation hooks, and prompt
+assembly receipts remains follow-up work under #1761.
+
 The observation metric keys are:
 
 - `tool_observation.record_count`

--- a/services/mlx-worker-python/tests/test_workspace_path_resolver.py
+++ b/services/mlx-worker-python/tests/test_workspace_path_resolver.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from worker.runtime.workspace_paths import WorkspacePathResolver
+
+
+def test_workspace_path_resolver_allows_relative_and_absolute_workspace_paths(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "notes").mkdir()
+
+    resolver = WorkspacePathResolver(workspace)
+    relative = resolver.resolve("notes/today.md", operation="read")
+    absolute = resolver.resolve(workspace / "notes" / "today.md", operation="write")
+
+    assert resolver.workspace_root == workspace.resolve()
+    assert relative.allowed is True
+    assert relative.resolved_path == workspace.resolve() / "notes" / "today.md"
+    assert relative.refusal_reason == ""
+    assert absolute.allowed is True
+    assert absolute.resolved_path == relative.resolved_path
+    assert absolute.receipt_fields() == {
+        "operation": "write",
+        "workspace_root": str(workspace.resolve()),
+        "requested_path": str(workspace / "notes" / "today.md"),
+        "resolved_path": str(workspace.resolve() / "notes" / "today.md"),
+        "allowed": True,
+        "refusal_reason": "",
+    }
+
+
+def test_workspace_path_resolver_rejects_parent_traversal_and_absolute_escapes(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+
+    resolver = WorkspacePathResolver(workspace)
+    traversal = resolver.resolve("../outside/secret.txt", operation="read")
+    absolute = resolver.resolve(outside / "secret.txt", operation="write")
+
+    assert traversal.allowed is False
+    assert traversal.refusal_reason == "path_escapes_workspace"
+    assert traversal.resolved_path == outside.resolve() / "secret.txt"
+    assert absolute.allowed is False
+    assert absolute.refusal_reason == "path_escapes_workspace"
+
+
+def test_workspace_path_resolver_rejects_symlink_escapes(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    (workspace / "external").symlink_to(outside)
+
+    resolution = WorkspacePathResolver(workspace).resolve("external/secret.txt", operation="write")
+
+    assert resolution.allowed is False
+    assert resolution.refusal_reason == "path_escapes_workspace"
+    assert resolution.resolved_path == outside.resolve() / "secret.txt"
+
+
+def test_workspace_path_resolver_rejects_sensitive_filenames_inside_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    resolution = WorkspacePathResolver(workspace).resolve("config/.env", operation="read")
+
+    assert resolution.allowed is False
+    assert resolution.refusal_reason == "sensitive_path"
+    assert resolution.receipt_fields()["workspace_root"] == str(workspace.resolve())
+
+
+def test_workspace_path_resolver_extends_sensitive_filename_defaults(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    resolver = WorkspacePathResolver(workspace, extra_sensitive_filenames=["secrets.toml"])
+
+    assert resolver.resolve("config/secrets.toml", operation="read").refusal_reason == "sensitive_path"
+    assert resolver.resolve("config/.env", operation="read").refusal_reason == "sensitive_path"

--- a/services/mlx-worker-python/worker/runtime/workspace_paths.py
+++ b/services/mlx-worker-python/worker/runtime/workspace_paths.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from os import fspath
+from pathlib import Path
+
+
+_SENSITIVE_FILENAMES = frozenset(
+    {
+        ".env",
+        ".env.local",
+        ".env.production",
+        ".npmrc",
+        ".netrc",
+        ".pypirc",
+        "id_rsa",
+        "id_dsa",
+        "id_ecdsa",
+        "id_ed25519",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspacePathResolution:
+    operation: str
+    workspace_root: Path
+    requested_path: str
+    resolved_path: Path
+    allowed: bool
+    refusal_reason: str = ""
+
+    def receipt_fields(self) -> dict[str, object]:
+        return {
+            "operation": self.operation,
+            "workspace_root": str(self.workspace_root),
+            "requested_path": self.requested_path,
+            "resolved_path": str(self.resolved_path),
+            "allowed": self.allowed,
+            "refusal_reason": self.refusal_reason,
+        }
+
+
+class WorkspacePathResolver:
+    def __init__(
+        self,
+        workspace_root: str | Path,
+        *,
+        extra_sensitive_filenames: Iterable[str] = (),
+    ) -> None:
+        self._workspace_root = Path(workspace_root).expanduser().resolve(strict=False)
+        self._sensitive_filenames = frozenset(
+            name.casefold() for name in (*_SENSITIVE_FILENAMES, *extra_sensitive_filenames)
+        )
+
+    @property
+    def workspace_root(self) -> Path:
+        return self._workspace_root
+
+    def resolve(self, requested_path: str | Path, *, operation: str) -> WorkspacePathResolution:
+        requested_text = fspath(requested_path)
+        candidate = Path(requested_text).expanduser()
+        if not candidate.is_absolute():
+            candidate = self._workspace_root / candidate
+        resolved_path = candidate.resolve(strict=False)
+
+        refusal_reason = ""
+        if not _is_relative_to(resolved_path, self._workspace_root):
+            refusal_reason = "path_escapes_workspace"
+        elif _has_sensitive_filename(resolved_path, self._workspace_root, self._sensitive_filenames):
+            refusal_reason = "sensitive_path"
+
+        return WorkspacePathResolution(
+            operation=operation,
+            workspace_root=self._workspace_root,
+            requested_path=requested_text,
+            resolved_path=resolved_path,
+            allowed=not refusal_reason,
+            refusal_reason=refusal_reason,
+        )
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _has_sensitive_filename(path: Path, root: Path, sensitive_filenames: frozenset[str]) -> bool:
+    relative_parts = path.relative_to(root).parts
+    return any(part.casefold() in sensitive_filenames for part in relative_parts)


### PR DESCRIPTION
## Summary
- Add a shared Python worker `WorkspacePathResolver` and receipt value object for workspace-scoped filesystem requests.
- Block traversal, absolute-path escapes, symlink escapes, and sensitive credential filenames before future tools open or mutate paths.
- Document the #1761 workspace path boundary and record this slice as the shared primitive before read/write/edit tool integration.

## Plan or Spec
- `docs/plans/2026-06-08-issue-1761-workspace-path-resolver.md`
- `docs/unified-agentic-tool-runtime-contract.md`
- Refs #1761

## Commands Run
```text
make bootstrap
# rc=0; configured .githooks and synced the locked Python worker environment.

make proto
# rc=0; no generated artifact diff.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_workspace_path_resolver.py
# rc=0; 5 passed in 0.06s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file .runtime/coverage/issue1761-workspace-paths.coverage -m pytest -q services/mlx-worker-python/tests/test_workspace_path_resolver.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file .runtime/coverage/issue1761-workspace-paths.coverage -o .runtime/coverage/issue1761-workspace-paths.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/issue1761-workspace-paths.json --diff-from origin/main services/mlx-worker-python/worker/runtime/workspace_paths.py services/mlx-worker-python/tests/test_workspace_path_resolver.py
# rc=0; TOTAL 100.00% 97/97 changed lines.

git diff --cached --name-only origin/main > .runtime/perf/issue-1761-workspace-paths/scope/changed-files.txt
jq -R -s 'split("\n")[:-1]' .runtime/perf/issue-1761-workspace-paths/scope/changed-files.txt > .runtime/perf/issue-1761-workspace-paths/scope/changed-files.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/perf/issue-1761-workspace-paths/scope/changed-files.json --output .runtime/perf/issue-1761-workspace-paths/scope/scope.json > .runtime/perf/issue-1761-workspace-paths/scope/scope.stdout.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/perf/issue-1761-workspace-paths/scope/scope.json --results-dir .runtime/perf/issue-1761-workspace-paths/probes --output-dir .runtime/perf/issue-1761-workspace-paths/report --format terminal --sticky-comment
# rc=0; Status ok, changed files 4, selected probes 0, regressions 0, verification failures 0.

git commit -m "Add workspace path resolver boundary"
# rc=0; pre-commit ran full local gate:
# - make swift-test: rc=0, elapsed=711.1s
# - make py-test: rc=0, 3673 passed, 14 skipped, 2 warnings in 177.58s
# - make integration-test: rc=0, 117 passed, 1 skipped in 781.10s
# - pre-commit scoped performance: Status ok, changed files 4, selected probes 0, regressions 0, verification failures 0.
```

## Coverage and Metrics
- Changed-line coverage: 100.00% (97/97) for `worker/runtime/workspace_paths.py` and `tests/test_workspace_path_resolver.py`.
- Local scoped performance report: `Status: ok`, changed files `4`, selected probes `0`, regressions `0`, verification failures `0`.
- Pre-commit scoped performance report: `Status: ok`, changed files `4`, selected probes `0`, regressions `0`, verification failures `0`.
- Observability mode: `minimal`; the resolver returns deterministic receipt fields and does not add runtime metrics or evidence-mode probes.
- Probe overhead: `N/A`; no registered PR-scoped probes were selected because this slice adds a lightweight path-boundary primitive and documentation only.

## Known Gaps
- Concrete read/write/edit tools, local-job mutation hooks, and prompt assembly receipts remain deferred follow-up work under #1761.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes; `make proto` produced no diff.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
