### PR TITLE
Add workspace file tool resolver boundary

### DIFF
--- a/docs/plans/2026-06-08-issue-1761-workspace-file-tools.md
+++ b/docs/plans/2026-06-08-issue-1761-workspace-file-tools.md
@@ -16,6 +16,9 @@ workflow file surfaces:
 - edit UTF-8 workspace files by exact text replacement only after resolver
   admission
 - return a machine-readable receipt for allowed and refused operations
+- return `status = failed` receipts for admitted paths when filesystem or
+  decoding errors occur instead of letting those exceptions escape the tool
+  boundary
 - prove refused paths do not reach the final read or mutation path
 - document the concrete operator boundary in the unified agentic tool runtime
   contract
@@ -36,7 +39,10 @@ The operator lives in `worker.runtime.workspace_file_tools` because it is
 runtime safety infrastructure, not productization schema validation. Receipts
 reuse the resolver fields and add `schema_version`, `tool_name`, `status`,
 byte counts, and edit replacement counts so future tool observations can attach
-the decision without reconstructing filesystem state.
+the decision without reconstructing filesystem state. Byte counters describe
+completed tool effects only: failed receipts keep `bytes_read = 0` and
+`bytes_written = 0` even when a preflight read happened before a replacement
+count mismatch.
 
 ## Performance Probes And Metrics
 
@@ -62,6 +68,7 @@ Verification will include:
    - symlink escapes being refused before read/write/edit mutation
    - sensitive filenames being refused before parent-directory creation or file
      mutation
+   - admitted missing-file and write parent errors returning failed receipts
 2. Implement `WorkspaceFileTools` and `WorkspaceFileToolResult` in
    `services/mlx-worker-python/worker/runtime/workspace_file_tools.py`.
 3. Update `docs/unified-agentic-tool-runtime-contract.md` so the workspace path
@@ -78,6 +85,8 @@ Verification will include:
   receipts with resolver refusal reasons.
 - Refused write/edit calls leave outside files and sensitive-path parent
   directories unchanged.
+- Filesystem and text decoding failures after resolver admission produce
+  `status = failed` receipts without escaping exceptions to the caller.
 - Successful calls include workspace resolver receipt fields and operation
   metrics.
 - Focused tests, changed-line coverage, full pre-commit, CI, and remote

--- a/docs/plans/2026-06-08-issue-1761-workspace-file-tools.md
+++ b/docs/plans/2026-06-08-issue-1761-workspace-file-tools.md
@@ -1,0 +1,84 @@
+# Issue 1761 Workspace File Tools Plan
+
+## Goal
+
+Add concrete Python worker workspace file read/write/edit operators that route
+every requested path through `WorkspacePathResolver` before any filesystem read
+or mutation.
+
+## Scope
+
+This slice covers a reusable runtime primitive for future agent, MCP, and
+workflow file surfaces:
+
+- read UTF-8 workspace files only after resolver admission
+- write UTF-8 workspace files only after resolver admission
+- edit UTF-8 workspace files by exact text replacement only after resolver
+  admission
+- return a machine-readable receipt for allowed and refused operations
+- prove refused paths do not reach the final read or mutation path
+- document the concrete operator boundary in the unified agentic tool runtime
+  contract
+
+This slice does not expose new public MCP namespaces, change the Swift MCP
+catalog, or connect these operators to a live model-request tool execution path.
+Those surfaces can call this primitive once the executor surface is introduced.
+
+## Architecture
+
+The best end state is one workspace file operator layer shared by agentic tools,
+workflow actions, and local-job mutation surfaces. The layer accepts an active
+workspace root, delegates path containment and sensitive filename policy to the
+existing `WorkspacePathResolver`, and then performs the requested file operation
+only when `allowed = true`.
+
+The operator lives in `worker.runtime.workspace_file_tools` because it is
+runtime safety infrastructure, not productization schema validation. Receipts
+reuse the resolver fields and add `schema_version`, `tool_name`, `status`,
+byte counts, and edit replacement counts so future tool observations can attach
+the decision without reconstructing filesystem state.
+
+## Performance Probes And Metrics
+
+The path boundary adds one resolver call per requested file operation. Allowed
+reads/writes/edits already perform filesystem IO; blocked operations stop before
+opening or mutating the target. There is no registered PR-scoped synthetic probe
+expected for this new primitive. The PR-scoped performance report must still
+show `Status: ok`, regressions `0`, and verification failures `0`.
+
+Verification will include:
+
+- focused pytest for the workspace file tools
+- changed-line coverage for the new module and tests with a target of at least
+  95 percent
+- full local pre-commit gate before opening the PR
+- remote PR performance report with no regressions
+
+## Implementation Steps
+
+1. Add failing tests in
+   `services/mlx-worker-python/tests/test_workspace_file_tools.py` for:
+   - allowed read/write/edit paths emitting resolver receipts
+   - symlink escapes being refused before read/write/edit mutation
+   - sensitive filenames being refused before parent-directory creation or file
+     mutation
+2. Implement `WorkspaceFileTools` and `WorkspaceFileToolResult` in
+   `services/mlx-worker-python/worker/runtime/workspace_file_tools.py`.
+3. Update `docs/unified-agentic-tool-runtime-contract.md` so the workspace path
+   boundary identifies this file-tool primitive as the first concrete
+   read/write/edit implementation under #1761.
+4. Run focused tests, changed-scope coverage, `git diff --check`, commit, run
+   the full pre-commit gate, open the PR, and monitor CI plus performance.
+
+## Success Criteria
+
+- Every read/write/edit method calls `WorkspacePathResolver.resolve()` before
+  any file open, write, parent-directory creation, or edit mutation.
+- Traversal, symlink escapes, and sensitive filenames produce `status = failed`
+  receipts with resolver refusal reasons.
+- Refused write/edit calls leave outside files and sensitive-path parent
+  directories unchanged.
+- Successful calls include workspace resolver receipt fields and operation
+  metrics.
+- Focused tests, changed-line coverage, full pre-commit, CI, and remote
+  performance report pass without regressions.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -259,9 +259,17 @@ Workspace path receipts must include:
 - `allowed`
 - `refusal_reason`
 
-The v1 workspace resolver slice only introduces the shared boundary primitive.
-Adding concrete read/write/edit tools, local-job mutation hooks, and prompt
-assembly receipts remains follow-up work under #1761.
+The v1 workspace resolver slice introduced the shared boundary primitive. The
+v1 Python worker file-tool slice adds `worker.runtime.workspace_file_tools` as
+the first concrete read/write/edit operator set. Those operators call
+`WorkspacePathResolver` before any file open, parent-directory creation, write,
+or exact-replacement edit mutation, and failed resolver decisions return a
+receipt instead of touching the target path.
+
+Live MCP, agent, workflow, and local-job mutation surfaces must reuse this
+operator layer or preserve the same resolver-before-filesystem-access invariant
+when they expose file operations. Broader prompt assembly receipts and direct
+surface integrations remain follow-up work under #1761.
 
 The observation metric keys are:
 

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -264,7 +264,12 @@ v1 Python worker file-tool slice adds `worker.runtime.workspace_file_tools` as
 the first concrete read/write/edit operator set. Those operators call
 `WorkspacePathResolver` before any file open, parent-directory creation, write,
 or exact-replacement edit mutation, and failed resolver decisions return a
-receipt instead of touching the target path.
+receipt instead of touching the target path. Filesystem and text-decoding
+failures after resolver admission must also stay inside this boundary as
+`status = failed` receipts rather than escaping into the worker or agent loop.
+Receipt byte counters describe completed tool effects only; failed receipts keep
+byte counters at zero even if a preflight read occurred before the operation was
+rejected.
 
 Live MCP, agent, workflow, and local-job mutation surfaces must reuse this
 operator layer or preserve the same resolver-before-filesystem-access invariant

--- a/services/mlx-worker-python/tests/test_workspace_file_tools.py
+++ b/services/mlx-worker-python/tests/test_workspace_file_tools.py
@@ -223,6 +223,63 @@ def test_workspace_file_tools_write_encoding_failure_returns_failed_receipt_with
     assert not (workspace / "nested").exists()
 
 
+def test_workspace_file_tools_write_failure_cleans_up_created_parent_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "nested" / "deep" / "output.txt"
+    tools = WorkspaceFileTools(workspace)
+
+    def fail_write_bytes(self: Path, data: bytes) -> int:
+        if self == target:
+            self.touch()
+            raise OSError("simulated write failure")
+        return original_write_bytes(self, data)
+
+    original_write_bytes = Path.write_bytes
+    monkeypatch.setattr(Path, "write_bytes", fail_write_bytes)
+
+    result = tools.write_text("nested/deep/output.txt", "content\n", create_parent_dirs=True)
+
+    assert result.status == "failed"
+    assert result.bytes_written == 0
+    assert result.receipt["allowed"] is True
+    assert result.receipt["error"] == "simulated write failure"
+    assert not (workspace / "nested").exists()
+    assert not target.exists()
+
+
+def test_workspace_file_tools_write_failure_preserves_existing_parent_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    existing_parent = workspace / "existing"
+    existing_parent.mkdir(parents=True)
+    target = existing_parent / "output.txt"
+    tools = WorkspaceFileTools(workspace)
+
+    def fail_write_bytes(self: Path, data: bytes) -> int:
+        if self == target:
+            self.touch()
+            raise OSError("simulated write failure")
+        return original_write_bytes(self, data)
+
+    original_write_bytes = Path.write_bytes
+    monkeypatch.setattr(Path, "write_bytes", fail_write_bytes)
+
+    result = tools.write_text("existing/output.txt", "content\n", create_parent_dirs=True)
+
+    assert result.status == "failed"
+    assert result.bytes_written == 0
+    assert result.receipt["allowed"] is True
+    assert result.receipt["error"] == "simulated write failure"
+    assert existing_parent.exists()
+    assert not target.exists()
+
+
 def test_workspace_file_tools_edit_write_failure_returns_failed_receipt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -249,4 +306,24 @@ def test_workspace_file_tools_edit_write_failure_returns_failed_receipt(
     assert result.replacement_count == 0
     assert result.receipt["allowed"] is True
     assert result.receipt["error"] == "simulated write failure"
+    assert target.read_text(encoding="utf-8") == "alpha\n"
+
+
+def test_workspace_file_tools_edit_encoding_failure_returns_failed_receipt_without_mutating_file(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "draft.txt"
+    target.write_text("alpha\n", encoding="utf-8")
+    tools = WorkspaceFileTools(workspace)
+
+    result = tools.edit_text("draft.txt", old_text="alpha", new_text="snowman \u2603", encoding="latin-1")
+
+    assert result.status == "failed"
+    assert result.bytes_read == 0
+    assert result.bytes_written == 0
+    assert result.replacement_count == 0
+    assert result.receipt["allowed"] is True
+    assert "codec" in result.receipt["error"]
     assert target.read_text(encoding="utf-8") == "alpha\n"

--- a/services/mlx-worker-python/tests/test_workspace_file_tools.py
+++ b/services/mlx-worker-python/tests/test_workspace_file_tools.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from worker.runtime.workspace_file_tools import WorkspaceFileTools
 
 
@@ -23,6 +25,7 @@ def test_workspace_file_tools_read_write_and_edit_allowed_paths_emit_receipts(tm
     assert read_result.bytes_read == len("alpha\n".encode("utf-8"))
     assert edit_result.status == "completed"
     assert edit_result.replacement_count == 1
+    assert edit_result.bytes_read == len("alpha\n".encode("utf-8"))
     assert edit_result.bytes_written == len("beta\n".encode("utf-8"))
     assert read_result.receipt == {
         "schema_version": "melix.workspace_file_tool_receipt.v1",
@@ -110,3 +113,106 @@ def test_workspace_file_tools_edit_rejects_empty_old_text_without_mutating_file(
     assert result.status == "failed"
     assert result.receipt["allowed"] is True
     assert result.receipt["error"] == "workspace edit requires non-empty old_text"
+
+
+def test_workspace_file_tools_read_missing_file_returns_failed_receipt(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    tools = WorkspaceFileTools(workspace)
+
+    result = tools.read_text("missing.txt")
+
+    assert result.status == "failed"
+    assert result.content == ""
+    assert result.bytes_read == 0
+    assert result.receipt["allowed"] is True
+    assert "No such file or directory" in result.receipt["error"]
+
+
+def test_workspace_file_tools_write_parent_creation_failure_returns_failed_receipt(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    blocker = workspace / "blocker"
+    blocker.write_text("not a directory\n", encoding="utf-8")
+    tools = WorkspaceFileTools(workspace)
+
+    result = tools.write_text("blocker/output.txt", "content\n", create_parent_dirs=True)
+
+    assert result.status == "failed"
+    assert result.bytes_written == 0
+    assert result.receipt["allowed"] is True
+    assert result.receipt["error"]
+    assert blocker.read_text(encoding="utf-8") == "not a directory\n"
+
+
+def test_workspace_file_tools_edit_missing_file_returns_failed_receipt(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    tools = WorkspaceFileTools(workspace)
+
+    result = tools.edit_text("missing.txt", old_text="alpha", new_text="beta")
+
+    assert result.status == "failed"
+    assert result.bytes_read == 0
+    assert result.bytes_written == 0
+    assert result.replacement_count == 0
+    assert result.receipt["allowed"] is True
+    assert "No such file or directory" in result.receipt["error"]
+
+
+def test_workspace_file_tools_read_decoding_failure_returns_failed_receipt(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "binary.txt"
+    target.write_bytes(b"\xff")
+    tools = WorkspaceFileTools(workspace)
+
+    result = tools.read_text("binary.txt", encoding="utf-8")
+
+    assert result.status == "failed"
+    assert result.bytes_read == 0
+    assert result.receipt["allowed"] is True
+    assert "codec" in result.receipt["error"]
+
+
+def test_workspace_file_tools_write_encoding_failure_returns_failed_receipt_without_file(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    tools = WorkspaceFileTools(workspace)
+
+    result = tools.write_text("latin1.txt", "snowman \u2603", encoding="latin-1")
+
+    assert result.status == "failed"
+    assert result.bytes_written == 0
+    assert result.receipt["allowed"] is True
+    assert "codec" in result.receipt["error"]
+    assert not (workspace / "latin1.txt").exists()
+
+
+def test_workspace_file_tools_edit_write_failure_returns_failed_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "draft.txt"
+    target.write_text("alpha\n", encoding="utf-8")
+    tools = WorkspaceFileTools(workspace)
+
+    def fail_write_bytes(self: Path, data: bytes) -> int:
+        if self == target:
+            raise OSError("simulated write failure")
+        return original_write_bytes(self, data)
+
+    original_write_bytes = Path.write_bytes
+    monkeypatch.setattr(Path, "write_bytes", fail_write_bytes)
+
+    result = tools.edit_text("draft.txt", old_text="alpha", new_text="beta", expected_replacements=1)
+
+    assert result.status == "failed"
+    assert result.bytes_read == 0
+    assert result.bytes_written == 0
+    assert result.replacement_count == 0
+    assert result.receipt["allowed"] is True
+    assert result.receipt["error"] == "simulated write failure"
+    assert target.read_text(encoding="utf-8") == "alpha\n"

--- a/services/mlx-worker-python/tests/test_workspace_file_tools.py
+++ b/services/mlx-worker-python/tests/test_workspace_file_tools.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from worker.runtime.workspace_file_tools import WorkspaceFileTools
+
+
+def test_workspace_file_tools_read_write_and_edit_allowed_paths_emit_receipts(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    tools = WorkspaceFileTools(workspace)
+
+    write_result = tools.write_text("notes/today.md", "alpha\n", create_parent_dirs=True)
+    read_result = tools.read_text("notes/today.md")
+    edit_result = tools.edit_text("notes/today.md", old_text="alpha", new_text="beta", expected_replacements=1)
+
+    assert tools.workspace_root == workspace.resolve()
+    assert (workspace / "notes" / "today.md").read_text(encoding="utf-8") == "beta\n"
+    assert write_result.status == "completed"
+    assert write_result.bytes_written == len("alpha\n".encode("utf-8"))
+    assert read_result.status == "completed"
+    assert read_result.content == "alpha\n"
+    assert read_result.bytes_read == len("alpha\n".encode("utf-8"))
+    assert edit_result.status == "completed"
+    assert edit_result.replacement_count == 1
+    assert edit_result.bytes_written == len("beta\n".encode("utf-8"))
+    assert read_result.receipt == {
+        "schema_version": "melix.workspace_file_tool_receipt.v1",
+        "tool_name": "workspace_file.read",
+        "status": "completed",
+        "operation": "read",
+        "workspace_root": str(workspace.resolve()),
+        "requested_path": "notes/today.md",
+        "resolved_path": str(workspace.resolve() / "notes" / "today.md"),
+        "allowed": True,
+        "refusal_reason": "",
+        "bytes_read": len("alpha\n".encode("utf-8")),
+        "bytes_written": 0,
+        "replacement_count": 0,
+    }
+
+
+def test_workspace_file_tools_rejects_symlink_escapes_before_reading_or_mutating(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret\n", encoding="utf-8")
+    (workspace / "external").symlink_to(outside)
+    tools = WorkspaceFileTools(workspace)
+
+    read_result = tools.read_text("external/secret.txt")
+    write_result = tools.write_text("external/secret.txt", "changed\n")
+    edit_result = tools.edit_text("external/secret.txt", old_text="secret", new_text="changed")
+
+    assert (outside / "secret.txt").read_text(encoding="utf-8") == "secret\n"
+    for result in (read_result, write_result, edit_result):
+        assert result.status == "failed"
+        assert result.content == ""
+        assert result.bytes_read == 0
+        assert result.bytes_written == 0
+        assert result.replacement_count == 0
+        assert result.receipt["allowed"] is False
+        assert result.receipt["refusal_reason"] == "path_escapes_workspace"
+        assert result.receipt["resolved_path"] == str(outside.resolve() / "secret.txt")
+
+
+def test_workspace_file_tools_rejects_sensitive_paths_before_parent_creation_or_mutation(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    tools = WorkspaceFileTools(workspace)
+
+    result = tools.write_text("config/.env", "TOKEN=secret\n", create_parent_dirs=True)
+
+    assert result.status == "failed"
+    assert result.receipt["allowed"] is False
+    assert result.receipt["refusal_reason"] == "sensitive_path"
+    assert result.bytes_written == 0
+    assert not (workspace / "config").exists()
+
+
+def test_workspace_file_tools_edit_replacement_mismatch_fails_without_mutating_file(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "draft.txt"
+    target.write_text("alpha alpha\n", encoding="utf-8")
+    tools = WorkspaceFileTools(workspace)
+
+    result = tools.edit_text("draft.txt", old_text="alpha", new_text="beta", expected_replacements=1)
+
+    assert target.read_text(encoding="utf-8") == "alpha alpha\n"
+    assert result.status == "failed"
+    assert result.bytes_read == 0
+    assert result.bytes_written == 0
+    assert result.replacement_count == 0
+    assert result.receipt["allowed"] is True
+    assert result.receipt["error"] == "workspace edit replacement count mismatch: expected 1, found 2"
+
+
+def test_workspace_file_tools_edit_rejects_empty_old_text_without_mutating_file(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "draft.txt"
+    target.write_text("alpha\n", encoding="utf-8")
+    tools = WorkspaceFileTools(workspace)
+
+    result = tools.edit_text("draft.txt", old_text="", new_text="beta")
+
+    assert target.read_text(encoding="utf-8") == "alpha\n"
+    assert result.status == "failed"
+    assert result.receipt["allowed"] is True
+    assert result.receipt["error"] == "workspace edit requires non-empty old_text"

--- a/services/mlx-worker-python/tests/test_workspace_file_tools.py
+++ b/services/mlx-worker-python/tests/test_workspace_file_tools.py
@@ -100,6 +100,24 @@ def test_workspace_file_tools_edit_replacement_mismatch_fails_without_mutating_f
     assert result.receipt["error"] == "workspace edit replacement count mismatch: expected 1, found 2"
 
 
+def test_workspace_file_tools_edit_zero_matches_fails_without_mutating_file(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "draft.txt"
+    target.write_text("alpha\n", encoding="utf-8")
+    tools = WorkspaceFileTools(workspace)
+
+    result = tools.edit_text("draft.txt", old_text="gamma", new_text="delta")
+
+    assert target.read_text(encoding="utf-8") == "alpha\n"
+    assert result.status == "failed"
+    assert result.bytes_read == 0
+    assert result.bytes_written == 0
+    assert result.replacement_count == 0
+    assert result.receipt["allowed"] is True
+    assert result.receipt["error"] == "workspace edit found no occurrences of old_text"
+
+
 def test_workspace_file_tools_edit_rejects_empty_old_text_without_mutating_file(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -187,6 +205,22 @@ def test_workspace_file_tools_write_encoding_failure_returns_failed_receipt_with
     assert result.receipt["allowed"] is True
     assert "codec" in result.receipt["error"]
     assert not (workspace / "latin1.txt").exists()
+
+
+def test_workspace_file_tools_write_encoding_failure_returns_failed_receipt_without_parent_dir(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    tools = WorkspaceFileTools(workspace)
+
+    result = tools.write_text("nested/latin1.txt", "snowman \u2603", encoding="latin-1", create_parent_dirs=True)
+
+    assert result.status == "failed"
+    assert result.bytes_written == 0
+    assert result.receipt["allowed"] is True
+    assert "codec" in result.receipt["error"]
+    assert not (workspace / "nested").exists()
 
 
 def test_workspace_file_tools_edit_write_failure_returns_failed_receipt(

--- a/services/mlx-worker-python/worker/runtime/workspace_file_tools.py
+++ b/services/mlx-worker-python/worker/runtime/workspace_file_tools.py
@@ -80,11 +80,16 @@ class WorkspaceFileTools:
         except UnicodeError as exc:
             return _failed_result(tool_name="workspace_file.write", resolution=resolution, error=str(exc))
 
+        created_parent_dirs: list[Path] = []
+        target_existed = resolution.resolved_path.exists()
         try:
             if create_parent_dirs:
-                resolution.resolved_path.parent.mkdir(parents=True, exist_ok=True)
+                created_parent_dirs = _create_parent_dirs_for_file(resolution.resolved_path)
             resolution.resolved_path.write_bytes(encoded_content)
         except OSError as exc:
+            if not target_existed:
+                _remove_file_if_present(resolution.resolved_path)
+            _remove_empty_dirs(created_parent_dirs)
             return _failed_result(tool_name="workspace_file.write", resolution=resolution, error=str(exc))
         return WorkspaceFileToolResult(
             tool_name="workspace_file.write",
@@ -170,3 +175,29 @@ def _failed_result(*, tool_name: str, resolution: WorkspacePathResolution, error
         resolution=resolution,
         error=error,
     )
+
+
+def _create_parent_dirs_for_file(path: Path) -> list[Path]:
+    missing_dirs: list[Path] = []
+    current = path.parent
+    while not current.exists():
+        missing_dirs.append(current)
+        current = current.parent
+    if missing_dirs:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    return missing_dirs
+
+
+def _remove_empty_dirs(paths: list[Path]) -> None:
+    for path in paths:
+        try:
+            path.rmdir()
+        except OSError:
+            continue
+
+
+def _remove_file_if_present(path: Path) -> None:
+    try:
+        path.unlink()
+    except OSError:
+        pass

--- a/services/mlx-worker-python/worker/runtime/workspace_file_tools.py
+++ b/services/mlx-worker-python/worker/runtime/workspace_file_tools.py
@@ -49,7 +49,12 @@ class WorkspaceFileTools:
         if not resolution.allowed:
             return _refused_result(tool_name="workspace_file.read", resolution=resolution)
 
-        content = resolution.resolved_path.read_text(encoding=encoding)
+        try:
+            content = resolution.resolved_path.read_text(encoding=encoding)
+        except OSError as exc:
+            return _failed_result(tool_name="workspace_file.read", resolution=resolution, error=str(exc))
+        except UnicodeError as exc:
+            return _failed_result(tool_name="workspace_file.read", resolution=resolution, error=str(exc))
         return WorkspaceFileToolResult(
             tool_name="workspace_file.read",
             status="completed",
@@ -70,14 +75,20 @@ class WorkspaceFileTools:
         if not resolution.allowed:
             return _refused_result(tool_name="workspace_file.write", resolution=resolution)
 
-        if create_parent_dirs:
-            resolution.resolved_path.parent.mkdir(parents=True, exist_ok=True)
-        resolution.resolved_path.write_text(content, encoding=encoding)
+        try:
+            if create_parent_dirs:
+                resolution.resolved_path.parent.mkdir(parents=True, exist_ok=True)
+            encoded_content = content.encode(encoding)
+            resolution.resolved_path.write_bytes(encoded_content)
+        except OSError as exc:
+            return _failed_result(tool_name="workspace_file.write", resolution=resolution, error=str(exc))
+        except UnicodeError as exc:
+            return _failed_result(tool_name="workspace_file.write", resolution=resolution, error=str(exc))
         return WorkspaceFileToolResult(
             tool_name="workspace_file.write",
             status="completed",
             resolution=resolution,
-            bytes_written=len(content.encode(encoding)),
+            bytes_written=len(encoded_content),
         )
 
     def edit_text(
@@ -100,7 +111,12 @@ class WorkspaceFileTools:
                 error="workspace edit requires non-empty old_text",
             )
 
-        original = resolution.resolved_path.read_text(encoding=encoding)
+        try:
+            original = resolution.resolved_path.read_text(encoding=encoding)
+        except OSError as exc:
+            return _failed_result(tool_name="workspace_file.edit", resolution=resolution, error=str(exc))
+        except UnicodeError as exc:
+            return _failed_result(tool_name="workspace_file.edit", resolution=resolution, error=str(exc))
         replacement_count = original.count(old_text)
         if expected_replacements is not None and replacement_count != expected_replacements:
             return WorkspaceFileToolResult(
@@ -113,13 +129,19 @@ class WorkspaceFileTools:
                 ),
             )
         updated = original.replace(old_text, new_text)
-        resolution.resolved_path.write_text(updated, encoding=encoding)
+        try:
+            encoded_updated = updated.encode(encoding)
+            resolution.resolved_path.write_bytes(encoded_updated)
+        except OSError as exc:
+            return _failed_result(tool_name="workspace_file.edit", resolution=resolution, error=str(exc))
+        except UnicodeError as exc:
+            return _failed_result(tool_name="workspace_file.edit", resolution=resolution, error=str(exc))
         return WorkspaceFileToolResult(
             tool_name="workspace_file.edit",
             status="completed",
             resolution=resolution,
             bytes_read=len(original.encode(encoding)),
-            bytes_written=len(updated.encode(encoding)),
+            bytes_written=len(encoded_updated),
             replacement_count=replacement_count,
         )
 
@@ -129,4 +151,13 @@ def _refused_result(*, tool_name: str, resolution: WorkspacePathResolution) -> W
         tool_name=tool_name,
         status="failed",
         resolution=resolution,
+    )
+
+
+def _failed_result(*, tool_name: str, resolution: WorkspacePathResolution, error: str) -> WorkspaceFileToolResult:
+    return WorkspaceFileToolResult(
+        tool_name=tool_name,
+        status="failed",
+        resolution=resolution,
+        error=error,
     )

--- a/services/mlx-worker-python/worker/runtime/workspace_file_tools.py
+++ b/services/mlx-worker-python/worker/runtime/workspace_file_tools.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from worker.runtime.workspace_paths import WorkspacePathResolution, WorkspacePathResolver
+
+
+RECEIPT_SCHEMA_VERSION = "melix.workspace_file_tool_receipt.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceFileToolResult:
+    tool_name: str
+    status: str
+    resolution: WorkspacePathResolution
+    content: str = ""
+    bytes_read: int = 0
+    bytes_written: int = 0
+    replacement_count: int = 0
+    error: str = ""
+
+    @property
+    def receipt(self) -> dict[str, object]:
+        receipt = {
+            "schema_version": RECEIPT_SCHEMA_VERSION,
+            "tool_name": self.tool_name,
+            "status": self.status,
+            **self.resolution.receipt_fields(),
+            "bytes_read": self.bytes_read,
+            "bytes_written": self.bytes_written,
+            "replacement_count": self.replacement_count,
+        }
+        if self.error:
+            receipt["error"] = self.error
+        return receipt
+
+
+class WorkspaceFileTools:
+    def __init__(self, workspace_root: str | Path, *, resolver: WorkspacePathResolver | None = None) -> None:
+        self._resolver = resolver or WorkspacePathResolver(workspace_root)
+
+    @property
+    def workspace_root(self) -> Path:
+        return self._resolver.workspace_root
+
+    def read_text(self, requested_path: str | Path, *, encoding: str = "utf-8") -> WorkspaceFileToolResult:
+        resolution = self._resolver.resolve(requested_path, operation="read")
+        if not resolution.allowed:
+            return _refused_result(tool_name="workspace_file.read", resolution=resolution)
+
+        content = resolution.resolved_path.read_text(encoding=encoding)
+        return WorkspaceFileToolResult(
+            tool_name="workspace_file.read",
+            status="completed",
+            resolution=resolution,
+            content=content,
+            bytes_read=len(content.encode(encoding)),
+        )
+
+    def write_text(
+        self,
+        requested_path: str | Path,
+        content: str,
+        *,
+        encoding: str = "utf-8",
+        create_parent_dirs: bool = False,
+    ) -> WorkspaceFileToolResult:
+        resolution = self._resolver.resolve(requested_path, operation="write")
+        if not resolution.allowed:
+            return _refused_result(tool_name="workspace_file.write", resolution=resolution)
+
+        if create_parent_dirs:
+            resolution.resolved_path.parent.mkdir(parents=True, exist_ok=True)
+        resolution.resolved_path.write_text(content, encoding=encoding)
+        return WorkspaceFileToolResult(
+            tool_name="workspace_file.write",
+            status="completed",
+            resolution=resolution,
+            bytes_written=len(content.encode(encoding)),
+        )
+
+    def edit_text(
+        self,
+        requested_path: str | Path,
+        *,
+        old_text: str,
+        new_text: str,
+        expected_replacements: int | None = None,
+        encoding: str = "utf-8",
+    ) -> WorkspaceFileToolResult:
+        resolution = self._resolver.resolve(requested_path, operation="edit")
+        if not resolution.allowed:
+            return _refused_result(tool_name="workspace_file.edit", resolution=resolution)
+        if not old_text:
+            return WorkspaceFileToolResult(
+                tool_name="workspace_file.edit",
+                status="failed",
+                resolution=resolution,
+                error="workspace edit requires non-empty old_text",
+            )
+
+        original = resolution.resolved_path.read_text(encoding=encoding)
+        replacement_count = original.count(old_text)
+        if expected_replacements is not None and replacement_count != expected_replacements:
+            return WorkspaceFileToolResult(
+                tool_name="workspace_file.edit",
+                status="failed",
+                resolution=resolution,
+                error=(
+                    "workspace edit replacement count mismatch: "
+                    f"expected {expected_replacements}, found {replacement_count}"
+                ),
+            )
+        updated = original.replace(old_text, new_text)
+        resolution.resolved_path.write_text(updated, encoding=encoding)
+        return WorkspaceFileToolResult(
+            tool_name="workspace_file.edit",
+            status="completed",
+            resolution=resolution,
+            bytes_read=len(original.encode(encoding)),
+            bytes_written=len(updated.encode(encoding)),
+            replacement_count=replacement_count,
+        )
+
+
+def _refused_result(*, tool_name: str, resolution: WorkspacePathResolution) -> WorkspaceFileToolResult:
+    return WorkspaceFileToolResult(
+        tool_name=tool_name,
+        status="failed",
+        resolution=resolution,
+    )

--- a/services/mlx-worker-python/worker/runtime/workspace_file_tools.py
+++ b/services/mlx-worker-python/worker/runtime/workspace_file_tools.py
@@ -76,13 +76,15 @@ class WorkspaceFileTools:
             return _refused_result(tool_name="workspace_file.write", resolution=resolution)
 
         try:
+            encoded_content = content.encode(encoding)
+        except UnicodeError as exc:
+            return _failed_result(tool_name="workspace_file.write", resolution=resolution, error=str(exc))
+
+        try:
             if create_parent_dirs:
                 resolution.resolved_path.parent.mkdir(parents=True, exist_ok=True)
-            encoded_content = content.encode(encoding)
             resolution.resolved_path.write_bytes(encoded_content)
         except OSError as exc:
-            return _failed_result(tool_name="workspace_file.write", resolution=resolution, error=str(exc))
-        except UnicodeError as exc:
             return _failed_result(tool_name="workspace_file.write", resolution=resolution, error=str(exc))
         return WorkspaceFileToolResult(
             tool_name="workspace_file.write",
@@ -118,6 +120,13 @@ class WorkspaceFileTools:
         except UnicodeError as exc:
             return _failed_result(tool_name="workspace_file.edit", resolution=resolution, error=str(exc))
         replacement_count = original.count(old_text)
+        if replacement_count == 0:
+            return WorkspaceFileToolResult(
+                tool_name="workspace_file.edit",
+                status="failed",
+                resolution=resolution,
+                error="workspace edit found no occurrences of old_text",
+            )
         if expected_replacements is not None and replacement_count != expected_replacements:
             return WorkspaceFileToolResult(
                 tool_name="workspace_file.edit",


### PR DESCRIPTION
## Summary
- Add `worker.runtime.workspace_file_tools` with resolver-gated workspace read, write, and edit operators for issue #1761.
- Return deterministic receipts for allowed, refused, and admitted-but-failed file operations, and document the new boundary in the unified agentic runtime contract.

## Plan or Spec
- `docs/plans/2026-06-08-issue-1761-workspace-file-tools.md`
- `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
make bootstrap
Result: passed

make proto
Result: passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_workspace_file_tools.py services/mlx-worker-python/tests/test_workspace_path_resolver.py
Result before review update: 10 passed in 0.04s
Result after review update: 16 passed in 0.06s
Result after latest review update and latest origin/main merge: 18 passed in 0.08s
Result after merging origin/main 2dce70c6 into 35e552c6: 18 passed in 0.04s
Result after write-failure cleanup review update on 966e8749: 21 passed in 0.09s
Result after merging origin/main d675ebf5 into 70bc219a: 21 passed in 0.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_workspace_file_tools.py services/mlx-worker-python/tests/test_workspace_path_resolver.py
Result after review update: 16 passed in 0.08s
Result after latest review update and latest origin/main merge: 18 passed in 0.09s
Result after merging origin/main 2dce70c6 into 35e552c6: 18 passed in 0.08s
Result after write-failure cleanup review update on 966e8749: 21 passed in 0.24s
Result after merging origin/main d675ebf5 into 70bc219a: 21 passed in 0.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage report -m --include='services/mlx-worker-python/worker/runtime/workspace_file_tools.py,services/mlx-worker-python/worker/runtime/workspace_paths.py,services/mlx-worker-python/tests/test_workspace_file_tools.py,services/mlx-worker-python/tests/test_workspace_path_resolver.py'
Result after review update: TOTAL 330 statements, 5 missed, 98%; workspace_file_tools.py 95%, workspace_paths.py 100%
Result after latest review update and latest origin/main merge: TOTAL 357 statements, 5 missed, 99%; workspace_file_tools.py 95%, workspace_paths.py 100%
Result after merging origin/main 2dce70c6 into 35e552c6: TOTAL 357 statements, 5 missed, 99%; workspace_file_tools.py 95%, workspace_paths.py 100%
Result after write-failure cleanup review update on 966e8749: TOTAL 435 statements, 7 missed, 98%; workspace_file_tools.py 96%, workspace_paths.py 100%
Result after merging origin/main d675ebf5 into 70bc219a: TOTAL 435 statements, 7 missed, 98%; workspace_file_tools.py 96%, workspace_paths.py 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q tests/test_changed_scope_coverage.py
Result before review update: 36 passed in 0.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
Result after review update and latest origin/main merge: 39 passed in 0.21s
Result after merging origin/main 2dce70c6 into 35e552c6: 39 passed in 0.17s
Result after write-failure cleanup review update on 966e8749: 39 passed in 0.18s
Result after merging origin/main d675ebf5 into 70bc219a: 39 passed in 0.17s

git diff --check
Result: passed

git merge origin/main
Result: merged latest origin/main e0028d48 into df54ef03

make swift-test
Result after latest origin/main merge: passed; Swift test run with 796 tests in 25 suites passed after 27.672s; macOS menubar package completed rc=0 elapsed=161s

make py-test
Result after latest origin/main merge: 3699 passed, 14 skipped, 2 warnings in 156.36s

make integration-test
Result after latest origin/main merge: 117 passed, 1 skipped in 680.27s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/local-pr-scoped-performance/1937-merge/scope/changed-files.json --output .runtime/local-pr-scoped-performance/1937-merge/scope/scope.json
Result after latest origin/main merge: selected_count 0 for 4 changed files

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/local-pr-scoped-performance/1937-merge/scope/scope.json --results-dir .runtime/local-pr-scoped-performance/1937-merge/probes --output-dir .runtime/local-pr-scoped-performance/1937-merge/report --format terminal --sticky-comment
Result after latest origin/main merge: Status ok, changed files 4, selected probes 0, direct/gated probes 0, regressions 0, context regressions 0, verification failures 0

git merge origin/main
Result: merged latest origin/main 2dce70c6 into 35e552c6

git merge origin/main
Result: merged latest origin/main d675ebf5 into 70bc219a

make swift-test
Result after merging origin/main 2dce70c6 into 35e552c6: passed; Swift test run with 796 tests in 25 suites passed after 26.186s; macOS menubar package completed rc=0 elapsed=27s

make py-test
Result after merging origin/main 2dce70c6 into 35e552c6: 3699 passed, 14 skipped, 2 warnings in 155.85s

make integration-test
Result after merging origin/main 2dce70c6 into 35e552c6: 117 passed, 1 skipped in 427.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/local-pr-scoped-performance/1937-merge-latest/scope/changed-files.json --output .runtime/local-pr-scoped-performance/1937-merge-latest/scope/scope.json
Result after merging origin/main 2dce70c6 into 35e552c6: selected_count 0 for 4 changed files

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/local-pr-scoped-performance/1937-merge-latest/scope/scope.json --results-dir .runtime/local-pr-scoped-performance/1937-merge-latest/probes --output-dir .runtime/local-pr-scoped-performance/1937-merge-latest/report --format terminal --sticky-comment
Result after merging origin/main 2dce70c6 into 35e552c6: Status ok, changed files 4, selected probes 0, direct/gated probes 0, regressions 0, context regressions 0, verification failures 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/local-pr-scoped-performance/1937-review-cleanup/scope/changed-files.json --output .runtime/local-pr-scoped-performance/1937-review-cleanup/scope/scope.json
Result after write-failure cleanup review update on 966e8749: selected_count 0 for 4 changed files

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/local-pr-scoped-performance/1937-review-cleanup/scope/scope.json --results-dir .runtime/local-pr-scoped-performance/1937-review-cleanup/probes --output-dir .runtime/local-pr-scoped-performance/1937-review-cleanup/report --format terminal --sticky-comment
Result after write-failure cleanup review update on 966e8749: Status ok, changed files 4, selected probes 0, direct/gated probes 0, regressions 0, context regressions 0, verification failures 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/local-pr-scoped-performance/1937-merge-d675ebf5/scope/changed-files.json --output .runtime/local-pr-scoped-performance/1937-merge-d675ebf5/scope/scope.json
Result after merging origin/main d675ebf5 into 70bc219a: selected_count 0 for 4 changed files

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/local-pr-scoped-performance/1937-merge-d675ebf5/scope/scope.json --results-dir .runtime/local-pr-scoped-performance/1937-merge-d675ebf5/probes --output-dir .runtime/local-pr-scoped-performance/1937-merge-d675ebf5/report --format terminal --sticky-comment
Result after merging origin/main d675ebf5 into 70bc219a: Status ok, changed files 4, selected probes 0, direct/gated probes 0, regressions 0, context regressions 0, verification failures 0

git commit -m "Add workspace file tool resolver boundary"
Result: hook passed; make swift-test passed; make py-test passed, 3688 passed, 14 skipped, 2 warnings; make integration-test passed, 117 passed, 1 skipped; pre-commit scoped performance Status ok, 0 regressions

git commit -m "Handle workspace file tool IO failures"
Result: hook passed; make swift-test passed; make py-test passed, 3695 passed, 14 skipped, 2 warnings; make integration-test passed, 117 passed, 1 skipped; pre-commit scoped performance Status ok, changed files 4, selected probes 0, regressions 0, context regressions 0, verification failures 0

git commit -m "Handle workspace file review edge cases"
Result: hook passed after latest origin/main merge; make swift-test passed; make py-test passed, 3698 passed, 14 skipped, 2 warnings; make integration-test passed, 117 passed, 1 skipped; pre-commit scoped performance Status ok, changed files 2, selected probes 0, regressions 0, context regressions 0, verification failures 0

git commit -m "Clean up failed workspace write parents"
Result: hook passed; make swift-test passed, Swift test run with 796 tests in 25 suites passed after 26.289s; make py-test passed, 3702 passed, 14 skipped, 2 warnings in 156.24s; make integration-test passed, 117 passed, 1 skipped in 643.75s; pre-commit scoped performance Status ok, changed files 2, selected probes 0, regressions 0, context regressions 0, verification failures 0

make swift-test
Result after merging origin/main d675ebf5 into 70bc219a: passed; Swift test run with 796 tests in 25 suites passed after 27.548s; macOS menubar package completed rc=0 elapsed=148s

make py-test
Result after merging origin/main d675ebf5 into 70bc219a: 3704 passed, 14 skipped, 2 warnings in 156.43s

make integration-test
Result after merging origin/main d675ebf5 into 70bc219a: 117 passed, 1 skipped in 632.11s
```

## Coverage and Metrics
- Changed Python workspace file/resolver scope coverage after merging origin/main d675ebf5 into 70bc219a: 98% line coverage, 435 statements, 7 missed; `workspace_file_tools.py` 96%, `workspace_paths.py` 100%.
- Local PR-scoped performance report after merging origin/main d675ebf5 into 70bc219a: `Status: ok`, changed files 4, selected probes 0, regressions 0, context regressions 0, verification failures 0.
- Latest pre-commit scoped performance report on 966e8749: `Status: ok`, changed files 2, selected probes 0, regressions 0, context regressions 0, verification failures 0.
- Observability mode: minimal receipt evidence for local file-tool calls.
- Probe overhead: N/A, no registered PR-scoped performance probe was selected for this resolver-boundary primitive.

## Known Gaps
- This PR adds the reusable Python worker file-tool primitive only; it does not expose new public MCP namespaces or a live model-request file executor.
- Broader retrieved-doc, skill, memory, generic tool-output, and background-job prompt boundaries remain tracked under issue #1761.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
