### PR TITLE
Add agentic judge refusal receipts

### DIFF
--- a/docs/benchmark-evaluation-contract.md
+++ b/docs/benchmark-evaluation-contract.md
@@ -1441,6 +1441,15 @@ prompt data only; they must not be projected into system or developer
 instructions. The receipt count must match the number of admitted user-payload
 fields.
 
+When the judge user-payload validator rejects context before prompt snapshot
+persistence, the validation error must expose `refusal_receipts` using the same
+`melix.untrusted_context_receipt.v1` schema. Refusal receipts mark the refused
+segment as `included = false`, `boundary_checked = true`, `policy =
+data_only`, and `message_role = user`. Unsupported top-level user-payload
+fields use `reason = unsupported_user_payload_field`; forbidden nested no-leak
+keys use `reason = forbidden_user_payload_key`. Rejected segments must not be
+included in the persisted `messages` payload.
+
 `agentic-judge-audit.jsonl` is one JSON object per selected sample. Each row
 must include:
 

--- a/docs/plans/2026-06-08-issue-1761-agentic-judge-refusal-receipts.md
+++ b/docs/plans/2026-06-08-issue-1761-agentic-judge-refusal-receipts.md
@@ -1,0 +1,70 @@
+# Issue 1761 Agentic Judge Refusal Receipt Plan
+
+## Goal
+
+Record machine-readable refusal receipts when agentic judge prompt context is
+rejected before prompt snapshot persistence.
+
+## Scope
+
+This slice covers the existing Python worker validator for
+`agentic-judge-prompt-snapshots.jsonl` user payloads. It adds receipt evidence
+for the two current rejection paths:
+
+- unsupported user-payload fields
+- forbidden nested no-leak keys such as hidden gold, credentials, tokens, and
+  remote base URLs
+
+This slice does not change judge scoring, prompt wording, accepted prompt
+snapshot rows, generic chat prompt assembly, skill entrypoints, memory
+entrypoints, background-job continuations, or broader RAG stores.
+
+## Architecture
+
+Accepted prompt segments already emit `melix.untrusted_context_receipt.v1`
+receipts with `included = true`. Rejected segments should use the same schema
+with `included = false`, `boundary_checked = true`, and a stable refusal reason
+so operators can distinguish hidden instructions or unsupported wrapper shapes
+from generic Python exceptions.
+
+The implementation keeps `ValueError` compatibility by introducing a small
+subclass that carries `refusal_receipts`. Existing callers that catch
+`ValueError` keep working, while tests and future evidence publishers can read
+the structured receipts.
+
+## Performance Probes And Metrics
+
+The new path only builds receipts when validation fails. Accepted snapshot rows
+still use the fixed receipt loop from the previous slice. The changed
+`evaluation_core.py` path selects the evaluation scoped performance probes.
+
+Verification will include:
+
+- focused pytest for validator refusal receipts
+- changed-line coverage for modified Python and test lines with a target of at
+  least 95 percent
+- local PR-scoped performance report with `Status: ok`
+
+## Implementation Steps
+
+1. Add failing tests that assert unsupported-field and forbidden-key validation
+   errors carry `refusal_receipts`.
+2. Add a `ValueError` subclass for agentic judge context validation failures.
+3. Add a helper that builds deterministic rejected untrusted-context receipts.
+4. Update the validator to raise the subclass with refusal receipts for both
+   existing rejection paths.
+5. Update benchmark/evaluation and unified runtime contracts with the rejected
+   receipt behavior.
+6. Run focused tests, changed-line coverage, scoped performance, full gates,
+   and PR checks.
+
+## Success Criteria
+
+- Unsupported user-payload fields fail before prompt snapshot persistence and
+  expose receipts with `reason = unsupported_user_payload_field`.
+- Forbidden nested keys fail before prompt snapshot persistence and expose
+  receipts with `reason = forbidden_user_payload_key`.
+- Refusal receipts use the same schema as admitted prompt-context receipts,
+  mark `included = false`, and keep the segment in the user role/data-only
+  policy.
+- Accepted prompt snapshot rows remain unchanged.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -226,6 +226,14 @@ assembly, RAG stores, skill entrypoints, memory entrypoints, and background-job
 continuations must reuse this receipt shape when they add their prompt-context
 boundary evidence under #1761.
 
+Rejected prompt-context segments should use the same receipt schema with
+`included = false`. For the agentic judge prompt boundary, unsupported
+top-level user-payload fields emit `reason =
+unsupported_user_payload_field`, and forbidden nested no-leak keys emit
+`reason = forbidden_user_payload_key`. These refusal receipts are attached to
+the validation error before prompt snapshot persistence so refused segments
+cannot appear in the final prompt messages.
+
 ### Workspace Path Boundary
 
 Agent and workflow tools that read, write, or edit local files must resolve

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -1289,6 +1289,22 @@ def test_agentic_judge_payload_no_leak_validator_rejects_forbidden_keys(
     with pytest.raises(ValueError) as exc_info:
         EvaluationCore._validate_agentic_judge_user_payload(user_payload)
     assert str(exc_info.value) == f"agentic judge context contains forbidden field {expected_path}"
+    assert exc_info.value.refusal_receipts == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": f"agentic_judge_user_payload:{expected_path}",
+            "source_type": "agentic_judge_user_payload",
+            "source_field": expected_path,
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": False,
+            "owner_scope_checked": False,
+            "reason": "forbidden_user_payload_key",
+            "corrective_action": "Remove this field before projecting the sample-derived context into the judge user payload.",
+        }
+    ]
 
 
 def test_agentic_judge_payload_no_leak_validator_allows_explicit_answer_values() -> None:
@@ -1320,10 +1336,7 @@ def test_agentic_judge_payload_no_leak_validator_allows_explicit_answer_values()
 
 
 def test_agentic_judge_payload_no_leak_validator_rejects_extra_payload_fields() -> None:
-    with pytest.raises(
-        ValueError,
-        match="agentic judge context contains unsupported user payload fields: hidden_gold",
-    ):
+    with pytest.raises(ValueError) as exc_info:
         EvaluationCore._validate_agentic_judge_user_payload(
             {
                 "question": "What text is visible?",
@@ -1338,6 +1351,23 @@ def test_agentic_judge_payload_no_leak_validator_rejects_extra_payload_fields() 
                 "hidden_gold": "MELIX",
             }
         )
+    assert str(exc_info.value) == "agentic judge context contains unsupported user payload fields: hidden_gold"
+    assert exc_info.value.refusal_receipts == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": "agentic_judge_user_payload:hidden_gold",
+            "source_type": "agentic_judge_user_payload",
+            "source_field": "hidden_gold",
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": False,
+            "owner_scope_checked": False,
+            "reason": "unsupported_user_payload_field",
+            "corrective_action": "Remove this field before projecting the sample-derived context into the judge user payload.",
+        }
+    ]
 
 
 def test_run_local_suite_returns_agentic_judge_artifacts_without_jobs_root(

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -203,6 +203,12 @@ _AGENTIC_JUDGE_FORBIDDEN_CONTEXT_KEYS = frozenset(
 )
 
 
+class AgenticJudgeContextValidationError(ValueError):
+    def __init__(self, message: str, *, refusal_receipts: list[dict[str, object]]) -> None:
+        super().__init__(message)
+        self.refusal_receipts = refusal_receipts
+
+
 @dataclass(frozen=True)
 class EvaluationRun:
     job: EvaluationJob | EvaluationCompareJob
@@ -2515,6 +2521,30 @@ class EvaluationCore:
         }
 
     @staticmethod
+    def _agentic_judge_refusal_receipt(
+        *,
+        source_field: str,
+        reason: str,
+    ) -> dict[str, object]:
+        return {
+            "schema_version": _UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION,
+            "segment_id": f"agentic_judge_user_payload:{source_field}",
+            "source_type": "agentic_judge_user_payload",
+            "source_field": source_field,
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": False,
+            "owner_scope_checked": False,
+            "reason": reason,
+            "corrective_action": (
+                "Remove this field before projecting the sample-derived context "
+                "into the judge user payload."
+            ),
+        }
+
+    @staticmethod
     def _agentic_judge_audit_row(
         *,
         job_id: str,
@@ -2554,13 +2584,28 @@ class EvaluationCore:
     def _validate_agentic_judge_user_payload(user_payload: dict[str, object]) -> None:
         unsupported_fields = sorted(set(user_payload) - _AGENTIC_JUDGE_USER_PAYLOAD_FIELDS)
         if unsupported_fields:
-            raise ValueError(
+            raise AgenticJudgeContextValidationError(
                 "agentic judge context contains unsupported user payload fields: "
-                + ", ".join(unsupported_fields)
+                + ", ".join(unsupported_fields),
+                refusal_receipts=[
+                    EvaluationCore._agentic_judge_refusal_receipt(
+                        source_field=source_field,
+                        reason="unsupported_user_payload_field",
+                    )
+                    for source_field in unsupported_fields
+                ],
             )
         for field_path, field_name in EvaluationCore._iter_json_field_paths(user_payload):
             if EvaluationCore._agentic_judge_context_key_is_forbidden(field_name):
-                raise ValueError(f"agentic judge context contains forbidden field {field_path}")
+                raise AgenticJudgeContextValidationError(
+                    f"agentic judge context contains forbidden field {field_path}",
+                    refusal_receipts=[
+                        EvaluationCore._agentic_judge_refusal_receipt(
+                            source_field=field_path,
+                            reason="forbidden_user_payload_key",
+                        )
+                    ],
+                )
 
     @staticmethod
     def _iter_json_field_paths(


### PR DESCRIPTION
## Summary
- Adds machine-readable refusal receipts when agentic judge prompt user payload validation rejects unsupported fields or forbidden nested no-leak keys.
- Documents the rejected-context receipt contract so refused sample-derived segments remain visible for audit while staying out of persisted judge prompt messages.

## Plan or Spec
- Issue: #1761
- Plan: `docs/plans/2026-06-08-issue-1761-agentic-judge-refusal-receipts.md`
- Specs updated: `docs/benchmark-evaluation-contract.md`, `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_forbidden_keys services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_extra_payload_fields
# Expected red result before implementation: 6 failed; all failures were AttributeError for missing refusal_receipts.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_forbidden_keys services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_extra_payload_fields services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_allows_explicit_answer_values services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_prompt_snapshot_rejects_hidden_gold_context services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_writes_agentic_judge_prompt_snapshot_and_audit
# 9 passed in 1.32s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_forbidden_keys services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_extra_payload_fields services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_allows_explicit_answer_values services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_prompt_snapshot_rejects_hidden_gold_context services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_writes_agentic_judge_prompt_snapshot_and_audit
# 9 passed in 0.50s.

python3 scripts/changed_scope_coverage.py --coverage-json .runtime/coverage-issue-1761-refusal.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py
# TOTAL 13 0 100%.

make bootstrap
# completed successfully.

make proto
# completed successfully.

git diff --cached --check
# no output.

MELIX_PRE_COMMIT_FORCE=1 UV_PYTHON=3.12 .githooks/pre-commit
# make swift-test: rc=0, elapsed=525.0s.
# make py-test: rc=0, 3683 passed, 14 skipped, 2 warnings in 187.81s.
# make integration-test: rc=0, 117 passed, 1 skipped in 719.75s.
# PR scoped performance: Status ok, selected probes 6, regressions 0, context regressions 0, verification failures 0.
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 13 0 100%`) for `evaluation_core.py` and `test_evaluation_core.py`.
- Metrics report: `.runtime/pre-commit-performance/20260608-065314-66bfefde/report/report.md`.
- Performance report status: `ok`; regressions `0`; context regressions `0`; verification failures `0`.
- Probe coverage: six direct evaluation probes all passed targeted tests with 100% coverage.
- Observability mode: minimal contract/audit receipts for rejected agentic judge prompt context.
- Probe overhead: N/A for production runtime; this change adds refusal metadata on validation errors and uses existing PR-scoped performance probes.

## Known Gaps
- This slice covers agentic judge prompt user-payload validator rejection receipts only.
- Broader #1761 work remains for retrieved docs, skills, memories, generic tool output, background-job continuations, and concrete resolver integration in read/write/edit tools.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
