### PR TITLE
perf: use set for tool registry builtin membership

### DIFF
--- a/docs/plans/2026-06-09-tool-registry-builtin-name-set.md
+++ b/docs/plans/2026-06-09-tool-registry-builtin-name-set.md
@@ -1,0 +1,32 @@
+# Tool registry built-in name membership fast path
+
+## Scope
+
+This Python-only performance slice is limited to the agentic tool selection
+membership check in `worker.runtime.tool_registry.select_agentic_tools_for_turn`.
+It keeps tool selection behavior unchanged while avoiding repeated linear tuple
+membership scans for built-in tool ids.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+That probe watches `services/mlx-worker-python/worker/runtime/tool_registry.py`,
+`services/mlx-worker-python/tests/test_tool_registry.py`,
+`services/mlx-worker-python/tests/test_pr_scoped_performance.py`, and
+`scripts/tool_registry_select_probe.py`, and includes focused `test_command`,
+`coverage_command`, and `probe_command` entries.
+
+## Implementation plan
+
+- Add a module-level frozenset snapshot for built-in agentic tool names.
+- Use that set in the `add_tool` selection guard while preserving registry order
+  through the existing tuple and selected-name list.
+- Add a focused regression test proving unknown ids are still ignored and the
+  set mirrors the canonical tuple.
+
+## Verification plan
+
+Run the registered focused tool-registry tests, changed-scope coverage, and the
+registered select probe locally on Linux before pushing. GitHub Actions
+PR-scoped performance remains the merge gate.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -595,6 +595,26 @@ def test_agentic_tool_selection_preserves_always_available_tools_with_vector_hit
     assert result.registry.metrics().schema_bytes < built_in_tool_registry().metrics().schema_bytes
 
 
+def test_agentic_tool_selection_uses_builtin_name_set_for_membership() -> None:
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Search local evidence, then visit the cited page.",
+            vector_selected_tool_ids=("unknown_tool", "text_search"),
+            vector_available=True,
+            max_selected_tools=4,
+        )
+    )
+
+    assert tool_registry_module._BUILTIN_AGENTIC_TOOL_NAME_SET == frozenset(
+        BUILTIN_AGENTIC_TOOL_NAMES
+    )
+    assert result.registry.names() == ("local_compute", "text_search")
+    assert result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"},
+        {"tool_id": "text_search", "source": "vector"},
+    ]
+
+
 def test_agentic_tool_selection_uses_keyword_fallback_when_vector_unavailable() -> None:
     result = select_agentic_tools_for_turn(
         ToolSelectionInput(

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -57,6 +57,7 @@ BUILTIN_AGENTIC_TOOL_NAMES = (
     "visit",
     "local_compute",
 )
+_BUILTIN_AGENTIC_TOOL_NAME_SET = frozenset(BUILTIN_AGENTIC_TOOL_NAMES)
 ALWAYS_AVAILABLE_AGENTIC_TOOL_NAMES = ("local_compute",)
 
 
@@ -456,7 +457,7 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
         normalized_name = tool_name.strip()
         if not normalized_name or normalized_name in selected_sources:
             return
-        if normalized_name not in BUILTIN_AGENTIC_TOOL_NAMES:
+        if normalized_name not in _BUILTIN_AGENTIC_TOOL_NAME_SET:
             return
         selected_sources[normalized_name] = source
         selected_names.append(normalized_name)


### PR DESCRIPTION
## Summary
- Add a cached frozenset snapshot for built-in agentic tool-name membership checks.
- Keep canonical tool ordering on the existing tuple while using O(1) membership in `select_agentic_tools_for_turn`.
- Add a focused regression test and plan note for the slice.

## Plan or Spec
- `docs/plans/2026-06-09-tool-registry-builtin-name-set.md`
- Registered PR-scoped probe: `tool-registry-select-name-index-cache`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 72 passed.
- Changed-scope coverage: 100% (7/7 measurable changed lines).
- Local Linux registered probe baseline (origin/main): `selector_planning_elapsed_ms_mean=71.10870275646448`, `elapsed_ms_mean=21.399923413991928`.
- Local Linux registered probe after change: `selector_planning_elapsed_ms_mean=66.85723783448339`, `elapsed_ms_mean=21.22011911123991`.
- Delta: selector planning -4.251464921981096 ms (-5.978825034316347%); overall select loop -0.17980430275201797 ms (-0.8402100291370969%).

## Known Gaps
- Local verification is Linux/Python only. GitHub Actions PR-scoped performance is still required before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally and showed improvement.
- [ ] PR-scoped performance workflow passed in CI.
