### PR TITLE
Add provider model-list URL receipt classifications

### DIFF
--- a/docs/plans/2026-06-09-issue-1757-model-list-url-receipts.md
+++ b/docs/plans/2026-06-09-issue-1757-model-list-url-receipts.md
@@ -1,0 +1,127 @@
+# Issue 1757 Model-List URL Receipt Slice
+
+## Goal
+
+Extend provider endpoint health receipts with redacted model-list URL
+classification evidence so operators can see which endpoint shape was
+normalized and which provider-specific model-list URL class was probed.
+
+## Scope
+
+This slice covers the watch-note requirement for endpoint model-list URL
+receipts:
+
+- classify input endpoint shape after normalization;
+- classify the provider-specific model-list endpoint used by the probe;
+- expose a stable probe status field beside the existing last-probe status;
+- record whether authentication or URL credentials were redacted from receipt
+  evidence;
+- record whether a provider-specific model-list fallback transform was applied.
+
+This slice does not add persistent last-result storage, UI controls, owner-scope
+credential lookup, pinned model provenance, background-helper resolution, or
+full provider conformance tests.
+
+## Architecture
+
+`ProviderEndpointHealthProbe` already owns provider URL normalization, model-list
+URL construction, request authentication, capability parsing, and failure
+classification. This slice keeps the new evidence in that same receipt path.
+The probe will compute a small `ProviderEndpointURLClassification` value while
+normalizing the operator-provided URL, then carry it into both success and
+failure receipts.
+
+The new receipt fields are metadata only. They must not include API keys, raw
+authorization headers, provider response bodies, or full prompt/session content.
+
+## Receipt Semantics
+
+- `normalized_base_kind`
+  - `base_url`: input was already a base host or non-versioned root.
+  - `versioned_base`: input was a versioned API root such as `/v1`.
+  - `chat_completions_endpoint`: input was a chat completions endpoint.
+  - `messages_endpoint`: input was an Anthropic messages endpoint.
+  - `ollama_chat_endpoint`, `ollama_generate_endpoint`, `ollama_tags_endpoint`:
+    input was an Ollama endpoint.
+  - `models_endpoint`: input was already a model-list endpoint.
+- `models_endpoint_kind`
+  - `openai_models`
+  - `anthropic_models`
+  - `ollama_tags`
+  - `local_runtime_models`
+- `probe_status`
+  - `ok` on successful model-list parsing.
+  - the typed failure reason on failures.
+- `auth_redacted`
+  - `true` when the request has an API key, URL user/password credentials, or a
+    query string/fragment that was stripped from receipt evidence.
+  - `false` only when no credential-bearing input was present.
+- `fallback_attempted`
+  - `true` when the probe rewrites a supplied endpoint or provider API root into
+    the provider-specific model-list URL.
+  - `false` when the supplied URL already targets the model-list endpoint.
+
+## Performance Probes And Metrics
+
+The changed path runs only when an operator asks for provider endpoint health.
+The added work is constant-time string classification and boolean derivation per
+probe.
+
+Success metrics:
+
+- focused Swift provider endpoint tests pass;
+- changed-line coverage for touched Swift scope is at least 95 percent;
+- local scoped performance report is `Status: ok` with zero regressions;
+- remote PR scoped performance report is `Status: ok` with zero regressions.
+
+## Verification
+
+Focused Swift tests:
+
+```bash
+HOME="$PWD/.swift-home/provider-url-receipts" \
+CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/provider-url-receipts" \
+xcrun swift test --package-path services/control-plane-swift --filter RemoteProviderClientTests
+```
+
+Changed-line coverage:
+
+```bash
+HOME="$PWD/.swift-home/provider-url-receipts-coverage" \
+CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/provider-url-receipts-coverage" \
+xcrun swift test --enable-code-coverage --package-path services/control-plane-swift --filter RemoteProviderClientTests
+
+python3.11 scripts/swift_changed_line_coverage.py \
+  --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests \
+  --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata \
+  --diff-from origin/main \
+  services/control-plane-swift/Sources/XPCService/ProviderEndpointHealthProbe.swift \
+  services/control-plane-swift/Tests/ControlPlaneTests/RemoteProviderClientTests.swift
+```
+
+Full gate:
+
+```bash
+.githooks/pre-commit
+```
+
+## Implementation Steps
+
+1. Add a failing table-driven Swift test for base URL, `/v1`,
+   `/v1/chat/completions`, Ollama `/api/chat`, and already-normalized model-list
+   inputs. Assert model-list request URLs and new receipt fields.
+2. Extend `ProviderEndpointHealthReceipt` with the new Codable fields and stable
+   defaults.
+3. Refactor URL normalization to return the normalized URL plus
+   `normalized_base_kind`, `auth_redacted`, and `fallback_attempted` inputs.
+4. Classify model-list endpoint kind when constructing the provider-specific
+   probe URL.
+5. Update docs and run focused tests, coverage, full local gate, and scoped
+   performance before opening the PR.
+
+## Known Gaps
+
+- The receipt is not yet persisted or rendered in App/CLI diagnostics.
+- Owner-scoped credential lookup and cross-owner refusal receipts remain future
+  #1757 work.
+- Pinned/cached/live model provenance remains future #1757 work.

--- a/services/control-plane-swift/Sources/XPCService/ProviderEndpointHealthProbe.swift
+++ b/services/control-plane-swift/Sources/XPCService/ProviderEndpointHealthProbe.swift
@@ -66,6 +66,11 @@ public struct ProviderEndpointHealthReceipt: Codable, Equatable, Sendable, Custo
     public let endpointID: String
     public let providerKind: String
     public let baseURLRedacted: String
+    public let normalizedBaseKind: String
+    public let modelsEndpointKind: String
+    public let probeStatus: String
+    public let authRedacted: Bool
+    public let fallbackAttempted: Bool
     public let modelCount: Int
     public let capabilities: ProviderEndpointCapabilities
     public let toolSupportMode: ProviderEndpointToolSupportMode
@@ -80,6 +85,11 @@ public struct ProviderEndpointHealthReceipt: Codable, Equatable, Sendable, Custo
         endpointID: String,
         providerKind: String,
         baseURLRedacted: String,
+        normalizedBaseKind: String = "base_url",
+        modelsEndpointKind: String = "openai_models",
+        probeStatus: String = "ok",
+        authRedacted: Bool = false,
+        fallbackAttempted: Bool = false,
         modelCount: Int,
         capabilities: ProviderEndpointCapabilities,
         toolSupportMode: ProviderEndpointToolSupportMode = .auto,
@@ -93,6 +103,11 @@ public struct ProviderEndpointHealthReceipt: Codable, Equatable, Sendable, Custo
         self.endpointID = endpointID
         self.providerKind = providerKind
         self.baseURLRedacted = baseURLRedacted
+        self.normalizedBaseKind = normalizedBaseKind
+        self.modelsEndpointKind = modelsEndpointKind
+        self.probeStatus = probeStatus
+        self.authRedacted = authRedacted
+        self.fallbackAttempted = fallbackAttempted
         self.modelCount = modelCount
         self.capabilities = capabilities
         self.toolSupportMode = toolSupportMode
@@ -108,6 +123,11 @@ public struct ProviderEndpointHealthReceipt: Codable, Equatable, Sendable, Custo
         case endpointID = "endpoint_id"
         case providerKind = "provider_kind"
         case baseURLRedacted = "base_url_redacted"
+        case normalizedBaseKind = "normalized_base_kind"
+        case modelsEndpointKind = "models_endpoint_kind"
+        case probeStatus = "probe_status"
+        case authRedacted = "auth_redacted"
+        case fallbackAttempted = "fallback_attempted"
         case modelCount = "model_count"
         case capabilities
         case toolSupportMode = "tool_support_mode"
@@ -119,7 +139,7 @@ public struct ProviderEndpointHealthReceipt: Codable, Equatable, Sendable, Custo
     }
 
     public var description: String {
-        "ProviderEndpointHealthReceipt(schemaVersion: \(schemaVersion), endpointID: \(endpointID), providerKind: \(providerKind), baseURLRedacted: \(baseURLRedacted), modelCount: \(modelCount), capabilities: \(capabilities), toolSupportMode: \(toolSupportMode.rawValue), detectedToolSupport: \(detectedToolSupport), overrideSource: \(overrideSource), lastProbeStatus: \(lastProbeStatus), latencyMS: \(latencyMS), failureReason: \(failureReason))"
+        "ProviderEndpointHealthReceipt(schemaVersion: \(schemaVersion), endpointID: \(endpointID), providerKind: \(providerKind), baseURLRedacted: \(baseURLRedacted), normalizedBaseKind: \(normalizedBaseKind), modelsEndpointKind: \(modelsEndpointKind), probeStatus: \(probeStatus), authRedacted: \(authRedacted), fallbackAttempted: \(fallbackAttempted), modelCount: \(modelCount), capabilities: \(capabilities), toolSupportMode: \(toolSupportMode.rawValue), detectedToolSupport: \(detectedToolSupport), overrideSource: \(overrideSource), lastProbeStatus: \(lastProbeStatus), latencyMS: \(latencyMS), failureReason: \(failureReason))"
     }
 
     public func jsonObject(encoder: JSONEncoder) throws -> [String: Any] {
@@ -144,16 +164,20 @@ public struct ProviderEndpointHealthProbe: Sendable {
     }
 
     public func probe(_ request: ProviderEndpointProbeRequest) async throws -> ProviderEndpointHealthReceipt {
-        let normalizedBase = try normalizedBaseURL(from: request.baseURL)
+        let trimmedAPIKey = request.apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let urlContext = try normalizedBaseURLContext(from: request.baseURL, apiKey: trimmedAPIKey)
         let providerKind = normalizedProviderKind(request.providerKind)
-        let modelListURL = try modelListURL(baseURL: normalizedBase, providerKind: providerKind)
-        var httpRequest = URLRequest(url: modelListURL)
+        let modelListTarget = try modelListTarget(baseURL: urlContext.normalizedBase, providerKind: providerKind)
+        let fallbackAttempted = fallbackAttempted(
+            normalizedBaseKind: urlContext.normalizedBaseKind,
+            modelsEndpointKind: modelListTarget.endpointKind
+        )
+        var httpRequest = URLRequest(url: modelListTarget.url)
         httpRequest.httpMethod = "GET"
         httpRequest.timeoutInterval = TimeInterval(request.timeoutSeconds == 0 ? 30 : request.timeoutSeconds)
         httpRequest.setValue("application/json", forHTTPHeaderField: "Accept")
         // Keep OpenAI/Python first for providers that key compatibility behavior off SDK user agents.
         httpRequest.setValue("OpenAI/Python 1.0.0 Melix/0.1", forHTTPHeaderField: "User-Agent")
-        let trimmedAPIKey = request.apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         configureAuthenticationHeaders(on: &httpRequest, providerKind: providerKind, apiKey: trimmedAPIKey)
 
         let startedAtMS = latencyClock()
@@ -167,7 +191,9 @@ public struct ProviderEndpointHealthProbe: Sendable {
             return failureReceipt(
                 request: request,
                 providerKind: providerKind,
-                baseURL: normalizedBase,
+                urlContext: urlContext,
+                modelsEndpointKind: modelListTarget.endpointKind,
+                fallbackAttempted: fallbackAttempted,
                 latencyMS: elapsedMilliseconds(since: startedAtMS),
                 reason: "transport_failed"
             )
@@ -176,7 +202,9 @@ public struct ProviderEndpointHealthProbe: Sendable {
             return failureReceipt(
                 request: request,
                 providerKind: providerKind,
-                baseURL: normalizedBase,
+                urlContext: urlContext,
+                modelsEndpointKind: modelListTarget.endpointKind,
+                fallbackAttempted: fallbackAttempted,
                 latencyMS: elapsedMilliseconds(since: startedAtMS),
                 reason: response.statusCode == 401 || response.statusCode == 403 ? "auth_failed" : "model_list_failed"
             )
@@ -188,7 +216,9 @@ public struct ProviderEndpointHealthProbe: Sendable {
             return failureReceipt(
                 request: request,
                 providerKind: providerKind,
-                baseURL: normalizedBase,
+                urlContext: urlContext,
+                modelsEndpointKind: modelListTarget.endpointKind,
+                fallbackAttempted: fallbackAttempted,
                 latencyMS: elapsedMilliseconds(since: startedAtMS),
                 reason: "model_list_malformed"
             )
@@ -196,7 +226,12 @@ public struct ProviderEndpointHealthProbe: Sendable {
         return ProviderEndpointHealthReceipt(
             endpointID: request.endpointID,
             providerKind: providerKind,
-            baseURLRedacted: normalizedBase.absoluteString,
+            baseURLRedacted: urlContext.normalizedBase.absoluteString,
+            normalizedBaseKind: urlContext.normalizedBaseKind,
+            modelsEndpointKind: modelListTarget.endpointKind,
+            probeStatus: "ok",
+            authRedacted: urlContext.authRedacted,
+            fallbackAttempted: fallbackAttempted,
             modelCount: summary.chatModelCount,
             capabilities: effectiveCapabilities(
                 summary.capabilities,
@@ -219,14 +254,21 @@ public struct ProviderEndpointHealthProbe: Sendable {
     private func failureReceipt(
         request: ProviderEndpointProbeRequest,
         providerKind: String,
-        baseURL: URL,
+        urlContext: ProviderEndpointURLContext,
+        modelsEndpointKind: String,
+        fallbackAttempted: Bool,
         latencyMS: UInt32,
         reason: String
     ) -> ProviderEndpointHealthReceipt {
         ProviderEndpointHealthReceipt(
             endpointID: request.endpointID,
             providerKind: providerKind,
-            baseURLRedacted: baseURL.absoluteString,
+            baseURLRedacted: urlContext.normalizedBase.absoluteString,
+            normalizedBaseKind: urlContext.normalizedBaseKind,
+            modelsEndpointKind: modelsEndpointKind,
+            probeStatus: reason,
+            authRedacted: urlContext.authRedacted,
+            fallbackAttempted: fallbackAttempted,
             modelCount: 0,
             capabilities: ProviderEndpointCapabilities(),
             toolSupportMode: request.toolSupportMode,
@@ -269,7 +311,7 @@ public struct ProviderEndpointHealthProbe: Sendable {
         }
     }
 
-    private func normalizedBaseURL(from rawValue: String) throws -> URL {
+    private func normalizedBaseURLContext(from rawValue: String, apiKey: String) throws -> ProviderEndpointURLContext {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.isEmpty == false else {
             throw RemoteProviderError.invalidRequest("provider endpoint base_url is empty")
@@ -283,6 +325,13 @@ public struct ProviderEndpointHealthProbe: Sendable {
             throw RemoteProviderError.invalidRequest("provider endpoint base_url is invalid: \(rawValue)")
         }
 
+        let authRedacted = apiKey.isEmpty == false
+            || components.user != nil
+            || components.password != nil
+            || components.query != nil
+            || components.fragment != nil
+        let normalizedBaseKind = normalizedBaseKind(for: components.path)
+
         components.user = nil
         components.password = nil
         components.query = nil
@@ -292,7 +341,40 @@ public struct ProviderEndpointHealthProbe: Sendable {
         guard let url = components.url else {
             throw RemoteProviderError.invalidRequest("provider endpoint base_url is invalid: \(rawValue)")
         }
-        return url
+        return ProviderEndpointURLContext(
+            normalizedBase: url,
+            normalizedBaseKind: normalizedBaseKind,
+            authRedacted: authRedacted
+        )
+    }
+
+    private func normalizedBaseKind(for path: String) -> String {
+        var normalized = path
+        while normalized.hasSuffix("/") {
+            normalized.removeLast()
+        }
+        if normalized.hasSuffix("/chat/completions") {
+            return "chat_completions_endpoint"
+        }
+        if normalized.hasSuffix("/messages") {
+            return "messages_endpoint"
+        }
+        if normalized.hasSuffix("/api/chat") {
+            return "ollama_chat_endpoint"
+        }
+        if normalized.hasSuffix("/api/generate") {
+            return "ollama_generate_endpoint"
+        }
+        if normalized.hasSuffix("/api/tags") {
+            return "ollama_tags_endpoint"
+        }
+        if normalized.hasSuffix("/models") {
+            return "models_endpoint"
+        }
+        if normalized == "/v1" || normalized.hasSuffix("/v1") {
+            return "versioned_base"
+        }
+        return "base_url"
     }
 
     private func normalizedPath(_ path: String) -> String {
@@ -300,8 +382,14 @@ public struct ProviderEndpointHealthProbe: Sendable {
         while normalized.hasSuffix("/") {
             normalized.removeLast()
         }
+        for suffix in ["/api/chat", "/api/generate", "/api/tags"] {
+            if normalized.hasSuffix(suffix) {
+                normalized.removeLast(suffix.count - "/api".count)
+                return normalized.isEmpty ? "" : normalized
+            }
+        }
         // Strip one endpoint suffix only; keep this list ordered from most specific to broadest.
-        for suffix in ["/chat/completions", "/messages", "/api/chat", "/api/generate", "/api/tags", "/models"] {
+        for suffix in ["/chat/completions", "/messages", "/models"] {
             if normalized.hasSuffix(suffix) {
                 normalized.removeLast(suffix.count)
                 break
@@ -310,19 +398,40 @@ public struct ProviderEndpointHealthProbe: Sendable {
         return normalized.isEmpty ? "" : normalized
     }
 
-    private func modelListURL(baseURL: URL, providerKind: String) throws -> URL {
+    private func modelListTarget(baseURL: URL, providerKind: String) throws -> ProviderEndpointModelListTarget {
         switch providerKind {
-        case "openai-compatible", "anthropic":
-            return baseURL.appendingPathComponent("models")
+        case "openai-compatible":
+            return ProviderEndpointModelListTarget(
+                url: baseURL.appendingPathComponent("models"),
+                endpointKind: "openai_models"
+            )
+        case "anthropic":
+            return ProviderEndpointModelListTarget(
+                url: baseURL.appendingPathComponent("models"),
+                endpointKind: "anthropic_models"
+            )
         case "ollama-native":
             let root = droppingAPISuffix(from: baseURL)
-            return root.appendingPathComponent("api/tags")
+            return ProviderEndpointModelListTarget(
+                url: root.appendingPathComponent("api/tags"),
+                endpointKind: "ollama_tags"
+            )
         case "local-runtime":
             let root = droppingV1Suffix(from: baseURL)
-            return root.appendingPathComponent("v1/models")
+            return ProviderEndpointModelListTarget(
+                url: root.appendingPathComponent("v1/models"),
+                endpointKind: "local_runtime_models"
+            )
         default:
             throw RemoteProviderError.invalidRequest("unsupported provider endpoint probe kind: \(providerKind)")
         }
+    }
+
+    private func fallbackAttempted(normalizedBaseKind: String, modelsEndpointKind: String) -> Bool {
+        if modelsEndpointKind == "ollama_tags" {
+            return normalizedBaseKind != "ollama_tags_endpoint"
+        }
+        return normalizedBaseKind != "models_endpoint"
     }
 
     private func configureAuthenticationHeaders(on request: inout URLRequest, providerKind: String, apiKey: String) {
@@ -479,4 +588,15 @@ public struct ProviderEndpointHealthProbe: Sendable {
 private struct ProviderEndpointModelSummary {
     let chatModelCount: Int
     let capabilities: ProviderEndpointCapabilities
+}
+
+private struct ProviderEndpointURLContext {
+    let normalizedBase: URL
+    let normalizedBaseKind: String
+    let authRedacted: Bool
+}
+
+private struct ProviderEndpointModelListTarget {
+    let url: URL
+    let endpointKind: String
 }

--- a/services/control-plane-swift/Tests/ControlPlaneTests/RemoteProviderClientTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/RemoteProviderClientTests.swift
@@ -129,6 +129,136 @@ struct RemoteProviderClientTests {
         }
     }
 
+    @Test("endpoint probe records redacted model list URL classification receipts")
+    func endpointProbeRecordsRedactedModelListURLClassificationReceipts() async throws {
+        let cases: [
+            (
+                providerKind: String,
+                baseURL: String,
+                apiKey: String,
+                responseBody: String,
+                expectedRequestURL: String,
+                expectedBaseURLRedacted: String,
+                expectedNormalizedBaseKind: String,
+                expectedModelsEndpointKind: String,
+                expectedAuthRedacted: Bool,
+                expectedFallbackAttempted: Bool
+            )
+        ] = [
+            (
+                providerKind: "openai-compatible",
+                baseURL: "https://api.example.test",
+                apiKey: "",
+                responseBody: #"{ "data": [{ "id": "gpt-4.1", "object": "model" }] }"#,
+                expectedRequestURL: "https://api.example.test/models",
+                expectedBaseURLRedacted: "https://api.example.test",
+                expectedNormalizedBaseKind: "base_url",
+                expectedModelsEndpointKind: "openai_models",
+                expectedAuthRedacted: false,
+                expectedFallbackAttempted: true
+            ),
+            (
+                providerKind: "openai-compatible",
+                baseURL: "https://api.example.test/v1?api_key=sk-secret",
+                apiKey: "sk-secret",
+                responseBody: #"{ "data": [{ "id": "gpt-4.1", "object": "model" }] }"#,
+                expectedRequestURL: "https://api.example.test/v1/models",
+                expectedBaseURLRedacted: "https://api.example.test/v1",
+                expectedNormalizedBaseKind: "versioned_base",
+                expectedModelsEndpointKind: "openai_models",
+                expectedAuthRedacted: true,
+                expectedFallbackAttempted: true
+            ),
+            (
+                providerKind: "openai-compatible",
+                baseURL: "https://api.example.test/v1/chat/completions#secret",
+                apiKey: "",
+                responseBody: #"{ "data": [{ "id": "gpt-4.1", "object": "model" }] }"#,
+                expectedRequestURL: "https://api.example.test/v1/models",
+                expectedBaseURLRedacted: "https://api.example.test/v1",
+                expectedNormalizedBaseKind: "chat_completions_endpoint",
+                expectedModelsEndpointKind: "openai_models",
+                expectedAuthRedacted: true,
+                expectedFallbackAttempted: true
+            ),
+            (
+                providerKind: "ollama-native",
+                baseURL: "http://127.0.0.1:11434/api/chat",
+                apiKey: "",
+                responseBody: #"{ "models": [{ "name": "llama3.2" }] }"#,
+                expectedRequestURL: "http://127.0.0.1:11434/api/tags",
+                expectedBaseURLRedacted: "http://127.0.0.1:11434/api",
+                expectedNormalizedBaseKind: "ollama_chat_endpoint",
+                expectedModelsEndpointKind: "ollama_tags",
+                expectedAuthRedacted: false,
+                expectedFallbackAttempted: true
+            ),
+            (
+                providerKind: "ollama-native",
+                baseURL: "http://127.0.0.1:11434/api/generate",
+                apiKey: "",
+                responseBody: #"{ "models": [{ "name": "llama3.2" }] }"#,
+                expectedRequestURL: "http://127.0.0.1:11434/api/tags",
+                expectedBaseURLRedacted: "http://127.0.0.1:11434/api",
+                expectedNormalizedBaseKind: "ollama_generate_endpoint",
+                expectedModelsEndpointKind: "ollama_tags",
+                expectedAuthRedacted: false,
+                expectedFallbackAttempted: true
+            ),
+            (
+                providerKind: "ollama-native",
+                baseURL: "http://127.0.0.1:11434/api/tags",
+                apiKey: "",
+                responseBody: #"{ "models": [{ "name": "llama3.2" }] }"#,
+                expectedRequestURL: "http://127.0.0.1:11434/api/tags",
+                expectedBaseURLRedacted: "http://127.0.0.1:11434/api",
+                expectedNormalizedBaseKind: "ollama_tags_endpoint",
+                expectedModelsEndpointKind: "ollama_tags",
+                expectedAuthRedacted: false,
+                expectedFallbackAttempted: false
+            ),
+            (
+                providerKind: "local-runtime",
+                baseURL: "http://127.0.0.1:12436/v1/models",
+                apiKey: "",
+                responseBody: #"{ "data": [{ "id": "melix-dev-text", "object": "model" }] }"#,
+                expectedRequestURL: "http://127.0.0.1:12436/v1/models",
+                expectedBaseURLRedacted: "http://127.0.0.1:12436/v1",
+                expectedNormalizedBaseKind: "models_endpoint",
+                expectedModelsEndpointKind: "local_runtime_models",
+                expectedAuthRedacted: false,
+                expectedFallbackAttempted: false
+            ),
+        ]
+
+        for testCase in cases {
+            let transport = RecordingRemoteProviderTransport(response: .init(
+                statusCode: 200,
+                headers: ["content-type": "application/json"],
+                body: Data(testCase.responseBody.utf8)
+            ))
+            let probe = ProviderEndpointHealthProbe(transport: transport, latencyClock: { 1 })
+
+            let receipt = try await probe.probe(
+                ProviderEndpointProbeRequest(
+                    endpointID: "\(testCase.providerKind)-url-classification",
+                    providerKind: testCase.providerKind,
+                    baseURL: testCase.baseURL,
+                    apiKey: testCase.apiKey
+                )
+            )
+
+            #expect(await transport.lastRequest?.url?.absoluteString == testCase.expectedRequestURL)
+            #expect(receipt.baseURLRedacted == testCase.expectedBaseURLRedacted)
+            #expect(receipt.normalizedBaseKind == testCase.expectedNormalizedBaseKind)
+            #expect(receipt.modelsEndpointKind == testCase.expectedModelsEndpointKind)
+            #expect(receipt.probeStatus == "ok")
+            #expect(receipt.authRedacted == testCase.expectedAuthRedacted)
+            #expect(receipt.fallbackAttempted == testCase.expectedFallbackAttempted)
+            #expect(String(describing: receipt).contains("sk-secret") == false)
+        }
+    }
+
     @Test("endpoint probe normalizes provider kind casing for routing and receipts")
     func endpointProbeNormalizesProviderKindCasingForRoutingAndReceipts() async throws {
         let transport = RecordingRemoteProviderTransport(response: .init(
@@ -411,6 +541,11 @@ struct RemoteProviderClientTests {
             endpointID: "openai-main",
             providerKind: "openai-compatible",
             baseURLRedacted: "https://api.example.test/v1",
+            normalizedBaseKind: "versioned_base",
+            modelsEndpointKind: "openai_models",
+            probeStatus: "ok",
+            authRedacted: true,
+            fallbackAttempted: true,
             modelCount: 2,
             capabilities: ProviderEndpointCapabilities(
                 chat: true,
@@ -434,6 +569,11 @@ struct RemoteProviderClientTests {
         #expect(object["endpoint_id"] as? String == "openai-main")
         #expect(object["provider_kind"] as? String == "openai-compatible")
         #expect(object["base_url_redacted"] as? String == "https://api.example.test/v1")
+        #expect(object["normalized_base_kind"] as? String == "versioned_base")
+        #expect(object["models_endpoint_kind"] as? String == "openai_models")
+        #expect(object["probe_status"] as? String == "ok")
+        #expect(object["auth_redacted"] as? Bool == true)
+        #expect(object["fallback_attempted"] as? Bool == true)
         #expect(object["model_count"] as? Int == 2)
         #expect(object["tool_support_mode"] as? String == "force_on")
         #expect(object["detected_tool_support"] as? Bool == false)


### PR DESCRIPTION
## Summary
- Added redacted provider endpoint model-list URL classifications for the #1757 endpoint health probe slice.
- Classified normalized input shape, provider model-list endpoint kind, probe status, auth redaction, and fallback URL transformation for success and failure receipts.
- Added the governing plan plus Swift tests that cover base URLs, `/v1`, full chat endpoints, Ollama-native endpoints, and stable snake_case receipt JSON.

## Plan or Spec
- `docs/plans/2026-06-09-issue-1757-model-list-url-receipts.md`
- Part of #1757: endpoint model-list URL receipts. This PR does not close #1757 because capability classification, hidden model filtering, persistent/displayed receipts, and latency/auth integration remain future slices.

## Commands Run
```text
HOME="$PWD/.swift-home/provider-url-receipts-red" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/provider-url-receipts-red" xcrun swift test --package-path services/control-plane-swift --filter RemoteProviderClientTests/endpointProbeRecordsRedactedModelListURLClassificationReceipts
# RED: failed as expected before implementation because ProviderEndpointHealthReceipt had no normalizedBaseKind/modelsEndpointKind/probeStatus/authRedacted/fallbackAttempted members.

HOME="$PWD/.swift-home/provider-url-receipts-green" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/provider-url-receipts-green" xcrun swift test --package-path services/control-plane-swift --filter RemoteProviderClientTests/endpointProbeRecordsRedactedModelListURLClassificationReceipts
# PASS: 1 test passed.

HOME="$PWD/.swift-home/provider-url-receipts" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/provider-url-receipts" xcrun swift test --package-path services/control-plane-swift --filter RemoteProviderClientTests
# PASS: 20 tests passed.

HOME="$PWD/.swift-home/provider-url-receipts-coverage" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/provider-url-receipts-coverage" xcrun swift test --enable-code-coverage --package-path services/control-plane-swift --filter RemoteProviderClientTests
# PASS: 20 tests passed.

python3.11 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/XPCService/ProviderEndpointHealthProbe.swift services/control-plane-swift/Tests/ControlPlaneTests/RemoteProviderClientTests.swift
# PASS: TOTAL 100.00% (250/250).

HOME="$PWD/.swift-home/provider-url-receipts-review" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/provider-url-receipts-review" xcrun swift test --package-path services/control-plane-swift --filter RemoteProviderClientTests
# PASS after review refactor: 20 tests passed.

HOME="$PWD/.swift-home/provider-url-receipts-review-coverage" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/provider-url-receipts-review-coverage" xcrun swift test --enable-code-coverage --package-path services/control-plane-swift --filter RemoteProviderClientTests
# PASS after review refactor: 20 tests passed.

python3.11 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/XPCService/ProviderEndpointHealthProbe.swift services/control-plane-swift/Tests/ControlPlaneTests/RemoteProviderClientTests.swift
# PASS after review refactor: TOTAL 100.00% (246/246).

git diff --check
# PASS: no whitespace errors.

make proto
# PASS: ./scripts/proto_gen.sh completed; no generated artifact diff.

.githooks/pre-commit
# PASS before review refactor: make swift-test completed rc=0; make py-test completed rc=0 with 3755 passed, 14 skipped, 2 warnings; make integration-test completed rc=0 with 117 passed, 1 skipped; scoped performance report status ok with regressions 0.

.githooks/pre-commit
# PASS after review refactor: make swift-test completed rc=0.
# PASS after review refactor: make py-test completed rc=0; 3755 passed, 14 skipped, 2 warnings.
# PASS after review refactor: make integration-test completed rc=0; 117 passed, 1 skipped.
# PASS after review refactor: scoped performance report status ok; regressions 0.
```

## Coverage and Metrics
- Changed-line coverage after the review refactor: `services/control-plane-swift/Sources/XPCService/ProviderEndpointHealthProbe.swift` 100.00% (108/108), `services/control-plane-swift/Tests/ControlPlaneTests/RemoteProviderClientTests.swift` 100.00% (138/138), total 100.00% (246/246).
- Local scoped performance report before review refactor: `.runtime/pre-commit-performance/20260609-175956-6c0a26df/report/report.md`; status `ok`, changed files 3, selected probes 0, regressions 0.
- Local scoped performance report after review refactor: `.runtime/pre-commit-performance/20260609-182210-3bb52d66/report/report.md`; status `ok`, changed files 1, selected probes 0, regressions 0.
- Observability mode: minimal redacted receipt metadata. Probe overhead is constant-time URL parsing and string classification on the existing operator-triggered endpoint health path; no production request path or raw secret logging was added.

## Known Gaps
- Persistent/displayed receipt history is not implemented in this slice.
- Capability classification for chat, streaming, tools, JSON/structured output, and embeddings remains for a later #1757 slice.
- Hidden/non-chat model filtering, owner-scoped credential lookup, live/cached/pinned model-list provenance, and latency presentation remain for later #1757 slices.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes; `make proto` produced no diff.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
