### PR TITLE
Add explicit session restore receipts

### DIFF
--- a/docs/plans/2026-06-10-issue-1761-explicit-session-restore-receipts.md
+++ b/docs/plans/2026-06-10-issue-1761-explicit-session-restore-receipts.md
@@ -1,0 +1,70 @@
+# Issue 1761 Explicit Session Restore Receipt Plan
+
+## Goal
+
+Make caller-supplied session restore snapshot IDs visible as untrusted session
+context boundaries without claiming owner-scope validation that has not run.
+
+## Scope
+
+This slice covers:
+
+- control-plane `RequestCoordinator` handling for explicit
+  `execution.cache_hints.restore_snapshot_id` values;
+- session-context receipt evidence with `owner_scope_checked = false` for
+  caller-supplied restore snapshot IDs;
+- focused Swift tests for the explicit restore path; and
+- contract documentation for the distinction between implicit session-graph
+  restores and explicit caller-supplied restores.
+
+This slice does not validate explicit snapshot ownership, change snapshot
+lookup, alter cache restore routing, or add a durable RAG, skill, or memory
+store.
+
+## Best End-State Architecture
+
+Every restore snapshot ID that can influence prompt continuation should have a
+redacted untrusted-context receipt. Session-graph selected snapshots may record
+`owner_scope_checked = true` because the request session and branch lookup has
+already matched. Caller-supplied explicit restore IDs should record the same
+session-context boundary but keep `owner_scope_checked = false` until a future
+owner-aware snapshot lookup validates the ID.
+
+## Performance Probes And Metrics
+
+The changed path creates one small JSON receipt for requests that already carry
+an explicit restore snapshot ID. It does not add store scans, model inference,
+filesystem IO, or scheduler work.
+
+Verification must include:
+
+- a focused Swift test for explicit restore snapshot receipt evidence;
+- changed-line coverage for the touched Swift request-coordinator scope at or
+  above 95 percent;
+- the local pre-commit gate before commit on this host; and
+- a PR-scoped performance report with status `ok`, regressions `0`, context
+  regressions `0`, and verification failures `0`.
+
+## Implementation Steps
+
+1. Add a failing request-coordinator test that expects explicit restore
+   snapshot IDs to attach `melix.session_context.*` receipt ext fields with
+   `owner_scope_checked = false`.
+2. Extend `SessionContextBoundaryReceipts` to accept the owner-scope result
+   used in the receipt while preserving the existing implicit restore default.
+3. Attach an explicit restore receipt before implicit session-graph restore
+   resolution, without overwriting existing receipt ext fields.
+4. Update the unified runtime contract to document explicit restore receipt
+   semantics.
+5. Run focused Swift tests, coverage, local gate, and PR-scoped performance
+   before opening the PR.
+
+## Success Criteria
+
+- Explicit restore snapshot IDs are no longer invisible to session-context
+  receipt evidence.
+- Explicit restore receipts do not claim owner-scope validation.
+- Implicit session-graph restore receipts continue to record
+  `owner_scope_checked = true`.
+- No raw prompt text, hidden reasoning text, or private prompt content appears
+  in the receipt JSON.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -335,9 +335,11 @@ The session-context receipt uses `source_type = background_continuation`,
 selected snapshot ID as `source_id`. `owner_scope_checked` is `true` only for
 the in-memory session graph lookup that matched the request session and
 selected branch before setting the restore snapshot. Caller-supplied explicit
-`restore_snapshot_id` values are not marked as owner-scope checked by this
-slice. The receipt must not include raw prompt text, hidden reasoning text,
-prior model output, or private prompt bodies.
+`restore_snapshot_id` values must still emit the same redacted session-context
+receipt so the boundary is visible, but they must record
+`owner_scope_checked = false` until a future owner-aware snapshot lookup
+validates the ID. The receipt must not include raw prompt text, hidden
+reasoning text, prior model output, or private prompt bodies.
 
 The v1 Python worker prompt-context primitive is
 `worker.runtime.untrusted_context.untrusted_context_receipt`. It constructs the

--- a/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
+++ b/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
@@ -1563,12 +1563,14 @@ public actor RequestCoordinator {
         var workerRequest = translatedRequest.workerRequest
         let restoreSnapshotID = workerRequest.execution.cacheHints.restoreSnapshotID
         if !restoreSnapshotID.isEmpty {
+            let receiptExtFields = SessionContextBoundaryReceipts(
+                requestID: workerRequest.execution.id.requestID,
+                restoreSnapshotID: restoreSnapshotID,
+                ownerScopeChecked: false
+            ).extFields
+            // Preserve receipt metadata already attached by an upstream boundary step.
             workerRequest.execution.ext.merge(
-                SessionContextBoundaryReceipts(
-                    requestID: workerRequest.execution.id.requestID,
-                    restoreSnapshotID: restoreSnapshotID,
-                    ownerScopeChecked: false
-                ).extFields,
+                receiptExtFields,
                 uniquingKeysWith: { existingValue, _ in existingValue }
             )
         }

--- a/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
+++ b/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
@@ -1560,14 +1560,31 @@ public actor RequestCoordinator {
     private func resolvedRecoveryRequest(
         _ translatedRequest: TranslatedChatRequest
     ) async -> TranslatedChatRequest {
-        guard
-            let sessionGraphStore,
-            !translatedRequest.workerRequest.execution.id.sessionID.isEmpty
-        else {
-            return translatedRequest
+        var workerRequest = translatedRequest.workerRequest
+        if !workerRequest.execution.cacheHints.restoreSnapshotID.isEmpty {
+            workerRequest.execution.ext.merge(
+                SessionContextBoundaryReceipts(
+                    requestID: workerRequest.execution.id.requestID,
+                    restoreSnapshotID: workerRequest.execution.cacheHints.restoreSnapshotID,
+                    ownerScopeChecked: false
+                ).extFields,
+                uniquingKeysWith: { existingValue, _ in existingValue }
+            )
         }
 
-        var workerRequest = translatedRequest.workerRequest
+        guard
+            let sessionGraphStore,
+            !workerRequest.execution.id.sessionID.isEmpty
+        else {
+            return TranslatedChatRequest(
+                requestID: translatedRequest.requestID,
+                modelID: translatedRequest.modelID,
+                responseModelID: translatedRequest.responseModelID,
+                workerRequest: workerRequest,
+                stream: translatedRequest.stream
+            )
+        }
+
         if workerRequest.execution.id.branchID.isEmpty {
             workerRequest.execution.id.branchID = "branch-main"
         }

--- a/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
+++ b/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
@@ -1561,11 +1561,12 @@ public actor RequestCoordinator {
         _ translatedRequest: TranslatedChatRequest
     ) async -> TranslatedChatRequest {
         var workerRequest = translatedRequest.workerRequest
-        if !workerRequest.execution.cacheHints.restoreSnapshotID.isEmpty {
+        let restoreSnapshotID = workerRequest.execution.cacheHints.restoreSnapshotID
+        if !restoreSnapshotID.isEmpty {
             workerRequest.execution.ext.merge(
                 SessionContextBoundaryReceipts(
                     requestID: workerRequest.execution.id.requestID,
-                    restoreSnapshotID: workerRequest.execution.cacheHints.restoreSnapshotID,
+                    restoreSnapshotID: restoreSnapshotID,
                     ownerScopeChecked: false
                 ).extFields,
                 uniquingKeysWith: { existingValue, _ in existingValue }

--- a/services/control-plane-swift/Sources/Requests/SessionContextBoundaryReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/SessionContextBoundaryReceipt.swift
@@ -5,7 +5,11 @@ struct SessionContextBoundaryReceipts: Sendable, Equatable {
 
     private let receipts: [[String: SessionContextReceiptValue]]
 
-    init(requestID: String, restoreSnapshotID: String) {
+    init(
+        requestID: String,
+        restoreSnapshotID: String,
+        ownerScopeChecked: Bool = true
+    ) {
         let normalizedRequestID = requestID.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedSnapshotID = restoreSnapshotID.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedRequestID.isEmpty, !normalizedSnapshotID.isEmpty else {
@@ -24,7 +28,7 @@ struct SessionContextBoundaryReceipts: Sendable, Equatable {
             "policy": .string("data_only"),
             "boundary_checked": .bool(true),
             "included": .bool(true),
-            "owner_scope_checked": .bool(true),
+            "owner_scope_checked": .bool(ownerScopeChecked),
             "reason": .string("background continuation is prompt data, not instructions"),
             "corrective_action": .string(
                 "Keep background continuation evidence in user-role data context and do not project it into system or developer instructions."

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -2119,8 +2119,8 @@ struct RequestCoordinatorTests {
         _ = await consumer.result
     }
 
-    @Test("explicit restore snapshot ids do not claim session context owner checks")
-    func explicitRestoreSnapshotIDsDoNotClaimSessionContextOwnerChecks() async throws {
+    @Test("explicit restore snapshot ids attach receipts without claiming owner checks")
+    func explicitRestoreSnapshotIDsAttachReceiptsWithoutClaimingOwnerChecks() async throws {
         let workerClient = PhaseAwareWorkerClient()
         let sessionGraphStore = SessionGraphStore(nowUnixMs: { 9_200 })
         let coordinator = RequestCoordinator(
@@ -2148,13 +2148,70 @@ struct RequestCoordinatorTests {
         defer { consumer.cancel() }
 
         let prefillRequest = try #require(await waitForPrefillRequest(workerClient: workerClient))
+        let ext = prefillRequest.execution.ext
+        let receiptsJSON = try #require(ext["melix.session_context.receipts_json"])
+        let receipts = try #require(
+            try JSONSerialization.jsonObject(with: Data(receiptsJSON.utf8)) as? [[String: Any]]
+        )
+        let receipt = try #require(receipts.first)
+
         #expect(prefillRequest.execution.cacheHints.restoreSnapshotID == "snap-caller-supplied")
-        #expect(prefillRequest.execution.ext["melix.session_context.receipt_schema"] == nil)
-        #expect(prefillRequest.execution.ext["melix.session_context.receipt_count"] == nil)
-        #expect(prefillRequest.execution.ext["melix.session_context.receipts_json"] == nil)
+        #expect(ext["melix.session_context.receipt_schema"] == "melix.untrusted_context_receipt.v1")
+        #expect(ext["melix.session_context.receipt_count"] == "1")
+        #expect(receipts.count == 1)
+        #expect(receipt["schema_version"] as? String == "melix.untrusted_context_receipt.v1")
+        #expect(receipt["segment_id"] as? String == "req-explicit-restore:session-context:restore-snapshot")
+        #expect(receipt["source_type"] as? String == "background_continuation")
+        #expect(receipt["source_field"] as? String == "execution.cache_hints.restore_snapshot_id")
+        #expect(receipt["source_id"] as? String == "snap-caller-supplied")
+        #expect(receipt["boundary_checked"] as? Bool == true)
+        #expect(receipt["included"] as? Bool == true)
+        #expect(receipt["owner_scope_checked"] as? Bool == false)
 
         _ = try #require(await waitForDecodeRequest(workerClient: workerClient))
         await workerClient.finishDecode(requestID: "req-explicit-restore")
+        _ = await consumer.result
+    }
+
+    @Test("explicit restore receipts do not require a session graph store")
+    func explicitRestoreReceiptsDoNotRequireSessionGraphStore() async throws {
+        let workerClient = PhaseAwareWorkerClient()
+        let coordinator = RequestCoordinator(
+            workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+            abortRegistry: AbortRegistry()
+        )
+
+        let execution = try await coordinator.startChatCompletion(
+            makeTranslatedChatRequest(
+                requestID: "req-explicit-restore-no-store",
+                restoreSnapshotID: "snap-no-session-store",
+                saveBoundarySnapshot: true
+            )
+        )
+        let consumer = Task {
+            do {
+                for try await _ in execution.stream {
+                }
+            } catch {
+            }
+        }
+        defer { consumer.cancel() }
+
+        let prefillRequest = try #require(await waitForPrefillRequest(workerClient: workerClient))
+        let ext = prefillRequest.execution.ext
+        let receiptsJSON = try #require(ext["melix.session_context.receipts_json"])
+        let receipts = try #require(
+            try JSONSerialization.jsonObject(with: Data(receiptsJSON.utf8)) as? [[String: Any]]
+        )
+        let receipt = try #require(receipts.first)
+
+        #expect(prefillRequest.execution.cacheHints.restoreSnapshotID == "snap-no-session-store")
+        #expect(ext["melix.session_context.receipt_count"] == "1")
+        #expect(receipt["source_id"] as? String == "snap-no-session-store")
+        #expect(receipt["owner_scope_checked"] as? Bool == false)
+
+        _ = try #require(await waitForDecodeRequest(workerClient: workerClient))
+        await workerClient.finishDecode(requestID: "req-explicit-restore-no-store")
         _ = await consumer.result
     }
 

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -2143,6 +2143,7 @@ struct RequestCoordinatorTests {
                 for try await _ in execution.stream {
                 }
             } catch {
+                Issue.record(error)
             }
         }
         defer { consumer.cancel() }
@@ -2193,6 +2194,7 @@ struct RequestCoordinatorTests {
                 for try await _ in execution.stream {
                 }
             } catch {
+                Issue.record(error)
             }
         }
         defer { consumer.cancel() }
@@ -2212,6 +2214,51 @@ struct RequestCoordinatorTests {
 
         _ = try #require(await waitForDecodeRequest(workerClient: workerClient))
         await workerClient.finishDecode(requestID: "req-explicit-restore-no-store")
+        _ = await consumer.result
+    }
+
+    @Test("explicit restore receipts preserve existing receipt ext metadata")
+    func explicitRestoreReceiptsPreserveExistingReceiptExtMetadata() async throws {
+        let workerClient = PhaseAwareWorkerClient()
+        let coordinator = RequestCoordinator(
+            workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+            abortRegistry: AbortRegistry()
+        )
+
+        let execution = try await coordinator.startChatCompletion(
+            makeTranslatedChatRequest(
+                requestID: "req-explicit-restore-existing-ext",
+                restoreSnapshotID: "snap-caller-supplied",
+                saveBoundarySnapshot: true,
+                executionExt: [
+                    "melix.session_context.receipt_schema": "existing.schema",
+                    "melix.session_context.receipt_count": "7",
+                    "melix.session_context.receipts_json": "[{\"source_id\":\"existing-snapshot\"}]",
+                    "melix.unrelated": "kept",
+                ]
+            )
+        )
+        let consumer = Task {
+            do {
+                for try await _ in execution.stream {
+                }
+            } catch {
+                Issue.record(error)
+            }
+        }
+        defer { consumer.cancel() }
+
+        let prefillRequest = try #require(await waitForPrefillRequest(workerClient: workerClient))
+        let ext = prefillRequest.execution.ext
+
+        #expect(prefillRequest.execution.cacheHints.restoreSnapshotID == "snap-caller-supplied")
+        #expect(ext["melix.session_context.receipt_schema"] == "existing.schema")
+        #expect(ext["melix.session_context.receipt_count"] == "7")
+        #expect(ext["melix.session_context.receipts_json"] == "[{\"source_id\":\"existing-snapshot\"}]")
+        #expect(ext["melix.unrelated"] == "kept")
+
+        _ = try #require(await waitForDecodeRequest(workerClient: workerClient))
+        await workerClient.finishDecode(requestID: "req-explicit-restore-existing-ext")
         _ = await consumer.result
     }
 


### PR DESCRIPTION
## Summary
- Add a request/session entrypoint receipt for caller-supplied `execution.cache_hints.restore_snapshot_id` values.
- Mark explicit restore receipts with `owner_scope_checked=false` while preserving implicit session-graph restore receipts as owner-scope checked.
- Preserve upstream `melix.session_context.*` receipt metadata when a boundary step has already attached it, and make the new stream-consumer tests fail directly on stream errors.
- Update the unified runtime contract and add a focused issue #1761 plan for this slice.

## Plan or Spec
- `docs/plans/2026-06-10-issue-1761-explicit-session-restore-receipts.md`
- `docs/unified-agentic-tool-runtime-contract.md`
- Continues #1761.

## Commands Run
```text
swift test --package-path services/control-plane-swift --filter 'RequestCoordinatorTests/explicitRestoreSnapshotIDsAttachReceiptsWithoutClaimingOwnerChecks'
# RED: failed because explicit restore_snapshot_id did not attach melix.session_context.receipts_json.

swift test --package-path services/control-plane-swift --filter 'RequestCoordinatorTests/explicitRestoreSnapshotIDsAttachReceiptsWithoutClaimingOwnerChecks|RequestCoordinatorTests/explicitRestoreReceiptsDoNotRequireSessionGraphStore|RequestCoordinatorTests/sessionFollowUpRestoreRequestsAttachSessionContextReceipts|RequestCoordinatorTests/emptySessionContextReceiptInputsDoNotAttachExtMetadata'
# PASS: 4 selected RequestCoordinator tests.

swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'RequestCoordinatorTests/explicitRestoreSnapshotIDsAttachReceiptsWithoutClaimingOwnerChecks|RequestCoordinatorTests/explicitRestoreReceiptsDoNotRequireSessionGraphStore|RequestCoordinatorTests/sessionFollowUpRestoreRequestsAttachSessionContextReceipts|RequestCoordinatorTests/emptySessionContextReceiptInputsDoNotAttachExtMetadata'
# PASS: coverage build for the focused changed-scope tests.

python3.11 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/Requests/RequestCoordinator.swift services/control-plane-swift/Sources/Requests/SessionContextBoundaryReceipt.swift services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
# PASS: TOTAL 100.00% 81/81 changed executable lines.
#   services/control-plane-swift/Sources/Requests/RequestCoordinator.swift 100.00% 20/20
#   services/control-plane-swift/Sources/Requests/SessionContextBoundaryReceipt.swift 100.00% 2/2
#   services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift 100.00% 59/59

xcrun swift test --package-path services/control-plane-swift --filter 'RequestCoordinatorTests/explicitRestoreSnapshotIDsAttachReceiptsWithoutClaimingOwnerChecks|RequestCoordinatorTests/explicitRestoreReceiptsDoNotRequireSessionGraphStore|RequestCoordinatorTests/explicitRestoreReceiptsPreserveExistingReceiptExtMetadata|RequestCoordinatorTests/sessionFollowUpRestoreRequestsAttachSessionContextReceipts|RequestCoordinatorTests/emptySessionContextReceiptInputsDoNotAttachExtMetadata'
# PASS: 5 selected RequestCoordinator tests after review follow-ups.

xcrun swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'RequestCoordinatorTests/explicitRestoreSnapshotIDsAttachReceiptsWithoutClaimingOwnerChecks|RequestCoordinatorTests/explicitRestoreReceiptsDoNotRequireSessionGraphStore|RequestCoordinatorTests/explicitRestoreReceiptsPreserveExistingReceiptExtMetadata|RequestCoordinatorTests/sessionFollowUpRestoreRequestsAttachSessionContextReceipts|RequestCoordinatorTests/emptySessionContextReceiptInputsDoNotAttachExtMetadata'
# PASS: coverage build for the review follow-up changed-scope tests.

python3.11 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/Requests/RequestCoordinator.swift services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
# PASS: TOTAL 100.00% 6/6 changed executable lines.
#   services/control-plane-swift/Sources/Requests/RequestCoordinator.swift 100.00% 0/0
#   services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift 100.00% 6/6

git diff --check && git diff --cached --check
# PASS: no whitespace errors.

MELIX_PRE_COMMIT_FORCE=1 .githooks/pre-commit
# PASS: make swift-test rc=0 elapsed=422.1s.
# PASS: make py-test rc=0, 3797 passed, 14 skipped, 2 warnings in 159.40s.
# PASS: make integration-test rc=0, 117 passed, 1 skipped in 682.44s.
# PASS: scoped performance report Status ok, Regressions 0, Context regressions 0, Verification failures 0.

git commit --no-edit
# PASS: pre-commit hook re-ran the full gate.
# PASS: make swift-test rc=0 elapsed=449.8s.
# PASS: make py-test rc=0, 3797 passed, 14 skipped, 2 warnings in 159.42s.
# PASS: make integration-test rc=0, 117 passed, 1 skipped in 686.98s.
# PASS: scoped performance report Status ok, Regressions 0, Context regressions 0, Verification failures 0.

git merge --no-commit --no-ff -s ours origin/codex/issue-1761-live-rag-entrypoint-20260610b
git diff --exit-code 2e6ea55b07a4d73dd78755dc37663d4de2bed2fb 97ae312c
# PASS: no-content topology merge only; final tree is identical to the tree verified by the full pre-commit gate above.
```

## Coverage and Metrics
- Changed-line coverage: 100.00% (81/81 changed executable Swift lines for the initial implementation slice; 6/6 changed executable Swift lines for the review follow-up slice).
- Pre-commit performance report: `.runtime/pre-commit-performance/20260610-104843-dbfed1c6/report/report.md`.
- Structured report: `.runtime/pre-commit-performance/20260610-104843-dbfed1c6/report/report.json`.
- Performance status: `ok`; selected probes: 1; direct/gated probes: 1; regressions: 0; context regressions: 0; verification failures: 0.
- Same-cohort batching probe evidence remained neutral across base and head, including `failure_count=0`, `scheduler_admission_cohort_size=2`, `scheduler_continuous_batch_size=2`, and `worker_decode_batch_size=1`.
- Observability mode: local pre-commit scoped performance probe only; no runtime debug logging or deferred probe overhead added by this change.

## Known Gaps
- Caller-supplied restore snapshot IDs are still not owner-validated in this slice; receipts explicitly expose that by setting `owner_scope_checked=false`.
- The broad `swift test --package-path services/control-plane-swift --filter RequestCoordinatorTests` attempt was stopped after it hung without useful output; the focused RequestCoordinator tests and the full pre-commit gates above passed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
