### PR TITLE
perf: trim trajectory manifest string coercion

### DIFF
--- a/docs/plans/2026-06-08-trajectory-manifest-path-bindings.md
+++ b/docs/plans/2026-06-08-trajectory-manifest-path-bindings.md
@@ -1,0 +1,50 @@
+# Trajectory Manifest Path Bindings Performance Slice
+
+## Scope
+
+This Python-only performance slice narrows the trajectory snapshot manifest JSON
+loader in `services/mlx-worker-python/worker/trajectory_provenance.py`.
+
+The slice keeps behavior unchanged while avoiding repeated `str(...)` calls for
+manifest fields that are already exact strings in the hot manifest extraction
+path. Non-string values continue to be coerced through `str(value).strip()`.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped probe
+`trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`.
+
+Required local commands:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names \
+  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes \
+  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_accepts_dict_subclass \
+  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q \
+  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names \
+  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes \
+  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_accepts_dict_subclass \
+  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && \
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && \
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" \
+  uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
+```
+
+## Decision Rule
+
+Accept only if focused tests and changed-scope coverage pass and the registered
+probe shows a stable improvement or a clearly non-regressing result on Linux.
+PR-scoped performance CI remains the merge gate for the registered probe.

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -298,6 +298,20 @@ def test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs(
         "trajectory_split": "train",
         "trajectory_trace_digest": "abc123",
     }
+    assert trajectory_provenance_from_snapshot_manifest(
+        {
+            "format": "agentic_tool_trace",
+            "source_dataset_id": 123,
+            "version": " 2026-06-08 ",
+            "trajectory_trace_digest": 456,
+        }
+    ) == {
+        "trajectory_dataset_id": "123",
+        "trajectory_dataset_version": "2026-06-08",
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "trajectory_split": "train",
+        "trajectory_trace_digest": "456",
+    }
     assert (
         load_trajectory_provenance_from_normalized_snapshot(
             format_name="text",

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -11,6 +11,12 @@ _PATH_READ_BYTES = Path.read_bytes
 _STR = str
 
 
+def _strip_manifest_text(value: Any) -> str:
+    if type(value) is str:
+        return value.strip()
+    return _STR(value).strip()
+
+
 TRAJECTORY_PROVENANCE_FIELDS = (
     "trajectory_dataset_id",
     "trajectory_dataset_version",
@@ -110,31 +116,31 @@ def _trajectory_provenance_from_snapshot_manifest(
     copy_nested: bool,
 ) -> dict[str, Any]:
     manifest_get = manifest.get
-    to_str = _STR
+    strip_text = _strip_manifest_text
     if (
-        to_str(manifest_get("format", "")).strip() != "agentic_tool_trace"
-        and not to_str(manifest_get("trajectory_trace_digest", "")).strip()
+        strip_text(manifest_get("format", "")) != "agentic_tool_trace"
+        and not strip_text(manifest_get("trajectory_trace_digest", ""))
     ):
         return {}
 
     provenance: dict[str, Any] = {}
-    dataset_id = to_str(
+    dataset_id = strip_text(
         manifest_get("source_dataset_id") or manifest_get("dataset_id") or ""
-    ).strip()
+    )
     if dataset_id:
         provenance["trajectory_dataset_id"] = dataset_id
-    dataset_version = to_str(manifest_get("version") or "").strip()
+    dataset_version = strip_text(manifest_get("version") or "")
     if dataset_version:
         provenance["trajectory_dataset_version"] = dataset_version
-    schema_version = to_str(
+    schema_version = strip_text(
         manifest_get("trajectory_schema_version") or "melix.agentic_tool_trace.v1"
-    ).strip()
+    )
     if schema_version:
         provenance["trajectory_schema_version"] = schema_version
-    split = to_str(manifest_get("trajectory_split") or "train").strip()
+    split = strip_text(manifest_get("trajectory_split") or "train")
     if split:
         provenance["trajectory_split"] = split
-    trace_digest = to_str(manifest_get("trajectory_trace_digest") or "").strip()
+    trace_digest = strip_text(manifest_get("trajectory_trace_digest") or "")
     if trace_digest:
         provenance["trajectory_trace_digest"] = trace_digest
     if snapshot_manifest_path is not None:


### PR DESCRIPTION
## Summary
- Optimize trajectory snapshot manifest extraction by avoiding repeated `str(...)` calls for manifest fields that are already exact strings.
- Preserve non-string coercion semantics with a focused regression assertion.
- Document the slice and registered probe workflow.

## Plan or Spec
- `docs/plans/2026-06-08-trajectory-manifest-path-bindings.md`
- Registered PR-scoped probe: `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_accepts_dict_subclass services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 8 passed in 0.53s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_accepts_dict_subclass services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py services/mlx-worker-python/tests/test_trajectory_provenance.py
# TOTAL 11 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
# {"old_mean_ms": 1392.9910151287913, "new_mean_ms": 700.0894337892532, "delta_ms": -692.9015813395381, "speedup": 1.9897329511019604, ...}

Custom origin/main-vs-head microcheck for this exact slice
# {"origin_main_mean_ms": 213.9274672205959, "head_mean_ms": 209.85377114266157, "delta_ms": -4.073696077934329, "speedup": 1.019412069917795, "samples": 7, "iterations": 3000}

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 11 0 100%` for `worker/trajectory_provenance.py` and `tests/test_trajectory_provenance.py`.
- Registered local probe (`trajectory-manifest-json-load`): `old_mean_ms=1392.9910`, `new_mean_ms=700.0894`, `delta_ms=-692.9016`, `speedup=1.9897`.
- Exact slice microcheck against `origin/main`: `origin_main_mean_ms=213.9275`, `head_mean_ms=209.8538`, `delta_ms=-4.0737`, `speedup=1.0194`.
- PR-scoped performance CI is still required as the merge gate for the registered probe report.

## Known Gaps
- Linux-only local validation for this Python slice; GitHub Actions PR-scoped performance remains the authoritative registered probe validation before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
