### PR TITLE
Forward prompt context receipts into worker completion evidence

### DIFF
--- a/docs/plans/2026-06-09-issue-1761-worker-prompt-context-receipt-evidence.md
+++ b/docs/plans/2026-06-09-issue-1761-worker-prompt-context-receipt-evidence.md
@@ -1,0 +1,75 @@
+# Worker Prompt Context Receipt Evidence
+
+## Goal
+
+Preserve chat prompt-context boundary receipts in Python worker completion
+evidence so the executed request proves which untrusted prompt segments crossed
+from the Swift control plane into the worker runtime.
+
+## Scope
+
+This slice covers `worker.engine.engine_core.EngineCore.generate(...)` and its
+completed `parser_metrics`.
+
+In scope:
+
+- forward `melix.prompt_context.receipt_schema` from `ExecutionMetadata.ext` as
+  `prompt_context_receipt_schema`
+- forward `melix.prompt_context.receipt_count` as
+  `prompt_context_receipt_count`
+- forward `melix.prompt_context.receipts_json` as
+  `prompt_context_receipts_json`
+- keep plain and structured generation paths consistent
+- document the worker evidence handoff in the unified runtime contract
+
+Out of scope:
+
+- changing prompt text, template rendering, parser behavior, or message roles
+- parsing or rewriting the receipt JSON in the worker
+- adding new RAG store, skill, memory, or background-continuation admission
+  logic
+- adding protobuf fields for prompt-context receipts
+
+## Architecture
+
+The Swift control plane now records `melix.untrusted_context_receipt.v1` prompt
+context receipts in `GenerateRequest.execution.ext`. The Python worker already
+copies other request-local evidence, such as compatibility policy receipts and
+allowed-tool receipts, into `Completed.parser_metrics`. This slice adds the same
+handoff for prompt-context receipts.
+
+The worker treats these values as opaque evidence strings. It only forwards
+non-empty ext values into completion metrics and does not parse raw receipt JSON.
+That keeps the worker from revalidating or mutating receipt contents and avoids
+accidentally exposing prompt text, media URLs, media bytes, or tool arguments.
+
+## Performance Probes
+
+The path adds up to three map lookups and string assignments per completed
+generate request. No registered PR-scoped probe targets this metadata handoff.
+The PR-scoped performance workflow remains the merge gate and should report
+`Status: ok`, `Regressions: 0`, `Context regressions: 0`, and
+`Verification failures: 0`.
+
+## Verification
+
+- TDD red/green pytest for completed parser metrics on a request carrying
+  `melix.prompt_context.*` ext fields
+- focused receipt pytest file
+- changed-line coverage for touched Python source and test lines, target at
+  least 95 percent
+- `git diff --check`
+- `.githooks/pre-commit` full local gate before commit
+- remote CI and PR-scoped performance report before merge
+
+## Success Criteria
+
+- Completed generate events expose the three prompt-context receipt metrics when
+  the request ext contains the three Swift control-plane receipt keys.
+- Requests without prompt-context receipt ext do not emit empty
+  prompt-context metrics.
+- Plain and structured generation paths preserve existing completion, token
+  route, compatibility policy, and allowed-tool receipt behavior.
+- The unified runtime contract identifies the Python worker completion evidence
+  handoff and leaves RAG, skill, memory, and background admission boundaries for
+  later #1761 slices.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -260,6 +260,17 @@ Receipts are stored in `ExecutionMetadata.ext` as:
 - `melix.prompt_context.receipt_count`
 - `melix.prompt_context.receipts_json`
 
+The Python worker completion evidence slice forwards those three request-local
+ext values into `Completed.parser_metrics` as:
+
+- `prompt_context_receipt_schema`
+- `prompt_context_receipt_count`
+- `prompt_context_receipts_json`
+
+The worker treats the receipt JSON as opaque evidence and does not parse or
+mutate it. Source-specific RAG, skill, memory, and background-continuation
+admission points still need their own admission/refusal receipts.
+
 The chat prompt receipt must not include raw message content, media URLs, media
 bytes, tool arguments, or private prompt text. It records only segment IDs,
 source fields, roles, data-only policy, and corrective guidance. RAG stores,

--- a/services/mlx-worker-python/tests/test_generate_stream.py
+++ b/services/mlx-worker-python/tests/test_generate_stream.py
@@ -61,6 +61,33 @@ def test_text_native_mtp_parser_metrics_fast_paths_empty_events() -> None:
     assert engine_core_module._text_native_mtp_parser_metrics(None) == {}
     assert engine_core_module._text_native_mtp_parser_metrics(RuntimeTokenEvent(text="plain")) == {}
 
+    metrics: dict[str, str] = {}
+
+    engine_core_module._apply_prompt_context_receipt_metrics(
+        metrics,
+        {
+            "melix.prompt_context.receipt_schema": "melix.untrusted_context_receipt.v1",
+            "melix.prompt_context.receipt_count": "1",
+            "melix.prompt_context.receipts_json": '[{"segment_id":"req:user:0:text:0"}]',
+        },
+    )
+
+    assert metrics == {
+        "prompt_context_receipt_schema": "melix.untrusted_context_receipt.v1",
+        "prompt_context_receipt_count": "1",
+        "prompt_context_receipts_json": '[{"segment_id":"req:user:0:text:0"}]',
+    }
+
+    metrics = {}
+    engine_core_module._apply_prompt_context_receipt_metrics(
+        metrics,
+        {"melix.prompt_context.receipt_schema": None},
+    )
+    assert metrics == {}
+
+    engine_core_module._apply_prompt_context_receipt_metrics(metrics, object())
+    assert metrics == {}
+
 
 def test_text_native_mtp_parser_metrics_preserves_speculative_and_timing_values() -> None:
     metrics = engine_core_module._text_native_mtp_parser_metrics(

--- a/services/mlx-worker-python/tests/test_generate_stream_receipts.py
+++ b/services/mlx-worker-python/tests/test_generate_stream_receipts.py
@@ -547,6 +547,61 @@ def test_generate_records_request_local_allowed_tools_receipt() -> None:
     }
 
 
+def test_generate_completed_event_preserves_prompt_context_boundary_receipts() -> None:
+    inference_service, model_handle = _build_services(TokenRoutedVisibleBackend())
+    receipts = [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": "req-prompt-context:user:0:text:0",
+            "source_type": "chat_message",
+            "source_field": "text",
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": True,
+            "owner_scope_checked": False,
+            "reason": "chat message part is prompt data, not instructions",
+            "corrective_action": "keep segment in user-role data context",
+        }
+    ]
+    receipts_json = json.dumps(receipts, separators=(",", ":"), sort_keys=True)
+    request = inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id="req-prompt-context-receipt"),
+            model_handle=model_handle,
+            ext={
+                "melix.prompt_context.receipt_schema": "melix.untrusted_context_receipt.v1",
+                "melix.prompt_context.receipt_count": "1",
+                "melix.prompt_context.receipts_json": receipts_json,
+            },
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[common_pb2.MessagePart(text="private prompt text")],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=16),
+        stream=True,
+    )
+
+    completed = next(
+        event.completed
+        for event in inference_service.Generate(request, context=None)
+        if event.HasField("completed")
+    )
+
+    assert (
+        completed.parser_metrics["prompt_context_receipt_schema"]
+        == "melix.untrusted_context_receipt.v1"
+    )
+    assert completed.parser_metrics["prompt_context_receipt_count"] == "1"
+    assert completed.parser_metrics["prompt_context_receipts_json"] == receipts_json
+    assert json.loads(completed.parser_metrics["prompt_context_receipts_json"]) == receipts
+    assert "private prompt text" not in completed.parser_metrics["prompt_context_receipts_json"]
+
+
 def test_generate_treats_equivalent_duplicate_tool_schemas_as_same() -> None:
     inference_service, model_handle = _build_services(TokenRoutedVisibleBackend())
     request = inference_pb2.GenerateRequest(

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -51,6 +51,11 @@ _DEFAULT_OMITTED_ALLOWED_TOOLS_RECEIPT_JSON = _COMPACT_SORTED_JSON_ENCODER.encod
         "tool_source_ids": [],
     }
 )
+_PROMPT_CONTEXT_RECEIPT_METRIC_KEYS = {
+    "melix.prompt_context.receipt_schema": "prompt_context_receipt_schema",
+    "melix.prompt_context.receipt_count": "prompt_context_receipt_count",
+    "melix.prompt_context.receipts_json": "prompt_context_receipts_json",
+}
 
 
 def _canonical_json_schema_key(schema: str) -> str:
@@ -68,6 +73,21 @@ def _parser_metric_text(value: int | str) -> str:
     if value == 0:
         return _METRIC_ZERO_TEXT
     return str(value)
+
+
+def _apply_prompt_context_receipt_metrics(parser_metrics: dict[str, str], execution_ext: object) -> None:
+    if not execution_ext:
+        return
+    get_value = getattr(execution_ext, "get", None)
+    if not callable(get_value):
+        return
+    for ext_key, metric_key in _PROMPT_CONTEXT_RECEIPT_METRIC_KEYS.items():
+        raw_value = get_value(ext_key, None)
+        if raw_value is None:
+            continue
+        value = str(raw_value)
+        if value:
+            parser_metrics[metric_key] = value
 
 
 def _text_native_mtp_parser_metrics(event: RuntimeTokenEvent | None) -> dict[str, str]:
@@ -540,6 +560,7 @@ class EngineCore:
                     token_route_receipt_json = token_route_receipt.to_json()
                 parser_metrics["token_route_receipt_json"] = token_route_receipt_json
                 parser_metrics["allowed_tools_receipt_json"] = allowed_tools_receipt_json
+            _apply_prompt_context_receipt_metrics(parser_metrics, execution_ext)
             finalization_receipt = finalize_text_response(
                 response_id=request_id,
                 created=created,


### PR DESCRIPTION
## Summary
- Forward Swift control-plane prompt-context receipt ext values into Python worker completed `parser_metrics`.
- Add a #1761 worker-evidence plan and update the unified runtime contract to document the request-local handoff.
- Cover the completion event with an integration-style receipt test, selected probe coverage, and review-driven `None`/non-mapping ext guard cases.

## Plan or Spec
- `docs/plans/2026-06-09-issue-1761-worker-prompt-context-receipt-evidence.md`
- `docs/unified-agentic-tool-runtime-contract.md`
- Part of #1761.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_generate_stream_receipts.py::test_generate_completed_event_preserves_prompt_context_boundary_receipts
# red before implementation: failed on missing prompt_context_receipt_schema

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_generate_stream_receipts.py::test_generate_completed_event_preserves_prompt_context_boundary_receipts
# 1 passed in 0.16s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_generate_stream_receipts.py
# 23 passed in 0.46s before review fix; 23 passed in 0.53s after review fix

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_generate_stream.py::test_text_native_mtp_parser_metrics_fast_paths_empty_events
# review-fix red: failed because None became "None"; review-fix green: 1 passed in 0.21s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file=.runtime/coverage/prompt_context_receipt.coverage -m pytest -q services/mlx-worker-python/tests/test_generate_stream_receipts.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file=.runtime/coverage/prompt_context_receipt.coverage -o .runtime/coverage/prompt_context_receipt.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json .runtime/coverage/prompt_context_receipt.json services/mlx-worker-python/worker/engine/engine_core.py services/mlx-worker-python/tests/test_generate_stream_receipts.py
# 23 passed; changed-line coverage 100% for measured touched lines

export UV_PYTHON=3.12; jq -r '.[] | select(.id=="engine-generate-usage-token-elision") | .coverage_command' infra/perf/pr_scoped_probes.json | zsh -e
# 23 passed; TOTAL 12 0 100% after review fix

/usr/bin/git diff --cached --check
# passed

.githooks/pre-commit
# initial PR branch: make swift-test passed in 176.9s; make py-test 3738 passed, 14 skipped, 2 warnings in 180.53s; make integration-test 117 passed, 1 skipped in 424.45s; PR-scoped performance Status ok, regressions 0, context regressions 0, verification failures 0
# after review fix: make swift-test passed in 155.9s; make py-test 3738 passed, 14 skipped, 2 warnings in 164.90s; make integration-test 117 passed, 1 skipped in 419.95s; PR-scoped performance Status ok, regressions 0, context regressions 0, verification failures 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% for the focused receipt test scope and 100% for the `engine-generate-usage-token-elision` PR-scoped probe coverage path after the review fix.
- Local pre-commit performance reports:
  - `.runtime/pre-commit-performance/20260609-062735-65cc7acd/report/report.md`
  - `.runtime/pre-commit-performance/20260609-064616-ae4bb0e3/report/report.md`
- Latest local report status: `ok`; selected probes: 1; regressions: 0; context regressions: 0; verification failures: 0.
- Latest local probe metrics: `prompt_token_count_calls_per_request` neutral at 0.000, `request_state_append_calls_per_request` neutral at 0.000, `elapsed_ms_mean` +0.26% neutral, `fallback_elapsed_ms_mean` +0.09% neutral, `fallback_peak_bytes_mean` +0.81% neutral.
- Observability mode: evidence. The worker forwards existing receipt strings only; probe overhead is up to three request-ext map lookups and three string assignments on completed generation.

## Known Gaps
- This is a worker completion evidence handoff only. Source-specific RAG, skill, memory, and background-continuation admission/refusal receipts remain for later #1761 slices.
- No protobuf schema changes or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
