### PR TITLE
Add skill memory entrypoint receipt metadata

### DIFF
--- a/docs/plans/2026-06-10-issue-1761-skill-memory-entrypoint-receipts.md
+++ b/docs/plans/2026-06-10-issue-1761-skill-memory-entrypoint-receipts.md
@@ -1,0 +1,84 @@
+# Issue 1761 Skill And Memory Entrypoint Receipt Metadata Plan
+
+## Goal
+
+Make the Python worker skill and memory prompt-context admission primitive
+ready for concrete skill-store and memory-store entrypoints by routing admitted
+evidence through the source-evidence helper and allowing entrypoint-local
+receipt metadata.
+
+## Scope
+
+This slice covers:
+
+- `worker.runtime.skill_memory_context` support for optional entrypoint-local
+  `segment_id`, `source_field`, `reason`, and `corrective_action` values.
+- Reuse of `PromptContextSourceEvidence` and
+  `admit_prompt_context_source_evidence` for admitted skill and memory
+  evidence.
+- Focused Python tests proving that concrete callers can keep stable public
+  receipt fields without exposing raw skill or memory payloads.
+- Runtime contract documentation for the entrypoint-ready skill/memory
+  admission surface.
+
+This slice does not implement a skill store, memory store, skill lookup,
+memory persistence, chat/session wiring, or retrieval ranking. Future callers
+must still perform lookup, redaction, and owner-scope checks before calling
+these helpers.
+
+## Best End-State Architecture
+
+Concrete skill and memory entrypoints should hand already-redacted source
+evidence to a single prompt-context admission surface. The entrypoint may need
+stable public receipt IDs or source fields that differ from the generic
+`skill` and `memory` defaults, but the actual receipt construction should stay
+centralized in `worker.runtime.prompt_context`.
+
+The skill/memory helper should therefore match the retrieval helper shape:
+validate source IDs, payloads, owner-scope evidence, and optional entrypoint
+receipt fields; emit refused receipts before prompt assembly when malformed;
+and admit valid evidence through `PromptContextSourceEvidence`.
+
+## Performance Probes And Metrics
+
+The changed path performs a small constant amount of string validation and
+constructs one `PromptContextSourceEvidence` object per admitted skill or
+memory payload. It adds no filesystem scans, store lookups, network calls,
+model inference, scheduler work, or tool execution.
+
+Verification must include:
+
+- focused red/green tests for `test_skill_memory_context.py`;
+- adjacent prompt-context tests;
+- changed-line coverage for the touched Python files with at least 95 percent
+  coverage;
+- full local pre-commit gate before commit on this host;
+- PR-scoped performance report with status `ok`, regressions `0`, context
+  regressions `0`, and verification failures `0`.
+
+## Implementation Steps
+
+1. Add failing tests proving `admit_skill_context` and `admit_memory_context`
+   accept optional entrypoint receipt metadata:
+   - custom `segment_id`;
+   - custom `source_field`;
+   - custom `reason`;
+   - custom `corrective_action`.
+2. Add failing tests proving malformed optional entrypoint text values produce
+   refused receipts with `included = false`, `source_type = skill|memory`, and
+   the existing `invalid_skill_context_field` or
+   `invalid_memory_context_field` reason.
+3. Migrate admitted skill and memory evidence to
+   `PromptContextSourceEvidence` and `admit_prompt_context_source_evidence`.
+4. Preserve existing default payloads, default receipt shape, source ID
+   normalization, owner-scope handling, and refusal behavior.
+5. Update the unified runtime contract to document the entrypoint-local fields
+   and the fact that this is still not a concrete store implementation.
+
+## Success Criteria
+
+- Existing skill and memory admission behavior remains backward compatible.
+- Concrete future entrypoints can preserve stable receipt IDs and source
+  fields without bypassing the shared source-evidence helper.
+- Malformed entrypoint receipt metadata fails closed before prompt assembly.
+- Receipt JSON remains redacted from raw skill and memory payload text.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -429,9 +429,15 @@ matching the source type and `source_id` set to the redacted skill or memory
 identifier. Malformed source IDs, payload objects, or owner-scope metadata
 produce `included = false` refusal receipts with `reason =
 invalid_skill_context_field` or `invalid_memory_context_field` and no user
-payload. These helpers do not implement skill lookup, memory persistence,
-retrieval ranking, or chat/session wiring; they are only the prompt-context
-boundary for evidence admitted by those later surfaces.
+payload. Concrete entrypoints may pass entrypoint-local `segment_id`,
+`source_field`, `reason`, and `corrective_action` values so public receipt
+fields remain stable for agent-skill catalogs, skill stores, pinned memories,
+or retrieved-memory stores while receipt generation still routes through
+`PromptContextSourceEvidence`. Malformed entrypoint receipt metadata fails
+closed before prompt assembly with the same refusal reason. These helpers do
+not implement skill lookup, memory persistence, retrieval ranking, or
+chat/session wiring; they are only the prompt-context boundary for evidence
+admitted by those later surfaces.
 
 The Python worker retrieval admission primitives are
 `worker.runtime.retrieval_context.admit_retrieved_document_context` and

--- a/services/mlx-worker-python/tests/test_prompt_context.py
+++ b/services/mlx-worker-python/tests/test_prompt_context.py
@@ -176,6 +176,33 @@ def test_prompt_context_source_refusal_receipt_records_policy_text_without_paylo
     }
 
 
+def test_prompt_context_source_refusal_receipt_accepts_corrective_action_override() -> None:
+    receipt = refused_source_prompt_context_receipt(
+        segment_id="memory:malformed:payload",
+        source_type="memory",
+        source_field="payload",
+        source_id="memory:malformed",
+        reason="invalid_memory_context_field",
+        corrective_action="Reject malformed memory context before prompt assembly.",
+    )
+
+    assert receipt == {
+        "schema_version": "melix.untrusted_context_receipt.v1",
+        "segment_id": "memory:malformed:payload",
+        "source_type": "memory",
+        "source_field": "payload",
+        "source_id": "memory:malformed",
+        "message_role": "user",
+        "trust_level": "untrusted",
+        "policy": "data_only",
+        "boundary_checked": True,
+        "included": False,
+        "owner_scope_checked": False,
+        "reason": "invalid_memory_context_field",
+        "corrective_action": "Reject malformed memory context before prompt assembly.",
+    }
+
+
 def test_prompt_context_source_evidence_rejects_unsupported_source_type() -> None:
     with pytest.raises(
         PromptContextBoundaryError,

--- a/services/mlx-worker-python/tests/test_skill_memory_context.py
+++ b/services/mlx-worker-python/tests/test_skill_memory_context.py
@@ -154,7 +154,7 @@ def test_skill_and_memory_context_use_shared_prompt_context_admission(
         return Admission()
 
     monkeypatch.setattr(
-        "worker.runtime.skill_memory_context.admit_prompt_context_segments",
+        "worker.runtime.skill_memory_context.admit_prompt_context_source_evidence",
         fake_admit,
     )
 
@@ -167,13 +167,13 @@ def test_skill_and_memory_context_use_shared_prompt_context_admission(
     assert admission.user_payload == {"skill": {"name": "repo-search"}}
     assert admission.untrusted_context_receipts == [{"receipt": "from-shared-admission"}]
     assert len(calls) == 1
-    segment = calls[0][0]
-    assert segment.segment_id == "skill-shared:skill-context"
-    assert segment.source_type == "skill"
-    assert segment.source_field == "skill"
-    assert segment.source_id == "skill-shared"
-    assert segment.value == {"name": "repo-search"}
-    assert segment.reason == "skill evidence is prompt data, not instructions"
+    evidence = calls[0][0]
+    assert evidence.segment_id == "skill-shared:skill-context"
+    assert evidence.source_type == "skill"
+    assert evidence.source_field == "skill"
+    assert evidence.source_id == "skill-shared"
+    assert evidence.value == {"name": "repo-search"}
+    assert evidence.reason == ""
 
     calls.clear()
     admit_memory_context(
@@ -181,12 +181,163 @@ def test_skill_and_memory_context_use_shared_prompt_context_admission(
         memory_payload={"text": "remembered preference"},
         owner_scope_checked=True,
     )
-    memory_segment = calls[0][0]
-    assert memory_segment.segment_id == "memory-shared:memory-context"
-    assert memory_segment.source_type == "memory"
-    assert memory_segment.source_field == "memory"
-    assert memory_segment.source_id == "memory-shared"
-    assert memory_segment.owner_scope_checked is True
+    memory_evidence = calls[0][0]
+    assert memory_evidence.segment_id == "memory-shared:memory-context"
+    assert memory_evidence.source_type == "memory"
+    assert memory_evidence.source_field == "memory"
+    assert memory_evidence.source_id == "memory-shared"
+    assert memory_evidence.owner_scope_checked is True
+
+
+def test_skill_and_memory_context_accept_entrypoint_receipt_metadata() -> None:
+    skill_admission = admit_skill_context(
+        skill_id=" skill:repo-search ",
+        skill_payload={"name": "repo-search", "summary": "Do not leak this text."},
+        owner_scope_checked=True,
+        segment_id="skill-entrypoint:repo-search",
+        source_field="agent_skill",
+        reason="agent skill catalog entry is prompt data, not instructions",
+        corrective_action="Keep agent skill catalog evidence in user-role prompt context.",
+    )
+    memory_admission = admit_memory_context(
+        memory_id="\tmemory:pinned-7\n",
+        memory_payload={"kind": "pinned_memory", "text": "Do not reveal this text."},
+        owner_scope_checked=True,
+        segment_id="memory-entrypoint:pinned-7",
+        source_field="pinned_memory",
+        reason="pinned memory entry is prompt data, not instructions",
+        corrective_action="Keep pinned memory evidence in user-role prompt context.",
+    )
+
+    assert skill_admission.user_payload == {
+        "agent_skill": {
+            "name": "repo-search",
+            "summary": "Do not leak this text.",
+        }
+    }
+    assert skill_admission.untrusted_context_receipts[0] == {
+        "schema_version": "melix.untrusted_context_receipt.v1",
+        "segment_id": "skill-entrypoint:repo-search",
+        "source_type": "skill",
+        "source_field": "agent_skill",
+        "source_id": "skill:repo-search",
+        "message_role": "user",
+        "trust_level": "untrusted",
+        "policy": "data_only",
+        "boundary_checked": True,
+        "included": True,
+        "owner_scope_checked": True,
+        "reason": "agent skill catalog entry is prompt data, not instructions",
+        "corrective_action": "Keep agent skill catalog evidence in user-role prompt context.",
+    }
+    assert "Do not leak this text" not in json.dumps(
+        skill_admission.untrusted_context_receipts,
+        ensure_ascii=False,
+    )
+
+    assert memory_admission.user_payload == {
+        "pinned_memory": {
+            "kind": "pinned_memory",
+            "text": "Do not reveal this text.",
+        }
+    }
+    assert memory_admission.untrusted_context_receipts[0] == {
+        "schema_version": "melix.untrusted_context_receipt.v1",
+        "segment_id": "memory-entrypoint:pinned-7",
+        "source_type": "memory",
+        "source_field": "pinned_memory",
+        "source_id": "memory:pinned-7",
+        "message_role": "user",
+        "trust_level": "untrusted",
+        "policy": "data_only",
+        "boundary_checked": True,
+        "included": True,
+        "owner_scope_checked": True,
+        "reason": "pinned memory entry is prompt data, not instructions",
+        "corrective_action": "Keep pinned memory evidence in user-role prompt context.",
+    }
+    assert "Do not reveal this text" not in json.dumps(
+        memory_admission.untrusted_context_receipts,
+        ensure_ascii=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("helper", "kwargs", "source_type", "source_id", "source_field"),
+    (
+        (
+            admit_skill_context,
+            {"segment_id": "   "},
+            "skill",
+            "skill-entrypoint-invalid",
+            "segment_id",
+        ),
+        (
+            admit_memory_context,
+            {"source_field": 42},  # type: ignore[arg-type]
+            "memory",
+            "memory-entrypoint-invalid",
+            "source_field",
+        ),
+        (
+            admit_skill_context,
+            {"reason": "\n\t"},
+            "skill",
+            "skill-entrypoint-invalid",
+            "reason",
+        ),
+        (
+            admit_memory_context,
+            {"corrective_action": object()},  # type: ignore[arg-type]
+            "memory",
+            "memory-entrypoint-invalid",
+            "corrective_action",
+        ),
+    ),
+)
+def test_skill_and_memory_context_refuse_malformed_entrypoint_receipt_metadata(
+    helper: object,
+    kwargs: dict[str, object],
+    source_type: str,
+    source_id: str,
+    source_field: str,
+) -> None:
+    if source_type == "skill":
+        params: dict[str, object] = {
+            "skill_id": source_id,
+            "skill_payload": {"name": "repo-search"},
+            "owner_scope_checked": True,
+        }
+    else:
+        params = {
+            "memory_id": source_id,
+            "memory_payload": {"text": "remembered preference"},
+            "owner_scope_checked": True,
+        }
+    params.update(kwargs)
+
+    with pytest.raises(SkillMemoryContextAdmissionError) as exc_info:
+        helper(**params)
+
+    assert exc_info.value.refusal_receipts == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": f"{source_id}:{source_type}-context",
+            "source_type": source_type,
+            "source_field": source_field,
+            "source_id": source_id,
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": False,
+            "owner_scope_checked": False,
+            "reason": f"invalid_{source_type}_context_field",
+            "corrective_action": (
+                f"Reject malformed {source_type} context before prompt assembly."
+            ),
+        }
+    ]
 
 
 @pytest.mark.parametrize(

--- a/services/mlx-worker-python/worker/runtime/prompt_context.py
+++ b/services/mlx-worker-python/worker/runtime/prompt_context.py
@@ -193,8 +193,10 @@ def refused_source_prompt_context_receipt(
     reason: str,
     source_id: str = "",
     owner_scope_checked: bool = False,
+    corrective_action: str = "",
 ) -> dict[str, object]:
-    _, _, corrective_action = _source_context_policy(source_type)
+    _, _, default_corrective_action = _source_context_policy(source_type)
+    _require_optional_text(corrective_action, "corrective_action")
     return refused_prompt_context_receipt(
         segment_id=segment_id,
         source_type=source_type,
@@ -202,7 +204,7 @@ def refused_source_prompt_context_receipt(
         source_id=source_id,
         owner_scope_checked=owner_scope_checked,
         reason=reason,
-        corrective_action=corrective_action,
+        corrective_action=corrective_action or default_corrective_action,
     )
 
 

--- a/services/mlx-worker-python/worker/runtime/skill_memory_context.py
+++ b/services/mlx-worker-python/worker/runtime/skill_memory_context.py
@@ -75,12 +75,13 @@ def _admit_context(
     corrective_action: str,
 ) -> PromptContextAdmission:
     normalized_source_id = _source_id_or_refusal(context_kind, source_id)
+    default_segment_id = f"{normalized_source_id}:{context_kind}-context"
     normalized_segment_id = _entrypoint_text_or_default(
         context_kind,
         segment_id,
-        default=f"{normalized_source_id}:{context_kind}-context",
+        default=default_segment_id,
         field_name="segment_id",
-        refusal_segment_id=f"{normalized_source_id}:{context_kind}-context",
+        refusal_segment_id=default_segment_id,
         source_id=normalized_source_id,
     )
     normalized_source_field = _entrypoint_text_or_default(

--- a/services/mlx-worker-python/worker/runtime/skill_memory_context.py
+++ b/services/mlx-worker-python/worker/runtime/skill_memory_context.py
@@ -4,9 +4,9 @@ from typing import Any, Literal, NoReturn
 
 from worker.runtime.prompt_context import (
     PromptContextAdmission,
-    PromptContextSegment,
-    admit_prompt_context_segments,
-    refused_prompt_context_receipt,
+    PromptContextSourceEvidence,
+    admit_prompt_context_source_evidence,
+    refused_source_prompt_context_receipt,
 )
 
 
@@ -24,12 +24,20 @@ def admit_skill_context(
     skill_id: str,
     skill_payload: dict[str, Any],
     owner_scope_checked: bool,
+    segment_id: str = "",
+    source_field: str = "",
+    reason: str = "",
+    corrective_action: str = "",
 ) -> PromptContextAdmission:
     return _admit_context(
         context_kind="skill",
         source_id=skill_id,
         payload=skill_payload,
         owner_scope_checked=owner_scope_checked,
+        segment_id=segment_id,
+        source_field=source_field,
+        reason=reason,
+        corrective_action=corrective_action,
     )
 
 
@@ -38,12 +46,20 @@ def admit_memory_context(
     memory_id: str,
     memory_payload: dict[str, Any],
     owner_scope_checked: bool,
+    segment_id: str = "",
+    source_field: str = "",
+    reason: str = "",
+    corrective_action: str = "",
 ) -> PromptContextAdmission:
     return _admit_context(
         context_kind="memory",
         source_id=memory_id,
         payload=memory_payload,
         owner_scope_checked=owner_scope_checked,
+        segment_id=segment_id,
+        source_field=source_field,
+        reason=reason,
+        corrective_action=corrective_action,
     )
 
 
@@ -53,13 +69,46 @@ def _admit_context(
     source_id: Any,
     payload: Any,
     owner_scope_checked: Any,
+    segment_id: str,
+    source_field: str,
+    reason: str,
+    corrective_action: str,
 ) -> PromptContextAdmission:
     normalized_source_id = _source_id_or_refusal(context_kind, source_id)
-    segment_id = f"{normalized_source_id}:{context_kind}-context"
+    normalized_segment_id = _entrypoint_text_or_default(
+        context_kind,
+        segment_id,
+        default=f"{normalized_source_id}:{context_kind}-context",
+        field_name="segment_id",
+        refusal_segment_id=f"{normalized_source_id}:{context_kind}-context",
+        source_id=normalized_source_id,
+    )
+    normalized_source_field = _entrypoint_text_or_default(
+        context_kind,
+        source_field,
+        default=context_kind,
+        field_name="source_field",
+        refusal_segment_id=normalized_segment_id,
+        source_id=normalized_source_id,
+    )
+    normalized_reason = _entrypoint_optional_text(
+        context_kind,
+        reason,
+        segment_id=normalized_segment_id,
+        source_id=normalized_source_id,
+        field_name="reason",
+    )
+    normalized_corrective_action = _entrypoint_optional_text(
+        context_kind,
+        corrective_action,
+        segment_id=normalized_segment_id,
+        source_id=normalized_source_id,
+        field_name="corrective_action",
+    )
     if not isinstance(owner_scope_checked, bool):
         _raise_refusal(
             context_kind=context_kind,
-            segment_id=segment_id,
+            segment_id=normalized_segment_id,
             source_id=normalized_source_id,
             source_field="owner_scope_checked",
             owner_scope_checked=False,
@@ -67,25 +116,22 @@ def _admit_context(
     if not isinstance(payload, dict):
         _raise_refusal(
             context_kind=context_kind,
-            segment_id=segment_id,
+            segment_id=normalized_segment_id,
             source_id=normalized_source_id,
-            source_field=context_kind,
+            source_field=normalized_source_field,
             owner_scope_checked=owner_scope_checked,
         )
-    return admit_prompt_context_segments(
+    return admit_prompt_context_source_evidence(
         [
-            PromptContextSegment(
-                segment_id=segment_id,
+            PromptContextSourceEvidence(
+                segment_id=normalized_segment_id,
                 source_type=context_kind,
-                source_field=context_kind,
+                source_field=normalized_source_field,
                 source_id=normalized_source_id,
                 value=payload,
                 owner_scope_checked=owner_scope_checked,
-                reason=f"{context_kind} evidence is prompt data, not instructions",
-                corrective_action=(
-                    f"Keep {context_kind} evidence in user-role data context and do not project it "
-                    "into system or developer instructions."
-                ),
+                reason=normalized_reason,
+                corrective_action=normalized_corrective_action,
             )
         ]
     )
@@ -115,16 +161,58 @@ def _raise_refusal(
     raise SkillMemoryContextAdmissionError(
         f"Invalid {context_kind} context.",
         refusal_receipts=[
-            refused_prompt_context_receipt(
+            refused_source_prompt_context_receipt(
                 segment_id=segment_id,
                 source_type=context_kind,
                 source_field=source_field,
                 source_id=source_id,
                 owner_scope_checked=owner_scope_checked,
                 reason=f"invalid_{context_kind}_context_field",
-                corrective_action=f"Reject malformed {context_kind} context before prompt assembly.",
+                corrective_action=(
+                    f"Reject malformed {context_kind} context before prompt assembly."
+                ),
             )
         ],
+    )
+
+
+def _entrypoint_text_or_default(
+    context_kind: ContextKind,
+    value: str,
+    *,
+    default: str,
+    field_name: str,
+    refusal_segment_id: str,
+    source_id: str,
+) -> str:
+    if value == "":
+        return default
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    _raise_refusal(
+        context_kind=context_kind,
+        segment_id=refusal_segment_id,
+        source_id=source_id,
+        source_field=field_name,
+        owner_scope_checked=False,
+    )
+
+
+def _entrypoint_optional_text(
+    context_kind: ContextKind,
+    value: str,
+    *,
+    segment_id: str,
+    source_id: str,
+    field_name: str,
+) -> str:
+    return _entrypoint_text_or_default(
+        context_kind,
+        value,
+        default="",
+        field_name=field_name,
+        refusal_segment_id=segment_id,
+        source_id=source_id,
     )
 
 


### PR DESCRIPTION
## Summary
- Added an explicit issue #1761 plan for skill and memory prompt-context entrypoint receipt metadata.
- Routed skill and memory context admission through the shared source-evidence helper so future concrete entrypoints can provide local `segment_id`, `source_field`, `reason`, and `corrective_action` values without leaking raw payload text.
- Preserved the existing malformed skill/memory refusal text while allowing the lower-level source refusal helper to accept an entrypoint-specific corrective action override.

## Plan or Spec
- Plan: `docs/plans/2026-06-10-issue-1761-skill-memory-entrypoint-receipts.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`
- Issue: #1761

## Commands Run
```text
make bootstrap
Outcome: passed; configured repository git hooks and confirmed the locked Python environment.

make proto
Outcome: passed; no generated artifact drift.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_skill_memory_context.py -q
Outcome before implementation: failed as expected, 5 failed and 13 passed, because skill/memory helpers did not yet accept entrypoint-local receipt metadata.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_skill_memory_context.py -q
Outcome after implementation: passed, 18 passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_skill_memory_context.py services/mlx-worker-python/tests/test_prompt_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_background_continuation.py -q
Outcome: passed, 54 passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 COVERAGE_FILE=/tmp/issue1761-skill-memory-entrypoints.coverage uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest services/mlx-worker-python/tests/test_skill_memory_context.py services/mlx-worker-python/tests/test_prompt_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_background_continuation.py -q && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 COVERAGE_FILE=/tmp/issue1761-skill-memory-entrypoints.coverage uv run --project services/mlx-worker-python --extra mlx coverage json -o /tmp/issue1761-skill-memory-entrypoints-coverage.json && python3.11 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue1761-skill-memory-entrypoints-coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/prompt_context.py services/mlx-worker-python/worker/runtime/skill_memory_context.py services/mlx-worker-python/tests/test_prompt_context.py services/mlx-worker-python/tests/test_skill_memory_context.py
Outcome: passed; changed-line coverage TOTAL 100.00% (50/50).

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 COVERAGE_FILE=/tmp/issue1761-skill-memory-entrypoints-review.coverage uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest services/mlx-worker-python/tests/test_skill_memory_context.py services/mlx-worker-python/tests/test_prompt_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_background_continuation.py -q && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 COVERAGE_FILE=/tmp/issue1761-skill-memory-entrypoints-review.coverage uv run --project services/mlx-worker-python --extra mlx coverage json -o /tmp/issue1761-skill-memory-entrypoints-review-coverage.json && python3.11 scripts/python_changed_line_coverage.py --coverage-json /tmp/issue1761-skill-memory-entrypoints-review-coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/prompt_context.py services/mlx-worker-python/worker/runtime/skill_memory_context.py services/mlx-worker-python/tests/test_prompt_context.py services/mlx-worker-python/tests/test_skill_memory_context.py
Outcome after review fix: passed; changed-line coverage TOTAL 100.00% (50/50).

git commit -m "Add skill memory entrypoint receipt metadata"
Outcome: passed after the pre-commit hook ran the full local gate.

Pre-commit hook: make swift-test
Outcome: passed in 656.5s.

Pre-commit hook: make py-test
Outcome: passed in 171.2s; 3803 passed, 14 skipped, 2 warnings.

Pre-commit hook: make integration-test
Outcome: passed in 780.6s; 117 passed, 1 skipped.

Pre-commit hook: scoped performance report
Outcome: Status ok; changed files 6; selected probes 0; regressions 0; context regressions 0; verification failures 0.
Report: .runtime/pre-commit-performance/20260610-121234-c50ce573/report/report.md

git commit -m "Address skill memory receipt review"
Outcome: passed after the pre-commit hook ran the full local gate for the review fix.

Review-fix pre-commit hook: make swift-test
Outcome: passed in 271.3s.

Review-fix pre-commit hook: make py-test
Outcome: passed in 158.6s; 3803 passed, 14 skipped, 2 warnings.

Review-fix pre-commit hook: make integration-test
Outcome: passed in 432.7s; 117 passed, 1 skipped.

Review-fix pre-commit hook: scoped performance report
Outcome: Status ok; changed files 1; selected probes 0; regressions 0; context regressions 0; verification failures 0.
Report: .runtime/pre-commit-performance/20260610-123849-1f2d99dd/report/report.md
```

## Coverage and Metrics
- Changed-line coverage for the touched Python worker paths is 100.00% (50/50), above the 95% repository threshold.
- Full Python worker test suite passed through the pre-commit hook: 3803 passed, 14 skipped.
- Full integration suite passed through the pre-commit hook: 117 passed, 1 skipped.
- Scoped performance report: `Status: ok`; selected probes `0`; regressions `0`; context regressions `0`; verification failures `0`.
- Review-fix scoped performance report: `Status: ok`; selected probes `0`; regressions `0`; context regressions `0`; verification failures `0`.
- Observability mode: evidence. The change only shapes prompt-context boundary receipt metadata for admitted/refused skill and memory payloads.
- Probe overhead: no registered performance probe was selected for this change set. Runtime overhead is bounded to request-local string normalization and receipt construction for admitted/refused skill or memory context payloads.

## Known Gaps
- This slice does not add a concrete skill store, memory store, chat-session lookup path, or durable/live RAG wiring.
- Future entrypoint callers remain responsible for lookup, redaction, owner-scope checks, and deciding which source identifiers to pass into these helpers.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or are explicitly not applicable: no protobuf schema changed.
- [x] Dependency changes include updated lockfiles, or are explicitly not applicable: no dependency changed.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
