### PR TITLE
Join cookbook effective config evidence

### DIFF
--- a/Sources/MelixCLICore/MelixCookbook.swift
+++ b/Sources/MelixCLICore/MelixCookbook.swift
@@ -68,7 +68,7 @@ private enum MelixCookbookRecommendationPlanner {
         let host = selectHost(options)
         let backend = recommendBackend(for: host)
         let state = makeStateReceipt(melixHome: melixHome)
-        let evidence = makeEvidenceReceipt()
+        let evidence = makeEvidenceReceipt(options: options, host: host, melixHome: melixHome)
         return [
             "schema_version": "melix.cookbook.recommendation.v1",
             "model_id": trimmedString(options.modelID),
@@ -96,7 +96,7 @@ private enum MelixCookbookRecommendationPlanner {
         let host = selectHost(options)
         let backend = recommendBackend(for: host)
         let state = makeStateReceipt(melixHome: melixHome)
-        let evidence = makeEvidenceReceipt()
+        let evidence = makeEvidenceReceipt(options: options, host: host, melixHome: melixHome)
         let hostDisplay = host.platform.isEmpty
             ? "unavailable (\(host.source.rawValue))"
             : "\(host.platform)/\(host.arch) (\(host.source.rawValue))"
@@ -112,6 +112,7 @@ private enum MelixCookbookRecommendationPlanner {
             "Cache enabled: \(state.cacheEnabled)",
             "Fit evidence: \(evidence.fitReceiptSource) (\(evidence.fitReceiptSchemaVersion))",
             "Profile evidence: \(evidence.profileReceiptSource) (\(evidence.profileReceiptSchemaVersion))",
+            "Effective config: \(displayPath(evidence.effectiveConfigPath))",
             "Benchmark receipts: \(displayList(evidence.benchmarkReceipts))",
             "Missing receipts: \(displayList(evidence.missingReceipts))",
         ]
@@ -157,16 +158,80 @@ private enum MelixCookbookRecommendationPlanner {
         )
     }
 
-    private static func makeEvidenceReceipt() -> MelixCookbookEvidenceReceipt {
-        MelixCookbookEvidenceReceipt(
+    private static func makeEvidenceReceipt(
+        options: CookbookRecommendOptions,
+        host: MelixCookbookHostSelection,
+        melixHome: MelixHome
+    ) -> MelixCookbookEvidenceReceipt {
+        let effectiveConfigPath = matchingEffectiveConfigURL(
+            options: options,
+            host: host,
+            melixHome: melixHome
+        )?.path ?? ""
+        var missingReceipts = ["effective_config", "benchmark_receipt", "model_fit_receipt"]
+        if effectiveConfigPath.isEmpty == false {
+            missingReceipts.removeAll { $0 == "effective_config" }
+        }
+        return MelixCookbookEvidenceReceipt(
             fitReceiptSchemaVersion: "melix.memory_fit_receipt.v1",
             fitReceiptSource: "cookbook.host_selection",
             profileReceiptSchemaVersion: "melix.cookbook.profile_receipt.v1",
             profileReceiptSource: "cookbook.backend_selection",
             benchmarkReceipts: [],
-            missingReceipts: ["effective_config", "benchmark_receipt", "model_fit_receipt"],
-            effectiveConfigPath: ""
+            missingReceipts: missingReceipts,
+            effectiveConfigPath: effectiveConfigPath
         )
+    }
+
+    private static func matchingEffectiveConfigURL(
+        options: CookbookRecommendOptions,
+        host: MelixCookbookHostSelection,
+        melixHome: MelixHome
+    ) -> URL? {
+        let root = melixHome.stateDirectoryURL
+            .appendingPathComponent("cookbook", isDirectory: true)
+            .appendingPathComponent("evidence", isDirectory: true)
+            .appendingPathComponent("effective-configs", isDirectory: true)
+        let urls = (try? FileManager.default.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        return urls
+            .filter { $0.pathExtension.lowercased() == "json" }
+            .sorted { $0.path < $1.path }
+            .first { effectiveConfig(at: $0, matches: options, host: host) }
+            // Preserve MELIX_HOME spelling instead of FileManager's resolved /private/var paths.
+            .map { root.appendingPathComponent($0.lastPathComponent) }
+    }
+
+    private static func effectiveConfig(
+        at url: URL,
+        matches options: CookbookRecommendOptions,
+        host: MelixCookbookHostSelection
+    ) -> Bool {
+        guard let resourceValues = try? url.resourceValues(forKeys: [.isRegularFileKey]),
+              resourceValues.isRegularFile == true,
+              let data = try? Data(contentsOf: url)
+        else {
+            return false
+        }
+        let jsonObject = try? JSONSerialization.jsonObject(with: data)
+        guard let payload = jsonObject as? [String: Any],
+              nonEmpty(payload["schema_version"] as? String ?? "") != nil,
+              let modelID = payload["model_id"] as? String,
+              !trimmedString(modelID).isEmpty,
+              trimmedString(modelID) == trimmedString(options.modelID),
+              let workload = payload["workload"] as? String,
+              !trimmedString(workload).isEmpty,
+              trimmedString(workload) == trimmedString(options.workload),
+              let hostPayload = payload["host"] as? [String: Any]
+        else {
+            return false
+        }
+        return trimmedString(hostPayload["platform"] as? String ?? "") == host.platform
+            && trimmedString(hostPayload["arch"] as? String ?? "") == host.arch
+            && trimmedString(hostPayload["host_platform_source"] as? String ?? "") == host.source.rawValue
     }
 
     private static func selectHost(_ options: CookbookRecommendOptions) -> MelixCookbookHostSelection {
@@ -256,6 +321,10 @@ private enum MelixCookbookRecommendationPlanner {
 
     private static func displayList(_ values: [String]) -> String {
         values.isEmpty ? "none" : values.joined(separator: ", ")
+    }
+
+    private static func displayPath(_ value: String) -> String {
+        value.isEmpty ? "none" : value
     }
 }
 

--- a/docs/plans/2026-06-08-issue-1762-effective-config-evidence-join.md
+++ b/docs/plans/2026-06-08-issue-1762-effective-config-evidence-join.md
@@ -1,0 +1,167 @@
+# Issue 1762 Effective Config Evidence Join Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the cookbook recommendation's `effective_config` missing marker with a real local receipt path when a matching effective-config artifact already exists.
+
+**Architecture:** Keep `melix cookbook recommend` read-only and deterministic. The Swift cookbook planner scans a worktree-local evidence directory under `MELIX_HOME`, validates candidate `effective-config.json` files against the requested model, workload, and selected host, and joins only exact matches into the existing evidence receipt payload.
+
+**Tech Stack:** Swift CLI planner and tests, `Foundation` JSON parsing, Swift Testing.
+
+---
+
+## Scope
+
+- Extend `MelixCookbookRecommendationPlanner` to look for persisted effective config receipts at:
+  - `${MELIX_HOME}/state/cookbook/evidence/effective-configs/*.json`
+- Treat a candidate as matching only when it has:
+  - `schema_version` as a non-empty string.
+  - `model_id` equal to the trimmed cookbook request model ID.
+  - `workload` equal to the trimmed cookbook request workload.
+  - `host.platform`, `host.arch`, and `host.host_platform_source` equal to the planner's selected host.
+- Sort candidates by absolute path before matching so duplicate artifacts produce deterministic output.
+- When a match exists:
+  - Set `evidence.effective_config_path` to the matched absolute path.
+  - Remove `effective_config` from `evidence.missing_receipts`.
+  - Render the same effective config path in text output.
+- When no match exists, preserve the current missing receipt behavior.
+- Keep benchmark receipts and model-fit receipts out of scope for this slice.
+- Do not create receipt files, load models, run network calls, or mutate cookbook state.
+
+## Files
+
+- Modify: `Sources/MelixCLICore/MelixCookbook.swift`
+  - Add deterministic effective-config discovery and validation helpers.
+  - Pass `CookbookRecommendOptions`, selected host, and `MelixHome` into evidence creation.
+  - Add an `Effective config:` line to text output.
+- Modify: `tests/MelixCLITests/MelixCLIRunnerTests.swift`
+  - Add a RED test for joining a matching effective config receipt.
+  - Add a test that stale or mismatched host artifacts remain missing.
+  - Add a review-followup test that receipts with missing or empty identity fields cannot match empty request values.
+- Create: `docs/plans/2026-06-08-issue-1762-effective-config-evidence-join.md`
+  - Record this slice's plan, verification, and metrics.
+
+## Task 1: Add RED Tests
+
+- [x] Add `cookbookRecommendationJoinsMatchingEffectiveConfigReceipt` to `tests/MelixCLITests/MelixCLIRunnerTests.swift`.
+- [x] The test should create `${MELIX_HOME}/state/cookbook/evidence/effective-configs/qwen-chat.json` with:
+
+```json
+{
+  "schema_version": "melix.diagnostics.effective_config.v1",
+  "model_id": "mlx-community/Qwen3.5-9B-MLX-4bit",
+  "workload": "chat",
+  "host": {
+    "platform": "macos",
+    "arch": "arm64",
+    "host_platform_source": "hardware_probe"
+  },
+  "serving_profile": {
+    "selected_backend": "mlx-native"
+  }
+}
+```
+
+- [x] Assert JSON output has `evidence.effective_config_path` equal to that file path.
+- [x] Assert `evidence.missing_receipts` equals `["benchmark_receipt", "model_fit_receipt"]`.
+- [x] Assert text output includes `Effective config: <path>` and the shortened missing receipt list.
+- [x] Add `cookbookRecommendationKeepsMismatchedEffectiveConfigReceiptMissing`.
+- [x] The mismatch test should create an artifact for the same model and workload but `host.platform = "linux"`, then assert `effective_config_path == ""` and `missing_receipts` still contains `effective_config`.
+- [x] Run the matching test before production changes:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" \
+swift test --filter 'MelixCLIRunnerTests/cookbookRecommendationJoinsMatchingEffectiveConfigReceipt'
+```
+
+Expected: FAIL because `effective_config_path` is still empty.
+
+## Task 2: Implement Effective Config Matching
+
+- [x] Change `makePayload` and `makeText` to call:
+
+```swift
+let evidence = makeEvidenceReceipt(options: options, host: host, melixHome: melixHome)
+```
+
+- [x] Add helper logic in `MelixCookbook.swift`:
+  - Build `melixHome.stateDirectoryURL/cookbook/evidence/effective-configs`.
+  - Ignore the directory when it does not exist.
+  - Read only `.json` files.
+  - Parse each file with `JSONSerialization`.
+  - Require exact model, workload, and host matches.
+  - Return the first match after sorting candidate URLs by path.
+- [x] Keep malformed or unreadable JSON files ignored so stale operator state cannot break recommendations.
+- [x] Require parsed `model_id` and `workload` to be present and non-empty before comparing them with request values.
+- [x] In `makeEvidenceReceipt`, start with `["effective_config", "benchmark_receipt", "model_fit_receipt"]` and remove `effective_config` only when a path is found.
+- [x] In text output, render:
+
+```text
+Effective config: none
+```
+
+or:
+
+```text
+Effective config: /absolute/path/to/effective-config.json
+```
+
+## Task 3: Verify Locally
+
+- [x] Run the new matching test and confirm PASS:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" \
+swift test --filter 'MelixCLIRunnerTests/cookbookRecommendationJoinsMatchingEffectiveConfigReceipt'
+```
+
+- [x] Run the focused cookbook suite:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" \
+swift test --filter 'MelixCLIRunnerTests/cookbookRecommendation'
+```
+
+- [x] Run Swift changed-line coverage for touched files:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" \
+swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
+
+UV_PYTHON=3.12 uv run --project services/mlx-worker-python python \
+scripts/swift_changed_line_coverage.py \
+  --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests \
+  --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata \
+  --diff-from origin/main \
+  Sources/MelixCLICore/MelixCookbook.swift \
+  tests/MelixCLITests/MelixCLIRunnerTests.swift
+```
+
+- [x] Run full local gates before commit when feasible:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```
+
+## Metrics
+
+- `cookbook.plan_ms` remains the planning duration probe.
+- This slice adds bounded local filesystem scanning of one shallow evidence directory.
+- Success metric: focused cookbook tests pass, touched Swift changed-line coverage is at least 95 percent, full local gates pass or have a documented blocker, and the PR performance report shows zero in-scope regressions.
+
+## Verification Results
+
+- RED check: `swift test --filter 'MelixCLIRunnerTests/cookbookRecommendationJoinsMatchingEffectiveConfigReceipt'` failed before implementation because `effective_config_path` remained empty and `missing_receipts` still included `effective_config`.
+- Focused Swift: `swift test --filter 'MelixCLIRunnerTests/cookbookRecommendation'` passed with 12 tests after adding missing/empty receipt identity coverage.
+- Swift coverage: `swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'` passed with 352 tests; `scripts/swift_changed_line_coverage.py` reported 99.51 percent changed-line coverage for touched Swift files.
+- Python gate: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest` passed with 4134 tests and 15 skips after synchronizing the stale Phase 8 acceptance bundle expectation from `--model-id` to the current `server session update --model` CLI contract.
+- Integration gate: `make integration-test` passed with 117 tests and 1 skip.
+- Python changed-line coverage for the stale Phase 8 test expectation is N/A because the only changed Python line is a non-executable expected-argv string literal; the focused test covering that expectation passed.
+
+## Known Gaps
+
+- Benchmark receipts remain missing until benchmark artifact matching lands.
+- Model-fit receipts remain missing until model-specific fit evidence is joined.
+- This slice does not infer matches from existing diagnostics bundles outside the cookbook evidence directory.

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -4434,8 +4434,158 @@ struct MelixCLIRunnerTests {
         )))
         #expect(textOutput.contains("Fit evidence: cookbook.host_selection (melix.memory_fit_receipt.v1)"))
         #expect(textOutput.contains("Profile evidence: cookbook.backend_selection (melix.cookbook.profile_receipt.v1)"))
+        #expect(textOutput.contains("Effective config: none"))
         #expect(textOutput.contains("Benchmark receipts: none"))
         #expect(textOutput.contains("Missing receipts: effective_config, benchmark_receipt, model_fit_receipt"))
+    }
+
+    @Test("cookbook recommendation joins matching effective config receipt")
+    func cookbookRecommendationJoinsMatchingEffectiveConfigReceipt() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let evidenceRoot = root
+            .appendingPathComponent("state", isDirectory: true)
+            .appendingPathComponent("cookbook", isDirectory: true)
+            .appendingPathComponent("evidence", isDirectory: true)
+            .appendingPathComponent("effective-configs", isDirectory: true)
+        try FileManager.default.createDirectory(at: evidenceRoot, withIntermediateDirectories: true)
+        let effectiveConfigURL = evidenceRoot.appendingPathComponent("qwen-chat.json")
+        try Data("""
+        {
+          "schema_version": "melix.diagnostics.effective_config.v1",
+          "model_id": "mlx-community/Qwen3.5-9B-MLX-4bit",
+          "workload": "chat",
+          "host": {
+            "platform": "macos",
+            "arch": "arm64",
+            "host_platform_source": "hardware_probe"
+          },
+          "serving_profile": {
+            "selected_backend": "mlx-native"
+          }
+        }
+        """.utf8).write(to: effectiveConfigURL)
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: ["MELIX_HOME": root.path]
+        )
+
+        let output = try await runner.run(.cookbookRecommend(.init(
+            modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+            workload: "chat",
+            serverPlatform: "macos",
+            serverArch: "arm64",
+            json: true
+        )))
+        let payload = try #require(parseJSONObject(output))
+        let evidence = try #require(payload["evidence"] as? [String: Any])
+        let missingReceipts = try #require(evidence["missing_receipts"] as? [String])
+
+        #expect(evidence["effective_config_path"] as? String == effectiveConfigURL.path)
+        #expect(missingReceipts == ["benchmark_receipt", "model_fit_receipt"])
+
+        let textOutput = try await runner.run(.cookbookRecommend(.init(
+            modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+            workload: "chat",
+            serverPlatform: "macos",
+            serverArch: "arm64"
+        )))
+        #expect(textOutput.contains("Effective config: \(effectiveConfigURL.path)"))
+        #expect(textOutput.contains("Missing receipts: benchmark_receipt, model_fit_receipt"))
+    }
+
+    @Test("cookbook recommendation keeps mismatched effective config receipt missing")
+    func cookbookRecommendationKeepsMismatchedEffectiveConfigReceiptMissing() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let evidenceRoot = root
+            .appendingPathComponent("state", isDirectory: true)
+            .appendingPathComponent("cookbook", isDirectory: true)
+            .appendingPathComponent("evidence", isDirectory: true)
+            .appendingPathComponent("effective-configs", isDirectory: true)
+        try FileManager.default.createDirectory(at: evidenceRoot, withIntermediateDirectories: true)
+        try Data("""
+        {
+          "schema_version": "melix.diagnostics.effective_config.v1",
+          "model_id": "mlx-community/Qwen3.5-9B-MLX-4bit",
+          "workload": "chat",
+          "host": {
+            "platform": "linux",
+            "arch": "arm64",
+            "host_platform_source": "hardware_probe"
+          }
+        }
+        """.utf8).write(to: evidenceRoot.appendingPathComponent("linux-host.json"))
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: ["MELIX_HOME": root.path]
+        )
+
+        let output = try await runner.run(.cookbookRecommend(.init(
+            modelID: "mlx-community/Qwen3.5-9B-MLX-4bit",
+            workload: "chat",
+            serverPlatform: "macos",
+            serverArch: "arm64",
+            json: true
+        )))
+        let payload = try #require(parseJSONObject(output))
+        let evidence = try #require(payload["evidence"] as? [String: Any])
+        let missingReceipts = try #require(evidence["missing_receipts"] as? [String])
+
+        #expect(evidence["effective_config_path"] as? String == "")
+        #expect(missingReceipts == ["effective_config", "benchmark_receipt", "model_fit_receipt"])
+    }
+
+    @Test("cookbook recommendation ignores effective config receipts with empty identity")
+    func cookbookRecommendationIgnoresEffectiveConfigReceiptsWithEmptyIdentity() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let evidenceRoot = root
+            .appendingPathComponent("state", isDirectory: true)
+            .appendingPathComponent("cookbook", isDirectory: true)
+            .appendingPathComponent("evidence", isDirectory: true)
+            .appendingPathComponent("effective-configs", isDirectory: true)
+        try FileManager.default.createDirectory(at: evidenceRoot, withIntermediateDirectories: true)
+        try Data("""
+        {
+          "schema_version": "melix.diagnostics.effective_config.v1",
+          "host": {
+            "platform": "macos",
+            "arch": "arm64",
+            "host_platform_source": "hardware_probe"
+          }
+        }
+        """.utf8).write(to: evidenceRoot.appendingPathComponent("missing-identity.json"))
+        try Data("""
+        {
+          "schema_version": "melix.diagnostics.effective_config.v1",
+          "model_id": "  ",
+          "workload": "",
+          "host": {
+            "platform": "macos",
+            "arch": "arm64",
+            "host_platform_source": "hardware_probe"
+          }
+        }
+        """.utf8).write(to: evidenceRoot.appendingPathComponent("empty-identity.json"))
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: ["MELIX_HOME": root.path]
+        )
+
+        let output = try await runner.run(.cookbookRecommend(.init(
+            modelID: "",
+            workload: "",
+            serverPlatform: "macos",
+            serverArch: "arm64",
+            json: true
+        )))
+        let payload = try #require(parseJSONObject(output))
+        let evidence = try #require(payload["evidence"] as? [String: Any])
+        let missingReceipts = try #require(evidence["missing_receipts"] as? [String])
+
+        #expect(evidence["effective_config_path"] as? String == "")
+        #expect(missingReceipts == ["effective_config", "benchmark_receipt", "model_fit_receipt"])
     }
 
     @Test("cookbook recommendation disables cache when data root state is missing")

--- a/tests/test_phase8_acceptance_bundle.py
+++ b/tests/test_phase8_acceptance_bundle.py
@@ -228,7 +228,7 @@ def test_run_acceptance_bundle_shells_out_in_expected_order(tmp_path: Path) -> N
             "update",
             "--server-session-id",
             "server-session-1",
-            "--model-id",
+            "--model",
             "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
             "--json",
         ],


### PR DESCRIPTION
## Summary
- Join matching local effective-config evidence into `melix cookbook recommend` JSON and text output.
- Keep cookbook recommendation read-only and deterministic by scanning `MELIX_HOME/state/cookbook/evidence/effective-configs/*.json` for exact model, workload, and host matches.
- Sync a stale Phase 8 acceptance bundle test expectation with the current `server session update --model` CLI contract.

## Plan or Spec
- `docs/plans/2026-06-08-issue-1762-effective-config-evidence-join.md`
- Refs #1762. This PR implements the effective-config evidence join slice; benchmark and model-fit receipt joins remain deferred below.

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --filter 'MelixCLIRunnerTests/cookbookRecommendationJoinsMatchingEffectiveConfigReceipt'
- RED before implementation: failed because effective_config_path was empty and effective_config stayed in missing_receipts.
- PASS after implementation.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --filter 'MelixCLIRunnerTests/cookbookRecommendation'
- PASS: 12 tests.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
- PASS: 352 tests.

UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/swift_changed_line_coverage.py --binary .build/arm64-apple-macosx/debug/melixPackageTests.xctest/Contents/MacOS/melixPackageTests --profdata .build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main Sources/MelixCLICore/MelixCookbook.swift tests/MelixCLITests/MelixCLIRunnerTests.swift
- PASS: TOTAL 99.51% changed-line coverage.

make swift-test
- PASS via pre-commit: rc=0, elapsed=147.4s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest tests/test_phase8_acceptance_bundle.py::test_run_acceptance_bundle_shells_out_in_expected_order
- PASS: 1 test.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest
- PASS: 4134 passed, 15 skipped.

make py-test
- PASS via pre-commit: 3714 passed, 14 skipped, 2 warnings.

make integration-test
- PASS via pre-commit: 117 passed, 1 skipped.

git commit --amend --no-edit
- PASS: versioned pre-commit hook ran full gate and scoped performance report.
```

## Coverage and Metrics
- Swift changed-line coverage: 99.51% total for touched Swift files.
- `Sources/MelixCLICore/MelixCookbook.swift`: 98.33% changed-line coverage.
- `tests/MelixCLITests/MelixCLIRunnerTests.swift`: 100.00% changed-line coverage.
- Python changed-line coverage for `tests/test_phase8_acceptance_bundle.py`: N/A because the only changed line is a non-executable expected-argv string literal; the focused test covering that expectation passed.
- Pre-commit scoped performance report: `.runtime/pre-commit-performance/20260608-193945-a46ccf88/report/report.md`.
- Performance status: ok; regressions: 0; context regressions: 0; verification failures: 0.
- Selected probe: `swift-cli-json-envelope-encoding`; elapsed_ms_mean improved from 105654.116 to 12895.709 (-87.79%).
- Observability mode: minimal existing CLI planning metric (`cookbook.plan_ms`); no new runtime metrics, debug artifacts, model loads, or network calls. Probe overhead for this slice is bounded to one shallow local directory scan under `MELIX_HOME`.

## Known Gaps
- Benchmark receipts remain missing until benchmark artifact matching lands.
- Model-fit receipts remain missing until model-specific fit evidence is joined.
- This slice does not infer matches from existing diagnostics bundles outside the cookbook evidence directory.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
