### PR TITLE
perf: fast-path OCR token count cache hits

### DIFF
--- a/docs/plans/2026-06-08-ocr-token-count-identity-fastpath.md
+++ b/docs/plans/2026-06-08-ocr-token-count-identity-fastpath.md
@@ -1,0 +1,30 @@
+# Deterministic OCR token-count identity fast path
+
+This Python-only performance slice is limited to the deterministic OCR runtime's repeated prompt-token accounting path in `services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py`.
+
+## Scope
+
+Registered PR-scoped probe: `deterministic-ocr-token-count-scan` in `infra/perf/pr_scoped_probes.json`.
+
+The affected registry entry already provides focused `test_command`, `coverage_command`, and `probe_command` entries covering the OCR runtime, shared whitespace token counter, probe selector tests, and `scripts/deterministic_ocr_token_count_probe.py`.
+
+## Optimization
+
+Repeated OCR accounting often asks for the token count of the same prepared single-image request that was just counted. The runtime already caches that identity, but the hot hit still read the request media lists and checked the single-image shape before returning the cached value.
+
+This slice moves the same-request identity check to the beginning of `prompt_token_count()` so the repeated hot hit returns the cached count without re-reading the request media containers. Misses still follow the existing single-image and fallback semantics.
+
+## Verification plan
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_same_request_cache services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_same_request_cache services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_ocr_token_count_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py
+```
+
+## Success criteria
+
+- Focused OCR tests pass locally on Linux.
+- Changed-scope coverage remains at least 95% for the touched OCR/runtime scope.
+- Registered probe reports a lower `elapsed_ms_mean` than the `origin/main` baseline on the same Linux worktree.
+- CI PR-scoped performance report completes successfully before merge.

--- a/services/mlx-worker-python/tests/test_vision_runtime.py
+++ b/services/mlx-worker-python/tests/test_vision_runtime.py
@@ -329,6 +329,16 @@ def test_ocr_single_image_token_count_reuses_same_request_cache(
 
     assert runtime.prompt_token_count(request) == len(prompt_text.split()) + 16
     assert runtime.prompt_token_count(request) == len(prompt_text.split()) + 16
+
+    class ExplodingMediaList(list):
+        def __bool__(self) -> bool:  # pragma: no cover - exercised only on regression
+            raise AssertionError("identity cache hits should not re-read request videos")
+
+        def __len__(self) -> int:  # pragma: no cover - exercised only on regression
+            raise AssertionError("identity cache hits should not re-read request images")
+
+    object.__setattr__(request, "images", ExplodingMediaList(request.images))
+    object.__setattr__(request, "videos", ExplodingMediaList(request.videos))
     assert runtime.prompt_token_count(request) == len(prompt_text.split()) + 16
 
     equivalent_request = PreparedVisionRequest(

--- a/services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py
@@ -70,10 +70,10 @@ class DeterministicOCRRuntime(DeterministicProbeMixin[VisionProbeSnapshot]):
         return prepared
 
     def prompt_token_count(self, prepared_request: PreparedVisionRequest) -> int:
+        if prepared_request is self._last_single_prompt_request:
+            return self._last_single_prompt_token_count
         images = prepared_request.images
         if not prepared_request.videos and len(images) == 1:
-            if prepared_request is self._last_single_prompt_request:
-                return self._last_single_prompt_token_count
             prompt_text = prepared_request.prompt_text
             input_bytes = prepared_request.preprocess_input_bytes
             if (


### PR DESCRIPTION
## Summary
- Fast-path repeated deterministic OCR prompt-token cache hits before re-reading request media containers.
- Add a regression assertion that identity-cache hits do not touch media list shape checks.
- Document the slice and registered probe evidence plan.

## Plan or Spec
- `docs/plans/2026-06-08-ocr-token-count-identity-fastpath.md`
- Registered PR-scoped probe: `deterministic-ocr-token-count-scan` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py
exit 0; elapsed_ms_mean=1289.215924, peak_bytes_mean=211.2, iterations=80000, sample_count=5

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_same_request_cache services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once
exit 0; 10 passed in 1.96s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_ocr_text_from_inline_image_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_token_count_scans_whitespace_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_precomputed_input_bytes services/mlx-worker-python/tests/test_vision_runtime.py::test_ocr_single_image_token_count_reuses_same_request_cache services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_ocr_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_ocr_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_ocr_runtime.py services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_ocr_token_count_probe.py
exit 0; 10 passed; TOTAL 5 0 100%

# Registered local probe on this branch
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_ocr_token_count_probe.py
exit 0; elapsed_ms_mean=1243.363899, peak_bytes_mean=211.2, iterations=80000, sample_count=5

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Local registered probe (Linux): `old_mean=1289.215924ms`, `new_mean=1243.363899ms`, `delta_ms=-45.852025`, `speedup=1.036877x`, `improvement=3.557%`.
- Registered CI PR-scoped performance workflow is required before merge and will be treated as the authoritative PR validation report.

## Known Gaps
- Linux local validation only; this is a Python OCR runtime path, so no Swift runtime effect is claimed.
- CI PR-scoped performance report is pending after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
