### PR TITLE
perf: elide closure audit directory path wrappers

### DIFF
--- a/docs/plans/2026-06-08-closure-audit-text-file-path-elision.md
+++ b/docs/plans/2026-06-08-closure-audit-text-file-path-elision.md
@@ -1,0 +1,46 @@
+# Closure Audit Text-File Path Elision
+
+## Scope
+
+This Python performance slice is limited to the closure-audit fallback text-file
+walker used when curated probe evidence files do not saturate the required probe
+source map. The change keeps deterministic sorted traversal and symlink-avoidance
+semantics intact while avoiding a `Path(...)` object construction for every
+recursive directory descent.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`closure-audit-probe-source-short-circuit` in `infra/perf/pr_scoped_probes.json`.
+The probe already declares focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/closure_audit.py`
+- `services/mlx-worker-python/tests/test_closure_audit.py`
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Plan
+
+1. Confirm the registered probe covers the closure-audit fallback scan path.
+2. Preserve existing test coverage for deterministic sorted traversal, early
+   probe-source saturation, and focused PR-scoped probe selection.
+3. Reuse `DirEntry.path` directly for recursive `os.scandir` calls and construct
+   `Path` objects only for yielded text files.
+4. Run focused tests, changed-scope coverage, and the registered closure-audit
+   probe locally on Linux.
+5. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Validation
+
+Local Linux validation must include:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/closure_audit.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_closure_audit as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
+```
+
+CI validation comes from the registered PR-scoped performance report.

--- a/services/mlx-worker-python/worker/productization/closure_audit.py
+++ b/services/mlx-worker-python/worker/productization/closure_audit.py
@@ -489,15 +489,16 @@ def _iter_probe_text_files(root: Path) -> Iterator[Path]:
         yield from _iter_text_files_sorted(candidate)
 
 
-def _iter_text_files_sorted(root: Path) -> Iterator[Path]:
+def _iter_text_files_sorted(root: Path | str) -> Iterator[Path]:
     with os.scandir(root) as scandir_entries:
         entries = sorted(scandir_entries, key=lambda entry: entry.name)
     for entry in entries:
+        entry_path = entry.path
         if entry.is_dir(follow_symlinks=False):
-            yield from _iter_text_files_sorted(Path(entry.path))
+            yield from _iter_text_files_sorted(entry_path)
             continue
         if entry.name.endswith(_TEXT_FILE_SUFFIXES) and entry.is_file(follow_symlinks=False):
-            yield Path(entry.path)
+            yield Path(entry_path)
 
 
 


### PR DESCRIPTION
## Summary
- Avoid constructing a `Path` wrapper for each recursive closure-audit directory descent.
- Keep deterministic sorted traversal, suffix filtering, and `follow_symlinks=False` behavior unchanged.

## Plan or Spec
- `docs/plans/2026-06-08-closure-audit-text-file-path-elision.md`

## Commands Run
```text
# Baseline from origin/main before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
# exit 0; 19 passed in 15.83s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/closure_probe_once.py
# exit 0; {"elapsed_ms_mean": 3.393, "finding_count": 2.0, "peak_bytes_mean": 33157.667, "probe_file_reads_mean": 1.0}

# Head after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
# exit 0; 19 passed in 14.34s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_only_matching_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_evaluation_job_id_probe
# exit 0; 19 passed in 48.47s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# exit 0; Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/closure_audit.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_closure_audit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/closure_probe_once.py
# exit 0; {"elapsed_ms_mean": 3.364, "finding_count": 2.0, "peak_bytes_mean": 33118.333, "probe_file_reads_mean": 1.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Registered probe: `closure-audit-probe-source-short-circuit` covers this path and will run in CI.
- Local Linux probe delta: `elapsed_ms_mean` 3.393 -> 3.364 ms (`-0.029 ms`, about `-0.85%`); `peak_bytes_mean` 33157.667 -> 33118.333 bytes (`-39.334`); `probe_file_reads_mean` unchanged at 1.0.

## Known Gaps
- Full repository gates were not run locally; this PR is limited to the registered closure-audit Python slice.
- CI PR-scoped performance report is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
