### PR TITLE
perf: stream macOS native binary scan entries

### DIFF
--- a/docs/plans/2026-06-08-macos-app-native-binary-unsorted-scan.md
+++ b/docs/plans/2026-06-08-macos-app-native-binary-unsorted-scan.md
@@ -1,0 +1,36 @@
+# macOS app native binary unsorted scandir slice
+
+## Context
+
+The macOS app bundle productization helper scans packaged Python runtime and
+site-packages trees to collect native binary candidates for the stripping step.
+The affected path is covered by the registered PR-scoped probe
+`macos-app-native-binary-scandir` in `infra/perf/pr_scoped_probes.json`. The
+registry entry provides focused `test_command`, `coverage_command`, and
+`probe_command` entries for `worker.productization.macos_app_bundle`, its focused
+unit tests, and the PR-scoped performance registry checks.
+
+## Slice
+
+This Python-only slice removes the per-directory `sorted(...)` materialization
+inside `_iter_python_native_binary_candidates()`. Candidate semantics remain the
+same: the helper still uses an explicit `os.scandir()` stack, does not follow
+directory symlinks, collects runtime executables only from `bin`, and keeps the
+native binary suffix checks on `entry.name`. The stripping step already dedupes
+candidate paths before invoking `strip`, so deterministic traversal ordering is
+not part of the externally observed result.
+
+## Verification
+
+- Focused tests: run the registered `macos-app-native-binary-scandir`
+  `test_command` locally on Linux.
+- Coverage: run the registered `coverage_command` and changed-scope coverage
+  locally on Linux.
+- Metrics: run the registered `probe_command` locally before and after the change
+  with repeated samples, then use the PR-scoped performance workflow as the merge
+  gate in CI.
+
+## Boundaries
+
+This is a Python packaging-path optimization and is locally verifiable on Linux.
+It does not change Swift runtime behavior or generated protocol artifacts.

--- a/services/mlx-worker-python/tests/test_macos_app_bundle.py
+++ b/services/mlx-worker-python/tests/test_macos_app_bundle.py
@@ -610,8 +610,12 @@ def test_bundle_slimming_helpers_cover_runtime_edge_cases(
     def fail_splitext(path: str):  # pragma: no cover - regression guard
         raise AssertionError("_iter_python_native_binary_candidates() should use direct suffix checks")
 
+    def fail_sorted(iterable, *args: object, **kwargs: object):  # pragma: no cover - regression guard
+        raise AssertionError("_iter_python_native_binary_candidates() should stream scandir entries")
+
     monkeypatch.setattr(Path, "rglob", fail_rglob)
     monkeypatch.setattr(macos_app_bundle_module.os.path, "splitext", fail_splitext)
+    monkeypatch.setattr(macos_app_bundle_module, "sorted", fail_sorted, raising=False)
     assert set(_iter_python_native_binary_candidates(runtime, site_packages)) == {
         python_versioned,
         runtime_so,

--- a/services/mlx-worker-python/worker/productization/macos_app_bundle.py
+++ b/services/mlx-worker-python/worker/productization/macos_app_bundle.py
@@ -450,27 +450,28 @@ def _iter_python_native_binary_candidates(
         while stack:
             current = stack.pop()
             try:
-                with os.scandir(current) as iterator:
-                    entries = sorted(iterator, key=lambda entry: entry.name)
+                with os.scandir(current) as entries:
+                    include_current_runtime_executables = (
+                        include_runtime_executables and current.name == "bin"
+                    )
+                    for entry in entries:
+                        try:
+                            if entry.is_dir(follow_symlinks=False):
+                                stack.append(Path(entry.path))
+                                continue
+                            if entry.is_symlink() or not entry.is_file(follow_symlinks=False):
+                                continue
+                        except OSError:
+                            continue
+                        if entry.name.endswith(_PYTHON_NATIVE_BINARY_SUFFIXES):
+                            selected.append(Path(entry.path))
+                            continue
+                        if not include_current_runtime_executables:
+                            continue
+                        if entry.name in _PYTHON_RUNTIME_EXECUTABLE_NAMES or entry.name.startswith("python3."):
+                            selected.append(Path(entry.path))
             except OSError:
                 continue
-            include_current_runtime_executables = include_runtime_executables and current.name == "bin"
-            for entry in reversed(entries):
-                try:
-                    if entry.is_dir(follow_symlinks=False):
-                        stack.append(Path(entry.path))
-                        continue
-                    if entry.is_symlink() or not entry.is_file(follow_symlinks=False):
-                        continue
-                except OSError:
-                    continue
-                if entry.name.endswith(_PYTHON_NATIVE_BINARY_SUFFIXES):
-                    selected.append(Path(entry.path))
-                    continue
-                if not include_current_runtime_executables:
-                    continue
-                if entry.name in _PYTHON_RUNTIME_EXECUTABLE_NAMES or entry.name.startswith("python3."):
-                    selected.append(Path(entry.path))
         return selected
 
     candidates = collect(python_runtime_path, include_runtime_executables=True)


### PR DESCRIPTION
## Summary
- Stream `os.scandir()` entries directly in `_iter_python_native_binary_candidates()` instead of sorting and reversing each directory listing.
- Add a regression guard proving the native binary candidate scan does not call `sorted(...)`.
- Document the Python-only performance slice and its registered probe coverage.

## Plan or Spec
- `docs/plans/2026-06-08-macos-app-native-binary-unsorted-scan.md`
- Registered probe: `macos-app-native-binary-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_bundle_slimming_helpers_cover_runtime_edge_cases services/mlx-worker-python/tests/test_macos_app_bundle.py::test_iter_python_native_binary_candidates_tolerates_scandir_metadata_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` → 4 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` → 40 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/macos_app_bundle.py services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_pr_scoped_performance.py` → TOTAL 19 0 100%
- Registered probe workload (`macos-app-native-binary-scandir`) run locally 3x before and after the change via the same Python payload.
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (19/19 measurable changed lines covered).
- Baseline local probe elapsed means: 6.026402 ms, 5.245248 ms, 4.944812 ms; aggregate mean 5.405487 ms.
- Candidate local probe elapsed means: 4.513450 ms, 4.549731 ms, 4.400082 ms; aggregate mean 4.487754 ms.
- Local delta: -0.917733 ms mean, ~16.98% faster; candidate count stayed 1802.
- CI PR-scoped performance report is required as the merge gate for the registered probe validation.

## Known Gaps
- Linux local verification covers the Python packaging helper path only. This PR does not claim Swift runtime performance changes.
- Traversal order is no longer explicitly sorted, but stripping dedupes candidate paths and does not expose deterministic candidate order as behavior.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at 100%.
- [x] Registered probe workload was measured locally before and after the change.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
