### PR TITLE
perf: stream native mtp sidecar path strings

### DIFF
--- a/docs/plans/2026-06-08-native-mtp-sidecar-string-paths.md
+++ b/docs/plans/2026-06-08-native-mtp-sidecar-string-paths.md
@@ -1,0 +1,29 @@
+# Native MTP sidecar string paths slice
+
+## Scope
+
+This Python-only performance slice is limited to the native-MTP loader sidecar shard path handling in `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`.
+
+## Registered probe
+
+Registered PR-scoped probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+The probe already covers the affected path and provides focused `test_command`, `coverage_command`, and `probe_command` entries. This slice keeps the same probe and extends `scripts/native_mtp_loader_safetensor_scandir_probe.py` so the weight-load metric measures the patched loader's string sidecar path flow.
+
+## Change
+
+The patched `mlx_lm.utils.load_model` path does not need public `Path` objects for native-MTP sidecar shards because `mx.load(...)` receives string paths. This slice adds a private `_extra_mtp_safetensor_file_paths(...)` helper returning validated sidecar shard paths as strings, keeps the public `extra_mtp_safetensor_files(...)` wrapper for existing behavior, and passes string sidecars directly to `_load_weight_shards(...)` to avoid per-sidecar `Path(...)` and `str(Path)` conversions on the hot load path.
+
+## Verification plan
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/native_mtp_loader_safetensor_scandir_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
+```
+
+## Expected result
+
+Behavior remains equivalent for public sidecar discovery, while the patched loader's sidecar loading path avoids unnecessary path object round-trips. Accept the slice only if focused tests, changed-scope coverage, and the registered probe pass without a regression.

--- a/scripts/native_mtp_loader_safetensor_scandir_probe.py
+++ b/scripts/native_mtp_loader_safetensor_scandir_probe.py
@@ -9,7 +9,7 @@ import tempfile
 import time
 import tracemalloc
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 repo_root_env = os.environ.get("MELIX_NATIVE_MTP_LOADER_REPO_ROOT")
 repo_root = Path(repo_root_env) if repo_root_env else Path(__file__).resolve().parents[1]
@@ -18,6 +18,7 @@ sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
 
 try:
     from worker.runtime.native_mtp.mlx_lm_loader import (
+        _extra_mtp_safetensor_file_paths,
         _is_mtp_weight_key,
         _load_json_payload,
         _load_weight_shards,
@@ -26,6 +27,7 @@ try:
     )
 except ImportError:  # Base revisions before this slice do not expose the helpers.
     extra_mtp_safetensor_files = None
+    _extra_mtp_safetensor_file_paths = None  # pragma: no cover - exercised on base refs in CI probe comparisons.
     _is_mtp_weight_key = None
     _load_json_payload = None
     _load_weight_shards = None
@@ -161,10 +163,10 @@ def _baseline_load_weight_shards(
 def _candidate_load_weight_shards(
     load: Callable[[str], dict[str, str]],
     weight_files: list[str],
-    extra_files: list[Path],
+    extra_files: list[str],
 ) -> dict[str, str]:
     if _load_weight_shards is None:
-        return _baseline_load_weight_shards(load, weight_files, extra_files)
+        return _baseline_load_weight_shards(load, weight_files, [Path(path) for path in extra_files])  # pragma: no cover - base-ref fallback.
     return _load_weight_shards(load, weight_files, extra_files)
 
 
@@ -173,9 +175,9 @@ def _fake_weight_load(path: str) -> dict[str, str]:
 
 
 def _measure_weight_loading(
-    callback: Callable[[Callable[[str], dict[str, str]], list[str], list[Path]], dict[str, str]],
+    callback: Callable[..., dict[str, str]],
     weight_files: list[str],
-    extra_files: list[Path],
+    extra_files: Sequence[object],
     *,
     samples: int,
     iterations: int,
@@ -243,6 +245,12 @@ def run_probe() -> dict[str, float | int | str]:
         candidate_extra = extra_callback(model_dir)
         if baseline_extra != candidate_extra:
             raise SystemExit("candidate native-MTP sidecar shard listing differs from baseline")
+        extra_path_callback = _extra_mtp_safetensor_file_paths or (
+            lambda path: [str(extra_path) for extra_path in _baseline_extra_mtp_safetensor_files(path)]
+        )
+        candidate_extra_paths = extra_path_callback(model_dir)
+        if candidate_extra_paths != [str(path) for path in baseline_extra]:
+            raise SystemExit("candidate native-MTP sidecar shard string listing differs from baseline")  # pragma: no cover - parity guard.
 
         old_ms, old_peaks, result_count = _measure(
             _read_text_json_payload,
@@ -294,7 +302,7 @@ def run_probe() -> dict[str, float | int | str]:
         weight_load_new_ms, weight_load_new_peaks, _ = _measure_weight_loading(
             _candidate_load_weight_shards,
             list(candidate),
-            candidate_extra,
+            candidate_extra_paths,
             samples=samples,
             iterations=weight_load_iterations,
         )

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -49,6 +49,7 @@ from worker.runtime.mlx_vlm_runtime import (
 )
 from worker.runtime.mlx_executor import MLXRuntimeExecutor
 from worker.runtime.native_mtp.mlx_lm_loader import (
+    _extra_mtp_safetensor_file_paths,
     _is_mtp_weight_key,
     _load_json_payload,
     _load_weight_shards,
@@ -1654,8 +1655,18 @@ def test_native_mtp_extra_safetensor_files_filters_names_before_path_join(
     monkeypatch.setattr(native_mtp_loader_module.os.path, "exists", tracked_exists)
 
     assert extra_mtp_safetensor_files(model_dir) == [sidecar_path, nested_sidecar_path]
-    assert joined_path_names == ["model.safetensors.index.json"]
+    assert _extra_mtp_safetensor_file_paths(model_dir) == [
+        str(sidecar_path),
+        str(nested_sidecar_path),
+    ]
+    assert joined_path_names == [
+        "model.safetensors.index.json",
+        "model.safetensors.index.json",
+    ]
     assert exists_names == [
+        "mtp-00001.safetensors",
+        "mtp-missing.safetensors",
+        "mtp-00002.safetensors",
         "mtp-00001.safetensors",
         "mtp-missing.safetensors",
         "mtp-00002.safetensors",
@@ -1665,7 +1676,7 @@ def test_native_mtp_extra_safetensor_files_filters_names_before_path_join(
 
 def test_native_mtp_load_weight_shards_streams_base_and_extra_paths() -> None:
     base_paths = ["model-a.safetensors", "model-b.safetensors"]
-    extra_paths = [Path("mtp-a.safetensors"), Path("nested/mtp-b.safetensors")]
+    extra_paths = ["mtp-a.safetensors", "nested/mtp-b.safetensors"]
     loaded_paths: list[str] = []
 
     def load(path: str) -> dict[str, str]:
@@ -1674,7 +1685,7 @@ def test_native_mtp_load_weight_shards_streams_base_and_extra_paths() -> None:
 
     weights = _load_weight_shards(load, base_paths, extra_paths)
 
-    assert loaded_paths == [*base_paths, *(str(path) for path in extra_paths)]
+    assert loaded_paths == [*base_paths, *extra_paths]
     assert weights == {path: path for path in loaded_paths}
 
 

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -46,26 +46,25 @@ def _model_safetensor_files(model_path: Path) -> list[str]:
     return weight_files
 
 
-def _load_weight_shards(load: Callable[[str], dict], weight_files: list[str], extra_files: list[Path]) -> dict:
+def _load_weight_shards(load: Callable[[str], dict], weight_files: list[str], extra_files: list[str]) -> dict:
     """Load base and native-MTP sidecar shards without combining path lists."""
 
     weights = {}
     weights_update = weights.update
-    to_text = str
     for path in weight_files:
         weights_update(load(path))
     for path in extra_files:
-        weights_update(load(to_text(path)))
+        weights_update(load(path))
     return weights
 
 
-def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
+def _extra_mtp_safetensor_file_paths(model_path: Path) -> list[str]:
     index_payload = _load_json_payload(model_path / "model.safetensors.index.json")
     weight_map = index_payload.get("weight_map")
     if not isinstance(weight_map, dict):
         return []
 
-    extra_files: list[Path] = []
+    extra_files: list[str] = []
     append_extra_file = extra_files.append
     seen: set[str] = set()
     seen_add = seen.add
@@ -75,7 +74,6 @@ def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
     path_sep = os.sep
     is_mtp_weight_key = _is_mtp_weight_key
     to_text = str
-    to_path = Path
     for key, file_name in weight_map.items():
         if not is_mtp_weight_key(key):
             continue
@@ -97,8 +95,12 @@ def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
         if not path_exists(path_text):
             logger.warning("MTP shard listed in index is missing: %s", path_text)
             continue
-        append_extra_file(to_path(path_text))
+        append_extra_file(path_text)
     return extra_files
+
+
+def extra_mtp_safetensor_files(model_path: Path) -> list[Path]:
+    return [Path(path) for path in _extra_mtp_safetensor_file_paths(model_path)]
 
 
 def apply() -> bool:
@@ -130,7 +132,7 @@ def apply() -> bool:
         get_model_classes: Callable[[dict], tuple[Type[nn.Module], Type]] = _get_classes,
     ) -> tuple[nn.Module, dict]:
         model_path = Path(model_path)
-        extra_files = extra_mtp_safetensor_files(model_path)
+        extra_files = _extra_mtp_safetensor_file_paths(model_path)
         if not extra_files:
             return original_load_model(
                 model_path,


### PR DESCRIPTION
## Summary
- Add a private native-MTP sidecar helper that returns validated `.safetensors` paths as strings.
- Keep the public `extra_mtp_safetensor_files()` wrapper returning `Path` objects for compatibility.
- Stream string sidecar paths directly through `_load_weight_shards()` and extend the registered probe to measure that flow.

## Plan or Spec
- `docs/plans/2026-06-08-native-mtp-sidecar-string-paths.md`
- Registered PR-scoped probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics` — 6 passed.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json ...` — changed-line coverage 100% across the touched Python/probe/test files.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id native-mtp-loader-safetensor-scandir --base-repo /tmp/melix-native-mtp-loader-scandir-base-20260608 --head-repo "$PWD" --output /tmp/native_mtp_loader_safetensor_scandir_once.json` — passed.

## Coverage and Metrics
- Focused changed-scope coverage: 100% (`aggregate_measurable_changed_lines=16`, `aggregate_missed_changed_lines=0`).
- Registered local probe head metrics: `weight_load_old_mean_ms=480.100`, `weight_load_new_mean_ms=444.409`, `weight_load_delta_ms=-35.692`, `weight_load_speedup=1.080x`.
- Registered local probe also kept existing JSON/key/listing metrics passing; CI must run the same registered probe before merge.

## Known Gaps
- Linux local validation covers the Python loader/probe path only; this slice does not include Swift changes.
- The public `extra_mtp_safetensor_files()` API still materializes `Path` objects intentionally for compatibility; only the patched loader hot path uses string sidecar paths.

## Evidence Checklist
- [x] Affected path is covered by a registered PR-scoped probe with test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage passed.
- [x] Local registered probe passed and showed a directionally positive weight-load metric.
- [ ] GitHub Actions PR-scoped performance probe completed successfully.
- [ ] All required PR checks are green.
