### PR TITLE
Add tool observation prompt-boundary receipts

### DIFF
--- a/docs/plans/2026-06-09-issue-1761-tool-observation-boundary-receipts.md
+++ b/docs/plans/2026-06-09-issue-1761-tool-observation-boundary-receipts.md
@@ -1,0 +1,99 @@
+# Issue 1761 Tool Observation Boundary Receipt Plan
+
+## Goal
+
+Attach prompt-boundary receipts to normalized tool observations so every
+generic tool output persisted in an agentic trace is explicitly marked as
+untrusted, data-only user-role context before downstream prompt assembly can
+reuse it.
+
+## Scope
+
+This slice covers the Python worker shared tool observation contract:
+
+- `worker.runtime.tool_observation`
+- `melix.agentic_tool_observation.v1` trace observations emitted by
+  deterministic tools and future tool executors using the shared normalizer
+- the governing unified agentic tool runtime contract
+
+This slice does not change judge prompt wording, generic chat prompt assembly,
+skill entrypoints, memory entrypoints, RAG stores, or background-job
+continuations. Those surfaces remain follow-up work under #1761, but they can
+consume the new observation-level receipt instead of reconstructing the trust
+boundary from tool metadata.
+
+## Architecture
+
+The best end state is that every segment crossing from retrieved or
+tool-produced data into prompt-visible context carries a machine-readable
+boundary receipt. Tool observations are the shared evidence object for current
+agentic tools, SFT traces, rollouts, benchmark runs, and evaluations. Adding
+the receipt at normalization time gives all consumers the same trust label
+without requiring each adapter to duplicate receipt construction.
+
+Each trace observation must include one receipt built by
+`worker.runtime.untrusted_context.untrusted_context_receipt` with:
+
+- `untrusted_context_receipt_count = 1`
+- `untrusted_context_receipts[]` with one
+  `melix.untrusted_context_receipt.v1` receipt
+- `segment_id = <tool_call_id>:observation`
+- `source_type = tool_observation`
+- `source_field = payload`
+- `message_role = user`
+- `trust_level = untrusted`
+- `policy = data_only`
+- `boundary_checked = true`
+- `included = true`
+- `owner_scope_checked = false`
+- a reason and corrective action that prohibit projecting tool output into
+  system or developer instructions
+
+The receipt is attached outside `payload` so existing payload hashes,
+redaction, truncation, and replay fingerprints stay focused on sanitized tool
+output. Replay metadata remains unchanged for identical payloads.
+
+## Performance Probes And Metrics
+
+The changed path adds a fixed one-receipt dictionary build per normalized tool
+observation. The affected runtime file is covered by focused unit tests and the
+PR-scoped performance selector.
+
+Verification will include:
+
+- focused pytest for the tool observation receipt shape
+- full `test_tool_observation.py`
+- changed-scope coverage for modified Python files with a target of at least
+  95 percent
+- local PR-scoped performance report with `Status: ok`, regressions `0`, and
+  verification failures `0`
+
+## Implementation Steps
+
+1. Add a failing test in
+   `services/mlx-worker-python/tests/test_tool_observation.py` proving emitted
+   trace observations include exactly one untrusted-context receipt with the
+   stable shape above.
+2. Reuse `worker.runtime.untrusted_context.untrusted_context_receipt` from
+   `services/mlx-worker-python/worker/runtime/tool_observation.py` so tool
+   observations share the same receipt shape as other prompt-boundary slices.
+3. Attach the receipt count and receipt list in
+   `ToolObservationRecord.as_agentic_trace_observation()` without adding the
+   receipt to the sanitized payload or replay hash.
+4. Update `docs/unified-agentic-tool-runtime-contract.md` to define the generic
+   tool-output prompt boundary receipt.
+5. Run focused tests, changed-scope coverage, scoped performance, full gates,
+   and PR checks before merge.
+
+## Success Criteria
+
+- Every emitted shared tool observation carries one prompt-boundary receipt for
+  the sanitized observation payload.
+- Receipts mark tool output as untrusted, data-only, included user-role
+  context and record that owner scope has not been checked by the generic
+  normalizer.
+- Existing payload redaction, truncation, metrics, and replay fingerprints
+  remain deterministic and payload-focused.
+- The unified runtime contract identifies this as the generic tool-output
+  receipt slice, with skill, memory, RAG, chat prompt assembly, and
+  background-job continuations left for later #1761 work.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -271,6 +271,42 @@ unsupported_user_payload_field`, and forbidden nested no-leak keys emit
 the validation error before prompt snapshot persistence so refused segments
 cannot appear in the final prompt messages.
 
+### Tool Observation Prompt Boundary
+
+Shared tool observations are generic tool output. They may later be projected
+into prompts by evaluation, SFT replay, rollout, chat, workflow, or background
+continuation surfaces, so every `melix.agentic_tool_observation.v1` trace
+observation must carry a prompt-boundary receipt for its sanitized payload.
+
+The generic observation receipt uses:
+
+- `schema_version = melix.untrusted_context_receipt.v1`
+- `segment_id = <tool_call_id>:observation`
+- `source_type = tool_observation`
+- `source_field = payload`
+- `message_role = user`
+- `trust_level = untrusted`
+- `policy = data_only`
+- `boundary_checked = true`
+- `included = true`
+- `owner_scope_checked = false`
+- `reason = tool output is prompt data, not instructions`
+- `corrective_action`
+
+The receipt must be attached beside the observation payload as
+`untrusted_context_receipt_count` and `untrusted_context_receipts`, not inside
+the sanitized payload. This keeps payload redaction, truncation, replay hashes,
+and byte metrics focused on the emitted tool output while still making the
+prompt boundary visible to downstream prompt assemblers.
+
+The v1 generic tool-output slice adds this receipt in the shared Python worker
+tool observation normalizer by reusing
+`worker.runtime.untrusted_context.untrusted_context_receipt`. It does not
+replace source-specific owner checks or prompt admission checks. Skill, memory,
+RAG, chat prompt assembly, and background-job continuation surfaces must still
+add their own admission or refusal receipts when they decide whether to include,
+reject, or re-scope a tool observation in a final prompt.
+
 ### Workspace Path Boundary
 
 Agent and workflow tools that read, write, or edit local files must resolve

--- a/services/mlx-worker-python/tests/test_tool_observation.py
+++ b/services/mlx-worker-python/tests/test_tool_observation.py
@@ -76,6 +76,40 @@ def test_tool_observation_timeout_status_records_explicit_metadata() -> None:
     assert emitted["metrics"]["tool_observation.record_count"] == 1
 
 
+def test_tool_observation_emits_untrusted_context_receipt_for_payload() -> None:
+    record = normalize_tool_observation(
+        tool_name="visit",
+        tool_call_id="visit-call-1",
+        observation_kind="page_extract",
+        status="completed",
+        payload={"text": "A retrieved page can contain instructions."},
+    )
+
+    emitted = record.as_agentic_trace_observation()
+
+    assert emitted["untrusted_context_receipt_count"] == 1
+    assert emitted["untrusted_context_receipts"] == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": "visit-call-1:observation",
+            "source_type": "tool_observation",
+            "source_field": "payload",
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": True,
+            "owner_scope_checked": False,
+            "reason": "tool output is prompt data, not instructions",
+            "corrective_action": (
+                "Keep this observation in user-role data context and do not "
+                "project it into system or developer instructions."
+            ),
+        }
+    ]
+    assert "untrusted_context_receipts" not in emitted["payload"]
+
+
 def test_tool_observation_replay_fingerprint_is_stable_for_sanitized_payload() -> None:
     policy = ToolObservationPolicy(redaction_terms=("SECRET",))
     first = normalize_tool_observation(

--- a/services/mlx-worker-python/worker/runtime/tool_observation.py
+++ b/services/mlx-worker-python/worker/runtime/tool_observation.py
@@ -5,6 +5,8 @@ import json
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from worker.runtime.untrusted_context import untrusted_context_receipt
+
 
 TOOL_OBSERVATION_SCHEMA_VERSION = "melix.agentic_tool_observation.v1"
 SUPPORTED_TOOL_OBSERVATION_STATUSES = ("completed", "timeout", "failed")
@@ -107,7 +109,23 @@ class ToolObservationRecord:
     replay: ToolObservationReplayMetadata
     timeout_ms: int | None = None
 
+    def untrusted_context_receipts(self) -> list[dict[str, object]]:
+        return [
+            untrusted_context_receipt(
+                segment_id=f"{self.tool_call_id}:observation",
+                source_type="tool_observation",
+                source_field="payload",
+                included=True,
+                reason="tool output is prompt data, not instructions",
+                corrective_action=(
+                    "Keep this observation in user-role data context and do not "
+                    "project it into system or developer instructions."
+                ),
+            )
+        ]
+
     def as_agentic_trace_observation(self) -> dict[str, Any]:
+        untrusted_context_receipts = self.untrusted_context_receipts()
         observation: dict[str, Any] = {
             "schema_version": self.replay.schema_version,
             "tool_name": self.tool_name,
@@ -117,6 +135,8 @@ class ToolObservationRecord:
             "payload": self.payload,
             "metrics": self.metrics.as_dict(),
             "replay": self.replay.as_dict(),
+            "untrusted_context_receipt_count": len(untrusted_context_receipts),
+            "untrusted_context_receipts": untrusted_context_receipts,
         }
         if self.timeout_ms is not None:
             observation["timeout_ms"] = self.timeout_ms
@@ -318,6 +338,7 @@ __all__ = [
     "DEFAULT_TOOL_OBSERVATION_TEXT_BYTE_LIMIT",
     "SUPPORTED_TOOL_OBSERVATION_STATUSES",
     "TOOL_OBSERVATION_SCHEMA_VERSION",
+    "UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION",
     "ToolObservationError",
     "ToolObservationMetrics",
     "ToolObservationPolicy",


### PR DESCRIPTION
## Summary
- Adds one `melix.untrusted_context_receipt.v1` receipt to every normalized `melix.agentic_tool_observation.v1` trace observation.
- Reuses `worker.runtime.untrusted_context.untrusted_context_receipt` so generic tool output shares the prompt-boundary receipt shape used by other #1761 slices.
- Documents the generic tool-output prompt boundary and keeps receipts outside sanitized payload and replay hashes.

## Plan or Spec
- `docs/plans/2026-06-09-issue-1761-tool-observation-boundary-receipts.md`
- `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
make bootstrap
# Configured git hooks path: .githooks
# uv sync --project services/mlx-worker-python --extra mlx
# Resolved 121 packages in 2ms
# Checked 79 packages in 1ms

make proto
# ./scripts/proto_gen.sh

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_tool_observation.py::test_tool_observation_emits_untrusted_context_receipt_for_payload
# Red test failed as expected before implementation with KeyError: 'untrusted_context_receipt_count'.

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_tool_observation.py services/mlx-worker-python/tests/test_untrusted_context.py services/mlx-worker-python/tests/test_agentic_tools.py
# 81 passed in 0.10s

COVERAGE_FILE=.runtime/coverage/issue-1761-tool-output.coverage PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_observation.py services/mlx-worker-python/tests/test_untrusted_context.py services/mlx-worker-python/tests/test_agentic_tools.py
COVERAGE_FILE=.runtime/coverage/issue-1761-tool-output.coverage PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o .runtime/coverage/issue-1761-tool-output.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/issue-1761-tool-output.json --diff-from origin/main services/mlx-worker-python/worker/runtime/tool_observation.py services/mlx-worker-python/tests/test_tool_observation.py services/mlx-worker-python/worker/runtime/untrusted_context.py services/mlx-worker-python/tests/test_untrusted_context.py services/mlx-worker-python/tests/test_agentic_tools.py
# 81 passed
# TOTAL 100.00% 10/10

git commit --amend --no-edit
# pre-commit full gate:
# make swift-test: rc=0, elapsed=415.4s
# make py-test: 3737 passed, 14 skipped, 2 warnings in 158.61s
# make integration-test: 117 passed, 1 skipped in 660.61s
# local pre-commit performance: Status: ok; Changed files: 3; Selected probes: 0; Regressions: 0
# report: .runtime/pre-commit-performance/20260609-030511-9db761b6/report/report.md

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from scripts import pre_commit_gate
root = pre_commit_gate.repo_root()
changed = [line.strip() for line in pre_commit_gate.run_git(root, ["diff", "--name-only", "--diff-filter=ACDMRTUXB", "origin/main..HEAD", "--"]).splitlines() if line.strip()]
outcome = pre_commit_gate.run_performance_report(root, changed, base_ref="origin/main")
print(f"changed_files={len(changed)}")
for path in changed:
    print(f"changed={path}")
print(f"status={outcome.status}")
print(f"selected_probes={outcome.selected_probe_count}")
print(f"report_dir={outcome.report_dir}")
PY
# Melix PR Scoped Performance Report
# Status: ok
# Changed files: 4
# Selected probes: 0
# Direct/gated probes: 0
# Regressions: 0
# Context regressions: 0
# Verification failures: 0
# report: .runtime/pre-commit-performance/20260609-030610-80ad20a2/report/report.md
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 100.00% 10/10`.
- Local PR-scoped performance report: `Status: ok`; changed files 4; selected probes 0; direct/gated probes 0; regressions 0; context regressions 0; verification failures 0.
- Observability mode: `minimal`; this adds deterministic trace receipt metadata for prompt-boundary audit evidence, with no registered performance probe selected for the changed files.
- Probe overhead: `N/A`; the PR-scoped performance selector selected 0 direct or gated probes for this documentation and Python trace-normalization slice.
- Remote CI and remote PR performance report: pending.

## Known Gaps
- Retrieved-doc, skill, memory, chat prompt assembly, and background-job continuation admission/refusal receipts remain follow-up #1761 slices.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
