### PR TITLE
perf: bind lora auxiliary module scan locals

### DIFF
--- a/docs/plans/2026-06-08-lora-aux-module-local-bindings.md
+++ b/docs/plans/2026-06-08-lora-aux-module-local-bindings.md
@@ -1,0 +1,31 @@
+# LoRA auxiliary module local binding slice
+
+## Scope
+
+Optimize exactly one Python hot path in
+`services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py`:
+`_aux_modules_restored`, which scans a base model directory for custom LoRA
+auxiliary Python modules when building canary receipt fields.
+
+## Registered probe
+
+Registered PR-scoped probe: `lora-aux-modules-scandir` in
+`infra/perf/pr_scoped_probes.json`.
+
+The registry entry covers the affected LoRA runtime metadata module and includes
+focused `test_command`, `coverage_command`, and `probe_command` entries. The
+probe records auxiliary-module scan latency, `os.scandir` call count, peak
+memory, and adjacent LoRA receipt hot-path metrics.
+
+## Slice decision
+
+Keep behavior unchanged and bind the auxiliary prefix tuple and `os.scandir`
+lookup once before the directory-entry loop. This avoids repeated global/module
+lookups while preserving the existing single-`scandir` traversal and `OSError`
+fallback behavior.
+
+## Verification expectation
+
+Before merge, run the focused registry tests, changed-scope coverage command,
+and registered probe locally on Linux. The PR-scoped performance workflow must
+also complete successfully on GitHub Actions before merging.

--- a/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
@@ -336,11 +336,13 @@ def _processor_resume_mode(base_model_dir: Path) -> str:
 
 
 def _aux_modules_restored(base_model_dir: Path) -> bool:
+    auxiliary_prefixes = _AUXILIARY_MODULE_PREFIXES
+    scandir = os.scandir
     try:
-        with os.scandir(base_model_dir) as entries:
+        with scandir(base_model_dir) as entries:
             for entry in entries:
                 name = entry.name
-                if name.endswith(".py") and name.startswith(_AUXILIARY_MODULE_PREFIXES):
+                if name.endswith(".py") and name.startswith(auxiliary_prefixes):
                     return True
     except OSError:
         return False


### PR DESCRIPTION
## Summary
- Bind the LoRA auxiliary-module scan prefix tuple and `os.scandir` lookup once before the hot directory-entry loop.
- Preserve the existing single-`scandir` traversal and `OSError` fallback behavior.
- Add a focused plan note for this performance slice.

## Plan or Spec
- `docs/plans/2026-06-08-lora-aux-module-local-bindings.md`
- Registered PR-scoped probe: `lora-aux-modules-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe before change, 3 runs with MELIX_LORA_AUX_MODULES_PROBE_NOISE_FILES=8000 and MELIX_LORA_AUX_MODULES_PROBE_SAMPLES=9
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LORA_AUX_MODULES_PROBE_NOISE_FILES=8000 MELIX_LORA_AUX_MODULES_PROBE_SAMPLES=9 uv run --project services/mlx-worker-python python3 scripts/lora_aux_modules_scandir_probe.py
# exit 0 for all 3 runs

# Head probe after change, same settings, 3 runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LORA_AUX_MODULES_PROBE_NOISE_FILES=8000 MELIX_LORA_AUX_MODULES_PROBE_SAMPLES=9 uv run --project services/mlx-worker-python python3 scripts/lora_aux_modules_scandir_probe.py
# exit 0 for all 3 runs

# Registered focused test command for lora-aux-modules-scandir
bash /tmp/lora_test_cmd.sh
# 14 passed in 1.05s, exit 0

# Registered changed-scope coverage command for lora-aux-modules-scandir
bash /tmp/lora_cov_cmd.sh
# 14 passed in 0.35s; changed_line_coverage=100.00%, exit 0

# Registered probe command for lora-aux-modules-scandir
bash /tmp/lora_probe_cmd.sh
# emitted JSON metrics, exit 0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%` for changed measurable lines.
- Local Linux registered probe (default registered command): `elapsed_ms_mean=1.3966312898056847`, `scandir_calls_mean=1.0`, `peak_bytes_mean=815.0`, `sample_count=7.0`.
- Local before/after auxiliary scan probe (3-run mean, 8000 noise files, 9 samples/run): `old_mean=4.195231ms`, `new_mean=3.933629ms`, `delta_ms=-0.261601ms`, `speedup=1.0665x` (`6.24%` improvement).
- PR-scoped performance workflow is required for CI-side registered probe validation before merge.

## Known Gaps
- None for the Python slice. Swift/macOS runtime validation is not applicable to this change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
