### PR TITLE
Add chat prompt context boundary receipts

### DIFF
--- a/docs/plans/2026-06-09-issue-1761-chat-prompt-context-boundary-receipts.md
+++ b/docs/plans/2026-06-09-issue-1761-chat-prompt-context-boundary-receipts.md
@@ -1,0 +1,76 @@
+# Chat Prompt Context Boundary Receipts
+
+## Goal
+
+Add a small control-plane prompt-boundary evidence slice for issue #1761 by
+recording untrusted-context receipts for chat/request messages before they are
+sent to the worker runtime.
+
+## Scope
+
+This slice covers the Swift `ChatRequestTranslator` path that turns
+OpenAI-compatible Chat Completions, Completions, Responses, and Melix Messages
+requests into `Melix_Worker_V1_GenerateRequest.messages`.
+
+In scope:
+
+- record one receipt per non-empty non-system/developer message part projected
+  into the worker request
+- store the receipt count and canonical JSON array in `execution.ext`
+- keep the original message roles, content, media parts, and protocol schema
+  unchanged
+- update the unified agentic tool runtime contract to document this chat prompt
+  assembly boundary
+
+Out of scope:
+
+- rewriting prompt text or changing chat-template behavior
+- adding protobuf fields for receipts
+- classifying operator-configured system or developer instructions as
+  untrusted
+- broader RAG store, skill, memory, and background continuation wiring
+
+## Architecture
+
+The new helper is Swift-local and mirrors the Python
+`melix.untrusted_context_receipt.v1` shape so request evidence has the same
+field names across the control plane and Python worker. It intentionally omits
+raw prompt text and stores only segment identifiers, source type/field, message
+role, trust policy, inclusion status, and corrective guidance.
+
+`ChatRequestTranslator.translate(...)` builds the receipts after request
+shaping and before assigning `generateRequest.messages`. This records the
+boundary closest to the worker request without changing request shaping,
+token-count estimation, media normalization, or cache fingerprints.
+
+## Performance Probes
+
+The changed path performs a fixed linear pass over already-shaped messages and
+message parts. The output is a small JSON receipt array in `execution.ext`.
+No registered PR-scoped probe currently targets this metadata-only path; the
+PR-scoped performance workflow remains the remote gate. Local verification must
+include changed-scope coverage for the touched Swift lines.
+
+## Verification
+
+- TDD red/green Swift test for `ChatRequestTranslator` receipt ext fields
+- focused Swift test for the touched translator behavior
+- changed-scope coverage for the touched Swift source and test file, target
+  at least 95 percent
+- `make bootstrap`
+- `make proto`
+- `.githooks/pre-commit` full local gate before commit
+- PR-scoped performance report with status `ok` and zero regressions before
+  merge
+
+## Success Criteria
+
+- Worker `GenerateRequest.execution.ext` includes:
+  - `melix.prompt_context.receipt_schema =
+    melix.untrusted_context_receipt.v1`
+  - `melix.prompt_context.receipt_count`
+  - `melix.prompt_context.receipts_json`
+- Receipts include no raw prompt text, private tool arguments, or media URLs.
+- System/developer messages are not marked as untrusted user data in this
+  slice.
+- Existing request translation behavior remains unchanged.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -249,10 +249,23 @@ admitted untrusted segment. The receipt shape is:
 
 The v1 agentic judge prompt snapshot slice records this receipt for every
 sample-derived user-payload field admitted into the judge user message. It does
-not change judge prompt wording or scorer behavior. Broader chat prompt
-assembly, RAG stores, skill entrypoints, memory entrypoints, and background-job
-continuations must reuse this receipt shape when they add their prompt-context
-boundary evidence under #1761.
+not change judge prompt wording or scorer behavior.
+
+The v1 control-plane chat prompt assembly slice records the same receipt shape
+for non-empty non-system/developer message parts after request shaping and
+before `Melix_Worker_V1_GenerateRequest.messages` is sent to the worker.
+Receipts are stored in `ExecutionMetadata.ext` as:
+
+- `melix.prompt_context.receipt_schema`
+- `melix.prompt_context.receipt_count`
+- `melix.prompt_context.receipts_json`
+
+The chat prompt receipt must not include raw message content, media URLs, media
+bytes, tool arguments, or private prompt text. It records only segment IDs,
+source fields, roles, data-only policy, and corrective guidance. RAG stores,
+skill entrypoints, memory entrypoints, and background-job continuations must
+reuse this receipt shape when they add their prompt-context boundary evidence
+under #1761.
 
 The v1 Python worker prompt-context primitive is
 `worker.runtime.untrusted_context.untrusted_context_receipt`. It constructs the

--- a/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
+++ b/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
@@ -2696,6 +2696,14 @@ public struct ChatRequestTranslator: Sendable {
             compatibilityPolicyReceipt.extFields,
             uniquingKeysWith: { _, new in new }
         )
+        let promptContextReceipts = PromptContextBoundaryReceipts(
+            requestID: requestID,
+            messages: shapedRequest.messages
+        )
+        generateRequest.execution.ext.merge(
+            promptContextReceipts.extFields,
+            uniquingKeysWith: { _, receiptValue in receiptValue }
+        )
         if !(shapedRequest.sessionID ?? "").isEmpty {
             generateRequest.execution.cacheHints.allowL1 = true
             generateRequest.execution.cacheHints.allowL2 = true

--- a/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
@@ -101,8 +101,7 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
     }
 
     private static func canonicalJSONString(_ object: [[String: Any]]) -> String {
-        guard JSONSerialization.isValidJSONObject(object),
-              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]) else {
+        guard let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]) else {
             return "[]"
         }
         return String(data: data, encoding: .utf8) ?? "[]"

--- a/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
@@ -1,0 +1,124 @@
+import Foundation
+import MelixWorkerProtocol
+
+struct PromptContextBoundaryReceipts: Sendable, Equatable {
+    static let schemaVersion = "melix.untrusted_context_receipt.v1"
+
+    private let receipts: [[String: PromptContextReceiptValue]]
+
+    init(requestID: String, messages: [NormalizedTextMessage]) {
+        var receipts: [[String: PromptContextReceiptValue]] = []
+        for (messageIndex, message) in messages.enumerated() where Self.isUntrustedMessageRole(message.role) {
+            for (partIndex, part) in message.parts.enumerated() {
+                guard let sourceField = Self.sourceField(for: part, messageIndex: messageIndex, partIndex: partIndex) else {
+                    continue
+                }
+                receipts.append(
+                    [
+                        "schema_version": .string(Self.schemaVersion),
+                        "segment_id": .string("\(requestID):message-\(messageIndex):part-\(partIndex)"),
+                        "source_type": .string("chat_prompt_message"),
+                        "source_field": .string(sourceField),
+                        "message_role": .string(message.role),
+                        "trust_level": .string("untrusted"),
+                        "policy": .string("data_only"),
+                        "boundary_checked": .bool(true),
+                        "included": .bool(true),
+                        "owner_scope_checked": .bool(false),
+                        "reason": .string("chat message content is prompt data, not instructions"),
+                        "corrective_action": .string(
+                            "Keep this message part in its original role and do not promote it into system or developer instructions."
+                        ),
+                    ]
+                )
+            }
+        }
+        self.receipts = receipts
+    }
+
+    var extFields: [String: String] {
+        guard !receipts.isEmpty else {
+            return [:]
+        }
+        return [
+            "melix.prompt_context.receipt_schema": Self.schemaVersion,
+            "melix.prompt_context.receipt_count": String(receipts.count),
+            "melix.prompt_context.receipts_json": Self.canonicalJSONString(receipts.map { receipt in
+                receipt.mapValues(\.jsonValue)
+            }),
+        ]
+    }
+
+    private static func isUntrustedMessageRole(_ role: String) -> Bool {
+        let normalizedRole = role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return !normalizedRole.isEmpty && normalizedRole != "system" && normalizedRole != "developer"
+    }
+
+    private static func sourceField(
+        for part: Melix_Worker_V1_MessagePart,
+        messageIndex: Int,
+        partIndex: Int
+    ) -> String? {
+        switch part.part {
+        case .text(let value)?:
+            guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return nil
+            }
+            return "messages[\(messageIndex)].parts[\(partIndex)].text"
+        case .imageUri(let value)?:
+            guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return nil
+            }
+            return "messages[\(messageIndex)].parts[\(partIndex)].image_uri"
+        case .imageBytes(let value)?:
+            guard !value.isEmpty else {
+                return nil
+            }
+            return "messages[\(messageIndex)].parts[\(partIndex)].image_bytes"
+        case .audioUri(let value)?:
+            guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return nil
+            }
+            return "messages[\(messageIndex)].parts[\(partIndex)].audio_uri"
+        case .audioBytes(let value)?:
+            guard !value.isEmpty else {
+                return nil
+            }
+            return "messages[\(messageIndex)].parts[\(partIndex)].audio_bytes"
+        case .videoUri(let value)?:
+            guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return nil
+            }
+            return "messages[\(messageIndex)].parts[\(partIndex)].video_uri"
+        case .videoBytes(let value)?:
+            guard !value.isEmpty else {
+                return nil
+            }
+            return "messages[\(messageIndex)].parts[\(partIndex)].video_bytes"
+        case nil:
+            return nil
+        }
+    }
+
+    private static func canonicalJSONString(_ object: [[String: Any]]) -> String {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]) else {
+            return "[]"
+        }
+        return String(data: data, encoding: .utf8) ?? "[]"
+    }
+}
+
+private enum PromptContextReceiptValue: Sendable, Equatable {
+    case string(String)
+    case bool(Bool)
+
+    var jsonValue: Any {
+        switch self {
+        case .string(let value):
+            return value
+        case .bool(let value):
+            return value
+        }
+    }
+}

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import MelixControlPlaneCore
 import MelixControlPlaneProtocol
+import MelixWorkerProtocol
 
 struct ToolParserRegistryTests {
     @Test("registered parsers declare audit receipts for wire formats and selector surfaces")
@@ -267,6 +268,143 @@ struct ToolParserRegistryTests {
         #expect(receipt.contains(#""tool_namespaces":["tools.search"]"#))
         #expect(receipt.contains(#""effective_config_hash":"\#(ext["melix.compat.effective_config_hash"] ?? "")""#))
         #expect(Set(receiptObject.keys) == compatReceiptFieldNames())
+    }
+
+    @Test("translated text requests attach prompt context boundary receipts")
+    func translatedTextRequestsAttachPromptContextBoundaryReceipts() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-prompt-context" })
+        let request = OpenAIChatCompletionsRequest(
+            model: "melix-dev-text",
+            messages: [
+                .init(role: "system", content: "Answer with repository rules."),
+                .init(role: "user", content: "Summarize this untrusted page."),
+            ],
+            stream: false
+        )
+
+        let translated = try translator.translate(request, modelHandle: "worker-text")
+        let ext = translated.workerRequest.execution.ext
+        let receiptsJSON = try #require(ext["melix.prompt_context.receipts_json"])
+        let receipts = try #require(
+            try JSONSerialization.jsonObject(with: Data(receiptsJSON.utf8)) as? [[String: Any]]
+        )
+        let receipt = try #require(receipts.first)
+
+        #expect(ext["melix.prompt_context.receipt_schema"] == "melix.untrusted_context_receipt.v1")
+        #expect(ext["melix.prompt_context.receipt_count"] == "1")
+        #expect(receipts.count == 1)
+        #expect(receipt["schema_version"] as? String == "melix.untrusted_context_receipt.v1")
+        #expect(receipt["segment_id"] as? String == "req-prompt-context:message-1:part-0")
+        #expect(receipt["source_type"] as? String == "chat_prompt_message")
+        #expect(receipt["source_field"] as? String == "messages[1].parts[0].text")
+        #expect(receipt["message_role"] as? String == "user")
+        #expect(receipt["trust_level"] as? String == "untrusted")
+        #expect(receipt["policy"] as? String == "data_only")
+        #expect(receipt["boundary_checked"] as? Bool == true)
+        #expect(receipt["included"] as? Bool == true)
+        #expect(receipt["owner_scope_checked"] as? Bool == false)
+        #expect(receipt["reason"] as? String == "chat message content is prompt data, not instructions")
+        #expect(
+            receipt["corrective_action"] as? String ==
+                "Keep this message part in its original role and do not promote it into system or developer instructions."
+        )
+        #expect(receiptsJSON.contains("Summarize this untrusted page.") == false)
+        #expect(receiptsJSON.contains("Answer with repository rules.") == false)
+    }
+
+    @Test("trusted-only prompt messages do not attach prompt context boundary receipts")
+    func trustedOnlyPromptMessagesDoNotAttachPromptContextBoundaryReceipts() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-prompt-trusted" })
+        let request = makeNormalizedRequest(messages: [
+            .init(role: "system", content: "Use repository policy."),
+            .init(role: "developer", content: "Prefer concise answers."),
+        ])
+
+        let translated = try translator.translate(request, modelHandle: "worker-text")
+        let ext = translated.workerRequest.execution.ext
+
+        #expect(ext["melix.prompt_context.receipt_schema"] == nil)
+        #expect(ext["melix.prompt_context.receipt_count"] == nil)
+        #expect(ext["melix.prompt_context.receipts_json"] == nil)
+    }
+
+    @Test("prompt context boundary receipts cover multimodal message parts without raw payloads")
+    func promptContextBoundaryReceiptsCoverMultimodalMessagePartsWithoutRawPayloads() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-prompt-media" })
+        let request = makeNormalizedRequest(messages: [
+            .init(role: "system", parts: [
+                Self.messagePart(text: "system rules stay trusted"),
+            ]),
+            .init(role: "developer", parts: [
+                Self.messagePart(text: "developer rules stay trusted"),
+            ]),
+            .init(role: "user", parts: [
+                Self.messagePart(text: "inspect media"),
+                Self.messagePart(imageURI: "file:///tmp/untrusted-image.png"),
+                Self.messagePart(imageBytes: Data("image-bytes".utf8)),
+                Self.messagePart(audioURI: "file:///tmp/untrusted-audio.wav"),
+                Self.messagePart(audioBytes: Data("audio-bytes".utf8)),
+                Self.messagePart(videoURI: "file:///tmp/untrusted-video.mp4"),
+                Self.messagePart(videoBytes: Data("video-bytes".utf8)),
+                Self.messagePart(text: "   "),
+                Self.messagePart(imageURI: "   "),
+                Self.messagePart(imageBytes: Data()),
+                Self.messagePart(audioURI: "   "),
+                Self.messagePart(audioBytes: Data()),
+                Self.messagePart(videoURI: "   "),
+                Self.messagePart(videoBytes: Data()),
+                Melix_Worker_V1_MessagePart(),
+            ]),
+            .init(role: "assistant", parts: [
+                Self.messagePart(text: "assistant transcript data"),
+            ]),
+        ])
+
+        let translated = try translator.translate(request, modelHandle: "worker-vlm")
+        let ext = translated.workerRequest.execution.ext
+        let receiptsJSON = try #require(ext["melix.prompt_context.receipts_json"])
+        let receipts = try #require(
+            try JSONSerialization.jsonObject(with: Data(receiptsJSON.utf8)) as? [[String: Any]]
+        )
+        let sourceFields = receipts.compactMap { $0["source_field"] as? String }
+        let segmentIDs = receipts.compactMap { $0["segment_id"] as? String }
+        let roles = receipts.compactMap { $0["message_role"] as? String }
+
+        #expect(ext["melix.prompt_context.receipt_schema"] == "melix.untrusted_context_receipt.v1")
+        #expect(ext["melix.prompt_context.receipt_count"] == "8")
+        #expect(receipts.count == 8)
+        #expect(sourceFields == [
+            "messages[2].parts[0].text",
+            "messages[2].parts[1].image_uri",
+            "messages[2].parts[2].image_bytes",
+            "messages[2].parts[3].audio_uri",
+            "messages[2].parts[4].audio_bytes",
+            "messages[2].parts[5].video_uri",
+            "messages[2].parts[6].video_bytes",
+            "messages[3].parts[0].text",
+        ])
+        #expect(segmentIDs == [
+            "req-prompt-media:message-2:part-0",
+            "req-prompt-media:message-2:part-1",
+            "req-prompt-media:message-2:part-2",
+            "req-prompt-media:message-2:part-3",
+            "req-prompt-media:message-2:part-4",
+            "req-prompt-media:message-2:part-5",
+            "req-prompt-media:message-2:part-6",
+            "req-prompt-media:message-3:part-0",
+        ])
+        #expect(roles == ["user", "user", "user", "user", "user", "user", "user", "assistant"])
+        #expect(receipts.allSatisfy { $0["policy"] as? String == "data_only" })
+        #expect(receiptsJSON.contains("system rules stay trusted") == false)
+        #expect(receiptsJSON.contains("developer rules stay trusted") == false)
+        #expect(receiptsJSON.contains("inspect media") == false)
+        #expect(receiptsJSON.contains("assistant transcript data") == false)
+        #expect(receiptsJSON.contains("file:///tmp/untrusted-image.png") == false)
+        #expect(receiptsJSON.contains("file:///tmp/untrusted-audio.wav") == false)
+        #expect(receiptsJSON.contains("file:///tmp/untrusted-video.mp4") == false)
+        #expect(receiptsJSON.contains("image-bytes") == false)
+        #expect(receiptsJSON.contains("audio-bytes") == false)
+        #expect(receiptsJSON.contains("video-bytes") == false)
     }
 
     @Test("request-local compatibility policy receipt overrides do not mutate default requests")
@@ -557,14 +695,15 @@ struct ToolParserRegistryTests {
     }
 
     private func makeNormalizedRequest(
+        messages: [NormalizedTextMessage] = [
+            .init(role: "user", content: "Call a tool."),
+        ],
         toolParser: ToolParserSelection? = nil
     ) -> NormalizedTextRequest {
         NormalizedTextRequest(
             endpoint: .responses,
             model: "melix-dev-text",
-            messages: [
-                .init(role: "user", content: "Call a tool."),
-            ],
+            messages: messages,
             stream: true,
             temperature: nil,
             topP: nil,
@@ -576,6 +715,48 @@ struct ToolParserRegistryTests {
             saveBoundarySnapshot: nil,
             toolParser: toolParser
         )
+    }
+
+    private static func messagePart(text: String) -> Melix_Worker_V1_MessagePart {
+        var part = Melix_Worker_V1_MessagePart()
+        part.text = text
+        return part
+    }
+
+    private static func messagePart(imageURI: String) -> Melix_Worker_V1_MessagePart {
+        var part = Melix_Worker_V1_MessagePart()
+        part.imageUri = imageURI
+        return part
+    }
+
+    private static func messagePart(imageBytes: Data) -> Melix_Worker_V1_MessagePart {
+        var part = Melix_Worker_V1_MessagePart()
+        part.imageBytes = imageBytes
+        return part
+    }
+
+    private static func messagePart(audioURI: String) -> Melix_Worker_V1_MessagePart {
+        var part = Melix_Worker_V1_MessagePart()
+        part.audioUri = audioURI
+        return part
+    }
+
+    private static func messagePart(audioBytes: Data) -> Melix_Worker_V1_MessagePart {
+        var part = Melix_Worker_V1_MessagePart()
+        part.audioBytes = audioBytes
+        return part
+    }
+
+    private static func messagePart(videoURI: String) -> Melix_Worker_V1_MessagePart {
+        var part = Melix_Worker_V1_MessagePart()
+        part.videoUri = videoURI
+        return part
+    }
+
+    private static func messagePart(videoBytes: Data) -> Melix_Worker_V1_MessagePart {
+        var part = Melix_Worker_V1_MessagePart()
+        part.videoBytes = videoBytes
+        return part
     }
 
     private func compatReceiptFieldNames() -> Set<String> {


### PR DESCRIPTION
## Summary
- Add control-plane chat prompt context boundary receipts for non-empty non-system/developer message parts before `GenerateRequest` dispatch.
- Store receipt schema, count, and JSON evidence in `execution.ext` without raw prompt text, media URLs, or media bytes.
- Document the #1761 chat prompt boundary slice and keep broader RAG/skill/memory/background contexts out of scope.

## Plan or Spec
- `docs/plans/2026-06-09-issue-1761-chat-prompt-context-boundary-receipts.md`
- `docs/unified-agentic-tool-runtime-contract.md`
- Issue: #1761

## Commands Run
```text
# TDD red, expected failure before implementation
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'translatedTextRequestsAttachPromptContextBoundaryReceipts'
Result: failed as expected because melix.prompt_context.receipts_json was nil.

# Focused tests
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'ToolParserRegistryTests'
Result: passed, 19 tests.

# Changed-line coverage
python3.11 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
Result: TOTAL 99.64% (275/276).

# Repository setup and generated artifact check
make bootstrap
Result: passed.
make proto
Result: passed; no generated artifact diff.

git diff --check
Result: passed.

# Full local pre-commit gate, run manually before committing
.githooks/pre-commit
Result: passed.
- make swift-test: passed.
- make py-test: passed, 3737 passed, 14 skipped, 2 warnings.
- make integration-test: passed, 117 passed, 1 skipped.
- local PR-scoped performance report: Status ok, Regressions 0, Context regressions 0, Verification failures 0.
```

## Coverage and Metrics
- Changed-line coverage: `99.64% (275/276)` for the touched Swift executable/test scope.
- Local PR-scoped performance report: `.runtime/pre-commit-performance/20260609-041930-44a29a84/report/report.md`
  - Status: `ok`
  - Selected probes: `0`
  - Regressions: `0`
  - Context regressions: `0`
  - Verification failures: `0`
- Observability mode: evidence metadata in `GenerateRequest.execution.ext`; no runtime counters added.
- Probe overhead: N/A, no registered PR-scoped probe was selected for this metadata-only path.

## Known Gaps
- RAG store, skill entrypoint, memory entrypoint, and background continuation context boundaries remain follow-up #1761 slices.
- No protobuf fields were added; receipts are intentionally carried in `ExecutionMetadata.ext` for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
