### PR TITLE
Add MCP catalog boundary receipts

### DIFF
--- a/docs/plans/2026-06-10-issue-1761-mcp-tool-catalog-boundary-receipts.md
+++ b/docs/plans/2026-06-10-issue-1761-mcp-tool-catalog-boundary-receipts.md
@@ -1,0 +1,221 @@
+# Issue 1761 MCP Tool Catalog Boundary Receipts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development or superpowers:executing-plans to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** Record untrusted-context boundary receipts when MCP tool catalog
+sources are auto-injected into worker request metadata.
+
+**Architecture:** MCP tool catalogs are local skill/tool context and must be
+treated as untrusted prompt-adjacent data. The control-plane translator will
+attach request-local, redacted receipt evidence for the injected MCP source IDs
+without copying tool namespaces, configuration paths, schemas, or prompt text.
+
+**Tech Stack:** Swift control-plane request translation, Swift Testing,
+`ExecutionMetadata.ext`, canonical JSON receipt evidence.
+
+---
+
+## Scope
+
+This slice covers:
+
+- MCP tool catalog source IDs that `TextRequestShaper` auto-injects through a
+  `ToolParserSelection`.
+- A Swift receipt helper that emits `melix.untrusted_context_receipt.v1`
+  evidence under MCP-specific `ExecutionMetadata.ext` keys.
+- Focused Swift tests proving that receipts are attached and remain redacted.
+- Runtime contract documentation for the new MCP receipt keys.
+
+This slice does not change MCP catalog loading, tool namespace normalization,
+tool schema exposure, parser selection behavior, Python worker parsing, or live
+MCP execution.
+
+## Best End-State Architecture
+
+MCP tools, agent skills, retrieved memories, retrieved documents, tool output,
+and background continuations all cross an explicit untrusted-context boundary
+before they influence model prompts or prompt-adjacent execution metadata.
+Request translation should keep the already-redacted catalog source IDs as
+metadata, attach a machine-readable receipt for each source, and avoid copying
+the raw tool catalog into receipt JSON.
+
+The receipt helper belongs beside the existing prompt-context receipt helpers
+in `services/control-plane-swift/Sources/Requests`. It should be deterministic,
+small, and independent from `MCPToolCatalog` loading so it records only the
+source IDs that were actually selected by `TextRequestShaper`.
+
+## Performance Probes And Metrics
+
+The changed path creates one small dictionary per injected MCP source ID and
+serializes one sorted JSON array. Runtime cost is linear in enabled MCP source
+count and does not add filesystem reads, network calls, model inference,
+scheduler work, or tool schema traversal.
+
+Verification must include:
+
+- focused red/green Swift test for MCP boundary receipt attachment;
+- adjacent `ToolParserRegistryTests`;
+- changed-line coverage for the Swift files touched by this slice with at
+  least 95 percent coverage, or an explicit scoped coverage report if the
+  changed lines are exercised by package coverage;
+- full local pre-commit gate before commit on this host;
+- PR performance report with status `ok`, regressions `0`, context
+  regressions `0`, and verification failures `0`.
+
+## Implementation Steps
+
+### Task 1: Add The Failing Translator Test
+
+**Files:**
+
+- Modify:
+  `services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift`
+
+- [ ] **Step 1: Add a Swift Testing case that translates a request with an MCP
+      catalog containing enabled `filesystem` and `math` sources.**
+
+The test must assert:
+
+- `melix.mcp.source_ids = filesystem,math`;
+- `melix.mcp.prompt_context.receipt_schema =
+  melix.untrusted_context_receipt.v1`;
+- `melix.mcp.prompt_context.receipt_count = 2`;
+- receipt `source_id` values are `filesystem` and `math`;
+- receipt `source_type = skill`;
+- receipt `source_field = mcp_tool_catalog`;
+- receipt `message_role = user`;
+- receipt `policy = data_only`;
+- receipt `included = true`;
+- receipt `owner_scope_checked = false`;
+- receipt JSON omits the MCP config path and tool namespaces.
+
+- [ ] **Step 2: Run the focused test and verify it fails because the MCP receipt
+      ext fields are absent.**
+
+```bash
+xcrun swift test --package-path services/control-plane-swift --filter ToolParserRegistryTests/translatedMCPToolCatalogsAttachSkillPromptContextReceipts
+```
+
+Expected: fail at the `melix.mcp.prompt_context.receipts_json` requirement.
+
+### Task 2: Implement The MCP Receipt Helper
+
+**Files:**
+
+- Create:
+  `services/control-plane-swift/Sources/Requests/MCPPromptContextBoundaryReceipt.swift`
+- Modify:
+  `services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift`
+
+- [ ] **Step 1: Add `MCPPromptContextBoundaryReceipts` with deterministic JSON
+      output.**
+
+The helper must:
+
+- accept `requestID` and selected `sourceIDs`;
+- emit no ext fields when `sourceIDs` is empty;
+- create `segment_id = <requestID>:mcp-source-<index>`;
+- set `source_type = skill`;
+- set `source_field = mcp_tool_catalog`;
+- set `message_role = user`;
+- set `trust_level = untrusted`;
+- set `policy = data_only`;
+- set `boundary_checked = true`;
+- set `included = true`;
+- set `owner_scope_checked = false`;
+- use skill-specific reason and corrective-action text;
+- serialize sorted-key JSON.
+
+- [ ] **Step 2: Merge the helper's ext fields when
+      `ChatRequestTranslator.translate` writes `melix.mcp.source_ids`.**
+
+The translator should use the selected `toolParser.mcpSourceIDs`, not raw
+catalog sources, so disabled and refused sources never receive admitted
+receipts.
+
+- [ ] **Step 3: Run the focused test and verify it passes.**
+
+```bash
+xcrun swift test --package-path services/control-plane-swift --filter ToolParserRegistryTests/translatedMCPToolCatalogsAttachSkillPromptContextReceipts
+```
+
+### Task 3: Document The Runtime Contract
+
+**Files:**
+
+- Modify: `docs/unified-agentic-tool-runtime-contract.md`
+
+- [ ] **Step 1: Add the MCP-specific receipt keys to the untrusted prompt
+      context contract.**
+
+Document:
+
+- `melix.mcp.prompt_context.receipt_schema`;
+- `melix.mcp.prompt_context.receipt_count`;
+- `melix.mcp.prompt_context.receipts_json`;
+- one admitted receipt per selected MCP source ID;
+- receipts use `source_type = skill` and `source_field = mcp_tool_catalog`;
+- receipts omit config paths, tool namespaces, tool schemas, and private prompt
+  text.
+
+- [ ] **Step 2: Run adjacent Swift tests.**
+
+```bash
+xcrun swift test --package-path services/control-plane-swift --filter ToolParserRegistryTests
+```
+
+### Task 4: Verify, Commit, And Open The PR
+
+**Files:**
+
+- Verify all touched files.
+
+- [ ] **Step 1: Run formatting and diff checks.**
+
+```bash
+git diff --check
+```
+
+- [ ] **Step 2: Run scoped coverage and metrics.**
+
+Use the repository's changed-line or package coverage tooling for the touched
+Swift request path. The changed scope must report at least 95 percent coverage,
+or the PR evidence must explain why the scope is not currently measurable and
+include the strongest available package coverage output.
+
+- [ ] **Step 3: Run the full local pre-commit gate.**
+
+```bash
+.githooks/pre-commit
+```
+
+- [ ] **Step 4: Commit a focused change.**
+
+```bash
+git add services/control-plane-swift/Sources/Requests/MCPPromptContextBoundaryReceipt.swift \
+  services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift \
+  services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift \
+  docs/unified-agentic-tool-runtime-contract.md \
+  docs/plans/2026-06-10-issue-1761-mcp-tool-catalog-boundary-receipts.md
+git commit -m "Add MCP catalog boundary receipts"
+```
+
+- [ ] **Step 5: Open a PR using the repository template headings exactly, then
+      wait for CI, review, and the performance report.**
+
+The PR must not merge until review threads are resolved, CI is green, the
+branch is current with `origin/main`, and the performance report status is
+`ok` with zero regressions.
+
+## Success Criteria
+
+- MCP tool catalog source IDs receive redacted untrusted-context receipt
+  evidence when they are injected into worker request metadata.
+- Receipt JSON contains source metadata and policy only, not config paths, tool
+  namespaces, tool schemas, raw tool payloads, or private prompt text.
+- Existing MCP parser-selection behavior is unchanged.
+- Local verification, remote CI, code review, and PR performance report are all
+  acceptable before squash merge.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -322,6 +322,23 @@ skill entrypoints, memory entrypoints, and background-job continuations must
 reuse this receipt shape when they add their prompt-context boundary evidence
 under #1761.
 
+The v1 MCP tool catalog prompt-adjacent metadata slice records the same receipt
+shape when `TextRequestShaper` auto-injects MCP catalog sources into
+`ToolParserSelection`. These receipts are stored in `ExecutionMetadata.ext` as:
+
+- `melix.mcp.prompt_context.receipt_schema`
+- `melix.mcp.prompt_context.receipt_count`
+- `melix.mcp.prompt_context.receipts_json`
+
+The MCP receipt records one admitted segment per selected MCP source ID after
+catalog normalization, high-risk namespace refusal, and enabled-source
+filtering. Each receipt uses `source_type = skill`, `source_field =
+mcp_tool_catalog`, and `source_id` set to the redacted MCP source ID. This
+records that the catalog source is prompt-adjacent skill/tool evidence and not
+trusted instructions. The receipt must not include MCP config paths, tool
+namespaces, tool schemas, tool arguments, private prompt text, or raw source
+payloads.
+
 The v1 control-plane session-context slice records the same receipt shape when
 `RequestCoordinator` resolves an implicit follow-up restore snapshot from
 `SessionGraphStore`. These receipts are stored in `ExecutionMetadata.ext` as:

--- a/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
+++ b/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
@@ -2575,6 +2575,13 @@ public struct ChatRequestTranslator: Sendable {
             }
             if !toolParser.mcpSourceIDs.isEmpty {
                 generateRequest.execution.ext["melix.mcp.source_ids"] = toolParser.mcpSourceIDs.joined(separator: ",")
+                generateRequest.execution.ext.merge(
+                    MCPPromptContextBoundaryReceipts(
+                        requestID: requestID,
+                        sourceIDs: toolParser.mcpSourceIDs
+                    ).extFields,
+                    uniquingKeysWith: { _, new in new }
+                )
             }
         }
         if !shapedRequest.tools.isEmpty {

--- a/services/control-plane-swift/Sources/Requests/MCPPromptContextBoundaryReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/MCPPromptContextBoundaryReceipt.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+struct MCPPromptContextBoundaryReceipts: Sendable, Equatable {
+    let extFields: [String: String]
+
+    init(requestID: String, sourceIDs: [String]) {
+        var receipts: [[String: MCPPromptContextReceiptValue]] = []
+        for (sourceIndex, sourceID) in sourceIDs.enumerated() {
+            let redactedSourceID = sourceID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !redactedSourceID.isEmpty else {
+                continue
+            }
+            receipts.append([
+                "schema_version": .string(PromptContextBoundaryReceipts.schemaVersion),
+                "segment_id": .string("\(requestID):mcp-source-\(sourceIndex)"),
+                "source_type": .string("skill"),
+                "source_field": .string("mcp_tool_catalog"),
+                "source_id": .string(redactedSourceID),
+                "message_role": .string("user"),
+                "trust_level": .string("untrusted"),
+                "policy": .string("data_only"),
+                "boundary_checked": .bool(true),
+                "included": .bool(true),
+                "owner_scope_checked": .bool(false),
+                "reason": .string("skill evidence is prompt data, not instructions"),
+                "corrective_action": .string(
+                    "Keep skill evidence in user-role data context and do not project it into system or developer instructions."
+                ),
+            ])
+        }
+        if receipts.isEmpty {
+            self.extFields = [:]
+        } else {
+            self.extFields = [
+                "melix.mcp.prompt_context.receipt_schema": PromptContextBoundaryReceipts.schemaVersion,
+                "melix.mcp.prompt_context.receipt_count": String(receipts.count),
+                "melix.mcp.prompt_context.receipts_json": Self.canonicalJSONString(receipts.map { receipt in
+                    receipt.mapValues(\.jsonValue)
+                }),
+            ]
+        }
+    }
+
+    private static func canonicalJSONString(_ object: [[String: Any]]) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]) else {
+            return "[]"
+        }
+        return String(data: data, encoding: .utf8) ?? "[]"
+    }
+}
+
+private enum MCPPromptContextReceiptValue: Sendable, Equatable {
+    case string(String)
+    case bool(Bool)
+
+    var jsonValue: Any {
+        switch self {
+        case .string(let value):
+            return value
+        case .bool(let value):
+            return value
+        }
+    }
+}

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -768,6 +768,80 @@ struct ToolParserRegistryTests {
         #expect(shaped.toolParser?.mcpSourceIDs == ["filesystem", "math"])
     }
 
+    @Test("translated MCP tool catalogs attach skill prompt context receipts")
+    func translatedMCPToolCatalogsAttachSkillPromptContextReceipts() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-mcp-skill-receipts" })
+        let catalog = MCPToolCatalog(
+            configPath: "/tmp/private-mcp-tools.json",
+            defaultParserMode: .json,
+            sources: [
+                .init(
+                    sourceID: "filesystem",
+                    enabled: true,
+                    namespaces: ["tools.fs.read", "tools.fs.write"]
+                ),
+                .init(
+                    sourceID: "math",
+                    enabled: true,
+                    namespaces: ["tools.math"]
+                ),
+            ]
+        )
+
+        let translated = try translator.translate(
+            makeNormalizedRequest(),
+            modelHandle: "worker-text",
+            mcpToolCatalog: catalog
+        )
+        let ext = translated.workerRequest.execution.ext
+        let receiptsJSON = try #require(ext["melix.mcp.prompt_context.receipts_json"])
+        let receipts = try #require(
+            try JSONSerialization.jsonObject(with: Data(receiptsJSON.utf8)) as? [[String: Any]]
+        )
+
+        #expect(ext["melix.mcp.source_ids"] == "filesystem,math")
+        #expect(ext["melix.mcp.prompt_context.receipt_schema"] == "melix.untrusted_context_receipt.v1")
+        #expect(ext["melix.mcp.prompt_context.receipt_count"] == "2")
+        #expect(receipts.compactMap { $0["source_id"] as? String } == ["filesystem", "math"])
+        #expect(receipts.compactMap { $0["segment_id"] as? String } == [
+            "req-mcp-skill-receipts:mcp-source-0",
+            "req-mcp-skill-receipts:mcp-source-1",
+        ])
+        #expect(receipts.allSatisfy { $0["source_type"] as? String == "skill" })
+        #expect(receipts.allSatisfy { $0["source_field"] as? String == "mcp_tool_catalog" })
+        #expect(receipts.allSatisfy { $0["message_role"] as? String == "user" })
+        #expect(receipts.allSatisfy { $0["policy"] as? String == "data_only" })
+        #expect(receipts.allSatisfy { $0["included"] as? Bool == true })
+        #expect(receipts.allSatisfy { $0["owner_scope_checked"] as? Bool == false })
+        #expect(receipts.allSatisfy { $0["reason"] as? String == "skill evidence is prompt data, not instructions" })
+        #expect(receiptsJSON.contains("private-mcp-tools") == false)
+        #expect(receiptsJSON.contains("tools.fs.read") == false)
+        #expect(receiptsJSON.contains("tools.math") == false)
+    }
+
+    @Test("MCP prompt context receipts ignore blank source ids")
+    func mcpPromptContextReceiptsIgnoreBlankSourceIDs() throws {
+        #expect(
+            MCPPromptContextBoundaryReceipts(
+                requestID: "req-mcp-empty",
+                sourceIDs: ["  ", "\n"]
+            ).extFields.isEmpty
+        )
+
+        let ext = MCPPromptContextBoundaryReceipts(
+            requestID: "req-mcp-trimmed",
+            sourceIDs: ["  filesystem  ", ""]
+        ).extFields
+        let receiptsJSON = try #require(ext["melix.mcp.prompt_context.receipts_json"])
+        let receipts = try #require(
+            try JSONSerialization.jsonObject(with: Data(receiptsJSON.utf8)) as? [[String: Any]]
+        )
+
+        #expect(ext["melix.mcp.prompt_context.receipt_count"] == "1")
+        #expect(receipts.compactMap { $0["source_id"] as? String } == ["filesystem"])
+        #expect(receipts.compactMap { $0["segment_id"] as? String } == ["req-mcp-trimmed:mcp-source-0"])
+    }
+
     @Test("mcp tool catalogs merge into model defaults without losing model parser mode")
     func mcpToolCatalogsMergeIntoModelDefaultsWithoutLosingModelParserMode() throws {
         var settings = Melix_Controlplane_V1_ModelSettings()


### PR DESCRIPTION
## Summary
- Add redacted untrusted-context receipts when MCP tool catalog source IDs are auto-injected into worker request metadata.
- Document the MCP prompt-context receipt contract and keep receipts limited to selected source IDs plus policy metadata.
- Cover receipt attachment, redaction, and blank source-ID behavior in `ToolParserRegistryTests`.

## Plan or Spec
- Issue: #1761
- Plan: `docs/plans/2026-06-10-issue-1761-mcp-tool-catalog-boundary-receipts.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
make bootstrap
pass

make proto
pass; no generated artifact diff

xcrun swift test --package-path services/control-plane-swift --filter ToolParserRegistryTests/translatedMCPToolCatalogsAttachSkillPromptContextReceipts
RED: failed as expected because melix.mcp.prompt_context.receipts_json was absent

xcrun swift test --package-path services/control-plane-swift --filter ToolParserRegistryTests/translatedMCPToolCatalogsAttachSkillPromptContextReceipts
pass

xcrun swift test --package-path services/control-plane-swift --filter ToolParserRegistryTests/mcpPromptContextReceiptsIgnoreBlankSourceIDs
pass

xcrun swift test --package-path services/control-plane-swift --filter ToolParserRegistryTests
pass; 24 tests

xcrun swift test --package-path services/control-plane-swift --enable-code-coverage --filter ToolParserRegistryTests
pass; 24 tests

python3.11 scripts/swift_changed_line_coverage.py \
  --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests \
  --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata \
  services/control-plane-swift/Sources/Requests/MCPPromptContextBoundaryReceipt.swift \
  services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift \
  services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
pass; TOTAL 99.23% changed-line coverage, 129/130 covered

git diff --check && git diff --cached --check
pass

.githooks/pre-commit
pass; make swift-test rc=0 in 479.0s; make py-test rc=0 with 3797 passed, 14 skipped in 183.79s; make integration-test rc=0 with 117 passed, 1 skipped in 725.64s; scoped performance report status ok

git fetch origin main && git merge-base --is-ancestor origin/main HEAD && git status --short --branch
pass; branch includes origin/main and is ahead by one commit

Review update: compute MCP receipt extFields once during initialization.

xcrun swift test --package-path services/control-plane-swift --filter ToolParserRegistryTests/translatedMCPToolCatalogsAttachSkillPromptContextReceipts
pass

xcrun swift test --package-path services/control-plane-swift --filter ToolParserRegistryTests
pass; 24 tests

xcrun swift test --package-path services/control-plane-swift --enable-code-coverage --filter ToolParserRegistryTests
pass; 24 tests

python3.11 scripts/swift_changed_line_coverage.py --diff-from origin/main \
  --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests \
  --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata \
  services/control-plane-swift/Sources/Requests/MCPPromptContextBoundaryReceipt.swift \
  services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift \
  services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
pass; TOTAL 99.22% changed-line coverage, 127/128 covered

.githooks/pre-commit
pass after review update; make swift-test rc=0 in 217.7s; make py-test rc=0 with 3797 passed, 14 skipped in 158.50s; make integration-test rc=0 with 117 passed, 1 skipped in 446.85s; scoped performance report status ok
```

## Coverage and Metrics
- Changed-line coverage: 99.22% total, 127/128 lines covered against `origin/main` after the review update.
- Per-file changed-line coverage:
  - `services/control-plane-swift/Sources/Requests/MCPPromptContextBoundaryReceipt.swift`: 98.04%, 50/51 covered; only uncovered line is the defensive JSON serialization fallback.
  - `services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift`: 100.00%, 7/7 covered.
  - `services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift`: 100.00%, 70/70 covered.
- Local scoped performance report: `.runtime/pre-commit-performance/20260610-081548-7a6b884a/report/report.md`
  - Status: `ok`
  - Changed files: `5`
  - Selected probes: `0`
  - Direct/gated probes: `0`
  - Regressions: `0`
  - Context regressions: `0`
  - Verification failures: `0`
- Local scoped performance report after review update: `.runtime/pre-commit-performance/20260610-084041-c82808c7/report/report.md`
  - Status: `ok`
  - Changed files: `1`
  - Selected probes: `0`
  - Direct/gated probes: `0`
  - Regressions: `0`
  - Context regressions: `0`
  - Verification failures: `0`
- Observability mode: `evidence`.
- Probe overhead: one small dictionary per selected MCP source ID plus one sorted JSON array; no filesystem reads, network calls, model work, scheduler work, or tool schema traversal.

## Known Gaps
- This slice does not implement live MCP execution, skill-store admission, memory-store admission, or tool-result admission; those remain separate #1761 surfaces.
- No PR-scoped performance probe was registered for this metadata-only path, so the local report selected zero direct probes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A because no protocol schema changed.
- [x] Dependency changes include updated lockfiles, or N/A because no dependencies changed.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
