### PR TITLE
Add shared untrusted context receipts

### DIFF
--- a/docs/plans/2026-06-09-issue-1761-shared-untrusted-context-helper.md
+++ b/docs/plans/2026-06-09-issue-1761-shared-untrusted-context-helper.md
@@ -1,0 +1,71 @@
+# Issue 1761 Shared Untrusted Context Helper Plan
+
+## Scope
+
+This slice introduces a shared Python worker helper for untrusted prompt-context
+receipts and migrates the existing agentic judge prompt snapshot receipt
+construction to that helper.
+
+The slice covers:
+
+- a reusable `worker.runtime.untrusted_context` helper for data-only untrusted
+  prompt-context receipts
+- admitted and refused receipt construction with the existing
+  `melix.untrusted_context_receipt.v1` shape
+- an optional source identifier for future retrieved-doc, skill, memory, and
+  tool-output segments without changing existing agentic judge artifact JSON
+- agentic judge prompt snapshot and refusal receipts that preserve their current
+  persisted field values
+
+This slice does not wire new retrieved-doc, skill, memory, background-job, or
+live tool-output prompt surfaces. Those surfaces remain follow-up work under
+#1761 and should reuse the helper introduced here when their concrete admission
+points are added.
+
+## Architecture
+
+The Python worker already emits untrusted-context receipts from
+`worker.engine.evaluation_core`, but the receipt builder is local to the
+agentic judge surface. A shared runtime helper keeps the receipt schema, policy,
+trust level, message role, owner-scope flag, and data-only corrective actions in
+one place so future prompt-context entrypoints do not reimplement the boundary
+shape.
+
+The helper stays side-effect-free. It accepts source metadata and returns plain
+JSON-serializable dictionaries. Existing judge snapshot code remains
+responsible for building messages and validating no-leak payload keys; it
+delegates only receipt construction.
+
+## Performance Probes
+
+This path allocates a small dictionary per prompt-context segment. The scoped
+performance gate is expected to select the existing agentic judge prompt
+snapshot tests or report no direct synthetic probe. Success means the PR-scoped
+performance report is `Status: ok`, `Regressions: 0`, and
+`Verification failures: 0`.
+
+## Verification
+
+Verification will include:
+
+- focused red/green pytest for `worker.runtime.untrusted_context`
+- focused agentic judge prompt snapshot tests proving persisted receipt JSON is
+  unchanged after migration
+- changed-scope coverage for the touched Python files
+- `git diff --check`
+- local PR-scoped performance report
+
+## Implementation Steps
+
+1. Add failing tests for admitted, refused, and optional-source-id receipt
+   construction in `services/mlx-worker-python/tests/test_untrusted_context.py`.
+2. Implement `services/mlx-worker-python/worker/runtime/untrusted_context.py`
+   with shared receipt builders and schema constants.
+3. Migrate `EvaluationCore._agentic_judge_untrusted_context_receipt` and
+   `_agentic_judge_refusal_receipt` to call the shared helper while preserving
+   the existing output shape.
+4. Update `docs/unified-agentic-tool-runtime-contract.md` to name the helper as
+   the reusable v1 prompt-context boundary primitive for follow-up #1761
+   surfaces.
+5. Run the focused tests, changed-scope coverage, whitespace check, and scoped
+   performance report before opening the PR.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -254,6 +254,15 @@ assembly, RAG stores, skill entrypoints, memory entrypoints, and background-job
 continuations must reuse this receipt shape when they add their prompt-context
 boundary evidence under #1761.
 
+The v1 Python worker prompt-context primitive is
+`worker.runtime.untrusted_context.untrusted_context_receipt`. It constructs the
+stable `melix.untrusted_context_receipt.v1` dictionary for both admitted and
+refused untrusted user-message segments. Existing agentic judge prompt
+snapshots use this helper, and later retrieved-document, skill, memory,
+tool-output, and background-continuation admission points must use the same
+helper or preserve its exact receipt shape when they record prompt-boundary
+evidence.
+
 Rejected prompt-context segments should use the same receipt schema with
 `included = false`. For the agentic judge prompt boundary, unsupported
 top-level user-payload fields emit `reason =

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -260,8 +260,8 @@ stable `melix.untrusted_context_receipt.v1` dictionary for both admitted and
 refused untrusted user-message segments. Existing agentic judge prompt
 snapshots use this helper, and later retrieved-document, skill, memory,
 tool-output, and background-continuation admission points must use the same
-helper or preserve its exact receipt shape when they record prompt-boundary
-evidence.
+helper or preserve its exact receipt shape, including the optional `source_id`
+field for retrieved segments, when they record prompt-boundary evidence.
 
 Rejected prompt-context segments should use the same receipt schema with
 `included = false`. For the agentic judge prompt boundary, unsupported

--- a/services/mlx-worker-python/tests/test_untrusted_context.py
+++ b/services/mlx-worker-python/tests/test_untrusted_context.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from worker.runtime.untrusted_context import (
+    UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION,
+    untrusted_context_receipt,
+)
+
+
+def test_untrusted_context_receipt_records_admitted_user_data_boundary() -> None:
+    receipt = untrusted_context_receipt(
+        segment_id="sample-1:tool_observations",
+        source_type="agentic_judge_user_payload",
+        source_field="tool_observations",
+        included=True,
+        reason="sample-derived context is prompt data, not instructions",
+        corrective_action=(
+            "Keep this segment in the user payload and do not project it into "
+            "system or developer instructions."
+        ),
+    )
+
+    assert UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION == "melix.untrusted_context_receipt.v1"
+    assert receipt == {
+        "schema_version": "melix.untrusted_context_receipt.v1",
+        "segment_id": "sample-1:tool_observations",
+        "source_type": "agentic_judge_user_payload",
+        "source_field": "tool_observations",
+        "message_role": "user",
+        "trust_level": "untrusted",
+        "policy": "data_only",
+        "boundary_checked": True,
+        "included": True,
+        "owner_scope_checked": False,
+        "reason": "sample-derived context is prompt data, not instructions",
+        "corrective_action": (
+            "Keep this segment in the user payload and do not project it into "
+            "system or developer instructions."
+        ),
+    }
+
+
+def test_untrusted_context_receipt_records_refused_user_data_boundary() -> None:
+    receipt = untrusted_context_receipt(
+        segment_id="agentic_judge_user_payload:hidden_gold",
+        source_type="agentic_judge_user_payload",
+        source_field="hidden_gold",
+        included=False,
+        reason="unsupported_user_payload_field",
+        corrective_action=(
+            "Remove this field before projecting the sample-derived context "
+            "into the judge user payload."
+        ),
+    )
+
+    assert receipt["included"] is False
+    assert receipt["boundary_checked"] is True
+    assert receipt["policy"] == "data_only"
+    assert receipt["message_role"] == "user"
+    assert receipt["reason"] == "unsupported_user_payload_field"
+
+
+def test_untrusted_context_receipt_can_attach_source_id_for_retrieved_segments() -> None:
+    receipt = untrusted_context_receipt(
+        segment_id="retrieved-docs:doc-7:text",
+        source_type="retrieved_document",
+        source_field="text",
+        source_id="doc-7",
+        included=True,
+        owner_scope_checked=True,
+        reason="retrieved document is prompt data, not instructions",
+        corrective_action="Keep retrieved document text in user data segments only.",
+    )
+
+    assert receipt["source_id"] == "doc-7"
+    assert receipt["owner_scope_checked"] is True
+    assert receipt["trust_level"] == "untrusted"

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -84,6 +84,7 @@ from worker.productization.evaluation_schemas import (
 from worker.productization.evaluation_store import EvaluationStore
 from worker.productization.probe_policy import ProbePolicy
 from worker.runtime.agentic_tools import execute_agentic_tool_calls
+from worker.runtime.untrusted_context import untrusted_context_receipt
 
 
 _SUITE_SCORE_MODES = {
@@ -139,7 +140,6 @@ _AGENTIC_TOOL_METRIC_NAMES = (
 )
 _AGENTIC_JUDGE_PROMPT_SNAPSHOT_SCHEMA_VERSION = "melix.agentic_judge_prompt_snapshot.v1"
 _AGENTIC_JUDGE_AUDIT_SCHEMA_VERSION = "melix.agentic_judge_audit.v1"
-_UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION = "melix.untrusted_context_receipt.v1"
 _AGENTIC_JUDGE_PROMPT_VERSION = "agentic-answer-equivalence.v1"
 _AGENTIC_JUDGE_SYSTEM_PROMPT = """You are an answer equivalence judge for Melix agentic multimodal evaluation.
 
@@ -2502,23 +2502,17 @@ class EvaluationCore:
         sample_id: str,
         source_field: str,
     ) -> dict[str, object]:
-        return {
-            "schema_version": _UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION,
-            "segment_id": f"{sample_id}:{source_field}",
-            "source_type": "agentic_judge_user_payload",
-            "source_field": source_field,
-            "message_role": "user",
-            "trust_level": "untrusted",
-            "policy": "data_only",
-            "boundary_checked": True,
-            "included": True,
-            "owner_scope_checked": False,
-            "reason": "sample-derived context is prompt data, not instructions",
-            "corrective_action": (
+        return untrusted_context_receipt(
+            segment_id=f"{sample_id}:{source_field}",
+            source_type="agentic_judge_user_payload",
+            source_field=source_field,
+            included=True,
+            reason="sample-derived context is prompt data, not instructions",
+            corrective_action=(
                 "Keep this segment in the user payload and do not project it into "
                 "system or developer instructions."
             ),
-        }
+        )
 
     @staticmethod
     def _agentic_judge_refusal_receipt(
@@ -2526,23 +2520,17 @@ class EvaluationCore:
         source_field: str,
         reason: str,
     ) -> dict[str, object]:
-        return {
-            "schema_version": _UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION,
-            "segment_id": f"agentic_judge_user_payload:{source_field}",
-            "source_type": "agentic_judge_user_payload",
-            "source_field": source_field,
-            "message_role": "user",
-            "trust_level": "untrusted",
-            "policy": "data_only",
-            "boundary_checked": True,
-            "included": False,
-            "owner_scope_checked": False,
-            "reason": reason,
-            "corrective_action": (
+        return untrusted_context_receipt(
+            segment_id=f"agentic_judge_user_payload:{source_field}",
+            source_type="agentic_judge_user_payload",
+            source_field=source_field,
+            included=False,
+            reason=reason,
+            corrective_action=(
                 "Remove this field before projecting the sample-derived context "
                 "into the judge user payload."
             ),
-        }
+        )
 
     @staticmethod
     def _agentic_judge_audit_row(

--- a/services/mlx-worker-python/worker/runtime/untrusted_context.py
+++ b/services/mlx-worker-python/worker/runtime/untrusted_context.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
-
 UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION = "melix.untrusted_context_receipt.v1"
 
 
@@ -17,8 +14,8 @@ def untrusted_context_receipt(
     source_id: str = "",
     message_role: str = "user",
     owner_scope_checked: bool = False,
-) -> dict[str, Any]:
-    receipt: dict[str, Any] = {
+) -> dict[str, object]:
+    receipt: dict[str, object] = {
         "schema_version": UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION,
         "segment_id": segment_id,
         "source_type": source_type,

--- a/services/mlx-worker-python/worker/runtime/untrusted_context.py
+++ b/services/mlx-worker-python/worker/runtime/untrusted_context.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION = "melix.untrusted_context_receipt.v1"
+
+
+def untrusted_context_receipt(
+    *,
+    segment_id: str,
+    source_type: str,
+    source_field: str,
+    included: bool,
+    reason: str,
+    corrective_action: str,
+    source_id: str = "",
+    message_role: str = "user",
+    owner_scope_checked: bool = False,
+) -> dict[str, Any]:
+    receipt: dict[str, Any] = {
+        "schema_version": UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION,
+        "segment_id": segment_id,
+        "source_type": source_type,
+        "source_field": source_field,
+        "message_role": message_role,
+        "trust_level": "untrusted",
+        "policy": "data_only",
+        "boundary_checked": True,
+        "included": included,
+        "owner_scope_checked": owner_scope_checked,
+        "reason": reason,
+        "corrective_action": corrective_action,
+    }
+    if source_id:
+        receipt["source_id"] = source_id
+    return receipt


### PR DESCRIPTION
## Summary
- Add a shared Python worker untrusted-context receipt helper for prompt-boundary evidence.
- Migrate existing agentic judge prompt snapshot and refusal receipts to the shared helper while preserving the current `melix.untrusted_context_receipt.v1` JSON shape.
- Document the helper as the reusable v1 primitive for follow-up retrieved-document, skill, memory, tool-output, and background-continuation admission points.

## Plan or Spec
- Issue: #1761
- Plan: `docs/plans/2026-06-09-issue-1761-shared-untrusted-context-helper.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_untrusted_context.py -q
# Red run before helper existed: failed with ModuleNotFoundError: No module named 'worker.runtime.untrusted_context'.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_untrusted_context.py -q
# 3 passed in 0.01s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_evaluation_core.py -q -k "agentic_judge_prompt_snapshot or agentic_judge_payload_no_leak_validator or run_local_suite_returns_agentic_judge"
# 10 passed, 100 deselected in 2.19s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_untrusted_context.py services/mlx-worker-python/tests/test_evaluation_core.py -q -k "untrusted_context or agentic_judge_prompt_snapshot or agentic_judge_payload_no_leak_validator or run_local_suite_returns_agentic_judge"
# 13 passed, 100 deselected in 0.51s

git diff --check
# passed

rm -f coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_untrusted_context.py services/mlx-worker-python/tests/test_evaluation_core.py -k "untrusted_context or agentic_judge_prompt_snapshot or agentic_judge_payload_no_leak_validator or run_local_suite_returns_agentic_judge" && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/untrusted_context.py services/mlx-worker-python/worker/engine/evaluation_core.py && rm -f coverage.json
# 13 passed, 100 deselected; changed-line coverage 100% for both changed Python files; aggregate TOTAL 11 0 100%.

.githooks/pre-commit
# make swift-test: rc=0, elapsed 566.2s
# make py-test: rc=0; 3734 passed, 14 skipped, 2 warnings in 170.70s
# make integration-test: rc=0; 117 passed, 1 skipped in 735.40s
# PR scoped performance report: Status ok; Regressions 0; Context regressions 0; Verification failures 0

make bootstrap
# rc=0; configured git hooks path and checked Python environment

make proto
# rc=0; proto generation completed with no working-tree changes

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_untrusted_context.py services/mlx-worker-python/tests/test_evaluation_core.py -q -k "untrusted_context or agentic_judge_prompt_snapshot or agentic_judge_payload_no_leak_validator or run_local_suite_returns_agentic_judge"
# Review-fix rerun: 13 passed, 100 deselected in 1.10s

git diff --check
# Review-fix rerun: passed

rm -f coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_untrusted_context.py services/mlx-worker-python/tests/test_evaluation_core.py -k "untrusted_context or agentic_judge_prompt_snapshot or agentic_judge_payload_no_leak_validator or run_local_suite_returns_agentic_judge" && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/untrusted_context.py services/mlx-worker-python/worker/engine/evaluation_core.py && rm -f coverage.json
# Review-fix rerun: 13 passed, 100 deselected in 0.68s; changed-line coverage 100%; aggregate TOTAL 1 0 100%.

.githooks/pre-commit
# Review-fix commit hook: make swift-test rc=0, elapsed 624.2s
# Review-fix commit hook: make py-test rc=0; 3734 passed, 14 skipped, 2 warnings in 165.03s
# Review-fix commit hook: make integration-test rc=0; 117 passed, 1 skipped in 753.67s
# Review-fix PR scoped performance report: Status ok; Changed files 2; Selected probes 0; Regressions 0; Context regressions 0; Verification failures 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` for `services/mlx-worker-python/worker/runtime/untrusted_context.py` and changed lines in `services/mlx-worker-python/worker/engine/evaluation_core.py`; aggregate `TOTAL 11 0 100%`.
- Local PR-scoped performance report: `.runtime/pre-commit-performance/20260609-001831-38007476/report/report.md`.
- Performance status: `ok`; selected probes `5`; direct/gated probes `5`; regressions `0`; context regressions `0`; verification failures `0`.
- Review-fix local PR-scoped performance report: `.runtime/pre-commit-performance/20260609-005046-318394ea/report/report.md`; status `ok`; changed files `2`; selected probes `0`; regressions `0`; context regressions `0`; verification failures `0`.
- Observability mode: `evidence`. This change emits structured prompt-boundary receipt evidence; it does not add production runtime metrics.
- Probe overhead: `N/A`; no new probe was added. Existing evaluation scoped probes selected this change and reported neutral deltas.

## Known Gaps
- This PR does not wire new retrieved-document, skill, memory, background-job, or live tool-output prompt surfaces. Those remain follow-up work under #1761 and should reuse `worker.runtime.untrusted_context.untrusted_context_receipt`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
