### PR TITLE
perf: fast-path text family name normalization

### DIFF
--- a/docs/plans/2026-06-08-text-family-lowercase-name-fastpath.md
+++ b/docs/plans/2026-06-08-text-family-lowercase-name-fastpath.md
@@ -1,0 +1,34 @@
+# Text Family Lowercase Name Fast Path
+
+## Scope
+
+This slice keeps text-family config resolution behavior unchanged while reducing
+per-resolution string normalization work for already-normalized model family
+names.
+
+## Registered Probe
+
+The affected path is already covered by the PR-scoped registered probe
+`text-family-config-copy-elision` in `infra/perf/pr_scoped_probes.json`. The
+probe includes focused `test_command`, `coverage_command`, and `probe_command`
+entries for:
+
+- `services/mlx-worker-python/worker/runtime/text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_text_family_adapters.py`
+- `scripts/text_family_config_probe.py`
+
+## Change
+
+`detect_text_family_identity()` now checks exact explicit family IDs before
+falling back to `strip().lower()`, and `_detected_architecture()` / `_model_type()`
+return already-lowercase model names without allocating a lowercased copy.
+Fallback normalization remains in place for mixed-case, whitespace-padded, and
+unsupported explicit inputs.
+
+## Validation Plan
+
+- Add focused regression tests proving exact family IDs and lowercase
+  `model_type` values avoid normalization allocation.
+- Run the registered text-family tests and PR-scoped probe locally on Linux.
+- Use the PR-scoped performance workflow as the merge gate for base/head probe
+  validation.

--- a/services/mlx-worker-python/tests/test_text_family_adapters.py
+++ b/services/mlx-worker-python/tests/test_text_family_adapters.py
@@ -117,6 +117,40 @@ def test_detect_text_family_identity_prefers_explicit_supported_override() -> No
     assert detected.source == "explicit_override"
 
 
+def test_detect_text_family_identity_uses_exact_explicit_family_fast_path() -> None:
+    class NoNormalizeFamily(str):
+        def strip(self, *args: object, **kwargs: object) -> str:  # pragma: no cover
+            raise AssertionError("exact explicit family ids should avoid strip allocation")
+
+        def lower(self) -> str:  # pragma: no cover
+            raise AssertionError("exact explicit family ids should avoid lower allocation")
+
+    detected = detect_text_family_identity(
+        model_path="models/unknown-text-model",
+        config_payload={"model_type": "llama"},
+        explicit_family_id=NoNormalizeFamily("qwen3moe"),
+    )
+
+    assert detected.family_id == "qwen3moe"
+    assert detected.architecture == "llama"
+    assert detected.source == "explicit_override"
+
+
+def test_detect_text_family_identity_uses_lowercase_model_type_fast_path() -> None:
+    class NoLowerModelType(str):
+        def lower(self) -> str:  # pragma: no cover
+            raise AssertionError("lowercase model_type should avoid lower allocation")
+
+    detected = detect_text_family_identity(
+        model_path="models/unknown-text-model",
+        config_payload={"model_type": NoLowerModelType("qwen3_moe")},
+        explicit_family_id="qwen3moe",
+    )
+
+    assert detected.architecture == "qwen3_moe"
+    assert detected.family_id == "qwen3moe"
+
+
 def test_detect_text_family_identity_rejects_unsupported_explicit_override() -> None:
     with pytest.raises(ValueError, match="Unsupported text family adapter"):
         detect_text_family_identity(

--- a/services/mlx-worker-python/worker/runtime/text_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/text_family_adapters.py
@@ -164,9 +164,11 @@ def detect_text_family_identity(
     config_payload: Mapping[str, Any] | None = None,
     explicit_family_id: str = "",
 ) -> TextFamilyDetection:
-    explicit_family_id = explicit_family_id.strip().lower()
     if explicit_family_id:
         descriptor = _TEXT_FAMILY_ADAPTERS.get(explicit_family_id)
+        if descriptor is None:
+            explicit_family_id = explicit_family_id.strip().lower()
+            descriptor = _TEXT_FAMILY_ADAPTERS.get(explicit_family_id)
         if descriptor is None:
             raise ValueError(f"Unsupported text family adapter: {explicit_family_id}")
         architecture = _detected_architecture(config_payload) or descriptor.default_architecture
@@ -302,17 +304,17 @@ def _detected_architecture(config_payload: Mapping[str, Any] | None) -> str:
     config_payload = _config_mapping(config_payload)
     model_type = _string(config_payload.get("model_type"))
     if model_type:
-        return model_type.lower()
+        return _lowercase_model_name(model_type)
     architectures = config_payload.get("architectures")
     if isinstance(architectures, list):
         for item in architectures:
             if isinstance(item, str) and item.strip():
-                return item.strip().lower()
+                return _lowercase_model_name(item.strip())
     text_config = config_payload.get("text_config")
     if isinstance(text_config, Mapping):
         nested_model_type = _string(text_config.get("model_type"))
         if nested_model_type:
-            return nested_model_type.lower()
+            return _lowercase_model_name(nested_model_type)
     return ""
 
 
@@ -320,8 +322,14 @@ def _model_type(config_payload: Mapping[str, Any] | None) -> str:
     config_payload = _config_mapping(config_payload)
     model_type = _string(config_payload.get("model_type"))
     if model_type:
-        return model_type.lower()
+        return _lowercase_model_name(model_type)
     return ""
+
+
+def _lowercase_model_name(value: str) -> str:
+    if value.islower():
+        return value
+    return value.lower()
 
 
 def _inferred_attention_profile(config_payload: Mapping[str, Any] | None, *, default: str) -> str:


### PR DESCRIPTION
## Summary
- Fast-path exact text family IDs before falling back to normalization.
- Avoid lowercasing allocation for already-lowercase model family names in text family detection.
- Add regression tests and a governing plan for the lowercase-name fast path.

## Plan or Spec
- `docs/plans/2026-06-08-text-family-lowercase-name-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py::test_detect_text_family_identity_uses_exact_explicit_family_fast_path
# exit 1 before implementation; reproduced the exact-family normalization allocation path

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py::test_detect_text_family_identity_uses_lowercase_model_type_fast_path
# exit 1 before implementation; reproduced lowercase model_type lower() allocation

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics
# exit 0; 23 passed in 2.49s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/text_family_adapters.py services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/text_family_config_probe.py
# exit 0; changed-scope coverage 100.00% (22/22 changed lines)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py
# exit 0; {"config_copy_calls_mean": 0.0, "elapsed_ms_mean": 262.0450831949711, "iterations": 10000, "peak_bytes_mean": 1076.6}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/text_family_compare.py
# exit 0; old_mean_ms=537.4814654434366, new_mean_ms=530.7934623477714, delta_ms=-6.688003095665181, speedup=1.0126000103054835, old_peak_bytes_mean=1291.5714285714287, new_peak_bytes_mean=1021.7142857142857, samples=7, iterations=20000

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered PR-scoped probe: `text-family-config-copy-elision` in `infra/perf/pr_scoped_probes.json`.
- Changed-scope coverage: 100.00% (22/22 changed executable lines).
- Local registered probe: `elapsed_ms_mean=262.0450831949711`, `peak_bytes_mean=1076.6`, `config_copy_calls_mean=0.0`.
- Local base/head comparison: `old_mean_ms=537.4814654434366`, `new_mean_ms=530.7934623477714`, `delta_ms=-6.688003095665181`, `speedup=1.0126000103054835`; peak bytes improved from `1291.5714285714287` to `1021.7142857142857`.
- CI is required for the repository registered PR-scoped performance report before merge.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; CI is the broad gate.
- No Swift runtime effect is claimed; this is a Linux-verified Python slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
