### PR TITLE
perf: cache changed-scope allowlist parsing

### DIFF
--- a/docs/plans/2026-06-08-changed-scope-allowlist-raw-cache.md
+++ b/docs/plans/2026-06-08-changed-scope-allowlist-raw-cache.md
@@ -1,0 +1,35 @@
+# Changed-scope allowlist raw parse cache
+
+## Scope
+
+This Python-only performance slice is limited to `scripts/changed_scope_coverage.py`
+and the focused changed-scope coverage tests. The hot path is repeated parsing of
+`MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON` for probe and CI coverage workflows that
+invoke the allowlist helper with the same raw environment value.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`changed-scope-coverage-measured-set-filter` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` values and runs `scripts/changed_scope_coverage_measured_probe.py`.
+
+## Plan
+
+1. Preserve the existing allowlist semantics for empty values, simple JSON string
+   values, escaped JSON strings, JSON string payloads, and JSON list payloads.
+2. Cache parsing by the stripped raw environment value so repeated helper calls
+   reuse the same immutable `frozenset` result without repeatedly invoking the
+   JSON decoder.
+3. Add a focused regression test that proves identical raw JSON list payloads are
+   decoded once and then served from cache.
+4. Verify with the registered focused tests, changed-scope coverage command, and
+   the registered local Linux probe before using PR-scoped performance CI as the
+   merge gate.
+
+## Metrics
+
+Success is measured by the registered probe's
+`allowlist_parse_elapsed_ms_mean` while preserving `source_read_calls_mean == 0.0`
+and changed-line coverage at or above 95%. This slice is Linux-verifiable and
+does not claim any Swift runtime effect.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Mapping
+from functools import lru_cache
 import json
 import os
 from pathlib import Path
@@ -115,8 +116,8 @@ def _changed_lines_by_path(repo_root: Path, rel_paths: list[str]) -> dict[str, s
     return {rel_path: changed_by_path.get(rel_path, set()) for rel_path in rel_paths}
 
 
-def _coverage_path_allowlist(env: Mapping[str, str]) -> frozenset[str] | None:
-    raw_value = env.get("MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON", "").strip()
+@lru_cache(maxsize=16)
+def _coverage_path_allowlist_from_raw(raw_value: str) -> frozenset[str] | None:
     if not raw_value:
         return None
     if (
@@ -136,6 +137,11 @@ def _coverage_path_allowlist(env: Mapping[str, str]) -> frozenset[str] | None:
     if not isinstance(payload, list):
         raise SystemExit("MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON must be a JSON list")
     return frozenset(str(path) for path in payload if str(path))
+
+
+def _coverage_path_allowlist(env: Mapping[str, str]) -> frozenset[str] | None:
+    raw_value = env.get("MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON", "").strip()
+    return _coverage_path_allowlist_from_raw(raw_value)
 
 
 def _filter_coverage_paths(paths: list[str], allowlist: frozenset[str] | None) -> list[str]:

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -210,6 +210,8 @@ def test_coverage_path_allowlist_accepts_single_string_payload() -> None:
 
 
 def test_coverage_path_allowlist_parses_simple_string_without_json_decoder(monkeypatch) -> None:
+    changed_scope_coverage._coverage_path_allowlist_from_raw.cache_clear()
+
     def fail_loads(*args: object, **kwargs: object) -> object:  # pragma: no cover
         raise AssertionError("simple single-string allowlists should avoid json.loads")
 
@@ -218,6 +220,28 @@ def test_coverage_path_allowlist_parses_simple_string_without_json_decoder(monke
     assert changed_scope_coverage._coverage_path_allowlist(
         {"MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON": '"pkg/direct.py"'}
     ) == {"pkg/direct.py"}
+
+
+def test_coverage_path_allowlist_reuses_cached_raw_payload_parse(monkeypatch) -> None:
+    changed_scope_coverage._coverage_path_allowlist_from_raw.cache_clear()
+    calls = 0
+    original_loads = changed_scope_coverage.json.loads
+
+    def counted_loads(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        return original_loads(*args, **kwargs)
+
+    monkeypatch.setattr(changed_scope_coverage.json, "loads", counted_loads)
+    payload = '["direct.py", "context.py"]'
+
+    assert changed_scope_coverage._coverage_path_allowlist(
+        {"MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON": payload}
+    ) == {"direct.py", "context.py"}
+    assert changed_scope_coverage._coverage_path_allowlist(
+        {"MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON": payload}
+    ) == {"direct.py", "context.py"}
+    assert calls == 1
 
 
 def test_coverage_path_allowlist_escaped_string_uses_json_decoder() -> None:


### PR DESCRIPTION
## Summary
- Cache `MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON` parsing by stripped raw value in `scripts/changed_scope_coverage.py`.
- Add a regression test proving identical JSON list payloads are decoded once and reused from cache.
- Add a focused plan for the changed-scope allowlist raw parse cache slice.

## Plan or Spec
- `docs/plans/2026-06-08-changed-scope-allowlist-raw-cache.md`
- Registered PR-scoped probe: `changed-scope-coverage-measured-set-filter` in `infra/perf/pr_scoped_probes.json` (has focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 40 passed in 0.28s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 40 passed in 0.59s; TOTAL 19 0 100%

python3 scripts/changed_scope_coverage_measured_probe.py
# {"allowlist_parse_count": 10000.0, "allowlist_parse_elapsed_ms_mean": 2.849242982587644, "elapsed_ms_mean": 0.22756940286074365, "measured_lines_per_path": 500.0, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 19 0 100%`.
- Registered local Linux probe before change: `allowlist_parse_elapsed_ms_mean=6.739570027483361`, `elapsed_ms_mean=0.23328798956104688`, `source_read_calls_mean=0.0`.
- Registered local Linux probe after change: `allowlist_parse_elapsed_ms_mean=2.849242982587644`, `elapsed_ms_mean=0.22756940286074365`, `source_read_calls_mean=0.0`.
- Delta: `allowlist_parse_elapsed_ms_mean=-3.890327044895717 ms` (`57.72366826119934%` lower). CI PR-scoped performance is still the merge gate.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this narrow Python tooling slice; GitHub Actions remains required before merge.
- No Swift runtime effect is claimed; this slice is Linux-verifiable Python tooling only.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A (tooling cache only); probe overhead tracked by registered PR-scoped performance report.
- [x] Deferred work and known gaps are stated explicitly.
