### PR TITLE
perf: append embedding cycle copies directly

### DIFF
--- a/docs/plans/2026-06-08-embedding-cycle-extend-loop.md
+++ b/docs/plans/2026-06-08-embedding-cycle-extend-loop.md
@@ -1,0 +1,45 @@
+# Embedding Cycle Replay Extension Loop Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to the repeated-cycle branch in
+`DeterministicEmbeddingRuntime.embed_inputs(...)`. The path handles large
+embedding batches where the ordered input cycle is repeated multiple times and
+must still return distinct vector lists for each output position.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`deterministic-embedding-duplicate-input-cache` in
+`infra/perf/pr_scoped_probes.json`. The entry already includes focused
+`test_command`, `coverage_command`, and `probe_command` values for Linux CI.
+This slice extends that registered probe with `peak_bytes_mean` so the replay
+path's allocation behavior is measured alongside elapsed time and backend call
+count.
+
+## Optimization
+
+The prior repeated-cycle branch built all replayed vector copies in an
+intermediate list comprehension before extending the response vector list. This
+slice appends those defensive copies directly from a nested loop, preserving the
+same output order and object isolation while avoiding the temporary replay list.
+
+## Verification plan
+
+1. Add a regression test for repeated-cycle replay that proves the backend only
+   embeds the first cycle and all repeated outputs remain distinct mutable lists.
+2. Run the registered focused test command for
+   `deterministic-embedding-duplicate-input-cache` locally on Linux.
+3. Run the registered changed-scope coverage command locally on Linux.
+4. Run the registered probe locally on Linux and compare with the pre-change
+   baseline.
+5. Use PR-scoped performance CI as the merge gate.
+
+## Success metrics
+
+- Focused tests pass.
+- Changed-scope coverage for touched paths is at least 95%.
+- Registered probe reports lower `peak_bytes_mean` and no increase in
+  `embed_text_calls_mean`; `elapsed_ms_mean` is tracked as a secondary
+  lower-is-better metric.
+- CI PR-scoped performance report completes without regressions.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -548,6 +548,12 @@
         "warn_pct": 5.0
       },
       {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
         "key": "embed_text_calls_mean",
         "unit": "calls",
         "direction": "lower_is_better",

--- a/scripts/deterministic_embedding_duplicate_probe.py
+++ b/scripts/deterministic_embedding_duplicate_probe.py
@@ -4,6 +4,7 @@ import json
 import statistics
 import sys
 import time
+import tracemalloc
 from pathlib import Path
 
 repo_root = Path.cwd()
@@ -87,6 +88,7 @@ def run_probe() -> dict[str, float]:
     sample_count = 5
     elapsed_samples: list[float] = []
     call_samples: list[float] = []
+    peak_samples: list[float] = []
     checksum = 0.0
 
     for _ in range(sample_count):
@@ -98,9 +100,13 @@ def run_probe() -> dict[str, float]:
             "embedding_backend": backend,
             "embedding_family_adapter": CountingEmbeddingFamilyAdapter(),
         }
+        tracemalloc.start()
         started = time.perf_counter()
         vectors = runtime.embed_inputs(loaded_model, inputs)
         elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_samples.append(float(peak_bytes))
         call_samples.append(float(backend.calls))
         checksum = sum(vector[0] for vector in vectors)
 
@@ -109,6 +115,7 @@ def run_probe() -> dict[str, float]:
     assert vectors[0] is not vectors[len(unique_inputs)]
     return {
         "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+        "peak_bytes_mean": round(statistics.fmean(peak_samples), 6),
         "embed_text_calls_mean": round(statistics.fmean(call_samples), 6),
         "input_count": float(len(inputs)),
         "unique_input_count": float(expected_unique_count),

--- a/services/mlx-worker-python/tests/test_embedding_runtime.py
+++ b/services/mlx-worker-python/tests/test_embedding_runtime.py
@@ -397,6 +397,32 @@ def test_embed_runtime_reuses_duplicate_inputs_within_one_request() -> None:
     assert vectors[2] == [1.0, 1.0, 1.0, 1.0]
 
 
+def test_embed_runtime_replays_repeated_cycles_without_shared_vectors() -> None:
+    runtime = DeterministicEmbeddingRuntime()
+    backend = CountingEmbeddingBackend()
+    family = CountingEmbeddingFamilyAdapter()
+    cycle = [f"document-{index}" for index in range(1024)]
+
+    vectors = runtime.embed_inputs(
+        {
+            "model_id": "melix-dev-embed-counting-cycle",
+            "dimensions": 2,
+            "embedding_backend": backend,
+            "embedding_family_adapter": family,
+        },
+        cycle * 3,
+    )
+
+    assert len(backend.calls) == len(cycle)
+    assert len(vectors) == len(cycle) * 3
+    assert vectors[0] == vectors[len(cycle)] == vectors[len(cycle) * 2]
+    assert vectors[0] is not vectors[len(cycle)]
+    assert vectors[len(cycle)] is not vectors[len(cycle) * 2]
+    vectors[len(cycle)][0] = 99.0
+    assert vectors[0] == [1.0, 1.0]
+    assert vectors[len(cycle) * 2] == [1.0, 1.0]
+
+
 def test_load_model_rejects_unsupported_embedding_backend() -> None:
     runtime = DeterministicEmbeddingRuntime()
     model = WorkerModelCatalog.dev_embedding_model(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2612,6 +2612,7 @@ def test_deterministic_embedding_duplicate_probe_script_emits_metrics(
     assert 0 < metrics["unique_input_count"] < metrics["input_count"]
     assert metrics["embed_text_calls_mean"] == metrics["unique_input_count"]
     assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["peak_bytes_mean"] > 0
     assert metrics["checksum"] > 0
 
 

--- a/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
@@ -69,10 +69,9 @@ class DeterministicEmbeddingRuntime:
                 vector = embed_text(backend, text, dimensions)
                 append_vector(vector)
             cycle_vectors = tuple(vectors)
-            repeat_count = len(inputs) // cycle_length - 1
-            vectors.extend(
-                [vector.copy() for _ in range(repeat_count) for vector in cycle_vectors]
-            )
+            for _ in range(len(inputs) // cycle_length - 1):
+                for vector in cycle_vectors:
+                    append_vector(vector.copy())
             return vectors
 
         vector_cache: dict[str, list[float]] = {}


### PR DESCRIPTION
## Summary
- Append repeated embedding-cycle vector copies directly instead of materializing the replay list before extending the response vector list.
- Add regression coverage proving repeated-cycle replay embeds only the first cycle and preserves distinct mutable output vectors.
- Extend the registered `deterministic-embedding-duplicate-input-cache` probe with `peak_bytes_mean` so allocation behavior is tracked for this path.

## Plan or Spec
- `docs/plans/2026-06-08-embedding-cycle-extend-loop.md`
- Registered PR-scoped probe: `deterministic-embedding-duplicate-input-cache`

## Commands Run
- `git status --short && git branch --show-current`
- `git fetch origin && git reset --hard origin/main`
- Baseline probe before implementation: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_duplicate_probe.py`
- Focused tests: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics`
- Changed-scope coverage: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_duplicate_probe.py`
- Registered probe after implementation, repeated 3 times: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_duplicate_probe.py`
- Local same-process old-vs-new diagnostic with `tracemalloc` for the repeated-cycle branch.
- `git diff --check`

## Coverage and Metrics
- Focused tests: `18 passed in 2.04s`
- Changed-scope coverage: `TOTAL 24 0 100%`
- Baseline registered probe before implementation, before adding peak tracking: `elapsed_ms_mean=4.987138`, `embed_text_calls_mean=512.0`, `input_count=8192.0`, `unique_input_count=512.0`, `checksum=2169.411765`
- Local same-process old-vs-new diagnostic with identical peak tracking:
  - old: `elapsed_ms_mean=26.589166`, `peak_bytes_mean=3081689.714`, `embed_text_calls_mean=512.0`
  - new: `elapsed_ms_mean=26.053350`, `peak_bytes_mean=3015703.429`, `embed_text_calls_mean=512.0`
  - delta: `elapsed_ms_mean=-0.536 ms`, `peak_bytes_mean=-65986.286 bytes`
- Registered probe after implementation (3 local runs):
  - run 1: `elapsed_ms_mean=27.887798`, `peak_bytes_mean=3016335.2`, `embed_text_calls_mean=512.0`
  - run 2: `elapsed_ms_mean=23.802884`, `peak_bytes_mean=3016335.2`, `embed_text_calls_mean=512.0`
  - run 3: `elapsed_ms_mean=24.522110`, `peak_bytes_mean=3016335.2`, `embed_text_calls_mean=512.0`

## Known Gaps
- This is a Python-only slice locally verified on Linux.
- The new `peak_bytes_mean` metric is added in this PR; PR-scoped CI is still required as the registered probe validation source before merge.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before starting.
- [x] Affected path has a registered PR-scoped performance probe with focused `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally on Linux.
- [ ] PR-scoped performance CI completed successfully.
- [ ] All required GitHub checks are green.
