### PR TITLE
perf: split stream channel header token directly

### DIFF
--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -1272,10 +1272,7 @@ class RequestStreamAssembler:
         stripped = header.strip()
         if not stripped:
             return ""
-        for index, character in enumerate(stripped):
-            if character.isspace():
-                return stripped[:index].lower()
-        return stripped.lower()
+        return stripped.split(None, 1)[0].lower()
 
     @classmethod
     def _legacy_pipe_channel_header_body(cls, header: str, channel_name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Replace the Python stream assembler pipe-channel header scan loop with `split(None, 1)` to extract the first channel token in C while preserving existing whitespace semantics.
- Keep the registered `stream-assembler-parser-mode-cache` probe and behavior surface unchanged.

## Plan or Spec
- `docs/runbooks/structured-streaming-reasoning-continuity.md` governs stream assembler channel routing and parser metrics.
- No doc behavior update: this is an internal Python parser micro-optimization with no protocol or workflow change.

## Commands Run
```text
# focused behavior/probe-script smoke
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_pipe_channel_name_lowercases_only_the_channel_token services/mlx-worker-python/tests/test_stream_assembler.py::test_next_structural_tag_after_returns_without_marker_tail_scans services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics
# exit 0; 3 passed in 1.11s

# registered PR-scoped test_command for stream-assembler-parser-mode-cache
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics
# exit 0; 88 passed in 0.20s

# registered PR-scoped coverage_command for stream-assembler-parser-mode-cache
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_parser_mode_probe.py
# exit 0; TOTAL 1 0 100%

# registered probe equivalent (direct script form, same script selected by probe_command)
MELIX_STREAM_ASSEMBLER_PARSER_MODE_SAMPLES=512 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_parser_mode_probe.py
# exit 0; elapsed_ms_mean=3.60012413966615, channel_name_calls_mean=13.0, channel_name_checksum=86.0

# repeated baseline/head probe comparison, 3 runs each, samples=512
origin/main elapsed_ms_mean: 3.670932133900351, 3.855334158288315, 3.7485281891349587
head elapsed_ms_mean: 3.538560929882806, 3.509418143039511, 3.66032232886937
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` for `services/mlx-worker-python/worker/runtime/stream_assembler.py` changed line 1275.
- Registered probe: `stream-assembler-parser-mode-cache` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/runtime/stream_assembler.py` with focused `test_command`, `coverage_command`, and `probe_command`.
- Local Linux probe means over three 512-sample runs:
  - old_mean=3.7582648271078747 ms
  - new_mean=3.569433800597229 ms
  - delta_ms=-0.18883102651064565 ms
  - speedup=1.0529022352169835x (~5.02% lower elapsed mean)
- CI must still run the registered PR-scoped performance workflow and report for merge validation.

## Known Gaps
- None for the Python slice. Swift/macOS runtime effects are not involved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. (N/A: no behavior or workflow change.)
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
