### PR TITLE
Add agentic judge prompt boundary receipts

### DIFF
--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -1411,6 +1411,8 @@ Each row must include:
 - `media_refs`
 - `tool_calls`
 - `agentic_tool_observation_count`
+- `untrusted_context_receipt_count`
+- `untrusted_context_receipts`
 
 `messages` must contain the judge system instruction and a user payload with the
 question, expected answer, model final answer, parse status, scoring mode,
@@ -1428,6 +1430,16 @@ answer keys, reference solutions, provider credentials, API keys, tokens,
 passwords, or remote base URLs. Literal answer text remains allowed as a value
 inside `expected_answer`, `final_answer`, and executed observations because
 those fields are part of the explicit scoring boundary.
+
+Each admitted user-payload field must also have an untrusted-context receipt in
+the prompt snapshot. The receipt marks the segment as `trust_level =
+untrusted`, `policy = data_only`, `message_role = user`, and
+`boundary_checked = true`. These receipts document that sample-derived
+questions, expected answers, final answers, parse status, scoring mode,
+evidence ids, media refs, raw tool calls, and executed tool observations are
+prompt data only; they must not be projected into system or developer
+instructions. The receipt count must match the number of admitted user-payload
+fields.
 
 `agentic-judge-audit.jsonl` is one JSON object per selected sample. Each row
 must include:

--- a/docs/plans/2026-06-08-issue-1761-agentic-judge-prompt-receipts.md
+++ b/docs/plans/2026-06-08-issue-1761-agentic-judge-prompt-receipts.md
@@ -1,0 +1,97 @@
+# Issue 1761 Agentic Judge Prompt Boundary Receipt Plan
+
+## Goal
+
+Add the first prompt-construction receipt slice for untrusted agentic
+evaluation context. Agentic judge prompt snapshots must make the trust boundary
+machine-readable for each sample-derived segment projected into the judge user
+message.
+
+## Scope
+
+This slice covers `agentic-judge-prompt-snapshots.jsonl` rows written by the
+Python worker evaluation core for agentic evaluation suites.
+
+The slice records receipts for the existing user-payload fields:
+
+- `question`
+- `expected_answer`
+- `final_answer`
+- `parse_status`
+- `scoring_mode`
+- `evidence_ids`
+- `media_refs`
+- `tool_calls`
+- `tool_observations`
+
+This slice does not change judge scoring, prompt wording, remote judge calls,
+generic chat prompt assembly, skill entrypoints, memory entrypoints, or
+background-job continuation behavior. Those remain follow-up #1761 surfaces.
+
+## Architecture
+
+The best end-state architecture is that every untrusted segment included in a
+prompt is accompanied by a receipt that explains why it is safe to include as
+data and which trusted role, if any, it can influence. This slice adds that
+receipt at an already persisted prompt snapshot boundary without changing model
+runtime behavior.
+
+Each receipt uses a stable shape:
+
+- `schema_version = melix.untrusted_context_receipt.v1`
+- `segment_id`
+- `source_type`
+- `source_field`
+- `message_role`
+- `trust_level = untrusted`
+- `policy = data_only`
+- `boundary_checked = true`
+- `included = true`
+- `owner_scope_checked = false`
+- `reason`
+- `corrective_action`
+
+The prompt snapshot row also records:
+
+- `untrusted_context_receipt_count`
+- `untrusted_context_receipts`
+
+The existing no-leak validator remains the fail-closed gate for forbidden
+nested keys. These receipts document admitted untrusted segments; they do not
+weaken that validator or turn sample content into trusted instructions.
+
+## Performance Probes And Metrics
+
+The receipt builder is a small fixed loop over the existing judge user payload
+fields. The affected path already has registered evaluation scoped performance
+coverage because `evaluation_core.py` changes select evaluation probes.
+
+Verification will include:
+
+- focused pytest for agentic judge prompt snapshot receipts
+- changed-line coverage for modified Python and test lines with a target of at
+  least 95 percent
+- local PR-scoped performance report with `Status: ok`
+
+## Implementation Steps
+
+1. Add failing tests proving prompt snapshots include one receipt per admitted
+   user-payload segment and that persisted rows expose receipt counts.
+2. Implement a small helper in `EvaluationCore` that builds deterministic
+   untrusted-context receipts from the judge user payload keys.
+3. Add the receipt fields to agentic judge prompt snapshot rows.
+4. Update `docs/benchmark-evaluation-contract.md` and
+   `docs/unified-agentic-tool-runtime-contract.md` with the prompt-construction
+   boundary receipt.
+5. Run focused tests, changed-line coverage, scoped performance, and PR gates.
+
+## Success Criteria
+
+- Agentic judge prompt snapshots expose `untrusted_context_receipts` with one
+  receipt for every user-payload segment admitted into the user message.
+- Receipts identify each segment as untrusted, data-only, checked, included,
+  and projected only into the user role.
+- Existing no-leak rejection behavior remains unchanged.
+- The contract documents this as the first prompt-construction receipt slice,
+  with broader skill, memory, RAG, chat prompt assembly, and background-job
+  surfaces left for later #1761 work.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -195,6 +195,37 @@ search rows, image search rows, pages, layouts, and crops. Broader RAG stores,
 skill entrypoints, memory entrypoints, and background-job continuations must
 reuse the same receipt shape when they add owner-aware payloads under #1761.
 
+### Prompt Construction Boundary
+
+Retrieved documents, skills, memories, tool observations, media references,
+sample questions, expected answers, and model final answers must remain
+untrusted data when they are projected into prompt messages. Prompt assembly
+must keep those segments out of system and developer instructions unless the
+operator has explicitly configured them as trusted instructions.
+
+Prompt snapshots and prompt evidence should record one receipt for each
+admitted untrusted segment. The receipt shape is:
+
+- `schema_version = melix.untrusted_context_receipt.v1`
+- `segment_id`
+- `source_type`
+- `source_field`
+- `message_role`
+- `trust_level = untrusted`
+- `policy = data_only`
+- `boundary_checked = true`
+- `included`
+- `owner_scope_checked`
+- `reason`
+- `corrective_action`
+
+The v1 agentic judge prompt snapshot slice records this receipt for every
+sample-derived user-payload field admitted into the judge user message. It does
+not change judge prompt wording or scorer behavior. Broader chat prompt
+assembly, RAG stores, skill entrypoints, memory entrypoints, and background-job
+continuations must reuse this receipt shape when they add their prompt-context
+boundary evidence under #1761.
+
 ### Workspace Path Boundary
 
 Agent and workflow tools that read, write, or edit local files must resolve

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -1011,6 +1011,37 @@ def test_run_local_suite_writes_agentic_judge_prompt_snapshot_and_audit(
     assert snapshot["media_refs"][0]["uri"] == "media/sign.ppm"
     assert snapshot["tool_calls"] == raw_tool_calls
     assert snapshot["agentic_tool_observation_count"] == 1
+    assert snapshot["untrusted_context_receipt_count"] == 9
+    receipt_by_field = {
+        receipt["source_field"]: receipt
+        for receipt in snapshot["untrusted_context_receipts"]
+    }
+    assert set(receipt_by_field) == {
+        "question",
+        "expected_answer",
+        "final_answer",
+        "parse_status",
+        "scoring_mode",
+        "evidence_ids",
+        "media_refs",
+        "tool_calls",
+        "tool_observations",
+    }
+    tool_observation_receipt = receipt_by_field["tool_observations"]
+    assert tool_observation_receipt == {
+        "schema_version": "melix.untrusted_context_receipt.v1",
+        "segment_id": "agentic-judge-1:tool_observations",
+        "source_type": "agentic_judge_user_payload",
+        "source_field": "tool_observations",
+        "message_role": "user",
+        "trust_level": "untrusted",
+        "policy": "data_only",
+        "boundary_checked": True,
+        "included": True,
+        "owner_scope_checked": False,
+        "reason": "sample-derived context is prompt data, not instructions",
+        "corrective_action": "Keep this segment in the user payload and do not project it into system or developer instructions.",
+    }
     assert snapshot["messages"][0]["role"] == "system"
     assert snapshot["messages"][1]["role"] == "user"
     user_payload = json.loads(snapshot["messages"][1]["content"])
@@ -1054,6 +1085,29 @@ def test_run_local_suite_writes_agentic_judge_prompt_snapshot_and_audit(
     assert tuple_snapshot["allowed_tools"] == ["image_crop"]
     assert tuple_snapshot["evidence_ids"] == ["img-1#sign"]
     assert tuple_snapshot["media_refs"] == [{"id": "img-1", "uri": "media/sign.ppm"}]
+    assert tuple_snapshot["untrusted_context_receipt_count"] == 9
+    assert tuple_snapshot["untrusted_context_receipts"][0]["segment_id"] == "agentic-judge-1:question"
+    assert tuple_snapshot["untrusted_context_receipts"][0]["policy"] == "data_only"
+    ordered_receipts = EvaluationCore._agentic_judge_untrusted_context_receipts(
+        sample_id="sample-1",
+        user_payload={"question": "Q", "tool_observations": []},
+    )
+    assert [receipt["segment_id"] for receipt in ordered_receipts] == [
+        "sample-1:question",
+        "sample-1:tool_observations",
+    ]
+    assert [receipt["source_field"] for receipt in ordered_receipts] == [
+        "question",
+        "tool_observations",
+    ]
+    assert all(receipt["schema_version"] == "melix.untrusted_context_receipt.v1" for receipt in ordered_receipts)
+    assert all(receipt["trust_level"] == "untrusted" for receipt in ordered_receipts)
+    assert all(receipt["policy"] == "data_only" for receipt in ordered_receipts)
+    assert all(receipt["boundary_checked"] is True for receipt in ordered_receipts)
+    assert EvaluationCore._agentic_judge_untrusted_context_receipts(
+        sample_id="sample-1",
+        user_payload={},
+    ) == []
     assert EvaluationCore._object_dict_list(None, field_name="tool_calls") == []
     assert EvaluationCore._object_dict_list(
         (

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -139,6 +139,7 @@ _AGENTIC_TOOL_METRIC_NAMES = (
 )
 _AGENTIC_JUDGE_PROMPT_SNAPSHOT_SCHEMA_VERSION = "melix.agentic_judge_prompt_snapshot.v1"
 _AGENTIC_JUDGE_AUDIT_SCHEMA_VERSION = "melix.agentic_judge_audit.v1"
+_UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION = "melix.untrusted_context_receipt.v1"
 _AGENTIC_JUDGE_PROMPT_VERSION = "agentic-answer-equivalence.v1"
 _AGENTIC_JUDGE_SYSTEM_PROMPT = """You are an answer equivalence judge for Melix agentic multimodal evaluation.
 
@@ -2444,6 +2445,10 @@ class EvaluationCore:
             "tool_observations": tool_observations,
         }
         EvaluationCore._validate_agentic_judge_user_payload(user_payload)
+        untrusted_context_receipts = EvaluationCore._agentic_judge_untrusted_context_receipts(
+            sample_id=sample_record.sample_id,
+            user_payload=user_payload,
+        )
         return {
             "schema_version": _AGENTIC_JUDGE_PROMPT_SNAPSHOT_SCHEMA_VERSION,
             "job_id": job_id,
@@ -2467,6 +2472,46 @@ class EvaluationCore:
             "media_refs": media_refs,
             "tool_calls": tool_calls,
             "agentic_tool_observation_count": len(tool_observations),
+            "untrusted_context_receipt_count": len(untrusted_context_receipts),
+            "untrusted_context_receipts": untrusted_context_receipts,
+        }
+
+    @staticmethod
+    def _agentic_judge_untrusted_context_receipts(
+        *,
+        sample_id: str,
+        user_payload: dict[str, object],
+    ) -> list[dict[str, object]]:
+        return [
+            EvaluationCore._agentic_judge_untrusted_context_receipt(
+                sample_id=sample_id,
+                source_field=source_field,
+            )
+            for source_field in user_payload
+        ]
+
+    @staticmethod
+    def _agentic_judge_untrusted_context_receipt(
+        *,
+        sample_id: str,
+        source_field: str,
+    ) -> dict[str, object]:
+        return {
+            "schema_version": _UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION,
+            "segment_id": f"{sample_id}:{source_field}",
+            "source_type": "agentic_judge_user_payload",
+            "source_field": source_field,
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": True,
+            "owner_scope_checked": False,
+            "reason": "sample-derived context is prompt data, not instructions",
+            "corrective_action": (
+                "Keep this segment in the user payload and do not project it into "
+                "system or developer instructions."
+            ),
         }
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Add untrusted-context receipts to agentic judge prompt snapshots for each admitted sample-derived user payload segment.
- Document the prompt-construction boundary in the unified agentic tool runtime and benchmark/evaluation contracts.
- Preserve existing no-leak validation, judge prompt messages, and scoring behavior while adding explicit boundary evidence.

## Plan or Spec
- `docs/plans/2026-06-08-issue-1761-agentic-judge-prompt-receipts.md`
- `docs/unified-agentic-tool-runtime-contract.md`
- `docs/benchmark-evaluation-contract.md`

## Commands Run
```text
make bootstrap
  - completed rc=0
make proto
  - completed rc=0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_writes_agentic_judge_prompt_snapshot_and_audit
  - red before implementation: failed with KeyError: 'untrusted_context_receipt_count'
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q <agentic judge focused selection>
  - 11 passed in 0.63s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q <agentic judge focused selection> && coverage json && python3 scripts/changed_scope_coverage.py ...
  - 11 passed in 0.62s; TOTAL 24/24 changed lines covered (100.00%)
UV_PYTHON=3.12 uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY' ... gate.run_performance_report(...)
  - Status ok; selected probes 6; regressions 0; verification failures 0
make swift-test
  - pre-commit: completed rc=0 elapsed=200.8s
make py-test
  - pre-commit: 3683 passed, 14 skipped, 2 warnings in 160.41s; completed rc=0 elapsed=161.0s
make integration-test
  - pre-commit: 117 passed, 1 skipped in 412.18s; completed rc=0 elapsed=413.1s
git commit -m "Add agentic judge prompt boundary receipts"
  - pre-commit scoped performance: Status ok; selected probes 6; regressions 0; verification failures 0
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 24/24 (100.00%)`.
- File coverage: `evaluation_core.py 8/8 (100.00%)`; `test_evaluation_core.py 16/16 (100.00%)`.
- Local scoped performance report: `.runtime/pre-commit-performance/20260608-060241-81a78f4b/report/report.md`.
- Scoped performance summary: status `ok`; selected probes `6`; direct/gated probes `6`; regressions `0`; context regressions `0`; verification failures `0`.
- Observability mode: evidence. The added receipts are written into agentic judge prompt snapshot artifacts.
- Probe overhead: fixed-size receipt construction over the existing user-payload fields for each prompt snapshot; no runtime serving path changes.

## Known Gaps
- This slice covers agentic judge prompt snapshots only.
- Broader chat prompt assembly, RAG stores, skills, memories, background-job continuation, and tool-output boundary receipts remain under issue #1761.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
