### PR TITLE
Add session context boundary receipts

### DIFF
--- a/docs/plans/2026-06-10-issue-1761-session-context-admission.md
+++ b/docs/plans/2026-06-10-issue-1761-session-context-admission.md
@@ -1,0 +1,100 @@
+# Issue 1761 Session Context Admission Receipts
+
+## Goal
+
+Make session-backed snapshot restoration visible as an untrusted-context
+boundary when the control plane projects prior session state into a follow-up
+worker request.
+
+## Scope
+
+This slice covers the Swift `RequestCoordinator` path that resolves an implicit
+follow-up restore snapshot from `SessionGraphStore`. When the coordinator finds
+a branch resume snapshot for the same session and branch, it attaches a
+redacted `melix.untrusted_context_receipt.v1` receipt to the worker request
+metadata before dispatch.
+
+In scope:
+
+- emit one session-context receipt when `SessionGraphStore` supplies an
+  implicit follow-up restore snapshot;
+- classify the receipt as `source_type = background_continuation`;
+- set `owner_scope_checked = true` only for the session graph lookup that
+  matched the request session and selected branch;
+- store receipt metadata under `ExecutionMetadata.ext` keys namespaced as
+  `melix.session_context.*`;
+- keep receipt JSON limited to IDs, source fields, policy, and corrective
+  guidance.
+
+Out of scope:
+
+- adding protobuf fields to `SessionState`, `SnapshotRef`, or worker requests;
+- changing snapshot restore behavior, scheduler lanes, cache hints, prompt
+  messages, or worker execution;
+- validating caller-supplied explicit `restore_snapshot_id` values;
+- implementing durable background-job, RAG, skill, or memory entrypoint stores.
+
+## Best End-State Architecture
+
+Session, RAG, skill, memory, and background-job continuation stores should each
+perform owner-scope checks at their source-specific admission point and attach
+redacted receipt evidence before untrusted data is projected into prompt or
+model context.
+
+For session follow-ups, the control plane already has the authoritative
+`SessionGraphStore` lookup that decides which branch resume snapshot is reused.
+That lookup is the narrow owner-scope check for this slice: the requested
+session and selected branch must lead to the resume snapshot before the receipt
+can claim `owner_scope_checked = true`.
+
+## Performance Probes And Metrics
+
+The changed path adds one small dictionary-to-JSON receipt after an in-memory
+session graph lookup that already happens for follow-up restore. It does not
+add filesystem IO, worker RPCs, hashing, protobuf regeneration, or model
+inference.
+
+Verification must include:
+
+- focused red/green Swift test for session follow-up prefill request metadata;
+- changed-scope coverage for touched Swift source and test files with at least
+  95 percent coverage;
+- full local pre-commit gate before commit on this host;
+- PR-scoped performance report with status `ok`, regressions `0`, context
+  regressions `0`, and verification failures `0`.
+
+Metrics:
+
+- No new runtime metric is required for this metadata-only receipt. The
+  existing `session_graph.restore_snapshot_count` metric remains the restore
+  behavior signal.
+
+## Implementation Steps
+
+1. Add a failing `RequestCoordinatorTests` case proving a session follow-up
+   prefill request carries `melix.session_context.*` receipt metadata and does
+   not leak raw prompt text.
+2. Add a small Swift receipt helper for session-context admission evidence.
+3. Attach the receipt from `resolvedRecoveryRequest` only when
+   `SessionGraphStore` supplies the implicit restore snapshot.
+4. Keep explicit request `restore_snapshot_id` unchanged and without a verified
+   session-context receipt.
+5. Update the unified agentic tool runtime contract with the session-context
+   receipt namespace and owner-scope rule.
+6. Run focused tests, changed-scope coverage, full local gate, and PR-scoped
+   performance before merge.
+
+## Success Criteria
+
+- Implicit session follow-up restore requests include
+  `melix.session_context.receipt_schema =
+  melix.untrusted_context_receipt.v1`.
+- The receipt uses `source_type = background_continuation`,
+  `source_field = execution.cache_hints.restore_snapshot_id`, and
+  `owner_scope_checked = true`.
+- The receipt JSON records the selected snapshot ID as source metadata but does
+  not include raw user message text, hidden reasoning text, or prompt bodies.
+- Caller-supplied explicit restore snapshot IDs are not marked as
+  owner-scope-checked by this session graph slice.
+- Existing scheduler route selection, phase-aware prefill, and restore behavior
+  remain unchanged.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -322,6 +322,23 @@ skill entrypoints, memory entrypoints, and background-job continuations must
 reuse this receipt shape when they add their prompt-context boundary evidence
 under #1761.
 
+The v1 control-plane session-context slice records the same receipt shape when
+`RequestCoordinator` resolves an implicit follow-up restore snapshot from
+`SessionGraphStore`. These receipts are stored in `ExecutionMetadata.ext` as:
+
+- `melix.session_context.receipt_schema`
+- `melix.session_context.receipt_count`
+- `melix.session_context.receipts_json`
+
+The session-context receipt uses `source_type = background_continuation`,
+`source_field = execution.cache_hints.restore_snapshot_id`, and records the
+selected snapshot ID as `source_id`. `owner_scope_checked` is `true` only for
+the in-memory session graph lookup that matched the request session and
+selected branch before setting the restore snapshot. Caller-supplied explicit
+`restore_snapshot_id` values are not marked as owner-scope checked by this
+slice. The receipt must not include raw prompt text, hidden reasoning text,
+prior model output, or private prompt bodies.
+
 The v1 Python worker prompt-context primitive is
 `worker.runtime.untrusted_context.untrusted_context_receipt`. It constructs the
 stable `melix.untrusted_context_receipt.v1` dictionary for both admitted and

--- a/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
+++ b/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
@@ -1582,6 +1582,13 @@ public actor RequestCoordinator {
                 ?? session.branches.first(where: { $0.branchID == session.activeBranchID })
             if let branch, !branch.resumeSnapshotID.isEmpty {
                 workerRequest.execution.cacheHints.restoreSnapshotID = branch.resumeSnapshotID
+                workerRequest.execution.ext.merge(
+                    SessionContextBoundaryReceipts(
+                        requestID: workerRequest.execution.id.requestID,
+                        restoreSnapshotID: branch.resumeSnapshotID
+                    ).extFields,
+                    uniquingKeysWith: { _, receiptValue in receiptValue }
+                )
             }
         }
 

--- a/services/control-plane-swift/Sources/Requests/SessionContextBoundaryReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/SessionContextBoundaryReceipt.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+struct SessionContextBoundaryReceipts: Sendable, Equatable {
+    static let schemaVersion = "melix.untrusted_context_receipt.v1"
+
+    private let receipts: [[String: SessionContextReceiptValue]]
+
+    init(requestID: String, restoreSnapshotID: String) {
+        let normalizedRequestID = requestID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedSnapshotID = restoreSnapshotID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedRequestID.isEmpty, !normalizedSnapshotID.isEmpty else {
+            self.receipts = []
+            return
+        }
+
+        self.receipts = [[
+            "schema_version": .string(Self.schemaVersion),
+            "segment_id": .string("\(normalizedRequestID):session-context:restore-snapshot"),
+            "source_type": .string("background_continuation"),
+            "source_field": .string("execution.cache_hints.restore_snapshot_id"),
+            "source_id": .string(normalizedSnapshotID),
+            "message_role": .string("user"),
+            "trust_level": .string("untrusted"),
+            "policy": .string("data_only"),
+            "boundary_checked": .bool(true),
+            "included": .bool(true),
+            "owner_scope_checked": .bool(true),
+            "reason": .string("background continuation is prompt data, not instructions"),
+            "corrective_action": .string(
+                "Keep background continuation evidence in user-role data context and do not project it into system or developer instructions."
+            ),
+        ]]
+    }
+
+    var extFields: [String: String] {
+        guard !receipts.isEmpty else {
+            return [:]
+        }
+        return [
+            "melix.session_context.receipt_schema": Self.schemaVersion,
+            "melix.session_context.receipt_count": String(receipts.count),
+            "melix.session_context.receipts_json": Self.canonicalJSONString(receipts.map { receipt in
+                receipt.mapValues(\.jsonValue)
+            }),
+        ]
+    }
+
+    private static func canonicalJSONString(_ object: [[String: Any]]) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]) else {
+            return "[]"
+        }
+        return String(data: data, encoding: .utf8) ?? "[]"
+    }
+}
+
+private enum SessionContextReceiptValue: Sendable, Equatable {
+    case string(String)
+    case bool(Bool)
+
+    var jsonValue: Any {
+        switch self {
+        case .string(let value):
+            return value
+        case .bool(let value):
+            return value
+        }
+    }
+}

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -2038,6 +2038,132 @@ struct RequestCoordinatorTests {
         #expect(metrics.values["session_graph.restore_snapshot_count", default: 0] >= 1)
     }
 
+    @Test("session follow-up restore requests attach redacted session context receipts")
+    func sessionFollowUpRestoreRequestsAttachSessionContextReceipts() async throws {
+        let workerClient = PhaseAwareWorkerClient()
+        let sessionGraphStore = SessionGraphStore(nowUnixMs: { 9_100 })
+        _ = await sessionGraphStore.recordRequestStart(
+            sessionID: "session-boundary",
+            branchID: "branch-main",
+            requestID: "req-parent"
+        )
+        var snapshot = Melix_Controlplane_V1_SnapshotRef()
+        snapshot.snapshotID = "snap-boundary"
+        snapshot.requestID = "req-parent"
+        snapshot.tokenBoundary = 6
+        _ = await sessionGraphStore.recordSnapshotHydration(
+            sessionID: "session-boundary",
+            branchID: "branch-main",
+            snapshot: snapshot
+        )
+
+        let coordinator = RequestCoordinator(
+            workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+            abortRegistry: AbortRegistry(),
+            sessionGraphStore: sessionGraphStore
+        )
+
+        let execution = try await coordinator.startChatCompletion(
+            makeTranslatedChatRequest(
+                requestID: "req-boundary",
+                messages: [makeWorkerTextMessage("raw user prompt must not appear in receipts")],
+                sessionID: "session-boundary",
+                branchID: "branch-main",
+                parentRequestID: "req-parent",
+                saveBoundarySnapshot: true,
+                executionExt: ["melix.reasoning.continuity_key": "hidden-reasoning-key"]
+            )
+        )
+        let consumer = Task {
+            do {
+                for try await _ in execution.stream {
+                }
+            } catch {
+            }
+        }
+        defer { consumer.cancel() }
+
+        let prefillRequest = try #require(await waitForPrefillRequest(workerClient: workerClient))
+        let ext = prefillRequest.execution.ext
+        let receiptsJSON = try #require(ext["melix.session_context.receipts_json"])
+        let receipts = try #require(
+            try JSONSerialization.jsonObject(with: Data(receiptsJSON.utf8)) as? [[String: Any]]
+        )
+        let receipt = try #require(receipts.first)
+
+        #expect(prefillRequest.execution.cacheHints.restoreSnapshotID == "snap-boundary")
+        #expect(ext["melix.session_context.receipt_schema"] == "melix.untrusted_context_receipt.v1")
+        #expect(ext["melix.session_context.receipt_count"] == "1")
+        #expect(receipts.count == 1)
+        #expect(receipt["schema_version"] as? String == "melix.untrusted_context_receipt.v1")
+        #expect(receipt["segment_id"] as? String == "req-boundary:session-context:restore-snapshot")
+        #expect(receipt["source_type"] as? String == "background_continuation")
+        #expect(receipt["source_field"] as? String == "execution.cache_hints.restore_snapshot_id")
+        #expect(receipt["source_id"] as? String == "snap-boundary")
+        #expect(receipt["message_role"] as? String == "user")
+        #expect(receipt["trust_level"] as? String == "untrusted")
+        #expect(receipt["policy"] as? String == "data_only")
+        #expect(receipt["boundary_checked"] as? Bool == true)
+        #expect(receipt["included"] as? Bool == true)
+        #expect(receipt["owner_scope_checked"] as? Bool == true)
+        #expect(receipt["reason"] as? String == "background continuation is prompt data, not instructions")
+        #expect(
+            receipt["corrective_action"] as? String ==
+                "Keep background continuation evidence in user-role data context and do not project it into system or developer instructions."
+        )
+        #expect(receiptsJSON.contains("raw user prompt") == false)
+        #expect(receiptsJSON.contains("hidden-reasoning-key") == false)
+
+        _ = try #require(await waitForDecodeRequest(workerClient: workerClient))
+        await workerClient.finishDecode(requestID: "req-boundary")
+        _ = await consumer.result
+    }
+
+    @Test("explicit restore snapshot ids do not claim session context owner checks")
+    func explicitRestoreSnapshotIDsDoNotClaimSessionContextOwnerChecks() async throws {
+        let workerClient = PhaseAwareWorkerClient()
+        let sessionGraphStore = SessionGraphStore(nowUnixMs: { 9_200 })
+        let coordinator = RequestCoordinator(
+            workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+            abortRegistry: AbortRegistry(),
+            sessionGraphStore: sessionGraphStore
+        )
+
+        let execution = try await coordinator.startChatCompletion(
+            makeTranslatedChatRequest(
+                requestID: "req-explicit-restore",
+                sessionID: "session-explicit-restore",
+                branchID: "branch-main",
+                restoreSnapshotID: "snap-caller-supplied",
+                saveBoundarySnapshot: true
+            )
+        )
+        let consumer = Task {
+            do {
+                for try await _ in execution.stream {
+                }
+            } catch {
+            }
+        }
+        defer { consumer.cancel() }
+
+        let prefillRequest = try #require(await waitForPrefillRequest(workerClient: workerClient))
+        #expect(prefillRequest.execution.cacheHints.restoreSnapshotID == "snap-caller-supplied")
+        #expect(prefillRequest.execution.ext["melix.session_context.receipt_schema"] == nil)
+        #expect(prefillRequest.execution.ext["melix.session_context.receipt_count"] == nil)
+        #expect(prefillRequest.execution.ext["melix.session_context.receipts_json"] == nil)
+
+        _ = try #require(await waitForDecodeRequest(workerClient: workerClient))
+        await workerClient.finishDecode(requestID: "req-explicit-restore")
+        _ = await consumer.result
+    }
+
+    @Test("empty session context receipt inputs do not attach ext metadata")
+    func emptySessionContextReceiptInputsDoNotAttachExtMetadata() {
+        #expect(SessionContextBoundaryReceipts(requestID: " ", restoreSnapshotID: "snap-empty").extFields.isEmpty)
+        #expect(SessionContextBoundaryReceipts(requestID: "req-empty", restoreSnapshotID: " ").extFields.isEmpty)
+    }
+
     @Test("phase-aware vlm requests preserve tool parser metadata and stream tool call deltas")
     func phaseAwareVLMRequestsPreserveToolParserMetadataAndStreamToolCallDeltas() async throws {
         let workerClient = PhaseAwareWorkerClient()


### PR DESCRIPTION
## Summary
- Add session-context admission receipts when `RequestCoordinator` restores an implicit session follow-up snapshot from `SessionGraphStore`.
- Keep caller-supplied explicit `restore_snapshot_id` values unchanged and without a verified session-context owner-scope receipt.
- Document the `melix.session_context.*` metadata namespace and add focused request-coordinator coverage for receipt contents and redaction.

## Plan or Spec
- Plan: `docs/plans/2026-06-10-issue-1761-session-context-admission.md`
- Governing spec: `docs/unified-agentic-tool-runtime-contract.md`
- Issue: #1761

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'RequestCoordinatorTests/(sessionFollowUpRestoreRequestsAttachSessionContextReceipts|explicitRestoreSnapshotIDsDoNotClaimSessionContextOwnerChecks)'
# red run before implementation: failed as expected because melix.session_context.receipts_json was nil for the implicit restore path; explicit restore case passed.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'RequestCoordinatorTests/(sessionFollowUpRestoreRequestsAttachSessionContextReceipts|explicitRestoreSnapshotIDsDoNotClaimSessionContextOwnerChecks)'
# green run after implementation: 2 tests passed.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'RequestCoordinatorTests/(sessionTaggedRequestsHydrateSessionGraphRequestHeads|sessionFollowUpRequestsRestoreLatestBranchSnapshot|sessionFollowUpRestoreRequestsAttachSessionContextReceipts|explicitRestoreSnapshotIDsDoNotClaimSessionContextOwnerChecks|warmFollowUpRequestsPreferHotPrefillLanesAndRefreshCacheObservability|partialRestorePlansRecordWalkBackMetricsAndMetadata)'
# 6 tests passed.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'RequestCoordinatorTests/(sessionTaggedRequestsHydrateSessionGraphRequestHeads|sessionFollowUpRequestsRestoreLatestBranchSnapshot|sessionFollowUpRestoreRequestsAttachSessionContextReceipts|explicitRestoreSnapshotIDsDoNotClaimSessionContextOwnerChecks|emptySessionContextReceiptInputsDoNotAttachExtMetadata|warmFollowUpRequestsPreferHotPrefillLanesAndRefreshCacheObservability|partialRestorePlansRecordWalkBackMetricsAndMetadata)'
# 7 tests passed.

python3.11 scripts/swift_changed_line_coverage.py --diff-from origin/main --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/Requests/RequestCoordinator.swift services/control-plane-swift/Sources/Requests/SessionContextBoundaryReceipt.swift services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
# TOTAL 99.44% changed-line coverage: RequestCoordinator.swift 100.00% (7/7), SessionContextBoundaryReceipt.swift 98.08% (51/52), RequestCoordinatorTests.swift 100.00% (120/120).

git diff --check
# passed.

make bootstrap
# passed; installed repository hooks.

make proto
# passed; no generated artifact drift.

.githooks/pre-commit
# passed: make swift-test rc=0 elapsed=474.8s; make py-test rc=0 with 3790 passed, 14 skipped, 2 warnings; make integration-test rc=0 with 117 passed, 1 skipped; PR-scoped performance status ok with regressions 0, context regressions 0, verification failures 0.

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-bodies/issue-1761-session-context-admission.md
# passed.
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 99.44%` for the touched Swift request-coordinator source and tests.
- Pre-commit performance report: `.runtime/pre-commit-performance/20260610-051116-8d6d10e2/report/report.md`
- PR-scoped performance status: `ok`; selected probes: `1`; direct/gated probes: `1`; regressions: `0`; context regressions: `0`; verification failures: `0`.
- Probe: `same-cohort-batching-probe-evidence`; targeted tests: `pass`; coverage: `pass (100.0%)`; all base/head deltas neutral.
- Observability mode: `evidence` for receipt metadata stored in `ExecutionMetadata.ext`; probe overhead: one small in-memory dictionary-to-JSON serialization only on implicit session restore admission. No filesystem IO, worker RPC, hashing, protobuf regeneration, or model inference was added.

## Known Gaps
- Explicit caller-supplied `restore_snapshot_id` values remain out of scope and are not marked owner-scope checked by this slice.
- No protobuf, Python worker, scheduler, cache-lane, or prompt-body behavior changes are included.
- `SessionContextBoundaryReceipts.canonicalJSONString` keeps an unhit defensive fallback for JSON serialization failure; changed-line coverage remains above the required 95% threshold.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
