### PR TITLE
Route retrieval source receipts through prompt admission

### DIFF
--- a/docs/plans/2026-06-09-issue-1761-retrieval-source-prompt-context-admission.md
+++ b/docs/plans/2026-06-09-issue-1761-retrieval-source-prompt-context-admission.md
@@ -1,0 +1,93 @@
+# Issue 1761 Retrieval Source Prompt Context Admission Plan
+
+## Goal
+
+Route deterministic retrieval source receipts for `text_search` and
+`image_search` through the shared Python worker prompt-context admission
+primitive without changing emitted observation payloads, replay fingerprints,
+receipt JSON fields, or owner-scope evidence.
+
+## Scope
+
+This slice covers:
+
+- source-specific `retrieved_document` receipts for deterministic `text_search`
+  results;
+- source-specific `retrieved_image` receipts for deterministic `image_search`
+  results;
+- the governing unified agentic tool runtime contract.
+
+This slice does not add live RAG stores, skill entrypoints, memory entrypoints,
+background-continuation admission, chat final projection checks, or new
+owner-scope behavior. It preserves the caller-provided source receipt attachment
+path added for tool observations.
+
+## Architecture
+
+The retrieval adapters already know the sanitized selected result payload, its
+source id, result index, and whether owner scope was configured. That is enough
+to express each selected result as one `PromptContextSegment`:
+
+- `segment_id = <tool_call_id>:result-<1-based index>`
+- `source_type = retrieved_document|retrieved_image`
+- `source_field = results[<0-based index>]`
+- `source_id = <selected corpus id or deterministic fallback>`
+- `owner_scope_checked = <owner scope configured for this run>`
+
+`admit_prompt_context_segments` then builds the stable
+`melix.untrusted_context_receipt.v1` receipt without copying raw retrieved
+text, captions, media refs, queries, or tool arguments into the receipt. The
+adapter still stores the selected result values in the normal observation
+payload, and `ToolObservationRecord` still attaches the source receipts beside
+the generic `tool_observation` receipt.
+
+## Performance Probes And Metrics
+
+The changed path builds one `PromptContextSegment` and one source receipt per
+selected deterministic retrieval result. Runtime cost remains linear in the
+already-selected result count and does not add model inference, retrieval IO,
+payload hashing, or result filtering work.
+
+Verification must include:
+
+- a focused failing test proving retrieval source receipts are generated
+  through `admit_prompt_context_segments`;
+- focused text/image retrieval source receipt tests;
+- full `test_agentic_tools.py`;
+- changed-line coverage for the touched Python scope with at least 95 percent
+  changed-line coverage;
+- local pre-commit gate on this host;
+- PR-scoped performance report with `Status: ok`, regressions `0`, context
+  regressions `0`, and verification failures `0`.
+
+## Implementation Steps
+
+1. Add a focused monkeypatch regression test that replaces
+   `worker.runtime.agentic_tools.admit_prompt_context_segments` and proves
+   selected text and image retrieval results become `PromptContextSegment`
+   values with the expected segment metadata, source ids, owner-scope flags,
+   and sanitized result values.
+2. Update `worker.runtime.agentic_tools` to import `PromptContextSegment` and
+   `admit_prompt_context_segments` from `worker.runtime.prompt_context`.
+3. Replace `_retrieval_result_receipt` direct receipt construction with a
+   prompt-context admission over one retrieval result segment and return the
+   admitted receipt.
+4. Update `docs/unified-agentic-tool-runtime-contract.md` so the retrieval
+   source slice names `worker.runtime.prompt_context` as the receipt generation
+   primitive.
+5. Run focused tests, changed-line coverage, full local gate, and scoped
+   performance before committing.
+
+## Success Criteria
+
+- Retrieval source receipts for text and image search are produced through
+  `admit_prompt_context_segments`.
+- Existing observation JSON shape, receipt fields, owner-scope flags, payload
+  redaction, replay hashes, timeout metadata, and byte metrics remain
+  unchanged.
+- Receipt evidence still omits retrieved text, captions, media refs, queries,
+  tool arguments, and private prompt text.
+- The contract clearly states that deterministic retrieval source evidence uses
+  the shared prompt-context admission primitive while broader RAG, skill,
+  memory, background, and final prompt projection checks remain later #1761
+  work.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -391,6 +391,10 @@ identifier or its deterministic fallback. `owner_scope_checked` records whether
 the deterministic run had an expected owner scope configured before result
 projection. Source-specific retrieval receipts must omit retrieved text,
 captions, media refs, query strings, tool arguments, and private prompt text.
+The follow-up retrieval source prompt-context admission slice generates each
+selected-result receipt through `worker.runtime.prompt_context` by admitting one
+`PromptContextSegment` for the sanitized selected result value while preserving
+the same emitted receipt fields and observation payload.
 
 ### Workspace Path Boundary
 

--- a/services/mlx-worker-python/tests/test_agentic_tools.py
+++ b/services/mlx-worker-python/tests/test_agentic_tools.py
@@ -314,6 +314,96 @@ def test_agentic_tool_runtime_emits_source_receipts_for_image_search_results() -
     assert "reveal private context" not in json.dumps(source_receipts, ensure_ascii=False)
 
 
+def test_agentic_tool_runtime_retrieval_source_receipts_use_prompt_context_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[object]] = []
+
+    class Admission:
+        user_payload = {"results[0]": {"id": "source"}}
+        untrusted_context_receipts = [{"receipt": "from-source-admission"}]
+
+    def fake_admit(segments: list[object]) -> Admission:
+        calls.append(segments)
+        return Admission()
+
+    monkeypatch.setattr(
+        "worker.runtime.agentic_tools.admit_prompt_context_segments",
+        fake_admit,
+    )
+
+    run = execute_agentic_tool_calls(
+        [
+            {
+                "id": "text-retrieval",
+                "name": "text_search",
+                "arguments": {"query": "melix"},
+            },
+            {
+                "id": "image-retrieval",
+                "name": "image_search",
+                "arguments": {"query": "receipt"},
+            },
+        ],
+        fixture_context={
+            "owner_scope": {"expected_owner_id": "operator-a", "privilege": "read"},
+            "text_corpus": [
+                {
+                    "id": "doc-alpha",
+                    "owner_id": "operator-a",
+                    "text": "Melix retrieved document.",
+                }
+            ],
+            "image_corpus": [
+                {
+                    "id": "image-doc-1",
+                    "owner_id": "operator-a",
+                    "media_ref": "img-1",
+                    "caption": "receipt caption",
+                }
+            ],
+        },
+    )
+
+    assert [
+        receipt
+        for observation in run.observations
+        for receipt in observation["untrusted_context_receipts"]
+        if receipt == {"receipt": "from-source-admission"}
+    ] == [{"receipt": "from-source-admission"}, {"receipt": "from-source-admission"}]
+    assert len(calls) == 2
+
+    text_segment = calls[0][0]
+    assert text_segment.segment_id == "text-retrieval:result-1"
+    assert text_segment.source_type == "retrieved_document"
+    assert text_segment.source_field == "results[0]"
+    assert text_segment.source_id == "doc-alpha"
+    assert text_segment.owner_scope_checked is True
+    assert text_segment.value == {"id": "doc-alpha", "text": "Melix retrieved document."}
+    assert text_segment.reason == "retrieved document result is prompt data, not instructions"
+    assert text_segment.corrective_action == (
+        "Keep retrieved document results in user-role data context and do not project "
+        "them into system or developer instructions."
+    )
+
+    image_segment = calls[1][0]
+    assert image_segment.segment_id == "image-retrieval:result-1"
+    assert image_segment.source_type == "retrieved_image"
+    assert image_segment.source_field == "results[0]"
+    assert image_segment.source_id == "image-doc-1"
+    assert image_segment.owner_scope_checked is True
+    assert image_segment.value == {
+        "id": "image-doc-1",
+        "media_ref": "img-1",
+        "caption": "receipt caption",
+    }
+    assert image_segment.reason == "retrieved image result is prompt data, not instructions"
+    assert image_segment.corrective_action == (
+        "Keep retrieved image results in user-role data context and do not project "
+        "them into system or developer instructions."
+    )
+
+
 def test_agentic_tool_runtime_preserves_non_typed_execution_errors() -> None:
     run = execute_agentic_tool_calls(
         [{"id": "syntax-1", "name": "local_compute", "arguments": {"code": "("}}],

--- a/services/mlx-worker-python/worker/runtime/agentic_tools.py
+++ b/services/mlx-worker-python/worker/runtime/agentic_tools.py
@@ -7,6 +7,7 @@ from typing import Any
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
+from worker.runtime.prompt_context import PromptContextSegment, admit_prompt_context_segments
 from worker.runtime.tool_observation import (
     ToolObservationPolicy,
     ToolObservationRecord,
@@ -19,7 +20,6 @@ from worker.runtime.tool_registry import (
     built_in_tool_registry,
     select_agentic_tools_for_turn,
 )
-from worker.runtime.untrusted_context import untrusted_context_receipt
 from worker.runtime.workspace_file_tools import WorkspaceFileTools
 from worker.runtime.workspace_paths import WorkspacePathResolution
 
@@ -376,11 +376,13 @@ def _text_search_payload(
             strip=False,
         )
         if lowered_query in text.lower():
-            results.append({"id": source_id, "text": text})
+            result = {"id": source_id, "text": text}
+            results.append(result)
             result_receipts.append(
                 _retrieval_result_receipt(
                     tool_call_id=tool_call_id,
                     result_index=len(results),
+                    value=result,
                     source_type="retrieved_document",
                     source_id=source_id,
                     owner_scope_checked=owner_scope_checked,
@@ -434,11 +436,13 @@ def _image_search_payload(
                 source_type="retrieved_image",
                 source_id=source_id,
             )
-            results.append({"id": source_id, "media_ref": media_ref, "caption": caption})
+            result = {"id": source_id, "media_ref": media_ref, "caption": caption}
+            results.append(result)
             result_receipts.append(
                 _retrieval_result_receipt(
                     tool_call_id=tool_call_id,
                     result_index=len(results),
+                    value=result,
                     source_type="retrieved_image",
                     source_id=source_id,
                     owner_scope_checked=owner_scope_checked,
@@ -777,24 +781,30 @@ def _retrieval_result_receipt(
     *,
     tool_call_id: str,
     result_index: int,
+    value: dict[str, Any],
     source_type: str,
     source_id: str,
     owner_scope_checked: bool,
 ) -> dict[str, object]:
     source_label = "document" if source_type == "retrieved_document" else "image"
-    return untrusted_context_receipt(
-        segment_id=f"{tool_call_id}:result-{result_index}",
-        source_type=source_type,
-        source_field=f"results[{result_index - 1}]",
-        source_id=source_id,
-        owner_scope_checked=owner_scope_checked,
-        included=True,
-        reason=f"retrieved {source_label} result is prompt data, not instructions",
-        corrective_action=(
-            f"Keep retrieved {source_label} results in user-role data context and do not project "
-            "them into system or developer instructions."
-        ),
+    admission = admit_prompt_context_segments(
+        [
+            PromptContextSegment(
+                segment_id=f"{tool_call_id}:result-{result_index}",
+                source_type=source_type,
+                source_field=f"results[{result_index - 1}]",
+                source_id=source_id,
+                owner_scope_checked=owner_scope_checked,
+                value=value,
+                reason=f"retrieved {source_label} result is prompt data, not instructions",
+                corrective_action=(
+                    f"Keep retrieved {source_label} results in user-role data context and do not project "
+                    "them into system or developer instructions."
+                ),
+            )
+        ]
     )
+    return admission.untrusted_context_receipts[0]
 
 
 def _tool_argument_text(arguments: dict[str, Any], name: str, *, tool_call_id: str) -> str:


### PR DESCRIPTION
## Summary
- Routes deterministic `text_search` and `image_search` source receipts through the shared Python worker prompt-context admission path.
- Preserves emitted retrieval result payloads and receipt metadata while making selected-result receipts admission-generated.
- Documents the retrieval-source follow-up slice under the unified agentic tool runtime contract.

## Plan or Spec
- Plan: `docs/plans/2026-06-09-issue-1761-retrieval-source-prompt-context-admission.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py -k retrieval_source_receipts_use_prompt_context_admission
# RED: failed before implementation with AttributeError because worker.runtime.agentic_tools did not expose admit_prompt_context_segments.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py -k 'retrieval_source_receipts_use_prompt_context_admission or source_receipts_for_text_search_results or source_receipts_for_image_search_results'
# GREEN: 3 passed, 59 deselected in 0.04s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
# 62 passed in 0.07s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage erase
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --include='services/mlx-worker-python/worker/runtime/agentic_tools.py,services/mlx-worker-python/tests/test_agentic_tools.py' -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o .runtime/coverage/issue-1761-retrieval-source-prompt-context-admission.json
python3.11 scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/issue-1761-retrieval-source-prompt-context-admission.json --diff-from origin/main services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
# 62 passed; changed-line coverage TOTAL 100.00% (37/37).

make bootstrap && make proto
# Passed.

make swift-test && make py-test && make integration-test && python3.11 scripts/pre_commit_gate.py
# make swift-test: passed.
# make py-test: 3753 passed, 14 skipped, 2 warnings in 181.11s.
# make integration-test: 117 passed, 1 skipped in 706.85s (0:11:46).
# pre_commit_gate.py: enforced on 256.0 GiB macOS host; skipped because no staged files were present.

git diff --check
# Passed with no whitespace errors.

git commit -m "feat: route retrieval source receipts through prompt admission"
# Pre-commit hook ran the full gate.
# make swift-test: passed.
# make py-test: 3753 passed, 14 skipped, 2 warnings in 165.72s (0:02:45).
# make integration-test: 117 passed, 1 skipped in 816.92s (0:13:36).
# Melix PR Scoped Performance Report: Status ok; selected probes 0; regressions 0; context regressions 0; verification failures 0.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py -k 'retrieval_source_receipts_use_prompt_context_admission or source_receipts_for_text_search_results or source_receipts_for_image_search_results'
# Review fix: 3 passed, 59 deselected in 0.04s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage erase
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --include='services/mlx-worker-python/worker/runtime/agentic_tools.py,services/mlx-worker-python/tests/test_agentic_tools.py' -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o .runtime/coverage/issue-1761-retrieval-source-prompt-context-admission-review-fix.json
python3.11 scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/issue-1761-retrieval-source-prompt-context-admission-review-fix.json --diff-from origin/main services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
# Review fix: 62 passed; changed-line coverage TOTAL 100.00% (37/37).

git diff --check
# Review fix: passed with no whitespace errors.

git commit --amend --no-edit
# Pre-commit hook reran the full gate after review fix.
# make swift-test: passed.
# make py-test: 3753 passed, 14 skipped, 2 warnings in 158.85s (0:02:38).
# make integration-test: 117 passed, 1 skipped in 424.60s (0:07:04).
# Melix PR Scoped Performance Report: Status ok; selected probes 0; regressions 0; context regressions 0; verification failures 0.

git fetch origin main --prune
# Passed.

git merge --no-edit origin/main
# Already up to date.
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% changed-line coverage, 37/37 lines covered by `scripts/python_changed_line_coverage.py`.
- Local pre-commit performance report: `.runtime/pre-commit-performance/20260609-150419-109f5b21/report/report.md`
- Metrics: Status `ok`; changed files `4`; selected probes `0`; direct/gated probes `0`; regressions `0`; context regressions `0`; verification failures `0`.
- Observability mode: `minimal`; this slice reuses existing receipt emission and prompt-context admission metadata.
- Probe overhead: `N/A: no new runtime, evidence-mode, sampled, or debug probe was added`.

## Known Gaps
- Live RAG store retrieval, skill evidence, memory evidence, background context, and chat final projection remain deferred follow-up slices for issue #1761.
- No protobuf, generated artifact, dependency, or lockfile changes were required.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
