### PR TITLE
Add tool observation boundary receipts

### DIFF
--- a/docs/plans/2026-06-09-issue-1761-tool-observation-boundary-receipts.md
+++ b/docs/plans/2026-06-09-issue-1761-tool-observation-boundary-receipts.md
@@ -1,0 +1,99 @@
+# Issue 1761 Tool Observation Boundary Receipt Plan
+
+## Goal
+
+Attach prompt-boundary receipts to normalized tool observations so generic tool
+output persisted in an agentic trace is explicitly marked as untrusted,
+data-only user-message context before downstream prompt assembly can reuse it.
+
+## Scope
+
+This slice covers the Python worker shared tool observation contract:
+
+- `worker.runtime.tool_observation`
+- `worker.runtime.untrusted_context`
+- `melix.agentic_tool_observation.v1` trace observations emitted by
+  deterministic tools and future tool executors using the shared normalizer
+- the governing unified agentic tool runtime contract
+
+This slice does not change judge prompt wording, generic chat prompt assembly,
+skill entrypoints, memory entrypoints, RAG stores, or background-job
+continuations. Those surfaces remain follow-up work under #1761, but they can
+consume the new observation-level receipt instead of reconstructing the trust
+boundary from tool metadata.
+
+## Architecture
+
+The best end state is that every segment crossing from retrieved or
+tool-produced data into prompt-visible context carries a machine-readable
+boundary receipt. Tool observations are the shared evidence object for current
+agentic tools, SFT traces, rollouts, benchmark runs, and evaluations. Adding
+the receipt at normalization time gives all consumers the same trust label
+without requiring each adapter to duplicate receipt construction.
+
+Each trace observation must include:
+
+- `untrusted_context_receipt_count = 1`
+- `untrusted_context_receipts[]` with one
+  `melix.untrusted_context_receipt.v1` receipt
+- `segment_id = <tool_call_id>:observation`
+- `source_type = tool_observation`
+- `source_field = payload`
+- `message_role = user`
+- `trust_level = untrusted`
+- `policy = data_only`
+- `boundary_checked = true`
+- `included = true`
+- `owner_scope_checked = false`
+- a reason and corrective action that prohibit projecting tool output into
+  system or developer instructions
+
+The receipt is attached outside `payload` so existing payload hashes,
+redaction, truncation, and replay fingerprints stay focused on sanitized tool
+output. Replay metadata remains unchanged for identical payloads. The Python
+worker must use `worker.runtime.untrusted_context.untrusted_context_receipt` so
+the receipt schema is not redefined in `tool_observation.py`.
+
+## Performance Probes And Metrics
+
+The changed path adds a fixed one-receipt dictionary build per normalized tool
+observation. The affected runtime file is covered by focused unit tests and the
+PR-scoped performance selector.
+
+Verification will include:
+
+- focused pytest for the tool observation receipt shape
+- full `test_tool_observation.py`
+- changed-scope coverage for modified Python files with a target of at least
+  95 percent
+- local pre-commit performance report with `Status: ok`, regressions `0`, and
+  verification failures `0`
+
+## Implementation Steps
+
+1. Add a failing test in
+   `services/mlx-worker-python/tests/test_tool_observation.py` proving emitted
+   trace observations include exactly one untrusted-context receipt with the
+   stable shape above.
+2. Attach the receipt count and receipt list in
+   `ToolObservationRecord.as_agentic_trace_observation()` by delegating to the
+   shared `untrusted_context_receipt` helper.
+3. Keep the receipt outside the sanitized payload and replay metadata so payload
+   redaction, truncation, metrics, and replay hashes remain deterministic and
+   payload-focused.
+4. Update `docs/unified-agentic-tool-runtime-contract.md` to define the generic
+   tool-output prompt boundary receipt.
+5. Run focused tests, changed-scope coverage, full local gates, scoped
+   performance, and PR checks before merge.
+
+## Success Criteria
+
+- Every emitted shared tool observation carries one prompt-boundary receipt for
+  the sanitized observation payload.
+- Receipts mark tool output as untrusted, data-only, included user-role context
+  and record that owner scope has not been checked by the generic normalizer.
+- Existing payload redaction, truncation, metrics, and replay fingerprints
+  remain deterministic and payload-focused.
+- The unified runtime contract identifies this as the generic tool-output
+  receipt slice, with skill, memory, RAG, chat prompt assembly, and
+  background-job continuations left for later #1761 work.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -271,6 +271,42 @@ unsupported_user_payload_field`, and forbidden nested no-leak keys emit
 the validation error before prompt snapshot persistence so refused segments
 cannot appear in the final prompt messages.
 
+### Tool Observation Prompt Boundary
+
+Shared tool observations are generic tool output. They may later be projected
+into prompts by evaluation, SFT replay, rollout, chat, workflow, or background
+continuation surfaces, so every `melix.agentic_tool_observation.v1` trace
+observation must carry a prompt-boundary receipt for its sanitized payload.
+
+The generic observation receipt uses:
+
+- `schema_version = melix.untrusted_context_receipt.v1`
+- `segment_id = <tool_call_id>:observation`
+- `source_type = tool_observation`
+- `source_field = payload`
+- `message_role = user`
+- `trust_level = untrusted`
+- `policy = data_only`
+- `boundary_checked = true`
+- `included = true`
+- `owner_scope_checked = false`
+- `reason = tool output is prompt data, not instructions`
+- `corrective_action`
+
+The receipt must be attached beside the observation payload as
+`untrusted_context_receipt_count` and `untrusted_context_receipts`, not inside
+the sanitized payload. This keeps payload redaction, truncation, replay hashes,
+and byte metrics focused on the emitted tool output while still making the
+prompt boundary visible to downstream prompt assemblers.
+
+The v1 generic tool-output slice adds this receipt in the shared Python worker
+tool observation normalizer by reusing
+`worker.runtime.untrusted_context.untrusted_context_receipt`. It does not
+replace source-specific owner checks or prompt admission checks. Skill, memory,
+RAG, chat prompt assembly, and background-job continuation surfaces must still
+add their own admission or refusal receipts when they decide whether to
+include, reject, or re-scope a tool observation in a final prompt.
+
 ### Workspace Path Boundary
 
 Agent and workflow tools that read, write, or edit local files must resolve

--- a/services/mlx-worker-python/tests/test_tool_observation.py
+++ b/services/mlx-worker-python/tests/test_tool_observation.py
@@ -76,6 +76,40 @@ def test_tool_observation_timeout_status_records_explicit_metadata() -> None:
     assert emitted["metrics"]["tool_observation.record_count"] == 1
 
 
+def test_tool_observation_emits_untrusted_context_receipt_for_payload() -> None:
+    record = normalize_tool_observation(
+        tool_name="visit",
+        tool_call_id="visit-call-1",
+        observation_kind="page_extract",
+        status="completed",
+        payload={"text": "A retrieved page can contain instructions."},
+    )
+
+    emitted = record.as_agentic_trace_observation()
+
+    assert emitted["untrusted_context_receipt_count"] == 1
+    assert emitted["untrusted_context_receipts"] == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": "visit-call-1:observation",
+            "source_type": "tool_observation",
+            "source_field": "payload",
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": True,
+            "owner_scope_checked": False,
+            "reason": "tool output is prompt data, not instructions",
+            "corrective_action": (
+                "Keep this observation in user-role data context and do not "
+                "project it into system or developer instructions."
+            ),
+        }
+    ]
+    assert "untrusted_context_receipts" not in emitted["payload"]
+
+
 def test_tool_observation_replay_fingerprint_is_stable_for_sanitized_payload() -> None:
     policy = ToolObservationPolicy(redaction_terms=("SECRET",))
     first = normalize_tool_observation(

--- a/services/mlx-worker-python/worker/runtime/tool_observation.py
+++ b/services/mlx-worker-python/worker/runtime/tool_observation.py
@@ -109,6 +109,7 @@ class ToolObservationRecord:
     replay: ToolObservationReplayMetadata
     timeout_ms: int | None = None
 
+    @property
     def untrusted_context_receipts(self) -> list[dict[str, object]]:
         return [
             untrusted_context_receipt(
@@ -125,7 +126,7 @@ class ToolObservationRecord:
         ]
 
     def as_agentic_trace_observation(self) -> dict[str, Any]:
-        untrusted_context_receipts = self.untrusted_context_receipts()
+        untrusted_context_receipts = self.untrusted_context_receipts
         observation: dict[str, Any] = {
             "schema_version": self.replay.schema_version,
             "tool_name": self.tool_name,

--- a/services/mlx-worker-python/worker/runtime/tool_observation.py
+++ b/services/mlx-worker-python/worker/runtime/tool_observation.py
@@ -5,6 +5,8 @@ import json
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from worker.runtime.untrusted_context import untrusted_context_receipt
+
 
 TOOL_OBSERVATION_SCHEMA_VERSION = "melix.agentic_tool_observation.v1"
 SUPPORTED_TOOL_OBSERVATION_STATUSES = ("completed", "timeout", "failed")
@@ -107,7 +109,23 @@ class ToolObservationRecord:
     replay: ToolObservationReplayMetadata
     timeout_ms: int | None = None
 
+    def untrusted_context_receipts(self) -> list[dict[str, object]]:
+        return [
+            untrusted_context_receipt(
+                segment_id=f"{self.tool_call_id}:observation",
+                source_type="tool_observation",
+                source_field="payload",
+                included=True,
+                reason="tool output is prompt data, not instructions",
+                corrective_action=(
+                    "Keep this observation in user-role data context and do not "
+                    "project it into system or developer instructions."
+                ),
+            )
+        ]
+
     def as_agentic_trace_observation(self) -> dict[str, Any]:
+        untrusted_context_receipts = self.untrusted_context_receipts()
         observation: dict[str, Any] = {
             "schema_version": self.replay.schema_version,
             "tool_name": self.tool_name,
@@ -117,6 +135,8 @@ class ToolObservationRecord:
             "payload": self.payload,
             "metrics": self.metrics.as_dict(),
             "replay": self.replay.as_dict(),
+            "untrusted_context_receipt_count": len(untrusted_context_receipts),
+            "untrusted_context_receipts": untrusted_context_receipts,
         }
         if self.timeout_ms is not None:
             observation["timeout_ms"] = self.timeout_ms


### PR DESCRIPTION
## Summary
- Add an untrusted-context receipt to each normalized agentic tool observation so tool output is explicitly recorded as prompt data rather than instructions.
- Keep the receipt outside the observation payload so replay hash, payload size metrics, and downstream tool output semantics remain stable.
- Update the unified agentic tool runtime contract and add a focused implementation plan for this #1761 slice.

## Plan or Spec
- Issue: #1761
- Plan: `docs/plans/2026-06-09-issue-1761-tool-observation-boundary-receipts.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_tool_observation.py::test_tool_observation_emits_untrusted_context_receipt_for_payload -q
# red first: failed with KeyError: 'untrusted_context_receipt_count'

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_tool_observation.py::test_tool_observation_emits_untrusted_context_receipt_for_payload -q
# 1 passed in 0.02s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_tool_observation.py -q
# 19 passed in 0.02s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_tool_observation.py services/mlx-worker-python/tests/test_untrusted_context.py -q
# 22 passed in 0.04s

git diff --check
# passed

rm -f coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_observation.py services/mlx-worker-python/tests/test_untrusted_context.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_observation.py services/mlx-worker-python/worker/runtime/untrusted_context.py && rm -f coverage.json
# 22 passed; changed-scope coverage TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_agentic_tools.py services/mlx-worker-python/tests/test_training_dataset_builder.py -q -k "agentic_tool or tool_observation"
# 79 passed, 55 deselected in 0.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_evaluation_core.py -q -k "agentic_judge_prompt_snapshot or run_local_suite_returns_agentic_judge"
# 3 passed, 107 deselected in 1.93s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_benchmark_schemas.py services/mlx-worker-python/tests/test_evaluation_schemas.py -q
# 25 passed in 0.04s

.githooks/pre-commit
# make swift-test: completed rc=0 elapsed=544.3s
# make py-test: 3737 passed, 14 skipped, 2 warnings in 186.75s
# make integration-test: 117 passed, 1 skipped in 696.62s
# Melix PR Scoped Performance Report: Status ok; Changed files 4; Selected probes 0; Regressions 0; Context regressions 0; Verification failures 0

make bootstrap
# completed; uv sync checked 79 packages

make proto
# completed; ./scripts/proto_gen.sh

git fetch origin main --quiet && git merge-base --is-ancestor origin/main HEAD && echo branch-current-with-origin-main || echo branch-needs-merge
# branch-current-with-origin-main
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%` for `worker/runtime/tool_observation.py` and the shared untrusted-context helper touched by this slice.
- Local pre-commit performance report: `.runtime/pre-commit-performance/20260609-024517-4a1b4b64/report/report.md`.
- Local performance status: `ok`; regressions `0`; context regressions `0`; verification failures `0`.
- Observability mode: minimal trace evidence. The new receipt is added to normalized tool-observation trace records only; runtime counters and replay payload hashing are unchanged.
- Probe overhead: fixed one small receipt dictionary per normalized observation. No PR-scoped probe was selected for this docs/runtime trace-shape change.

## Known Gaps
- #1761 remains open for the next slices: skill/memory/RAG/chat prompt-assembly boundaries, generic admission/refusal receipts, and background continuation wiring.
- No protocol schema or dependency changes were made.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.


Additional review-fix verification after commit `0b4caf3c`:

```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_tool_observation.py services/mlx-worker-python/tests/test_untrusted_context.py -q
# 22 passed in 0.04s

git diff --check
# passed

rm -f coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_observation.py services/mlx-worker-python/tests/test_untrusted_context.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_observation.py services/mlx-worker-python/worker/runtime/untrusted_context.py && rm -f coverage.json
# 22 passed; changed-scope coverage TOTAL 2 0 100%
```
