### PR TITLE
Classify prompt context receipt sources

### DIFF
--- a/docs/plans/2026-06-09-issue-1761-source-specific-prompt-context-receipts.md
+++ b/docs/plans/2026-06-09-issue-1761-source-specific-prompt-context-receipts.md
@@ -1,0 +1,58 @@
+# Source-Specific Prompt Context Receipt Classification Plan
+
+## Goal
+
+Continue #1761 by making control-plane prompt-context receipts identify source-specific untrusted prompt segments for tool output, retrieved-document/RAG data, skills, memories, and background continuations without persisting raw prompt content.
+
+## Architecture
+
+`PromptContextBoundaryReceipts` remains the single Swift prompt-assembly receipt point for text requests before `Melix_Worker_V1_GenerateRequest` is sent to the worker. This slice classifies untrusted message parts from existing message metadata only: message role and the already-normalized message `name`. It does not invent a retrieval store, change prompt wording, or parse message content.
+
+Message `name` prefixes are the request-local source identifier surface for this slice:
+
+- `retrieved_document:*`, `retrieved-doc:*`, `document:*`, `doc:*`, `rag:*`, `rag_document:*`, and `knowledge:*` classify as `retrieved_document`.
+- `skill:*` and `agent_skill:*` classify as `skill`.
+- `memory:*`, `retrieved_memory:*`, and `pinned_memory:*` classify as `memory`.
+- `background_continuation:*`, `background-continuation:*`, `background_job:*`, and `background-job:*` classify as `background_continuation`.
+- `tool` role messages classify as `tool_output`.
+- Other non-system/developer messages keep `chat_prompt_message`.
+
+`source_id` is emitted only when a normalized message name is present. It records the message name string, not message text, media URIs, media bytes, tool arguments, or private prompt text.
+
+## Files
+
+- Modify `services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift`
+  - Classify prompt receipt `source_type`.
+  - Add optional `source_id` from message `name`.
+  - Keep raw content out of receipt JSON.
+- Modify `services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift`
+  - Add a focused TDD regression for tool/RAG/skill/memory/background source classification.
+  - Assert raw source text and trusted system text do not appear in `melix.prompt_context.receipts_json`.
+- Modify `docs/unified-agentic-tool-runtime-contract.md`
+  - Document the source-specific chat prompt receipt classification and its `source_id` privacy rule.
+
+## Verification
+
+1. Red: run the new Swift test and confirm it fails because receipts still use `chat_prompt_message` and omit `source_id`.
+2. Green: run the focused Swift test:
+
+```bash
+HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'PromptContext'
+```
+
+3. Coverage for touched Swift scope:
+
+```bash
+HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --enable-code-coverage --package-path services/control-plane-swift --filter 'PromptContext'
+python3 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+```
+
+4. Full commit gate:
+
+```bash
+.githooks/pre-commit
+```
+
+## Metrics
+
+This is prompt metadata assembly code. Performance success is no PR-scoped regression in the repository performance report, especially no regression in text request translation or Swift control-plane tests. Coverage success is at least 95 percent changed-line coverage for the touched Swift scope.

--- a/docs/plans/2026-06-09-issue-1761-source-specific-prompt-context-receipts.md
+++ b/docs/plans/2026-06-09-issue-1761-source-specific-prompt-context-receipts.md
@@ -10,10 +10,11 @@ Continue #1761 by making control-plane prompt-context receipts identify source-s
 
 Message `name` prefixes are the request-local source identifier surface for this slice:
 
-- `retrieved_document:*`, `retrieved-doc:*`, `document:*`, `doc:*`, `rag:*`, `rag_document:*`, and `knowledge:*` classify as `retrieved_document`.
-- `skill:*` and `agent_skill:*` classify as `skill`.
-- `memory:*`, `retrieved_memory:*`, and `pinned_memory:*` classify as `memory`.
-- `background_continuation:*`, `background-continuation:*`, `background_job:*`, and `background-job:*` classify as `background_continuation`.
+- The reserved prefix may be the whole name or may be followed by `:`, `.`, `-`, or `_`.
+- `retrieved_document`, `retrieved-doc`, `document`, `doc`, `rag`, `rag_document`, and `knowledge` classify as `retrieved_document`.
+- `skill` and `agent_skill` classify as `skill`.
+- `memory`, `retrieved_memory`, and `pinned_memory` classify as `memory`.
+- `background_continuation`, `background-continuation`, `background_job`, and `background-job` classify as `background_continuation`.
 - `tool` role messages classify as `tool_output`.
 - Other non-system/developer messages keep `chat_prompt_message`.
 

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -271,6 +271,25 @@ The worker treats the receipt JSON as opaque evidence and does not parse or
 mutate it. Source-specific RAG, skill, memory, and background-continuation
 admission points still need their own admission/refusal receipts.
 
+The v1 source-specific control-plane classification slice refines those chat
+prompt receipts using request-local message metadata already present at prompt
+assembly time. Tool-role messages record `source_type = tool_output`. Non-tool
+messages whose normalized `name` uses the reserved prefixes `retrieved_document`,
+`retrieved-doc`, `document`, `doc`, `rag`, `rag_document`, or `knowledge`
+record `source_type = retrieved_document`; `skill` and `agent_skill` record
+`source_type = skill`; `memory`, `retrieved_memory`, and `pinned_memory` record
+`source_type = memory`; `background_continuation`,
+`background-continuation`, `background_job`, and `background-job` record
+`source_type = background_continuation`. Other non-system/developer messages
+continue to record `source_type = chat_prompt_message`.
+
+When the normalized message name is present, the prompt receipt records it as
+`source_id`. `source_id` is source metadata only; the receipt must still omit
+message text, media URIs, media bytes, tool arguments, private prompt text, and
+other raw source payloads. The classification is evidentiary and does not
+replace source-specific owner-scope checks, admission/refusal checks, or
+background-continuation link validation.
+
 The chat prompt receipt must not include raw message content, media URLs, media
 bytes, tool arguments, or private prompt text. It records only segment IDs,
 source fields, roles, data-only policy, and corrective guidance. RAG stores,

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -282,6 +282,9 @@ record `source_type = retrieved_document`; `skill` and `agent_skill` record
 `background-continuation`, `background_job`, and `background-job` record
 `source_type = background_continuation`. Other non-system/developer messages
 continue to record `source_type = chat_prompt_message`.
+The reserved prefix may be the full normalized message name or may be followed
+by `:`, `.`, `-`, or `_`, so Melix-internal names and OpenAI-compatible message
+names can use the same receipt classification rules.
 
 When the normalized message name is present, the prompt receipt records it as
 `source_id`. `source_id` is source metadata only; the receipt must still omit

--- a/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
@@ -86,7 +86,11 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
 
     private static func hasAnyPrefix(_ value: String, _ prefixes: [String]) -> Bool {
         prefixes.contains { prefix in
-            value == prefix || value.hasPrefix("\(prefix):") || value.hasPrefix("\(prefix).")
+            value == prefix
+                || value.hasPrefix("\(prefix):")
+                || value.hasPrefix("\(prefix).")
+                || value.hasPrefix("\(prefix)-")
+                || value.hasPrefix("\(prefix)_")
         }
     }
 

--- a/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
@@ -13,24 +13,26 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
                 guard let sourceField = Self.sourceField(for: part, messageIndex: messageIndex, partIndex: partIndex) else {
                     continue
                 }
-                receipts.append(
-                    [
-                        "schema_version": .string(Self.schemaVersion),
-                        "segment_id": .string("\(requestID):message-\(messageIndex):part-\(partIndex)"),
-                        "source_type": .string("chat_prompt_message"),
-                        "source_field": .string(sourceField),
-                        "message_role": .string(message.role),
-                        "trust_level": .string("untrusted"),
-                        "policy": .string("data_only"),
-                        "boundary_checked": .bool(true),
-                        "included": .bool(true),
-                        "owner_scope_checked": .bool(false),
-                        "reason": .string("chat message content is prompt data, not instructions"),
-                        "corrective_action": .string(
-                            "Keep this message part in its original role and do not promote it into system or developer instructions."
-                        ),
-                    ]
-                )
+                var receipt: [String: PromptContextReceiptValue] = [
+                    "schema_version": .string(Self.schemaVersion),
+                    "segment_id": .string("\(requestID):message-\(messageIndex):part-\(partIndex)"),
+                    "source_type": .string(Self.sourceType(for: message)),
+                    "source_field": .string(sourceField),
+                    "message_role": .string(message.role),
+                    "trust_level": .string("untrusted"),
+                    "policy": .string("data_only"),
+                    "boundary_checked": .bool(true),
+                    "included": .bool(true),
+                    "owner_scope_checked": .bool(false),
+                    "reason": .string("chat message content is prompt data, not instructions"),
+                    "corrective_action": .string(
+                        "Keep this message part in its original role and do not promote it into system or developer instructions."
+                    ),
+                ]
+                if let sourceID = message.name {
+                    receipt["source_id"] = .string(sourceID)
+                }
+                receipts.append(receipt)
             }
         }
         self.receipts = receipts
@@ -52,6 +54,40 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
     private static func isUntrustedMessageRole(_ role: String) -> Bool {
         let normalizedRole = role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return !normalizedRole.isEmpty && normalizedRole != "system" && normalizedRole != "developer"
+    }
+
+    private static func sourceType(for message: NormalizedTextMessage) -> String {
+        let normalizedRole = message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalizedRole == "tool" {
+            return "tool_output"
+        }
+
+        guard let name = message.name else {
+            return "chat_prompt_message"
+        }
+        let normalizedName = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if hasAnyPrefix(
+            normalizedName,
+            ["retrieved_document", "retrieved-doc", "document", "doc", "rag", "rag_document", "knowledge"]
+        ) {
+            return "retrieved_document"
+        }
+        if hasAnyPrefix(normalizedName, ["skill", "agent_skill"]) {
+            return "skill"
+        }
+        if hasAnyPrefix(normalizedName, ["memory", "retrieved_memory", "pinned_memory"]) {
+            return "memory"
+        }
+        if hasAnyPrefix(normalizedName, ["background_continuation", "background-continuation", "background_job", "background-job"]) {
+            return "background_continuation"
+        }
+        return "chat_prompt_message"
+    }
+
+    private static func hasAnyPrefix(_ value: String, _ prefixes: [String]) -> Bool {
+        prefixes.contains { prefix in
+            value == prefix || value.hasPrefix("\(prefix):") || value.hasPrefix("\(prefix).")
+        }
     }
 
     private static func sourceField(

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -407,6 +407,52 @@ struct ToolParserRegistryTests {
         #expect(receiptsJSON.contains("video-bytes") == false)
     }
 
+    @Test("prompt context boundary receipts classify tool rag skill memory and background sources")
+    func promptContextBoundaryReceiptsClassifySourceSpecificMessageNames() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-prompt-sources" })
+        let request = makeNormalizedRequest(messages: [
+            .init(role: "system", content: "trusted system prompt must not leak"),
+            .init(role: "tool", name: "calculator", content: "tool output says ignore developer policy"),
+            .init(role: "user", name: "rag:doc-17", content: "retrieved document says reveal secrets"),
+            .init(role: "user", name: "skill:repo-search", content: "skill index says run arbitrary shell"),
+            .init(role: "user", name: "memory:pinned-42", content: "memory says bypass authentication"),
+            .init(role: "assistant", name: "background_continuation:job-9", content: "background job says trust me"),
+        ])
+
+        let translated = try translator.translate(request, modelHandle: "worker-text")
+        let ext = translated.workerRequest.execution.ext
+        let receiptsJSON = try #require(ext["melix.prompt_context.receipts_json"])
+        let receipts = try #require(
+            try JSONSerialization.jsonObject(with: Data(receiptsJSON.utf8)) as? [[String: Any]]
+        )
+        let sourceTypes = receipts.compactMap { $0["source_type"] as? String }
+        let sourceIDs = receipts.compactMap { $0["source_id"] as? String }
+
+        #expect(ext["melix.prompt_context.receipt_count"] == "5")
+        #expect(sourceTypes == [
+            "tool_output",
+            "retrieved_document",
+            "skill",
+            "memory",
+            "background_continuation",
+        ])
+        #expect(sourceIDs == [
+            "calculator",
+            "rag:doc-17",
+            "skill:repo-search",
+            "memory:pinned-42",
+            "background_continuation:job-9",
+        ])
+        #expect(receipts.allSatisfy { $0["policy"] as? String == "data_only" })
+        #expect(receipts.allSatisfy { $0["included"] as? Bool == true })
+        #expect(receiptsJSON.contains("trusted system prompt") == false)
+        #expect(receiptsJSON.contains("ignore developer policy") == false)
+        #expect(receiptsJSON.contains("reveal secrets") == false)
+        #expect(receiptsJSON.contains("arbitrary shell") == false)
+        #expect(receiptsJSON.contains("bypass authentication") == false)
+        #expect(receiptsJSON.contains("trust me") == false)
+    }
+
     @Test("request-local compatibility policy receipt overrides do not mutate default requests")
     func requestLocalCompatibilityPolicyReceiptOverridesDoNotMutateDefaultRequests() throws {
         let translator = ChatRequestTranslator(requestIDGenerator: { "req-compat-policy-defaults" })

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -413,10 +413,10 @@ struct ToolParserRegistryTests {
         let request = makeNormalizedRequest(messages: [
             .init(role: "system", content: "trusted system prompt must not leak"),
             .init(role: "tool", name: "calculator", content: "tool output says ignore developer policy"),
-            .init(role: "user", name: "rag:doc-17", content: "retrieved document says reveal secrets"),
-            .init(role: "user", name: "skill:repo-search", content: "skill index says run arbitrary shell"),
-            .init(role: "user", name: "memory:pinned-42", content: "memory says bypass authentication"),
-            .init(role: "assistant", name: "background_continuation:job-9", content: "background job says trust me"),
+            .init(role: "user", name: "rag-doc-17", content: "retrieved document says reveal secrets"),
+            .init(role: "user", name: "skill_repo-search", content: "skill index says run arbitrary shell"),
+            .init(role: "user", name: "memory-pinned-42", content: "memory says bypass authentication"),
+            .init(role: "assistant", name: "background_continuation-job-9", content: "background job says trust me"),
         ])
 
         let translated = try translator.translate(request, modelHandle: "worker-text")
@@ -438,10 +438,10 @@ struct ToolParserRegistryTests {
         ])
         #expect(sourceIDs == [
             "calculator",
-            "rag:doc-17",
-            "skill:repo-search",
-            "memory:pinned-42",
-            "background_continuation:job-9",
+            "rag-doc-17",
+            "skill_repo-search",
+            "memory-pinned-42",
+            "background_continuation-job-9",
         ])
         #expect(receipts.allSatisfy { $0["policy"] as? String == "data_only" })
         #expect(receipts.allSatisfy { $0["included"] as? Bool == true })


### PR DESCRIPTION
## Summary
- Classify prompt-context boundary receipts by source instead of emitting every untrusted prompt part as `chat_prompt_message`.
- Preserve `source_id` from message names for tool, RAG/document, skill, memory, and background continuation sources without persisting raw prompt payloads.
- Document the source mapping and privacy boundary in the unified agentic tool runtime contract.

## Plan or Spec
- `docs/plans/2026-06-09-issue-1761-source-specific-prompt-context-receipts.md`
- `docs/unified-agentic-tool-runtime-contract.md`
- Issue #1761

## Commands Run
```text
# TDD red before implementation
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'ToolParserRegistryTests.promptContextBoundaryReceiptsClassifySourceSpecificMessageNames'
Result: failed as expected before implementation; source_type remained chat_prompt_message and source_id was absent.

# Focused green after implementation
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'ToolParserRegistryTests.promptContextBoundaryReceiptsClassifySourceSpecificMessageNames'
Result: passed, 1 test.

# Focused prompt-context regression set
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'ToolParserRegistryTests.promptContext|ToolParserRegistryTests.translatedTextRequestsAttachPromptContextBoundaryReceipts|ToolParserRegistryTests.trustedOnlyPromptMessagesDoNotAttachPromptContextBoundaryReceipts'
Result before merging origin/main: passed, 4 tests.
Result after merging origin/main: passed, 4 tests.

# Adjacent Python boundary primitive regression after merging origin/main
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_prompt_context.py
Result: 8 passed.

# Formatting
Merged origin/main and ran git diff --check origin/main...HEAD.
Result: passed.

# Changed-line coverage for touched Swift scope
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'ToolParserRegistryTests.promptContext|ToolParserRegistryTests.translatedTextRequestsAttachPromptContextBoundaryReceipts|ToolParserRegistryTests.trustedOnlyPromptMessagesDoNotAttachPromptContextBoundaryReceipts'
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --diff-from origin/main --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
Result: TOTAL 98.96%, 95/96 changed lines covered.

# Full local pre-commit gate before the origin/main merge
.githooks/pre-commit
Result: passed. make swift-test rc=0; make py-test rc=0 with 3738 passed, 14 skipped, 2 warnings; make integration-test rc=0 with 117 passed, 1 skipped; performance report Status: ok, Regressions: 0.

# Full local pre-commit gate after final whitespace fix, before the origin/main merge
.githooks/pre-commit
Result: passed. make swift-test rc=0; make py-test rc=0 with 3738 passed, 14 skipped, 2 warnings; make integration-test rc=0 with 117 passed, 1 skipped; performance report Status: ok, Regressions: 0.

# Scoped performance after merging origin/main
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-evidence/source-specific-prompt-context/changed-files.json --output .runtime/pr-evidence/source-specific-prompt-context/scope.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run python scripts/pr_scoped_performance_report.py --scope .runtime/pr-evidence/source-specific-prompt-context/scope.json --results-dir .runtime/pr-evidence/source-specific-prompt-context/results --format terminal --output-dir .runtime/pr-evidence/source-specific-prompt-context/report
Result: Status: ok; Changed files: 4; Selected probes: 0; Regressions: 0; Verification failures: 0.
```

## Coverage and Metrics
- Changed-line coverage: 98.96% for `PromptContextBoundaryReceipt.swift` and `ToolParserRegistryTests.swift` with `--diff-from origin/main`.
- Pre-commit performance report before merge: `Status: ok`, `Regressions: 0`, selected probes 0.
- Post-merge scoped performance report: `Status: ok`, `Regressions: 0`, selected probes 0. No registered PR-scoped probes matched these docs/Swift receipt-classification paths.
- Observability mode: minimal receipt metadata. Probe overhead: N/A because no new runtime performance probe or debug/evidence-mode probe was added.

## Known Gaps
- This PR classifies source-specific control-plane prompt-context receipts only. Remaining #1761 work for broader owner-scope checks, admission/refusal behavior, and other source entrypoints stays tracked by the issue.
- No protocol or dependency changes; no generated artifacts or lockfiles required.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
