### PR TITLE
Classify assistant prompt projections

### DIFF
--- a/docs/plans/2026-06-09-issue-1761-chat-final-projection-receipts.md
+++ b/docs/plans/2026-06-09-issue-1761-chat-final-projection-receipts.md
@@ -1,0 +1,46 @@
+# Chat Final Projection Prompt Context Receipts
+
+## Goal
+
+Continue issue #1761 by classifying assistant/model final-answer content as its
+own untrusted prompt-context source when prior model output is projected back
+into a later worker request.
+
+## Scope
+
+This slice updates the Swift `PromptContextBoundaryReceipts` metadata path used
+by `ChatRequestTranslator`. It does not alter prompt message content, message
+roles, cache scope, worker protobuf fields, or persisted conversation payloads.
+
+In scope:
+
+- classify non-tool assistant message parts as `source_type =
+  model_final_answer`
+- preserve existing `tool` role classification as `tool_output`
+- keep raw assistant text, tool output, media URIs, media bytes, and private
+  prompt text out of receipt JSON
+- document the new source-specific receipt class in the unified runtime
+  contract
+
+Out of scope:
+
+- changing chat-template rendering or assistant transcript persistence
+- adding owner-scope checks for background continuations, skills, memories, or
+  live RAG stores
+- adding protobuf fields for prompt receipts
+
+## Performance Probes
+
+The changed path is a constant-time branch in the existing linear prompt
+receipt pass over shaped messages. The local and remote PR-scoped performance
+reports remain the regression gate.
+
+## Verification
+
+1. Focused Swift test for `PromptContextBoundaryReceipts` source
+   classification.
+2. Changed-scope Swift coverage for the touched source and test scope, at least
+   95 percent.
+3. Full local pre-commit gate before commit on the macOS host.
+4. Remote PR checks and PR-scoped performance report with status `ok` and zero
+   regressions before merge.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -280,8 +280,11 @@ record `source_type = retrieved_document`; `skill` and `agent_skill` record
 `source_type = skill`; `memory`, `retrieved_memory`, and `pinned_memory` record
 `source_type = memory`; `background_continuation`,
 `background-continuation`, `background_job`, and `background-job` record
-`source_type = background_continuation`. Other non-system/developer messages
-continue to record `source_type = chat_prompt_message`.
+`source_type = background_continuation`. Non-tool assistant messages record
+`source_type = model_final_answer` because prior model output remains
+untrusted data when it is projected back into a later prompt. Other
+non-system/developer messages continue to record `source_type =
+chat_prompt_message`.
 
 A reserved prefix matches either the exact normalized message name or the prefix
 followed by `:`, `.`, `_`, or `-`. The `_` and `-` separators preserve
@@ -388,6 +391,9 @@ replace source-specific owner checks or final projection checks. Skill, memory,
 RAG, chat prompt assembly, and background-job continuation surfaces must still
 add their own admission or refusal receipts when they decide whether to
 include, reject, or re-scope a tool observation in a final prompt.
+The `model_final_answer` classification records the projection boundary for
+prior assistant output only; it does not mark generated text as trusted
+instructions and does not change assistant transcript storage.
 
 The v1 deterministic retrieval source slice lets callers attach
 source-specific untrusted-context receipts beside the generic tool-observation

--- a/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
@@ -62,24 +62,26 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
             return "tool_output"
         }
 
-        guard let name = message.name else {
-            return "chat_prompt_message"
+        if let name = message.name {
+            let normalizedName = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if hasAnyPrefix(
+                normalizedName,
+                ["retrieved_document", "retrieved-doc", "document", "doc", "rag", "rag_document", "knowledge"]
+            ) {
+                return "retrieved_document"
+            }
+            if hasAnyPrefix(normalizedName, ["skill", "agent_skill"]) {
+                return "skill"
+            }
+            if hasAnyPrefix(normalizedName, ["memory", "retrieved_memory", "pinned_memory"]) {
+                return "memory"
+            }
+            if hasAnyPrefix(normalizedName, ["background_continuation", "background-continuation", "background_job", "background-job"]) {
+                return "background_continuation"
+            }
         }
-        let normalizedName = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if hasAnyPrefix(
-            normalizedName,
-            ["retrieved_document", "retrieved-doc", "document", "doc", "rag", "rag_document", "knowledge"]
-        ) {
-            return "retrieved_document"
-        }
-        if hasAnyPrefix(normalizedName, ["skill", "agent_skill"]) {
-            return "skill"
-        }
-        if hasAnyPrefix(normalizedName, ["memory", "retrieved_memory", "pinned_memory"]) {
-            return "memory"
-        }
-        if hasAnyPrefix(normalizedName, ["background_continuation", "background-continuation", "background_job", "background-job"]) {
-            return "background_continuation"
+        if normalizedRole == "assistant" {
+            return "model_final_answer"
         }
         return "chat_prompt_message"
     }

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -367,6 +367,7 @@ struct ToolParserRegistryTests {
             try JSONSerialization.jsonObject(with: Data(receiptsJSON.utf8)) as? [[String: Any]]
         )
         let sourceFields = receipts.compactMap { $0["source_field"] as? String }
+        let sourceTypes = receipts.compactMap { $0["source_type"] as? String }
         let segmentIDs = receipts.compactMap { $0["segment_id"] as? String }
         let roles = receipts.compactMap { $0["message_role"] as? String }
 
@@ -382,6 +383,16 @@ struct ToolParserRegistryTests {
             "messages[2].parts[5].video_uri",
             "messages[2].parts[6].video_bytes",
             "messages[3].parts[0].text",
+        ])
+        #expect(sourceTypes == [
+            "chat_prompt_message",
+            "chat_prompt_message",
+            "chat_prompt_message",
+            "chat_prompt_message",
+            "chat_prompt_message",
+            "chat_prompt_message",
+            "chat_prompt_message",
+            "model_final_answer",
         ])
         #expect(segmentIDs == [
             "req-prompt-media:message-2:part-0",
@@ -451,6 +462,34 @@ struct ToolParserRegistryTests {
         #expect(receiptsJSON.contains("arbitrary shell") == false)
         #expect(receiptsJSON.contains("bypass authentication") == false)
         #expect(receiptsJSON.contains("trust me") == false)
+    }
+
+    @Test("prompt context boundary receipts classify assistant history as model final answer")
+    func promptContextBoundaryReceiptsClassifyAssistantHistoryAsModelFinalAnswer() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-prompt-final" })
+        let request = makeNormalizedRequest(messages: [
+            .init(role: "user", content: "Continue from the previous answer."),
+            .init(role: "assistant", name: "previous_answer_7", content: "assistant final text must stay data"),
+        ])
+
+        let translated = try translator.translate(request, modelHandle: "worker-text")
+        let ext = translated.workerRequest.execution.ext
+        let receiptsJSON = try #require(ext["melix.prompt_context.receipts_json"])
+        let receipts = try #require(
+            try JSONSerialization.jsonObject(with: Data(receiptsJSON.utf8)) as? [[String: Any]]
+        )
+        let finalReceipt = try #require(
+            receipts.first { $0["source_field"] as? String == "messages[1].parts[0].text" }
+        )
+
+        #expect(ext["melix.prompt_context.receipt_count"] == "2")
+        #expect(finalReceipt["source_type"] as? String == "model_final_answer")
+        #expect(finalReceipt["source_id"] as? String == "previous_answer_7")
+        #expect(finalReceipt["message_role"] as? String == "assistant")
+        #expect(finalReceipt["included"] as? Bool == true)
+        #expect(finalReceipt["policy"] as? String == "data_only")
+        #expect(receiptsJSON.contains("assistant final text") == false)
+        #expect(receiptsJSON.contains("Continue from the previous answer.") == false)
     }
 
     @Test("request-local compatibility policy receipt overrides do not mutate default requests")


### PR DESCRIPTION
## Summary
- Classify non-tool assistant history projected into later worker prompt context boundary receipts as `model_final_answer`.
- Preserve reserved source names such as `background_continuation_*`, `retrieved_document_*`, `skill_*`, and `memory_*` before applying the assistant fallback.
- Update the unified runtime contract and add focused Swift coverage that proves receipt metadata is emitted without raw assistant/user payloads.

## Plan or Spec
- Plan: `docs/plans/2026-06-09-issue-1761-chat-final-projection-receipts.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`
- Issue: #1761

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'promptContextBoundaryReceiptsCoverMultimodalMessagePartsWithoutRawPayloads'
Outcome: failed before the implementation because assistant history was still classified as chat_prompt_message.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'promptContextBoundaryReceipts(CoverMultimodalMessagePartsWithoutRawPayloads|ClassifySourceSpecificMessageNames)'
Outcome: passed after preserving reserved source-name precedence.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'promptContextBoundaryReceipts(ClassifyAssistantHistoryAsModelFinalAnswer|CoverMultimodalMessagePartsWithoutRawPayloads|ClassifySourceSpecificMessageNames)'
Outcome: passed, 3 tests.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --enable-code-coverage --package-path services/control-plane-swift --filter 'ToolParserRegistryTests' && python3.11 scripts/swift_changed_line_coverage.py --diff-from origin/main --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
Outcome: passed; ToolParserRegistryTests passed, 21 tests.

make bootstrap
Outcome: passed; configured hooks and verified locked Python environment.

make proto
Outcome: passed; no generated artifact drift.

git commit -m "Classify assistant prompt projections"
Outcome: passed with pre-commit hook.
  make swift-test: passed.
  make py-test: passed, 3755 passed, 14 skipped, 2 warnings in 209.91s.
  make integration-test: passed, 117 passed, 1 skipped in 792.25s.
  Melix PR Scoped Performance Report: Status ok, Regressions 0, Context regressions 0, Verification failures 0.
```

## Coverage and Metrics
- Changed-line coverage: `100.00%`, 56/56 executable changed lines.
  - `services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift`: 100.00%, 19/19.
  - `services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift`: 100.00%, 37/37.
- Metrics report: `.runtime/pre-commit-performance/20260609-175319-6c0a26df/report/report.md`
  - Status: `ok`
  - Changed files: 4
  - Selected probes: 0
  - Regressions: 0
  - Context regressions: 0
  - Verification failures: 0
  - No registered performance probes were selected for this change set.
- Observability mode: minimal metadata-only receipts; no raw prompt, assistant answer, or user payload is copied into receipts.
- Probe overhead: N/A because no PR-scoped performance probes were selected and this change only changes source-type metadata classification for existing receipts.

## Known Gaps
- Remaining #1761 work is intentionally deferred to later slices: live RAG store retrieval receipts, skill evidence receipts, memory evidence receipts, background continuation coverage beyond reserved-name classification, and owner-scope/admission/refusal handling.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
