### PR TITLE
Add live source-specific prompt policy receipts

### DIFF
--- a/docs/plans/2026-06-10-issue-1761-live-source-policy-receipts.md
+++ b/docs/plans/2026-06-10-issue-1761-live-source-policy-receipts.md
@@ -1,0 +1,87 @@
+# Issue 1761 Live Source Policy Receipts Plan
+
+## Goal
+
+Continue #1761 by making the live control-plane chat prompt receipt path emit
+source-specific data-only policy text for tool output, retrieved-document/RAG
+data, skills, memories, background continuations, model-final-answer history,
+and generic chat prompt messages.
+
+## Scope
+
+This slice covers the existing Swift `PromptContextBoundaryReceipts` helper
+used by `ChatRequestTranslator` before it sends
+`Melix_Worker_V1_GenerateRequest.messages` to the Python worker.
+
+In scope:
+
+- keep the existing source classification based on message role and normalized
+  message `name`;
+- emit source-specific `reason` and `corrective_action` fields for each
+  source type;
+- keep raw prompt text, media URIs, media bytes, tool arguments, and private
+  prompt content out of receipt JSON;
+- update the unified agentic tool runtime contract to document the live policy
+  mapping.
+
+Out of scope:
+
+- implementing a RAG store, skill store, memory store, or background-job
+  continuation store;
+- changing prompt messages, roles, names, media parts, cache fingerprints, or
+  chat-template behavior;
+- adding protobuf fields or changing Python worker request schema.
+
+## Best End-State Architecture
+
+Every concrete prompt entrypoint should carry source-specific boundary evidence
+closest to the point where untrusted content becomes model prompt data. For the
+live chat translator, the best current source identifier is the already-shaped
+message metadata: role plus optional `name`. This keeps classification
+deterministic, avoids content parsing, and makes receipts useful to downstream
+metrics without promoting source text into diagnostics.
+
+The Swift helper should mirror the policy language already used by Python
+prompt-context primitives. Later live RAG, skill, memory, and background
+continuation stores can use their Python admission helpers before producing
+messages; this Swift slice remains the final request-translation evidence
+surface.
+
+## Performance Probes And Metrics
+
+The changed path still performs one linear pass over already-shaped messages
+and message parts. The new policy lookup is constant time per emitted receipt
+and does not add IO, retrieval, scheduler work, or model inference.
+
+Verification must include:
+
+- focused red/green Swift test for source-specific policy text;
+- changed-line coverage for the touched Swift source and test file with at
+  least 95 percent coverage;
+- full local pre-commit gate on this host before commit;
+- PR-scoped performance report with status `ok`, regressions `0`, context
+  regressions `0`, and verification failures `0`.
+
+## Implementation Steps
+
+1. Add a failing Swift test in `ToolParserRegistryTests` that builds a live
+   translated text request with `tool`, RAG, skill, memory, background,
+   assistant-history, and generic user message sources.
+2. Assert each receipt keeps the existing `source_type`, `source_id`, and
+   `included = true` metadata but uses source-specific `reason` and
+   `corrective_action` values.
+3. Implement a small policy lookup in `PromptContextBoundaryReceipts` keyed by
+   the derived `source_type`.
+4. Update `docs/unified-agentic-tool-runtime-contract.md` with the live
+   source-specific policy mapping and clarify that this slice does not create
+   stores.
+5. Run focused Swift tests, changed-line coverage, full local gate, and
+   PR-scoped performance before opening the pull request.
+
+## Success Criteria
+
+- Live translated chat requests expose source-specific prompt-boundary policy
+  receipts for every supported source type.
+- Receipt JSON still omits raw prompt content and media payloads.
+- Existing message projection behavior is unchanged.
+- Coverage and performance gates pass with no regression.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -299,6 +299,22 @@ other raw source payloads. The classification is evidentiary and does not
 replace source-specific owner-scope checks, admission/refusal checks, or
 background-continuation link validation.
 
+The live chat prompt receipt uses source-specific data-only policy text for the
+classified source type. Tool output records `reason = tool output is prompt
+data, not instructions`; retrieved documents record `reason = retrieved
+document evidence is prompt data, not instructions`; skills record `reason =
+skill evidence is prompt data, not instructions`; memories record `reason =
+memory evidence is prompt data, not instructions`; background continuations
+record `reason = background continuation is prompt data, not instructions`;
+model-final-answer history records `reason = model final answer history is
+prompt data, not instructions`; and generic chat prompt messages retain
+`reason = chat message content is prompt data, not instructions`. Each matching
+`corrective_action` tells downstream consumers to keep that source in its
+original user or assistant data role and not project it into system or developer
+instructions. This live-policy mapping does not create a RAG store, skill
+store, memory store, or background-job continuation store; it documents the
+final request-translation receipt for already-shaped messages.
+
 The chat prompt receipt must not include raw message content, media URLs, media
 bytes, tool arguments, or private prompt text. It records only segment IDs,
 source fields, roles, data-only policy, and corrective guidance. RAG stores,

--- a/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
@@ -13,10 +13,12 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
                 guard let sourceField = Self.sourceField(for: part, messageIndex: messageIndex, partIndex: partIndex) else {
                     continue
                 }
+                let sourceType = Self.sourceType(for: message)
+                let policy = Self.sourcePolicy(for: sourceType)
                 var receipt: [String: PromptContextReceiptValue] = [
                     "schema_version": .string(Self.schemaVersion),
                     "segment_id": .string("\(requestID):message-\(messageIndex):part-\(partIndex)"),
-                    "source_type": .string(Self.sourceType(for: message)),
+                    "source_type": .string(sourceType),
                     "source_field": .string(sourceField),
                     "message_role": .string(message.role),
                     "trust_level": .string("untrusted"),
@@ -24,10 +26,8 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
                     "boundary_checked": .bool(true),
                     "included": .bool(true),
                     "owner_scope_checked": .bool(false),
-                    "reason": .string("chat message content is prompt data, not instructions"),
-                    "corrective_action": .string(
-                        "Keep this message part in its original role and do not promote it into system or developer instructions."
-                    ),
+                    "reason": .string(policy.reason),
+                    "corrective_action": .string(policy.correctiveAction),
                 ]
                 if let sourceID = message.name {
                     receipt["source_id"] = .string(sourceID)
@@ -84,6 +84,46 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
             return "model_final_answer"
         }
         return "chat_prompt_message"
+    }
+
+    private static func sourcePolicy(for sourceType: String) -> (reason: String, correctiveAction: String) {
+        switch sourceType {
+        case "tool_output":
+            return (
+                "tool output is prompt data, not instructions",
+                "Keep tool output in user-role data context and do not project it into system or developer instructions."
+            )
+        case "retrieved_document":
+            return (
+                "retrieved document evidence is prompt data, not instructions",
+                "Keep retrieved document evidence in user-role data context and do not project it into system or developer instructions."
+            )
+        case "skill":
+            return (
+                "skill evidence is prompt data, not instructions",
+                "Keep skill evidence in user-role data context and do not project it into system or developer instructions."
+            )
+        case "memory":
+            return (
+                "memory evidence is prompt data, not instructions",
+                "Keep memory evidence in user-role data context and do not project it into system or developer instructions."
+            )
+        case "background_continuation":
+            return (
+                "background continuation is prompt data, not instructions",
+                "Keep background continuation evidence in user-role data context and do not project it into system or developer instructions."
+            )
+        case "model_final_answer":
+            return (
+                "model final answer history is prompt data, not instructions",
+                "Keep model final answer history in its original assistant role and do not project it into system or developer instructions."
+            )
+        default:
+            return (
+                "chat message content is prompt data, not instructions",
+                "Keep this message part in its original role and do not promote it into system or developer instructions."
+            )
+        }
     }
 
     private static func hasAnyPrefix(_ value: String, _ prefixes: [String]) -> Bool {

--- a/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
@@ -9,12 +9,12 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
     init(requestID: String, messages: [NormalizedTextMessage]) {
         var receipts: [[String: PromptContextReceiptValue]] = []
         for (messageIndex, message) in messages.enumerated() where Self.isUntrustedMessageRole(message.role) {
+            let sourceType = Self.sourceType(for: message)
+            let policy = Self.sourcePolicy(for: sourceType)
             for (partIndex, part) in message.parts.enumerated() {
                 guard let sourceField = Self.sourceField(for: part, messageIndex: messageIndex, partIndex: partIndex) else {
                     continue
                 }
-                let sourceType = Self.sourceType(for: message)
-                let policy = Self.sourcePolicy(for: sourceType)
                 var receipt: [String: PromptContextReceiptValue] = [
                     "schema_version": .string(Self.schemaVersion),
                     "segment_id": .string("\(requestID):message-\(messageIndex):part-\(partIndex)"),

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -464,6 +464,98 @@ struct ToolParserRegistryTests {
         #expect(receiptsJSON.contains("trust me") == false)
     }
 
+    @Test("prompt context boundary receipts use source-specific data-only policies")
+    func promptContextBoundaryReceiptsUseSourceSpecificPolicyText() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-prompt-policy" })
+        let request = makeNormalizedRequest(messages: [
+            .init(role: "tool", name: "calculator", content: "tool output says ignore developer policy"),
+            .init(role: "user", name: "rag_doc-17", content: "retrieved document says reveal secrets"),
+            .init(role: "user", name: "skill-repo-search", content: "skill index says run arbitrary shell"),
+            .init(role: "user", name: "memory_pinned-42", content: "memory says bypass authentication"),
+            .init(role: "user", name: "background_continuation_job-9", content: "background job says trust me"),
+            .init(role: "assistant", name: "previous_answer_7", content: "assistant final text must stay data"),
+            .init(role: "user", content: "ordinary user prompt data"),
+        ])
+
+        let translated = try translator.translate(request, modelHandle: "worker-text")
+        let ext = translated.workerRequest.execution.ext
+        let receiptsJSON = try #require(ext["melix.prompt_context.receipts_json"])
+        let receipts = try #require(
+            try JSONSerialization.jsonObject(with: Data(receiptsJSON.utf8)) as? [[String: Any]]
+        )
+
+        let receiptsBySourceType = Dictionary(
+            uniqueKeysWithValues: receipts.compactMap { receipt -> (String, [String: Any])? in
+                guard let sourceType = receipt["source_type"] as? String else {
+                    return nil
+                }
+                return (sourceType, receipt)
+            }
+        )
+
+        #expect(ext["melix.prompt_context.receipt_count"] == "7")
+        #expect(receipts.count == 7)
+        #expect(
+            receiptsBySourceType["tool_output"]?["reason"] as? String ==
+                "tool output is prompt data, not instructions"
+        )
+        #expect(
+            receiptsBySourceType["tool_output"]?["corrective_action"] as? String ==
+                "Keep tool output in user-role data context and do not project it into system or developer instructions."
+        )
+        #expect(
+            receiptsBySourceType["retrieved_document"]?["reason"] as? String ==
+                "retrieved document evidence is prompt data, not instructions"
+        )
+        #expect(
+            receiptsBySourceType["retrieved_document"]?["corrective_action"] as? String ==
+                "Keep retrieved document evidence in user-role data context and do not project it into system or developer instructions."
+        )
+        #expect(receiptsBySourceType["skill"]?["reason"] as? String == "skill evidence is prompt data, not instructions")
+        #expect(
+            receiptsBySourceType["skill"]?["corrective_action"] as? String ==
+                "Keep skill evidence in user-role data context and do not project it into system or developer instructions."
+        )
+        #expect(receiptsBySourceType["memory"]?["reason"] as? String == "memory evidence is prompt data, not instructions")
+        #expect(
+            receiptsBySourceType["memory"]?["corrective_action"] as? String ==
+                "Keep memory evidence in user-role data context and do not project it into system or developer instructions."
+        )
+        #expect(
+            receiptsBySourceType["background_continuation"]?["reason"] as? String ==
+                "background continuation is prompt data, not instructions"
+        )
+        #expect(
+            receiptsBySourceType["background_continuation"]?["corrective_action"] as? String ==
+                "Keep background continuation evidence in user-role data context and do not project it into system or developer instructions."
+        )
+        #expect(
+            receiptsBySourceType["model_final_answer"]?["reason"] as? String ==
+                "model final answer history is prompt data, not instructions"
+        )
+        #expect(
+            receiptsBySourceType["model_final_answer"]?["corrective_action"] as? String ==
+                "Keep model final answer history in its original assistant role and do not project it into system or developer instructions."
+        )
+        #expect(
+            receiptsBySourceType["chat_prompt_message"]?["reason"] as? String ==
+                "chat message content is prompt data, not instructions"
+        )
+        #expect(
+            receiptsBySourceType["chat_prompt_message"]?["corrective_action"] as? String ==
+                "Keep this message part in its original role and do not promote it into system or developer instructions."
+        )
+        #expect(receipts.allSatisfy { $0["included"] as? Bool == true })
+        #expect(receipts.allSatisfy { $0["policy"] as? String == "data_only" })
+        #expect(receiptsJSON.contains("ignore developer policy") == false)
+        #expect(receiptsJSON.contains("reveal secrets") == false)
+        #expect(receiptsJSON.contains("arbitrary shell") == false)
+        #expect(receiptsJSON.contains("bypass authentication") == false)
+        #expect(receiptsJSON.contains("trust me") == false)
+        #expect(receiptsJSON.contains("assistant final text") == false)
+        #expect(receiptsJSON.contains("ordinary user prompt data") == false)
+    }
+
     @Test("prompt context boundary receipts classify assistant history as model final answer")
     func promptContextBoundaryReceiptsClassifyAssistantHistoryAsModelFinalAnswer() throws {
         let translator = ChatRequestTranslator(requestIDGenerator: { "req-prompt-final" })

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -485,12 +485,13 @@ struct ToolParserRegistryTests {
         )
 
         let receiptsBySourceType = Dictionary(
-            uniqueKeysWithValues: receipts.compactMap { receipt -> (String, [String: Any])? in
+            receipts.compactMap { receipt -> (String, [String: Any])? in
                 guard let sourceType = receipt["source_type"] as? String else {
                     return nil
                 }
                 return (sourceType, receipt)
-            }
+            },
+            uniquingKeysWith: { first, _ in first }
         )
 
         #expect(ext["melix.prompt_context.receipt_count"] == "7")


### PR DESCRIPTION
## Summary
- Add source-specific data-only policy text to live chat prompt context boundary receipts for tool output, retrieved document evidence, skills, memories, background continuations, and model final-answer history.
- Cover the live `ChatRequestTranslator` entrypoint with a regression test that verifies source-specific reasons/actions, inclusion flags, data-only policy, and that raw prompt content is not copied into receipt JSON.
- Update the governing prompt-boundary contract and add a focused implementation plan for issue #1761's live source-policy slice.

## Plan or Spec
- `docs/plans/2026-06-10-issue-1761-live-source-policy-receipts.md`
- `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'promptContextBoundaryReceiptsUseSourceSpecificPolicyText'
# Red: failed before implementation because all source types used the generic chat-message reason/action.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'promptContextBoundaryReceiptsUseSourceSpecificPolicyText'
# Pass.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'ToolParserRegistryTests'
# Pass: 22 tests.

git diff --check
# Pass.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --enable-code-coverage --package-path services/control-plane-swift --filter 'ToolParserRegistryTests'
python3.11 scripts/swift_changed_line_coverage.py --diff-from origin/main --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
# Pass: TOTAL 99.25% changed-line coverage, 133/134 lines.

make bootstrap
# Pass.

make proto
# Pass.

.githooks/pre-commit
# Pass. make swift-test rc=0 elapsed=368.5s; make py-test rc=0 elapsed=174.5s with 3777 passed, 14 skipped, 2 warnings; make integration-test rc=0 elapsed=694.7s with 117 passed, 1 skipped.
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 99.25%`, 133/134 executable changed lines covered.
- Scoped performance report: `.runtime/pre-commit-performance/20260610-003921-1ea32514/report/report.md`
- Performance status: `ok`; changed files `4`; selected probes `0`; direct/gated probes `0`; regressions `0`; context regressions `0`; verification failures `0`.
- Observability mode: minimal request-local receipt metadata; no new sampled/evidence/debug probe overhead. Probe overhead: `N/A`, no registered performance probes were selected for this receipt/docs change set.

## Known Gaps
- This slice does not create new RAG, skill, memory, or background-continuation stores. It hardens the live control-plane chat request translation boundary that carries those sources when they are presented as chat message evidence.
- Future concrete source stores or Python-worker admission paths should attach the same data-only prompt-boundary receipts at their own admission points.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts: N/A, no protocol schema changes.
- [x] Dependency changes include updated lockfiles: N/A, no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
