### PR TITLE
perf: prioritize uppercase hub size markers

### DIFF
--- a/docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md
+++ b/docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md
@@ -48,3 +48,11 @@ exactly two tokens. Two-token values keep the existing integer/float multiplier
 semantics, while values with extra words still return `0` so callers can fall
 back to the regex parser when appropriate. The registered
 `hub-catalog-size-hint-regex-precompile` probe remains the validation gate.
+
+## 2026-06-08 Follow-up: Uppercase Model Marker Fast Path
+
+This slice keeps the same registered `hub-catalog-size-hint-regex-precompile`
+probe and reorders `_may_contain_model_marker(...)` so uppercase `MODEL SIZE`
+text exits on the first substring scan. Hugging Face card/readme metadata often
+uses uppercase headings, while the helper still checks all four case combinations
+and preserves the downstream regex fallback behavior.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -382,6 +382,19 @@ def test_direct_card_size_hint_preserves_case_insensitive_label_prefix() -> None
     assert hub_catalog_module._direct_card_size_hint_from_text("model-size: 2 GB") == 0
 
 
+def test_size_hint_model_marker_scan_preserves_case_insensitive_pairs() -> None:
+    for text in (
+        "model size",
+        "mOdel size",
+        "Model size",
+        "MOdel size",
+        "prefix MO suffix",
+    ):
+        assert hub_catalog_module._may_contain_model_marker(text) is True
+    for text in ("", "m", "M", "metadata only", "adapter notes"):
+        assert hub_catalog_module._may_contain_model_marker(text) is False
+
+
 def test_weight_or_config_file_preserves_case_insensitive_matches() -> None:
     assert hub_catalog_module._is_weight_or_config_file("config.json") is True
     assert hub_catalog_module._is_weight_or_config_file("model.safetensors") is True

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -880,7 +880,7 @@ def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:
 
 
 def _may_contain_model_marker(text: str) -> bool:
-    return "mo" in text or "mO" in text or "Mo" in text or "MO" in text
+    return "MO" in text or "Mo" in text or "mo" in text or "mO" in text
 
 
 def _parameter_count(value: Any) -> int:


### PR DESCRIPTION
## Summary
- Prioritizes the uppercase `MO` marker in `_may_contain_model_marker(...)` so common uppercase `MODEL SIZE` readme/card text exits on the first substring scan.
- Adds regression coverage for all case-insensitive marker pairs and negative marker inputs.
- Updates the hub catalog size-hint performance plan with this follow-up slice.

## Plan or Spec
- `docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md`
- Registered PR-scoped probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`, which already includes focused `test_command`, `coverage_command`, and `probe_command` entries for the touched path.

## Commands Run
```text
# Baseline probe on origin/main / branch start
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=5 MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
exit 0; elapsed_ms_mean=1484.2739352025092; size_hint_calls_mean=40000.0; payload_compatibility_elapsed_ms_mean=207.14544598013163

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py::test_size_hint_model_marker_scan_preserves_case_insensitive_pairs services/mlx-worker-python/tests/test_hub_catalog.py::test_direct_card_size_hint_preserves_case_insensitive_label_prefix services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
exit 0; 3 passed in 1.20s

# Registered focused test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
exit 0; 77 passed in 0.29s

# Registered coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
exit 0; 77 passed; TOTAL 6 0 100%

# Head probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=5 MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
exit 0; elapsed_ms_mean=1472.069430630654; size_hint_calls_mean=40000.0; payload_compatibility_elapsed_ms_mean=204.74512791261077

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Local registered probe (Linux): `elapsed_ms_mean` 1484.2739352025092 ms -> 1472.069430630654 ms (`delta_ms=-12.204505`, `speedup=0.822%`).
- `size_hint_calls_mean` remained 40000.0, so parser fallback behavior stayed unchanged.
- `payload_compatibility_elapsed_ms_mean` moved 207.14544598013163 ms -> 204.74512791261077 ms (adjacent informational metric; not the optimized code path).
- CI PR-scoped performance report is still required as the merge gate.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this is a focused Python performance slice and CI remains the broader gate.
- Observability mode: N/A; no runtime observability behavior changed. Probe overhead: N/A; reused existing registered PR-scoped probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
