### PR TITLE
perf: scan hub size hint fields before joining

### DIFF
--- a/docs/plans/2026-06-08-hub-catalog-size-hint-sequential-scan.md
+++ b/docs/plans/2026-06-08-hub-catalog-size-hint-sequential-scan.md
@@ -1,0 +1,19 @@
+# Hub catalog size-hint sequential text scan
+
+## Scope
+
+This Python-only performance slice is limited to `worker.model_ops.hub_catalog._size_hint_bytes(...)`, specifically the fallback path that scans multiple Hub metadata text fields for explicit `Model size` hints.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`. The probe watches `services/mlx-worker-python/worker/model_ops/hub_catalog.py`, `services/mlx-worker-python/tests/test_hub_catalog.py`, `services/mlx-worker-python/tests/test_pr_scoped_performance.py`, and `scripts/hub_catalog_size_hint_probe.py`, and it already includes focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Plan
+
+When description, README, and card-description text are all present, the current fallback allocates a joined string before calling `_size_hint_from_text(...)`. Most Hub payloads place the complete explicit size hint within one field, so scan each candidate field in order first and return the first matching hint. Keep a final joined-text fallback only for unusual boundary-spanning text so behavior remains compatible.
+
+The probe payload will include a multi-field README hint case so the registered performance report directly exercises the common sequential-scan path.
+
+## Verification
+
+Run the registered focused hub-catalog tests, changed-scope coverage, and the registered hub-catalog size-hint probe locally on Linux before pushing. GitHub Actions PR-scoped performance remains the merge and final metrics gate.

--- a/scripts/hub_catalog_size_hint_probe.py
+++ b/scripts/hub_catalog_size_hint_probe.py
@@ -30,8 +30,8 @@ def _payload(index: int) -> tuple[dict[str, Any], int]:
     return {
         "cardData": {"description": f"training corpus {value} kb"},
         "description": f"tokenizer assets {value} MB",
-        "readme": f"adapter notes {value} MB",
-    }, 0
+        "readme": f"README\nModel size: {value} MB\nadapter notes",
+    }, value * 1024 * 1024
 
 
 def _compatibility_payload(index: int) -> tuple[dict[str, Any], bool]:

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -395,6 +395,31 @@ def test_size_hint_model_marker_scan_preserves_case_insensitive_pairs() -> None:
         assert hub_catalog_module._may_contain_model_marker(text) is False
 
 
+def test_size_hint_scans_multiple_text_fields_before_joining(monkeypatch: pytest.MonkeyPatch) -> None:
+    scanned_texts: list[str] = []
+    original_size_hint = hub_catalog_module._size_hint_from_text
+
+    def tracking_size_hint(text: str, *, allow_bare: bool) -> int:
+        scanned_texts.append(text)
+        return original_size_hint(text, allow_bare=allow_bare)
+
+    monkeypatch.setattr(hub_catalog_module, "_size_hint_from_text", tracking_size_hint)
+
+    assert (
+        hub_catalog_module._size_hint_bytes(
+            {
+                "description": "adapter summary without size",
+                "readme": "README\nModel size: 12 GB\nother metadata",
+                "cardData": {"description": "card metadata without size"},
+            }
+        )
+        == 12 * GB
+    )
+    assert scanned_texts == [
+        "README\nModel size: 12 GB\nother metadata",
+    ]
+
+
 def test_weight_or_config_file_preserves_case_insensitive_matches() -> None:
     assert hub_catalog_module._is_weight_or_config_file("config.json") is True
     assert hub_catalog_module._is_weight_or_config_file("model.safetensors") is True
@@ -1136,10 +1161,11 @@ def test_size_hint_bytes_preserves_combined_marker_parsing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[tuple[str, bool]] = []
+    original_size_hint = hub_catalog_module._size_hint_from_text
 
     def tracked(text: str, *, allow_bare: bool) -> int:
         calls.append((text, allow_bare))
-        return 5 * MB
+        return original_size_hint(text, allow_bare=allow_bare)
 
     monkeypatch.setattr(hub_catalog_module, "_size_hint_from_text", tracked)
 
@@ -1153,7 +1179,10 @@ def test_size_hint_bytes_preserves_combined_marker_parsing(
         )
         == 5 * MB
     )
-    assert calls == [("Model size:\n5 MB\noperator note", False)]
+    assert calls == [
+        ("Model size:", False),
+        ("Model size:\n5 MB\noperator note", False),
+    ]
 
 
 def test_size_hint_bytes_uses_direct_card_model_size_without_regex(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2448,8 +2448,8 @@ def test_hub_catalog_size_hint_probe_script_emits_metrics(
     assert exc_info.value.code == 0
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["sample_count"] == 1.0
-    assert metrics["size_hint_calls_mean"] == 2.0
-    assert metrics["matched_hint_count"] == 4.0
+    assert metrics["size_hint_calls_mean"] == 3.0
+    assert metrics["matched_hint_count"] == 5.0
     assert metrics["payload_compatibility_calls_mean"] == 8.0
     assert metrics["payload_compatibility_matched_count"] == 7.0
     assert metrics["payload_compatibility_elapsed_ms_mean"] >= 0

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -771,6 +771,12 @@ def _size_hint_bytes(payload: dict[str, Any], *, card_data: dict[str, Any] | Non
         or _may_contain_model_marker(card_description_text)
     ):
         return 0
+    for text in (description_text, readme_text, card_description_text):
+        if not text or not _may_contain_model_marker(text):
+            continue
+        hint = _size_hint_from_text(text, allow_bare=False)
+        if hint > 0:
+            return hint
     text = "\n".join(
         text
         for text in (description_text, readme_text, card_description_text)


### PR DESCRIPTION
## Summary
- Scan Hub catalog description/README/card-description size-hint fields individually before allocating a joined fallback string.
- Keep the joined fallback for boundary-spanning `Model size` metadata so behavior remains compatible.
- Extend the registered size-hint probe payload to exercise the multi-field README hint path.

## Plan or Spec
- Added `docs/plans/2026-06-08-hub-catalog-size-hint-sequential-scan.md`.
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json` (already has focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- Base probe: `PYTHONPATH="$BASE:$BASE/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$BASE" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=80000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- Head probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=80000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 78 passed.
- Changed-scope coverage: 100% (`TOTAL 20 0 100%`).
- Local Linux registered probe comparison using the updated probe script:
  - base `elapsed_ms_mean=843.673050403595`, `peak_bytes_mean=2058.0`, `size_hint_calls_mean=32000.0`
  - head `elapsed_ms_mean=720.3434524126351`, `peak_bytes_mean=1976.0`, `size_hint_calls_mean=32000.0`
  - delta `-123.32959799095988 ms`, speedup `14.61817441388719%` (`1.1712094384670173x`)

## Known Gaps
- Local validation is Linux-only. The registered PR-scoped performance workflow remains the merge gate for CI validation.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branch creation.
- [x] Exactly one Python performance slice implemented.
- [x] Affected path has a registered PR-scoped performance probe with focused commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe run locally with base/head comparison.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
