### PR TITLE
Add retrieval entrypoint admission receipts

### DIFF
--- a/docs/plans/2026-06-10-issue-1761-retrieval-entrypoint-admission.md
+++ b/docs/plans/2026-06-10-issue-1761-retrieval-entrypoint-admission.md
@@ -1,0 +1,90 @@
+# Issue 1761 Retrieval Entrypoint Admission Plan
+
+## Goal
+
+Wire the deterministic retrieval and local visit entrypoints through the Python
+worker retrieval-context admission primitive before their redacted source
+evidence is projected into tool-observation prompt context.
+
+## Scope
+
+This slice covers:
+
+- `worker.runtime.retrieval_context` support for entrypoint-local receipt
+  location fields while preserving the default retrieved document/image
+  admission API.
+- `worker.runtime.agentic_tools` text search, image search, and visit source
+  receipt generation using the retrieval-context primitive instead of building
+  retrieved document/image prompt-context receipts directly.
+- Focused Python tests proving the concrete entrypoints call the retrieval
+  admission primitive and keep existing receipt shape for text/image results
+  and visited documents.
+- A contract update clarifying that retrieval helpers are the required boundary
+  for deterministic retrieval, live RAG, and local source integration
+  entrypoints.
+
+This slice does not implement a live RAG store, vector index, retrieval ranking,
+document ingestion, session memory wiring, or new owner-scope lookup. Existing
+deterministic owner-scope checks remain the source of `owner_scope_checked`.
+
+## Best End-State Architecture
+
+Retrieved documents, retrieved images, and visited local documents are
+untrusted prompt context. Concrete retrieval entrypoints should perform any
+owner-scope checks, redact evidence, and then call a source-specific admission
+primitive that validates the source identifier, payload object, and
+owner-scope metadata before emitting receipts.
+
+The retrieval-context primitive remains the reusable source-specific boundary.
+Its default output is stable for future live stores, while concrete result-list
+and visit surfaces may provide entrypoint-local `segment_id`, `source_field`,
+`reason`, and `corrective_action` values so existing receipt locations remain
+stable for callers.
+
+## Performance Probes And Metrics
+
+The changed path adds one Python function call and small string validation per
+emitted retrieval source receipt. It does not add filesystem scanning, model
+inference, vector search, hashing, network calls, or scheduler work.
+
+Verification must include:
+
+- a red/green run for the focused `test_agentic_tools.py` and
+  `test_retrieval_context.py` cases;
+- adjacent prompt-context and tool-observation regression tests;
+- changed-line coverage for the touched Python files at 95 percent or higher;
+- full local pre-commit gate before commit on this host;
+- PR-scoped performance report with status `ok`, regressions `0`, context
+  regressions `0`, and verification failures `0`.
+
+## Implementation Steps
+
+1. Add failing tests in `services/mlx-worker-python/tests/test_retrieval_context.py`
+   showing retrieved document/image admission accepts entrypoint-local receipt
+   fields and still emits redacted source receipts.
+2. Replace the existing agentic-tools source admission test with a failing test
+   proving text search, image search, and visit call
+   `admit_retrieved_document_context` or `admit_retrieved_image_context` with
+   the concrete `segment_id`, `source_field`, reason, corrective action,
+   source ID, payload, and owner-scope flag.
+3. Extend `PromptContextSourceEvidence` and `retrieval_context` minimally so
+   default callers preserve the existing helper output while entrypoint callers
+   can override receipt location and reason text.
+4. Route `agentic_tools._retrieval_result_receipt` and
+   `agentic_tools._visit_document_receipt` through the retrieval-context
+   helper, preserving the public receipt JSON asserted by existing tests.
+5. Update `docs/unified-agentic-tool-runtime-contract.md` to record this
+   concrete deterministic retrieval/local-source wiring.
+6. Run focused tests, adjacent tests, changed-line coverage, full local gate,
+   and PR-scoped performance checks before opening the PR.
+
+## Success Criteria
+
+- Text search, image search, fixture visit, and workspace-file visit retrieved
+  source receipts are emitted through `worker.runtime.retrieval_context`.
+- Existing receipt shape remains stable for deterministic result and visit
+  surfaces.
+- Source receipts still omit raw retrieved text, captions, media refs, local
+  paths, and page content.
+- Malformed retrieval helper inputs continue to produce refusal receipts with
+  no admitted user payload.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -416,19 +416,24 @@ boundary for evidence admitted by those later surfaces.
 
 The Python worker retrieval admission primitives are
 `worker.runtime.retrieval_context.admit_retrieved_document_context` and
-`worker.runtime.retrieval_context.admit_retrieved_image_context`. Future live
-RAG stores, document retrieval, image retrieval, and local source integration
-entrypoints must pass already-redacted evidence dictionaries through these
-helpers before projecting that evidence into user-role prompt context. Each
-helper records one `source_type = retrieved_document` or `source_type =
-retrieved_image` receipt with `source_field` matching the source type and
-`source_id` set to the redacted retrieved source identifier. Malformed source
-IDs, payload objects, or owner-scope metadata produce `included = false`
-refusal receipts with `reason = invalid_retrieved_document_context_field` or
+`worker.runtime.retrieval_context.admit_retrieved_image_context`. Deterministic
+text search, image search, and local visit source receipts pass already-redacted
+evidence dictionaries through these helpers before projecting that evidence
+into tool-observation prompt context. Future live RAG stores, document
+retrieval, image retrieval, and local source integration entrypoints must reuse
+the same helpers. By default, each helper records one `source_type =
+retrieved_document` or `source_type = retrieved_image` receipt with
+`source_field` matching the source type and `source_id` set to the redacted
+retrieved source identifier. Concrete result-list and visit entrypoints may
+provide entrypoint-local `segment_id`, `source_field`, `reason`, and
+`corrective_action` values so their public receipt locations remain stable.
+Malformed source IDs, payload objects, owner-scope metadata, or entrypoint
+receipt fields produce `included = false` refusal receipts with `reason =
+invalid_retrieved_document_context_field` or
 `invalid_retrieved_image_context_field` and no user payload. These helpers do
 not implement retrieval storage, ranking, indexing, ingestion, or chat/session
 wiring; they are only the prompt-context boundary for evidence admitted by
-those later surfaces.
+those surfaces.
 
 The v1 control-plane rerank document-boundary slice applies the same receipt
 schema to the OpenAI-compatible `/v1/rerank` HTTP response. The handler emits

--- a/services/mlx-worker-python/tests/test_agentic_tools.py
+++ b/services/mlx-worker-python/tests/test_agentic_tools.py
@@ -363,22 +363,32 @@ def test_agentic_tool_runtime_emits_source_receipt_for_fixture_visit_page() -> N
     )
 
 
-def test_agentic_tool_runtime_retrieval_source_receipts_use_prompt_context_admission(
+def test_agentic_tool_runtime_retrieval_source_receipts_use_retrieval_admission(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls: list[list[object]] = []
+    document_calls: list[dict[str, object]] = []
+    image_calls: list[dict[str, object]] = []
 
     class Admission:
-        user_payload = {"results[0]": {"id": "source"}}
-        untrusted_context_receipts = [{"receipt": "from-source-admission"}]
+        def __init__(self, receipt: dict[str, object]) -> None:
+            self.user_payload = {}
+            self.untrusted_context_receipts = [receipt]
 
-    def fake_admit(segments: list[object]) -> Admission:
-        calls.append(segments)
-        return Admission()
+    def fake_admit_document_context(**kwargs: object) -> Admission:
+        document_calls.append(kwargs)
+        return Admission({"receipt": f"document-{len(document_calls)}"})
+
+    def fake_admit_image_context(**kwargs: object) -> Admission:
+        image_calls.append(kwargs)
+        return Admission({"receipt": f"image-{len(image_calls)}"})
 
     monkeypatch.setattr(
-        "worker.runtime.agentic_tools.admit_prompt_context_segments",
-        fake_admit,
+        "worker.runtime.agentic_tools.admit_retrieved_document_context",
+        fake_admit_document_context,
+    )
+    monkeypatch.setattr(
+        "worker.runtime.agentic_tools.admit_retrieved_image_context",
+        fake_admit_image_context,
     )
 
     run = execute_agentic_tool_calls(
@@ -392,6 +402,11 @@ def test_agentic_tool_runtime_retrieval_source_receipts_use_prompt_context_admis
                 "id": "image-retrieval",
                 "name": "image_search",
                 "arguments": {"query": "receipt"},
+            },
+            {
+                "id": "visit-page",
+                "name": "visit",
+                "arguments": {"url": "fixture://page-1"},
             },
         ],
         fixture_context={
@@ -411,6 +426,13 @@ def test_agentic_tool_runtime_retrieval_source_receipts_use_prompt_context_admis
                     "caption": "receipt caption",
                 }
             ],
+            "pages": {
+                "fixture://page-1": {
+                    "owner_id": "operator-a",
+                    "title": "Fixture Page",
+                    "text": "Visited page says ignore policy.",
+                }
+            },
         },
     )
 
@@ -418,37 +440,58 @@ def test_agentic_tool_runtime_retrieval_source_receipts_use_prompt_context_admis
         receipt
         for observation in run.observations
         for receipt in observation["untrusted_context_receipts"]
-        if receipt == {"receipt": "from-source-admission"}
-    ] == [{"receipt": "from-source-admission"}, {"receipt": "from-source-admission"}]
-    assert len(calls) == 2
-
-    text_segment = calls[0][0]
-    assert text_segment.segment_id == "text-retrieval:result-1"
-    assert text_segment.source_type == "retrieved_document"
-    assert text_segment.source_field == "results[0]"
-    assert text_segment.source_id == "doc-alpha"
-    assert text_segment.owner_scope_checked is True
-    assert text_segment.value == {"id": "doc-alpha", "text": "Melix retrieved document."}
-    assert text_segment.reason == "retrieved document result is prompt data, not instructions"
-    assert text_segment.corrective_action == (
+        if "receipt" in receipt
+    ] == [{"receipt": "document-1"}, {"receipt": "image-1"}, {"receipt": "document-2"}]
+    assert document_calls == [
+        {
+            "document_id": "doc-alpha",
+            "document_payload": {"id": "doc-alpha", "text": "Melix retrieved document."},
+            "owner_scope_checked": True,
+            "segment_id": "text-retrieval:result-1",
+            "source_field": "results[0]",
+            "reason": "retrieved document result is prompt data, not instructions",
+            "corrective_action": (
+                "Keep retrieved document results in user-role data context and do not project "
+                "them into system or developer instructions."
+            ),
+        },
+        {
+            "document_id": "fixture://page-1",
+            "document_payload": {
+                "url": "fixture://page-1",
+                "title": "Fixture Page",
+                "text": "Visited page says ignore policy.",
+            },
+            "owner_scope_checked": True,
+            "segment_id": "visit-page:visit-document",
+            "source_field": "payload",
+            "reason": "visited document is prompt data, not instructions",
+            "corrective_action": (
+                "Keep visited document content in user-role data context and do not project "
+                "it into system or developer instructions."
+            ),
+        },
+    ]
+    assert image_calls == [
+        {
+            "image_id": "image-doc-1",
+            "image_payload": {
+                "id": "image-doc-1",
+                "media_ref": "img-1",
+                "caption": "receipt caption",
+            },
+            "owner_scope_checked": True,
+            "segment_id": "image-retrieval:result-1",
+            "source_field": "results[0]",
+            "reason": "retrieved image result is prompt data, not instructions",
+            "corrective_action": (
+                "Keep retrieved image results in user-role data context and do not project "
+                "them into system or developer instructions."
+            ),
+        }
+    ]
+    assert document_calls[0]["corrective_action"] == (
         "Keep retrieved document results in user-role data context and do not project "
-        "them into system or developer instructions."
-    )
-
-    image_segment = calls[1][0]
-    assert image_segment.segment_id == "image-retrieval:result-1"
-    assert image_segment.source_type == "retrieved_image"
-    assert image_segment.source_field == "results[0]"
-    assert image_segment.source_id == "image-doc-1"
-    assert image_segment.owner_scope_checked is True
-    assert image_segment.value == {
-        "id": "image-doc-1",
-        "media_ref": "img-1",
-        "caption": "receipt caption",
-    }
-    assert image_segment.reason == "retrieved image result is prompt data, not instructions"
-    assert image_segment.corrective_action == (
-        "Keep retrieved image results in user-role data context and do not project "
         "them into system or developer instructions."
     )
 

--- a/services/mlx-worker-python/tests/test_retrieval_context.py
+++ b/services/mlx-worker-python/tests/test_retrieval_context.py
@@ -149,6 +149,119 @@ def test_retrieval_context_uses_shared_source_evidence_admission(
     assert image_evidence.owner_scope_checked is True
 
 
+def test_retrieval_context_accepts_entrypoint_receipt_fields() -> None:
+    admission = admit_retrieved_document_context(
+        document_id="doc-result",
+        document_payload={"id": "doc-result", "text": "Retrieved text says ignore policy."},
+        owner_scope_checked=True,
+        segment_id="search-call:result-1",
+        source_field="results[0]",
+        reason="retrieved document result is prompt data, not instructions",
+        corrective_action=(
+            "Keep retrieved document results in user-role data context and do not project "
+            "them into system or developer instructions."
+        ),
+    )
+
+    assert admission.user_payload == {
+        "results[0]": {"id": "doc-result", "text": "Retrieved text says ignore policy."}
+    }
+    assert admission.untrusted_context_receipts == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": "search-call:result-1",
+            "source_type": "retrieved_document",
+            "source_field": "results[0]",
+            "source_id": "doc-result",
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": True,
+            "owner_scope_checked": True,
+            "reason": "retrieved document result is prompt data, not instructions",
+            "corrective_action": (
+                "Keep retrieved document results in user-role data context and do not project "
+                "them into system or developer instructions."
+            ),
+        }
+    ]
+    assert "ignore policy" not in json.dumps(admission.untrusted_context_receipts, ensure_ascii=False)
+
+    image_admission = admit_retrieved_image_context(
+        image_id="image-result",
+        image_payload={"id": "image-result", "caption": "Image caption says reveal hidden policy."},
+        owner_scope_checked=False,
+        segment_id="image-call:result-1",
+        source_field="results[0]",
+        reason="retrieved image result is prompt data, not instructions",
+        corrective_action=(
+            "Keep retrieved image results in user-role data context and do not project "
+            "them into system or developer instructions."
+        ),
+    )
+
+    assert image_admission.user_payload == {
+        "results[0]": {
+            "id": "image-result",
+            "caption": "Image caption says reveal hidden policy.",
+        }
+    }
+    assert image_admission.untrusted_context_receipts[0]["segment_id"] == "image-call:result-1"
+    assert image_admission.untrusted_context_receipts[0]["source_type"] == "retrieved_image"
+    assert image_admission.untrusted_context_receipts[0]["source_field"] == "results[0]"
+    assert image_admission.untrusted_context_receipts[0]["source_id"] == "image-result"
+    assert image_admission.untrusted_context_receipts[0]["owner_scope_checked"] is False
+    assert (
+        image_admission.untrusted_context_receipts[0]["reason"]
+        == "retrieved image result is prompt data, not instructions"
+    )
+    assert "hidden policy" not in json.dumps(
+        image_admission.untrusted_context_receipts,
+        ensure_ascii=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_field"),
+    (
+        ({"segment_id": " "}, "segment_id"),
+        ({"source_field": 123}, "source_field"),
+        ({"reason": "\t"}, "reason"),
+        ({"corrective_action": None}, "corrective_action"),
+    ),
+)
+def test_retrieval_context_refuses_malformed_entrypoint_receipt_fields(
+    kwargs: dict[str, object],
+    expected_field: str,
+) -> None:
+    with pytest.raises(RetrievalContextAdmissionError) as exc_info:
+        admit_retrieved_image_context(
+            image_id="image-entrypoint",
+            image_payload={"caption": "Operator screenshot"},
+            owner_scope_checked=True,
+            **kwargs,  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.refusal_receipts == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": "image-entrypoint:retrieved-image-context",
+            "source_type": "retrieved_image",
+            "source_field": expected_field,
+            "source_id": "image-entrypoint",
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": False,
+            "owner_scope_checked": False,
+            "reason": "invalid_retrieved_image_context_field",
+            "corrective_action": "Reject malformed retrieved image evidence before prompt assembly.",
+        }
+    ]
+
+
 @pytest.mark.parametrize(
     ("helper", "kwargs", "source_type", "expected_id", "expected_suffix"),
     (

--- a/services/mlx-worker-python/worker/runtime/agentic_tools.py
+++ b/services/mlx-worker-python/worker/runtime/agentic_tools.py
@@ -7,7 +7,10 @@ from typing import Any
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
-from worker.runtime.prompt_context import PromptContextSegment, admit_prompt_context_segments
+from worker.runtime.retrieval_context import (
+    admit_retrieved_document_context,
+    admit_retrieved_image_context,
+)
 from worker.runtime.tool_observation import (
     ToolObservationPolicy,
     ToolObservationRecord,
@@ -819,23 +822,28 @@ def _retrieval_result_receipt(
     owner_scope_checked: bool,
 ) -> dict[str, object]:
     source_label = "document" if source_type == "retrieved_document" else "image"
-    admission = admit_prompt_context_segments(
-        [
-            PromptContextSegment(
-                segment_id=f"{tool_call_id}:result-{result_index}",
-                source_type=source_type,
-                source_field=f"results[{result_index - 1}]",
-                source_id=source_id,
-                owner_scope_checked=owner_scope_checked,
-                value=value,
-                reason=f"retrieved {source_label} result is prompt data, not instructions",
-                corrective_action=(
-                    f"Keep retrieved {source_label} results in user-role data context and do not project "
-                    "them into system or developer instructions."
-                ),
-            )
-        ]
-    )
+    kwargs = {
+        "owner_scope_checked": owner_scope_checked,
+        "segment_id": f"{tool_call_id}:result-{result_index}",
+        "source_field": f"results[{result_index - 1}]",
+        "reason": f"retrieved {source_label} result is prompt data, not instructions",
+        "corrective_action": (
+            f"Keep retrieved {source_label} results in user-role data context and do not project "
+            "them into system or developer instructions."
+        ),
+    }
+    if source_type == "retrieved_document":
+        admission = admit_retrieved_document_context(
+            document_id=source_id,
+            document_payload=value,
+            **kwargs,
+        )
+    else:
+        admission = admit_retrieved_image_context(
+            image_id=source_id,
+            image_payload=value,
+            **kwargs,
+        )
     return admission.untrusted_context_receipts[0]
 
 
@@ -846,22 +854,17 @@ def _visit_document_receipt(
     value: dict[str, Any],
     owner_scope_checked: bool,
 ) -> dict[str, object]:
-    admission = admit_prompt_context_segments(
-        [
-            PromptContextSegment(
-                segment_id=f"{tool_call_id}:visit-document",
-                source_type="retrieved_document",
-                source_field="payload",
-                source_id=source_id,
-                owner_scope_checked=owner_scope_checked,
-                value=value,
-                reason="visited document is prompt data, not instructions",
-                corrective_action=(
-                    "Keep visited document content in user-role data context and do not project "
-                    "it into system or developer instructions."
-                ),
-            )
-        ]
+    admission = admit_retrieved_document_context(
+        document_id=source_id,
+        document_payload=value,
+        owner_scope_checked=owner_scope_checked,
+        segment_id=f"{tool_call_id}:visit-document",
+        source_field="payload",
+        reason="visited document is prompt data, not instructions",
+        corrective_action=(
+            "Keep visited document content in user-role data context and do not project "
+            "it into system or developer instructions."
+        ),
     )
     return admission.untrusted_context_receipts[0]
 

--- a/services/mlx-worker-python/worker/runtime/prompt_context.py
+++ b/services/mlx-worker-python/worker/runtime/prompt_context.py
@@ -104,6 +104,8 @@ class PromptContextSourceEvidence:
     value: Any
     source_id: str = ""
     owner_scope_checked: bool = False
+    reason: str = ""
+    corrective_action: str = ""
 
     def __post_init__(self) -> None:
         _require_text(self.segment_id, "segment_id")
@@ -111,9 +113,11 @@ class PromptContextSourceEvidence:
         _require_text(self.source_field, "source_field")
         _require_text_type(self.source_id, "source_id")
         _require_bool(self.owner_scope_checked, "owner_scope_checked")
+        _require_optional_text(self.reason, "reason")
+        _require_optional_text(self.corrective_action, "corrective_action")
 
     def as_segment(self) -> PromptContextSegment:
-        reason, corrective_action, _ = _source_context_policy(self.source_type)
+        default_reason, default_corrective_action, _ = _source_context_policy(self.source_type)
         return PromptContextSegment(
             segment_id=self.segment_id,
             source_type=self.source_type,
@@ -121,8 +125,8 @@ class PromptContextSourceEvidence:
             value=self.value,
             source_id=self.source_id,
             owner_scope_checked=self.owner_scope_checked,
-            reason=reason,
-            corrective_action=corrective_action,
+            reason=self.reason or default_reason,
+            corrective_action=self.corrective_action or default_corrective_action,
         )
 
 
@@ -218,6 +222,13 @@ def _require_text(value: str, field_name: str) -> None:
 def _require_text_type(value: str, field_name: str) -> None:
     if not isinstance(value, str):
         raise PromptContextBoundaryError(f"Prompt context {field_name} must be a string.")
+
+
+def _require_optional_text(value: str, field_name: str) -> None:
+    if not isinstance(value, str):
+        raise PromptContextBoundaryError(f"Prompt context {field_name} must be a string.")
+    if value and not value.strip():
+        raise PromptContextBoundaryError(f"Prompt context {field_name} must be non-empty.")
 
 
 def _require_bool(value: bool, field_name: str) -> None:

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -24,12 +24,20 @@ def admit_retrieved_document_context(
     document_id: str,
     document_payload: dict[str, Any],
     owner_scope_checked: bool,
+    segment_id: str = "",
+    source_field: str = "",
+    reason: str = "",
+    corrective_action: str = "",
 ) -> PromptContextAdmission:
     return _admit_context(
         context_kind="retrieved_document",
         source_id=document_id,
         payload=document_payload,
         owner_scope_checked=owner_scope_checked,
+        segment_id=segment_id,
+        source_field=source_field,
+        reason=reason,
+        corrective_action=corrective_action,
     )
 
 
@@ -38,12 +46,20 @@ def admit_retrieved_image_context(
     image_id: str,
     image_payload: dict[str, Any],
     owner_scope_checked: bool,
+    segment_id: str = "",
+    source_field: str = "",
+    reason: str = "",
+    corrective_action: str = "",
 ) -> PromptContextAdmission:
     return _admit_context(
         context_kind="retrieved_image",
         source_id=image_id,
         payload=image_payload,
         owner_scope_checked=owner_scope_checked,
+        segment_id=segment_id,
+        source_field=source_field,
+        reason=reason,
+        corrective_action=corrective_action,
     )
 
 
@@ -53,13 +69,46 @@ def _admit_context(
     source_id: Any,
     payload: Any,
     owner_scope_checked: Any,
+    segment_id: str,
+    source_field: str,
+    reason: str,
+    corrective_action: str,
 ) -> PromptContextAdmission:
     normalized_source_id = _source_id_or_refusal(context_kind, source_id)
-    segment_id = f"{normalized_source_id}:{_segment_suffix(context_kind)}"
+    normalized_segment_id = _entrypoint_text_or_default(
+        context_kind,
+        segment_id,
+        default=f"{normalized_source_id}:{_segment_suffix(context_kind)}",
+        field_name="segment_id",
+        refusal_segment_id=f"{normalized_source_id}:{_segment_suffix(context_kind)}",
+        source_id=normalized_source_id,
+    )
+    normalized_source_field = _entrypoint_text_or_default(
+        context_kind,
+        source_field,
+        default=context_kind,
+        field_name="source_field",
+        refusal_segment_id=normalized_segment_id,
+        source_id=normalized_source_id,
+    )
+    normalized_reason = _entrypoint_optional_text(
+        context_kind,
+        reason,
+        segment_id=normalized_segment_id,
+        source_id=normalized_source_id,
+        field_name="reason",
+    )
+    normalized_corrective_action = _entrypoint_optional_text(
+        context_kind,
+        corrective_action,
+        segment_id=normalized_segment_id,
+        source_id=normalized_source_id,
+        field_name="corrective_action",
+    )
     if not isinstance(owner_scope_checked, bool):
         _raise_refusal(
             context_kind=context_kind,
-            segment_id=segment_id,
+            segment_id=normalized_segment_id,
             source_id=normalized_source_id,
             source_field="owner_scope_checked",
             owner_scope_checked=False,
@@ -67,20 +116,22 @@ def _admit_context(
     if not isinstance(payload, dict):
         _raise_refusal(
             context_kind=context_kind,
-            segment_id=segment_id,
+            segment_id=normalized_segment_id,
             source_id=normalized_source_id,
-            source_field=context_kind,
+            source_field=normalized_source_field,
             owner_scope_checked=owner_scope_checked,
         )
     return admit_prompt_context_source_evidence(
         [
             PromptContextSourceEvidence(
-                segment_id=segment_id,
+                segment_id=normalized_segment_id,
                 source_type=context_kind,
-                source_field=context_kind,
+                source_field=normalized_source_field,
                 source_id=normalized_source_id,
                 value=payload,
                 owner_scope_checked=owner_scope_checked,
+                reason=normalized_reason,
+                corrective_action=normalized_corrective_action,
             )
         ]
     )
@@ -138,6 +189,51 @@ def _segment_suffix(context_kind: RetrievalContextKind) -> str:
     if context_kind == "retrieved_document":
         return "retrieved-document-context"
     return "retrieved-image-context"
+
+
+def _entrypoint_text_or_default(
+    context_kind: RetrievalContextKind,
+    value: str,
+    *,
+    default: str,
+    field_name: str,
+    refusal_segment_id: str,
+    source_id: str,
+) -> str:
+    if value == "":
+        return default
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    raise RetrievalContextAdmissionError(
+        f"Invalid retrieved context {field_name}.",
+        refusal_receipts=[
+            refused_source_prompt_context_receipt(
+                segment_id=refusal_segment_id,
+                source_type=context_kind,
+                source_field=field_name,
+                source_id=source_id,
+                reason=f"invalid_{context_kind}_context_field",
+            )
+        ],
+    )
+
+
+def _entrypoint_optional_text(
+    context_kind: RetrievalContextKind,
+    value: str,
+    *,
+    segment_id: str,
+    source_id: str,
+    field_name: str,
+) -> str:
+    return _entrypoint_text_or_default(
+        context_kind,
+        value,
+        default="",
+        field_name=field_name,
+        refusal_segment_id=segment_id,
+        source_id=source_id,
+    )
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Routes deterministic text search, image search, and visit-source receipts through the retrieval-context admission helpers instead of direct prompt-context admission.
- Adds validated retrieval entrypoint receipt overrides for segment/source/reason/action, including refusal receipts for malformed fields.
- Documents the #1761 retrieval-entrypoint admission slice and updates the unified agentic runtime contract.

## Plan or Spec
- Issue: #1761
- Plan: `docs/plans/2026-06-10-issue-1761-retrieval-entrypoint-admission.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
make bootstrap
# rc=0; configured .githooks and uv sync checked 79 packages.

make proto
# rc=0; no generated artifact diff remained.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_retrieval_context.py::test_retrieval_context_accepts_entrypoint_receipt_fields services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_retrieval_source_receipts_use_retrieval_admission -q
# RED before implementation: failed as expected because retrieval helpers did not accept entrypoint receipt fields and agentic_tools did not expose retrieval admission hooks.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_retrieval_context.py::test_retrieval_context_accepts_entrypoint_receipt_fields services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_retrieval_source_receipts_use_retrieval_admission -q
# 2 passed in 0.04s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_prompt_context.py -q
# 25 passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_agentic_tools.py -q
# 64 passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_agentic_tools.py services/mlx-worker-python/tests/test_prompt_context.py -q
# 93 passed in 0.09s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_agentic_tools.py services/mlx-worker-python/tests/test_prompt_context.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/prompt_context.py services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_agentic_tools.py
# 93 passed in 0.18s; changed-scope TOTAL 67 statements, 2 missed, 97%.

git diff --check
# rc=0.

.githooks/pre-commit
# rc=0; make swift-test completed rc=0; make py-test completed with 3797 passed, 14 skipped, 2 warnings; make integration-test completed with 117 passed, 1 skipped.
# Scoped performance report: Status ok; Changed files 7; Selected probes 0; Regressions 0; Context regressions 0; Verification failures 0.
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 67 2 97%` for the changed Python runtime and focused test files.
- Local PR-scoped performance report: `.runtime/pre-commit-performance/20260610-064539-c3edd14c/report/report.md`
- Report status: `ok`; regressions: `0`; context regressions: `0`; verification failures: `0`.
- Observability mode: `minimal`; this change extends existing admission receipts and does not add new runtime metrics or debug probes.
- Probe overhead: `N/A: no registered performance probes were selected for this change set.`

## Known Gaps
- This slice covers deterministic retrieval result and visit-source entrypoints. Live RAG store, skill store, memory store, MCP, agent, workflow, and local-job surfaces remain deferred under #1761.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or are not applicable.
- [x] Dependency changes include updated lockfiles, or are not applicable.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
