### PR TITLE
Stabilize release gate badge concurrency

### DIFF
--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-gates-${{ github.event_name }}-${{ github.ref }}
+  group: release-gates-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.run_id || 'shared' }}
   cancel-in-progress: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/docs/plans/2026-06-07-readme-action-badges.md
+++ b/docs/plans/2026-06-07-readme-action-badges.md
@@ -8,13 +8,14 @@ Restore the root README action badges so they report meaningful release and app 
 
 - The `release-gates` workflow was manually disabled in GitHub Actions, leaving the README badge stuck on the latest historical failed or cancelled main run.
 - Main push-triggered `release-gates` runs also cancelled earlier main runs, so a fast merge sequence could leave the branch badge red even when no release gate failed.
+- GitHub Actions concurrency keeps at most one running and one pending run per concurrency group. Even with `cancel-in-progress: false` for `main` pushes, later `main` pushes can cancel older pending `release-gates` runs in the same group before they start; GitHub and Shields badges then report that cancelled run as failing.
 - The `package-self-contained-app` workflow is healthy, but the README badge queries all `main` workflow runs. Frequent push-triggered packaging runs can be cancelled by concurrency when newer main commits land, so the badge can briefly report failure even when the scheduled app artifact path is healthy.
 
 ## Scope
 
 - Re-enable the `release-gates` workflow in GitHub Actions and trigger a fresh `main` run.
 - Keep the release-gates README badge on `main` so real gate failures remain visible.
-- Keep main push-triggered `release-gates` runs from cancelling each other, while preserving cancellation for repeated non-main/manual/scheduled runs.
+- Keep main push-triggered `release-gates` runs from cancelling each other by assigning each `main` push run a unique concurrency group, while preserving cancellation for repeated non-main/manual/scheduled runs.
 - Scope the app packaging README badge to the scheduled packaging event, which is the durable public app artifact signal.
 - Add a focused README regression test for the badge URLs.
 

--- a/services/mlx-worker-python/tests/test_readme_action_badges.py
+++ b/services/mlx-worker-python/tests/test_readme_action_badges.py
@@ -31,5 +31,9 @@ def test_app_packaging_badge_reports_scheduled_main_artifact_status() -> None:
 def test_release_gates_main_push_runs_are_not_cancelled_by_later_main_pushes() -> None:
     workflow = RELEASE_GATES_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "release-gates-${{ github.event_name }}-${{ github.ref }}" in workflow
+    assert (
+        "release-gates-${{ github.event_name }}-${{ github.ref }}-"
+        "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && "
+        "github.run_id || 'shared' }}"
+    ) in workflow
     assert "github.event_name != 'push' || github.ref != 'refs/heads/main'" in workflow


### PR DESCRIPTION
## Summary
- Give main push release-gates runs unique concurrency groups so later main pushes do not cancel older pending gate runs and poison README status badges.
- Keep non-main/manual/scheduled release-gates runs in the shared concurrency lane and document the GitHub pending-run cancellation behavior.
- Keep the app packaging README badge scoped to scheduled main artifacts; current main app packaging runs are passing.

## Plan or Spec
- docs/plans/2026-06-07-readme-action-badges.md

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_readme_action_badges.py -q
-> 3 passed in 0.02s

ruby -e 'require "yaml"; [".github/workflows/release-gates.yml", ".github/workflows/package-self-contained-app.yml"].each { |p| data = YAML.load_file(p); puts "#{p}: #{data["name"]}" }'
-> .github/workflows/release-gates.yml: release-gates
-> .github/workflows/package-self-contained-app.yml: package-self-contained-app

git diff --check origin/main...HEAD
-> passed

git commit -m "ci: isolate release gate main push runs"
-> pre-commit full gate passed:
   make swift-test -> completed rc=0 elapsed=684.2s
   make py-test -> 3675 passed, 14 skipped, 2 warnings in 207.26s
   make integration-test -> 117 passed, 1 skipped in 785.98s
   scoped performance report -> Status: ok; Changed files: 3; Selected probes: 0; Regressions: 0; Context regressions: 0; Verification failures: 0
```

## Coverage and Metrics
- Coverage: focused README/workflow regression tests in `services/mlx-worker-python/tests/test_readme_action_badges.py`; full local pre-commit gate passed.
- Metrics: scoped performance report at `.runtime/pre-commit-performance/20260608-051813-5039830b/report/report.md` reported `Status: ok`, `Regressions: 0`, `Context regressions: 0`, and `Verification failures: 0`.
- Observability/probe overhead: `N/A`; CI concurrency/status presentation only, no runtime observability or probe implementation changes.

## Known Gaps
- Existing main release-gates runs started before this workflow change can still report cancelled/failing in badges until a post-merge main push run completes under the new concurrency group.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
