### PR TITLE
perf: simplify statistical percentile interpolation

### DIFF
--- a/docs/runbooks/phase-8-release-gates.md
+++ b/docs/runbooks/phase-8-release-gates.md
@@ -107,6 +107,13 @@ reporting:
   below zero
 - `inconclusive` otherwise
 
+Statistical-evidence performance maintenance is governed by the registered
+`statistical-evidence-bootstrap-single-sort` PR-scoped probe. The percentile
+helper may assume its input has already been sorted by the bootstrap pass and may
+compute adjacent interpolation bounds without an extra `floor`/`ceil` pair, as
+long as empty, singleton, lower-bound, upper-bound, and interpolated percentile
+semantics remain covered by the focused statistical evidence tests.
+
 The checked-in policy also includes an `m9` section for repository-owned ecosystem and security
 signals. The current required M9 probes include:
 

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -311,17 +311,16 @@ def _ordered_percentile(ordered: list[float], percentile: float) -> float:
     if not ordered:
         return 0.0
     bounded_percentile = min(max(percentile, 0.0), 1.0)
-    if len(ordered) == 1:
+    last_index = len(ordered) - 1
+    if last_index == 0:
         return ordered[0]
-    position = bounded_percentile * (len(ordered) - 1)
-    lower_index = int(math.floor(position))
-    upper_index = int(math.ceil(position))
+    position = bounded_percentile * last_index
+    lower_index = int(position)
     lower_value = ordered[lower_index]
-    upper_value = ordered[upper_index]
-    if lower_index == upper_index:
+    if position == lower_index:
         return lower_value
-    fraction = position - lower_index
-    return lower_value + (upper_value - lower_value) * fraction
+    upper_value = ordered[lower_index + 1]
+    return lower_value + (upper_value - lower_value) * (position - lower_index)
 
 
 def _percentile_ordered(ordered: list[float], percentile: float) -> float:


### PR DESCRIPTION
## Summary
- Simplify ordered percentile interpolation in `statistical_evidence.py` by using the non-negative integer index directly instead of `math.floor`/`math.ceil`.
- Keep bootstrap interval semantics unchanged while reducing the registered bootstrap probe runtime.
- Update the Phase 8 release-gate runbook with the registered PR-scoped probe and percentile-helper maintenance rule.

## Plan or Spec
- `docs/runbooks/phase-8-release-gates.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics
# 21 passed in 0.13s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_statistical_evidence_bootstrap_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_bootstrap_probe.py
# TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_bootstrap_probe.py
# before: {"elapsed_ms_mean": 150.94971107318997, "peak_bytes_mean": 44544.0, ...}
# after:  {"elapsed_ms_mean": 136.57490061596036, "peak_bytes_mean": 44635.2, ...}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Registered probe: `statistical-evidence-bootstrap-single-sort`.
- Local Linux probe delta: `elapsed_ms_mean` 150.949711 ms -> 136.574901 ms, delta -14.374810 ms, speedup 1.105x. `lower_bound_mean` and `upper_bound_mean` stayed unchanged at 0.31374 and 0.44190.
- CI PR-scoped performance report is required before merge and will validate the registered probe in GitHub Actions.

## Known Gaps
- Local validation is Linux/Python only. No Swift runtime path is touched.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: this is a deterministic statistical evidence helper optimization.
- [x] Deferred work and known gaps are stated explicitly.
