### PR TITLE
perf: skip duplicate native MTP basename checks

### DIFF
--- a/docs/plans/2026-06-08-native-mtp-extra-seen-before-basename.md
+++ b/docs/plans/2026-06-08-native-mtp-extra-seen-before-basename.md
@@ -1,0 +1,49 @@
+# Native MTP Extra Shard Duplicate Filter Performance Slice
+
+## Scope
+
+This Python-only performance slice narrows the native-MTP sidecar shard discovery
+loop in `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`.
+
+The slice keeps behavior unchanged while moving the duplicate `seen` check ahead
+of basename extraction for candidate `.safetensors` sidecar entries. Duplicate
+index entries now skip the path-separator/basename branch before joining or
+checking the filesystem.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.
+The probe already has focused `test_command`, `coverage_command`, and
+`probe_command` entries for this loader and its tests.
+
+Required local commands:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join \
+  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names \
+  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q \
+  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join \
+  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names \
+  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics && \
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && \
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" \
+  MELIX_NATIVE_MTP_LOADER_SAMPLES=7 MELIX_NATIVE_MTP_LOADER_DISTRACTOR_FILES=2000 \
+  uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
+```
+
+## Decision Rule
+
+Accept only if focused tests and changed-scope coverage pass and the registered
+probe shows non-regression with a clear improvement in `extra_new_mean_ms` or
+related native-MTP sidecar metrics. PR-scoped performance CI remains the merge
+gate for the registered probe.

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -1615,6 +1615,7 @@ def test_native_mtp_extra_safetensor_files_filters_names_before_path_join(
             "language_model.mtp.layers.3.weight": "mtp-00001.safetensors",
             "language_model.mtp.layers.4.weight": "mtp-missing.safetensors",
             "language_model.mtp.layers.5.weight": "nested/mtp-00002.safetensors",
+            "language_model.mtp.layers.5.duplicate_weight": "nested/mtp-00002.safetensors",
             "language_model.layers.0.weight": "ignored-mtp.safetensors",
         }
     }

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -85,12 +85,12 @@ def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
             file_name_text = to_text(file_name)
         if not file_name_text.endswith(".safetensors"):
             continue
+        if file_name_text in seen:
+            continue
         file_basename = file_name_text
         if path_sep in file_name_text:
             file_basename = file_name_text.rsplit(path_sep, 1)[-1]
         if file_basename.startswith("model"):
-            continue
-        if file_name_text in seen:
             continue
         seen_add(file_name_text)
         path_text = path_join(model_path_text, file_name_text)


### PR DESCRIPTION
## Summary
- Moves the native-MTP sidecar duplicate `seen` check before basename extraction in the extra shard discovery loop.
- Extends the duplicate nested sidecar regression case so duplicate entries still resolve once.
- Adds a focused plan for this registered Python performance slice.

## Plan or Spec
- `docs/plans/2026-06-08-native-mtp-extra-seen-before-basename.md`
- Registered probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics` — 5 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics` — 10 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q ... && coverage json ... && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` — changed-line coverage 100.00%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" MELIX_NATIVE_MTP_LOADER_SAMPLES=7 MELIX_NATIVE_MTP_LOADER_DISTRACTOR_FILES=2000 uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100.00% for `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`.
- Local registered probe (Linux, 7 samples, 2000 distractor files):
  - `extra_old_mean_ms=262.97190825321843`
  - `extra_new_mean_ms=44.22163078561425`
  - `extra_delta_ms=-218.75027746760418`
  - `extra_speedup=5.946680472461587`
  - `old_mean_ms=10.606358226920877`
  - `new_mean_ms=10.496312087135655`
  - `speedup=1.0104842671284608`
  - `weight_load_speedup=1.0775359251076844`
- PR-scoped performance CI is required as the merge gate for the registered probe.

## Known Gaps
- Local validation is Linux-only. The changed code is Python-only; no Swift runtime effect is claimed.
- The local probe uses synthetic native-MTP shard/index data; CI registered probe validation is still required before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is measured and passes 95%+.
- [x] Registered probe ran locally and shows improvement for the sidecar duplicate-filter path.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
