### PR TITLE
Route agentic judge prompt context receipts through admission

### DIFF
--- a/docs/plans/2026-06-09-issue-1761-agentic-judge-prompt-context-admission.md
+++ b/docs/plans/2026-06-09-issue-1761-agentic-judge-prompt-context-admission.md
@@ -1,0 +1,85 @@
+# Issue 1761 Agentic Judge Prompt Context Admission Plan
+
+## Goal
+
+Wire the agentic judge prompt snapshot boundary through the shared Python worker
+prompt-context admission primitive without changing persisted prompt text,
+receipt shape, or judge scoring behavior.
+
+## Scope
+
+This slice covers the Python worker agentic judge prompt snapshot entrypoint in
+`worker.engine.evaluation_core`.
+
+It will:
+
+- build admitted prompt-context receipts through
+  `worker.runtime.prompt_context.admit_prompt_context_segments`;
+- build validator refusal receipts through
+  `worker.runtime.prompt_context.refused_prompt_context_receipt`;
+- keep `agentic-judge-prompt-snapshots.jsonl` message content unchanged;
+- keep the `melix.untrusted_context_receipt.v1` receipt JSON shape unchanged;
+- keep raw user payload values out of receipts.
+
+This slice does not wire live chat, RAG stores, skill entrypoints, memory
+entrypoints, background continuations, or additional owner-scope gates.
+
+## Best End-State Architecture
+
+All prompt assemblers should make one explicit admission decision per untrusted
+segment before projecting it into a model-visible user-role payload. The shared
+prompt-context primitive is the small Python worker abstraction for those
+decisions: callers provide source metadata and segment values, and the primitive
+returns both the user payload and matching data-only receipts or a typed refusal
+receipt for rejected segments.
+
+The agentic judge path is the current concrete prompt snapshot entrypoint with
+stable fixture coverage. Wiring it through the primitive makes the existing
+admission contract executable before broader RAG, skill, memory, and
+background-continuation surfaces adopt the same boundary.
+
+## Performance Probes And Metrics
+
+The changed path is a deterministic Python loop over the existing agentic judge
+user payload fields. Runtime cost remains linear in the number of prompt
+segments and no additional model inference or tool execution is introduced.
+
+Verification must include:
+
+- focused pytest for prompt-context primitive and agentic judge prompt snapshot
+  receipts;
+- changed-line coverage for the touched Python scope with at least 95 percent
+  changed-line coverage;
+- the new helper-level prompt-context tests live in a focused test file so the
+  registered evaluation PR-scoped probes keep measuring the production
+  `evaluation_core.py` lines they exercise directly;
+- full local pre-commit gate on this host;
+- PR-scoped performance report with `Status: ok` and zero regressions.
+
+## Implementation Steps
+
+1. Add a focused failing test that monkeypatches the shared prompt-context
+   admission function and proves agentic judge prompt receipts are generated
+   through it.
+2. Add a focused failing test that monkeypatches the shared refusal helper and
+   proves agentic judge validation refusal receipts are generated through it.
+3. Update `evaluation_core.py` imports to consume `PromptContextSegment`,
+   `admit_prompt_context_segments`, and `refused_prompt_context_receipt`.
+4. Replace the direct admitted receipt helper with segment construction plus
+   `admit_prompt_context_segments`.
+5. Replace the direct refusal receipt helper with
+   `refused_prompt_context_receipt`.
+6. Keep the helper-level admission and refusal tests in a focused prompt-context
+   test file separate from the broad evaluation-core probe tests.
+7. Run the focused red/green tests, changed-line coverage, full gate, and
+   scoped performance report before committing.
+
+## Success Criteria
+
+- Agentic judge admitted receipts are produced through
+  `admit_prompt_context_segments`.
+- Agentic judge refusal receipts are produced through
+  `refused_prompt_context_receipt`.
+- Existing snapshot messages, receipt keys, refusal reasons, and no-leak
+  validation behavior remain unchanged.
+- Receipt evidence still omits raw prompt payload values.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -329,6 +329,12 @@ wording. Later RAG, skill, memory, chat prompt-assembly, and background
 continuation slices should use this primitive when they decide which untrusted
 segments are admitted into user-role prompt context.
 
+The agentic judge prompt snapshot entrypoint must build its admitted receipts
+through `admit_prompt_context_segments` and its validator refusal receipts
+through `refused_prompt_context_receipt`. This keeps the concrete prompt
+snapshot path aligned with the shared admission primitive while preserving the
+stable receipt JSON and persisted prompt payload.
+
 Rejected prompt-context segments should use the same receipt schema with
 `included = false`. For the agentic judge prompt boundary, unsupported
 top-level user-payload fields emit `reason =

--- a/services/mlx-worker-python/tests/test_evaluation_prompt_context.py
+++ b/services/mlx-worker-python/tests/test_evaluation_prompt_context.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+
+from worker.engine.evaluation_core import EvaluationCore
+
+
+def test_agentic_judge_prompt_receipts_use_shared_prompt_context_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[object]] = []
+
+    class Admission:
+        user_payload = {"question": "Q", "tool_observations": []}
+        untrusted_context_receipts = [
+            {
+                "schema_version": "melix.untrusted_context_receipt.v1",
+                "segment_id": "sample-1:question",
+                "source_type": "agentic_judge_user_payload",
+                "source_field": "question",
+                "message_role": "user",
+                "trust_level": "untrusted",
+                "policy": "data_only",
+                "boundary_checked": True,
+                "included": True,
+                "owner_scope_checked": False,
+                "reason": "sample-derived context is prompt data, not instructions",
+                "corrective_action": "Keep this segment in the user payload and do not project it into system or developer instructions.",
+            }
+        ]
+
+    def fake_admit(segments: list[object]) -> Admission:
+        calls.append(segments)
+        return Admission()
+
+    monkeypatch.setattr(
+        "worker.engine.evaluation_core.admit_prompt_context_segments",
+        fake_admit,
+    )
+
+    receipts = EvaluationCore._agentic_judge_untrusted_context_receipts(
+        sample_id="sample-1",
+        user_payload={"question": "Q", "tool_observations": []},
+    )
+
+    assert receipts == Admission.untrusted_context_receipts
+    assert len(calls) == 1
+    segments = calls[0]
+    assert [segment.segment_id for segment in segments] == [
+        "sample-1:question",
+        "sample-1:tool_observations",
+    ]
+    assert [segment.source_type for segment in segments] == [
+        "agentic_judge_user_payload",
+        "agentic_judge_user_payload",
+    ]
+    assert [segment.source_field for segment in segments] == [
+        "question",
+        "tool_observations",
+    ]
+    assert [segment.value for segment in segments] == ["Q", []]
+
+
+def test_agentic_judge_refusal_receipts_use_shared_prompt_context_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_refusal(**kwargs: object) -> dict[str, object]:
+        calls.append(kwargs)
+        return {"receipt": "from-shared-helper"}
+
+    monkeypatch.setattr(
+        "worker.engine.evaluation_core.refused_prompt_context_receipt",
+        fake_refusal,
+    )
+
+    receipt = EvaluationCore._agentic_judge_refusal_receipt(
+        source_field="hidden_gold",
+        reason="unsupported_user_payload_field",
+    )
+
+    assert receipt == {"receipt": "from-shared-helper"}
+    assert calls == [
+        {
+            "segment_id": "agentic_judge_user_payload:hidden_gold",
+            "source_type": "agentic_judge_user_payload",
+            "source_field": "hidden_gold",
+            "reason": "unsupported_user_payload_field",
+            "corrective_action": "Remove this field before projecting the sample-derived context into the judge user payload.",
+        }
+    ]

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -84,7 +84,11 @@ from worker.productization.evaluation_schemas import (
 from worker.productization.evaluation_store import EvaluationStore
 from worker.productization.probe_policy import ProbePolicy
 from worker.runtime.agentic_tools import execute_agentic_tool_calls
-from worker.runtime.untrusted_context import untrusted_context_receipt
+from worker.runtime.prompt_context import (
+    PromptContextSegment,
+    admit_prompt_context_segments,
+    refused_prompt_context_receipt,
+)
 
 
 _SUITE_SCORE_MODES = {
@@ -2488,31 +2492,23 @@ class EvaluationCore:
         sample_id: str,
         user_payload: dict[str, object],
     ) -> list[dict[str, object]]:
-        return [
-            EvaluationCore._agentic_judge_untrusted_context_receipt(
-                sample_id=sample_id,
-                source_field=source_field,
-            )
-            for source_field in user_payload
-        ]
-
-    @staticmethod
-    def _agentic_judge_untrusted_context_receipt(
-        *,
-        sample_id: str,
-        source_field: str,
-    ) -> dict[str, object]:
-        return untrusted_context_receipt(
-            segment_id=f"{sample_id}:{source_field}",
-            source_type="agentic_judge_user_payload",
-            source_field=source_field,
-            included=True,
-            reason="sample-derived context is prompt data, not instructions",
-            corrective_action=(
-                "Keep this segment in the user payload and do not project it into "
-                "system or developer instructions."
-            ),
+        admission = admit_prompt_context_segments(
+            [
+                PromptContextSegment(
+                    segment_id=f"{sample_id}:{source_field}",
+                    source_type="agentic_judge_user_payload",
+                    source_field=source_field,
+                    value=value,
+                    reason="sample-derived context is prompt data, not instructions",
+                    corrective_action=(
+                        "Keep this segment in the user payload and do not project it into "
+                        "system or developer instructions."
+                    ),
+                )
+                for source_field, value in user_payload.items()
+            ]
         )
+        return admission.untrusted_context_receipts
 
     @staticmethod
     def _agentic_judge_refusal_receipt(
@@ -2520,11 +2516,10 @@ class EvaluationCore:
         source_field: str,
         reason: str,
     ) -> dict[str, object]:
-        return untrusted_context_receipt(
+        return refused_prompt_context_receipt(
             segment_id=f"agentic_judge_user_payload:{source_field}",
             source_type="agentic_judge_user_payload",
             source_field=source_field,
-            included=False,
             reason=reason,
             corrective_action=(
                 "Remove this field before projecting the sample-derived context "


### PR DESCRIPTION
## Summary
- Route the agentic judge prompt snapshot context receipt path through the shared Python prompt-context admission primitive.
- Add focused tests that prove admitted and refused agentic judge user-payload context uses the shared helper boundary.
- Document this issue #1761 slice in the active plan and unified agentic runtime contract.

## Plan or Spec
- `docs/plans/2026-06-09-issue-1761-agentic-judge-prompt-context-admission.md`
- `docs/unified-agentic-tool-runtime-contract.md`
- GitHub issue: #1761

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_evaluation_prompt_context.py services/mlx-worker-python/tests/test_evaluation_core.py -k 'agentic_judge_prompt or no_leak_validator or prompt_context' services/mlx-worker-python/tests/test_prompt_context.py
Outcome: passed after implementation; 20 passed, 100 deselected.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage erase && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --include='services/mlx-worker-python/worker/engine/evaluation_core.py,services/mlx-worker-python/tests/test_evaluation_prompt_context.py' -m pytest -q services/mlx-worker-python/tests/test_evaluation_prompt_context.py services/mlx-worker-python/tests/test_evaluation_core.py -k 'agentic_judge_prompt or no_leak_validator or prompt_context' services/mlx-worker-python/tests/test_prompt_context.py && mkdir -p .runtime/coverage && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o .runtime/coverage/issue-1761-prompt-context-admission-split-tests.json && python3.11 scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/issue-1761-prompt-context-admission-split-tests.json --diff-from origin/main services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_prompt_context.py
Outcome: passed; changed-line coverage 100.00% (33/33).

git commit -m "feat: route judge prompt context receipts through admission"
Outcome: passed repository pre-commit gate:
- make swift-test: passed.
- make py-test: passed; 3748 passed, 14 skipped, 2 warnings.
- make integration-test: passed; 117 passed, 1 skipped.
- PR scoped performance report: Status ok; Regressions 0; Context regressions 0; Verification failures 0.
```

## Coverage and Metrics
- Changed-line coverage: 100.00% (33/33) for `services/mlx-worker-python/worker/engine/evaluation_core.py` and `services/mlx-worker-python/tests/test_evaluation_prompt_context.py`.
- Pre-commit performance report: `.runtime/pre-commit-performance/20260609-111826-6f88b65f/report/report.md`
- Report summary: Status `ok`; changed files `4`; selected probes `5`; direct/gated probes `5`; regressions `0`; context regressions `0`; verification failures `0`.
- Probe coverage: all selected probes passed targeted tests with 100.0% changed-line coverage.
- Observability mode: evidence, via existing PR-scoped performance probes for the evaluation path.
- Probe overhead: neutral or improved across selected probes; no blocking regression reported.

## Known Gaps
- This PR covers the agentic judge prompt snapshot entrypoint only.
- Remaining issue #1761 surfaces, including broader RAG retrieval, skill, memory, chat, background, and owner-scope context admission, stay deferred to later slices.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
