### PR TITLE
Refactor operator provider domain

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -1239,7 +1239,7 @@ public struct ServerSnapshotOptions: Equatable, Sendable {
 }
 
 public struct ServerControlOptions: Equatable, Sendable {
-    public let serverSessionID: String
+    public let providerID: String
     public let serverTitle: String
     public let defaultModelID: String
     public let servedModelIDs: [String]
@@ -1253,7 +1253,7 @@ public struct ServerControlOptions: Equatable, Sendable {
     public let json: Bool
 
     public init(
-        serverSessionID: String = ServerSessionRuntimeStore.defaultServerSessionID,
+        providerID: String = MelixProviderDefaults.defaultProviderID,
         serverTitle: String = "",
         defaultModelID: String = "",
         servedModelIDs: [String] = [],
@@ -1266,11 +1266,11 @@ public struct ServerControlOptions: Equatable, Sendable {
         modelIdleTimeoutSeconds: Int = 0,
         json: Bool = false
     ) {
-        if serverSessionID.isEmpty || serverSessionID == ServerSessionRuntimeStore.defaultServerSessionID {
-            self.serverSessionID = MelixServerStartShortcutName.sessionIDCandidate(for: serverTitle)
-                ?? ServerSessionRuntimeStore.defaultServerSessionID
+        if providerID.isEmpty || providerID == MelixProviderDefaults.defaultProviderID {
+            self.providerID = MelixServerStartShortcutName.sessionIDCandidate(for: serverTitle)
+                ?? MelixProviderDefaults.defaultProviderID
         } else {
-            self.serverSessionID = serverSessionID
+            self.providerID = providerID
         }
         self.serverTitle = serverTitle
         let resolvedDefaultModelID = MelixServerModelRosterNormalizer.resolvedDefaultModelID(
@@ -1314,22 +1314,22 @@ private enum MelixServerStartShortcutName {
 }
 
 public struct ServerIdlePolicyOptions: Equatable, Sendable {
-    public let serverSessionID: String
+    public let providerID: String
     public let autoSleepEnabled: Bool
     public let lightSleepAfterSeconds: UInt32
     public let deepSleepAfterSeconds: UInt32
     public let json: Bool
 
     public init(
-        serverSessionID: String = ServerSessionRuntimeStore.defaultServerSessionID,
+        providerID: String = MelixProviderDefaults.defaultProviderID,
         autoSleepEnabled: Bool,
         lightSleepAfterSeconds: UInt32,
         deepSleepAfterSeconds: UInt32,
         json: Bool = false
     ) {
-        self.serverSessionID = serverSessionID.isEmpty
-            ? ServerSessionRuntimeStore.defaultServerSessionID
-            : serverSessionID
+        self.providerID = providerID.isEmpty
+            ? MelixProviderDefaults.defaultProviderID
+            : providerID
         self.autoSleepEnabled = autoSleepEnabled
         self.lightSleepAfterSeconds = lightSleepAfterSeconds
         self.deepSleepAfterSeconds = deepSleepAfterSeconds
@@ -1799,7 +1799,7 @@ public struct ChatRunOptions: Equatable, Sendable {
     public let remoteModelID: String
     public let message: String
     public let systemPrompt: String
-    public let serverSessionID: String
+    public let providerID: String
     public let json: Bool
 
     public init(
@@ -1808,7 +1808,7 @@ public struct ChatRunOptions: Equatable, Sendable {
         remoteModelID: String = "",
         message: String,
         systemPrompt: String = "",
-        serverSessionID: String = ServerSessionRuntimeStore.defaultServerSessionID,
+        providerID: String = MelixProviderDefaults.defaultProviderID,
         json: Bool = false
     ) {
         self.modelID = modelID
@@ -1816,29 +1816,29 @@ public struct ChatRunOptions: Equatable, Sendable {
         self.remoteModelID = remoteModelID
         self.message = message
         self.systemPrompt = systemPrompt
-        self.serverSessionID = serverSessionID.isEmpty
-            ? ServerSessionRuntimeStore.defaultServerSessionID
-            : serverSessionID
+        self.providerID = providerID.isEmpty
+            ? MelixProviderDefaults.defaultProviderID
+            : providerID
         self.json = json
     }
 }
 
 public struct ChatRunReceipt: Codable, Equatable, Sendable {
     public let modelID: String
-    public let serverSessionID: String
+    public let providerID: String
     public let assistantText: String
     public let finishReason: String
     public let requestID: String
 
     public init(
         modelID: String,
-        serverSessionID: String,
+        providerID: String,
         assistantText: String,
         finishReason: String,
         requestID: String
     ) {
         self.modelID = modelID
-        self.serverSessionID = serverSessionID
+        self.providerID = providerID
         self.assistantText = assistantText
         self.finishReason = finishReason
         self.requestID = requestID
@@ -1883,7 +1883,7 @@ public struct ModelRootsRescanOptions: Equatable, Sendable {
     }
 }
 
-public struct ServerSessionListOptions: Equatable, Sendable {
+public struct ProviderListOptions: Equatable, Sendable {
     public let json: Bool
 
     public init(json: Bool = false) {
@@ -1891,7 +1891,7 @@ public struct ServerSessionListOptions: Equatable, Sendable {
     }
 }
 
-public struct ServerSessionCreateOptions: Equatable, Sendable {
+public struct ProviderCreateOptions: Equatable, Sendable {
     public let title: String
     public let defaultModelID: String
     public let servedModelIDs: [String]
@@ -1954,8 +1954,8 @@ public struct ServerSessionCreateOptions: Equatable, Sendable {
 
 }
 
-public struct ServerSessionUpdateOptions: Equatable, Sendable {
-    public let serverSessionID: String
+public struct ProviderUpdateOptions: Equatable, Sendable {
+    public let providerID: String
     public let title: String
     public let defaultModelID: String
     public let servedModelIDs: [String]
@@ -1975,7 +1975,7 @@ public struct ServerSessionUpdateOptions: Equatable, Sendable {
     public let json: Bool
 
     public init(
-        serverSessionID: String,
+        providerID: String,
         title: String = "",
         defaultModelID: String = "",
         servedModelIDs: [String] = [],
@@ -1994,7 +1994,7 @@ public struct ServerSessionUpdateOptions: Equatable, Sendable {
         numDraftTokens: Int = 0,
         json: Bool = false
     ) {
-        self.serverSessionID = serverSessionID
+        self.providerID = providerID
         self.title = title
         let resolvedDefaultModelID = MelixServerModelRosterNormalizer.resolvedDefaultModelID(
             defaultModelID,
@@ -2029,12 +2029,12 @@ private func normalizedServerAllowlist(_ values: [String]) -> [String] {
     values.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
 }
 
-public struct ServerSessionIDOptions: Equatable, Sendable {
-    public let serverSessionID: String
+public struct ProviderIDOptions: Equatable, Sendable {
+    public let providerID: String
     public let json: Bool
 
-    public init(serverSessionID: String, json: Bool = false) {
-        self.serverSessionID = serverSessionID
+    public init(providerID: String, json: Bool = false) {
+        self.providerID = providerID
         self.json = json
     }
 }
@@ -2388,11 +2388,11 @@ public enum MelixCLICommand: Equatable, Sendable {
     case modelRootsMove(ModelRootsMoveOptions)
     case modelRootsRescan(ModelRootsRescanOptions)
     case serverSnapshot(ServerSnapshotOptions)
-    case serverSessionList(ServerSessionListOptions)
-    case serverSessionCreate(ServerSessionCreateOptions)
-    case serverSessionUpdate(ServerSessionUpdateOptions)
-    case serverSessionRemove(ServerSessionIDOptions)
-    case serverSessionSelect(ServerSessionIDOptions)
+    case providerList(ProviderListOptions)
+    case providerCreate(ProviderCreateOptions)
+    case providerUpdate(ProviderUpdateOptions)
+    case providerRemove(ProviderIDOptions)
+    case providerSelect(ProviderIDOptions)
     case serverStart(ServerControlOptions)
     case serverPause(ServerControlOptions)
     case serverResume(ServerControlOptions)
@@ -2557,6 +2557,8 @@ public enum MelixCLIParser {
             return try parseCookbook(tail)
         case "server":
             return try parseServer(tail)
+        case "provider":
+            return try parseProvider(tail)
         case "remote-server":
             return try parseRemoteServer(tail)
         case "chat":
@@ -2646,23 +2648,23 @@ public enum MelixCLIParser {
       melix model roots move --path PATH --index N [--json]
       melix model roots rescan [--json]
       melix server snapshot [--json]
-      melix server session list [--json]
-      melix server session create --title TITLE (--model MODEL_ID ... | --models MODEL_ID[,MODEL_ID...]) [--default-model MODEL_ID] [--host HOST] [--port PORT] [--allowed-host HOST ...] [--allowed-origin ORIGIN ...] [--rate-limit-per-minute N] [--timeout-seconds N] [--model-idle-timeout-seconds N] [--acceleration-profile PROFILE] [--acceleration-mode MODE] [--draft-model-id MODEL_ID] [--num-draft-tokens N] [--json]
-      melix server session update --server-session-id ID [--title TITLE] [--model MODEL_ID ... | --models MODEL_ID[,MODEL_ID...]] [--default-model MODEL_ID] [--host HOST] [--port PORT] [--allowed-host HOST ... | --clear-allowed-hosts] [--allowed-origin ORIGIN ... | --clear-allowed-origins] [--rate-limit-per-minute N] [--timeout-seconds N] [--model-idle-timeout-seconds N] [--acceleration-profile PROFILE] [--acceleration-mode MODE] [--draft-model-id MODEL_ID] [--num-draft-tokens N] [--json]
-      melix server session remove --server-session-id ID [--json]
-      melix server session select --server-session-id ID [--json]
-      melix server start [TITLE] [--model MODEL_ID ... | --models MODEL_ID[,MODEL_ID...]] [--default-model MODEL_ID] [--host HOST] [--port PORT] [--allowed-host HOST ...] [--allowed-origin ORIGIN ...] [--rate-limit-per-minute N] [--timeout-seconds N] [--model-idle-timeout-seconds N] [--server-session-id ID] [--json]
-      melix server pause [--server-session-id ID] [--json]
-      melix server resume [--server-session-id ID] [--json]
-      melix server wake [--server-session-id ID] [--json]
-      melix server stop [--server-session-id ID] [--json]
-      melix server set-idle-policy [--server-session-id ID] --auto-sleep (true|false) --light-sleep-after N --deep-sleep-after N [--json]
+      melix provider list [--json]
+      melix provider create --title TITLE (--model MODEL_ID ... | --models MODEL_ID[,MODEL_ID...]) [--default-model MODEL_ID] [--host HOST] [--port PORT] [--allowed-host HOST ...] [--allowed-origin ORIGIN ...] [--rate-limit-per-minute N] [--timeout-seconds N] [--model-idle-timeout-seconds N] [--acceleration-profile PROFILE] [--acceleration-mode MODE] [--draft-model-id MODEL_ID] [--num-draft-tokens N] [--json]
+      melix provider update --provider-id ID [--title TITLE] [--model MODEL_ID ... | --models MODEL_ID[,MODEL_ID...]] [--default-model MODEL_ID] [--host HOST] [--port PORT] [--allowed-host HOST ... | --clear-allowed-hosts] [--allowed-origin ORIGIN ... | --clear-allowed-origins] [--rate-limit-per-minute N] [--timeout-seconds N] [--model-idle-timeout-seconds N] [--acceleration-profile PROFILE] [--acceleration-mode MODE] [--draft-model-id MODEL_ID] [--num-draft-tokens N] [--json]
+      melix provider remove --provider-id ID [--json]
+      melix provider select --provider-id ID [--json]
+      melix server start [TITLE] [--model MODEL_ID ... | --models MODEL_ID[,MODEL_ID...]] [--default-model MODEL_ID] [--host HOST] [--port PORT] [--allowed-host HOST ...] [--allowed-origin ORIGIN ...] [--rate-limit-per-minute N] [--timeout-seconds N] [--model-idle-timeout-seconds N] [--provider-id ID] [--json]
+      melix server pause [--provider-id ID] [--json]
+      melix server resume [--provider-id ID] [--json]
+      melix server wake [--provider-id ID] [--json]
+      melix server stop [--provider-id ID] [--json]
+      melix server set-idle-policy [--provider-id ID] --auto-sleep (true|false) --light-sleep-after N --deep-sleep-after N [--json]
       melix remote-server list [--json]
       melix remote-server add --remote-server-id ID --title TITLE --provider kimi|gemini|deepseek|glm|custom [--base-url URL] --model MODEL [--api-key KEY] [--timeout-seconds N] [--rate-limit-per-minute N] [--tool-support-mode auto|force-on|force-off] [--json]
       melix remote-server update --remote-server-id ID [--title TITLE] [--provider PROVIDER] [--base-url URL] [--model MODEL] [--api-key KEY] [--timeout-seconds N] [--rate-limit-per-minute N] [--tool-support-mode auto|force-on|force-off] [--json]
       melix remote-server remove --remote-server-id ID [--json]
       melix remote-server test --remote-server-id ID [--model MODEL] [--json]
-      melix chat run (--model-id MODEL_ID | --remote-server-id ID --model MODEL) --message TEXT [--system TEXT] [--server-session-id ID] [--json]
+      melix chat run (--model-id MODEL_ID | --remote-server-id ID --model MODEL) --message TEXT [--system TEXT] [--provider-id ID] [--json]
       melix lora list [--model-id MODEL_ID] [--json]
       melix lora run --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) --adapter-name NAME --eval-dataset-id DATASET_ID [--eval-suite SUITE ...] [--output-dir PATH] [--activation-mode (adapter_backed_runtime|fused_derived_model)] [--training-mode auto|lora|qlora|dora] [training options...] [evaluation options...] [--json]
       melix lora train --model-id MODEL_ID (--dataset-uri PATH | --hf-dataset-path REPO) --adapter-name NAME [--target-repo REPO] [--training-mode (lora|qlora|dora)] [--preset PRESET] [--experiment-group GROUP] [--rank N] [--alpha N] [--dropout N] [--target-modules CSV] [--num-layers N] [--batch-size N] [--epochs N] [--max-steps N] [--learning-rate N] [--max-seq-length N] [--sample-limit N] [--gradient-accumulation N] [--resume-adapter PATH | --resume-from-manifest PATH] [--hf-dataset-name NAME] [--hf-dataset-revision REV] [--hf-train-split SPLIT] [--hf-valid-split SPLIT] [--text-feature NAME] [--prompt-feature NAME] [--completion-feature NAME] [--chat-feature NAME] [--derived-model-alias NAME] [--response-only] [--mask-prompt] [--gradient-checkpointing] [--preflight-fit-check] [--allow-memory-risk] [--json]
@@ -3778,26 +3780,23 @@ public enum MelixCLIParser {
         guard let action = arguments.first else {
             throw MelixCLIError.usage(usageText)
         }
-        if action == "session" {
-            return try parseServerSession(Array(arguments.dropFirst()))
-        }
         if action == "start" {
             return try parseServerStart(Array(arguments.dropFirst()))
         }
         let values = try ArgumentCursor(arguments: Array(arguments.dropFirst())).parse()
-        let serverSessionID = values.single["--server-session-id"] ?? ServerSessionRuntimeStore.defaultServerSessionID
+        let providerID = values.single["--provider-id"] ?? MelixProviderDefaults.defaultProviderID
         let json = values.flags.contains("--json")
         switch action {
         case "snapshot":
             return .serverSnapshot(.init(json: json))
         case "pause":
-            return .serverPause(.init(serverSessionID: serverSessionID, json: json))
+            return .serverPause(.init(providerID: providerID, json: json))
         case "resume":
-            return .serverResume(.init(serverSessionID: serverSessionID, json: json))
+            return .serverResume(.init(providerID: providerID, json: json))
         case "wake":
-            return .serverWake(.init(serverSessionID: serverSessionID, json: json))
+            return .serverWake(.init(providerID: providerID, json: json))
         case "stop":
-            return .serverStop(.init(serverSessionID: serverSessionID, json: json))
+            return .serverStop(.init(providerID: providerID, json: json))
         case "set-idle-policy":
             guard let autoSleepValue = values.single["--auto-sleep"] else {
                 throw MelixCLIError.missingRequired("--auto-sleep is required for melix server set-idle-policy.")
@@ -3819,7 +3818,7 @@ public enum MelixCLIParser {
             }
             return .serverSetIdlePolicy(
                 .init(
-                    serverSessionID: serverSessionID,
+                    providerID: providerID,
                     autoSleepEnabled: autoSleepEnabled,
                     lightSleepAfterSeconds: lightSleepAfterSeconds,
                     deepSleepAfterSeconds: deepSleepAfterSeconds,
@@ -3844,7 +3843,7 @@ public enum MelixCLIParser {
         let values = try ArgumentCursor(arguments: optionArguments).parse(
             multiValueOptions: ["--model", "--models", "--allowed-host", "--allowed-origin"]
         )
-        let serverSessionID = values.single["--server-session-id"] ?? ServerSessionRuntimeStore.defaultServerSessionID
+        let providerID = values.single["--provider-id"] ?? MelixProviderDefaults.defaultProviderID
         let json = values.flags.contains("--json")
         let modelIDs = parsedModelRoster(
             singleModel: "",
@@ -3854,7 +3853,7 @@ public enum MelixCLIParser {
         let defaultModelID = (values.single["--default-model"] ?? modelIDs.first ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return .serverStart(.init(
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             serverTitle: serverTitle,
             defaultModelID: defaultModelID,
             servedModelIDs: modelIDs,
@@ -3881,7 +3880,7 @@ public enum MelixCLIParser {
         ))
     }
 
-    private static func parseServerSession(_ arguments: [String]) throws -> MelixCLICommand {
+    private static func parseProvider(_ arguments: [String]) throws -> MelixCLICommand {
         guard let action = arguments.first else {
             throw MelixCLIError.usage(usageText)
         }
@@ -3894,10 +3893,10 @@ public enum MelixCLIParser {
         )
         switch action {
         case "list":
-            return .serverSessionList(.init(json: values.flags.contains("--json")))
+            return .providerList(.init(json: values.flags.contains("--json")))
         case "create":
             guard let title = values.single["--title"], !title.isEmpty else {
-                throw MelixCLIError.missingRequired("--title is required for melix server session create.")
+                throw MelixCLIError.missingRequired("--title is required for melix provider create.")
             }
             let modelIDs = parsedModelRoster(
                 singleModel: "",
@@ -3907,7 +3906,7 @@ public enum MelixCLIParser {
             let defaultModelID = (values.single["--default-model"] ?? modelIDs.first ?? "")
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             guard !defaultModelID.isEmpty else {
-                throw MelixCLIError.missingRequired("--model or --models is required for melix server session create.")
+                throw MelixCLIError.missingRequired("--model or --models is required for melix provider create.")
             }
             let port = try parseIntValue(
                 values.single["--port"],
@@ -3929,8 +3928,8 @@ public enum MelixCLIParser {
                 option: "--model-idle-timeout-seconds",
                 defaultValue: 600
             ) ?? 600
-            let servingDefaults = try parseCreateServerSessionServingDefaults(values)
-            return .serverSessionCreate(
+            let servingDefaults = try parseCreateProviderServingDefaults(values)
+            return .providerCreate(
                 .init(
                     title: title,
                     defaultModelID: defaultModelID,
@@ -3950,8 +3949,8 @@ public enum MelixCLIParser {
                 )
             )
         case "update":
-            guard let serverSessionID = values.single["--server-session-id"], !serverSessionID.isEmpty else {
-                throw MelixCLIError.missingRequired("--server-session-id is required for melix server session update.")
+            guard let providerID = values.single["--provider-id"], !providerID.isEmpty else {
+                throw MelixCLIError.missingRequired("--provider-id is required for melix provider update.")
             }
             let clearAllowedHosts = values.flags.contains("--clear-allowed-hosts")
             let clearAllowedOrigins = values.flags.contains("--clear-allowed-origins")
@@ -3968,10 +3967,10 @@ public enum MelixCLIParser {
             )
             let defaultModelID = (values.single["--default-model"] ?? modelIDs.first ?? "")
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            let servingDefaults = try parseUpdateServerSessionServingDefaults(values)
-            return .serverSessionUpdate(
+            let servingDefaults = try parseUpdateProviderServingDefaults(values)
+            return .providerUpdate(
                 .init(
-                    serverSessionID: serverSessionID,
+                    providerID: providerID,
                     title: values.single["--title"] ?? "",
                     defaultModelID: defaultModelID,
                     servedModelIDs: modelIDs,
@@ -4004,21 +4003,21 @@ public enum MelixCLIParser {
                 )
             )
         case "remove":
-            guard let serverSessionID = values.single["--server-session-id"], !serverSessionID.isEmpty else {
-                throw MelixCLIError.missingRequired("--server-session-id is required for melix server session remove.")
+            guard let providerID = values.single["--provider-id"], !providerID.isEmpty else {
+                throw MelixCLIError.missingRequired("--provider-id is required for melix provider remove.")
             }
-            return .serverSessionRemove(.init(serverSessionID: serverSessionID, json: values.flags.contains("--json")))
+            return .providerRemove(.init(providerID: providerID, json: values.flags.contains("--json")))
         case "select":
-            guard let serverSessionID = values.single["--server-session-id"], !serverSessionID.isEmpty else {
-                throw MelixCLIError.missingRequired("--server-session-id is required for melix server session select.")
+            guard let providerID = values.single["--provider-id"], !providerID.isEmpty else {
+                throw MelixCLIError.missingRequired("--provider-id is required for melix provider select.")
             }
-            return .serverSessionSelect(.init(serverSessionID: serverSessionID, json: values.flags.contains("--json")))
+            return .providerSelect(.init(providerID: providerID, json: values.flags.contains("--json")))
         default:
             throw MelixCLIError.usage(usageText)
         }
     }
 
-    private static func parseCreateServerSessionServingDefaults(
+    private static func parseCreateProviderServingDefaults(
         _ values: ParsedArguments
     ) throws -> (accelerationProfile: String, accelerationMode: String, draftModelID: String, numDraftTokens: Int) {
         let profileID = try normalizedServingDefaultsAccelerationProfile(
@@ -4056,7 +4055,7 @@ public enum MelixCLIParser {
         return (profileID, accelerationMode, draftModelID, numDraftTokens)
     }
 
-    private static func parseUpdateServerSessionServingDefaults(
+    private static func parseUpdateProviderServingDefaults(
         _ values: ParsedArguments
     ) throws -> (accelerationProfile: String, accelerationMode: String, draftModelID: String, numDraftTokens: Int) {
         let profileID = try normalizedServingDefaultsAccelerationProfile(
@@ -4138,7 +4137,7 @@ public enum MelixCLIParser {
                     remoteModelID: remoteModelID,
                     message: message,
                     systemPrompt: values.single["--system"] ?? "",
-                    serverSessionID: values.single["--server-session-id"] ?? ServerSessionRuntimeStore.defaultServerSessionID,
+                    providerID: values.single["--provider-id"] ?? MelixProviderDefaults.defaultProviderID,
                     json: values.flags.contains("--json")
                 )
             )
@@ -7054,9 +7053,9 @@ public actor MelixCLIRunner {
     }
 
     public func applyConfiguredServerSessionGatewayConfig(
-        serverSessionID: String
+        providerID: String
     ) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        let configuredSession = try loadConfiguredServerSession(id: serverSessionID)
+        let configuredSession = try loadConfiguredProvider(id: providerID)
         return try await client.applyServerSessionGatewayConfig(
             serverSessionID: configuredSession.id,
             host: configuredSession.host,
@@ -7072,9 +7071,9 @@ public actor MelixCLIRunner {
     }
 
     public func applyConfiguredServerSessionServingDefaults(
-        serverSessionID: String
+        providerID: String
     ) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        let configuredSession = try loadConfiguredServerSession(id: serverSessionID)
+        let configuredSession = try loadConfiguredProvider(id: providerID)
         return try await client.applyServerSessionServingDefaults(
             serverSessionID: configuredSession.id,
             temperature: configuredSession.servingDefaults.temperature,
@@ -8180,20 +8179,20 @@ public actor MelixCLIRunner {
         case .serverSnapshot(let options):
             let snapshot = try await client.serverSnapshot()
             return try renderServerSnapshot(snapshot, json: options.json)
-        case .serverSessionList(let options):
+        case .providerList(let options):
             let state = try loadOperatorState()
             if options.json {
-                return try prettyJSON(ServerSessionListResponse(
-                    serverSessions: state.serverSessions,
-                    selectedServerSessionID: state.selectedServerSessionID
+                return try prettyJSON(ProviderListResponse(
+                    providers: state.providers,
+                    selectedProviderID: state.selectedProviderID
                 ))
             }
-            return renderServerSessions(state)
-        case .serverSessionCreate(let options):
+            return renderProviders(state)
+        case .providerCreate(let options):
             var createdID = ""
             let state = try mutateOperatorState { current in
-                let created = MelixOperatorServerSessionState(
-                    id: nextGeneratedServerSessionID(in: current.serverSessions),
+                let created = MelixOperatorProviderState(
+                    id: nextGeneratedProviderID(in: current.providers),
                     title: options.title,
                     defaultModelID: options.defaultModelID,
                     servedModelIDs: options.servedModelIDs,
@@ -8207,23 +8206,23 @@ public actor MelixCLIRunner {
                     servingDefaults: try servingDefaults(for: options),
                     lifecycle: .draft
                 )
-                current.serverSessions.append(created)
-                current.selectedServerSessionID = created.id
+                current.providers.append(created)
+                current.selectedProviderID = created.id
                 createdID = created.id
             }
             if options.json {
-                guard let created = state.serverSessions.first(where: { $0.id == createdID }) else {
-                    throw MelixCLIError.runtime("Created server session \(createdID) was not found in persisted state.")
+                guard let created = state.providers.first(where: { $0.id == createdID }) else {
+                    throw MelixCLIError.runtime("Created provider \(createdID) was not found in persisted state.")
                 }
                 return try prettyJSON(created)
             }
-            return renderServerSessions(state)
-        case .serverSessionUpdate(let options):
+            return renderProviders(state)
+        case .providerUpdate(let options):
             let state = try mutateOperatorState { current in
-                guard let index = current.serverSessions.firstIndex(where: { $0.id == options.serverSessionID }) else {
+                guard let index = current.providers.firstIndex(where: { $0.id == options.providerID }) else {
                     return
                 }
-                var session = current.serverSessions[index]
+                var session = current.providers[index]
                 if options.title.isEmpty == false {
                     session.title = options.title
                 }
@@ -8268,45 +8267,45 @@ public actor MelixCLIRunner {
                 }
                 try applyServingDefaultsUpdate(options, to: &session)
                 session.updatedAt = Date()
-                current.serverSessions[index] = session
+                current.providers[index] = session
             }
             if options.json {
-                guard let updated = state.serverSessions.first(where: { $0.id == options.serverSessionID }) else {
-                    throw MelixCLIError.runtime("Server session \(options.serverSessionID) was not found.")
+                guard let updated = state.providers.first(where: { $0.id == options.providerID }) else {
+                    throw MelixCLIError.runtime("Provider \(options.providerID) was not found.")
                 }
                 return try prettyJSON(updated)
             }
-            return renderServerSessions(state)
-        case .serverSessionRemove(let options):
+            return renderProviders(state)
+        case .providerRemove(let options):
             let state = try mutateOperatorState { current in
-                current.serverSessions.removeAll { $0.id == options.serverSessionID }
-                if current.selectedServerSessionID == options.serverSessionID {
-                    current.selectedServerSessionID = current.serverSessions.first?.id ?? ""
+                current.providers.removeAll { $0.id == options.providerID }
+                if current.selectedProviderID == options.providerID {
+                    current.selectedProviderID = current.providers.first?.id ?? ""
                 }
             }
             if options.json {
                 return try prettyJSON([
-                    "removed_id": options.serverSessionID,
-                    "selected_server_session_id": state.selectedServerSessionID,
+                    "removed_id": options.providerID,
+                    "selected_provider_id": state.selectedProviderID,
                 ])
             }
-            return renderServerSessions(state)
-        case .serverSessionSelect(let options):
+            return renderProviders(state)
+        case .providerSelect(let options):
             let state = try mutateOperatorState { current in
-                if current.serverSessions.contains(where: { $0.id == options.serverSessionID }) {
-                    current.selectedServerSessionID = options.serverSessionID
+                if current.providers.contains(where: { $0.id == options.providerID }) {
+                    current.selectedProviderID = options.providerID
                 }
             }
             if options.json {
                 return try prettyJSON([
-                    "selected_server_session_id": state.selectedServerSessionID,
+                    "selected_provider_id": state.selectedProviderID,
                 ])
             }
-            return renderServerSessions(state)
+            return renderProviders(state)
         case .serverStart(let options):
-            let targetServerSessionID = try upsertServerSessionForStartIfNeeded(options)
-            guard let configuredSession = try configuredServerSessionIfAvailable(id: targetServerSessionID) else {
-                let snapshot = try await client.startServerSession(serverSessionID: targetServerSessionID)
+            let targetProviderID = try upsertProviderForStartIfNeeded(options)
+            guard let configuredSession = try configuredProviderIfAvailable(id: targetProviderID) else {
+                let snapshot = try await client.startServerSession(serverSessionID: targetProviderID)
                 return try renderServerSnapshot(snapshot, json: options.json)
             }
             let serverSnapshot = try await client.serverSnapshot()
@@ -8315,7 +8314,7 @@ public actor MelixCLIRunner {
                     modelID: modelID,
                     serverSnapshot: serverSnapshot
                 ) else {
-                    try markServerSessionUnavailable(
+                    try markProviderUnavailable(
                         id: configuredSession.id,
                         message: "Unavailable",
                         lastError: "Bound model \(modelID) is missing."
@@ -8326,7 +8325,7 @@ public actor MelixCLIRunner {
                     modelID: modelID,
                     serverSnapshot: serverSnapshot
                 ) else {
-                    try markServerSessionUnavailable(
+                    try markProviderUnavailable(
                         id: configuredSession.id,
                         message: "Unavailable",
                         lastError: "Bound model \(modelID) is not serveable."
@@ -8364,31 +8363,31 @@ public actor MelixCLIRunner {
             let snapshot = try await client.startServerSession(serverSessionID: configuredSession.id)
             return try renderServerSnapshot(snapshot, json: options.json)
         case .serverPause(let options):
-            let snapshot = try await client.pauseServerSession(serverSessionID: options.serverSessionID)
+            let snapshot = try await client.pauseServerSession(serverSessionID: options.providerID)
             return try renderServerSnapshot(snapshot, json: options.json)
         case .serverResume(let options):
-            let snapshot = try await client.resumeServerSession(serverSessionID: options.serverSessionID)
+            let snapshot = try await client.resumeServerSession(serverSessionID: options.providerID)
             return try renderServerSnapshot(snapshot, json: options.json)
         case .serverWake(let options):
-            let snapshot = try await client.wakeServerSession(serverSessionID: options.serverSessionID)
+            let snapshot = try await client.wakeServerSession(serverSessionID: options.providerID)
             return try renderServerSnapshot(snapshot, json: options.json)
         case .serverStop(let options):
-            let snapshot = try await client.stopServerSession(serverSessionID: options.serverSessionID)
+            let snapshot = try await client.stopServerSession(serverSessionID: options.providerID)
             return try renderServerSnapshot(snapshot, json: options.json)
         case .serverSetIdlePolicy(let options):
-            if let configuredSession = try configuredServerSessionIfAvailable(id: options.serverSessionID) {
+            if let configuredSession = try configuredProviderIfAvailable(id: options.providerID) {
                 _ = try mutateOperatorState { state in
-                    guard let index = state.serverSessions.firstIndex(where: { $0.id == configuredSession.id }) else {
+                    guard let index = state.providers.firstIndex(where: { $0.id == configuredSession.id }) else {
                         return
                     }
-                    state.serverSessions[index].autoSleepEnabled = options.autoSleepEnabled
-                    state.serverSessions[index].lightSleepAfterSeconds = Int(options.lightSleepAfterSeconds)
-                    state.serverSessions[index].deepSleepAfterSeconds = Int(options.deepSleepAfterSeconds)
-                    state.serverSessions[index].updatedAt = Date()
+                    state.providers[index].autoSleepEnabled = options.autoSleepEnabled
+                    state.providers[index].lightSleepAfterSeconds = Int(options.lightSleepAfterSeconds)
+                    state.providers[index].deepSleepAfterSeconds = Int(options.deepSleepAfterSeconds)
+                    state.providers[index].updatedAt = Date()
                 }
             }
             let snapshot = try await client.updateServerIdlePolicy(
-                serverSessionID: options.serverSessionID,
+                serverSessionID: options.providerID,
                 autoSleepEnabled: options.autoSleepEnabled,
                 lightSleepAfterSeconds: options.lightSleepAfterSeconds,
                 deepSleepAfterSeconds: options.deepSleepAfterSeconds
@@ -8489,7 +8488,8 @@ public actor MelixCLIRunner {
                     ControlPlaneChatRequest(
                         modelID: options.modelID,
                         messages: buildChatMessages(options: options),
-                        remoteTarget: remoteTarget
+                        remoteTarget: remoteTarget,
+                        providerID: options.providerID
                     )
                 )
             } catch {
@@ -8498,7 +8498,7 @@ public actor MelixCLIRunner {
             let result = try await collectChatResult(from: execution)
             let receipt = ChatRunReceipt(
                 modelID: execution.modelID,
-                serverSessionID: options.serverSessionID,
+                providerID: options.providerID,
                 assistantText: result.assistantText,
                 finishReason: result.finishReason,
                 requestID: execution.requestID
@@ -9489,7 +9489,7 @@ public actor MelixCLIRunner {
     }
 
     private func loadOperatorState() throws -> MelixOperatorSessionState {
-        try operatorSessionStore.load() ?? MelixOperatorSessionState(selectedServerSessionID: "", serverSessions: [])
+        try operatorSessionStore.load() ?? MelixOperatorSessionState(selectedProviderID: "", providers: [])
     }
 
     private func commandRequiresConfiguredRegistryRootPriming(_ command: MelixCLICommand) -> Bool {
@@ -9584,9 +9584,9 @@ public actor MelixCLIRunner {
             return try loadOperatorState()
         } catch CocoaError.fileReadNoPermission,
                 CocoaError.fileReadNoSuchFile {
-            return MelixOperatorSessionState(selectedServerSessionID: "", serverSessions: [])
+            return MelixOperatorSessionState(selectedProviderID: "", providers: [])
         } catch {
-            return MelixOperatorSessionState(selectedServerSessionID: "", serverSessions: [])
+            return MelixOperatorSessionState(selectedProviderID: "", providers: [])
         }
     }
 
@@ -9600,13 +9600,13 @@ public actor MelixCLIRunner {
         return state
     }
 
-    private func loadConfiguredServerSession(id: String) throws -> MelixOperatorServerSessionState {
+    private func loadConfiguredProvider(id: String) throws -> MelixOperatorProviderState {
         let state = try loadOperatorState()
-        let resolvedID = id.isEmpty ? state.selectedServerSessionID : id
-        if let session = state.serverSessions.first(where: { $0.id == resolvedID }) {
+        let resolvedID = id.isEmpty ? state.selectedProviderID : id
+        if let session = state.providers.first(where: { $0.id == resolvedID }) {
             return session
         }
-        throw MelixCLIError.runtime("Server session \(resolvedID) is not configured.")
+        throw MelixCLIError.runtime("Provider \(resolvedID) is not configured.")
     }
 
     private func remoteServerStore() -> RemoteServerStore {
@@ -9826,11 +9826,11 @@ public actor MelixCLIRunner {
         return trimmed.isEmpty ? code : trimmed
     }
 
-    private func configuredServerSessionIfAvailable(
+    private func configuredProviderIfAvailable(
         id: String
-    ) throws -> MelixOperatorServerSessionState? {
+    ) throws -> MelixOperatorProviderState? {
         do {
-            return try loadConfiguredServerSession(id: id)
+            return try loadConfiguredProvider(id: id)
         } catch let error as MelixCLIError {
             if case .runtime = error {
                 return nil
@@ -9847,7 +9847,7 @@ public actor MelixCLIRunner {
 
     private func applyServerControlOptions(
         _ options: ServerControlOptions,
-        to session: inout MelixOperatorServerSessionState
+        to session: inout MelixOperatorProviderState
     ) {
         if !options.defaultModelID.isEmpty {
             session.defaultModelID = options.defaultModelID
@@ -9884,7 +9884,7 @@ public actor MelixCLIRunner {
         )
     }
 
-    private func upsertServerSessionForStartIfNeeded(_ options: ServerControlOptions) throws -> String {
+    private func upsertProviderForStartIfNeeded(_ options: ServerControlOptions) throws -> String {
         let title = options.serverTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         let host = options.host.trimmingCharacters(in: .whitespacesAndNewlines)
         let titleSessionID = MelixServerStartShortcutName.sessionIDCandidate(for: title)
@@ -9899,23 +9899,23 @@ public actor MelixCLIRunner {
             || options.timeoutSeconds > 0
             || options.modelIdleTimeoutSeconds > 0
         guard hasShortcutConfiguration else {
-            return options.serverSessionID
+            return options.providerID
         }
         guard title.isEmpty == false else {
             throw MelixCLIError.missingRequired("TITLE is required when passing --model, --models, --default-model, --host, --port, --allowed-host, --allowed-origin, --rate-limit-per-minute, --timeout-seconds, or --model-idle-timeout-seconds to melix server start.")
         }
         guard !options.defaultModelID.isEmpty else {
-            throw MelixCLIError.missingRequired("--model or --models is required when starting a titled server session.")
+            throw MelixCLIError.missingRequired("--model or --models is required when starting a titled provider.")
         }
 
         var resolvedID = ""
         let state = try mutateOperatorState { current in
-            if let index = current.serverSessions.firstIndex(where: { session in
+            if let index = current.providers.firstIndex(where: { session in
                 session.id == title
                     || session.title == title
                     || titleSessionID.map { session.id == $0 } == true
             }) {
-                var session = current.serverSessions[index]
+                var session = current.providers[index]
                 session.title = title
                 applyServerControlOptions(options, to: &session)
                 if host.isEmpty == false {
@@ -9931,15 +9931,15 @@ public actor MelixCLIRunner {
                     session.timeoutSeconds = options.timeoutSeconds
                 }
                 session.updatedAt = Date()
-                current.serverSessions[index] = session
-                current.selectedServerSessionID = session.id
+                current.providers[index] = session
+                current.selectedProviderID = session.id
                 resolvedID = session.id
             } else {
                 let createdID = nextServerStartShortcutSessionID(
                     options: options,
-                    existingSessions: current.serverSessions
+                    existingSessions: current.providers
                 )
-                let created = MelixOperatorServerSessionState(
+                let created = MelixOperatorProviderState(
                     id: createdID,
                     title: title,
                     defaultModelID: options.defaultModelID,
@@ -9955,59 +9955,59 @@ public actor MelixCLIRunner {
                         : 600,
                     lifecycle: .draft
                 )
-                current.serverSessions.append(created)
-                current.selectedServerSessionID = created.id
+                current.providers.append(created)
+                current.selectedProviderID = created.id
                 resolvedID = created.id
             }
         }
         guard resolvedID.isEmpty == false,
-              state.serverSessions.contains(where: { $0.id == resolvedID }) else {
-            throw MelixCLIError.runtime("Server session titled \(title) could not be created.")
+              state.providers.contains(where: { $0.id == resolvedID }) else {
+            throw MelixCLIError.runtime("Provider titled \(title) could not be created.")
         }
         return resolvedID
     }
 
-    private func nextGeneratedServerSessionID(in sessions: [MelixOperatorServerSessionState]) -> String {
+    private func nextGeneratedProviderID(in sessions: [MelixOperatorProviderState]) -> String {
         let existingIDs = Set(sessions.map(\.id))
         var index = 1
-        while existingIDs.contains("server-session-\(index)") {
+        while existingIDs.contains("provider-\(index)") {
             index += 1
         }
-        return "server-session-\(index)"
+        return "provider-\(index)"
     }
 
     private func nextServerStartShortcutSessionID(
         options: ServerControlOptions,
-        existingSessions: [MelixOperatorServerSessionState]
+        existingSessions: [MelixOperatorProviderState]
     ) -> String {
-        let id = options.serverSessionID
-        guard id != ServerSessionRuntimeStore.defaultServerSessionID,
+        let id = options.providerID
+        guard id != MelixProviderDefaults.defaultProviderID,
               !existingSessions.contains(where: { $0.id == id })
         else {
-            return nextGeneratedServerSessionID(in: existingSessions)
+            return nextGeneratedProviderID(in: existingSessions)
         }
         return id
     }
 
-    private func markServerSessionUnavailable(
+    private func markProviderUnavailable(
         id: String,
         message: String,
         lastError: String
     ) throws {
         _ = try mutateOperatorState { state in
-            guard let index = state.serverSessions.firstIndex(where: { $0.id == id }) else {
+            guard let index = state.providers.firstIndex(where: { $0.id == id }) else {
                 return
             }
-            state.serverSessions[index].lifecycle = .unavailable
-            state.serverSessions[index].lastKnownModelStateText = message
-            state.serverSessions[index].lastError = lastError
-            state.serverSessions[index].updatedAt = Date()
+            state.providers[index].lifecycle = .unavailable
+            state.providers[index].lastKnownModelStateText = message
+            state.providers[index].lastError = lastError
+            state.providers[index].updatedAt = Date()
         }
     }
 
     private func applyAccelerationProfile(
         _ profileID: String,
-        to defaults: inout MelixOperatorServerServingDefaultsState
+        to defaults: inout MelixOperatorProviderServingDefaultsState
     ) throws {
         let normalizedProfileID = profileID.trimmingCharacters(in: .whitespacesAndNewlines)
         guard normalizedProfileID.isEmpty == false else {
@@ -10030,9 +10030,9 @@ public actor MelixCLIRunner {
     }
 
     private func servingDefaults(
-        for options: ServerSessionCreateOptions
-    ) throws -> MelixOperatorServerServingDefaultsState {
-        var defaults = MelixOperatorServerServingDefaultsState()
+        for options: ProviderCreateOptions
+    ) throws -> MelixOperatorProviderServingDefaultsState {
+        var defaults = MelixOperatorProviderServingDefaultsState()
         try applyAccelerationProfile(options.accelerationProfile, to: &defaults)
         let rawAccelerationMode = options.accelerationMode.trimmingCharacters(in: .whitespacesAndNewlines)
         let accelerationMode = normalizedServingDefaultsAccelerationMode(options.accelerationMode)
@@ -10067,8 +10067,8 @@ public actor MelixCLIRunner {
     }
 
     private func applyServingDefaultsUpdate(
-        _ options: ServerSessionUpdateOptions,
-        to session: inout MelixOperatorServerSessionState
+        _ options: ProviderUpdateOptions,
+        to session: inout MelixOperatorProviderState
     ) throws {
         let rawAccelerationMode = options.accelerationMode.trimmingCharacters(in: .whitespacesAndNewlines)
         let accelerationMode = normalizedServingDefaultsAccelerationMode(options.accelerationMode)
@@ -10460,16 +10460,16 @@ public actor MelixCLIRunner {
         }.joined(separator: "\n") + "\n"
     }
 
-    private func renderServerSessions(_ state: MelixOperatorSessionState) -> String {
-        guard state.serverSessions.isEmpty == false else {
-            return "No server sessions configured.\n"
+    private func renderProviders(_ state: MelixOperatorSessionState) -> String {
+        guard state.providers.isEmpty == false else {
+            return "No providers configured.\n"
         }
-        let rows = state.serverSessions.map { session in
-            let selectedMarker = session.id == state.selectedServerSessionID ? "*" : ""
+        let rows = state.providers.map { session in
+            let selectedMarker = session.id == state.selectedProviderID ? "*" : ""
             let modelIDs = session.servedModelIDs.joined(separator: ",")
             return "\(selectedMarker)\(session.id)\t\(session.title)\t\(modelIDs)\t\(session.lifecycle.rawValue)"
         }
-        return (["server_session_id\ttitle\tmodel_ids\tlifecycle"] + rows).joined(separator: "\n") + "\n"
+        return (["provider_id\ttitle\tmodel_ids\tlifecycle"] + rows).joined(separator: "\n") + "\n"
     }
 
     private func renderRemoteServers(_ servers: [RemoteServer]) -> String {
@@ -13116,13 +13116,13 @@ private struct BenchExportCSVResponse: Encodable {
     let rowCount: Int
 }
 
-private struct ServerSessionListResponse: Encodable {
-    let serverSessions: [MelixOperatorServerSessionState]
-    let selectedServerSessionID: String
+private struct ProviderListResponse: Encodable {
+    let providers: [MelixOperatorProviderState]
+    let selectedProviderID: String
 
     enum CodingKeys: String, CodingKey {
-        case serverSessions = "server_sessions"
-        case selectedServerSessionID = "selected_server_session_id"
+        case providers = "providers"
+        case selectedProviderID = "selected_provider_id"
     }
 }
 

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -116,16 +116,16 @@ public enum MelixCLICommandCodec {
             return "model.roots.rescan"
         case .serverSnapshot:
             return "server.snapshot"
-        case .serverSessionList:
-            return "server.session.list"
-        case .serverSessionCreate:
-            return "server.session.create"
-        case .serverSessionUpdate:
-            return "server.session.update"
-        case .serverSessionRemove:
-            return "server.session.remove"
-        case .serverSessionSelect:
-            return "server.session.select"
+        case .providerList:
+            return "provider.list"
+        case .providerCreate:
+            return "provider.create"
+        case .providerUpdate:
+            return "provider.update"
+        case .providerRemove:
+            return "provider.remove"
+        case .providerSelect:
+            return "provider.select"
         case .serverStart:
             return "server.start"
         case .serverPause:
@@ -516,9 +516,9 @@ public enum MelixCLICommandCodec {
             appendOption("--path", value: options.path, into: &arguments)
             appendPositiveInt("--index", value: options.index, into: &arguments)
             json = options.json
-        case .serverSessionUpdate(let options):
-            arguments = ["server", "session", "update"]
-            appendOption("--server-session-id", value: options.serverSessionID, into: &arguments)
+        case .providerUpdate(let options):
+            arguments = ["provider", "update"]
+            appendOption("--provider-id", value: options.providerID, into: &arguments)
             appendOption("--title", value: options.title, into: &arguments)
             for modelID in options.servedModelIDs {
                 appendOption("--model", value: modelID, into: &arguments)
@@ -541,8 +541,8 @@ public enum MelixCLICommandCodec {
             appendOption("--draft-model-id", value: options.draftModelID, into: &arguments)
             appendPositiveInt("--num-draft-tokens", value: options.numDraftTokens, into: &arguments)
             json = options.json
-        case .serverSessionCreate(let options):
-            arguments = ["server", "session", "create"]
+        case .providerCreate(let options):
+            arguments = ["provider", "create"]
             appendOption("--title", value: options.title, into: &arguments)
             for modelID in options.servedModelIDs {
                 appendOption("--model", value: modelID, into: &arguments)
@@ -563,20 +563,20 @@ public enum MelixCLICommandCodec {
             appendOption("--draft-model-id", value: options.draftModelID, into: &arguments)
             appendPositiveInt("--num-draft-tokens", value: options.numDraftTokens, into: &arguments)
             json = options.json
-        case .serverSessionRemove(let options):
-            arguments = ["server", "session", "remove"]
-            appendOption("--server-session-id", value: options.serverSessionID, into: &arguments)
+        case .providerRemove(let options):
+            arguments = ["provider", "remove"]
+            appendOption("--provider-id", value: options.providerID, into: &arguments)
             json = options.json
-        case .serverSessionSelect(let options):
-            arguments = ["server", "session", "select"]
-            appendOption("--server-session-id", value: options.serverSessionID, into: &arguments)
+        case .providerSelect(let options):
+            arguments = ["provider", "select"]
+            appendOption("--provider-id", value: options.providerID, into: &arguments)
             json = options.json
         case .serverStart(let options):
             arguments = ["server", "start"]
             if options.serverTitle.isEmpty == false {
                 arguments.append(options.serverTitle)
             } else {
-                appendOption("--server-session-id", value: options.serverSessionID, into: &arguments)
+                appendOption("--provider-id", value: options.providerID, into: &arguments)
             }
             for modelID in options.servedModelIDs {
                 appendOption("--model", value: modelID, into: &arguments)
@@ -595,23 +595,23 @@ public enum MelixCLICommandCodec {
             json = options.json
         case .serverPause(let options):
             arguments = ["server", "pause"]
-            appendOption("--server-session-id", value: options.serverSessionID, into: &arguments)
+            appendOption("--provider-id", value: options.providerID, into: &arguments)
             json = options.json
         case .serverResume(let options):
             arguments = ["server", "resume"]
-            appendOption("--server-session-id", value: options.serverSessionID, into: &arguments)
+            appendOption("--provider-id", value: options.providerID, into: &arguments)
             json = options.json
         case .serverWake(let options):
             arguments = ["server", "wake"]
-            appendOption("--server-session-id", value: options.serverSessionID, into: &arguments)
+            appendOption("--provider-id", value: options.providerID, into: &arguments)
             json = options.json
         case .serverStop(let options):
             arguments = ["server", "stop"]
-            appendOption("--server-session-id", value: options.serverSessionID, into: &arguments)
+            appendOption("--provider-id", value: options.providerID, into: &arguments)
             json = options.json
         case .serverSetIdlePolicy(let options):
             arguments = ["server", "set-idle-policy"]
-            appendOption("--server-session-id", value: options.serverSessionID, into: &arguments)
+            appendOption("--provider-id", value: options.providerID, into: &arguments)
             appendOption("--auto-sleep", value: options.autoSleepEnabled ? "true" : "false", into: &arguments)
             appendPositiveUInt32("--light-sleep-after", value: options.lightSleepAfterSeconds, into: &arguments)
             appendPositiveUInt32("--deep-sleep-after", value: options.deepSleepAfterSeconds, into: &arguments)
@@ -646,7 +646,7 @@ public enum MelixCLICommandCodec {
             }
             appendOption("--message", value: options.message, into: &arguments)
             appendOption("--system", value: options.systemPrompt, into: &arguments)
-            appendOption("--server-session-id", value: options.serverSessionID, into: &arguments)
+            appendOption("--provider-id", value: options.providerID, into: &arguments)
             json = options.json
         case .loraTrain(let options):
             arguments = ["lora", "train"]

--- a/Sources/MelixCLICore/MelixHome.swift
+++ b/Sources/MelixCLICore/MelixHome.swift
@@ -21,7 +21,7 @@ public struct MelixHome: Equatable, Sendable {
     public let logsDirectoryURL: URL
     public let installDirectoryURL: URL
     public let operatorSessionFileURL: URL
-    public let serverSessionsFileURL: URL
+    public let providersFileURL: URL
     public let modelRootsFileURL: URL
     public let downloadQueueFileURL: URL
     public let localTrainingQueueFileURL: URL
@@ -29,7 +29,7 @@ public struct MelixHome: Equatable, Sendable {
     public let evaluationPromptsFileURL: URL
     public let loraTrainingJobsFileURL: URL
     public let runtimeSettingsFileURL: URL
-    public let serverSessionAPIKeysFileURL: URL
+    public let providerAPIKeysFileURL: URL
     public let remoteServerAPIKeysFileURL: URL
     public let huggingFaceTokenFileURL: URL
 
@@ -47,7 +47,7 @@ public struct MelixHome: Equatable, Sendable {
         self.logsDirectoryURL = layout.logsDirectoryURL
         self.installDirectoryURL = layout.installDirectoryURL
         self.operatorSessionFileURL = stateDirectoryURL.appendingPathComponent("operator-session.json")
-        self.serverSessionsFileURL = configDirectoryURL.appendingPathComponent("server-sessions.json")
+        self.providersFileURL = configDirectoryURL.appendingPathComponent("providers.json")
         self.modelRootsFileURL = configDirectoryURL.appendingPathComponent("model-roots.json")
         self.downloadQueueFileURL = stateDirectoryURL.appendingPathComponent("download-queue.json")
         self.localTrainingQueueFileURL = stateDirectoryURL.appendingPathComponent("local-training-queue.json")
@@ -55,7 +55,7 @@ public struct MelixHome: Equatable, Sendable {
         self.evaluationPromptsFileURL = configDirectoryURL.appendingPathComponent("evaluation-prompts.json")
         self.loraTrainingJobsFileURL = stateDirectoryURL.appendingPathComponent("lora-training-jobs.json")
         self.runtimeSettingsFileURL = rootURL.appendingPathComponent("runtime_settings.json")
-        self.serverSessionAPIKeysFileURL = secretsDirectoryURL.appendingPathComponent("server-session-api-keys.json")
+        self.providerAPIKeysFileURL = secretsDirectoryURL.appendingPathComponent("provider-api-keys.json")
         self.remoteServerAPIKeysFileURL = secretsDirectoryURL.appendingPathComponent("remote-server-api-keys.json")
         self.huggingFaceTokenFileURL = secretsDirectoryURL.appendingPathComponent("huggingface-token.json")
     }

--- a/Sources/MelixCLICore/MelixOperatorState.swift
+++ b/Sources/MelixCLICore/MelixOperatorState.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MelixControlPlaneCore
 
-public enum MelixOperatorServerSessionLifecycle: String, Codable, Sendable {
+public enum MelixOperatorProviderLifecycle: String, Codable, Sendable {
     case draft = "Draft"
     case starting = "Starting"
     case running = "Running"
@@ -13,7 +13,7 @@ public enum MelixOperatorServerSessionLifecycle: String, Codable, Sendable {
     case unavailable = "Unavailable"
 }
 
-public struct MelixOperatorServerServingDefaultsState: Codable, Equatable, Sendable {
+public struct MelixOperatorProviderServingDefaultsState: Codable, Equatable, Sendable {
     public var temperature: Double
     public var topP: Double
     public var maxTokens: Int
@@ -107,7 +107,7 @@ public struct MelixOperatorServerServingDefaultsState: Codable, Equatable, Senda
     }
 }
 
-public struct MelixOperatorServerSessionState: Codable, Equatable, Sendable {
+public struct MelixOperatorProviderState: Codable, Equatable, Sendable {
     public let id: String
     public var title: String
     public var defaultModelID: String
@@ -119,11 +119,11 @@ public struct MelixOperatorServerSessionState: Codable, Equatable, Sendable {
     public var rateLimitPerMinute: Int
     public var timeoutSeconds: Int
     public var modelIdleTimeoutSeconds: Int
-    public var servingDefaults: MelixOperatorServerServingDefaultsState
+    public var servingDefaults: MelixOperatorProviderServingDefaultsState
     public var autoSleepEnabled: Bool
     public var lightSleepAfterSeconds: Int
     public var deepSleepAfterSeconds: Int
-    public var lifecycle: MelixOperatorServerSessionLifecycle
+    public var lifecycle: MelixOperatorProviderLifecycle
     public var lastError: String
     public var lastKnownModelStateText: String
     public var createdAt: Date
@@ -141,11 +141,11 @@ public struct MelixOperatorServerSessionState: Codable, Equatable, Sendable {
         rateLimitPerMinute: Int = 120,
         timeoutSeconds: Int = 120,
         modelIdleTimeoutSeconds: Int = 600,
-        servingDefaults: MelixOperatorServerServingDefaultsState = .init(),
+        servingDefaults: MelixOperatorProviderServingDefaultsState = .init(),
         autoSleepEnabled: Bool = false,
         lightSleepAfterSeconds: Int = 0,
         deepSleepAfterSeconds: Int = 0,
-        lifecycle: MelixOperatorServerSessionLifecycle = .draft,
+        lifecycle: MelixOperatorProviderLifecycle = .draft,
         lastError: String = "",
         lastKnownModelStateText: String = "",
         createdAt: Date = Date(),
@@ -222,13 +222,13 @@ public struct MelixOperatorServerSessionState: Codable, Equatable, Sendable {
                 forKey: .modelIdleTimeoutSeconds
             ) ?? 600,
             servingDefaults: try container.decodeIfPresent(
-                MelixOperatorServerServingDefaultsState.self,
+                MelixOperatorProviderServingDefaultsState.self,
                 forKey: .servingDefaults
             ) ?? .init(),
             autoSleepEnabled: try container.decodeIfPresent(Bool.self, forKey: .autoSleepEnabled) ?? false,
             lightSleepAfterSeconds: try container.decodeIfPresent(Int.self, forKey: .lightSleepAfterSeconds) ?? 0,
             deepSleepAfterSeconds: try container.decodeIfPresent(Int.self, forKey: .deepSleepAfterSeconds) ?? 0,
-            lifecycle: try container.decodeIfPresent(MelixOperatorServerSessionLifecycle.self, forKey: .lifecycle) ?? .draft,
+            lifecycle: try container.decodeIfPresent(MelixOperatorProviderLifecycle.self, forKey: .lifecycle) ?? .draft,
             lastError: try container.decodeIfPresent(String.self, forKey: .lastError) ?? "",
             lastKnownModelStateText: try container.decodeIfPresent(String.self, forKey: .lastKnownModelStateText) ?? "",
             createdAt: try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date(),
@@ -353,9 +353,9 @@ public struct MelixOperatorSessionState: Codable, Equatable, Sendable {
     public var schemaVersion: Int
     public var selectedSurfaceID: String
     public var selectedToolSectionID: String
-    public var selectedServerSessionID: String
+    public var selectedProviderID: String
     public var selectedRuntimeJobID: String
-    public var serverSessions: [MelixOperatorServerSessionState]
+    public var providers: [MelixOperatorProviderState]
     public var dismissedBannerIDs: [String]
     public var downloadQueue: [MelixOperatorDownloadQueueEntryState]
     public var registryRoots: [String]
@@ -365,9 +365,9 @@ public struct MelixOperatorSessionState: Codable, Equatable, Sendable {
         schemaVersion: Int = 6,
         selectedSurfaceID: String = "chat",
         selectedToolSectionID: String = "modelsLibrary",
-        selectedServerSessionID: String,
+        selectedProviderID: String,
         selectedRuntimeJobID: String = "",
-        serverSessions: [MelixOperatorServerSessionState],
+        providers: [MelixOperatorProviderState],
         dismissedBannerIDs: [String] = [],
         downloadQueue: [MelixOperatorDownloadQueueEntryState] = [],
         registryRoots: [String] = [],
@@ -376,9 +376,9 @@ public struct MelixOperatorSessionState: Codable, Equatable, Sendable {
         self.schemaVersion = max(schemaVersion, 6)
         self.selectedSurfaceID = selectedSurfaceID
         self.selectedToolSectionID = selectedToolSectionID
-        self.selectedServerSessionID = selectedServerSessionID
+        self.selectedProviderID = selectedProviderID
         self.selectedRuntimeJobID = selectedRuntimeJobID
-        self.serverSessions = serverSessions
+        self.providers = providers
         self.dismissedBannerIDs = dismissedBannerIDs
         self.downloadQueue = downloadQueue
         self.registryRoots = registryRoots
@@ -389,9 +389,9 @@ public struct MelixOperatorSessionState: Codable, Equatable, Sendable {
         case schemaVersion = "schema_version"
         case selectedSurfaceID = "selected_surface"
         case selectedToolSectionID = "selected_tool_section"
-        case selectedServerSessionID = "selected_server_session_id"
+        case selectedProviderID = "selected_provider_id"
         case selectedRuntimeJobID = "selected_runtime_job_id"
-        case serverSessions = "server_sessions"
+        case providers = "providers"
         case dismissedBannerIDs = "dismissed_banner_ids"
         case downloadQueue = "download_queue"
         case registryRoots = "registry_roots"
@@ -404,9 +404,9 @@ public struct MelixOperatorSessionState: Codable, Equatable, Sendable {
             schemaVersion: try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 4,
             selectedSurfaceID: try container.decodeIfPresent(String.self, forKey: .selectedSurfaceID) ?? "chat",
             selectedToolSectionID: try container.decodeIfPresent(String.self, forKey: .selectedToolSectionID) ?? "modelsLibrary",
-            selectedServerSessionID: try container.decodeIfPresent(String.self, forKey: .selectedServerSessionID) ?? "",
+            selectedProviderID: try container.decodeIfPresent(String.self, forKey: .selectedProviderID) ?? "",
             selectedRuntimeJobID: try container.decodeIfPresent(String.self, forKey: .selectedRuntimeJobID) ?? "",
-            serverSessions: try container.decodeIfPresent([MelixOperatorServerSessionState].self, forKey: .serverSessions) ?? [],
+            providers: try container.decodeIfPresent([MelixOperatorProviderState].self, forKey: .providers) ?? [],
             dismissedBannerIDs: try container.decodeIfPresent([String].self, forKey: .dismissedBannerIDs) ?? [],
             downloadQueue: try container.decodeIfPresent([MelixOperatorDownloadQueueEntryState].self, forKey: .downloadQueue) ?? [],
             registryRoots: try container.decodeIfPresent([String].self, forKey: .registryRoots) ?? [],
@@ -420,9 +420,9 @@ public struct MelixOperatorSessionState: Codable, Equatable, Sendable {
         try container.encode(schemaVersion, forKey: .schemaVersion)
         try container.encode(selectedSurfaceID, forKey: .selectedSurfaceID)
         try container.encode(selectedToolSectionID, forKey: .selectedToolSectionID)
-        try container.encode(selectedServerSessionID, forKey: .selectedServerSessionID)
+        try container.encode(selectedProviderID, forKey: .selectedProviderID)
         try container.encode(selectedRuntimeJobID, forKey: .selectedRuntimeJobID)
-        try container.encode(serverSessions, forKey: .serverSessions)
+        try container.encode(providers, forKey: .providers)
         try container.encode(dismissedBannerIDs, forKey: .dismissedBannerIDs)
         try container.encode(downloadQueue, forKey: .downloadQueue)
         try container.encode(registryRoots, forKey: .registryRoots)
@@ -520,7 +520,7 @@ public struct MelixOperatorSessionStore: MelixOperatorSessionStoring {
         let fileManager = FileManager.default
         guard [
             melixHome.operatorSessionFileURL,
-            melixHome.serverSessionsFileURL,
+            melixHome.providersFileURL,
             melixHome.modelRootsFileURL,
             melixHome.downloadQueueFileURL,
         ].contains(where: { fileManager.fileExists(atPath: $0.path) }) else {
@@ -531,8 +531,8 @@ public struct MelixOperatorSessionStore: MelixOperatorSessionStoring {
 
         let ui = try loadDocument(OperatorSessionUIDocument.self, from: melixHome.operatorSessionFileURL)
             ?? OperatorSessionUIDocument()
-        let serverSessions = try loadDocument(ServerSessionsDocument.self, from: melixHome.serverSessionsFileURL)?
-            .serverSessions ?? []
+        let providers = try loadDocument(ServerSessionsDocument.self, from: melixHome.providersFileURL)?
+            .providers ?? []
         let modelRoots = try loadDocument(ModelRootsDocument.self, from: melixHome.modelRootsFileURL)?
             .registryRoots ?? []
         let downloadQueue = try loadDocument(DownloadQueueDocument.self, from: melixHome.downloadQueueFileURL)?
@@ -542,9 +542,9 @@ public struct MelixOperatorSessionStore: MelixOperatorSessionStoring {
             schemaVersion: ui.schemaVersion,
             selectedSurfaceID: ui.selectedSurfaceID,
             selectedToolSectionID: ui.selectedToolSectionID,
-            selectedServerSessionID: ui.selectedServerSessionID,
+            selectedProviderID: ui.selectedProviderID,
             selectedRuntimeJobID: ui.selectedRuntimeJobID,
-            serverSessions: serverSessions,
+            providers: providers,
             dismissedBannerIDs: ui.dismissedBannerIDs,
             downloadQueue: downloadQueue,
             registryRoots: modelRoots,
@@ -558,8 +558,8 @@ public struct MelixOperatorSessionStore: MelixOperatorSessionStoring {
             to: melixHome.operatorSessionFileURL
         )
         try saveDocument(
-            ServerSessionsDocument(serverSessions: state.serverSessions),
-            to: melixHome.serverSessionsFileURL
+            ServerSessionsDocument(providers: state.providers),
+            to: melixHome.providersFileURL
         )
         try saveDocument(
             ModelRootsDocument(registryRoots: state.registryRoots),
@@ -576,7 +576,7 @@ public struct MelixOperatorSessionStore: MelixOperatorSessionStoring {
             return
         }
         let splitFileURLs = [
-            melixHome.serverSessionsFileURL,
+            melixHome.providersFileURL,
             melixHome.modelRootsFileURL,
             melixHome.downloadQueueFileURL,
         ]
@@ -623,7 +623,7 @@ private struct OperatorSessionUIDocument: Codable, Equatable, Sendable {
     var schemaVersion: Int
     var selectedSurfaceID: String
     var selectedToolSectionID: String
-    var selectedServerSessionID: String
+    var selectedProviderID: String
     var selectedRuntimeJobID: String
     var dismissedBannerIDs: [String]
     var paneVisibility: [MelixOperatorPaneVisibilityState]
@@ -632,7 +632,7 @@ private struct OperatorSessionUIDocument: Codable, Equatable, Sendable {
         schemaVersion: Int = 7,
         selectedSurfaceID: String = "chat",
         selectedToolSectionID: String = "modelsLibrary",
-        selectedServerSessionID: String = "",
+        selectedProviderID: String = "",
         selectedRuntimeJobID: String = "",
         dismissedBannerIDs: [String] = [],
         paneVisibility: [MelixOperatorPaneVisibilityState] = MelixOperatorPaneVisibilityState.defaultStates
@@ -640,7 +640,7 @@ private struct OperatorSessionUIDocument: Codable, Equatable, Sendable {
         self.schemaVersion = max(schemaVersion, 7)
         self.selectedSurfaceID = selectedSurfaceID
         self.selectedToolSectionID = selectedToolSectionID
-        self.selectedServerSessionID = selectedServerSessionID
+        self.selectedProviderID = selectedProviderID
         self.selectedRuntimeJobID = selectedRuntimeJobID
         self.dismissedBannerIDs = dismissedBannerIDs
         self.paneVisibility = MelixOperatorPaneVisibilityState.mergedWithDefaults(paneVisibility)
@@ -651,7 +651,7 @@ private struct OperatorSessionUIDocument: Codable, Equatable, Sendable {
             schemaVersion: state.schemaVersion,
             selectedSurfaceID: state.selectedSurfaceID,
             selectedToolSectionID: state.selectedToolSectionID,
-            selectedServerSessionID: state.selectedServerSessionID,
+            selectedProviderID: state.selectedProviderID,
             selectedRuntimeJobID: state.selectedRuntimeJobID,
             dismissedBannerIDs: state.dismissedBannerIDs,
             paneVisibility: state.paneVisibility
@@ -664,7 +664,7 @@ private struct OperatorSessionUIDocument: Codable, Equatable, Sendable {
             schemaVersion: try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 6,
             selectedSurfaceID: try container.decodeIfPresent(String.self, forKey: .selectedSurfaceID) ?? "chat",
             selectedToolSectionID: try container.decodeIfPresent(String.self, forKey: .selectedToolSectionID) ?? "modelsLibrary",
-            selectedServerSessionID: try container.decodeIfPresent(String.self, forKey: .selectedServerSessionID) ?? "",
+            selectedProviderID: try container.decodeIfPresent(String.self, forKey: .selectedProviderID) ?? "",
             selectedRuntimeJobID: try container.decodeIfPresent(String.self, forKey: .selectedRuntimeJobID) ?? "",
             dismissedBannerIDs: try container.decodeIfPresent([String].self, forKey: .dismissedBannerIDs) ?? [],
             paneVisibility: try container.decodeIfPresent(
@@ -678,7 +678,7 @@ private struct OperatorSessionUIDocument: Codable, Equatable, Sendable {
         case schemaVersion = "schema_version"
         case selectedSurfaceID = "selected_surface"
         case selectedToolSectionID = "selected_tool_section"
-        case selectedServerSessionID = "selected_server_session_id"
+        case selectedProviderID = "selected_provider_id"
         case selectedRuntimeJobID = "selected_runtime_job_id"
         case dismissedBannerIDs = "dismissed_banner_ids"
         case paneVisibility = "pane_visibility"
@@ -687,16 +687,16 @@ private struct OperatorSessionUIDocument: Codable, Equatable, Sendable {
 
 private struct ServerSessionsDocument: Codable, Equatable, Sendable {
     var schemaVersion: Int
-    var serverSessions: [MelixOperatorServerSessionState]
+    var providers: [MelixOperatorProviderState]
 
-    init(schemaVersion: Int = 1, serverSessions: [MelixOperatorServerSessionState]) {
+    init(schemaVersion: Int = 1, providers: [MelixOperatorProviderState]) {
         self.schemaVersion = max(schemaVersion, 1)
-        self.serverSessions = serverSessions
+        self.providers = providers
     }
 
     enum CodingKeys: String, CodingKey {
         case schemaVersion = "schema_version"
-        case serverSessions = "server_sessions"
+        case providers = "providers"
     }
 }
 

--- a/Sources/MelixCLICore/MelixPipelineRunner.swift
+++ b/Sources/MelixCLICore/MelixPipelineRunner.swift
@@ -959,10 +959,10 @@ private enum MelixPipelineCommandBuilder {
                     hfToken: string("hf_token", args) ?? ""
                 )
             )
-        case "server.session.update":
-            return .serverSessionUpdate(
-                ServerSessionUpdateOptions(
-                    serverSessionID: string("server_session_id", args) ?? ServerSessionRuntimeStore.defaultServerSessionID,
+        case "provider.update":
+            return .providerUpdate(
+                ProviderUpdateOptions(
+                    providerID: string("provider_id", args) ?? MelixProviderDefaults.defaultProviderID,
                     title: string("title", args) ?? "",
                     defaultModelID: string("default_model_id", args) ?? string("model_id", args) ?? "",
                     servedModelIDs: try firstStringArray(["served_model_ids"], args),
@@ -976,16 +976,16 @@ private enum MelixPipelineCommandBuilder {
                     numDraftTokens: try int("num_draft_tokens", args) ?? 0
                 )
             )
-        case "server.session.select":
-            return .serverSessionSelect(
-                ServerSessionIDOptions(
-                    serverSessionID: string("server_session_id", args) ?? ServerSessionRuntimeStore.defaultServerSessionID
+        case "provider.select":
+            return .providerSelect(
+                ProviderIDOptions(
+                    providerID: string("provider_id", args) ?? MelixProviderDefaults.defaultProviderID
                 )
             )
         case "server.start":
             return .serverStart(
                 ServerControlOptions(
-                    serverSessionID: string("server_session_id", args) ?? ServerSessionRuntimeStore.defaultServerSessionID
+                    providerID: string("provider_id", args) ?? MelixProviderDefaults.defaultProviderID
                 )
             )
         case "chat.run":
@@ -994,7 +994,7 @@ private enum MelixPipelineCommandBuilder {
                     modelID: try requiredString("model_id", args),
                     message: try requiredString("message", args),
                     systemPrompt: string("system", args) ?? string("system_prompt", args) ?? "",
-                    serverSessionID: string("server_session_id", args) ?? ServerSessionRuntimeStore.defaultServerSessionID
+                    providerID: string("provider_id", args) ?? MelixProviderDefaults.defaultProviderID
                 )
             )
         case "lora.train":
@@ -1198,8 +1198,8 @@ private enum MelixPipelineCommandBuilder {
         "model.inspect",
         "model.roots.rescan",
         "dataset.hub.download",
-        "server.session.update",
-        "server.session.select",
+        "provider.update",
+        "provider.select",
         "server.start",
         "chat.run",
         "lora.train",

--- a/Sources/MelixCLICore/MelixProviderDefaults.swift
+++ b/Sources/MelixCLICore/MelixProviderDefaults.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum MelixProviderDefaults {
+    public static let defaultProviderID = "provider-1"
+}

--- a/Sources/MelixCLICore/SessionLifecycleSmokeCommand.swift
+++ b/Sources/MelixCLICore/SessionLifecycleSmokeCommand.swift
@@ -11,7 +11,7 @@ public enum SessionLifecycleSmokeCommand {
         let options = try parseArguments(arguments)
         let report: SessionLifecycleSmokeReport
         if let reportBuilder {
-            report = try await reportBuilder(options.serverSessionID, options.modelID, environment)
+            report = try await reportBuilder(options.providerID, options.modelID, environment)
         } else {
             let client: any ControlPlaneXPCClient
             let flushMetrics: @Sendable () async -> Void
@@ -31,7 +31,7 @@ public enum SessionLifecycleSmokeCommand {
                 flushMetrics: flushMetrics
             )
             report = try await runner.run(
-                serverSessionID: options.serverSessionID,
+                providerID: options.providerID,
                 modelID: options.modelID
             )
         }
@@ -42,12 +42,12 @@ public enum SessionLifecycleSmokeCommand {
     }
 
     struct Options: Equatable {
-        let serverSessionID: String
+        let providerID: String
         let modelID: String
     }
 
     static func parseArguments(_ arguments: [String]) throws -> Options {
-        var serverSessionID = ServerSessionRuntimeStore.defaultServerSessionID
+        var providerID = MelixProviderDefaults.defaultProviderID
         var modelID = "melix-dev-text"
 
         var index = 0
@@ -55,12 +55,12 @@ public enum SessionLifecycleSmokeCommand {
             switch arguments[index] {
             case "--json":
                 index += 1
-            case "--server-session-id":
+            case "--provider-id":
                 let valueIndex = index + 1
                 guard valueIndex < arguments.count else {
-                    throw MelixCLIError.missingValue("--server-session-id")
+                    throw MelixCLIError.missingValue("--provider-id")
                 }
-                serverSessionID = arguments[valueIndex]
+                providerID = arguments[valueIndex]
                 index += 2
             case "--model-id":
                 let valueIndex = index + 1
@@ -73,12 +73,12 @@ public enum SessionLifecycleSmokeCommand {
                 throw MelixCLIError.usage(
                     """
                     Usage:
-                      melix-session-lifecycle-smoke [--server-session-id ID] [--model-id MODEL] [--json]
+                      melix-session-lifecycle-smoke [--provider-id ID] [--model-id MODEL] [--json]
                     """
                 )
             }
         }
 
-        return Options(serverSessionID: serverSessionID, modelID: modelID)
+        return Options(providerID: providerID, modelID: modelID)
     }
 }

--- a/Sources/MelixCLICore/SessionLifecycleSmokeRunner.swift
+++ b/Sources/MelixCLICore/SessionLifecycleSmokeRunner.swift
@@ -32,20 +32,20 @@ public struct SessionLifecycleSmokeScenario: Encodable, Equatable, Sendable {
 
 public struct SessionLifecycleSmokeReport: Encodable, Equatable, Sendable {
     public let ok: Bool
-    public let serverSessionID: String
+    public let providerID: String
     public let modelID: String
     public let metrics: [String: Double]
     public let scenarios: [String: SessionLifecycleSmokeScenario]
 
     public init(
         ok: Bool,
-        serverSessionID: String,
+        providerID: String,
         modelID: String,
         metrics: [String: Double],
         scenarios: [String: SessionLifecycleSmokeScenario]
     ) {
         self.ok = ok
-        self.serverSessionID = serverSessionID
+        self.providerID = providerID
         self.modelID = modelID
         self.metrics = metrics
         self.scenarios = scenarios
@@ -94,15 +94,15 @@ public struct SessionLifecycleSmokeRunner: Sendable {
     }
 
     public func run(
-        serverSessionID: String = ServerSessionRuntimeStore.defaultServerSessionID,
+        providerID: String = MelixProviderDefaults.defaultProviderID,
         modelID: String = "melix-dev-text"
     ) async throws -> SessionLifecycleSmokeReport {
         _ = try await client.handshake()
         _ = try await client.loadModel(modelID: modelID)
 
         let pauseStartedAt = now()
-        let pausedSnapshot = try await client.pauseServerSession(serverSessionID: serverSessionID)
-        let pausedSession = try runtimeSession(in: pausedSnapshot, serverSessionID: serverSessionID)
+        let pausedSnapshot = try await client.pauseServerSession(serverSessionID: providerID)
+        let pausedSession = try runtimeSession(in: pausedSnapshot, providerID: providerID)
         let pauseAckMS = elapsedMS(since: pauseStartedAt)
 
         var blockedStatus = "unexpected_success"
@@ -110,7 +110,8 @@ public struct SessionLifecycleSmokeRunner: Sendable {
             _ = try await client.startChat(
                 ControlPlaneChatRequest(
                     modelID: modelID,
-                    messages: [.init(role: "user", content: "confirm the paused server blocks chat")]
+                    messages: [.init(role: "user", content: "confirm the paused server blocks chat")],
+                    providerID: providerID
                 )
             )
         } catch ControlPlaneChatExecutionError.unavailable {
@@ -120,24 +121,24 @@ public struct SessionLifecycleSmokeRunner: Sendable {
             blockedStatus = "unavailable"
         }
 
-        _ = try await client.resumeServerSession(serverSessionID: serverSessionID)
+        _ = try await client.resumeServerSession(serverSessionID: providerID)
 
         let idleStartedAt = now()
         _ = try await client.updateServerIdlePolicy(
-            serverSessionID: serverSessionID,
+            serverSessionID: providerID,
             autoSleepEnabled: true,
             lightSleepAfterSeconds: 1,
             deepSleepAfterSeconds: 5
         )
         let sleepingSession = try await waitForLifecycle(
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             expectedLifecycle: .sleeping,
             timeoutSeconds: 3
         )
         let idleToSleepMS = elapsedMS(since: idleStartedAt)
 
         _ = try await client.updateServerIdlePolicy(
-            serverSessionID: serverSessionID,
+            serverSessionID: providerID,
             autoSleepEnabled: true,
             lightSleepAfterSeconds: 10,
             deepSleepAfterSeconds: 30
@@ -147,12 +148,13 @@ public struct SessionLifecycleSmokeRunner: Sendable {
         let wakeExecution = try await client.startChat(
             ControlPlaneChatRequest(
                 modelID: modelID,
-                messages: [.init(role: "user", content: "wake the server")]
+                messages: [.init(role: "user", content: "wake the server")],
+                providerID: providerID
             )
         )
         async let wakeAssistantTask = collectAssistantText(from: wakeExecution)
         let readyAfterWake = try await waitForLifecycle(
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             expectedLifecycle: .ready,
             timeoutSeconds: 2
         )
@@ -160,21 +162,22 @@ public struct SessionLifecycleSmokeRunner: Sendable {
         let wakeAssistant = try await wakeAssistantTask
 
         _ = try await client.updateServerIdlePolicy(
-            serverSessionID: serverSessionID,
+            serverSessionID: providerID,
             autoSleepEnabled: false,
             lightSleepAfterSeconds: 1,
             deepSleepAfterSeconds: 5
         )
 
         let restartStartedAt = now()
-        _ = try await stopServerSessionWhenQuiescent(serverSessionID: serverSessionID, timeoutSeconds: 2)
-        let restartedSnapshot = try await client.startServerSession(serverSessionID: serverSessionID)
-        let restartedSession = try runtimeSession(in: restartedSnapshot, serverSessionID: serverSessionID)
+        _ = try await stopServerSessionWhenQuiescent(providerID: providerID, timeoutSeconds: 2)
+        let restartedSnapshot = try await client.startServerSession(serverSessionID: providerID)
+        let restartedSession = try runtimeSession(in: restartedSnapshot, providerID: providerID)
         let restartRecoveryMS = elapsedMS(since: restartStartedAt)
         let restartExecution = try await client.startChat(
             ControlPlaneChatRequest(
                 modelID: modelID,
-                messages: [.init(role: "user", content: "confirm restart recovery")]
+                messages: [.init(role: "user", content: "confirm restart recovery")],
+                providerID: providerID
             )
         )
         let restartAssistant = try await collectAssistantText(from: restartExecution)
@@ -191,7 +194,7 @@ public struct SessionLifecycleSmokeRunner: Sendable {
 
         return SessionLifecycleSmokeReport(
             ok: true,
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             modelID: modelID,
             metrics: metrics,
             scenarios: [
@@ -224,9 +227,9 @@ public struct SessionLifecycleSmokeRunner: Sendable {
 
     private func runtimeSession(
         in snapshot: Melix_Controlplane_V1_ServerSnapshot,
-        serverSessionID: String
+        providerID: String
     ) throws -> Melix_Controlplane_V1_ProviderRuntimeState {
-        let trimmedID = normalizedServerSessionID(serverSessionID)
+        let trimmedID = normalizedServerSessionID(providerID)
         guard let session = snapshot.providers.first(where: { $0.providerID == trimmedID }) else {
             throw SessionLifecycleSmokeRunnerError.missingRuntimeSession(trimmedID)
         }
@@ -234,7 +237,7 @@ public struct SessionLifecycleSmokeRunner: Sendable {
     }
 
     private func waitForLifecycle(
-        serverSessionID: String,
+        providerID: String,
         expectedLifecycle: Melix_Controlplane_V1_ProviderLifecycleState,
         timeoutSeconds: TimeInterval
     ) async throws -> Melix_Controlplane_V1_ProviderRuntimeState {
@@ -243,7 +246,7 @@ public struct SessionLifecycleSmokeRunner: Sendable {
 
         while now() <= deadline {
             let snapshot = try await client.serverSnapshot()
-            let session = try runtimeSession(in: snapshot, serverSessionID: serverSessionID)
+            let session = try runtimeSession(in: snapshot, providerID: providerID)
             observedLifecycle = session.lifecycleState
             if session.lifecycleState == expectedLifecycle {
                 return session
@@ -279,13 +282,13 @@ public struct SessionLifecycleSmokeRunner: Sendable {
     }
 
     private func stopServerSessionWhenQuiescent(
-        serverSessionID: String,
+        providerID: String,
         timeoutSeconds: TimeInterval
     ) async throws -> Melix_Controlplane_V1_ServerSnapshot {
         let deadline = now() + timeoutSeconds
         while now() <= deadline {
             do {
-                return try await client.stopServerSession(serverSessionID: serverSessionID)
+                return try await client.stopServerSession(serverSessionID: providerID)
             } catch let error as ControlPlaneXPCClientError {
                 if case .requestFailed(let code, _) = error, code == "conflict" {
                     try await sleep(0.05)
@@ -294,7 +297,7 @@ public struct SessionLifecycleSmokeRunner: Sendable {
                 throw error
             }
         }
-        return try await client.stopServerSession(serverSessionID: serverSessionID)
+        return try await client.stopServerSession(serverSessionID: providerID)
     }
 
     private func readExportedMetrics(
@@ -344,9 +347,9 @@ public struct SessionLifecycleSmokeRunner: Sendable {
         max(0, (now() - startedAt) * 1_000)
     }
 
-    private func normalizedServerSessionID(_ serverSessionID: String) -> String {
-        let trimmedID = serverSessionID.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmedID.isEmpty ? ServerSessionRuntimeStore.defaultServerSessionID : trimmedID
+    private func normalizedServerSessionID(_ providerID: String) -> String {
+        let trimmedID = providerID.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedID.isEmpty ? MelixProviderDefaults.defaultProviderID : trimmedID
     }
 }
 

--- a/apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/Phase8WindowUIAcceptanceRunner.swift
@@ -49,8 +49,8 @@ public enum Phase8WindowUIAcceptanceError: Error, LocalizedError {
             return "Window UI acceptance could not resolve the adapter manifest path from the LoRA training receipt."
         case .missingDerivedModelID:
             return "Window UI acceptance could not resolve the derived model id after activation."
-        case .missingServerSession(let serverSessionID):
-            return "Window UI acceptance could not find server session \(serverSessionID)."
+        case .missingServerSession(let providerID):
+            return "Window UI acceptance could not find provider \(providerID)."
         case .timeout(let description):
             return "Window UI acceptance timed out while waiting for \(description)."
         case .workflowFailed(let detail):
@@ -71,7 +71,7 @@ public struct Phase8WindowUIAcceptanceConfig: Equatable, Sendable {
     public let matrixSuites: [String]
     public let evaluationSuites: [String]
     public let evaluationDataset: String
-    public let serverSessionID: String
+    public let providerID: String
     public let cliEvidenceBundlePath: String
     public let timestamp: String
 
@@ -85,7 +85,7 @@ public struct Phase8WindowUIAcceptanceConfig: Equatable, Sendable {
         matrixSuites: [String],
         evaluationSuites: [String],
         evaluationDataset: String,
-        serverSessionID: String,
+        providerID: String,
         cliEvidenceBundlePath: String,
         timestamp: String
     ) {
@@ -98,7 +98,7 @@ public struct Phase8WindowUIAcceptanceConfig: Equatable, Sendable {
         self.matrixSuites = matrixSuites
         self.evaluationSuites = evaluationSuites
         self.evaluationDataset = evaluationDataset
-        self.serverSessionID = serverSessionID
+        self.providerID = providerID
         self.cliEvidenceBundlePath = cliEvidenceBundlePath
         self.timestamp = timestamp
     }
@@ -126,8 +126,8 @@ public struct Phase8WindowUIAcceptanceConfig: Equatable, Sendable {
         )
         self.evaluationDataset = Self.normalized(environment["MELIX_PHASE8_WINDOW_UI_ACCEPTANCE_EVALUATION_DATASET"])
             ?? "mmlu.dev.v1"
-        self.serverSessionID = Self.normalized(environment["MELIX_PHASE8_WINDOW_UI_ACCEPTANCE_SERVER_SESSION_ID"])
-            ?? "server-session-1"
+        self.providerID = Self.normalized(environment["MELIX_PHASE8_WINDOW_UI_ACCEPTANCE_PROVIDER_ID"])
+            ?? "provider-1"
         self.cliEvidenceBundlePath = Self.normalized(environment["MELIX_PHASE8_WINDOW_UI_ACCEPTANCE_CLI_BUNDLE_PATH"])
             ?? Self.discoverLatestCLIBundlePath(melixHome: melixHome.rootURL)
         self.timestamp = Self.normalized(environment["MELIX_PHASE8_WINDOW_UI_ACCEPTANCE_TIMESTAMP"])
@@ -195,7 +195,7 @@ public struct Phase8WindowUIAcceptanceResult: Codable, Equatable, Sendable {
 private struct Phase8WindowUIAcceptanceUIState: Codable, Equatable, Sendable {
     let selectedSurface: String
     let selectedToolSection: String
-    let selectedServerSessionID: String
+    let selectedProviderID: String
     let selectedServerLifecycle: String
 }
 
@@ -441,7 +441,7 @@ private struct Phase8WindowUIAcceptanceBundle: Codable, Equatable, Sendable {
     let managedModelPath: String
     let sourceKind: String
     let sourceLocator: String
-    let serverSessionID: String
+    let providerID: String
     let derivedModelID: String
     let trainingFixture: String
     let benchmarkSuites: [String]
@@ -531,7 +531,7 @@ public final class Phase8WindowUIAcceptanceRunner {
 
         await viewModel.start()
         try await waitFor("initial desktop foundation state") {
-            self.viewModel.serverSessions.isEmpty == false || self.viewModel.models.isEmpty == false
+            self.viewModel.providers.isEmpty == false || self.viewModel.models.isEmpty == false
         }
 
         var timings: [String: Double] = [:]
@@ -553,11 +553,11 @@ public final class Phase8WindowUIAcceptanceRunner {
             self.viewModel.serverModelOptions.contains(where: { $0.modelID == materializeReceipt.modelID })
         }
 
-        let serverSessionID = try await prepareServerSession(modelID: materializeReceipt.modelID)
+        let providerID = try await prepareServerSession(modelID: materializeReceipt.modelID)
         let sessionRebindStartedAt = Date()
         await viewModel.startSelectedServerSession()
-        try await waitFor("interactive server session readiness") {
-            self.viewModel.selectedServerSession?.id == serverSessionID
+        try await waitFor("interactive provider readiness") {
+            self.viewModel.selectedServerSession?.id == providerID
                 && self.viewModel.selectedServerSession?.isInteractiveReady == true
         }
         timings["phase8.ui.session_rebind_ms"] = elapsedMS(since: sessionRebindStartedAt)
@@ -645,7 +645,7 @@ public final class Phase8WindowUIAcceptanceRunner {
 
         await viewModel.refreshDesktopFoundation()
         viewModel.selectSurface(.server)
-        viewModel.selectServerSession(id: serverSessionID)
+        viewModel.selectServerSession(id: providerID)
 
         let renderStartedAt = Date()
         do {
@@ -666,7 +666,7 @@ public final class Phase8WindowUIAcceptanceRunner {
             managedModelPath: materializeReceipt.managedModelPath,
             sourceKind: materializeReceipt.sourceKind,
             sourceLocator: materializeReceipt.sourceLocator,
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             derivedModelID: derivedModelID,
             trainingFixture: config.trainingFixture,
             benchmarkSuites: config.benchSuites,
@@ -693,7 +693,7 @@ public final class Phase8WindowUIAcceptanceRunner {
             uiState: Phase8WindowUIAcceptanceUIState(
                 selectedSurface: viewModel.selectedSurface.rawValue,
                 selectedToolSection: viewModel.selectedToolSection.rawValue,
-                selectedServerSessionID: viewModel.selectedServerSession?.id ?? "",
+                selectedProviderID: viewModel.selectedServerSession?.id ?? "",
                 selectedServerLifecycle: viewModel.selectedServerSession?.lifecycle.rawValue ?? ""
             )
         )
@@ -877,34 +877,34 @@ public final class Phase8WindowUIAcceptanceRunner {
 
     private func prepareServerSession(modelID: String) async throws -> String {
         await viewModel.refreshDesktopFoundation()
-        if viewModel.serverSessions.isEmpty {
+        if viewModel.providers.isEmpty {
             viewModel.createServerSession()
-            try await waitFor("server session creation") {
-                self.viewModel.serverSessions.isEmpty == false
+            try await waitFor("provider creation") {
+                self.viewModel.providers.isEmpty == false
             }
         }
 
-        let serverSessionID: String
-        if viewModel.serverSessions.contains(where: { $0.id == config.serverSessionID }) {
-            serverSessionID = config.serverSessionID
-        } else if let first = viewModel.serverSessions.first?.id {
-            serverSessionID = first
+        let providerID: String
+        if viewModel.providers.contains(where: { $0.id == config.providerID }) {
+            providerID = config.providerID
+        } else if let first = viewModel.providers.first?.id {
+            providerID = first
         } else {
-            throw Phase8WindowUIAcceptanceError.missingServerSession(config.serverSessionID)
+            throw Phase8WindowUIAcceptanceError.missingServerSession(config.providerID)
         }
 
-        viewModel.selectServerSession(id: serverSessionID)
-        try await waitFor("server session selection") {
-            self.viewModel.selectedServerSession?.id == serverSessionID
+        viewModel.selectServerSession(id: providerID)
+        try await waitFor("provider selection") {
+            self.viewModel.selectedServerSession?.id == providerID
         }
         viewModel.updateSelectedServerSessionModelID(modelID)
-        return serverSessionID
+        return providerID
     }
 
     private func runChat(modelID: String, message: String) async throws -> ChatRunReceipt {
         try await cliWorkflowRunner.decodeJSON(
             ChatRunReceipt.self,
-            command: .chatRun(.init(modelID: modelID, message: message, systemPrompt: "", serverSessionID: "", json: true))
+            command: .chatRun(.init(modelID: modelID, message: message, systemPrompt: "", providerID: "", json: true))
         )
     }
 

--- a/apps/macos-menubar/Sources/AppMain/AppMain.swift
+++ b/apps/macos-menubar/Sources/AppMain/AppMain.swift
@@ -429,7 +429,7 @@ public final class MelixMenuBarBootstrap {
         operatorSessionStore: (any OperatorSessionStoring)? = nil,
         cliWorkflowRunner: (any MelixCLIWorkflowRunning)? = nil,
         operatorCommandRunner: MelixCLIRunner? = nil,
-        serverSessionAPIKeyStore: (any ServerSessionAPIKeyStoring)? = nil,
+        providerAPIKeyStore: (any ProviderAPIKeyStoring)? = nil,
         remoteServerStore: (any RemoteServerStoring)? = nil,
         evaluationPromptStore: (any EvaluationPromptStoring)? = nil,
         loraTrainingJobStore: (any LoraTrainingJobStoring)? = nil,
@@ -468,7 +468,7 @@ public final class MelixMenuBarBootstrap {
                 )
                 : nil
         )
-        let resolvedServerSessionAPIKeyStore = serverSessionAPIKeyStore ?? ServerSessionAPIKeyStore(melixHome: melixHome)
+        let resolvedProviderAPIKeyStore = providerAPIKeyStore ?? ProviderAPIKeyStore(melixHome: melixHome)
         let resolvedRemoteServerStore = remoteServerStore ?? RemoteServerStore(melixHome: melixHome)
         let resolvedEvaluationPromptStore = evaluationPromptStore ?? EvaluationPromptStore(melixHome: melixHome)
         let resolvedLoraTrainingJobStore = loraTrainingJobStore ?? LoraTrainingJobStore(melixHome: melixHome)
@@ -479,7 +479,7 @@ public final class MelixMenuBarBootstrap {
             operatorSessionStore: resolvedOperatorSessionStore,
             cliWorkflowRunner: cliWorkflowRunner,
             operatorCommandRunner: resolvedOperatorCommandRunner,
-            serverSessionAPIKeyStore: resolvedServerSessionAPIKeyStore,
+            providerAPIKeyStore: resolvedProviderAPIKeyStore,
             remoteServerStore: resolvedRemoteServerStore,
             evaluationPromptStore: resolvedEvaluationPromptStore,
             loraTrainingJobStore: resolvedLoraTrainingJobStore,
@@ -557,7 +557,7 @@ public final class MelixMenuBarBootstrap {
             melixHome: melixHome,
             operatorSessionStore: OperatorSessionStore(melixHome: melixHome),
             cliWorkflowRunner: cliWorkflowRunner,
-            serverSessionAPIKeyStore: ServerSessionAPIKeyStore(melixHome: melixHome),
+            providerAPIKeyStore: ProviderAPIKeyStore(melixHome: melixHome),
             remoteServerStore: RemoteServerStore(melixHome: melixHome),
             evaluationPromptStore: EvaluationPromptStore(melixHome: melixHome),
             loraTrainingJobStore: LoraTrainingJobStore(melixHome: melixHome),

--- a/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Chat/DesktopChatView.swift
@@ -365,31 +365,31 @@ struct DesktopChatSessionWorkspace: View {
 
     func startSelectedChatServerSession() {
         Task {
-            guard let serverSessionID = viewModel.selectedChatServerSession?.id else {
+            guard let providerID = viewModel.selectedChatServerSession?.id else {
                 openServerSurface()
                 return
             }
-            await viewModel.startServerSession(id: serverSessionID)
+            await viewModel.startServerSession(id: providerID)
         }
     }
 
     func resumeSelectedChatServerSession() {
         Task {
-            guard let serverSessionID = viewModel.selectedChatServerSession?.id else {
+            guard let providerID = viewModel.selectedChatServerSession?.id else {
                 openServerSurface()
                 return
             }
-            await viewModel.resumeServerSession(id: serverSessionID)
+            await viewModel.resumeServerSession(id: providerID)
         }
     }
 
     func wakeSelectedChatServerSession() {
         Task {
-            guard let serverSessionID = viewModel.selectedChatServerSession?.id else {
+            guard let providerID = viewModel.selectedChatServerSession?.id else {
                 openServerSurface()
                 return
             }
-            await viewModel.wakeServerSession(id: serverSessionID)
+            await viewModel.wakeServerSession(id: providerID)
         }
     }
 
@@ -704,13 +704,13 @@ private struct DesktopChatServerPicker: View {
 
     private var selectedServerBinding: Binding<String> {
         Binding(
-            get: { viewModel.selectedChatSession?.serverSessionID ?? "" },
-            set: { viewModel.bindSelectedChatSessionToServer(serverSessionID: $0) }
+            get: { viewModel.selectedChatSession?.providerID ?? "" },
+            set: { viewModel.bindSelectedChatSessionToServer(providerID: $0) }
         )
     }
 
     var body: some View {
-        if viewModel.serverSessions.isEmpty {
+        if viewModel.providers.isEmpty {
             Button {
                 viewModel.selectSurface(.server)
             } label: {
@@ -724,7 +724,7 @@ private struct DesktopChatServerPicker: View {
         } else {
             Picker("Server", selection: selectedServerBinding) {
                 Text("Choose Server").tag("")
-                ForEach(viewModel.serverSessions) { session in
+                ForEach(viewModel.providers) { session in
                     Text(session.title).tag(session.id)
                 }
             }
@@ -868,7 +868,7 @@ struct DesktopChatComposerSurface: View {
     let isStreaming: Bool
     let statusText: String
     let usageText: String
-    let serverSession: DesktopServerSessionState?
+    let serverSession: DesktopProviderState?
     let capabilities: [DesktopChatCapabilityRow]
     let onCommandSubmit: (String) -> Void
     let onSubmit: () -> Void
@@ -978,7 +978,7 @@ struct DesktopChatRuntimeControlStrip: View {
         let isProminent: Bool
     }
 
-    let serverSession: DesktopServerSessionState?
+    let serverSession: DesktopProviderState?
     let capabilities: [DesktopChatCapabilityRow]
     let onOpenServer: () -> Void
     let onStartServer: () -> Void
@@ -1062,7 +1062,7 @@ struct DesktopChatRuntimeControlStrip: View {
 }
 
 struct DesktopChatRuntimeServerCapsule: View {
-    let serverSession: DesktopServerSessionState?
+    let serverSession: DesktopProviderState?
 
     var body: some View {
         HStack(spacing: 6) {

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -291,31 +291,31 @@ struct DesktopCommandCenterView: View {
 
     let foundation: DesktopFoundationState
     let chatSessions: [DesktopChatSessionState]
-    let serverSessions: [DesktopServerSessionState]
+    let providers: [DesktopProviderState]
     private let viewModel: RuntimeViewModel?
 
     init(
         foundation: DesktopFoundationState,
         chatSessions: [DesktopChatSessionState],
-        serverSessions: [DesktopServerSessionState]
+        providers: [DesktopProviderState]
     ) {
         self.foundation = foundation
         self.chatSessions = chatSessions
-        self.serverSessions = serverSessions
+        self.providers = providers
         self.viewModel = nil
     }
 
     init(viewModel: RuntimeViewModel) {
         self.foundation = viewModel.desktopFoundationState
         self.chatSessions = viewModel.chatSessions
-        self.serverSessions = viewModel.serverSessions
+        self.providers = viewModel.providers
         self.viewModel = viewModel
     }
 
     var body: some View {
         let foundation = liveFoundation
         let chatSessions = liveChatSessions
-        let serverSessions = liveServerSessions
+        let providers = liveServerSessions
         let horizontalPadding = DesktopCommandCenterVisuals.contentPadding
 
         ScrollView {
@@ -337,12 +337,12 @@ struct DesktopCommandCenterView: View {
                         VStack(alignment: .leading, spacing: DesktopCommandCenterVisuals.sectionSpacing) {
                             DesktopCommandCenterRecoveryPanel(
                                 viewModel: viewModel,
-                                serverSessions: serverSessions
+                                providers: providers
                             )
                             DesktopCommandCenterWorkflowPanel(viewModel: viewModel)
                             DesktopCommandCenterSessionSummaryPanel(
                                 chatSessions: chatSessions,
-                                serverSessions: serverSessions
+                                providers: providers
                             )
                         }
                         .frame(width: DesktopCommandCenterVisuals.secondaryColumnWidth, alignment: .topLeading)
@@ -353,14 +353,14 @@ struct DesktopCommandCenterView: View {
                         DesktopCommandCenterRuntimePanel(foundation: foundation)
                         DesktopCommandCenterRecoveryPanel(
                             viewModel: viewModel,
-                            serverSessions: serverSessions
+                            providers: providers
                         )
                         DesktopCommandCenterPressurePanel(foundation: foundation)
                         DesktopCommandCenterWorkflowPanel(viewModel: viewModel)
                         DesktopCommandCenterActivityPanel(foundation: foundation)
                         DesktopCommandCenterSessionSummaryPanel(
                             chatSessions: chatSessions,
-                            serverSessions: serverSessions
+                            providers: providers
                         )
                     }
                 }
@@ -384,8 +384,8 @@ struct DesktopCommandCenterView: View {
         viewModel?.chatSessions ?? chatSessions
     }
 
-    private var liveServerSessions: [DesktopServerSessionState] {
-        viewModel?.serverSessions ?? serverSessions
+    private var liveServerSessions: [DesktopProviderState] {
+        viewModel?.providers ?? providers
     }
 }
 
@@ -662,10 +662,10 @@ private struct DesktopCommandCenterQueueLaneView: View {
 
 private struct DesktopCommandCenterRecoveryPanel: View {
     let viewModel: RuntimeViewModel?
-    let serverSessions: [DesktopServerSessionState]
+    let providers: [DesktopProviderState]
 
     var body: some View {
-        let recoverySessions = serverSessions.filter {
+        let recoverySessions = providers.filter {
             $0.lifecycle == .error || $0.lifecycle == .stopped || $0.lifecycle == .unavailable
         }
         let recoverableDownloads = viewModel?.recoverableDownloads ?? []
@@ -788,7 +788,7 @@ private struct DesktopCommandCenterDownloadRecoveryRow: View {
 }
 
 private struct DesktopCommandCenterServerRecoveryRow: View {
-    let session: DesktopServerSessionState
+    let session: DesktopProviderState
 
     var body: some View {
         VStack(alignment: .leading, spacing: MelixDesignTokens.Spacing.xs) {
@@ -898,7 +898,7 @@ private struct DesktopCommandCenterActivityRow: View {
 
 private struct DesktopCommandCenterSessionSummaryPanel: View {
     let chatSessions: [DesktopChatSessionState]
-    let serverSessions: [DesktopServerSessionState]
+    let providers: [DesktopProviderState]
 
     var body: some View {
         DesktopCommandCenterPanel(
@@ -912,9 +912,9 @@ private struct DesktopCommandCenterSessionSummaryPanel: View {
                     detail: chatSessions.first?.summaryText ?? "No chat sessions"
                 )
                 DesktopCommandCenterSessionMetricView(
-                    title: "Server Sessions",
-                    value: "\(serverSessions.count)",
-                    detail: serverSessions.first?.effectiveListenerLabel ?? "No listener configured"
+                    title: "Providers",
+                    value: "\(providers.count)",
+                    detail: providers.first?.effectiveListenerLabel ?? "No listener configured"
                 )
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -992,7 +992,7 @@ enum DesktopServerWorkspaceDefaults {
 }
 
 private struct DesktopServerOverviewCardsView: View {
-    let session: DesktopServerSessionState
+    let session: DesktopProviderState
 
     var body: some View {
         LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 10)], spacing: 10) {
@@ -1566,7 +1566,7 @@ private struct DesktopServerSessionEditor: View {
             VStack(alignment: .leading, spacing: 18) {
                 DesktopWorkspaceHeader(
                     title: "Server",
-                    subtitle: "Choose model, configure listener, then start the server session."
+                    subtitle: "Choose model, configure listener, then start the provider."
                 ) {}
 
                 if viewModel.isCreatingServerTarget {
@@ -1785,13 +1785,13 @@ private struct DesktopServerSessionEditor: View {
         }
     }
 
-    private func servingDefaultsCompactSummary(for session: DesktopServerSessionState) -> String {
+    private func servingDefaultsCompactSummary(for session: DesktopProviderState) -> String {
         let servingDefaults = session.servingDefaults
         return "Source: \(servingDefaults.sourceText) • requested temp \(String(format: "%.2f", servingDefaults.temperature)) • top_p \(String(format: "%.2f", servingDefaults.topP)) • max \(servingDefaults.maxTokens) • stream \(servingDefaults.streamIntervalTokens) • sequences \(servingDefaults.maxConcurrentRequests)"
     }
 
     @ViewBuilder
-    private func advancedServingDefaultsForm(for session: DesktopServerSessionState) -> some View {
+    private func advancedServingDefaultsForm(for session: DesktopProviderState) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
                                     TextField(
@@ -1943,13 +1943,13 @@ private struct DesktopServerSessionEditor: View {
             .padding(10)
             .background(Color.secondary.opacity(0.04), in: RoundedRectangle(cornerRadius: 10))
         case "accelerated_prefill":
-            accelerationModeReadOnlyCard("Uses the backend accelerated prefill profile for this server session.")
+            accelerationModeReadOnlyCard("Uses the backend accelerated prefill profile for this provider.")
         case "active_kv_quantized":
-            accelerationModeReadOnlyCard("Uses the backend active KV quantization profile for this server session.")
+            accelerationModeReadOnlyCard("Uses the backend active KV quantization profile for this provider.")
         case "sparse_prefill":
-            accelerationModeReadOnlyCard("Uses the backend sparse prefill profile for this server session.")
+            accelerationModeReadOnlyCard("Uses the backend sparse prefill profile for this provider.")
         default:
-            accelerationModeReadOnlyCard("No additional acceleration settings are enabled for this server session.")
+            accelerationModeReadOnlyCard("No additional acceleration settings are enabled for this provider.")
         }
     }
 
@@ -7064,7 +7064,7 @@ struct DesktopServingAccelerationProfilePicker: View {
 }
 
 struct DesktopServingAccelerationProfileSummary: View {
-    let servingDefaults: DesktopServerServingDefaultsState
+    let servingDefaults: DesktopProviderServingDefaultsState
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -10137,7 +10137,7 @@ struct DesktopAgentIntegrationExportsPanel: View {
                     ContentUnavailableView(
                         "No Integration Export",
                         systemImage: "square.and.arrow.up.on.square",
-                        description: Text("Start or select a server session to render reproducible agent integration exports.")
+                        description: Text("Start or select a provider to render reproducible agent integration exports.")
                     )
                 }
             }
@@ -10267,7 +10267,7 @@ struct DesktopAPIQuickStartGroup: Identifiable {
 
 struct DesktopAPIQuickStartPanel: View {
     let foundation: DesktopFoundationState
-    let selectedSession: DesktopServerSessionState?
+    let selectedSession: DesktopProviderState?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -10317,9 +10317,9 @@ struct DesktopAPIQuickStartPanel: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 ContentUnavailableView(
-                    "No Server Session Selected",
+                    "No Provider Selected",
                     systemImage: "network.slash",
-                    description: Text("Start or select a server session to render session-aware quick-start snippets.")
+                    description: Text("Start or select a provider to render session-aware quick-start snippets.")
                 )
             }
         }
@@ -10330,7 +10330,7 @@ struct DesktopAPIQuickStartPanel: View {
 
 func desktopAPIQuickStartGroups(
     foundation: DesktopFoundationState,
-    selectedSession: DesktopServerSessionState
+    selectedSession: DesktopProviderState
 ) -> [DesktopAPIQuickStartGroup] {
     let serviceBaseURL = selectedSession.effectiveBaseURL
     let serviceRootURL = serviceBaseURL.hasSuffix("/v1")
@@ -10653,7 +10653,7 @@ private func javascriptHeaderBlock(
 }
 
 private func primaryGatewayHeader(
-    for session: DesktopServerSessionState
+    for session: DesktopProviderState
 ) -> (String, String)? {
     switch session.sharedAccessState {
     case .localOnly:
@@ -10675,7 +10675,7 @@ private func primaryGatewayHeader(
 }
 
 struct DesktopServerGatewayAccessSummaryView: View {
-    let session: DesktopServerSessionState
+    let session: DesktopProviderState
 
     var body: some View {
         GroupBox("Gateway Access") {
@@ -10949,7 +10949,7 @@ struct DesktopAPIWorkspaceView: View {
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
                         } else {
-                            Text("No server session selected.")
+                            Text("No provider selected.")
                                 .foregroundStyle(.secondary)
                         }
                     }
@@ -10967,7 +10967,7 @@ struct DesktopAPIWorkspaceView: View {
 
 private struct DesktopAPIEndpointConsoleView: View {
     let baseURL: String
-    let selectedSession: DesktopServerSessionState?
+    let selectedSession: DesktopProviderState?
     let selectedExport: AgentIntegrationExport?
 
     private var modelID: String {
@@ -11005,7 +11005,7 @@ private struct DesktopAPIEndpointConsoleView: View {
                     DesktopAPIEndpointRow(
                         title: "Chat Completions",
                         endpoint: chatEndpoint,
-                        detail: selectedSession?.lifecycleSummaryText ?? "No server session selected."
+                        detail: selectedSession?.lifecycleSummaryText ?? "No provider selected."
                     )
                     DesktopAPIEndpointRow(
                         title: "Models",
@@ -11064,11 +11064,11 @@ private struct DesktopAPIEndpointRow: View {
 }
 
 func desktopAPIAuthenticationReferenceText(
-    selectedSession: DesktopServerSessionState?,
+    selectedSession: DesktopProviderState?,
     selectedExport: AgentIntegrationExport?
 ) -> String {
     guard let selectedSession else {
-        return "Select a server session to render auth guidance."
+        return "Select a provider to render auth guidance."
     }
 
     let exportLead = if let selectedExport {
@@ -11090,7 +11090,7 @@ func desktopAPIAuthenticationReferenceText(
     }
 }
 
-private func gatewayAccessHeaderText(_ session: DesktopServerSessionState) -> String {
+private func gatewayAccessHeaderText(_ session: DesktopProviderState) -> String {
     switch session.sharedAccessState {
     case .localOnly:
         if session.authMode == .bearerToken {
@@ -11129,7 +11129,7 @@ func desktopAPIAuthenticationReferenceText(selectedExport: AgentIntegrationExpor
     if let export = selectedExport {
         return "Selected target: \(export.target.rawValue). Use \(export.authPlaceholder) as the reproducible credential placeholder for \(export.baseURL)."
     }
-    return "Select a server session to render auth guidance."
+    return "Select a provider to render auth guidance."
 }
 
 enum RuntimeDiagnosticsArtifactClipboard {

--- a/apps/macos-menubar/Sources/AppMain/Models/AgentIntegrationExport.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/AgentIntegrationExport.swift
@@ -56,7 +56,7 @@ public struct AgentIntegrationExport: Identifiable, Equatable, Sendable {
     }
 
     public static func exports(
-        from session: DesktopServerSessionState
+        from session: DesktopProviderState
     ) -> [AgentIntegrationExport] {
         AgentIntegrationExportTarget.allCases.map { target in
             makeExport(target: target, session: session)
@@ -65,7 +65,7 @@ public struct AgentIntegrationExport: Identifiable, Equatable, Sendable {
 
     private static func makeExport(
         target: AgentIntegrationExportTarget,
-        session: DesktopServerSessionState
+        session: DesktopProviderState
     ) -> AgentIntegrationExport {
         let baseURL = session.effectiveBaseURL
         let modelID = session.modelID

--- a/apps/macos-menubar/Sources/AppMain/Models/DesktopShellState.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/DesktopShellState.swift
@@ -334,7 +334,7 @@ public struct DesktopPaneVisibilityState: Identifiable, Codable, Equatable, Send
 }
 
 public struct DesktopRuntimeEndpointState: Equatable, Sendable {
-    public let serverSessionID: String
+    public let providerID: String
     public let serverTitle: String
     public let modelID: String
     public let requestedBaseURL: String
@@ -342,12 +342,12 @@ public struct DesktopRuntimeEndpointState: Equatable, Sendable {
     public let sharedAccessSummaryText: String
 
     public static let fallback = DesktopRuntimeEndpointState(
-        serverSessionID: "",
+        providerID: "",
         serverTitle: "No Server",
         modelID: "",
         requestedBaseURL: "http://\(MelixGatewayDefaults.host):\(MelixGatewayDefaults.port)/v1",
         effectiveBaseURL: "http://\(MelixGatewayDefaults.host):\(MelixGatewayDefaults.port)/v1",
-        sharedAccessSummaryText: "No server session selected."
+        sharedAccessSummaryText: "No provider selected."
     )
 }
 
@@ -992,7 +992,7 @@ public enum DesktopSharedAccessState: String, Codable, Sendable {
     case enabled = "Enabled"
 }
 
-public enum DesktopServerSessionLifecycle: String, Codable, Sendable {
+public enum DesktopProviderLifecycle: String, Codable, Sendable {
     case draft = "Draft"
     case starting = "Starting"
     case running = "Running"
@@ -1021,7 +1021,7 @@ public enum DesktopServerWakeReason: String, Codable, Sendable {
     case policyApply = "Policy Apply"
 }
 
-public struct DesktopServerServingDefaultsState: Codable, Equatable, Sendable {
+public struct DesktopProviderServingDefaultsState: Codable, Equatable, Sendable {
     public var temperature: Double
     public var topP: Double
     public var maxTokens: Int
@@ -1226,7 +1226,7 @@ public struct DesktopServerServingDefaultsState: Codable, Equatable, Sendable {
     }
 }
 
-public struct DesktopServerSessionState: Codable, Identifiable, Equatable, Sendable {
+public struct DesktopProviderState: Codable, Identifiable, Equatable, Sendable {
     public let id: String
     public var title: String
     public var defaultModelID: String
@@ -1248,8 +1248,8 @@ public struct DesktopServerSessionState: Codable, Identifiable, Equatable, Senda
     public var rateLimitPerMinute: Int
     public var timeoutSeconds: Int
     public var modelIdleTimeoutSeconds: Int
-    public var servingDefaults: DesktopServerServingDefaultsState
-    public var lifecycle: DesktopServerSessionLifecycle
+    public var servingDefaults: DesktopProviderServingDefaultsState
+    public var lifecycle: DesktopProviderLifecycle
     public var powerState: DesktopServerPowerState
     public var wakeReason: DesktopServerWakeReason
     public var idleTimerSeconds: Int
@@ -1299,8 +1299,8 @@ public struct DesktopServerSessionState: Codable, Identifiable, Equatable, Senda
         rateLimitPerMinute: Int = 120,
         timeoutSeconds: Int = 120,
         modelIdleTimeoutSeconds: Int = 600,
-        servingDefaults: DesktopServerServingDefaultsState = DesktopServerServingDefaultsState(),
-        lifecycle: DesktopServerSessionLifecycle = .draft,
+        servingDefaults: DesktopProviderServingDefaultsState = DesktopProviderServingDefaultsState(),
+        lifecycle: DesktopProviderLifecycle = .draft,
         powerState: DesktopServerPowerState = .unavailable,
         wakeReason: DesktopServerWakeReason = .unspecified,
         idleTimerSeconds: Int = 0,
@@ -1506,9 +1506,9 @@ public struct DesktopServerSessionState: Codable, Identifiable, Equatable, Senda
         rateLimitPerMinute = try container.decodeIfPresent(Int.self, forKey: .rateLimitPerMinute) ?? 120
         timeoutSeconds = try container.decodeIfPresent(Int.self, forKey: .timeoutSeconds) ?? 120
         modelIdleTimeoutSeconds = try container.decodeIfPresent(Int.self, forKey: .modelIdleTimeoutSeconds) ?? 600
-        servingDefaults = try container.decodeIfPresent(DesktopServerServingDefaultsState.self, forKey: .servingDefaults)
-            ?? DesktopServerServingDefaultsState()
-        lifecycle = try container.decodeIfPresent(DesktopServerSessionLifecycle.self, forKey: .lifecycle) ?? .draft
+        servingDefaults = try container.decodeIfPresent(DesktopProviderServingDefaultsState.self, forKey: .servingDefaults)
+            ?? DesktopProviderServingDefaultsState()
+        lifecycle = try container.decodeIfPresent(DesktopProviderLifecycle.self, forKey: .lifecycle) ?? .draft
         powerState = try container.decodeIfPresent(DesktopServerPowerState.self, forKey: .powerState) ?? .unavailable
         wakeReason = try container.decodeIfPresent(DesktopServerWakeReason.self, forKey: .wakeReason) ?? .unspecified
         idleTimerSeconds = try container.decodeIfPresent(Int.self, forKey: .idleTimerSeconds) ?? 0
@@ -1572,7 +1572,7 @@ public struct DesktopServerSessionState: Codable, Identifiable, Equatable, Senda
 public struct DesktopChatSessionState: Identifiable, Equatable, Sendable {
     public let id: String
     public var title: String
-    public var serverSessionID: String
+    public var providerID: String
     public var branchID: String
     public var branchTitle: String
     public var transcript: [DesktopChatTranscriptEntry]
@@ -1587,7 +1587,7 @@ public struct DesktopChatSessionState: Identifiable, Equatable, Sendable {
     public init(
         id: String,
         title: String,
-        serverSessionID: String,
+        providerID: String,
         branchID: String = "main",
         branchTitle: String = "Main",
         transcript: [DesktopChatTranscriptEntry] = [],
@@ -1601,7 +1601,7 @@ public struct DesktopChatSessionState: Identifiable, Equatable, Sendable {
     ) {
         self.id = id
         self.title = title
-        self.serverSessionID = serverSessionID
+        self.providerID = providerID
         self.branchID = branchID
         self.branchTitle = branchTitle
         self.transcript = transcript
@@ -1619,7 +1619,7 @@ public struct DesktopChatSessionState: Identifiable, Equatable, Sendable {
     }
 
     public var hasServerBinding: Bool {
-        serverSessionID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        providerID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
     }
 
     public var displayBranchTitle: String? {
@@ -1703,7 +1703,7 @@ public struct DesktopBannerState: Equatable, Sendable {
     }
 }
 
-public extension DesktopServerSessionState {
+public extension DesktopProviderState {
     var isInteractiveReady: Bool {
         lifecycle == .running || lifecycle == .sleeping
     }
@@ -1839,37 +1839,37 @@ public extension DesktopServerSessionState {
         case .paused:
             return DesktopBannerState(
                 title: "\(title) Is Paused",
-                detail: "Resume the bound server session before sending prompts from this chat.",
+                detail: "Resume the bound provider before sending prompts from this chat.",
                 severity: .warning
             )
         case .starting:
             return DesktopBannerState(
                 title: "\(title) Is Starting",
-                detail: "Chat stays read-only until the server session finishes booting.",
+                detail: "Chat stays read-only until the provider finishes booting.",
                 severity: .info
             )
         case .stopping:
             return DesktopBannerState(
                 title: "\(title) Is Stopping",
-                detail: "This chat stays read-only while the bound server session drains.",
+                detail: "This chat stays read-only while the bound provider drains.",
                 severity: .warning
             )
         case .stopped:
             return DesktopBannerState(
                 title: "\(title) Is Stopped",
-                detail: "Start the bound server session before sending prompts from this chat.",
+                detail: "Start the bound provider before sending prompts from this chat.",
                 severity: .warning
             )
         case .error:
             return DesktopBannerState(
                 title: "\(title) Needs Recovery",
-                detail: lastError.isEmpty ? "The bound server session failed." : lastError,
+                detail: lastError.isEmpty ? "The bound provider failed." : lastError,
                 severity: .critical
             )
         case .draft, .unavailable:
             return DesktopBannerState(
-                title: "No Active Server Session",
-                detail: "Choose a valid server session and start it before sending prompts from this chat.",
+                title: "No Active Provider",
+                detail: "Choose a valid provider and start it before sending prompts from this chat.",
                 severity: .warning
             )
         }

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -2475,7 +2475,7 @@ public final class RuntimeViewModel {
     public private(set) var models: [RuntimeModelRow] = [] {
         didSet { refreshModelRegistryEntries() }
     }
-    public private(set) var serverSessions: [DesktopServerSessionState] = []
+    public private(set) var providers: [DesktopProviderState] = []
     public private(set) var remoteServers: [RemoteServer] = []
     public private(set) var chatSessions: [DesktopChatSessionState] = []
     public private(set) var lastError: String?
@@ -2786,7 +2786,7 @@ public final class RuntimeViewModel {
     }
 
     public var serverTargets: [RuntimeServerTargetState] {
-        let localTargets = serverSessions.filter { session in
+        let localTargets = providers.filter { session in
             Self.isHiddenPlaceholderModelID(session.modelID) == false
         }.map { session in
             let modelName = serverTargetModelName(for: session.modelID)
@@ -2854,8 +2854,8 @@ public final class RuntimeViewModel {
         {
             return selected
         }
-        if selectedServerSessionID.isEmpty == false,
-           let selected = targets.first(where: { $0.kind == .localServer && $0.serverID == selectedServerSessionID })
+        if selectedProviderID.isEmpty == false,
+           let selected = targets.first(where: { $0.kind == .localServer && $0.serverID == selectedProviderID })
         {
             return selected
         }
@@ -2911,7 +2911,7 @@ public final class RuntimeViewModel {
                 return nil
             }
             let profileSummaryText = Self.diagnosticsProfileSummaryText(
-                for: serverSessions.first(where: { $0.id == target.serverID })
+                for: providers.first(where: { $0.id == target.serverID })
             )
             let detailText = [target.detailText, target.statusText, profileSummaryText]
                 .filter { $0.isEmpty == false }
@@ -2961,7 +2961,7 @@ public final class RuntimeViewModel {
         return targets.first
     }
 
-    private static func diagnosticsProfileSummaryText(for session: DesktopServerSessionState?) -> String {
+    private static func diagnosticsProfileSummaryText(for session: DesktopProviderState?) -> String {
         guard let session else {
             return ""
         }
@@ -3140,7 +3140,7 @@ public final class RuntimeViewModel {
     private let operatorSessionStore: any OperatorSessionStoring
     private let cliWorkflowRunner: (any MelixCLIWorkflowRunning)?
     private let operatorCommandRunner: MelixCLIRunner?
-    private let serverSessionAPIKeyStore: any ServerSessionAPIKeyStoring
+    private let providerAPIKeyStore: any ProviderAPIKeyStoring
     private let remoteServerStore: any RemoteServerStoring
     private let evaluationPromptStore: any EvaluationPromptStoring
     private let loraTrainingJobStore: any LoraTrainingJobStoring
@@ -3160,7 +3160,7 @@ public final class RuntimeViewModel {
     private var chatPresentationLastFlushAt: ContinuousClock.Instant?
     private var chatPresentationMaxLagMs = 0.0
     private var chatPresentationFlushCount = 0.0
-    private var persistedServerSessions: [DesktopServerSessionState] = []
+    private var persistedServerSessions: [DesktopProviderState] = []
     private var diagnosticsServerTargetSelectionUserOverridden = false
     private var dismissedBannerIDs: Set<String> = []
     private var modelSettingsDraftModelID = ""
@@ -3401,7 +3401,7 @@ public final class RuntimeViewModel {
         operatorSessionStore: any OperatorSessionStoring = NullOperatorSessionStore(),
         cliWorkflowRunner: (any MelixCLIWorkflowRunning)? = nil,
         operatorCommandRunner: MelixCLIRunner? = nil,
-        serverSessionAPIKeyStore: any ServerSessionAPIKeyStoring = NullServerSessionAPIKeyStore(),
+        providerAPIKeyStore: any ProviderAPIKeyStoring = NullProviderAPIKeyStore(),
         remoteServerStore: any RemoteServerStoring = NullRemoteServerStore(),
         evaluationPromptStore: any EvaluationPromptStoring = NullEvaluationPromptStore(),
         loraTrainingJobStore: any LoraTrainingJobStoring = NullLoraTrainingJobStore(),
@@ -3413,7 +3413,7 @@ public final class RuntimeViewModel {
         self.operatorSessionStore = operatorSessionStore
         self.cliWorkflowRunner = cliWorkflowRunner
         self.operatorCommandRunner = operatorCommandRunner
-        self.serverSessionAPIKeyStore = serverSessionAPIKeyStore
+        self.providerAPIKeyStore = providerAPIKeyStore
         self.remoteServerStore = remoteServerStore
         self.evaluationPromptStore = evaluationPromptStore
         self.loraTrainingJobStore = loraTrainingJobStore
@@ -5675,7 +5675,7 @@ public final class RuntimeViewModel {
         diagnosticsServerTargetSelectionUserOverridden = true
         switch target.kind {
         case .localServer:
-            selectedServerSessionID = target.serverID
+            selectedProviderID = target.serverID
             selectedServerTargetID = Self.serverTargetID(kind: .localServer, serverID: target.serverID)
         case .remoteServer:
             selectedEvaluationRemoteServerID = target.serverID
@@ -5722,7 +5722,7 @@ public final class RuntimeViewModel {
             notifyStateChanged()
             return
         }
-        let nextIndex = serverSessions.count + 1
+        let nextIndex = providers.count + 1
         let defaultTitle = nextIndex == 1 ? "Primary Server" : "Server \(nextIndex)"
         let title = titleOverride.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? defaultTitle
@@ -5730,12 +5730,12 @@ public final class RuntimeViewModel {
         let host = hostOverride.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? MelixGatewayDefaults.host
             : hostOverride.trimmingCharacters(in: .whitespacesAndNewlines)
-        let port = max(1, portOverride ?? Self.defaultLocalServerPort(sessionOffset: serverSessions.count))
+        let port = max(1, portOverride ?? Self.defaultLocalServerPort(sessionOffset: providers.count))
         if let commandWorkflowRunner {
             Task {
                 do {
                     _ = try await commandWorkflowRunner.run(
-                        .serverSessionCreate(
+                        .providerCreate(
                             .init(
                                 title: title,
                                 defaultModelID: modelID,
@@ -5762,8 +5762,8 @@ public final class RuntimeViewModel {
             }
             return
         }
-        let session = DesktopServerSessionState(
-            id: "server-session-\(UUID().uuidString)",
+        let session = DesktopProviderState(
+            id: "provider-\(UUID().uuidString)",
             title: title,
             modelID: modelID,
             host: host,
@@ -5771,7 +5771,7 @@ public final class RuntimeViewModel {
             lifecycle: .draft
         )
         persistedServerSessions.append(session)
-        selectedServerSessionID = session.id
+        selectedProviderID = session.id
         selectedServerTargetID = Self.serverTargetID(kind: .localServer, serverID: session.id)
         isCreatingServerTarget = false
         syncServerSessionsWithModels()
@@ -5798,7 +5798,7 @@ public final class RuntimeViewModel {
     }
 
     public func selectServerSession(id: String) {
-        guard serverSessions.contains(where: { $0.id == id }) else {
+        guard providers.contains(where: { $0.id == id }) else {
             return
         }
         selectedServerTargetID = Self.serverTargetID(kind: .localServer, serverID: id)
@@ -5807,7 +5807,7 @@ public final class RuntimeViewModel {
             Task {
                 do {
                     _ = try await commandWorkflowRunner.run(
-                        .serverSessionSelect(.init(serverSessionID: id, json: true))
+                        .providerSelect(.init(providerID: id, json: true))
                     )
                     restoreOperatorSessionState()
                     syncServerSessionsWithModels()
@@ -5822,7 +5822,7 @@ public final class RuntimeViewModel {
             }
             return
         }
-        selectedServerSessionID = id
+        selectedProviderID = id
         selectedChatModelID = selectedServerSession?.modelID ?? selectedChatModelID
         refreshAgentIntegrationExports()
         maybeApplyStoredGatewayAccessForSelectedRunningSession()
@@ -5980,7 +5980,7 @@ public final class RuntimeViewModel {
     private static func applyServingAccelerationProfileDefaults(
         _ nextProfile: ServingAccelerationProfile,
         replacing previousProfile: ServingAccelerationProfile,
-        to servingDefaults: inout DesktopServerServingDefaultsState
+        to servingDefaults: inout DesktopProviderServingDefaultsState
     ) {
         let previousAccelerationMode = ServingAccelerationProfiles.controlPlaneRawValue(previousProfile.accelerationMode)
         if servingDefaults.accelerationMode == previousAccelerationMode {
@@ -6050,8 +6050,8 @@ public final class RuntimeViewModel {
 
         do {
             let primaryKey = try Self.makePrimaryAPIKey()
-            let persistedRecord = try serverSessionAPIKeyStore.savePrimaryKey(
-                serverSessionID: selectedServerSession.id,
+            let persistedRecord = try providerAPIKeyStore.savePrimaryKey(
+                providerID: selectedServerSession.id,
                 primaryKey: primaryKey,
                 keyID: "primary"
             )
@@ -6145,7 +6145,7 @@ public final class RuntimeViewModel {
         if await executeServerLifecycleCommand(
             .serverSetIdlePolicy(
                 .init(
-                    serverSessionID: serverSession.id,
+                    providerID: serverSession.id,
                     autoSleepEnabled: serverSession.autoSleepEnabled,
                     lightSleepAfterSeconds: UInt32(max(0, serverSession.lightSleepAfterSeconds)),
                     deepSleepAfterSeconds: UInt32(max(0, serverSession.deepSleepAfterSeconds)),
@@ -6156,88 +6156,88 @@ public final class RuntimeViewModel {
         ) {
             return
         }
-        await performServerIdlePolicyUpdate(serverSessionID: serverSession.id)
+        await performServerIdlePolicyUpdate(providerID: serverSession.id)
     }
 
-    public func startServerSession(id serverSessionID: String) async {
+    public func startServerSession(id providerID: String) async {
         if cliWorkflowRunner != nil {
-            await startServerSessionViaCLI(serverSessionID: serverSessionID)
+            await startServerSessionViaCLI(providerID: providerID)
             return
         }
         if await executeServerLifecycleCommand(
-            .serverStart(.init(serverSessionID: serverSessionID, json: true)),
+            .serverStart(.init(providerID: providerID, json: true)),
             metricName: "menu.server_start_ms"
         ) {
             return
         }
-        guard await persistGatewayConfig(for: serverSessionID) else {
+        guard await persistGatewayConfig(for: providerID) else {
             return
         }
-        guard await persistServingDefaults(for: serverSessionID) else {
+        guard await persistServingDefaults(for: providerID) else {
             return
         }
         await performServerLifecycleAction(
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             metricName: "menu.server_start_ms"
         ) { [client] targetServerSessionID in
             try await client.startServerSession(serverSessionID: targetServerSessionID)
         }
     }
 
-    public func pauseServerSession(id serverSessionID: String) async {
+    public func pauseServerSession(id providerID: String) async {
         if await executeServerLifecycleCommand(
-            .serverPause(.init(serverSessionID: serverSessionID, json: true)),
+            .serverPause(.init(providerID: providerID, json: true)),
             metricName: "menu.server_pause_ms"
         ) {
             return
         }
         await performServerLifecycleAction(
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             metricName: "menu.server_pause_ms"
         ) { [client] targetServerSessionID in
             try await client.pauseServerSession(serverSessionID: targetServerSessionID)
         }
     }
 
-    public func resumeServerSession(id serverSessionID: String) async {
+    public func resumeServerSession(id providerID: String) async {
         if await executeServerLifecycleCommand(
-            .serverResume(.init(serverSessionID: serverSessionID, json: true)),
+            .serverResume(.init(providerID: providerID, json: true)),
             metricName: "menu.server_resume_ms"
         ) {
             return
         }
         await performServerLifecycleAction(
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             metricName: "menu.server_resume_ms"
         ) { [client] targetServerSessionID in
             try await client.resumeServerSession(serverSessionID: targetServerSessionID)
         }
     }
 
-    public func wakeServerSession(id serverSessionID: String) async {
+    public func wakeServerSession(id providerID: String) async {
         if await executeServerLifecycleCommand(
-            .serverWake(.init(serverSessionID: serverSessionID, json: true)),
+            .serverWake(.init(providerID: providerID, json: true)),
             metricName: "menu.server_wake_ms"
         ) {
             return
         }
         await performServerLifecycleAction(
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             metricName: "menu.server_wake_ms"
         ) { [client] targetServerSessionID in
             try await client.wakeServerSession(serverSessionID: targetServerSessionID)
         }
     }
 
-    public func stopServerSession(id serverSessionID: String) async {
+    public func stopServerSession(id providerID: String) async {
         if await executeServerLifecycleCommand(
-            .serverStop(.init(serverSessionID: serverSessionID, json: true)),
+            .serverStop(.init(providerID: providerID, json: true)),
             metricName: "menu.server_stop_ms"
         ) {
             return
         }
         await performServerLifecycleAction(
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             metricName: "menu.server_stop_ms"
         ) { [client] targetServerSessionID in
             try await client.stopServerSession(serverSessionID: targetServerSessionID)
@@ -6245,9 +6245,9 @@ public final class RuntimeViewModel {
     }
 
     public func createChatSession() {
-        guard operatorStateRestored || serverSessions.isEmpty == false else {
-            setLastError("Create a Server Session before opening chat.")
-            chatStatusText = "No Server Session"
+        guard operatorStateRestored || providers.isEmpty == false else {
+            setLastError("Create a Provider before opening chat.")
+            chatStatusText = "No Provider"
             selectedSurface = .server
             notifyStateChanged()
             return
@@ -6257,7 +6257,7 @@ public final class RuntimeViewModel {
         let session = DesktopChatSessionState(
             id: "chat-session-\(UUID().uuidString)",
             title: nextIndex == 1 ? "Chat 1" : "Chat \(nextIndex)",
-            serverSessionID: "",
+            providerID: "",
             statusText: "Choose Server"
         )
         chatSessions.append(session)
@@ -6276,7 +6276,7 @@ public final class RuntimeViewModel {
         let forked = DesktopChatSessionState(
             id: "chat-session-\(UUID().uuidString)",
             title: "\(source.title) Fork",
-            serverSessionID: source.serverSessionID,
+            providerID: source.providerID,
             branchID: "branch-\(nextIndex)",
             branchTitle: "Branch \(nextIndex)",
             transcript: source.transcript,
@@ -6323,25 +6323,25 @@ public final class RuntimeViewModel {
         notifyStateChanged()
     }
 
-    public func bindSelectedChatSessionToServer(serverSessionID: String) {
+    public func bindSelectedChatSessionToServer(providerID: String) {
         guard
             let selectedChatSession,
-            let serverSession = serverSession(id: serverSessionID)
+            let serverSession = serverSession(id: providerID)
         else {
             return
         }
 
         replaceChatSession(id: selectedChatSession.id) { session in
-            session.serverSessionID = serverSession.id
-            if session.statusText == "Choose Server" || session.statusText == "No Server Session" {
+            session.providerID = serverSession.id
+            if session.statusText == "Choose Server" || session.statusText == "No Provider" {
                 session.statusText = "Idle"
             }
             session.updatedAt = Date()
         }
-        selectedServerSessionID = serverSession.id
+        selectedProviderID = serverSession.id
         selectedChatModelID = serverSession.modelID
         if selectedChatSessionID == selectedChatSession.id {
-            chatStatusText = chatStatusText == "Choose Server" || chatStatusText == "No Server Session"
+            chatStatusText = chatStatusText == "Choose Server" || chatStatusText == "No Provider"
                 ? "Idle"
                 : chatStatusText
         }
@@ -6365,7 +6365,7 @@ public final class RuntimeViewModel {
         let payload = """
         # \(sanitizedRichText(session.title))
 
-        - Server Session: \(session.serverSessionID)
+        - Provider: \(session.providerID)
         - Branch: \(sanitizedRichText(session.branchTitle))
         - Status: \(sanitizedRichText(session.statusText))
 
@@ -6390,8 +6390,8 @@ public final class RuntimeViewModel {
         }
     }
 
-    public func serverSession(id: String) -> DesktopServerSessionState? {
-        serverSessions.first(where: { $0.id == id })
+    public func serverSession(id: String) -> DesktopProviderState? {
+        providers.first(where: { $0.id == id })
     }
 
     public var primaryModel: RuntimeModelRow? {
@@ -6435,7 +6435,7 @@ public final class RuntimeViewModel {
             return .fallback
         }
         return DesktopRuntimeEndpointState(
-            serverSessionID: session.id,
+            providerID: session.id,
             serverTitle: session.title,
             modelID: session.modelID,
             requestedBaseURL: session.baseURL,
@@ -6451,11 +6451,11 @@ public final class RuntimeViewModel {
         return latestSnapshot.models.first(where: { $0.modelID == modelID })
     }
 
-    public var selectedServerSession: DesktopServerSessionState? {
-        guard !selectedServerSessionID.isEmpty else {
-            return serverSessions.first
+    public var selectedServerSession: DesktopProviderState? {
+        guard !selectedProviderID.isEmpty else {
+            return providers.first
         }
-        return serverSessions.first(where: { $0.id == selectedServerSessionID }) ?? serverSessions.first
+        return providers.first(where: { $0.id == selectedProviderID }) ?? providers.first
     }
 
     public var selectedChatSession: DesktopChatSessionState? {
@@ -6465,14 +6465,14 @@ public final class RuntimeViewModel {
         return chatSessions.first(where: { $0.id == selectedChatSessionID }) ?? chatSessions.first
     }
 
-    public var selectedChatServerSession: DesktopServerSessionState? {
+    public var selectedChatServerSession: DesktopProviderState? {
         guard
             let selectedChatSession,
             selectedChatSession.hasServerBinding
         else {
             return nil
         }
-        return serverSession(id: selectedChatSession.serverSessionID)
+        return serverSession(id: selectedChatSession.providerID)
     }
 
     public var selectedAgentIntegrationExport: AgentIntegrationExport? {
@@ -6540,10 +6540,10 @@ public final class RuntimeViewModel {
                 )
             )
         }
-        if let failingServer = serverSessions.first(where: { $0.lifecycle == .error }) {
+        if let failingServer = providers.first(where: { $0.lifecycle == .error }) {
             signals.append(
                 DesktopBannerState(
-                    id: "server-session-\(failingServer.id)-critical",
+                    id: "provider-\(failingServer.id)-critical",
                     title: "\(failingServer.title) Needs Recovery",
                     detail: failingServer.lastError,
                     severity: .critical
@@ -7164,7 +7164,7 @@ public final class RuntimeViewModel {
         }
     }
 
-    private var selectedServerSessionID = ""
+    private var selectedProviderID = ""
     private var selectedChatSessionID = ""
 
     public func start() async {
@@ -7294,15 +7294,15 @@ public final class RuntimeViewModel {
         }
 
         guard let serverSession = selectedChatServerSession else {
-            guard selectedChatSession != nil || serverSessions.isEmpty == false else {
-                chatStatusText = "No Server Session"
-                setLastError("Create a Server Session before sending chat prompts.")
+            guard selectedChatSession != nil || providers.isEmpty == false else {
+                chatStatusText = "No Provider"
+                setLastError("Create a Provider before sending chat prompts.")
                 selectedSurface = .server
                 notifyStateChanged()
                 return
             }
             chatStatusText = "Choose Server"
-            setLastError("Choose a Server Session before sending chat prompts.")
+            setLastError("Choose a Provider before sending chat prompts.")
             selectedSurface = .chat
             if let selectedChatSession {
                 replaceChatSession(id: selectedChatSession.id) { session in
@@ -7383,7 +7383,8 @@ public final class RuntimeViewModel {
             let execution = try await client.startChat(
                 ControlPlaneChatRequest(
                     modelID: modelID,
-                    messages: chatConversationMessages
+                    messages: chatConversationMessages,
+                    providerID: serverSession.id
                 )
             )
             lastChatRequestID = execution.requestID
@@ -10948,7 +10949,7 @@ public final class RuntimeViewModel {
         if let modelID = normalizedModelOperationAnchor(selectedServerSession?.modelID) {
             return modelID
         }
-        if let modelID = serverSessions.lazy.compactMap({ self.normalizedModelOperationAnchor($0.modelID) }).first {
+        if let modelID = providers.lazy.compactMap({ self.normalizedModelOperationAnchor($0.modelID) }).first {
             return modelID
         }
         if let modelID = primaryModel?.modelID, !modelID.isEmpty {
@@ -11109,50 +11110,50 @@ public final class RuntimeViewModel {
     }
 
     private func updateSelectedServerSession(
-        _ update: (inout DesktopServerSessionState) -> Void
+        _ update: (inout DesktopProviderState) -> Void
     ) {
-        replaceServerSession(id: selectedServerSessionID, update)
+        replaceServerSession(id: selectedProviderID, update)
         refreshAgentIntegrationExports()
         notifyStateChanged()
     }
 
     private func replaceServerSession(
         id: String,
-        _ update: (inout DesktopServerSessionState) -> Void
+        _ update: (inout DesktopProviderState) -> Void
     ) {
         if let index = persistedServerSessions.firstIndex(where: { $0.id == id }) {
             var session = persistedServerSessions[index]
             update(&session)
             persistedServerSessions[index] = session
         }
-        if let index = serverSessions.firstIndex(where: { $0.id == id }) {
-            var session = serverSessions[index]
+        if let index = providers.firstIndex(where: { $0.id == id }) {
+            var session = providers[index]
             update(&session)
-            serverSessions[index] = session
+            providers[index] = session
         }
     }
 
     private func performServerLifecycleAction(
-        serverSessionID: String,
+        providerID: String,
         metricName: String,
         action: @escaping @Sendable (String) async throws -> Melix_Controlplane_V1_ServerSnapshot
     ) async {
-        guard !serverSessionID.isEmpty else {
+        guard !providerID.isEmpty else {
             return
         }
 
-        selectedServerSessionID = serverSessionID
+        selectedProviderID = providerID
 
         let startedAt = Date()
         do {
-            let snapshot = try await action(serverSessionID)
+            let snapshot = try await action(providerID)
             await metrics.record(
                 name: metricName,
                 valueMs: Date().timeIntervalSince(startedAt) * 1_000
             )
             apply(snapshot: snapshot)
         } catch {
-            replaceServerSession(id: serverSessionID) { session in
+            replaceServerSession(id: providerID) { session in
                 session.lastError = String(describing: error)
                 session.updatedAt = Date()
             }
@@ -11161,8 +11162,8 @@ public final class RuntimeViewModel {
         }
     }
 
-    private func performServerIdlePolicyUpdate(serverSessionID: String) async {
-        guard let serverSession = serverSession(id: serverSessionID) else {
+    private func performServerIdlePolicyUpdate(providerID: String) async {
+        guard let serverSession = serverSession(id: providerID) else {
             return
         }
 
@@ -11186,8 +11187,8 @@ public final class RuntimeViewModel {
     }
 
     @discardableResult
-    private func persistGatewayConfig(for serverSessionID: String) async -> Bool {
-        guard let serverSession = serverSession(id: serverSessionID) else {
+    private func persistGatewayConfig(for providerID: String) async -> Bool {
+        guard let serverSession = serverSession(id: providerID) else {
             return false
         }
 
@@ -11196,7 +11197,7 @@ public final class RuntimeViewModel {
             let snapshot: Melix_Controlplane_V1_ServerSnapshot
             if let operatorCommandRunner {
                 snapshot = try await operatorCommandRunner.applyConfiguredServerSessionGatewayConfig(
-                    serverSessionID: serverSession.id
+                    providerID: serverSession.id
                 )
             } else {
                 snapshot = try await client.applyServerSessionGatewayConfig(
@@ -11226,8 +11227,8 @@ public final class RuntimeViewModel {
     }
 
     @discardableResult
-    private func persistServingDefaults(for serverSessionID: String) async -> Bool {
-        guard let serverSession = serverSession(id: serverSessionID) else {
+    private func persistServingDefaults(for providerID: String) async -> Bool {
+        guard let serverSession = serverSession(id: providerID) else {
             return false
         }
 
@@ -11236,7 +11237,7 @@ public final class RuntimeViewModel {
             let snapshot: Melix_Controlplane_V1_ServerSnapshot
             if let operatorCommandRunner {
                 snapshot = try await operatorCommandRunner.applyConfiguredServerSessionServingDefaults(
-                    serverSessionID: serverSession.id
+                    providerID: serverSession.id
                 )
             } else {
                 snapshot = try await client.applyServerSessionServingDefaults(
@@ -11270,20 +11271,20 @@ public final class RuntimeViewModel {
         }
     }
 
-    private func chatSubmissionBlockedMessage(for serverSession: DesktopServerSessionState) -> String {
+    private func chatSubmissionBlockedMessage(for serverSession: DesktopProviderState) -> String {
         switch serverSession.lifecycle {
         case .paused:
-            return "Resume the paused Server Session before sending chat prompts."
+            return "Resume the paused Provider before sending chat prompts."
         case .starting:
-            return "Wait for the Server Session to finish starting before sending chat prompts."
+            return "Wait for the Provider to finish starting before sending chat prompts."
         case .stopping:
-            return "Wait for the Server Session to finish stopping or start it again before sending chat prompts."
+            return "Wait for the Provider to finish stopping or start it again before sending chat prompts."
         case .stopped, .draft, .unavailable:
-            return "Start the bound Server Session before sending chat prompts."
+            return "Start the bound Provider before sending chat prompts."
         case .error:
             return serverSession.lastError.isEmpty
-                ? "Recover the failed Server Session before sending chat prompts."
-                : "Recover the failed Server Session before sending chat prompts. \(serverSession.lastError)"
+                ? "Recover the failed Provider before sending chat prompts."
+                : "Recover the failed Provider before sending chat prompts. \(serverSession.lastError)"
         case .running, .sleeping:
             return ""
         }
@@ -11304,8 +11305,8 @@ public final class RuntimeViewModel {
     private func loadChatSession(_ session: DesktopChatSessionState) {
         selectedChatSessionID = session.id
         if session.hasServerBinding,
-           (selectedServerSessionID.isEmpty || serverSession(id: session.serverSessionID) != nil) {
-            selectedServerSessionID = session.serverSessionID
+           (selectedProviderID.isEmpty || serverSession(id: session.providerID) != nil) {
+            selectedProviderID = session.providerID
         }
         chatTranscript = session.transcript
         chatStatusText = session.statusText
@@ -11322,21 +11323,21 @@ public final class RuntimeViewModel {
                 return nil
             }
         }
-        if let boundServer = serverSession(id: session.serverSessionID) {
+        if let boundServer = serverSession(id: session.providerID) {
             selectedChatModelID = boundServer.modelID
         }
     }
 
     private func ensureChatSessionsBoundToServerSessions() {
         if selectedServerSession == nil {
-            selectedServerSessionID = serverSessions.first?.id ?? ""
+            selectedProviderID = providers.first?.id ?? ""
         }
 
         if chatSessions.isEmpty {
             let session = DesktopChatSessionState(
                 id: "chat-session-\(UUID().uuidString)",
                 title: "Chat 1",
-                serverSessionID: "",
+                providerID: "",
                 statusText: "Choose Server"
             )
             chatSessions = [session]
@@ -11345,11 +11346,11 @@ public final class RuntimeViewModel {
         }
 
         chatSessions = chatSessions.map { session in
-            guard session.hasServerBinding, serverSession(id: session.serverSessionID) == nil else {
+            guard session.hasServerBinding, serverSession(id: session.providerID) == nil else {
                 return session
             }
             var unbound = session
-            unbound.serverSessionID = ""
+            unbound.providerID = ""
             unbound.statusText = "Choose Server"
             unbound.updatedAt = Date()
             return unbound
@@ -11366,10 +11367,10 @@ public final class RuntimeViewModel {
         let textModels = serverModelOptions.isEmpty ? serveableModels : serverModelOptions
 
         if persistedServerSessions.isEmpty, let firstTextModel = textModels.first {
-            let seededServerSessionID = latestSnapshot.providers.first?.providerID ?? "server-session-1"
+            let seededServerSessionID = latestSnapshot.providers.first?.providerID ?? "provider-1"
             let projectedConfig = Self.gatewayConfigProjection(
                 from: latestSnapshot,
-                serverSessionID: seededServerSessionID
+                providerID: seededServerSessionID
             )
             let projectedDefaultModelID = projectedConfig?.defaultModelID
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -11379,7 +11380,7 @@ public final class RuntimeViewModel {
                 } ?? firstTextModel,
                 title: "Primary Server",
                 port: projectedConfig?.port ?? MelixGatewayDefaults.port,
-                serverSessionID: seededServerSessionID,
+                providerID: seededServerSessionID,
                 modelIDOverride: projectedDefaultModelID?.isEmpty == false ? projectedDefaultModelID : nil
             )
             if projectedConfig != nil {
@@ -11389,15 +11390,15 @@ public final class RuntimeViewModel {
             } else {
                 persistedServerSessions = [seeded]
             }
-            selectedServerSessionID = seeded.id
+            selectedProviderID = seeded.id
         }
 
         guard persistedServerSessions.isEmpty == false else {
-            serverSessions = []
+            providers = []
             return
         }
 
-        serverSessions = persistedServerSessions.enumerated().map { offset, session in
+        providers = persistedServerSessions.enumerated().map { offset, session in
             var updated = session
             applyGatewayConfigProjection(to: &updated)
             applyServingDefaultsProjection(to: &updated)
@@ -11429,7 +11430,7 @@ public final class RuntimeViewModel {
         }
 
         if selectedServerSession == nil {
-            selectedServerSessionID = serverSessions.first?.id ?? ""
+            selectedProviderID = providers.first?.id ?? ""
         }
 
         maybeApplyStoredGatewayAccessForSelectedRunningSession()
@@ -11451,7 +11452,7 @@ public final class RuntimeViewModel {
             newLocalServerHostDraft = MelixGatewayDefaults.host
         }
         if newLocalServerPortDraft <= 0 {
-            newLocalServerPortDraft = Self.defaultLocalServerPort(sessionOffset: serverSessions.count)
+            newLocalServerPortDraft = Self.defaultLocalServerPort(sessionOffset: providers.count)
         }
     }
 
@@ -11467,8 +11468,8 @@ public final class RuntimeViewModel {
         {
             return
         }
-        if selectedServerSessionID.isEmpty == false,
-           let localTarget = targets.first(where: { $0.kind == .localServer && $0.serverID == selectedServerSessionID })
+        if selectedProviderID.isEmpty == false,
+           let localTarget = targets.first(where: { $0.kind == .localServer && $0.serverID == selectedProviderID })
         {
             selectedServerTargetID = localTarget.id
             return
@@ -11505,12 +11506,12 @@ public final class RuntimeViewModel {
         for model: RuntimeModelRow,
         title: String,
         port: Int,
-        serverSessionID: String = "server-session-\(UUID().uuidString)",
+        providerID: String = "provider-\(UUID().uuidString)",
         modelIDOverride: String? = nil,
         servedModelIDs: [String] = []
-    ) -> DesktopServerSessionState {
-        var session = DesktopServerSessionState(
-            id: serverSessionID,
+    ) -> DesktopProviderState {
+        var session = DesktopProviderState(
+            id: providerID,
             title: title,
             modelID: modelIDOverride ?? model.modelID,
             servedModelIDs: servedModelIDs,
@@ -11526,10 +11527,10 @@ public final class RuntimeViewModel {
 
     private func markServerSessions(
         for modelID: String,
-        lifecycle: DesktopServerSessionLifecycle,
+        lifecycle: DesktopProviderLifecycle,
         error: String
     ) {
-        serverSessions = serverSessions.map { session in
+        providers = providers.map { session in
             guard session.servedModelIDs.contains(modelID) else {
                 return session
             }
@@ -11551,15 +11552,15 @@ public final class RuntimeViewModel {
             if selectedSurface.isDomainSurface {
                 selectedToolSection = defaultToolSection(for: selectedSurface, current: selectedToolSection)
             }
-            selectedServerSessionID = restoredState.selectedServerSessionID
+            selectedProviderID = restoredState.selectedProviderID
             selectedRuntimeJobID = restoredState.selectedRuntimeJobID
             desktopPaneVisibility = DesktopPaneVisibilityState.mergedWithDefaults(restoredState.paneVisibility)
             dismissedBannerIDs = Set(restoredState.dismissedBannerIDs)
             registryConfiguredRootPaths = Self.normalizedRegistryRootPaths(restoredState.registryRoots)
             registryHasConfiguredRootOverride = registryConfiguredRootPaths.isEmpty == false
-            if restoredState.serverSessions.isEmpty == false {
-                persistedServerSessions = restoredState.serverSessions
-                serverSessions = restoredState.serverSessions
+            if restoredState.providers.isEmpty == false {
+                persistedServerSessions = restoredState.providers
+                providers = restoredState.providers
             }
             downloadQueue = restoredState.downloadQueue
             lastPersistedOperatorSessionState = restoredState
@@ -11572,9 +11573,9 @@ public final class RuntimeViewModel {
         OperatorSessionState(
             selectedSurface: selectedSurface,
             selectedToolSection: selectedToolSection,
-            selectedServerSessionID: selectedServerSessionID,
+            selectedProviderID: selectedProviderID,
             selectedRuntimeJobID: selectedRuntimeJobID,
-            serverSessions: persistedServerSessions,
+            providers: persistedServerSessions,
             dismissedBannerIDs: dismissedBannerIDs.sorted(),
             downloadQueue: downloadQueue,
             registryRoots: registryConfiguredRootPaths,
@@ -11635,17 +11636,17 @@ public final class RuntimeViewModel {
         return true
     }
 
-    private func startServerSessionViaCLI(serverSessionID: String) async {
-        guard let cliWorkflowRunner, let serverSession = serverSession(id: serverSessionID) else {
+    private func startServerSessionViaCLI(providerID: String) async {
+        guard let cliWorkflowRunner, let serverSession = serverSession(id: providerID) else {
             return
         }
 
         let startedAt = Date()
         do {
             _ = try await cliWorkflowRunner.run(
-                .serverSessionUpdate(
+                .providerUpdate(
                     .init(
-                        serverSessionID: serverSession.id,
+                        providerID: serverSession.id,
                         title: serverSession.title,
                         defaultModelID: serverSession.defaultModelID,
                         servedModelIDs: serverSession.servedModelIDs,
@@ -11664,15 +11665,15 @@ public final class RuntimeViewModel {
             )
             restoreOperatorSessionState()
             _ = try await cliWorkflowRunner.run(
-                .serverSessionSelect(.init(serverSessionID: serverSession.id, json: true))
+                .providerSelect(.init(providerID: serverSession.id, json: true))
             )
             restoreOperatorSessionState()
             let snapshotOutput = try await cliWorkflowRunner.run(
-                .serverStart(.init(serverSessionID: serverSession.id, json: true))
+                .serverStart(.init(providerID: serverSession.id, json: true))
             )
             try applyCLIServerSnapshotIfPresent(
                 output: snapshotOutput,
-                command: .serverStart(.init(serverSessionID: serverSession.id, json: true)),
+                command: .serverStart(.init(providerID: serverSession.id, json: true)),
                 surface: cliWorkflowRunner.surface
             )
             clearCLIWorkflowFailure()
@@ -11689,30 +11690,30 @@ public final class RuntimeViewModel {
 
     private func maybeApplyStoredGatewayAccessForSelectedRunningSession() {
         guard let selectedServerSession else {
-            scheduleGatewayAccessClear(serverSessionID: lastAppliedGatewaySessionID)
+            scheduleGatewayAccessClear(providerID: lastAppliedGatewaySessionID)
             return
         }
         guard selectedServerSession.retainsGatewayAccessConfiguration else {
-            scheduleGatewayAccessClear(serverSessionID: selectedServerSession.id)
+            scheduleGatewayAccessClear(providerID: selectedServerSession.id)
             return
         }
 
         do {
             guard
-                let persistedRecord = try serverSessionAPIKeyStore.loadPrimaryKey(
-                    serverSessionID: selectedServerSession.id
+                let persistedRecord = try providerAPIKeyStore.loadPrimaryKey(
+                    providerID: selectedServerSession.id
                 )
             else {
-                scheduleGatewayAccessClear(serverSessionID: selectedServerSession.id)
+                scheduleGatewayAccessClear(providerID: selectedServerSession.id)
                 return
             }
             guard persistedRecord.primaryKey.isEmpty == false else {
-                scheduleGatewayAccessClear(serverSessionID: selectedServerSession.id)
+                scheduleGatewayAccessClear(providerID: selectedServerSession.id)
                 return
             }
 
             scheduleGatewayAccessApply(
-                serverSessionID: selectedServerSession.id,
+                providerID: selectedServerSession.id,
                 primaryKey: persistedRecord.primaryKey,
                 keyID: persistedRecord.keyID,
                 label: persistedRecord.keyID,
@@ -11723,11 +11724,11 @@ public final class RuntimeViewModel {
         }
     }
 
-    private func scheduleGatewayAccessClear(serverSessionID: String) {
+    private func scheduleGatewayAccessClear(providerID: String) {
         guard lastAppliedGatewaySessionID.isEmpty == false else {
             return
         }
-        let targetServerSessionID = serverSessionID.isEmpty ? lastAppliedGatewaySessionID : serverSessionID
+        let targetServerSessionID = providerID.isEmpty ? lastAppliedGatewaySessionID : providerID
         gatewayApplyTask?.cancel()
         gatewayApplyTask = Task { @MainActor in
             do {
@@ -11741,7 +11742,7 @@ public final class RuntimeViewModel {
     }
 
     private func scheduleGatewayAccessApply(
-        serverSessionID: String,
+        providerID: String,
         primaryKey: String,
         keyID: String,
         label: String,
@@ -11752,7 +11753,7 @@ public final class RuntimeViewModel {
             return
         }
         if force == false,
-           lastAppliedGatewaySessionID == serverSessionID,
+           lastAppliedGatewaySessionID == providerID,
            lastAppliedGatewayPrimaryKey == primaryKey
         {
             return
@@ -11762,13 +11763,13 @@ public final class RuntimeViewModel {
         gatewayApplyTask = Task { @MainActor in
             do {
                 try await client.applyServerSessionGatewayAccess(
-                    serverSessionID: serverSessionID,
+                    serverSessionID: providerID,
                     primaryKey: primaryKey,
                     keyID: keyID,
                     label: label,
                     tokenHint: tokenHint
                 )
-                lastAppliedGatewaySessionID = serverSessionID
+                lastAppliedGatewaySessionID = providerID
                 lastAppliedGatewayPrimaryKey = primaryKey
             } catch {
                 recordLocalError("Gateway access apply failed: \(error)")
@@ -12526,7 +12527,7 @@ public final class RuntimeViewModel {
     private func selectedDiagnosticsEffectiveAccelerationProfileID() -> String {
         guard let target = selectedDiagnosticsServerTarget,
               target.kind == .localServer,
-              let session = serverSessions.first(where: { $0.id == target.serverID })
+              let session = providers.first(where: { $0.id == target.serverID })
         else {
             return ""
         }
@@ -13211,7 +13212,7 @@ public final class RuntimeViewModel {
         }
     }
 
-    private func applyGatewayAccessProjection(to session: inout DesktopServerSessionState) {
+    private func applyGatewayAccessProjection(to session: inout DesktopProviderState) {
         guard let projection = Self.gatewayAccessProjection(from: latestSnapshot) else {
             return
         }
@@ -13227,8 +13228,8 @@ public final class RuntimeViewModel {
         session.lastAuthSessionSignOutLatencyMs = projection.lastAuthSessionSignOutLatencyMs
     }
 
-    private func applyGatewayConfigProjection(to session: inout DesktopServerSessionState) {
-        guard let projection = Self.gatewayConfigProjection(from: latestSnapshot, serverSessionID: session.id) else {
+    private func applyGatewayConfigProjection(to session: inout DesktopProviderState) {
+        guard let projection = Self.gatewayConfigProjection(from: latestSnapshot, providerID: session.id) else {
             session.effectiveHost = session.host
             session.effectivePort = session.port
             return
@@ -13253,7 +13254,7 @@ public final class RuntimeViewModel {
 
     private func shouldAdoptGatewayRosterProjection(
         _ projection: GatewayConfigProjection,
-        for session: DesktopServerSessionState
+        for session: DesktopProviderState
     ) -> Bool {
         // Config-file projections can lag behind explicit operator edits.
         // Keep local roster intent unless the defaults still match, while an
@@ -13270,8 +13271,8 @@ public final class RuntimeViewModel {
         return localDefaultModelID == projectedDefaultModelID || session.servedModelIDs.isEmpty
     }
 
-    private func applyServingDefaultsProjection(to session: inout DesktopServerSessionState) {
-        guard let projection = Self.servingDefaultsProjection(from: latestSnapshot, serverSessionID: session.id) else {
+    private func applyServingDefaultsProjection(to session: inout DesktopProviderState) {
+        guard let projection = Self.servingDefaultsProjection(from: latestSnapshot, providerID: session.id) else {
             let effectiveBatchingDefaults = Self.effectiveBatchingDefaults(
                 concurrentProcessingEnabled: session.servingDefaults.concurrentProcessingEnabled,
                 maxConcurrentRequests: session.servingDefaults.maxConcurrentRequests,
@@ -13435,13 +13436,13 @@ public final class RuntimeViewModel {
 
     private static func gatewayConfigProjection(
         from snapshot: Melix_Controlplane_V1_ServerSnapshot,
-        serverSessionID: String
+        providerID: String
     ) -> GatewayConfigProjection? {
         guard snapshot.hasGatewayConfig else {
             return nil
         }
         guard
-            let listener = snapshot.gatewayConfig.listeners.first(where: { $0.providerID == serverSessionID })
+            let listener = snapshot.gatewayConfig.listeners.first(where: { $0.providerID == providerID })
                 ?? (snapshot.gatewayConfig.listeners.count == 1 ? snapshot.gatewayConfig.listeners.first : nil)
         else {
             return nil
@@ -13474,13 +13475,13 @@ public final class RuntimeViewModel {
 
     private static func servingDefaultsProjection(
         from snapshot: Melix_Controlplane_V1_ServerSnapshot,
-        serverSessionID: String
+        providerID: String
     ) -> ServingDefaultsProjection? {
         guard snapshot.hasServingDefaults else {
             return nil
         }
         guard
-            let summary = snapshot.servingDefaults.sessions.first(where: { $0.providerID == serverSessionID })
+            let summary = snapshot.servingDefaults.sessions.first(where: { $0.providerID == providerID })
                 ?? (snapshot.servingDefaults.sessions.count == 1 ? snapshot.servingDefaults.sessions.first : nil)
         else {
             return nil
@@ -13705,10 +13706,10 @@ public final class RuntimeViewModel {
     }
 
     private func runtimeSession(
-        for serverSessionID: String,
+        for providerID: String,
         fallbackIndex: Int
     ) -> Melix_Controlplane_V1_ProviderRuntimeState? {
-        if let exactMatch = latestSnapshot.providers.first(where: { $0.providerID == serverSessionID }) {
+        if let exactMatch = latestSnapshot.providers.first(where: { $0.providerID == providerID }) {
             return exactMatch
         }
         if latestSnapshot.providers.count == 1, fallbackIndex == 0 {
@@ -13718,7 +13719,7 @@ public final class RuntimeViewModel {
     }
 
     private func applyRuntimeSessionProjection(
-        to session: inout DesktopServerSessionState,
+        to session: inout DesktopProviderState,
         runtimeSession: Melix_Controlplane_V1_ProviderRuntimeState
     ) {
         session.lifecycle = Self.serverSessionLifecycle(runtimeSession.lifecycleState)
@@ -13823,7 +13824,7 @@ public final class RuntimeViewModel {
         statusTitle = "Melix \(serverStateText)"
 
         for provider in payload.providers {
-            updateServerSessionCollections(serverSessionID: provider.providerID) { session in
+            updateServerSessionCollections(providerID: provider.providerID) { session in
                 session.lifecycle = Self.cliServerSessionLifecycle(provider.lifecycleState)
                 session.powerState = Self.cliServerSessionPowerState(provider.powerState)
                 session.wakeReason = Self.cliServerWakeReason(provider.wakeReason)
@@ -13837,18 +13838,18 @@ public final class RuntimeViewModel {
     }
 
     private func updateServerSessionCollections(
-        serverSessionID: String,
-        update: (inout DesktopServerSessionState) -> Void
+        providerID: String,
+        update: (inout DesktopProviderState) -> Void
     ) {
-        if let index = persistedServerSessions.firstIndex(where: { $0.id == serverSessionID }) {
+        if let index = persistedServerSessions.firstIndex(where: { $0.id == providerID }) {
             var session = persistedServerSessions[index]
             update(&session)
             persistedServerSessions[index] = session
         }
-        if let index = serverSessions.firstIndex(where: { $0.id == serverSessionID }) {
-            var session = serverSessions[index]
+        if let index = providers.firstIndex(where: { $0.id == providerID }) {
+            var session = providers[index]
             update(&session)
-            serverSessions[index] = session
+            providers[index] = session
         }
     }
 
@@ -14033,7 +14034,7 @@ public final class RuntimeViewModel {
         }
     }
 
-    private static func cliServerSessionLifecycle(_ value: String) -> DesktopServerSessionLifecycle {
+    private static func cliServerSessionLifecycle(_ value: String) -> DesktopProviderLifecycle {
         switch value {
         case "ready":
             return .running
@@ -15319,7 +15320,7 @@ public final class RuntimeViewModel {
 
     private static func serverSessionLifecycle(
         _ state: Melix_Controlplane_V1_ProviderLifecycleState
-    ) -> DesktopServerSessionLifecycle {
+    ) -> DesktopProviderLifecycle {
         switch state {
         case .loading:
             return .starting

--- a/apps/macos-menubar/Sources/AppMain/Persistence/OperatorSessionStore.swift
+++ b/apps/macos-menubar/Sources/AppMain/Persistence/OperatorSessionStore.swift
@@ -5,9 +5,9 @@ public struct OperatorSessionState: Codable, Equatable, Sendable {
     public var schemaVersion: Int
     public var selectedSurface: DesktopSurface
     public var selectedToolSection: DesktopToolSection
-    public var selectedServerSessionID: String
+    public var selectedProviderID: String
     public var selectedRuntimeJobID: String
-    public var serverSessions: [DesktopServerSessionState]
+    public var providers: [DesktopProviderState]
     public var dismissedBannerIDs: [String]
     public var downloadQueue: [RuntimeDownloadQueueEntryState]
     public var registryRoots: [String]
@@ -17,9 +17,9 @@ public struct OperatorSessionState: Codable, Equatable, Sendable {
         schemaVersion: Int = 6,
         selectedSurface: DesktopSurface,
         selectedToolSection: DesktopToolSection = .modelsLibrary,
-        selectedServerSessionID: String,
+        selectedProviderID: String,
         selectedRuntimeJobID: String = "",
-        serverSessions: [DesktopServerSessionState],
+        providers: [DesktopProviderState],
         dismissedBannerIDs: [String] = [],
         downloadQueue: [RuntimeDownloadQueueEntryState] = [],
         registryRoots: [String] = [],
@@ -28,9 +28,9 @@ public struct OperatorSessionState: Codable, Equatable, Sendable {
         self.schemaVersion = max(schemaVersion, 6)
         self.selectedSurface = selectedSurface
         self.selectedToolSection = selectedToolSection
-        self.selectedServerSessionID = selectedServerSessionID
+        self.selectedProviderID = selectedProviderID
         self.selectedRuntimeJobID = selectedRuntimeJobID
-        self.serverSessions = serverSessions
+        self.providers = providers
         self.dismissedBannerIDs = dismissedBannerIDs
         self.downloadQueue = downloadQueue
         self.registryRoots = registryRoots
@@ -41,9 +41,9 @@ public struct OperatorSessionState: Codable, Equatable, Sendable {
         case schemaVersion = "schema_version"
         case selectedSurface = "selected_surface"
         case selectedToolSection = "selected_tool_section"
-        case selectedServerSessionID = "selected_server_session_id"
+        case selectedProviderID = "selected_provider_id"
         case selectedRuntimeJobID = "selected_runtime_job_id"
-        case serverSessions = "server_sessions"
+        case providers = "providers"
         case dismissedBannerIDs = "dismissed_banner_ids"
         case downloadQueue = "download_queue"
         case registryRoots = "registry_roots"
@@ -59,9 +59,9 @@ public struct OperatorSessionState: Codable, Equatable, Sendable {
             schemaVersion: try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 4,
             selectedSurface: DesktopSurface(operatorSessionID: selectedSurfaceID, selectedToolSection: selectedToolSection),
             selectedToolSection: selectedToolSection,
-            selectedServerSessionID: try container.decodeIfPresent(String.self, forKey: .selectedServerSessionID) ?? "",
+            selectedProviderID: try container.decodeIfPresent(String.self, forKey: .selectedProviderID) ?? "",
             selectedRuntimeJobID: try container.decodeIfPresent(String.self, forKey: .selectedRuntimeJobID) ?? "",
-            serverSessions: try container.decodeIfPresent([DesktopServerSessionState].self, forKey: .serverSessions) ?? [],
+            providers: try container.decodeIfPresent([DesktopProviderState].self, forKey: .providers) ?? [],
             dismissedBannerIDs: try container.decodeIfPresent([String].self, forKey: .dismissedBannerIDs) ?? [],
             downloadQueue: try container.decodeIfPresent([RuntimeDownloadQueueEntryState].self, forKey: .downloadQueue) ?? [],
             registryRoots: try container.decodeIfPresent([String].self, forKey: .registryRoots) ?? [],
@@ -75,9 +75,9 @@ public struct OperatorSessionState: Codable, Equatable, Sendable {
         try container.encode(schemaVersion, forKey: .schemaVersion)
         try container.encode(selectedSurface.operatorSessionID, forKey: .selectedSurface)
         try container.encode(selectedToolSection.operatorSessionID, forKey: .selectedToolSection)
-        try container.encode(selectedServerSessionID, forKey: .selectedServerSessionID)
+        try container.encode(selectedProviderID, forKey: .selectedProviderID)
         try container.encode(selectedRuntimeJobID, forKey: .selectedRuntimeJobID)
-        try container.encode(serverSessions, forKey: .serverSessions)
+        try container.encode(providers, forKey: .providers)
         try container.encode(dismissedBannerIDs, forKey: .dismissedBannerIDs)
         try container.encode(downloadQueue, forKey: .downloadQueue)
         try container.encode(registryRoots, forKey: .registryRoots)
@@ -133,9 +133,9 @@ private extension OperatorSessionState {
                 selectedToolSection: selectedToolSection
             ),
             selectedToolSection: selectedToolSection,
-            selectedServerSessionID: sharedState.selectedServerSessionID,
+            selectedProviderID: sharedState.selectedProviderID,
             selectedRuntimeJobID: sharedState.selectedRuntimeJobID,
-            serverSessions: sharedState.serverSessions.map(DesktopServerSessionState.init(sharedState:)),
+            providers: sharedState.providers.map(DesktopProviderState.init(sharedState:)),
             dismissedBannerIDs: sharedState.dismissedBannerIDs,
             downloadQueue: sharedState.downloadQueue.map(RuntimeDownloadQueueEntryState.init(sharedState:)),
             registryRoots: sharedState.registryRoots,
@@ -148,9 +148,9 @@ private extension OperatorSessionState {
             schemaVersion: schemaVersion,
             selectedSurfaceID: selectedSurface.operatorSessionID,
             selectedToolSectionID: selectedToolSection.operatorSessionID,
-            selectedServerSessionID: selectedServerSessionID,
+            selectedProviderID: selectedProviderID,
             selectedRuntimeJobID: selectedRuntimeJobID,
-            serverSessions: serverSessions.map(\.sharedState),
+            providers: providers.map(\.sharedState),
             dismissedBannerIDs: dismissedBannerIDs,
             downloadQueue: downloadQueue.map(\.sharedState),
             registryRoots: registryRoots,
@@ -177,8 +177,8 @@ private extension DesktopPaneVisibilityState {
     }
 }
 
-private extension DesktopServerServingDefaultsState {
-    init(sharedState: MelixOperatorServerServingDefaultsState) {
+private extension DesktopProviderServingDefaultsState {
+    init(sharedState: MelixOperatorProviderServingDefaultsState) {
         self.init(
             temperature: sharedState.temperature,
             topP: sharedState.topP,
@@ -196,8 +196,8 @@ private extension DesktopServerServingDefaultsState {
         )
     }
 
-    var sharedState: MelixOperatorServerServingDefaultsState {
-        MelixOperatorServerServingDefaultsState(
+    var sharedState: MelixOperatorProviderServingDefaultsState {
+        MelixOperatorProviderServingDefaultsState(
             temperature: temperature,
             topP: topP,
             maxTokens: maxTokens,
@@ -214,8 +214,8 @@ private extension DesktopServerServingDefaultsState {
     }
 }
 
-private extension DesktopServerSessionState {
-    init(sharedState: MelixOperatorServerSessionState) {
+private extension DesktopProviderState {
+    init(sharedState: MelixOperatorProviderState) {
         self.init(
             id: sharedState.id,
             title: sharedState.title,
@@ -228,8 +228,8 @@ private extension DesktopServerSessionState {
             rateLimitPerMinute: sharedState.rateLimitPerMinute,
             timeoutSeconds: sharedState.timeoutSeconds,
             modelIdleTimeoutSeconds: sharedState.modelIdleTimeoutSeconds,
-            servingDefaults: DesktopServerServingDefaultsState(sharedState: sharedState.servingDefaults),
-            lifecycle: DesktopServerSessionLifecycle(sharedState: sharedState.lifecycle),
+            servingDefaults: DesktopProviderServingDefaultsState(sharedState: sharedState.servingDefaults),
+            lifecycle: DesktopProviderLifecycle(sharedState: sharedState.lifecycle),
             autoSleepEnabled: sharedState.autoSleepEnabled,
             lightSleepAfterSeconds: sharedState.lightSleepAfterSeconds,
             deepSleepAfterSeconds: sharedState.deepSleepAfterSeconds,
@@ -240,8 +240,8 @@ private extension DesktopServerSessionState {
         )
     }
 
-    var sharedState: MelixOperatorServerSessionState {
-        MelixOperatorServerSessionState(
+    var sharedState: MelixOperatorProviderState {
+        MelixOperatorProviderState(
             id: id,
             title: title,
             defaultModelID: defaultModelID,
@@ -314,8 +314,8 @@ private extension RuntimeDownloadQueueEntryState {
     }
 }
 
-private extension DesktopServerSessionLifecycle {
-    init(sharedState: MelixOperatorServerSessionLifecycle) {
+private extension DesktopProviderLifecycle {
+    init(sharedState: MelixOperatorProviderLifecycle) {
         switch sharedState {
         case .draft:
             self = .draft
@@ -338,7 +338,7 @@ private extension DesktopServerSessionLifecycle {
         }
     }
 
-    var sharedState: MelixOperatorServerSessionLifecycle {
+    var sharedState: MelixOperatorProviderLifecycle {
         switch self {
         case .draft:
             return .draft

--- a/apps/macos-menubar/Sources/AppMain/Persistence/ProviderAPIKeyStore.swift
+++ b/apps/macos-menubar/Sources/AppMain/Persistence/ProviderAPIKeyStore.swift
@@ -1,38 +1,38 @@
 import Foundation
 
-public struct ServerSessionPrimaryAPIKeyRecord: Codable, Equatable, Sendable {
-    public var serverSessionID: String
+public struct ProviderPrimaryAPIKeyRecord: Codable, Equatable, Sendable {
+    public var providerID: String
     public var keyID: String
     public var primaryKey: String
     public var updatedAt: Date
 
     public init(
-        serverSessionID: String,
+        providerID: String,
         keyID: String,
         primaryKey: String,
         updatedAt: Date
     ) {
-        self.serverSessionID = serverSessionID
+        self.providerID = providerID
         self.keyID = keyID
         self.primaryKey = primaryKey
         self.updatedAt = updatedAt
     }
 
     enum CodingKeys: String, CodingKey {
-        case serverSessionID = "server_session_id"
+        case providerID = "provider_id"
         case keyID = "key_id"
         case primaryKey = "primary_key"
         case updatedAt = "updated_at"
     }
 }
 
-private struct ServerSessionAPIKeyStoreDocument: Codable, Equatable, Sendable {
+private struct ProviderAPIKeyStoreDocument: Codable, Equatable, Sendable {
     var schemaVersion: Int
-    var sessions: [ServerSessionPrimaryAPIKeyRecord]
+    var sessions: [ProviderPrimaryAPIKeyRecord]
 
     init(
         schemaVersion: Int = 1,
-        sessions: [ServerSessionPrimaryAPIKeyRecord] = []
+        sessions: [ProviderPrimaryAPIKeyRecord] = []
     ) {
         self.schemaVersion = schemaVersion
         self.sessions = sessions
@@ -44,31 +44,31 @@ private struct ServerSessionAPIKeyStoreDocument: Codable, Equatable, Sendable {
     }
 }
 
-public protocol ServerSessionAPIKeyStoring: Sendable {
-    func loadPrimaryKey(serverSessionID: String) throws -> ServerSessionPrimaryAPIKeyRecord?
+public protocol ProviderAPIKeyStoring: Sendable {
+    func loadPrimaryKey(providerID: String) throws -> ProviderPrimaryAPIKeyRecord?
     @discardableResult
     func savePrimaryKey(
-        serverSessionID: String,
+        providerID: String,
         primaryKey: String,
         keyID: String
-    ) throws -> ServerSessionPrimaryAPIKeyRecord
+    ) throws -> ProviderPrimaryAPIKeyRecord
 }
 
-public struct NullServerSessionAPIKeyStore: ServerSessionAPIKeyStoring {
+public struct NullProviderAPIKeyStore: ProviderAPIKeyStoring {
     public init() {}
 
-    public func loadPrimaryKey(serverSessionID: String) throws -> ServerSessionPrimaryAPIKeyRecord? {
-        _ = serverSessionID
+    public func loadPrimaryKey(providerID: String) throws -> ProviderPrimaryAPIKeyRecord? {
+        _ = providerID
         return nil
     }
 
     public func savePrimaryKey(
-        serverSessionID: String,
+        providerID: String,
         primaryKey: String,
         keyID: String
-    ) throws -> ServerSessionPrimaryAPIKeyRecord {
-        ServerSessionPrimaryAPIKeyRecord(
-            serverSessionID: serverSessionID,
+    ) throws -> ProviderPrimaryAPIKeyRecord {
+        ProviderPrimaryAPIKeyRecord(
+            providerID: providerID,
             keyID: keyID,
             primaryKey: primaryKey,
             updatedAt: Date()
@@ -76,50 +76,50 @@ public struct NullServerSessionAPIKeyStore: ServerSessionAPIKeyStoring {
     }
 }
 
-public struct ServerSessionAPIKeyStore: ServerSessionAPIKeyStoring {
+public struct ProviderAPIKeyStore: ProviderAPIKeyStoring {
     private let melixHome: MelixHome
 
     public init(melixHome: MelixHome) {
         self.melixHome = melixHome
     }
 
-    public func loadPrimaryKey(serverSessionID: String) throws -> ServerSessionPrimaryAPIKeyRecord? {
+    public func loadPrimaryKey(providerID: String) throws -> ProviderPrimaryAPIKeyRecord? {
         let document = try loadDocument()
-        return document.sessions.first(where: { $0.serverSessionID == serverSessionID })
+        return document.sessions.first(where: { $0.providerID == providerID })
     }
 
     @discardableResult
     public func savePrimaryKey(
-        serverSessionID: String,
+        providerID: String,
         primaryKey: String,
         keyID: String = "primary"
-    ) throws -> ServerSessionPrimaryAPIKeyRecord {
+    ) throws -> ProviderPrimaryAPIKeyRecord {
         var document = try loadDocument()
-        let record = ServerSessionPrimaryAPIKeyRecord(
-            serverSessionID: serverSessionID,
+        let record = ProviderPrimaryAPIKeyRecord(
+            providerID: providerID,
             keyID: keyID,
             primaryKey: primaryKey,
             updatedAt: Date()
         )
-        if let index = document.sessions.firstIndex(where: { $0.serverSessionID == serverSessionID }) {
+        if let index = document.sessions.firstIndex(where: { $0.providerID == providerID }) {
             document.sessions[index] = record
         } else {
             document.sessions.append(record)
-            document.sessions.sort { $0.serverSessionID < $1.serverSessionID }
+            document.sessions.sort { $0.providerID < $1.providerID }
         }
         let data = try Self.encoder.encode(document)
-        try melixHome.writeAtomically(data, to: melixHome.serverSessionAPIKeysFileURL)
+        try melixHome.writeAtomically(data, to: melixHome.providerAPIKeysFileURL)
         return record
     }
 
-    private func loadDocument() throws -> ServerSessionAPIKeyStoreDocument {
+    private func loadDocument() throws -> ProviderAPIKeyStoreDocument {
         let fileManager = FileManager.default
-        let fileURL = melixHome.serverSessionAPIKeysFileURL
+        let fileURL = melixHome.providerAPIKeysFileURL
         guard fileManager.fileExists(atPath: fileURL.path) else {
-            return ServerSessionAPIKeyStoreDocument()
+            return ProviderAPIKeyStoreDocument()
         }
         let data = try Data(contentsOf: fileURL)
-        return try Self.decoder.decode(ServerSessionAPIKeyStoreDocument.self, from: data)
+        return try Self.decoder.decode(ProviderAPIKeyStoreDocument.self, from: data)
     }
 
     private static let encoder: JSONEncoder = {

--- a/apps/macos-menubar/Tests/MenuBarTests/AgentIntegrationExportSmokeTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/AgentIntegrationExportSmokeTests.swift
@@ -7,8 +7,8 @@ import Testing
 struct AgentIntegrationExportSmokeTests {
     @Test("agent integration export smoke fixture produces all targets")
     func agentIntegrationExportSmokeFixtureProducesAllTargets() throws {
-        let session = DesktopServerSessionState(
-            id: "server-session-smoke",
+        let session = DesktopProviderState(
+            id: "provider-smoke",
             title: "Smoke Server",
             modelID: "melix-dev-text",
             host: "127.0.0.1",

--- a/apps/macos-menubar/Tests/MenuBarTests/AppMainBootstrapTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/AppMainBootstrapTests.swift
@@ -1172,10 +1172,10 @@ struct AppMainBootstrapTests {
         try await withEnvironmentValue("MELIX_HOME", melixHomePath.path) {
             let melixHome = MelixHome(environment: ProcessInfo.processInfo.environment)
             let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-            let apiKeyStore = ServerSessionAPIKeyStore(melixHome: melixHome)
+            let apiKeyStore = ProviderAPIKeyStore(melixHome: melixHome)
             let hfTokenStore = HuggingFaceTokenStore(melixHome: melixHome)
-            let serverSession = DesktopServerSessionState(
-                id: "server-session-1",
+            let serverSession = DesktopProviderState(
+                id: "provider-1",
                 title: "Primary Server",
                 modelID: "melix-dev-text"
             )
@@ -1183,12 +1183,12 @@ struct AppMainBootstrapTests {
             try operatorSessionStore.save(
                 OperatorSessionState(
                     selectedSurface: .server,
-                    selectedServerSessionID: serverSession.id,
-                    serverSessions: [serverSession]
+                    selectedProviderID: serverSession.id,
+                    providers: [serverSession]
                 )
             )
             try apiKeyStore.savePrimaryKey(
-                serverSessionID: serverSession.id,
+                providerID: serverSession.id,
                 primaryKey: "melix_sk_test_primary"
             )
             try hfTokenStore.saveToken("hf_secret_token")
@@ -1198,8 +1198,8 @@ struct AppMainBootstrapTests {
             #expect(try posixPermissions(at: melixHome.stateDirectoryURL) == 0o700)
             #expect(try posixPermissions(at: melixHome.secretsDirectoryURL) == 0o700)
             #expect(try posixPermissions(at: melixHome.operatorSessionFileURL) == 0o600)
-            #expect(try posixPermissions(at: melixHome.serverSessionsFileURL) == 0o600)
-            #expect(try posixPermissions(at: melixHome.serverSessionAPIKeysFileURL) == 0o600)
+            #expect(try posixPermissions(at: melixHome.providersFileURL) == 0o600)
+            #expect(try posixPermissions(at: melixHome.providerAPIKeysFileURL) == 0o600)
             #expect(try posixPermissions(at: melixHome.huggingFaceTokenFileURL) == 0o600)
         }
     }
@@ -1211,7 +1211,7 @@ struct AppMainBootstrapTests {
             client: FakeControlPlaneXPCClient(),
             melixHome: MelixHome(environment: ProcessInfo.processInfo.environment),
             operatorSessionStore: nil,
-            serverSessionAPIKeyStore: nil,
+            providerAPIKeyStore: nil,
             statusMenuFactory: { _, _, _ in RecordingInstallStatusMenu() }
         )
 

--- a/apps/macos-menubar/Tests/MenuBarTests/ControlPlaneXPCClientTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/ControlPlaneXPCClientTests.swift
@@ -56,42 +56,42 @@ struct ControlPlaneXPCClientTests {
         let service = ControlPlaneService()
         let client = LocalControlPlaneXPCClient(service: service)
         let initialSnapshot = try await client.serverSnapshot()
-        let serverSessionID = try #require(initialSnapshot.providers.first?.providerID)
+        let providerID = try #require(initialSnapshot.providers.first?.providerID)
 
-        let pausedSnapshot = try await client.pauseServerSession(serverSessionID: serverSessionID)
+        let pausedSnapshot = try await client.pauseServerSession(serverSessionID: providerID)
         let pausedSession = try #require(
-            pausedSnapshot.providers.first(where: { $0.providerID == serverSessionID })
+            pausedSnapshot.providers.first(where: { $0.providerID == providerID })
         )
         #expect(pausedSession.lifecycleState == .paused)
 
         let idlePolicySnapshot = try await client.updateServerIdlePolicy(
-            serverSessionID: serverSessionID,
+            serverSessionID: providerID,
             autoSleepEnabled: true,
             lightSleepAfterSeconds: 300,
             deepSleepAfterSeconds: 900
         )
         let idlePolicySession = try #require(
-            idlePolicySnapshot.providers.first(where: { $0.providerID == serverSessionID })
+            idlePolicySnapshot.providers.first(where: { $0.providerID == providerID })
         )
         #expect(idlePolicySession.autoSleepEnabled)
         #expect(idlePolicySession.lightSleepAfterSeconds == 300)
         #expect(idlePolicySession.deepSleepAfterSeconds == 900)
 
-        let resumedSnapshot = try await client.resumeServerSession(serverSessionID: serverSessionID)
+        let resumedSnapshot = try await client.resumeServerSession(serverSessionID: providerID)
         let resumedSession = try #require(
-            resumedSnapshot.providers.first(where: { $0.providerID == serverSessionID })
+            resumedSnapshot.providers.first(where: { $0.providerID == providerID })
         )
         #expect(resumedSession.lifecycleState == .ready)
 
-        let stoppedSnapshot = try await client.stopServerSession(serverSessionID: serverSessionID)
+        let stoppedSnapshot = try await client.stopServerSession(serverSessionID: providerID)
         let stoppedSession = try #require(
-            stoppedSnapshot.providers.first(where: { $0.providerID == serverSessionID })
+            stoppedSnapshot.providers.first(where: { $0.providerID == providerID })
         )
         #expect(stoppedSession.lifecycleState == .stopped)
 
-        let startedSnapshot = try await client.startServerSession(serverSessionID: serverSessionID)
+        let startedSnapshot = try await client.startServerSession(serverSessionID: providerID)
         let startedSession = try #require(
-            startedSnapshot.providers.first(where: { $0.providerID == serverSessionID })
+            startedSnapshot.providers.first(where: { $0.providerID == providerID })
         )
         #expect(startedSession.lifecycleState == .ready)
     }
@@ -351,7 +351,7 @@ struct ControlPlaneXPCClientTests {
 
         do {
             _ = try await client.applyServerSessionServingDefaults(
-                serverSessionID: "server-session-1",
+                serverSessionID: "provider-1",
                 temperature: 0.7,
                 topP: 1.0,
                 maxTokens: 256,
@@ -382,7 +382,7 @@ struct ControlPlaneXPCClientTests {
 
         do {
             _ = try await client.applyServerSessionGatewayConfig(
-                serverSessionID: "server-session-1",
+                serverSessionID: "provider-1",
                 host: "127.0.0.1",
                 port: 12_436,
                 defaultModelID: "melix-dev-text",
@@ -800,7 +800,7 @@ struct ControlPlaneXPCClientTests {
         let client = LocalControlPlaneXPCClient(service: service)
 
         try await client.applyServerSessionGatewayAccess(
-            serverSessionID: "server-session-123",
+                serverSessionID: "provider-123",
             primaryKey: "melix_sk_primary_123",
             keyID: "primary",
             label: "primary",
@@ -808,10 +808,10 @@ struct ControlPlaneXPCClientTests {
         )
         let request = try #require(await service.lastExecuteRequest)
 
-        #expect(request.requestID == "menubar-apply-gateway-access-server-session-123")
+        #expect(request.requestID == "menubar-apply-gateway-access-provider-123")
         #expect(request.commandType == "server.apply_gateway_access")
-        #expect(request.targetID == "server-session-123")
-        #expect(request.server.applyGatewayAccess.providerID == "server-session-123")
+        #expect(request.targetID == "provider-123")
+        #expect(request.server.applyGatewayAccess.providerID == "provider-123")
         #expect(request.server.applyGatewayAccess.mode == .apiKeys)
         #expect(request.server.applyGatewayAccess.sharedAccessEnabled)
         #expect(request.server.applyGatewayAccess.primaryKey.keyID == "primary")
@@ -825,13 +825,13 @@ struct ControlPlaneXPCClientTests {
         let service = RecordingExecuteControlPlaneService()
         let client = LocalControlPlaneXPCClient(service: service)
 
-        try await client.clearServerSessionGatewayAccess(serverSessionID: "server-session-123")
+        try await client.clearServerSessionGatewayAccess(serverSessionID: "provider-123")
         let request = try #require(await service.lastExecuteRequest)
 
-        #expect(request.requestID == "menubar-clear-gateway-access-server-session-123")
+        #expect(request.requestID == "menubar-clear-gateway-access-provider-123")
         #expect(request.commandType == "server.apply_gateway_access")
-        #expect(request.targetID == "server-session-123")
-        #expect(request.server.applyGatewayAccess.providerID == "server-session-123")
+        #expect(request.targetID == "provider-123")
+        #expect(request.server.applyGatewayAccess.providerID == "provider-123")
         #expect(request.server.applyGatewayAccess.mode == .none)
         #expect(request.server.applyGatewayAccess.sharedAccessEnabled == false)
         #expect(request.server.applyGatewayAccess.hasPrimaryKey == false)
@@ -845,7 +845,7 @@ struct ControlPlaneXPCClientTests {
         response.server = Melix_Controlplane_V1_ServerReply()
         response.server.snapshot.serverState = .serverReady
         var listener = Melix_Controlplane_V1_GatewayListenerConfigSummary()
-        listener.providerID = "server-session-123"
+        listener.providerID = "provider-123"
         listener.requestedHost = "0.0.0.0"
         listener.requestedPort = 18080
         listener.effectiveHost = "127.0.0.1"
@@ -865,7 +865,7 @@ struct ControlPlaneXPCClientTests {
         let client = LocalControlPlaneXPCClient(service: service)
 
         let snapshot = try await client.applyServerSessionGatewayConfig(
-            serverSessionID: "server-session-123",
+                serverSessionID: "provider-123",
             host: "0.0.0.0",
             port: 18080,
             defaultModelID: "melix-dev-text",
@@ -878,10 +878,10 @@ struct ControlPlaneXPCClientTests {
         )
         let request = try #require(await service.lastExecuteRequest)
 
-        #expect(request.requestID == "menubar-apply-gateway-config-server-session-123")
+        #expect(request.requestID == "menubar-apply-gateway-config-provider-123")
         #expect(request.commandType == "server.apply_gateway_config")
-        #expect(request.targetID == "server-session-123")
-        #expect(request.server.applyGatewayConfig.providerID == "server-session-123")
+        #expect(request.targetID == "provider-123")
+        #expect(request.server.applyGatewayConfig.providerID == "provider-123")
         #expect(request.server.applyGatewayConfig.host == "0.0.0.0")
         #expect(request.server.applyGatewayConfig.port == 18_080)
         #expect(request.server.applyGatewayConfig.defaultModelID == "melix-dev-text")
@@ -904,7 +904,7 @@ struct ControlPlaneXPCClientTests {
         response.ok = true
         response.server = Melix_Controlplane_V1_ServerReply()
         var servingDefaults = Melix_Controlplane_V1_ServingDefaultsSessionSummary()
-        servingDefaults.providerID = "server-session-123"
+        servingDefaults.providerID = "provider-123"
         servingDefaults.requestedTemperature = 0.33
         servingDefaults.requestedTopP = 0.92
         servingDefaults.requestedMaxTokens = 384
@@ -921,7 +921,7 @@ struct ControlPlaneXPCClientTests {
         let client = LocalControlPlaneXPCClient(service: service)
 
         let snapshot = try await client.applyServerSessionServingDefaults(
-            serverSessionID: "server-session-123",
+                serverSessionID: "provider-123",
             temperature: 0.33,
             topP: 0.92,
             maxTokens: 384,
@@ -937,10 +937,10 @@ struct ControlPlaneXPCClientTests {
         )
         let request = try #require(await service.lastExecuteRequest)
 
-        #expect(request.requestID == "menubar-apply-serving-defaults-server-session-123")
+        #expect(request.requestID == "menubar-apply-serving-defaults-provider-123")
         #expect(request.commandType == "server.apply_serving_defaults")
-        #expect(request.targetID == "server-session-123")
-        #expect(request.server.applyServingDefaults.providerID == "server-session-123")
+        #expect(request.targetID == "provider-123")
+        #expect(request.server.applyServingDefaults.providerID == "provider-123")
         #expect(request.server.applyServingDefaults.temperature == 0.33)
         #expect(request.server.applyServingDefaults.topP == 0.92)
         #expect(request.server.applyServingDefaults.maxTokens == 384)
@@ -1158,7 +1158,7 @@ struct ControlPlaneXPCClientTests {
 
         do {
             try await client.applyServerSessionGatewayAccess(
-                serverSessionID: "server-session-default",
+                serverSessionID: "provider-default",
                 primaryKey: "melix_sk_default",
                 keyID: "primary",
                 label: "primary",
@@ -1175,7 +1175,7 @@ struct ControlPlaneXPCClientTests {
         }
 
         do {
-            try await client.clearServerSessionGatewayAccess(serverSessionID: "server-session-default")
+            try await client.clearServerSessionGatewayAccess(serverSessionID: "provider-default")
             Issue.record("Expected clearServerSessionGatewayAccess to throw for the default protocol implementation")
         } catch let error as ControlPlaneXPCClientError {
             #expect(

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -413,13 +413,13 @@ struct DesktopFoundationViewTests {
         snapshot.serverState = .serverReady
         snapshot.models = [makeMenuBarModelSummary(modelID: desktopTestReadyModelID, state: .modelWarm)]
         var runtimeSession = Melix_Controlplane_V1_ProviderRuntimeState()
-        runtimeSession.providerID = "server-session-1"
+        runtimeSession.providerID = "provider-1"
         runtimeSession.lifecycleState = .ready
         runtimeSession.powerState = .active
         runtimeSession.wakeReason = .initialBoot
         snapshot.providers = [runtimeSession]
         var listener = Melix_Controlplane_V1_GatewayListenerConfigSummary()
-        listener.providerID = "server-session-1"
+        listener.providerID = "provider-1"
         listener.requestedHost = "0.0.0.0"
         listener.requestedPort = 18080
         listener.effectiveHost = "127.0.0.1"
@@ -433,7 +433,7 @@ struct DesktopFoundationViewTests {
         listener.requiresRestart = true
         snapshot.gatewayConfig.listeners = [listener]
         var servingDefaults = Melix_Controlplane_V1_ServingDefaultsSessionSummary()
-        servingDefaults.providerID = "server-session-1"
+        servingDefaults.providerID = "provider-1"
         servingDefaults.defaultModelID = desktopTestReadyModelID
         servingDefaults.requestedTemperature = 0.33
         servingDefaults.requestedTopP = 0.92
@@ -488,7 +488,7 @@ struct DesktopFoundationViewTests {
         snapshot.models = [makeMenuBarModelSummary(modelID: desktopTestReadyModelID, state: .modelWarm)]
         snapshot.providers = [makeDesktopRuntimeSession()]
         var servingDefaults = Melix_Controlplane_V1_ServingDefaultsSessionSummary()
-        servingDefaults.providerID = "server-session-1"
+        servingDefaults.providerID = "provider-1"
         servingDefaults.defaultModelID = desktopTestReadyModelID
         servingDefaults.requestedTemperature = 0.44
         servingDefaults.requestedTopP = 0.91
@@ -572,6 +572,46 @@ struct DesktopFoundationViewTests {
         #expect(viewModel.selectedServerSession?.servingDefaults.accelerationProfile == "low-memory")
     }
 
+    @Test("workspace server surface renders read-only acceleration modes")
+    @MainActor
+    func workspaceServerSurfaceRendersReadOnlyAccelerationModes() async throws {
+        let cases: [(String, Melix_Controlplane_V1_AccelerationMode, String)] = [
+            ("accelerated_prefill", .acceleratedPrefill, "Accelerated Prefill"),
+            ("active_kv_quantized", .activeKvQuantized, "Active KV Quantized"),
+            ("sparse_prefill", .sparsePrefill, "Sparse Prefill"),
+        ]
+
+        for (mode, accelerationMode, expectedModeText) in cases {
+            let client = FakeControlPlaneXPCClient()
+            var snapshot = Melix_Controlplane_V1_ServerSnapshot()
+            snapshot.serverState = .serverReady
+            snapshot.models = [makeMenuBarModelSummary(modelID: desktopTestReadyModelID, state: .modelWarm)]
+            snapshot.providers = [makeDesktopRuntimeSession()]
+            var servingDefaults = Melix_Controlplane_V1_ServingDefaultsSessionSummary()
+            servingDefaults.providerID = "provider-1"
+            servingDefaults.defaultModelID = desktopTestReadyModelID
+            servingDefaults.requestedAccelerationMode = accelerationMode
+            servingDefaults.effectiveAccelerationMode = accelerationMode
+            servingDefaults.source = .operatorOverride
+            snapshot.servingDefaults.sessions = [servingDefaults]
+            await client.configureSnapshot(snapshot)
+
+            let viewModel = RuntimeViewModel(client: client)
+            await viewModel.start()
+            viewModel.selectSurface(.server)
+
+            let view = hostView(
+                DesktopWorkspaceShellView(viewModel: viewModel),
+                size: CGSize(width: 1_280, height: 1_400)
+            )
+            let renderedTexts = renderedTextValues(in: view)
+
+            #expect(viewModel.selectedServerSession?.servingDefaults.accelerationMode == mode)
+            #expect(renderedTexts.contains(expectedModeText))
+            #expect(renderedTexts.contains("Resolved defaults: \(expectedModeText) • sequences 0 • prefill 1 • completion 1"))
+        }
+    }
+
     @Test("workspace server surface renders requested and effective acceleration profile receipts")
     @MainActor
     func workspaceServerSurfaceRendersRequestedAndEffectiveAccelerationProfileReceipts() async throws {
@@ -581,7 +621,7 @@ struct DesktopFoundationViewTests {
         snapshot.models = [makeMenuBarModelSummary(modelID: desktopTestReadyModelID, state: .modelWarm)]
         snapshot.providers = [makeDesktopRuntimeSession()]
         var servingDefaults = Melix_Controlplane_V1_ServingDefaultsSessionSummary()
-        servingDefaults.providerID = "server-session-1"
+        servingDefaults.providerID = "provider-1"
         servingDefaults.defaultModelID = desktopTestReadyModelID
         servingDefaults.requestedTemperature = 0.4
         servingDefaults.requestedTopP = 0.9
@@ -628,7 +668,7 @@ struct DesktopFoundationViewTests {
     @Test("profile regression renders requested effective and resolved serving receipts")
     @MainActor
     func profileRegressionRendersRequestedEffectiveAndResolvedServingReceipts() throws {
-        let servingDefaults = DesktopServerServingDefaultsState(
+        let servingDefaults = DesktopProviderServingDefaultsState(
             maxConcurrentRequests: 2,
             concurrentProcessingEnabled: true,
             prefillBatchSize: 2,
@@ -810,7 +850,7 @@ struct DesktopFoundationViewTests {
             DesktopCommandCenterView(
                 foundation: viewModel.desktopFoundationState,
                 chatSessions: viewModel.chatSessions,
-                serverSessions: viewModel.serverSessions
+                providers: viewModel.providers
             )
         )
 
@@ -4624,8 +4664,8 @@ struct DesktopFoundationViewTests {
             lastError: nil,
             recentEvents: []
         )
-        let session = DesktopServerSessionState(
-            id: "server-session-1",
+        let session = DesktopProviderState(
+            id: "provider-1",
             title: "Primary Session",
             modelID: "melix-dev-text",
             effectiveHost: "127.0.0.1",
@@ -4710,8 +4750,8 @@ struct DesktopFoundationViewTests {
             apiSurfaces: [],
             apiReference: []
         )
-        let session = DesktopServerSessionState(
-            id: "server-session-empty-api",
+        let session = DesktopProviderState(
+            id: "provider-empty-api",
             title: "Primary Session",
             modelID: "melix-dev-text",
             effectiveHost: "127.0.0.1",
@@ -4765,7 +4805,7 @@ struct DesktopFoundationViewTests {
             recentEvents: []
         )
 
-        let disabledSession = DesktopServerSessionState(
+        let disabledSession = DesktopProviderState(
             id: "disabled-session",
             title: "Disabled Session",
             modelID: "melix-dev-text",
@@ -4777,7 +4817,7 @@ struct DesktopFoundationViewTests {
             accessKeyHints: ["desktop-agent"],
             lifecycle: .running
         )
-        let unauthenticatedSession = DesktopServerSessionState(
+        let unauthenticatedSession = DesktopProviderState(
             id: "none-session",
             title: "Unauthenticated Session",
             modelID: "melix-dev-text",
@@ -4787,7 +4827,7 @@ struct DesktopFoundationViewTests {
             sharedAccessState: .enabled,
             lifecycle: .running
         )
-        let bearerSession = DesktopServerSessionState(
+        let bearerSession = DesktopProviderState(
             id: "bearer-session",
             title: "Bearer Session",
             modelID: "melix-dev-text",
@@ -4866,12 +4906,16 @@ struct DesktopFoundationViewTests {
             desktopAPIAuthenticationReferenceText(selectedExport: selectedExport)
                 .contains("Selected target:")
         )
+        #expect(
+            desktopAPIAuthenticationReferenceText(selectedExport: nil)
+                == "Select a provider to render auth guidance."
+        )
     }
 
     @Test("gateway access summary and auth guidance cover bearer disabled and enabled shared access")
     @MainActor
     func gatewayAccessSummaryAndAuthGuidanceCoverBearerDisabledAndEnabledStates() throws {
-        let bearerSession = DesktopServerSessionState(
+        let bearerSession = DesktopProviderState(
             id: "bearer-session",
             title: "Bearer Session",
             modelID: "melix-dev-text",
@@ -4882,7 +4926,7 @@ struct DesktopFoundationViewTests {
             accessKeyHints: ["desktop-agent"],
             lifecycle: .running
         )
-        let configuredDisabledSession = DesktopServerSessionState(
+        let configuredDisabledSession = DesktopProviderState(
             id: "disabled-session",
             title: "Disabled Session",
             modelID: "melix-dev-text",
@@ -4891,7 +4935,7 @@ struct DesktopFoundationViewTests {
             accessKeyHints: ["desktop-agent", "codex"],
             lifecycle: .running
         )
-        let enabledSession = DesktopServerSessionState(
+        let enabledSession = DesktopProviderState(
             id: "enabled-session",
             title: "Enabled Session",
             modelID: "melix-dev-text",
@@ -4909,7 +4953,7 @@ struct DesktopFoundationViewTests {
 
         #expect(
             desktopAPIAuthenticationReferenceText(selectedSession: nil, selectedExport: nil)
-                == "Select a server session to render auth guidance."
+                == "Select a provider to render auth guidance."
         )
         #expect(
             desktopAPIAuthenticationReferenceText(selectedSession: bearerSession, selectedExport: nil)
@@ -4928,7 +4972,7 @@ struct DesktopFoundationViewTests {
     @Test("gateway access summary renders persistent session summary and sign-out latency")
     @MainActor
     func gatewayAccessSummaryRendersPersistentSessionSummaryAndSignOutLatency() throws {
-        let session = DesktopServerSessionState(
+        let session = DesktopProviderState(
             id: "persistent-session",
             title: "Persistent Session",
             modelID: "melix-dev-text",
@@ -7436,8 +7480,8 @@ struct DesktopFoundationViewTests {
         var resumeCount = 0
         var wakeCount = 0
 
-        let baseSession = DesktopServerSessionState(
-            id: "server-session-chat-controls",
+        let baseSession = DesktopProviderState(
+            id: "provider-chat-controls",
             title: "Chat Runtime",
             modelID: "melix-dev-text",
             lifecycle: .running,
@@ -7562,8 +7606,8 @@ struct DesktopFoundationViewTests {
             isStreaming: false,
             statusText: "Ready",
             usageText: "12 prompt • 24 completion",
-            serverSession: DesktopServerSessionState(
-                id: "server-session-compose",
+            serverSession: DesktopProviderState(
+                id: "provider-compose",
                 title: "Compose Runtime",
                 modelID: "melix-dev-text",
                 lifecycle: .running,
@@ -7642,13 +7686,13 @@ struct DesktopFoundationViewTests {
         #expect(viewModel.selectedSurface == .server)
 
         workspace.startSelectedChatServerSession()
-        try await waitForRecordedClientAction("server.start:server-session-1", client: client)
+        try await waitForRecordedClientAction("server.start:provider-1", client: client)
 
         workspace.resumeSelectedChatServerSession()
-        try await waitForRecordedClientAction("server.resume:server-session-1", client: client)
+        try await waitForRecordedClientAction("server.resume:provider-1", client: client)
 
         workspace.wakeSelectedChatServerSession()
-        try await waitForRecordedClientAction("server.wake:server-session-1", client: client)
+        try await waitForRecordedClientAction("server.wake:provider-1", client: client)
 
         let emptyClient = FakeControlPlaneXPCClient()
         var emptySnapshot = Melix_Controlplane_V1_ServerSnapshot()
@@ -7696,8 +7740,8 @@ struct DesktopFoundationViewTests {
         #expect(hostView(streamingComposer.primaryActionLabel).fittingSize.width >= 0)
 
         let emptyCapsule = DesktopChatRuntimeServerCapsule(serverSession: nil)
-        var errorSession = DesktopServerSessionState(
-            id: "server-session-error",
+        var errorSession = DesktopProviderState(
+            id: "provider-error",
             title: "Broken Runtime",
             modelID: "melix-dev-text",
             lifecycle: .error,
@@ -8623,14 +8667,14 @@ struct DesktopFoundationViewTests {
         let mainSession = DesktopChatSessionState(
             id: "chat-main",
             title: "Chat 1",
-            serverSessionID: "server-main",
+            providerID: "server-main",
             branchID: "main",
             branchTitle: "Main"
         )
         let forkSession = DesktopChatSessionState(
             id: "chat-fork",
             title: "Chat 2",
-            serverSessionID: "server-main",
+            providerID: "server-main",
             branchID: "branch-2",
             branchTitle: "Branch 2"
         )
@@ -8928,12 +8972,12 @@ struct DesktopFoundationViewTests {
         #expect(pausedNotice.severity == .warning)
         #expect(viewModel.selectedChatServerSession?.isInteractiveReady == false)
 
-        let serverSessionID = try #require(viewModel.selectedServerSession?.id)
+        let providerID = try #require(viewModel.selectedServerSession?.id)
         await client.sendServerStateChanged(
             state: .serverReady,
             runtimeSessions: [
                 makeDesktopRuntimeSession(
-                    serverSessionID: serverSessionID,
+                    providerID: providerID,
                     lifecycleState: .sleeping,
                     powerState: .deepSleep,
                     wakeReason: .requestActivity,
@@ -8944,7 +8988,7 @@ struct DesktopFoundationViewTests {
                 )
             ]
         )
-        try await waitForDesktopFoundationCondition("expected chat-bound server session to enter sleeping state") {
+        try await waitForDesktopFoundationCondition("expected chat-bound provider to enter sleeping state") {
             viewModel.selectedChatServerSession?.lifecycle == .sleeping
         }
 
@@ -9596,7 +9640,7 @@ struct Phase8WindowUIAcceptanceRunnerTests {
                 "MELIX_PHASE8_WINDOW_UI_ACCEPTANCE_MATRIX_SUITES": "   ",
                 "MELIX_PHASE8_WINDOW_UI_ACCEPTANCE_EVALUATION_SUITES": " mmlu , gsm8k ",
                 "MELIX_PHASE8_WINDOW_UI_ACCEPTANCE_EVALUATION_DATASET": "   ",
-                "MELIX_PHASE8_WINDOW_UI_ACCEPTANCE_SERVER_SESSION_ID": "   ",
+                "MELIX_PHASE8_WINDOW_UI_ACCEPTANCE_PROVIDER_ID": "   ",
                 "MELIX_PHASE8_WINDOW_UI_ACCEPTANCE_CLI_BUNDLE_PATH": "   ",
                 "MELIX_PHASE8_WINDOW_UI_ACCEPTANCE_TIMESTAMP": "   ",
             ]
@@ -9611,12 +9655,16 @@ struct Phase8WindowUIAcceptanceRunnerTests {
         #expect(config.matrixSuites == ["smoke"])
         #expect(config.evaluationSuites == ["mmlu", "gsm8k"])
         #expect(config.evaluationDataset == "mmlu.dev.v1")
-        #expect(config.serverSessionID == "server-session-1")
+        #expect(config.providerID == "provider-1")
         #expect(
             URL(fileURLWithPath: config.cliEvidenceBundlePath).resolvingSymlinksInPath().path
                 == cliBundlePath.resolvingSymlinksInPath().path
         )
         #expect(config.timestamp.isEmpty == false)
+        #expect(
+            Phase8WindowUIAcceptanceError.missingServerSession("provider-missing").errorDescription
+                == "Window UI acceptance could not find provider provider-missing."
+        )
     }
 
     @Test("phase 8 window ui downloads surface exposes quantization modes")
@@ -9788,7 +9836,7 @@ struct Phase8WindowUIAcceptanceRunnerTests {
         derivedModel.modelID = derivedModelID
         snapshot.models = [baseModel, derivedModel]
         var runtimeSession = makeDesktopRuntimeSession()
-        runtimeSession.providerID = "server-session-1"
+        runtimeSession.providerID = "provider-1"
         runtimeSession.lifecycleState = .ready
         runtimeSession.powerState = .active
         snapshot.providers = [runtimeSession]
@@ -9809,21 +9857,21 @@ struct Phase8WindowUIAcceptanceRunnerTests {
                 )
             case .modelRootsRescan:
                 return .success("{\"registry_roots\":[\"/tmp/melix-managed\"]}\n")
-            case .serverSessionCreate:
-                return .success("{\"server_session_id\":\"server-session-1\"}\n")
-            case .serverSessionUpdate:
-                return .success("{\"server_session_id\":\"server-session-1\"}\n")
-            case .serverSessionSelect:
-                return .success("{\"selected_server_session_id\":\"server-session-1\"}\n")
+            case .providerCreate:
+                return .success("{\"provider_id\":\"provider-1\"}\n")
+            case .providerUpdate:
+                return .success("{\"provider_id\":\"provider-1\"}\n")
+            case .providerSelect:
+                return .success("{\"selected_provider_id\":\"provider-1\"}\n")
             case .serverStart(let options):
-                return .success(makeCLIServerSnapshotJSON(serverSessionID: options.serverSessionID))
+                return .success(makeCLIServerSnapshotJSON(providerID: options.providerID))
             case .chatRun(let options):
                 let assistantText = options.modelID == derivedModelID ? "DERIVED_OK" : "BASE_OK"
                 return .success(
                     """
                     {
                       "model_id": "\(options.modelID)",
-                      "server_session_id": "server-session-1",
+                      "provider_id": "provider-1",
                       "assistant_text": "\(assistantText)",
                       "finish_reason": "stop",
                       "request_id": "chat-\(assistantText.lowercased())"
@@ -9932,7 +9980,7 @@ struct Phase8WindowUIAcceptanceRunnerTests {
                 matrixSuites: ["smoke"],
                 evaluationSuites: ["mmlu"],
                 evaluationDataset: "mmlu.dev.v1",
-                serverSessionID: "server-session-1",
+                providerID: "provider-1",
                 cliEvidenceBundlePath: cliBundlePath.path,
                 timestamp: "2026-04-09T120000Z"
             ),
@@ -10057,7 +10105,7 @@ struct Phase8WindowUIAcceptanceRunnerTests {
         derivedModel.modelID = derivedModelID
         snapshot.models = [fallbackTextModel, derivedModel]
         var runtimeSession = makeDesktopRuntimeSession()
-        runtimeSession.providerID = "server-session-1"
+        runtimeSession.providerID = "provider-1"
         runtimeSession.lifecycleState = .ready
         runtimeSession.powerState = .active
         snapshot.providers = [runtimeSession]
@@ -10122,21 +10170,21 @@ struct Phase8WindowUIAcceptanceRunnerTests {
                 )
             case .modelRootsRescan:
                 return .success("{\"registry_roots\":[\"/tmp/melix-managed\"]}\n")
-            case .serverSessionCreate:
-                return .success("{\"server_session_id\":\"server-session-1\"}\n")
-            case .serverSessionUpdate:
-                return .success("{\"server_session_id\":\"server-session-1\"}\n")
-            case .serverSessionSelect:
-                return .success("{\"selected_server_session_id\":\"server-session-1\"}\n")
+            case .providerCreate:
+                return .success("{\"provider_id\":\"provider-1\"}\n")
+            case .providerUpdate:
+                return .success("{\"provider_id\":\"provider-1\"}\n")
+            case .providerSelect:
+                return .success("{\"selected_provider_id\":\"provider-1\"}\n")
             case .serverStart(let options):
-                return .success(makeCLIServerSnapshotJSON(serverSessionID: options.serverSessionID))
+                return .success(makeCLIServerSnapshotJSON(providerID: options.providerID))
             case .chatRun(let options):
                 let assistantText = options.modelID == derivedModelID ? "DERIVED_OK" : "BASE_OK"
                 return .success(
                     """
                     {
                       "model_id": "\(options.modelID)",
-                      "server_session_id": "server-session-1",
+                      "provider_id": "provider-1",
                       "assistant_text": "\(assistantText)",
                       "finish_reason": "stop",
                       "request_id": "chat-\(assistantText.lowercased())"
@@ -10275,7 +10323,7 @@ struct Phase8WindowUIAcceptanceRunnerTests {
                 matrixSuites: ["smoke"],
                 evaluationSuites: ["mmlu"],
                 evaluationDataset: "mmlu.dev.v1",
-                serverSessionID: "server-session-1",
+                providerID: "provider-1",
                 cliEvidenceBundlePath: cliBundlePath.path,
                 timestamp: "2026-04-09T120000Z"
             ),
@@ -10346,7 +10394,7 @@ struct Phase8WindowUIAcceptanceRunnerTests {
         derivedModel.modelID = "\(materializedModelID)-lora-adapter"
         snapshot.models = [fallbackTextModel, importedModel, derivedModel]
         var runtimeSession = makeDesktopRuntimeSession()
-        runtimeSession.providerID = "server-session-1"
+        runtimeSession.providerID = "provider-1"
         runtimeSession.lifecycleState = .ready
         runtimeSession.powerState = .active
         snapshot.providers = [runtimeSession]
@@ -10367,20 +10415,20 @@ struct Phase8WindowUIAcceptanceRunnerTests {
                 )
             case .modelRootsRescan:
                 return .success("{\"registry_roots\":[\"/tmp/melix-managed\"]}\n")
-            case .serverSessionCreate:
-                return .success("{\"server_session_id\":\"server-session-1\"}\n")
-            case .serverSessionUpdate:
-                return .success("{\"server_session_id\":\"server-session-1\"}\n")
-            case .serverSessionSelect:
-                return .success("{\"selected_server_session_id\":\"server-session-1\"}\n")
+            case .providerCreate:
+                return .success("{\"provider_id\":\"provider-1\"}\n")
+            case .providerUpdate:
+                return .success("{\"provider_id\":\"provider-1\"}\n")
+            case .providerSelect:
+                return .success("{\"selected_provider_id\":\"provider-1\"}\n")
             case .serverStart(let options):
-                return .success(makeCLIServerSnapshotJSON(serverSessionID: options.serverSessionID))
+                return .success(makeCLIServerSnapshotJSON(providerID: options.providerID))
             case .chatRun:
                 return .success(
                     """
                     {
                       "model_id": "\(materializedModelID)",
-                      "server_session_id": "server-session-1",
+                      "provider_id": "provider-1",
                       "assistant_text": "BASE_OK",
                       "finish_reason": "stop",
                       "request_id": "chat-base"
@@ -10417,7 +10465,7 @@ struct Phase8WindowUIAcceptanceRunnerTests {
                 matrixSuites: ["smoke"],
                 evaluationSuites: ["mmlu"],
                 evaluationDataset: "mmlu.dev.v1",
-                serverSessionID: "server-session-1",
+                providerID: "provider-1",
                 cliEvidenceBundlePath: cliBundlePath.path,
                 timestamp: "2026-04-09T120000Z"
             ),
@@ -10484,18 +10532,18 @@ struct Phase8WindowUIAcceptanceRunnerTests {
                 )
             case .modelRootsRescan:
                 return .success("{\"registry_roots\":[\"/tmp/melix-managed\"]}\n")
-            case .serverSessionUpdate:
-                return .success("{\"server_session_id\":\"server-session-1\"}\n")
-            case .serverSessionSelect:
-                return .success("{\"selected_server_session_id\":\"server-session-1\"}\n")
+            case .providerUpdate:
+                return .success("{\"provider_id\":\"provider-1\"}\n")
+            case .providerSelect:
+                return .success("{\"selected_provider_id\":\"provider-1\"}\n")
             case .serverStart(let options):
-                return .success(makeCLIServerSnapshotJSON(serverSessionID: options.serverSessionID))
+                return .success(makeCLIServerSnapshotJSON(providerID: options.providerID))
             case .chatRun:
                 return .success(
                     """
                     {
                       "model_id": "melix-dev-text",
-                      "server_session_id": "server-session-1",
+                      "provider_id": "provider-1",
                       "assistant_text": "BASE_OK",
                       "finish_reason": "stop",
                       "request_id": "chat-base"
@@ -10602,7 +10650,7 @@ struct Phase8WindowUIAcceptanceRunnerTests {
                 matrixSuites: ["smoke"],
                 evaluationSuites: ["mmlu"],
                 evaluationDataset: "mmlu.dev.v1",
-                serverSessionID: "server-session-1",
+                providerID: "provider-1",
                 cliEvidenceBundlePath: cliBundlePath.path,
                 timestamp: "2026-04-09T120000Z"
             ),
@@ -10976,8 +11024,8 @@ private func expectedDesktopJobTimestampText(_ unixMS: Int64) -> String {
 
 @MainActor
 private func bindSelectedChatSessionToPrimaryServer(_ viewModel: RuntimeViewModel) throws {
-    let serverSessionID = try #require(viewModel.selectedServerSession?.id)
-    viewModel.bindSelectedChatSessionToServer(serverSessionID: serverSessionID)
+    let providerID = try #require(viewModel.selectedServerSession?.id)
+    viewModel.bindSelectedChatSessionToServer(providerID: providerID)
 }
 
 @MainActor
@@ -11042,7 +11090,7 @@ private func waitForRecordedCLICommandCount(
 }
 
 private func makeDesktopRuntimeSession(
-    serverSessionID: String = "server-session-1",
+    providerID: String = "provider-1",
     lifecycleState: Melix_Controlplane_V1_ProviderLifecycleState = .ready,
     powerState: Melix_Controlplane_V1_ProviderPowerState = .active,
     wakeReason: Melix_Controlplane_V1_ProviderWakeReason = .initialBoot,
@@ -11052,7 +11100,7 @@ private func makeDesktopRuntimeSession(
     deepSleepAfterSeconds: UInt32 = 1800
 ) -> Melix_Controlplane_V1_ProviderRuntimeState {
     var runtimeSession = Melix_Controlplane_V1_ProviderRuntimeState()
-    runtimeSession.providerID = serverSessionID
+    runtimeSession.providerID = providerID
     runtimeSession.lifecycleState = lifecycleState
     runtimeSession.powerState = powerState
     runtimeSession.wakeReason = wakeReason

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopPolishSmokeTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopPolishSmokeTests.swift
@@ -92,7 +92,7 @@ struct DesktopPolishSmokeTests {
         await viewModel.refreshDownloadQueueState()
 
         let chatServerSessionID = try #require(viewModel.selectedServerSession?.id)
-        viewModel.bindSelectedChatSessionToServer(serverSessionID: chatServerSessionID)
+        viewModel.bindSelectedChatSessionToServer(providerID: chatServerSessionID)
         viewModel.chatComposerText = "Smooth bursty deltas"
         let submitTask = Task { @MainActor in
             await viewModel.submitChatPrompt()
@@ -287,9 +287,9 @@ private func makeDesktopPolishNamedModelOperationResult(
     return result
 }
 
-private func makeDesktopPolishServerSession() -> DesktopServerSessionState {
-    DesktopServerSessionState(
-        id: "server-session-1",
+private func makeDesktopPolishServerSession() -> DesktopProviderState {
+    DesktopProviderState(
+        id: "provider-1",
         title: "Dev Text Session",
         modelID: "melix-dev-text",
         host: "0.0.0.0",
@@ -317,7 +317,7 @@ private func makeDesktopPolishServerSession() -> DesktopServerSessionState {
 
 private func makeDesktopPolishRuntimeSession() -> Melix_Controlplane_V1_ProviderRuntimeState {
     var runtimeSession = Melix_Controlplane_V1_ProviderRuntimeState()
-    runtimeSession.providerID = "server-session-1"
+    runtimeSession.providerID = "provider-1"
     runtimeSession.lifecycleState = .ready
     runtimeSession.powerState = .active
     runtimeSession.wakeReason = .initialBoot

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopShellStateTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopShellStateTests.swift
@@ -115,8 +115,8 @@ struct DesktopShellStateTests {
               "schema_version": 5,
               "selected_surface": "tools",
               "selected_tool_section": "jobs",
-              "selected_server_session_id": "",
-              "server_sessions": []
+              "selected_provider_id": "",
+              "providers": []
             }
             """#.utf8
         )
@@ -146,8 +146,8 @@ struct DesktopShellStateTests {
           "schema_version": 4,
           "selected_surface": "api",
           "selected_tool_section": "settings",
-          "selected_server_session_id": "server-session-1",
-          "server_sessions": [],
+          "selected_provider_id": "provider-1",
+          "providers": [],
           "dismissed_banner_ids": [],
           "download_queue": [],
           "registry_roots": []
@@ -158,8 +158,8 @@ struct DesktopShellStateTests {
 
         #expect(restored.schemaVersion == OperatorSessionState(
             selectedSurface: .chat,
-            selectedServerSessionID: "",
-            serverSessions: []
+            selectedProviderID: "",
+            providers: []
         ).schemaVersion)
         #expect(restored.paneVisibility.count == DesktopSurface.allCases.count)
         #expect(restored.paneVisibility.first(where: { $0.surface == .api })?.showsSidebar == true)
@@ -168,8 +168,8 @@ struct DesktopShellStateTests {
         var customized = OperatorSessionState(
             selectedSurface: .tools,
             selectedToolSection: .settings,
-            selectedServerSessionID: "server-session-1",
-            serverSessions: [],
+            selectedProviderID: "provider-1",
+            providers: [],
             paneVisibility: [
                 DesktopPaneVisibilityState(surface: .tools, showsSidebar: false, showsInspector: true),
             ]
@@ -343,25 +343,25 @@ struct DesktopShellStateTests {
         #expect(stopping.chatWorkspaceNoticeState?.title == "Server Is Stopping")
 
         #expect(stopped.chatWorkspaceNoticeState?.severity == .warning)
-        #expect(stopped.chatWorkspaceNoticeState?.detail.contains("Start the bound server session") ?? false)
+        #expect(stopped.chatWorkspaceNoticeState?.detail.contains("Start the bound provider") ?? false)
 
         #expect(failedEmpty.chatWorkspaceNoticeState?.severity == .critical)
-        #expect(failedEmpty.chatWorkspaceNoticeState?.detail == "The bound server session failed.")
+        #expect(failedEmpty.chatWorkspaceNoticeState?.detail == "The bound provider failed.")
 
         #expect(failedFilled.chatWorkspaceNoticeState?.severity == .critical)
         #expect(failedFilled.chatWorkspaceNoticeState?.detail == "gpu lost")
 
         #expect(draft.chatWorkspaceNoticeState?.severity == .warning)
-        #expect(draft.chatWorkspaceNoticeState?.title == "No Active Server Session")
+        #expect(draft.chatWorkspaceNoticeState?.title == "No Active Provider")
 
         #expect(unavailable.chatWorkspaceNoticeState?.severity == .warning)
-        #expect(unavailable.chatWorkspaceNoticeState?.detail.contains("Choose a valid server session") ?? false)
+        #expect(unavailable.chatWorkspaceNoticeState?.detail.contains("Choose a valid provider") ?? false)
     }
 
     @Test("effective listener helpers and codable restore preserve gateway config projection")
     func effectiveListenerHelpersAndCodableRestorePreserveGatewayConfigProjection() throws {
-        let session = DesktopServerSessionState(
-            id: "server-session-1",
+        let session = DesktopProviderState(
+            id: "provider-1",
             title: "Server",
             modelID: "melix-dev-text",
             host: "0.0.0.0",
@@ -373,7 +373,7 @@ struct DesktopShellStateTests {
             gatewayConfigSourceText: "Operator Override",
             gatewayConfigActiveBinding: true,
             gatewayConfigRequiresRestart: true,
-            servingDefaults: DesktopServerServingDefaultsState(
+            servingDefaults: DesktopProviderServingDefaultsState(
                 temperature: 0.33,
                 topP: 0.92,
                 maxTokens: 384,
@@ -409,7 +409,7 @@ struct DesktopShellStateTests {
         #expect(session.effectiveListenerLabel == "127.0.0.1:12436")
 
         let encoded = try JSONEncoder().encode(session)
-        let decoded = try JSONDecoder().decode(DesktopServerSessionState.self, from: encoded)
+        let decoded = try JSONDecoder().decode(DesktopProviderState.self, from: encoded)
 
         #expect(decoded.host == "0.0.0.0")
         #expect(decoded.port == 18080)
@@ -437,7 +437,7 @@ struct DesktopShellStateTests {
 }
 
 private func makeDesktopShellSession(
-    lifecycle: DesktopServerSessionLifecycle,
+    lifecycle: DesktopProviderLifecycle,
     powerState: DesktopServerPowerState,
     idleTimerSeconds: Int = 0,
     autoSleepEnabled: Bool = false,
@@ -445,9 +445,9 @@ private func makeDesktopShellSession(
     deepSleepAfterSeconds: Int = 900,
     wakeReason: DesktopServerWakeReason = .initialBoot,
     lastError: String = ""
-) -> DesktopServerSessionState {
-    DesktopServerSessionState(
-        id: "server-session-1",
+) -> DesktopProviderState {
+    DesktopProviderState(
+        id: "provider-1",
         title: "Server",
         modelID: "melix-dev-text",
         lifecycle: lifecycle,

--- a/apps/macos-menubar/Tests/MenuBarTests/MelixSubprocessCLIWorkflowRunnerTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/MelixSubprocessCLIWorkflowRunnerTests.swift
@@ -178,7 +178,7 @@ struct MelixSubprocessCLIWorkflowRunnerTests {
             """
             {
               "model_id": "melix-dev-text",
-              "server_session_id": "server-session-1",
+              "provider_id": "provider-1",
               "assistant_text": "BASE_OK",
               "finish_reason": "stop",
               "request_id": "chat-base"
@@ -198,7 +198,7 @@ struct MelixSubprocessCLIWorkflowRunnerTests {
                     modelID: "melix-dev-text",
                     message: "Reply with BASE_OK",
                     systemPrompt: "You are Melix.",
-                    serverSessionID: "server-session-1",
+                    providerID: "provider-1",
                     json: true
                 )
             )
@@ -216,8 +216,8 @@ struct MelixSubprocessCLIWorkflowRunnerTests {
                 "Reply with BASE_OK",
                 "--system",
                 "You are Melix.",
-                "--server-session-id",
-                "server-session-1",
+                "--provider-id",
+                "provider-1",
                 "--json",
             ]
         )

--- a/apps/macos-menubar/Tests/MenuBarTests/OperatorSessionPersistenceSmokeTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/OperatorSessionPersistenceSmokeTests.swift
@@ -92,14 +92,14 @@ struct OperatorSessionPersistenceSmokeTests {
             OperatorSessionState(
                 selectedSurface: .server,
                 selectedToolSection: .jobs,
-                selectedServerSessionID: "server-session-shared",
+                selectedProviderID: "provider-shared",
                 selectedRuntimeJobID: "job-shared-selection",
-                serverSessions: [
-                    DesktopServerSessionState(
-                        id: "server-session-shared",
+                providers: [
+                    DesktopProviderState(
+                        id: "provider-shared",
                         title: "Shared Server",
                         modelID: "melix-dev-vlm",
-                        servingDefaults: DesktopServerServingDefaultsState(
+                        servingDefaults: DesktopProviderServingDefaultsState(
                             maxConcurrentRequests: 3,
                             concurrentProcessingEnabled: false,
                             prefillBatchSize: 1,
@@ -130,8 +130,8 @@ struct OperatorSessionPersistenceSmokeTests {
         let uiPayload = try #require(
             JSONSerialization.jsonObject(with: Data(contentsOf: melixHome.operatorSessionFileURL)) as? [String: Any]
         )
-        let serverSessionsPayload = try #require(
-            JSONSerialization.jsonObject(with: Data(contentsOf: melixHome.serverSessionsFileURL)) as? [String: Any]
+        let providersPayload = try #require(
+            JSONSerialization.jsonObject(with: Data(contentsOf: melixHome.providersFileURL)) as? [String: Any]
         )
         let modelRootsPayload = try #require(
             JSONSerialization.jsonObject(with: Data(contentsOf: melixHome.modelRootsFileURL)) as? [String: Any]
@@ -142,32 +142,32 @@ struct OperatorSessionPersistenceSmokeTests {
         #expect(sharedState.selectedRuntimeJobID == "job-shared-selection")
         #expect(restoredAppState.selectedToolSection == .jobs)
         #expect(restoredAppState.selectedRuntimeJobID == "job-shared-selection")
-        #expect(sharedState.selectedServerSessionID == "server-session-shared")
-        #expect(sharedState.serverSessions.first?.defaultModelID == "melix-dev-vlm")
-        #expect(sharedState.serverSessions.first?.servedModelIDs == ["melix-dev-vlm"])
-        #expect(sharedState.serverSessions.first?.servingDefaults.accelerationProfile == "long-session")
-        #expect(sharedState.serverSessions.first?.servingDefaults.accelerationMode == "sparse_prefill")
-        #expect(sharedState.serverSessions.first?.servingDefaults.maxConcurrentRequests == 3)
-        #expect(sharedState.serverSessions.first?.servingDefaults.concurrentProcessingEnabled == false)
-        #expect(sharedState.serverSessions.first?.servingDefaults.prefillBatchSize == 1)
-        #expect(sharedState.serverSessions.first?.servingDefaults.completionBatchSize == 1)
-        #expect(restoredAppState.serverSessions.first?.servingDefaults.accelerationProfile == "long-session")
-        #expect(restoredAppState.serverSessions.first?.servingDefaults.effectiveAccelerationProfile == "long-session")
-        #expect(restoredAppState.serverSessions.first?.servingDefaults.accelerationProfileIntent ==
+        #expect(sharedState.selectedProviderID == "provider-shared")
+        #expect(sharedState.providers.first?.defaultModelID == "melix-dev-vlm")
+        #expect(sharedState.providers.first?.servedModelIDs == ["melix-dev-vlm"])
+        #expect(sharedState.providers.first?.servingDefaults.accelerationProfile == "long-session")
+        #expect(sharedState.providers.first?.servingDefaults.accelerationMode == "sparse_prefill")
+        #expect(sharedState.providers.first?.servingDefaults.maxConcurrentRequests == 3)
+        #expect(sharedState.providers.first?.servingDefaults.concurrentProcessingEnabled == false)
+        #expect(sharedState.providers.first?.servingDefaults.prefillBatchSize == 1)
+        #expect(sharedState.providers.first?.servingDefaults.completionBatchSize == 1)
+        #expect(restoredAppState.providers.first?.servingDefaults.accelerationProfile == "long-session")
+        #expect(restoredAppState.providers.first?.servingDefaults.effectiveAccelerationProfile == "long-session")
+        #expect(restoredAppState.providers.first?.servingDefaults.accelerationProfileIntent ==
             "Repeated-session serving with bounded batching and baseline decode."
         )
-        #expect(sharedState.serverSessions.first?.autoSleepEnabled == true)
-        #expect(sharedState.serverSessions.first?.lightSleepAfterSeconds == 60)
-        #expect(sharedState.serverSessions.first?.deepSleepAfterSeconds == 600)
+        #expect(sharedState.providers.first?.autoSleepEnabled == true)
+        #expect(sharedState.providers.first?.lightSleepAfterSeconds == 60)
+        #expect(sharedState.providers.first?.deepSleepAfterSeconds == 600)
         #expect(sharedState.registryRoots == ["/tmp/models-a", "/tmp/models-b"])
         #expect(sharedState.paneVisibility.first(where: { $0.surfaceID == "server" })?.showsInspector == true)
         #expect(sharedState.paneVisibility.first(where: { $0.surfaceID == "api" })?.showsSidebar == false)
         #expect(uiPayload["selected_runtime_job_id"] as? String == "job-shared-selection")
-        #expect(uiPayload["server_sessions"] == nil)
+        #expect(uiPayload["providers"] == nil)
         #expect(uiPayload["registry_roots"] == nil)
-        #expect((serverSessionsPayload["server_sessions"] as? [[String: Any]])?.first?["id"] as? String == "server-session-shared")
+        #expect((providersPayload["providers"] as? [[String: Any]])?.first?["id"] as? String == "provider-shared")
         let persistedServingDefaults = try #require(
-            (serverSessionsPayload["server_sessions"] as? [[String: Any]])?.first?["serving_defaults"] as? [String: Any]
+            (providersPayload["providers"] as? [[String: Any]])?.first?["serving_defaults"] as? [String: Any]
         )
         #expect(persistedServingDefaults["acceleration_profile"] as? String == "long-session")
         #expect(persistedServingDefaults["acceleration_mode"] as? String == "sparse_prefill")
@@ -182,9 +182,9 @@ struct OperatorSessionPersistenceSmokeTests {
             schemaVersion: 1,
             selectedSurface: .jobs,
             selectedToolSection: .jobs,
-            selectedServerSessionID: "",
+            selectedProviderID: "",
             selectedRuntimeJobID: "job-codable-selection",
-            serverSessions: [],
+            providers: [],
             paneVisibility: []
         )
 
@@ -206,8 +206,8 @@ struct OperatorSessionPersistenceSmokeTests {
               "schema_version": 5,
               "selected_surface": "tools",
               "selected_tool_section": "jobs",
-              "selected_server_session_id": "",
-              "server_sessions": []
+              "selected_provider_id": "",
+              "providers": []
             }
             """#.utf8
         )
@@ -232,8 +232,8 @@ struct OperatorSessionPersistenceSmokeTests {
             OperatorSessionState(
                 selectedSurface: .tools,
                 selectedToolSection: .batchRuns,
-                selectedServerSessionID: "",
-                serverSessions: []
+                selectedProviderID: "",
+                providers: []
             )
         )
 
@@ -257,9 +257,9 @@ struct OperatorSessionPersistenceSmokeTests {
         let legacyState = MelixOperatorSessionState(
             selectedSurfaceID: "server",
             selectedToolSectionID: "downloads",
-            selectedServerSessionID: "legacy-server",
-            serverSessions: [
-                MelixOperatorServerSessionState(
+            selectedProviderID: "legacy-server",
+            providers: [
+                MelixOperatorProviderState(
                     id: "legacy-server",
                     title: "Legacy Server",
                     defaultModelID: "melix-dev-text",
@@ -297,7 +297,7 @@ struct OperatorSessionPersistenceSmokeTests {
         encoder.dateEncodingStrategy = .iso8601
         try melixHome.writeAtomically(try encoder.encode(legacyState), to: melixHome.operatorSessionFileURL)
 
-        #expect(FileManager.default.fileExists(atPath: melixHome.serverSessionsFileURL.path) == false)
+        #expect(FileManager.default.fileExists(atPath: melixHome.providersFileURL.path) == false)
         #expect(FileManager.default.fileExists(atPath: melixHome.modelRootsFileURL.path) == false)
         #expect(FileManager.default.fileExists(atPath: melixHome.downloadQueueFileURL.path) == false)
 
@@ -305,8 +305,8 @@ struct OperatorSessionPersistenceSmokeTests {
         let uiPayload = try #require(
             JSONSerialization.jsonObject(with: Data(contentsOf: melixHome.operatorSessionFileURL)) as? [String: Any]
         )
-        let serverSessionsPayload = try #require(
-            JSONSerialization.jsonObject(with: Data(contentsOf: melixHome.serverSessionsFileURL)) as? [String: Any]
+        let providersPayload = try #require(
+            JSONSerialization.jsonObject(with: Data(contentsOf: melixHome.providersFileURL)) as? [String: Any]
         )
         let modelRootsPayload = try #require(
             JSONSerialization.jsonObject(with: Data(contentsOf: melixHome.modelRootsFileURL)) as? [String: Any]
@@ -317,14 +317,14 @@ struct OperatorSessionPersistenceSmokeTests {
 
         #expect(restoredState.selectedSurfaceID == "server")
         #expect(restoredState.selectedToolSectionID == "downloads")
-        #expect(restoredState.selectedServerSessionID == "legacy-server")
-        #expect(restoredState.serverSessions.first?.title == "Legacy Server")
+        #expect(restoredState.selectedProviderID == "legacy-server")
+        #expect(restoredState.providers.first?.title == "Legacy Server")
         #expect(restoredState.registryRoots == ["/tmp/legacy-models-a", "/tmp/legacy-models-b"])
         #expect(restoredState.downloadQueue.first?.jobID == "job-legacy-download")
-        #expect(uiPayload["server_sessions"] == nil)
+        #expect(uiPayload["providers"] == nil)
         #expect(uiPayload["registry_roots"] == nil)
         #expect(uiPayload["download_queue"] == nil)
-        #expect((serverSessionsPayload["server_sessions"] as? [[String: Any]])?.first?["id"] as? String == "legacy-server")
+        #expect((providersPayload["providers"] as? [[String: Any]])?.first?["id"] as? String == "legacy-server")
         #expect(modelRootsPayload["registry_roots"] as? [String] == ["/tmp/legacy-models-a", "/tmp/legacy-models-b"])
         #expect((downloadQueuePayload["download_queue"] as? [[String: Any]])?.first?["job_id"] as? String == "job-legacy-download")
     }

--- a/apps/macos-menubar/Tests/MenuBarTests/Phase8LoRAWindowSmokeTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/Phase8LoRAWindowSmokeTests.swift
@@ -389,7 +389,7 @@ private func phase8LoRAWindowSnapshot(
 
 private func phase8LoRAWindowRuntimeSession() -> Melix_Controlplane_V1_ProviderRuntimeState {
     var runtimeSession = Melix_Controlplane_V1_ProviderRuntimeState()
-    runtimeSession.providerID = "server-session-1"
+    runtimeSession.providerID = "provider-1"
     runtimeSession.lifecycleState = .ready
     runtimeSession.powerState = .active
     runtimeSession.wakeReason = .initialBoot

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeSyntheticDatasetStateTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeSyntheticDatasetStateTests.swift
@@ -792,8 +792,8 @@ struct RuntimeSyntheticDatasetStateTests {
         let state = OperatorSessionState(
             selectedSurface: .tools,
             selectedToolSection: .syntheticDatasets,
-            selectedServerSessionID: "",
-            serverSessions: []
+            selectedProviderID: "",
+            providers: []
         )
         let encoded = try JSONEncoder().encode(state)
         let decoded = try JSONDecoder().decode(OperatorSessionState.self, from: encoded)

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -27,13 +27,13 @@ struct RuntimeViewModelTests {
         #expect(viewModel.primaryModel?.actionTitle == "Load")
         #expect(viewModel.selectedSurface == .chat)
         #expect(viewModel.selectedToolSection == .modelsLibrary)
-        #expect(viewModel.serverSessions.isEmpty == false)
+        #expect(viewModel.providers.isEmpty == false)
         #expect(viewModel.selectedServerSession?.modelID == "melix-dev-text")
         #expect(await metrics.snapshot()["menu.handshake_ms"] != nil)
         #expect(await metrics.snapshot()["menu.hydration_ms"] != nil)
     }
 
-    @Test("server session seed skips placeholders and uses the first ready model")
+    @Test("provider seed skips placeholders and uses the first ready model")
     @MainActor
     func serverSessionSeedSkipsPlaceholdersAndUsesTheFirstReadyModel() async throws {
         let client = FakeControlPlaneXPCClient()
@@ -425,7 +425,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureExportResult(
@@ -569,7 +569,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let store = FakeEvaluationPromptStore()
@@ -611,8 +611,8 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-        let restoredSession = DesktopServerSessionState(
-            id: "server-session-allowlist",
+        let restoredSession = DesktopProviderState(
+            id: "provider-allowlist",
             title: "Allowlist Server",
             modelID: "melix-dev-text",
             allowedHosts: ["operator.lan"],
@@ -621,8 +621,8 @@ struct RuntimeViewModelTests {
         try operatorSessionStore.save(
             OperatorSessionState(
                 selectedSurface: .api,
-                selectedServerSessionID: restoredSession.id,
-                serverSessions: [restoredSession]
+                selectedProviderID: restoredSession.id,
+                providers: [restoredSession]
             )
         )
         let client = FakeControlPlaneXPCClient()
@@ -645,7 +645,7 @@ struct RuntimeViewModelTests {
         let request = try #require(await client.recordedGatewayConfigApplyRequests.last)
         let session = try #require(viewModel.selectedServerSession)
 
-        #expect(request.serverSessionID == session.id)
+        #expect(request.providerID == session.id)
         #expect(request.host == "0.0.0.0")
         #expect(request.port == 18_080)
         #expect(request.defaultModelID == "melix-dev-text")
@@ -693,7 +693,7 @@ struct RuntimeViewModelTests {
         let request = try #require(await client.recordedServingDefaultsApplyRequests.last)
         let session = try #require(viewModel.selectedServerSession)
 
-        #expect(request.serverSessionID == session.id)
+        #expect(request.providerID == session.id)
         #expect(request.temperature == 0.33)
         #expect(request.topP == 0.92)
         #expect(request.maxTokens == 384)
@@ -741,7 +741,7 @@ struct RuntimeViewModelTests {
         await viewModel.applySelectedServerServingDefaults()
 
         let request = try #require(await client.recordedServingDefaultsApplyRequests.last)
-        #expect(request.serverSessionID == viewModel.selectedServerSession?.id)
+        #expect(request.providerID == viewModel.selectedServerSession?.id)
         #expect(request.accelerationMode == .speculativeDecode)
         #expect(await client.recordedModelSettingsUpdates.isEmpty)
         #expect(viewModel.modelSettingsLoadTrustModeText == "Unspecified")
@@ -904,7 +904,7 @@ struct RuntimeViewModelTests {
             runtimeSessions: [makeRuntimeSession()]
         )
         var servingDefaults = Melix_Controlplane_V1_ServingDefaultsSessionSummary()
-        servingDefaults.providerID = "server-session-1"
+        servingDefaults.providerID = "provider-1"
         servingDefaults.defaultModelID = "melix-dev-text"
         servingDefaults.requestedTemperature = 0.7
         servingDefaults.requestedTopP = 1.0
@@ -967,7 +967,7 @@ struct RuntimeViewModelTests {
         #expect(session.servingDefaults.modelOverrideApplied == false)
     }
 
-    @Test("starting a selected server session persists gateway config and serving defaults before the lifecycle mutation")
+    @Test("starting a selected provider persists gateway config and serving defaults before the lifecycle mutation")
     @MainActor
     func startingASelectedServerSessionPersistsGatewayConfigAndServingDefaultsBeforeTheLifecycleMutation() async throws {
         let temporaryRoot = FileManager.default.temporaryDirectory
@@ -977,8 +977,8 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-        let restoredSession = DesktopServerSessionState(
-            id: "server-session-start-allowlist",
+        let restoredSession = DesktopProviderState(
+            id: "provider-start-allowlist",
             title: "Start Allowlist Server",
             modelID: "melix-dev-text",
             allowedHosts: ["operator.lan"],
@@ -987,15 +987,15 @@ struct RuntimeViewModelTests {
         try operatorSessionStore.save(
             OperatorSessionState(
                 selectedSurface: .api,
-                selectedServerSessionID: restoredSession.id,
-                serverSessions: [restoredSession]
+                selectedProviderID: restoredSession.id,
+                providers: [restoredSession]
             )
         )
         let client = FakeControlPlaneXPCClient()
         let viewModel = RuntimeViewModel(client: client, operatorSessionStore: operatorSessionStore)
 
         await viewModel.start()
-        let serverSessionID = try #require(viewModel.selectedServerSession?.id)
+        let providerID = try #require(viewModel.selectedServerSession?.id)
         viewModel.updateSelectedServerSessionHost("127.0.0.1")
         viewModel.updateSelectedServerSessionPort(18081)
         viewModel.updateSelectedServerSessionStreamIntervalTokens(2)
@@ -1003,9 +1003,9 @@ struct RuntimeViewModelTests {
         await viewModel.startSelectedServerSession()
 
         let actions = await client.recordedActions
-        let applyConfigIndex = try #require(actions.firstIndex(of: "gateway.config:\(serverSessionID)"))
-        let applyServingDefaultsIndex = try #require(actions.firstIndex(of: "serving-defaults.apply:\(serverSessionID)"))
-        let startIndex = try #require(actions.firstIndex(of: "server.start:\(serverSessionID)"))
+        let applyConfigIndex = try #require(actions.firstIndex(of: "gateway.config:\(providerID)"))
+        let applyServingDefaultsIndex = try #require(actions.firstIndex(of: "serving-defaults.apply:\(providerID)"))
+        let startIndex = try #require(actions.firstIndex(of: "server.start:\(providerID)"))
 
         #expect(applyConfigIndex < startIndex)
         #expect(applyServingDefaultsIndex < startIndex)
@@ -1017,7 +1017,7 @@ struct RuntimeViewModelTests {
         #expect(viewModel.selectedServerSession?.lifecycle == .running)
     }
 
-    @Test("server session template start does not grant model load trust")
+    @Test("provider template start does not grant model load trust")
     @MainActor
     func serverSessionTemplateStartDoesNotGrantModelLoadTrust() async throws {
         let client = FakeControlPlaneXPCClient()
@@ -1031,13 +1031,13 @@ struct RuntimeViewModelTests {
 
         await viewModel.start()
         viewModel.createServerSession()
-        let serverSessionID = try #require(viewModel.selectedServerSession?.id)
+        let providerID = try #require(viewModel.selectedServerSession?.id)
 
         await viewModel.startSelectedServerSession()
 
         let actions = await client.recordedActions
-        #expect(actions.contains("serving-defaults.apply:\(serverSessionID)"))
-        #expect(actions.contains("server.start:\(serverSessionID)"))
+        #expect(actions.contains("serving-defaults.apply:\(providerID)"))
+        #expect(actions.contains("server.start:\(providerID)"))
         #expect(await client.recordedModelSettingsUpdates.isEmpty)
         #expect(viewModel.modelSettingsLoadTrustModeText == "Unspecified")
     }
@@ -1050,14 +1050,14 @@ struct RuntimeViewModelTests {
 
         await viewModel.start()
         viewModel.createServerSession()
-        let serverSessionID = try #require(viewModel.selectedServerSession?.id)
+        let providerID = try #require(viewModel.selectedServerSession?.id)
         await client.configureErrors(applyGatewayConfig: MenuBarTestError(description: "persist failed"))
 
         await viewModel.startSelectedServerSession()
 
         let actions = await client.recordedActions
-        #expect(actions.contains("gateway.config:\(serverSessionID)"))
-        #expect(actions.contains("server.start:\(serverSessionID)") == false)
+        #expect(actions.contains("gateway.config:\(providerID)"))
+        #expect(actions.contains("server.start:\(providerID)") == false)
         #expect(viewModel.lastError?.contains("Gateway config apply failed") == true)
         #expect(viewModel.lastError?.contains("persist failed") == true)
     }
@@ -1070,15 +1070,15 @@ struct RuntimeViewModelTests {
 
         await viewModel.start()
         viewModel.createServerSession()
-        let serverSessionID = try #require(viewModel.selectedServerSession?.id)
+        let providerID = try #require(viewModel.selectedServerSession?.id)
         await client.configureServingDefaultsApplyError(MenuBarTestError(description: "defaults persist failed"))
 
         await viewModel.startSelectedServerSession()
 
         let actions = await client.recordedActions
-        #expect(actions.contains("gateway.config:\(serverSessionID)"))
-        #expect(actions.contains("serving-defaults.apply:\(serverSessionID)"))
-        #expect(actions.contains("server.start:\(serverSessionID)") == false)
+        #expect(actions.contains("gateway.config:\(providerID)"))
+        #expect(actions.contains("serving-defaults.apply:\(providerID)"))
+        #expect(actions.contains("server.start:\(providerID)") == false)
         #expect(viewModel.lastError?.contains("Serving defaults apply failed") == true)
         #expect(viewModel.lastError?.contains("defaults persist failed") == true)
     }
@@ -1093,7 +1093,7 @@ struct RuntimeViewModelTests {
             runtimeSessions: [makeRuntimeSession()],
             gatewayConfig: makeGatewayConfigSummary(
                 listener: makeGatewayConfigListener(
-                    serverSessionID: "server-session-1",
+                    providerID: "provider-1",
                     requestedHost: "0.0.0.0",
                     requestedPort: 18_090,
                     effectiveHost: "127.0.0.1",
@@ -1143,7 +1143,7 @@ struct RuntimeViewModelTests {
                 runtimeSessions: [makeRuntimeSession()],
                 gatewayConfig: makeGatewayConfigSummary(
                     listener: makeGatewayConfigListener(
-                        serverSessionID: "server-session-1",
+                        providerID: "provider-1",
                         requestedHost: "127.0.0.1",
                         requestedPort: 11_434,
                         effectiveHost: "127.0.0.1",
@@ -1176,7 +1176,7 @@ struct RuntimeViewModelTests {
             runtimeSessions: [makeRuntimeSession()],
             gatewayConfig: makeGatewayConfigSummary(
                 listener: makeGatewayConfigListener(
-                    serverSessionID: "server-session-1",
+                    providerID: "provider-1",
                     requestedHost: "127.0.0.1",
                     requestedPort: 11_434,
                     effectiveHost: "127.0.0.1",
@@ -1191,7 +1191,7 @@ struct RuntimeViewModelTests {
             )
         )
         var servingDefaults = Melix_Controlplane_V1_ServingDefaultsSessionSummary()
-        servingDefaults.providerID = "server-session-1"
+        servingDefaults.providerID = "provider-1"
         servingDefaults.defaultModelID = "melix-dev-text"
         servingDefaults.requestedTemperature = 0.31
         servingDefaults.requestedTopP = 0.89
@@ -1332,9 +1332,9 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-        let apiKeyStore = ServerSessionAPIKeyStore(melixHome: melixHome)
-        let restoredServerSession = DesktopServerSessionState(
-            id: "server-session-restored",
+        let apiKeyStore = ProviderAPIKeyStore(melixHome: melixHome)
+        let restoredServerSession = DesktopProviderState(
+            id: "provider-restored",
             title: "Restored Server",
             modelID: "melix-dev-text",
             lifecycle: .running
@@ -1342,8 +1342,8 @@ struct RuntimeViewModelTests {
         try operatorSessionStore.save(
             OperatorSessionState(
                 selectedSurface: .api,
-                selectedServerSessionID: restoredServerSession.id,
-                serverSessions: [restoredServerSession]
+                selectedProviderID: restoredServerSession.id,
+                providers: [restoredServerSession]
             )
         )
 
@@ -1351,7 +1351,7 @@ struct RuntimeViewModelTests {
         let viewModel = RuntimeViewModel(
             client: client,
             operatorSessionStore: operatorSessionStore,
-            serverSessionAPIKeyStore: apiKeyStore
+            providerAPIKeyStore: apiKeyStore
         )
 
         await viewModel.start()
@@ -1403,8 +1403,8 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-        let restoredServerSession = DesktopServerSessionState(
-            id: "server-session-restored",
+        let restoredServerSession = DesktopProviderState(
+            id: "provider-restored",
             title: "Restored Server",
             modelID: "melix-dev-text",
             lifecycle: .running
@@ -1413,8 +1413,8 @@ struct RuntimeViewModelTests {
         try operatorSessionStore.save(
             OperatorSessionState(
                 selectedSurface: .tools,
-                selectedServerSessionID: restoredServerSession.id,
-                serverSessions: [restoredServerSession]
+                selectedProviderID: restoredServerSession.id,
+                providers: [restoredServerSession]
             )
         )
 
@@ -1519,7 +1519,7 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-        let apiKeyStore = ServerSessionAPIKeyStore(melixHome: melixHome)
+        let apiKeyStore = ProviderAPIKeyStore(melixHome: melixHome)
         let client = FakeControlPlaneXPCClient()
         await client.configureSnapshot(
             makeSnapshot(
@@ -1532,13 +1532,13 @@ struct RuntimeViewModelTests {
             client: client,
             metrics: metrics,
             operatorSessionStore: operatorSessionStore,
-            serverSessionAPIKeyStore: apiKeyStore
+            providerAPIKeyStore: apiKeyStore
         )
 
         await viewModel.start()
-        let selectedServerSessionID = try #require(viewModel.selectedServerSession?.id)
+        let selectedProviderID = try #require(viewModel.selectedServerSession?.id)
         let generatedPrimaryKey = try #require(await viewModel.generatePrimaryAPIKeyForSelectedServerSession())
-        let persistedPrimaryKey = try #require(try apiKeyStore.loadPrimaryKey(serverSessionID: selectedServerSessionID))
+        let persistedPrimaryKey = try #require(try apiKeyStore.loadPrimaryKey(providerID: selectedProviderID))
 
         #expect(generatedPrimaryKey.hasPrefix("melix_sk_"))
         #expect(persistedPrimaryKey.primaryKey == generatedPrimaryKey)
@@ -1560,7 +1560,7 @@ struct RuntimeViewModelTests {
         #expect(metricValues["gateway.api_key_persist_failures"] == 0)
     }
 
-    @Test("defers gateway apply when selected server session is not running")
+    @Test("defers gateway apply when selected provider is not running")
     @MainActor
     func defersGatewayApplyWhenSelectedServerSessionIsNotRunning() async throws {
         let temporaryRoot = FileManager.default.temporaryDirectory
@@ -1570,7 +1570,7 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-        let apiKeyStore = ServerSessionAPIKeyStore(melixHome: melixHome)
+        let apiKeyStore = ProviderAPIKeyStore(melixHome: melixHome)
         let client = FakeControlPlaneXPCClient()
         await client.configureSnapshot(
             makeSnapshot(
@@ -1581,7 +1581,7 @@ struct RuntimeViewModelTests {
         let viewModel = RuntimeViewModel(
             client: client,
             operatorSessionStore: operatorSessionStore,
-            serverSessionAPIKeyStore: apiKeyStore
+            providerAPIKeyStore: apiKeyStore
         )
 
         await viewModel.start()
@@ -1603,7 +1603,7 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-        let apiKeyStore = ServerSessionAPIKeyStore(melixHome: melixHome)
+        let apiKeyStore = ProviderAPIKeyStore(melixHome: melixHome)
         let client = FakeControlPlaneXPCClient()
         await client.configureSnapshot(
             makeSnapshot(
@@ -1614,12 +1614,12 @@ struct RuntimeViewModelTests {
         let viewModel = RuntimeViewModel(
             client: client,
             operatorSessionStore: operatorSessionStore,
-            serverSessionAPIKeyStore: apiKeyStore
+            providerAPIKeyStore: apiKeyStore
         )
 
         await viewModel.start()
         viewModel.createServerSession()
-        let selectedServerSessionID = try #require(viewModel.selectedServerSession?.id)
+        let selectedProviderID = try #require(viewModel.selectedServerSession?.id)
         let primaryKey = try #require(await viewModel.generatePrimaryAPIKeyForSelectedServerSession())
         #expect(await client.recordedGatewayAccessApplyRequests.isEmpty)
 
@@ -1632,11 +1632,11 @@ struct RuntimeViewModelTests {
         #expect(await client.recordedGatewayAccessApplyRequests.isEmpty == false)
 
         let appliedRequest = try #require(await client.recordedGatewayAccessApplyRequests.last)
-        #expect(appliedRequest.serverSessionID == selectedServerSessionID)
+        #expect(appliedRequest.providerID == selectedProviderID)
         #expect(appliedRequest.primaryKey == primaryKey)
     }
 
-    @Test("selecting a keyless server session clears previously applied gateway access")
+    @Test("selecting a keyless provider clears previously applied gateway access")
     @MainActor
     func selectingAKeylessServerSessionClearsPreviouslyAppliedGatewayAccess() async throws {
         let temporaryRoot = FileManager.default.temporaryDirectory
@@ -1646,7 +1646,7 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-        let apiKeyStore = ServerSessionAPIKeyStore(melixHome: melixHome)
+        let apiKeyStore = ProviderAPIKeyStore(melixHome: melixHome)
         let client = FakeControlPlaneXPCClient()
         await client.configureSnapshot(
             makeSnapshot(
@@ -1657,7 +1657,7 @@ struct RuntimeViewModelTests {
         let viewModel = RuntimeViewModel(
             client: client,
             operatorSessionStore: operatorSessionStore,
-            serverSessionAPIKeyStore: apiKeyStore
+            providerAPIKeyStore: apiKeyStore
         )
 
         await viewModel.start()
@@ -1679,7 +1679,7 @@ struct RuntimeViewModelTests {
         #expect(await client.recordedGatewayAccessClearRequests == [try #require(viewModel.selectedServerSession?.id)])
     }
 
-    @Test("stopping a keyed server session clears previously applied gateway access")
+    @Test("stopping a keyed provider clears previously applied gateway access")
     @MainActor
     func stoppingAKeyedServerSessionClearsPreviouslyAppliedGatewayAccess() async throws {
         let temporaryRoot = FileManager.default.temporaryDirectory
@@ -1689,7 +1689,7 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-        let apiKeyStore = ServerSessionAPIKeyStore(melixHome: melixHome)
+        let apiKeyStore = ProviderAPIKeyStore(melixHome: melixHome)
         let client = FakeControlPlaneXPCClient()
         await client.configureSnapshot(
             makeSnapshot(
@@ -1700,11 +1700,11 @@ struct RuntimeViewModelTests {
         let viewModel = RuntimeViewModel(
             client: client,
             operatorSessionStore: operatorSessionStore,
-            serverSessionAPIKeyStore: apiKeyStore
+            providerAPIKeyStore: apiKeyStore
         )
 
         await viewModel.start()
-        let selectedServerSessionID = try #require(viewModel.selectedServerSession?.id)
+        let selectedProviderID = try #require(viewModel.selectedServerSession?.id)
         _ = await viewModel.generatePrimaryAPIKeyForSelectedServerSession()
         var applyAttempts = 0
         while await client.recordedGatewayAccessApplyRequests.isEmpty, applyAttempts < 200 {
@@ -1720,7 +1720,7 @@ struct RuntimeViewModelTests {
             clearAttempts += 1
             try await Task.sleep(for: .milliseconds(10))
         }
-        #expect(await client.recordedGatewayAccessClearRequests == [selectedServerSessionID])
+        #expect(await client.recordedGatewayAccessClearRequests == [selectedProviderID])
     }
 
     @Test("gateway access clear failures surface as recoverable local errors")
@@ -1733,7 +1733,7 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-        let apiKeyStore = ServerSessionAPIKeyStore(melixHome: melixHome)
+        let apiKeyStore = ProviderAPIKeyStore(melixHome: melixHome)
         let client = FakeControlPlaneXPCClient()
         await client.configureSnapshot(
             makeSnapshot(
@@ -1744,7 +1744,7 @@ struct RuntimeViewModelTests {
         let viewModel = RuntimeViewModel(
             client: client,
             operatorSessionStore: operatorSessionStore,
-            serverSessionAPIKeyStore: apiKeyStore
+            providerAPIKeyStore: apiKeyStore
         )
 
         await viewModel.start()
@@ -1764,7 +1764,7 @@ struct RuntimeViewModelTests {
         }
     }
 
-    @Test("generate primary key returns nil when no server session exists")
+    @Test("generate primary key returns nil when no provider exists")
     @MainActor
     func generatePrimaryKeyReturnsNilWhenNoServerSessionExists() async throws {
         let client = EmptySnapshotControlPlaneXPCClient()
@@ -1785,7 +1785,7 @@ struct RuntimeViewModelTests {
             client: client,
             metrics: metrics,
             operatorSessionStore: NullOperatorSessionStore(),
-            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+            providerAPIKeyStore: ThrowingProviderAPIKeyStore(
                 throwOnLoad: false,
                 throwOnSave: true,
                 loadPrimaryKeyValue: nil
@@ -1811,7 +1811,7 @@ struct RuntimeViewModelTests {
         let viewModel = RuntimeViewModel(
             client: client,
             operatorSessionStore: ThrowingOperatorSessionStore(throwOnLoad: true, throwOnSave: false),
-            serverSessionAPIKeyStore: NullServerSessionAPIKeyStore()
+            providerAPIKeyStore: NullProviderAPIKeyStore()
         )
 
         await viewModel.start()
@@ -1826,7 +1826,7 @@ struct RuntimeViewModelTests {
         let viewModel = RuntimeViewModel(
             client: client,
             operatorSessionStore: ThrowingOperatorSessionStore(throwOnLoad: false, throwOnSave: true),
-            serverSessionAPIKeyStore: NullServerSessionAPIKeyStore()
+            providerAPIKeyStore: NullProviderAPIKeyStore()
         )
 
         await viewModel.start()
@@ -1843,7 +1843,7 @@ struct RuntimeViewModelTests {
         let viewModel = RuntimeViewModel(
             client: client,
             operatorSessionStore: NullOperatorSessionStore(),
-            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+            providerAPIKeyStore: ThrowingProviderAPIKeyStore(
                 throwOnLoad: true,
                 throwOnSave: false,
                 loadPrimaryKeyValue: nil
@@ -1857,7 +1857,7 @@ struct RuntimeViewModelTests {
         let applyFailureViewModel = RuntimeViewModel(
             client: client,
             operatorSessionStore: NullOperatorSessionStore(),
-            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+            providerAPIKeyStore: ThrowingProviderAPIKeyStore(
                 throwOnLoad: false,
                 throwOnSave: false,
                 loadPrimaryKeyValue: "melix_sk_apply_failure"
@@ -1877,7 +1877,7 @@ struct RuntimeViewModelTests {
         let emptyKeyViewModel = RuntimeViewModel(
             client: emptyKeyClient,
             operatorSessionStore: NullOperatorSessionStore(),
-            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+            providerAPIKeyStore: ThrowingProviderAPIKeyStore(
                 throwOnLoad: false,
                 throwOnSave: false,
                 loadPrimaryKeyValue: ""
@@ -1893,7 +1893,7 @@ struct RuntimeViewModelTests {
         let dedupeViewModel = RuntimeViewModel(
             client: dedupeClient,
             operatorSessionStore: NullOperatorSessionStore(),
-            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+            providerAPIKeyStore: ThrowingProviderAPIKeyStore(
                 throwOnLoad: false,
                 throwOnSave: false,
                 loadPrimaryKeyValue: "melix_sk_dedupe"
@@ -1908,7 +1908,7 @@ struct RuntimeViewModelTests {
         #expect(await dedupeClient.recordedGatewayAccessApplyRequests.count == 1)
     }
 
-    @Test("chat requires an interactive server session before sending prompts")
+    @Test("chat requires an interactive provider before sending prompts")
     @MainActor
     func chatRequiresInteractiveServerSession() async throws {
         let client = FakeControlPlaneXPCClient()
@@ -1923,7 +1923,7 @@ struct RuntimeViewModelTests {
         let actions = await client.recordedActions
         #expect(actions.contains(where: { $0.hasPrefix("chat:") }) == false)
         #expect(viewModel.chatStatusText == "Stopped")
-        #expect(viewModel.lastError == "Start the bound Server Session before sending chat prompts.")
+        #expect(viewModel.lastError == "Start the bound Provider before sending chat prompts.")
     }
 
     @Test("sleeping chat stays interactive while paused chat is blocked")
@@ -1957,12 +1957,12 @@ struct RuntimeViewModelTests {
         #expect(viewModel.selectedChatServerSession?.isInteractiveReady == true)
         #expect(viewModel.selectedChatServerSession?.chatWorkspaceNoticeState?.severity == .info)
 
-        let serverSessionID = try #require(viewModel.selectedServerSession?.id)
+        let providerID = try #require(viewModel.selectedServerSession?.id)
         await client.sendServerStateChanged(
             state: .serverReady,
             runtimeSessions: [
                 makeRuntimeSession(
-                    serverSessionID: serverSessionID,
+                    providerID: providerID,
                     lifecycleState: .paused,
                     powerState: .active,
                     wakeReason: .policyApply,
@@ -1974,7 +1974,7 @@ struct RuntimeViewModelTests {
             ]
         )
 
-        try await waitForRuntimeViewModelCondition("expected selected chat server session to enter paused state") {
+        try await waitForRuntimeViewModelCondition("expected selected chat provider to enter paused state") {
             viewModel.selectedChatServerSession?.lifecycle == .paused
         }
 
@@ -1984,7 +1984,7 @@ struct RuntimeViewModelTests {
 
         #expect(await client.recordedActions.filter { $0.hasPrefix("chat:") }.count == recordedChatCount)
         #expect(viewModel.chatStatusText == "Paused")
-        #expect(viewModel.lastError == "Resume the paused Server Session before sending chat prompts.")
+        #expect(viewModel.lastError == "Resume the paused Provider before sending chat prompts.")
     }
 
     @Test("new chat sessions require an explicit server selection before sending")
@@ -1999,7 +1999,7 @@ struct RuntimeViewModelTests {
         viewModel.createChatSession()
 
         #expect(viewModel.chatSessions.count == 2)
-        #expect(viewModel.selectedChatSession?.serverSessionID == "")
+        #expect(viewModel.selectedChatSession?.providerID == "")
         #expect(viewModel.selectedChatServerSession == nil)
 
         viewModel.chatComposerText = "should wait for server choice"
@@ -2007,13 +2007,13 @@ struct RuntimeViewModelTests {
 
         #expect(await client.recordedActions.contains(where: { $0.hasPrefix("chat:") }) == false)
         #expect(viewModel.chatStatusText == "Choose Server")
-        #expect(viewModel.lastError == "Choose a Server Session before sending chat prompts.")
+        #expect(viewModel.lastError == "Choose a Provider before sending chat prompts.")
 
-        viewModel.bindSelectedChatSessionToServer(serverSessionID: originalServerID)
+        viewModel.bindSelectedChatSessionToServer(providerID: originalServerID)
         viewModel.chatComposerText = "send after server choice"
         await viewModel.submitChatPrompt()
 
-        #expect(viewModel.selectedChatSession?.serverSessionID == originalServerID)
+        #expect(viewModel.selectedChatSession?.providerID == originalServerID)
         #expect(await client.recordedActions.contains("chat:melix-dev-text"))
     }
 
@@ -2044,7 +2044,7 @@ struct RuntimeViewModelTests {
         #expect(viewModel.lastError == "Hugging Face cache files are missing. Re-download this model to restore it.")
     }
 
-    @Test("surface selection command center and server session controls update shell state")
+    @Test("surface selection command center and provider controls update shell state")
     @MainActor
     func shellStateSelectionAndServerSessionControlsUpdateState() async throws {
         let client = FakeControlPlaneXPCClient()
@@ -2133,15 +2133,15 @@ struct RuntimeViewModelTests {
         let viewModel = RuntimeViewModel(client: client, metrics: metrics)
 
         await viewModel.start()
-        let serverSessionID = try #require(viewModel.selectedServerSession?.id)
+        let providerID = try #require(viewModel.selectedServerSession?.id)
 
         await viewModel.pauseSelectedServerSession()
-        #expect(await client.recordedActions.contains("server.pause:\(serverSessionID)"))
+        #expect(await client.recordedActions.contains("server.pause:\(providerID)"))
         #expect(viewModel.selectedServerSession?.lifecycle == .paused)
         #expect(viewModel.selectedServerSession?.wakeReason == .policyApply)
 
         await viewModel.resumeSelectedServerSession()
-        #expect(await client.recordedActions.contains("server.resume:\(serverSessionID)"))
+        #expect(await client.recordedActions.contains("server.resume:\(providerID)"))
         #expect(viewModel.selectedServerSession?.lifecycle == .running)
         #expect(viewModel.selectedServerSession?.wakeReason == .operatorResume)
 
@@ -2149,7 +2149,7 @@ struct RuntimeViewModelTests {
             state: .serverReady,
             runtimeSessions: [
                 makeRuntimeSession(
-                    serverSessionID: serverSessionID,
+                    providerID: providerID,
                     lifecycleState: .sleeping,
                     powerState: .lightSleep,
                     wakeReason: .requestActivity,
@@ -2160,12 +2160,12 @@ struct RuntimeViewModelTests {
                 )
             ]
         )
-        try await waitForRuntimeViewModelCondition("expected server session to enter sleeping state") {
+        try await waitForRuntimeViewModelCondition("expected provider to enter sleeping state") {
             viewModel.selectedServerSession?.lifecycle == .sleeping
         }
 
         await viewModel.wakeSelectedServerSession()
-        #expect(await client.recordedActions.contains("server.wake:\(serverSessionID)"))
+        #expect(await client.recordedActions.contains("server.wake:\(providerID)"))
         #expect(viewModel.selectedServerSession?.lifecycle == .running)
 
         viewModel.updateSelectedServerSessionAutoSleepEnabled(true)
@@ -2174,7 +2174,7 @@ struct RuntimeViewModelTests {
         await viewModel.applySelectedServerIdlePolicy()
 
         let idlePolicyRequest = try #require(await client.recordedServerIdlePolicyRequests.last)
-        #expect(idlePolicyRequest.serverSessionID == serverSessionID)
+        #expect(idlePolicyRequest.providerID == providerID)
         #expect(idlePolicyRequest.autoSleepEnabled)
         #expect(idlePolicyRequest.lightSleepAfterSeconds == 300)
         #expect(idlePolicyRequest.deepSleepAfterSeconds == 900)
@@ -2229,19 +2229,19 @@ struct RuntimeViewModelTests {
         await viewModel.resumeSelectedServerSession()
         #expect(viewModel.lastError?.contains("resume failed") == true)
 
-        let serverSessionID = try #require(viewModel.selectedServerSession?.id)
+        let providerID = try #require(viewModel.selectedServerSession?.id)
         await client.sendServerStateChanged(
             state: .serverReady,
             runtimeSessions: [
                 makeRuntimeSession(
-                    serverSessionID: serverSessionID,
+                    providerID: providerID,
                     lifecycleState: .sleeping,
                     powerState: .lightSleep,
                     wakeReason: .requestActivity
                 )
             ]
         )
-        try await waitForRuntimeViewModelCondition("expected server session to enter sleeping state before wake failure") {
+        try await waitForRuntimeViewModelCondition("expected provider to enter sleeping state before wake failure") {
             viewModel.selectedServerSession?.lifecycle == .sleeping
         }
 
@@ -2277,7 +2277,7 @@ struct RuntimeViewModelTests {
         #expect(viewModel.lastError?.contains("idle policy failed") == true)
     }
 
-    @Test("chat blocked messages cover starting restored stopped and failed server sessions")
+    @Test("chat blocked messages cover starting restored stopped and failed providers")
     @MainActor
     func chatBlockedMessagesCoverStartingStoppedAndFailedServerSessions() async throws {
         let client = FakeControlPlaneXPCClient()
@@ -2299,7 +2299,7 @@ struct RuntimeViewModelTests {
         try bindSelectedChatSessionToPrimaryServer(viewModel)
         viewModel.chatComposerText = "starting blocked"
         await viewModel.submitChatPrompt()
-        #expect(viewModel.lastError == "Wait for the Server Session to finish starting before sending chat prompts.")
+        #expect(viewModel.lastError == "Wait for the Provider to finish starting before sending chat prompts.")
 
         let temporaryRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("melix-menubar-stopping-chat-\(UUID().uuidString)")
@@ -2308,8 +2308,8 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-        let stoppingServer = DesktopServerSessionState(
-            id: "server-session-stopping",
+        let stoppingServer = DesktopProviderState(
+            id: "provider-stopping",
             title: "Stopping Server",
             modelID: "melix-dev-text",
             lifecycle: .stopping,
@@ -2318,8 +2318,8 @@ struct RuntimeViewModelTests {
         try operatorSessionStore.save(
             OperatorSessionState(
                 selectedSurface: .chat,
-                selectedServerSessionID: stoppingServer.id,
-                serverSessions: [stoppingServer]
+                selectedProviderID: stoppingServer.id,
+                providers: [stoppingServer]
             )
         )
 
@@ -2332,11 +2332,11 @@ struct RuntimeViewModelTests {
         stoppingViewModel.selectServerSession(id: stoppingServer.id)
         #expect(stoppingViewModel.selectedServerSession?.lifecycle == .stopped)
         stoppingViewModel.createChatSession()
-        stoppingViewModel.bindSelectedChatSessionToServer(serverSessionID: stoppingServer.id)
+        stoppingViewModel.bindSelectedChatSessionToServer(providerID: stoppingServer.id)
         #expect(stoppingViewModel.selectedChatServerSession?.lifecycle == .stopped)
         stoppingViewModel.chatComposerText = "stopping blocked"
         await stoppingViewModel.submitChatPrompt()
-        #expect(stoppingViewModel.lastError == "Start the bound Server Session before sending chat prompts.")
+        #expect(stoppingViewModel.lastError == "Start the bound Provider before sending chat prompts.")
 
         let failingClient = FakeControlPlaneXPCClient()
         let failingSnapshot = makeSnapshot(
@@ -2358,10 +2358,10 @@ struct RuntimeViewModelTests {
         await failingViewModel.pauseSelectedServerSession()
         failingViewModel.chatComposerText = "error blocked"
         await failingViewModel.submitChatPrompt()
-        #expect(failingViewModel.lastError == "Recover the failed Server Session before sending chat prompts. gpu lost")
+        #expect(failingViewModel.lastError == "Recover the failed Provider before sending chat prompts. gpu lost")
     }
 
-    @Test("agent integration exports mirror the selected server session and record metrics")
+    @Test("agent integration exports mirror the selected provider and record metrics")
     @MainActor
     func agentIntegrationExportsMirrorTheSelectedServerSessionAndRecordMetrics() async throws {
         let client = FakeControlPlaneXPCClient()
@@ -2414,7 +2414,7 @@ struct RuntimeViewModelTests {
         #expect(reboundExport.configFragment.contains("not-required"))
     }
 
-    @Test("shared-access snapshot hydrates server-session state and agent exports")
+    @Test("shared-access snapshot hydrates provider state and agent exports")
     @MainActor
     func sharedAccessSnapshotHydratesServerSessionStateAndAgentExports() async throws {
         let snapshot = makeSnapshot(
@@ -2513,7 +2513,7 @@ struct RuntimeViewModelTests {
 
     @Test("persistent session summary covers active-only and empty session states")
     func persistentSessionSummaryCoversActiveOnlyAndEmptyStates() {
-        let activeOnly = DesktopServerSessionState(
+        let activeOnly = DesktopProviderState(
             id: "active-only",
             title: "Active Only",
             modelID: "melix-dev-text",
@@ -2522,7 +2522,7 @@ struct RuntimeViewModelTests {
             expiredRememberedSessionCount: 0,
             authSessionRetentionSeconds: 300
         )
-        let empty = DesktopServerSessionState(
+        let empty = DesktopProviderState(
             id: "empty",
             title: "Empty",
             modelID: "melix-dev-text",
@@ -2614,22 +2614,22 @@ struct RuntimeViewModelTests {
         #expect(unknownSession.authTokenHint.isEmpty)
     }
 
-    @Test("server session shared-access summary text covers configured disabled and enabled states")
+    @Test("provider shared-access summary text covers configured disabled and enabled states")
     func serverSessionSharedAccessSummaryTextCoversConfiguredDisabledAndEnabledStates() {
-        let configuredDisabled = DesktopServerSessionState(
+        let configuredDisabled = DesktopProviderState(
             id: "configured-disabled",
             title: "Configured Disabled",
             modelID: "melix-dev-text",
             sharedAccessState: .configuredDisabled
         )
-        let enabledSingleKey = DesktopServerSessionState(
+        let enabledSingleKey = DesktopProviderState(
             id: "enabled-single",
             title: "Enabled Single",
             modelID: "melix-dev-text",
             sharedAccessState: .enabled,
             accessKeyCount: 1
         )
-        let enabledMultipleKeys = DesktopServerSessionState(
+        let enabledMultipleKeys = DesktopProviderState(
             id: "enabled-multi",
             title: "Enabled Multiple",
             modelID: "melix-dev-text",
@@ -2642,7 +2642,7 @@ struct RuntimeViewModelTests {
         #expect(enabledMultipleKeys.sharedAccessSummaryText == "Shared access is enabled for 2 keys.")
     }
 
-    @Test("agent integration exports stay empty when no server session is available")
+    @Test("agent integration exports stay empty when no provider is available")
     @MainActor
     func agentIntegrationExportsStayEmptyWhenNoServerSessionIsAvailable() async throws {
         let client = EmptySnapshotControlPlaneXPCClient()
@@ -2650,7 +2650,7 @@ struct RuntimeViewModelTests {
 
         await viewModel.start()
 
-        #expect(viewModel.serverSessions.isEmpty)
+        #expect(viewModel.providers.isEmpty)
         #expect(viewModel.agentIntegrationExports.isEmpty)
         #expect(viewModel.selectedAgentIntegrationExport == nil)
     }
@@ -2662,37 +2662,37 @@ struct RuntimeViewModelTests {
         let viewModel = RuntimeViewModel(client: client)
 
         await viewModel.start()
-        #expect(viewModel.serverSessions.isEmpty)
+        #expect(viewModel.providers.isEmpty)
         #expect(viewModel.chatSessions.count == 1)
-        #expect(viewModel.selectedChatSession?.serverSessionID == "")
+        #expect(viewModel.selectedChatSession?.providerID == "")
 
         viewModel.createChatSession()
         #expect(viewModel.chatSessions.count == 2)
-        #expect(viewModel.selectedChatSession?.serverSessionID == "")
+        #expect(viewModel.selectedChatSession?.providerID == "")
         #expect(viewModel.selectedSurface == .chat)
 
         viewModel.chatComposerText = "wait for server"
         await viewModel.submitChatPrompt()
         #expect(viewModel.chatStatusText == "Choose Server")
-        #expect(viewModel.lastError == "Choose a Server Session before sending chat prompts.")
+        #expect(viewModel.lastError == "Choose a Provider before sending chat prompts.")
 
         viewModel.createServerSession()
-        #expect(viewModel.serverSessions.isEmpty)
+        #expect(viewModel.providers.isEmpty)
         #expect(viewModel.lastError == "No Ready to Run model is available. Rescan or download a model before creating a local server.")
 
         viewModel.createServerSession(modelID: "melix-dev-text")
 
         let seededServer = try #require(viewModel.selectedServerSession)
         let seededChat = try #require(viewModel.selectedChatSession)
-        #expect(viewModel.serverSessions.count == 1)
+        #expect(viewModel.providers.count == 1)
         #expect(viewModel.chatSessions.count == 2)
         #expect(seededServer.title == "Primary Server")
         #expect(seededServer.modelID == "melix-dev-text")
         #expect(seededServer.port == 12436)
-        #expect(seededChat.serverSessionID == "")
+        #expect(seededChat.providerID == "")
 
-        viewModel.bindSelectedChatSessionToServer(serverSessionID: seededServer.id)
-        #expect(viewModel.selectedChatSession?.serverSessionID == seededServer.id)
+        viewModel.bindSelectedChatSessionToServer(providerID: seededServer.id)
+        #expect(viewModel.selectedChatSession?.providerID == seededServer.id)
         #expect(viewModel.selectedSurface == .server)
     }
 
@@ -2717,7 +2717,7 @@ struct RuntimeViewModelTests {
         let forkedSession = try #require(viewModel.selectedChatSession)
         #expect(viewModel.chatSessions.count == 2)
         #expect(forkedSession.title == "\(originalSession.title) Fork")
-        #expect(forkedSession.serverSessionID == originalSession.serverSessionID)
+        #expect(forkedSession.providerID == originalSession.providerID)
         #expect(forkedSession.branchID == "branch-2")
         #expect(forkedSession.branchTitle == "Branch 2")
         #expect(forkedSession.transcript == originalSession.transcript)
@@ -2790,12 +2790,12 @@ struct RuntimeViewModelTests {
 
         #expect(exportPath == nil)
         #expect(await client.recordedActions.isEmpty)
-        #expect(viewModel.chatStatusText == "No Server Session")
-        #expect(viewModel.lastError == "Create a Server Session before sending chat prompts.")
+        #expect(viewModel.chatStatusText == "No Provider")
+        #expect(viewModel.lastError == "Create a Provider before sending chat prompts.")
         #expect(viewModel.selectedSurface == .server)
     }
 
-    @Test("server session sync keeps missing bindings unavailable and surfaces recovery banners")
+    @Test("provider sync keeps missing bindings unavailable and surfaces recovery banners")
     @MainActor
     func serverSessionSyncKeepsMissingBindingsUnavailableAndSurfacesRecoveryBanners() async throws {
         let client = FakeControlPlaneXPCClient()
@@ -2931,7 +2931,7 @@ struct RuntimeViewModelTests {
             features: ["chat"]
         )
         let listener = makeGatewayConfigListener(
-            serverSessionID: "server-session-1",
+            providerID: "provider-1",
             requestedHost: "127.0.0.1",
             requestedPort: 12436,
             effectiveHost: "127.0.0.1",
@@ -2947,7 +2947,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [baseModel, selectedModel],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")],
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")],
                 gatewayConfig: makeGatewayConfigSummary(listener: listener)
             )
         )
@@ -2975,8 +2975,8 @@ struct RuntimeViewModelTests {
         let staleGatewayModelID = "melix-dev-qwen-local"
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-        let restoredServerSession = DesktopServerSessionState(
-            id: "server-session-1",
+        let restoredServerSession = DesktopProviderState(
+            id: "provider-1",
             title: "Primary Session",
             modelID: selectedModelID,
             lifecycle: .running
@@ -2984,14 +2984,14 @@ struct RuntimeViewModelTests {
         try operatorSessionStore.save(
             OperatorSessionState(
                 selectedSurface: .chat,
-                selectedServerSessionID: restoredServerSession.id,
-                serverSessions: [restoredServerSession]
+                selectedProviderID: restoredServerSession.id,
+                providers: [restoredServerSession]
             )
         )
 
         let client = FakeControlPlaneXPCClient()
         let listener = makeGatewayConfigListener(
-            serverSessionID: restoredServerSession.id,
+            providerID: restoredServerSession.id,
             requestedHost: "127.0.0.1",
             requestedPort: 12436,
             effectiveHost: "127.0.0.1",
@@ -3010,7 +3010,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: staleGatewayModelID, state: .modelWarm),
                     makeModelSummary(modelID: selectedModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: restoredServerSession.id)],
+                runtimeSessions: [makeRuntimeSession(providerID: restoredServerSession.id)],
                 gatewayConfig: makeGatewayConfigSummary(listener: listener)
             )
         )
@@ -3038,7 +3038,7 @@ struct RuntimeViewModelTests {
         let client = FakeControlPlaneXPCClient()
         let selectedModelID = "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"
         let listener = makeGatewayConfigListener(
-            serverSessionID: "server-session-1",
+            providerID: "provider-1",
             requestedHost: "127.0.0.1",
             requestedPort: 12436,
             effectiveHost: "127.0.0.1",
@@ -3059,7 +3059,7 @@ struct RuntimeViewModelTests {
                     state: .modelWarm,
                     features: ["chat"]
                 )],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")],
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")],
                 gatewayConfig: makeGatewayConfigSummary(listener: listener)
             )
         )
@@ -3975,13 +3975,13 @@ struct RuntimeViewModelTests {
 
         await viewModel.start()
         viewModel.createServerSession()
-        try await waitForRuntimeViewModelCondition("expected CLI-created server session to hydrate") {
-            viewModel.serverSessions.count >= 2
+        try await waitForRuntimeViewModelCondition("expected CLI-created provider to hydrate") {
+            viewModel.providers.count >= 2
         }
-        let serverSessionID = try #require(viewModel.serverSessions.map(\.id).sorted().last)
-        viewModel.selectServerSession(id: serverSessionID)
-        try await waitForRuntimeViewModelCondition("expected CLI-created server session to become selected") {
-            viewModel.selectedServerSession?.id == serverSessionID
+        let providerID = try #require(viewModel.providers.map(\.id).sorted().last)
+        viewModel.selectServerSession(id: providerID)
+        try await waitForRuntimeViewModelCondition("expected CLI-created provider to become selected") {
+            viewModel.selectedServerSession?.id == providerID
         }
         viewModel.updateSelectedServerSessionHost("127.0.0.1")
         viewModel.updateSelectedServerSessionPort(18081)
@@ -4008,12 +4008,12 @@ struct RuntimeViewModelTests {
         let gatewayRequest = try #require(await runnerClient.recordedGatewayConfigApplyRequests.first)
         let servingRequest = try #require(await runnerClient.recordedServingDefaultsApplyRequests.first)
 
-        #expect(gatewayRequest.serverSessionID == serverSessionID)
+        #expect(gatewayRequest.providerID == providerID)
         #expect(gatewayRequest.host == "127.0.0.1")
         #expect(gatewayRequest.port == 18081)
         #expect(gatewayRequest.rateLimitPerMinute == 360)
         #expect(gatewayRequest.timeoutSeconds == 75)
-        #expect(servingRequest.serverSessionID == serverSessionID)
+        #expect(servingRequest.providerID == providerID)
         #expect(servingRequest.temperature == 0.33)
         #expect(servingRequest.topP == 0.91)
         #expect(servingRequest.maxTokens == 640)
@@ -4876,14 +4876,14 @@ struct RuntimeViewModelTests {
         #expect(await metrics.snapshot()["desktop.reconnect_success_ms"] != nil)
     }
 
-    @Test("subscription reconnect reapplies stored gateway access for the selected running server session")
+    @Test("subscription reconnect reapplies stored gateway access for the selected running provider")
     @MainActor
     func subscriptionReconnectReappliesStoredGatewayAccessForSelectedRunningServerSession() async throws {
         let client = FakeControlPlaneXPCClient()
         let viewModel = RuntimeViewModel(
             client: client,
             operatorSessionStore: NullOperatorSessionStore(),
-            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+            providerAPIKeyStore: ThrowingProviderAPIKeyStore(
                 throwOnLoad: false,
                 throwOnSave: false,
                 loadPrimaryKeyValue: "melix_sk_reconnect"
@@ -5047,7 +5047,7 @@ struct RuntimeViewModelTests {
         #expect(hasCachePressureMetric)
     }
 
-    @Test("snapshot runtime sessions project typed lifecycle and power metadata into server sessions")
+    @Test("snapshot runtime sessions project typed lifecycle and power metadata into providers")
     @MainActor
     func snapshotRuntimeSessionsProjectTypedLifecycleAndPowerMetadataIntoServerSessions() async throws {
         let client = FakeControlPlaneXPCClient()
@@ -5071,8 +5071,8 @@ struct RuntimeViewModelTests {
 
         await viewModel.start()
 
-        let session = try #require(viewModel.serverSessions.first)
-        #expect(session.id == "server-session-1")
+        let session = try #require(viewModel.providers.first)
+        #expect(session.id == "provider-1")
         #expect(session.lifecycle == .sleeping)
         #expect(session.powerState == .deepSleep)
         #expect(session.wakeReason == .requestActivity)
@@ -5089,12 +5089,12 @@ struct RuntimeViewModelTests {
         let viewModel = RuntimeViewModel(client: client)
 
         await viewModel.start()
-        let serverSessionID = viewModel.serverSessions.first?.id ?? "server-session-1"
+        let providerID = viewModel.providers.first?.id ?? "provider-1"
         await client.sendServerStateChanged(
             state: .serverReady,
             runtimeSessions: [
                 makeRuntimeSession(
-                    serverSessionID: serverSessionID,
+                    providerID: providerID,
                     lifecycleState: .paused,
                     powerState: .active,
                     wakeReason: .policyApply,
@@ -5107,11 +5107,11 @@ struct RuntimeViewModelTests {
         )
 
         try await waitForRuntimeViewModelCondition("server runtime session event should project paused state") {
-            viewModel.serverSessions.first?.lifecycle == .paused
-                && viewModel.serverSessions.first?.wakeReason == .policyApply
+            viewModel.providers.first?.lifecycle == .paused
+                && viewModel.providers.first?.wakeReason == .policyApply
         }
 
-        let session = try #require(viewModel.serverSessions.first)
+        let session = try #require(viewModel.providers.first)
         let foundation = viewModel.desktopFoundationState
         #expect(session.lifecycle == .paused)
         #expect(session.powerState == .active)
@@ -5132,8 +5132,8 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
-        let restoredServerSession = DesktopServerSessionState(
-            id: "server-session-restored",
+        let restoredServerSession = DesktopProviderState(
+            id: "provider-restored",
             title: "Restored Server",
             modelID: "melix-dev-text",
             lifecycle: .running
@@ -5141,8 +5141,8 @@ struct RuntimeViewModelTests {
         try operatorSessionStore.save(
             OperatorSessionState(
                 selectedSurface: .server,
-                selectedServerSessionID: restoredServerSession.id,
-                serverSessions: [restoredServerSession]
+                selectedProviderID: restoredServerSession.id,
+                providers: [restoredServerSession]
             )
         )
 
@@ -5152,7 +5152,7 @@ struct RuntimeViewModelTests {
             models: [makeModelSummary(state: .modelWarm)],
             runtimeSessions: [
                 makeRuntimeSession(
-                    serverSessionID: "detached-runtime-session",
+                    providerID: "detached-runtime-session",
                     lifecycleState: .loading,
                     powerState: .lightSleep,
                     wakeReason: .operatorResume
@@ -5164,8 +5164,8 @@ struct RuntimeViewModelTests {
 
         await viewModel.start()
 
-        let sessionID = try #require(viewModel.serverSessions.first?.id)
-        let hydrated = try #require(viewModel.serverSessions.first)
+        let sessionID = try #require(viewModel.providers.first?.id)
+        let hydrated = try #require(viewModel.providers.first)
         #expect(hydrated.lifecycle == .starting)
         #expect(hydrated.powerState == .lightSleep)
         #expect(hydrated.wakeReason == .operatorResume)
@@ -5174,7 +5174,7 @@ struct RuntimeViewModelTests {
             state: .serverReady,
             runtimeSessions: [
                 makeRuntimeSession(
-                    serverSessionID: sessionID,
+                    providerID: sessionID,
                     lifecycleState: .stopped,
                     powerState: .stopped,
                     wakeReason: .toolActivity
@@ -5183,16 +5183,16 @@ struct RuntimeViewModelTests {
         )
 
         try await waitForRuntimeViewModelCondition("runtime session should project stopped/tool activity state") {
-            viewModel.serverSessions.first?.lifecycle == .stopped
-                && viewModel.serverSessions.first?.powerState == .stopped
-                && viewModel.serverSessions.first?.wakeReason == .toolActivity
+            viewModel.providers.first?.lifecycle == .stopped
+                && viewModel.providers.first?.powerState == .stopped
+                && viewModel.providers.first?.wakeReason == .toolActivity
         }
 
         await client.sendServerStateChanged(
             state: .serverReady,
             runtimeSessions: [
                 makeRuntimeSession(
-                    serverSessionID: sessionID,
+                    providerID: sessionID,
                     lifecycleState: .error,
                     powerState: .UNRECOGNIZED(777),
                     wakeReason: .initialBoot
@@ -5201,16 +5201,16 @@ struct RuntimeViewModelTests {
         )
 
         try await waitForRuntimeViewModelCondition("runtime session should project error and unavailable power state") {
-            viewModel.serverSessions.first?.lifecycle == .error
-                && viewModel.serverSessions.first?.powerState == .unavailable
-                && viewModel.serverSessions.first?.wakeReason == .initialBoot
+            viewModel.providers.first?.lifecycle == .error
+                && viewModel.providers.first?.powerState == .unavailable
+                && viewModel.providers.first?.wakeReason == .initialBoot
         }
 
         await client.sendServerStateChanged(
             state: .serverReady,
             runtimeSessions: [
                 makeRuntimeSession(
-                    serverSessionID: sessionID,
+                    providerID: sessionID,
                     lifecycleState: .ready,
                     powerState: .active,
                     wakeReason: .UNRECOGNIZED(888)
@@ -5219,16 +5219,16 @@ struct RuntimeViewModelTests {
         )
 
         try await waitForRuntimeViewModelCondition("runtime session should project ready state and unknown wake reason fallback") {
-            viewModel.serverSessions.first?.lifecycle == .running
-                && viewModel.serverSessions.first?.powerState == .active
-                && viewModel.serverSessions.first?.wakeReason == .unspecified
+            viewModel.providers.first?.lifecycle == .running
+                && viewModel.providers.first?.powerState == .active
+                && viewModel.providers.first?.wakeReason == .unspecified
         }
 
         await client.sendServerStateChanged(
             state: .serverReady,
             runtimeSessions: [
                 makeRuntimeSession(
-                    serverSessionID: sessionID,
+                    providerID: sessionID,
                     lifecycleState: .UNRECOGNIZED(999),
                     powerState: .active,
                     wakeReason: .initialBoot
@@ -5237,7 +5237,7 @@ struct RuntimeViewModelTests {
         )
 
         try await waitForRuntimeViewModelCondition("runtime session should fall back to unavailable lifecycle for unknown values") {
-            viewModel.serverSessions.first?.lifecycle == .unavailable
+            viewModel.providers.first?.lifecycle == .unavailable
         }
     }
 
@@ -5752,7 +5752,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureModelOperation(
@@ -5905,7 +5905,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureBenchResponse(
@@ -6040,7 +6040,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureBenchResponse(
@@ -6090,7 +6090,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureDoctorResponse("# <b>Doctor</b> [open](file:///tmp/melix)")
@@ -6151,7 +6151,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let viewModel = RuntimeViewModel(client: client)
@@ -6186,7 +6186,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [makeMenuBarImageModelSummary()],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let imageOnlyViewModel = RuntimeViewModel(client: imageOnlyClient)
@@ -6221,7 +6221,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [model],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let viewModel = RuntimeViewModel(client: client)
@@ -6261,7 +6261,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [supportedModel],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-2")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-2")]
             )
         )
         let supportedViewModel = RuntimeViewModel(client: supportedClient)
@@ -6277,7 +6277,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [makeModelSummary(modelID: modelID, state: .modelWarm)],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-3")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-3")]
             )
         )
         let noReceiptViewModel = RuntimeViewModel(client: noReceiptClient)
@@ -6295,7 +6295,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [makeModelSummary(modelID: testReadyModelID, state: .modelWarm)],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureModelOperation(
@@ -6353,7 +6353,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [makeModelSummary(modelID: testReadyModelID, state: .modelWarm)],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let workflowRunner = RecordingCLIWorkflowRunner(surface: .subprocess)
@@ -6447,7 +6447,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [model],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureModelOperation(
@@ -6546,7 +6546,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [model],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureExportResult(
@@ -6585,7 +6585,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [model],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-2")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-2")]
             )
         )
         await pendingClient.configureExportResult(
@@ -6679,7 +6679,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [model],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let viewModel = RuntimeViewModel(client: client)
@@ -6770,7 +6770,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [makeModelSummary(modelID: localModelID, state: .modelWarm)],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let remoteStore = FakeRemoteServerStore(
@@ -6827,13 +6827,13 @@ struct RuntimeViewModelTests {
         #expect(viewModel.lastError == "Remote Server benchmark is not supported yet; select a local running server.")
 
         let startNewTarget = try #require(viewModel.diagnosticsServerTargets.first { $0.kind == .startNewServer })
-        let serverSessionCount = viewModel.serverSessions.count
+        let serverSessionCount = viewModel.providers.count
         viewModel.selectDiagnosticsServerTarget(id: startNewTarget.id)
 
         #expect(viewModel.selectedSurface == .server)
         #expect(viewModel.isCreatingServerTarget)
         #expect(viewModel.selectedServerCreationKind == .localServer)
-        #expect(viewModel.serverSessions.count == serverSessionCount)
+        #expect(viewModel.providers.count == serverSessionCount)
         #expect(await client.recordedBenchRequests.isEmpty)
     }
 
@@ -6850,7 +6850,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: localModelID, state: .modelWarm),
                     makeModelSummary(modelID: alternateModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let viewModel = RuntimeViewModel(client: client)
@@ -6887,10 +6887,10 @@ struct RuntimeViewModelTests {
         var snapshot = makeSnapshot(
             serverState: .serverReady,
             models: [makeModelSummary(modelID: localModelID, state: .modelWarm)],
-            runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+            runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
         )
         var servingDefaults = Melix_Controlplane_V1_ServingDefaultsSessionSummary()
-        servingDefaults.providerID = "server-session-1"
+        servingDefaults.providerID = "provider-1"
         servingDefaults.defaultModelID = localModelID
         servingDefaults.requestedTemperature = 0.4
         servingDefaults.requestedTopP = 0.9
@@ -6937,10 +6937,10 @@ struct RuntimeViewModelTests {
         var snapshot = makeSnapshot(
             serverState: .serverReady,
             models: [makeModelSummary(modelID: localModelID, state: .modelWarm)],
-            runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+            runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
         )
         var servingDefaults = Melix_Controlplane_V1_ServingDefaultsSessionSummary()
-        servingDefaults.providerID = "server-session-1"
+        servingDefaults.providerID = "provider-1"
         servingDefaults.defaultModelID = localModelID
         servingDefaults.requestedAccelerationProfile = "throughput"
         servingDefaults.effectiveAccelerationProfile = "throughput"
@@ -7024,7 +7024,7 @@ struct RuntimeViewModelTests {
         })
     }
 
-    @Test("chat sends through a server session created from a text capable Hugging Face cache VLM model")
+    @Test("chat sends through a provider created from a text capable Hugging Face cache VLM model")
     @MainActor
     func chatSendsThroughServerCreatedFromTextCapableHFCacheVLMModel() async throws {
         let modelID = "unsloth/gemma-4-E4B-it-MLX-8bit"
@@ -7046,7 +7046,7 @@ struct RuntimeViewModelTests {
         let server = try #require(viewModel.selectedServerSession)
 
         await viewModel.startSelectedServerSession()
-        viewModel.bindSelectedChatSessionToServer(serverSessionID: server.id)
+        viewModel.bindSelectedChatSessionToServer(providerID: server.id)
         viewModel.chatComposerText = "Explain this image-ready model in text."
 
         await viewModel.submitChatPrompt()
@@ -7089,8 +7089,8 @@ struct RuntimeViewModelTests {
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
         let runningModelID = "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"
-        let restoredServerSession = DesktopServerSessionState(
-            id: "server-session-qwen",
+        let restoredServerSession = DesktopProviderState(
+            id: "provider-qwen",
             title: "Primary Session",
             modelID: runningModelID,
             lifecycle: .running
@@ -7098,8 +7098,8 @@ struct RuntimeViewModelTests {
         try operatorSessionStore.save(
             OperatorSessionState(
                 selectedSurface: .chat,
-                selectedServerSessionID: restoredServerSession.id,
-                serverSessions: [restoredServerSession]
+                selectedProviderID: restoredServerSession.id,
+                providers: [restoredServerSession]
             )
         )
 
@@ -7158,12 +7158,12 @@ struct RuntimeViewModelTests {
         viewModel.beginServerCreation()
         viewModel.newLocalServerTitleDraft = "   "
         viewModel.newLocalServerModelID = modelID
-        let sessionCount = viewModel.serverSessions.count
+        let sessionCount = viewModel.providers.count
         let targetCount = viewModel.serverTargets.count
 
         viewModel.createLocalServerFromDraft()
 
-        #expect(viewModel.serverSessions.count == sessionCount)
+        #expect(viewModel.providers.count == sessionCount)
         #expect(viewModel.serverTargets.count == targetCount)
         #expect(viewModel.isCreatingServerTarget)
         #expect(viewModel.lastError == "Local Server requires a session name.")
@@ -7216,7 +7216,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: baseModelID, state: .modelWarm),
                     makeModelSummary(modelID: derivedModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureModelOperation(
@@ -7260,7 +7260,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let remoteStore = FakeRemoteServerStore(
@@ -7513,7 +7513,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         var matrixJob = Melix_Controlplane_V1_BenchmarkMatrixJobSummary()
@@ -7651,7 +7651,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let viewModel = RuntimeViewModel(client: client)
@@ -7684,7 +7684,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [makeMenuBarImageModelSummary()],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let imageViewModel = RuntimeViewModel(client: imageClient)
@@ -7702,7 +7702,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let requestsViewModel = RuntimeViewModel(client: requestsClient)
@@ -7726,7 +7726,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let viewModel = RuntimeViewModel(client: client)
@@ -7776,7 +7776,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureExportResult(
@@ -7905,14 +7905,14 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [baseModel, targetModel],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await runnerClient.configureSnapshot(
             makeSnapshot(
                 serverState: .serverReady,
                 models: [baseModel, targetModel],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         var evaluationJob = Melix_Controlplane_V1_EvaluationJobSummary()
@@ -7996,7 +7996,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureExportResult(
@@ -8060,7 +8060,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [makeModelSummary(modelID: testReadyModelID, state: .modelWarm)],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let viewModel = RuntimeViewModel(client: client)
@@ -8124,7 +8124,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureExportResult(
@@ -8198,7 +8198,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await runnerClient.configureBenchResponse(
@@ -8283,8 +8283,8 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorStore = OperatorSessionStore(melixHome: melixHome)
-        let initialServerSession = DesktopServerSessionState(
-            id: "server-session-1",
+        let initialServerSession = DesktopProviderState(
+            id: "provider-1",
             title: "Primary Server",
             modelID: testReadyModelID,
             host: "127.0.0.1",
@@ -8293,8 +8293,8 @@ struct RuntimeViewModelTests {
         try operatorStore.save(
             OperatorSessionState(
                 selectedSurface: .server,
-                selectedServerSessionID: initialServerSession.id,
-                serverSessions: [initialServerSession]
+                selectedProviderID: initialServerSession.id,
+                providers: [initialServerSession]
             )
         )
 
@@ -8306,7 +8306,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await directClient.configureExportResult(
@@ -8320,13 +8320,13 @@ struct RuntimeViewModelTests {
                 {
                   "selected_surface": "server",
                   "selected_tool_section": "models_library",
-                  "selected_server_session_id": "server-session-1",
+                  "selected_provider_id": "provider-1",
                   "dismissed_banner_ids": [],
                   "download_queue": [],
                   "registry_roots": [],
-                  "server_sessions": [
+                  "providers": [
                     {
-                      "id": "server-session-1",
+                      "id": "provider-1",
                       "title": "Primary Server",
                       "model_id": "\(modelID)",
                       "host": "127.0.0.1",
@@ -8353,12 +8353,12 @@ struct RuntimeViewModelTests {
                 )
             case .modelRootsRescan:
                 return .success("{\"operation\":\"registry_snapshot\"}\n")
-            case .serverSessionUpdate(let options):
+            case .providerUpdate(let options):
                 return .success(sessionJSON(modelID: options.defaultModelID.isEmpty ? testReadyModelID : options.defaultModelID))
-            case .serverSessionSelect:
+            case .providerSelect:
                 return .success(sessionJSON(modelID: "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"))
             case .serverStart(let options):
-                return .success(makeCLIServerSnapshotJSON(serverSessionID: options.serverSessionID))
+                return .success(makeCLIServerSnapshotJSON(providerID: options.providerID))
             case .loraTrain:
                 return .success(
                     """
@@ -8450,11 +8450,11 @@ struct RuntimeViewModelTests {
             return false
         })
         #expect(recordedCommands.contains {
-            if case .serverSessionUpdate = $0 { return true }
+            if case .providerUpdate = $0 { return true }
             return false
         })
         #expect(recordedCommands.contains {
-            if case .serverSessionSelect = $0 { return true }
+            if case .providerSelect = $0 { return true }
             return false
         })
         #expect(recordedCommands.contains {
@@ -8534,8 +8534,8 @@ struct RuntimeViewModelTests {
 
         let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
         let operatorStore = OperatorSessionStore(melixHome: melixHome)
-        let initialServerSession = DesktopServerSessionState(
-            id: "server-session-1",
+        let initialServerSession = DesktopProviderState(
+            id: "provider-1",
             title: "Qwen DFlash",
             modelID: "mlx-community/Qwen3.5-27B-4bit",
             host: "127.0.0.1",
@@ -8544,8 +8544,8 @@ struct RuntimeViewModelTests {
         try operatorStore.save(
             OperatorSessionState(
                 selectedSurface: .server,
-                selectedServerSessionID: initialServerSession.id,
-                serverSessions: [initialServerSession]
+                selectedProviderID: initialServerSession.id,
+                providers: [initialServerSession]
             )
         )
         await directClient.configureSnapshot(
@@ -8561,7 +8561,7 @@ struct RuntimeViewModelTests {
         await workflowRunner.configureHandler { command in
             switch command {
             case .serverStart(let options):
-                return .success(makeCLIServerSnapshotJSON(serverSessionID: options.serverSessionID))
+                return .success(makeCLIServerSnapshotJSON(providerID: options.providerID))
             default:
                 return .success("{}\n")
             }
@@ -8581,12 +8581,12 @@ struct RuntimeViewModelTests {
 
         let recordedCommands = await workflowRunner.snapshotRecordedCommands()
         let updateCommand = try #require(recordedCommands.compactMap { command in
-            if case .serverSessionUpdate(let options) = command {
+            if case .providerUpdate(let options) = command {
                 return options
             }
             return nil
         }.first)
-        #expect(updateCommand.serverSessionID == "server-session-1")
+        #expect(updateCommand.providerID == "provider-1")
         #expect(updateCommand.accelerationMode == "speculative_decode")
         #expect(updateCommand.draftModelID == "z-lab/Qwen3.5-27B-DFlash")
         #expect(updateCommand.numDraftTokens == 4)
@@ -8667,9 +8667,9 @@ struct RuntimeViewModelTests {
         }
     }
 
-    @Test("cli create and select server session failures surface local error state")
+    @Test("cli create and select provider failures surface local error state")
     @MainActor
-    func cliCreateAndSelectServerSessionFailuresSurfaceLocalErrorState() async throws {
+    func cliCreateAndSelectProviderFailuresSurfaceLocalErrorState() async throws {
         let directClient = FakeControlPlaneXPCClient()
         let workflowRunner = RecordingCLIWorkflowRunner(surface: .subprocess)
         await directClient.configureSnapshot(
@@ -8680,19 +8680,19 @@ struct RuntimeViewModelTests {
         )
         await workflowRunner.configureHandler { command in
             switch command {
-            case .serverSessionCreate:
+            case .providerCreate:
                 return .failure(
                     .processFailed(
-                        commandID: "server.session.create",
+                        commandID: "provider.create",
                         surface: .subprocess,
                         exitCode: 3,
                         stderr: "create failed"
                     )
                 )
-            case .serverSessionSelect:
+            case .providerSelect:
                 return .failure(
                     .processFailed(
-                        commandID: "server.session.select",
+                        commandID: "provider.select",
                         surface: .subprocess,
                         exitCode: 4,
                         stderr: "select failed"
@@ -8708,16 +8708,16 @@ struct RuntimeViewModelTests {
 
         viewModel.createServerSession()
         try await waitForRuntimeViewModelCondition("expected create session CLI failure") {
-            viewModel.lastCLIWorkflowFailure?.commandID == "server.session.create"
+            viewModel.lastCLIWorkflowFailure?.commandID == "provider.create"
         }
-        #expect(viewModel.lastError?.contains("server.session.create") == true)
+        #expect(viewModel.lastError?.contains("provider.create") == true)
 
-        let selectedServerSessionID = try #require(viewModel.selectedServerSession?.id)
-        viewModel.selectServerSession(id: selectedServerSessionID)
+        let selectedProviderID = try #require(viewModel.selectedServerSession?.id)
+        viewModel.selectServerSession(id: selectedProviderID)
         try await waitForRuntimeViewModelCondition("expected select session CLI failure") {
-            viewModel.lastCLIWorkflowFailure?.commandID == "server.session.select"
+            viewModel.lastCLIWorkflowFailure?.commandID == "provider.select"
         }
-        #expect(viewModel.lastError?.contains("server.session.select") == true)
+        #expect(viewModel.lastError?.contains("provider.select") == true)
     }
 
     @Test("cli download and train failures surface typed local errors")
@@ -8865,7 +8865,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureExportResult(
@@ -8926,7 +8926,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
 
@@ -8984,7 +8984,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await viewModel.start()
@@ -9065,7 +9065,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureExportResult(
@@ -9114,7 +9114,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
 
@@ -9146,7 +9146,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
 
@@ -9190,7 +9190,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let viewModel = RuntimeViewModel(client: client)
@@ -10277,7 +10277,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [makeModelSummary(modelID: "melix-dev-text", state: .modelWarm)],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await client.configureModelOperation(
@@ -10405,7 +10405,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm)],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await diagnosticsClient.configureBenchResponse(
@@ -10431,8 +10431,8 @@ struct RuntimeViewModelTests {
         let diagnosticsOperatorStore = OperatorSessionStore(
             melixHome: MelixHome(environment: ["MELIX_HOME": diagnosticsRoot.path])
         )
-        let diagnosticsServerSession = DesktopServerSessionState(
-            id: "server-session-1",
+        let diagnosticsServerSession = DesktopProviderState(
+            id: "provider-1",
             title: "Follow-up Server",
             modelID: "melix-dev-text-lora",
             lifecycle: .running
@@ -10440,8 +10440,8 @@ struct RuntimeViewModelTests {
         try diagnosticsOperatorStore.save(
             OperatorSessionState(
                 selectedSurface: .tools,
-                selectedServerSessionID: diagnosticsServerSession.id,
-                serverSessions: [diagnosticsServerSession]
+                selectedProviderID: diagnosticsServerSession.id,
+                providers: [diagnosticsServerSession]
             )
         )
         let diagnosticsViewModel = RuntimeViewModel(
@@ -10452,8 +10452,8 @@ struct RuntimeViewModelTests {
         await diagnosticsViewModel.start()
         diagnosticsViewModel.selectedBenchmarkSuiteIDs = ["smoke"]
         diagnosticsViewModel.selectedEvaluationSuiteIDs = ["mmlu"]
-        #expect(diagnosticsViewModel.serverSessions.map(\.id).contains("server-session-1"))
-        #expect(diagnosticsViewModel.serverSessions.first?.lifecycle == .running)
+        #expect(diagnosticsViewModel.providers.map(\.id).contains("provider-1"))
+        #expect(diagnosticsViewModel.providers.first?.lifecycle == .running)
         #expect(diagnosticsViewModel.serverTargets.contains { $0.kind == .localServer && $0.isRunning })
         #expect(diagnosticsViewModel.diagnosticsServerTargets.contains { $0.kind == .localServer })
 
@@ -10569,7 +10569,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: "melix-dev-text-lora", state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         await runnerClient.configureSnapshot(
@@ -10691,7 +10691,7 @@ struct RuntimeViewModelTests {
             makeSnapshot(
                 serverState: .serverReady,
                 models: [makeModelSummary(modelID: testReadyModelID, state: .modelWarm)],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let viewModel = RuntimeViewModel(client: client)
@@ -10852,7 +10852,7 @@ struct RuntimeViewModelTests {
                     makeModelSummary(modelID: "melix-dev-text", state: .modelWarm),
                     makeModelSummary(modelID: testReadyModelID, state: .modelWarm),
                 ],
-                runtimeSessions: [makeRuntimeSession(serverSessionID: "server-session-1")]
+                runtimeSessions: [makeRuntimeSession(providerID: "provider-1")]
             )
         )
         let viewModel = RuntimeViewModel(client: client)
@@ -13390,8 +13390,8 @@ struct RuntimeViewModelTests {
 
 @MainActor
 private func bindSelectedChatSessionToPrimaryServer(_ viewModel: RuntimeViewModel) throws {
-    let serverSessionID = try #require(viewModel.selectedServerSession?.id)
-    viewModel.bindSelectedChatSessionToServer(serverSessionID: serverSessionID)
+    let providerID = try #require(viewModel.selectedServerSession?.id)
+    viewModel.bindSelectedChatSessionToServer(providerID: providerID)
 }
 
 @MainActor
@@ -13721,20 +13721,20 @@ private struct ThrowingOperatorSessionStore: OperatorSessionStoring {
     }
 }
 
-private struct ThrowingServerSessionAPIKeyStore: ServerSessionAPIKeyStoring {
+private struct ThrowingProviderAPIKeyStore: ProviderAPIKeyStoring {
     let throwOnLoad: Bool
     let throwOnSave: Bool
     let loadPrimaryKeyValue: String?
 
-    func loadPrimaryKey(serverSessionID: String) throws -> ServerSessionPrimaryAPIKeyRecord? {
+    func loadPrimaryKey(providerID: String) throws -> ProviderPrimaryAPIKeyRecord? {
         if throwOnLoad {
             throw MenuBarTestError(description: "load-key-failed")
         }
         guard let loadPrimaryKeyValue else {
             return nil
         }
-        return ServerSessionPrimaryAPIKeyRecord(
-            serverSessionID: serverSessionID,
+        return ProviderPrimaryAPIKeyRecord(
+            providerID: providerID,
             keyID: "primary",
             primaryKey: loadPrimaryKeyValue,
             updatedAt: Date()
@@ -13742,15 +13742,15 @@ private struct ThrowingServerSessionAPIKeyStore: ServerSessionAPIKeyStoring {
     }
 
     func savePrimaryKey(
-        serverSessionID: String,
+        providerID: String,
         primaryKey: String,
         keyID: String
-    ) throws -> ServerSessionPrimaryAPIKeyRecord {
+    ) throws -> ProviderPrimaryAPIKeyRecord {
         if throwOnSave {
             throw MenuBarTestError(description: "save-key-failed")
         }
-        return ServerSessionPrimaryAPIKeyRecord(
-            serverSessionID: serverSessionID,
+        return ProviderPrimaryAPIKeyRecord(
+            providerID: providerID,
             keyID: keyID,
             primaryKey: primaryKey,
             updatedAt: Date()
@@ -13779,7 +13779,7 @@ private func makeSnapshot(
 }
 
 private func makeRuntimeSession(
-    serverSessionID: String = "server-session-1",
+    providerID: String = "provider-1",
     lifecycleState: Melix_Controlplane_V1_ProviderLifecycleState = .ready,
     powerState: Melix_Controlplane_V1_ProviderPowerState = .active,
     wakeReason: Melix_Controlplane_V1_ProviderWakeReason = .initialBoot,
@@ -13789,7 +13789,7 @@ private func makeRuntimeSession(
     deepSleepAfterSeconds: UInt32 = 1800
 ) -> Melix_Controlplane_V1_ProviderRuntimeState {
     var runtimeSession = Melix_Controlplane_V1_ProviderRuntimeState()
-    runtimeSession.providerID = serverSessionID
+    runtimeSession.providerID = providerID
     runtimeSession.lifecycleState = lifecycleState
     runtimeSession.powerState = powerState
     runtimeSession.wakeReason = wakeReason
@@ -13832,7 +13832,7 @@ private func makeGatewayConfigSummary(
 }
 
 private func makeGatewayConfigListener(
-    serverSessionID: String,
+    providerID: String,
     requestedHost: String,
     requestedPort: UInt32,
     effectiveHost: String,
@@ -13845,7 +13845,7 @@ private func makeGatewayConfigListener(
     requiresRestart: Bool
 ) -> Melix_Controlplane_V1_GatewayListenerConfigSummary {
     var listener = Melix_Controlplane_V1_GatewayListenerConfigSummary()
-    listener.providerID = serverSessionID
+    listener.providerID = providerID
     listener.requestedHost = requestedHost
     listener.requestedPort = requestedPort
     listener.effectiveHost = effectiveHost

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeWorkflowRecipesStateTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeWorkflowRecipesStateTests.swift
@@ -917,8 +917,8 @@ struct RuntimeWorkflowRecipesStateTests {
         let state = OperatorSessionState(
             selectedSurface: .tools,
             selectedToolSection: .workflowRecipes,
-            selectedServerSessionID: "",
-            serverSessions: []
+            selectedProviderID: "",
+            providers: []
         )
         let decodedState = try JSONDecoder().decode(OperatorSessionState.self, from: encoder.encode(state))
         #expect(decodedState.selectedToolSection == .workflowRecipes)

--- a/apps/macos-menubar/Tests/MenuBarTests/StatusMenuTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/StatusMenuTests.swift
@@ -233,7 +233,7 @@ struct StatusMenuTests {
         snapshot.serverState = .serverReady
         snapshot.models = [ModelCatalog.devTextModel()]
         var runtimeSession = Melix_Controlplane_V1_ProviderRuntimeState()
-        runtimeSession.providerID = "server-session-1"
+        runtimeSession.providerID = "provider-1"
         runtimeSession.lifecycleState = .sleeping
         runtimeSession.powerState = .deepSleep
         runtimeSession.wakeReason = .policyApply
@@ -263,7 +263,7 @@ struct StatusMenuTests {
         try await eventually("wake action should reach the selected server", timeout: .seconds(2)) {
             viewModel.selectedServerSession?.lifecycle == .running
         }
-        #expect(await client.recordedActions.contains("server.wake:server-session-1"))
+        #expect(await client.recordedActions.contains("server.wake:provider-1"))
     }
 
     @Test("perform routes primary model actions to the view model")
@@ -605,7 +605,7 @@ private func makeStatusMenuSnapshot(
     snapshot.serverState = .serverReady
     snapshot.models = models
     var session = Melix_Controlplane_V1_ProviderRuntimeState()
-    session.providerID = "server-session-1"
+    session.providerID = "provider-1"
     session.lifecycleState = .ready
     session.powerState = .active
     snapshot.providers = [session]

--- a/apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
@@ -432,7 +432,7 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     struct RecordedGatewayAccessApplyRequest: Equatable, Sendable {
-        let serverSessionID: String
+        let providerID: String
         let primaryKey: String
         let keyID: String
         let label: String
@@ -440,7 +440,7 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     struct RecordedGatewayConfigApplyRequest: Equatable, Sendable {
-        let serverSessionID: String
+        let providerID: String
         let host: String
         let port: Int
         let defaultModelID: String
@@ -453,7 +453,7 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     struct RecordedServingDefaultsApplyRequest: Equatable, Sendable {
-        let serverSessionID: String
+        let providerID: String
         let temperature: Double
         let topP: Double
         let maxTokens: Int
@@ -508,7 +508,7 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     struct RecordedServerIdlePolicyRequest: Equatable, Sendable {
-        let serverSessionID: String
+        let providerID: String
         let autoSleepEnabled: Bool
         let lightSleepAfterSeconds: UInt32
         let deepSleepAfterSeconds: UInt32
@@ -1296,13 +1296,14 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
         label: String,
         tokenHint: String
     ) async throws {
-        recordedActions.append("gateway.apply:\(serverSessionID)")
+        let providerID = serverSessionID
+        recordedActions.append("gateway.apply:\(providerID)")
         if let applyGatewayAccessError {
             throw applyGatewayAccessError
         }
         recordedGatewayAccessApplyRequests.append(
             RecordedGatewayAccessApplyRequest(
-                serverSessionID: serverSessionID,
+                providerID: providerID,
                 primaryKey: primaryKey,
                 keyID: keyID,
                 label: label,
@@ -1312,11 +1313,12 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     func clearServerSessionGatewayAccess(serverSessionID: String) async throws {
-        recordedActions.append("gateway.clear:\(serverSessionID)")
+        let providerID = serverSessionID
+        recordedActions.append("gateway.clear:\(providerID)")
         if let clearGatewayAccessError {
             throw clearGatewayAccessError
         }
-        recordedGatewayAccessClearRequests.append(serverSessionID)
+        recordedGatewayAccessClearRequests.append(providerID)
     }
 
     func applyServerSessionGatewayConfig(
@@ -1331,14 +1333,15 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
         allowedHosts: [String],
         allowedOrigins: [String]
     ) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        recordedActions.append("gateway.config:\(serverSessionID)")
+        let providerID = serverSessionID
+        recordedActions.append("gateway.config:\(providerID)")
         if let applyGatewayConfigError {
             throw applyGatewayConfigError
         }
         let normalizedServedModelIDs = servedModelIDs.isEmpty ? [defaultModelID] : servedModelIDs
         recordedGatewayConfigApplyRequests.append(
             RecordedGatewayConfigApplyRequest(
-                serverSessionID: serverSessionID,
+                providerID: providerID,
                 host: host,
                 port: port,
                 defaultModelID: defaultModelID,
@@ -1353,7 +1356,7 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
 
         var snapshot = makeSnapshot(state: modelState)
         var config = snapshot.gatewayConfig
-        if let existingIndex = config.listeners.firstIndex(where: { $0.providerID == serverSessionID }) {
+        if let existingIndex = config.listeners.firstIndex(where: { $0.providerID == providerID }) {
             config.listeners[existingIndex].requestedHost = host
             config.listeners[existingIndex].requestedPort = UInt32(max(1, port))
             config.listeners[existingIndex].effectiveHost = host
@@ -1370,7 +1373,7 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
             config.listeners[existingIndex].requiresRestart = false
         } else {
             var listener = Melix_Controlplane_V1_GatewayListenerConfigSummary()
-            listener.providerID = serverSessionID
+            listener.providerID = providerID
             listener.requestedHost = host
             listener.requestedPort = UInt32(max(1, port))
             listener.effectiveHost = host
@@ -1407,13 +1410,14 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
         numDraftTokens: Int,
         accelerationProfile: String
     ) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        recordedActions.append("serving-defaults.apply:\(serverSessionID)")
+        let providerID = serverSessionID
+        recordedActions.append("serving-defaults.apply:\(providerID)")
         if let applyServingDefaultsError {
             throw applyServingDefaultsError
         }
         recordedServingDefaultsApplyRequests.append(
             RecordedServingDefaultsApplyRequest(
-                serverSessionID: serverSessionID,
+                providerID: providerID,
                 temperature: temperature,
                 topP: topP,
                 maxTokens: maxTokens,
@@ -1439,7 +1443,7 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
 
         var snapshot = snapshotOverride ?? makeSnapshot(state: modelState)
         var summary = snapshot.servingDefaults
-        if let existingIndex = summary.sessions.firstIndex(where: { $0.providerID == serverSessionID }) {
+        if let existingIndex = summary.sessions.firstIndex(where: { $0.providerID == providerID }) {
             summary.sessions[existingIndex].requestedTemperature = temperature
             summary.sessions[existingIndex].requestedTopP = topP
             summary.sessions[existingIndex].requestedMaxTokens = UInt32(max(1, maxTokens))
@@ -1466,8 +1470,8 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
             summary.sessions[existingIndex].modelOverrideApplied = false
         } else {
             var session = Melix_Controlplane_V1_ServingDefaultsSessionSummary()
-            session.providerID = serverSessionID
-            session.defaultModelID = snapshot.gatewayConfig.listeners.first(where: { $0.providerID == serverSessionID })?.defaultModelID ?? "melix-dev-text"
+            session.providerID = providerID
+            session.defaultModelID = snapshot.gatewayConfig.listeners.first(where: { $0.providerID == providerID })?.defaultModelID ?? "melix-dev-text"
             session.requestedTemperature = temperature
             session.requestedTopP = topP
             session.requestedMaxTokens = UInt32(max(1, maxTokens))
@@ -1499,11 +1503,12 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     func startServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        recordedActions.append("server.start:\(serverSessionID)")
+        let providerID = serverSessionID
+        recordedActions.append("server.start:\(providerID)")
         if let startServerError {
             throw startServerError
         }
-        return mutateRuntimeSession(serverSessionID: serverSessionID) { runtimeSession in
+        return mutateRuntimeSession(providerID: providerID) { runtimeSession in
             runtimeSession.lifecycleState = .ready
             runtimeSession.powerState = .active
             runtimeSession.wakeReason = .initialBoot
@@ -1511,11 +1516,12 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     func pauseServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        recordedActions.append("server.pause:\(serverSessionID)")
+        let providerID = serverSessionID
+        recordedActions.append("server.pause:\(providerID)")
         if let pauseServerError {
             throw pauseServerError
         }
-        return mutateRuntimeSession(serverSessionID: serverSessionID) { runtimeSession in
+        return mutateRuntimeSession(providerID: providerID) { runtimeSession in
             runtimeSession.lifecycleState = .paused
             runtimeSession.powerState = .active
             runtimeSession.wakeReason = .policyApply
@@ -1523,11 +1529,12 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     func resumeServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        recordedActions.append("server.resume:\(serverSessionID)")
+        let providerID = serverSessionID
+        recordedActions.append("server.resume:\(providerID)")
         if let resumeServerError {
             throw resumeServerError
         }
-        return mutateRuntimeSession(serverSessionID: serverSessionID) { runtimeSession in
+        return mutateRuntimeSession(providerID: providerID) { runtimeSession in
             runtimeSession.lifecycleState = .ready
             runtimeSession.powerState = .active
             runtimeSession.wakeReason = .operatorResume
@@ -1535,11 +1542,12 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     func wakeServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        recordedActions.append("server.wake:\(serverSessionID)")
+        let providerID = serverSessionID
+        recordedActions.append("server.wake:\(providerID)")
         if let wakeServerError {
             throw wakeServerError
         }
-        return mutateRuntimeSession(serverSessionID: serverSessionID) { runtimeSession in
+        return mutateRuntimeSession(providerID: providerID) { runtimeSession in
             runtimeSession.lifecycleState = .ready
             runtimeSession.powerState = .active
             runtimeSession.wakeReason = .operatorResume
@@ -1547,11 +1555,12 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     func stopServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        recordedActions.append("server.stop:\(serverSessionID)")
+        let providerID = serverSessionID
+        recordedActions.append("server.stop:\(providerID)")
         if let stopServerError {
             throw stopServerError
         }
-        return mutateRuntimeSession(serverSessionID: serverSessionID) { runtimeSession in
+        return mutateRuntimeSession(providerID: providerID) { runtimeSession in
             runtimeSession.lifecycleState = .stopped
             runtimeSession.powerState = .stopped
             runtimeSession.wakeReason = .policyApply
@@ -1564,19 +1573,20 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
         lightSleepAfterSeconds: UInt32,
         deepSleepAfterSeconds: UInt32
     ) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        recordedActions.append("server.idle_policy:\(serverSessionID)")
+        let providerID = serverSessionID
+        recordedActions.append("server.idle_policy:\(providerID)")
         if let updateServerIdlePolicyError {
             throw updateServerIdlePolicyError
         }
         recordedServerIdlePolicyRequests.append(
             RecordedServerIdlePolicyRequest(
-                serverSessionID: serverSessionID,
+                providerID: providerID,
                 autoSleepEnabled: autoSleepEnabled,
                 lightSleepAfterSeconds: lightSleepAfterSeconds,
                 deepSleepAfterSeconds: deepSleepAfterSeconds
             )
         )
-        return mutateRuntimeSession(serverSessionID: serverSessionID) { runtimeSession in
+        return mutateRuntimeSession(providerID: providerID) { runtimeSession in
             runtimeSession.autoSleepEnabled = autoSleepEnabled
             runtimeSession.lightSleepAfterSeconds = lightSleepAfterSeconds
             runtimeSession.deepSleepAfterSeconds = deepSleepAfterSeconds
@@ -1887,16 +1897,16 @@ actor FakeControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     private func mutateRuntimeSession(
-        serverSessionID: String,
+        providerID: String,
         _ update: (inout Melix_Controlplane_V1_ProviderRuntimeState) -> Void
     ) -> Melix_Controlplane_V1_ServerSnapshot {
         var snapshot = makeSnapshot(state: modelState)
-        let existingIndex = snapshot.providers.firstIndex(where: { $0.providerID == serverSessionID })
+        let existingIndex = snapshot.providers.firstIndex(where: { $0.providerID == providerID })
         if let existingIndex {
             update(&snapshot.providers[existingIndex])
         } else {
             var runtimeSession = Melix_Controlplane_V1_ProviderRuntimeState()
-            runtimeSession.providerID = serverSessionID
+            runtimeSession.providerID = providerID
             runtimeSession.lifecycleState = .ready
             runtimeSession.powerState = .active
             runtimeSession.wakeReason = .initialBoot
@@ -2747,7 +2757,7 @@ func makeManagedModelReceiptJSON(
 }
 
 func makeCLIServerSnapshotJSON(
-    serverSessionID: String,
+    providerID: String,
     lifecycleState: String = "ready",
     powerState: String = "active",
     serverState: String = "server_ready"
@@ -2757,7 +2767,7 @@ func makeCLIServerSnapshotJSON(
       "server_state": "\(serverState)",
       "providers": [
         {
-          "provider_id": "\(serverSessionID)",
+          "provider_id": "\(providerID)",
           "lifecycle_state": "\(lifecycleState)",
           "power_state": "\(powerState)",
           "wake_reason": "operator_resume",

--- a/docs/examples/pipelines/phase8-acceptance.pipeline.json
+++ b/docs/examples/pipelines/phase8-acceptance.pipeline.json
@@ -7,7 +7,7 @@
     "model_id": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
     "repo_id": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
     "revision": "main",
-    "server_session_id": "server-session-1",
+    "provider_id": "provider-1",
     "server_title": "Phase 8 Acceptance",
     "host": "127.0.0.1",
     "port": 8080,
@@ -110,10 +110,10 @@
       "args": {}
     },
     {
-      "id": "update_server_session",
-      "command": "server.session.update",
+      "id": "update_provider",
+      "command": "provider.update",
       "args": {
-        "server_session_id": "${inputs.server_session_id}",
+        "provider_id": "${inputs.provider_id}",
         "title": "${inputs.server_title}",
         "default_model_id": "${inputs.model_id}",
         "served_model_ids": ["${inputs.model_id}"],
@@ -127,7 +127,7 @@
       "id": "start_server",
       "command": "server.start",
       "args": {
-        "server_session_id": "${inputs.server_session_id}"
+        "provider_id": "${inputs.provider_id}"
       }
     },
     {
@@ -135,7 +135,7 @@
       "command": "chat.run",
       "args": {
         "model_id": "${inputs.model_id}",
-        "server_session_id": "${inputs.server_session_id}",
+        "provider_id": "${inputs.provider_id}",
         "message": "${inputs.base_chat_message}"
       },
       "checks": {
@@ -182,7 +182,7 @@
       "command": "chat.run",
       "args": {
         "model_id": "${inputs.derived_model_alias}",
-        "server_session_id": "${inputs.server_session_id}",
+        "provider_id": "${inputs.provider_id}",
         "message": "${inputs.derived_chat_message}"
       },
       "checks": {

--- a/docs/runbooks/admin-surface-persistence.md
+++ b/docs/runbooks/admin-surface-persistence.md
@@ -16,8 +16,8 @@ The current payload includes:
 
 - `selected_surface`
 - `selected_tool_section`
-- `selected_server_session_id`
-- `server_sessions`
+- `selected_provider_id`
+- `providers`
 
 `selected_tool_section` is persisted even when the operator is not currently focused on the Tools
 surface. This keeps the last-selected tools workspace deterministic the next time the operator

--- a/docs/runbooks/external-agent-integrations.md
+++ b/docs/runbooks/external-agent-integrations.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Render reproducible external coding-agent setup artifacts from the currently selected Melix server session without copying live secrets into repository-owned examples.
+Render reproducible external coding-agent setup artifacts from the currently selected Melix provider without copying live secrets into repository-owned examples.
 
 ## Supported Targets
 
@@ -12,7 +12,7 @@ Render reproducible external coding-agent setup artifacts from the currently sel
 - `OpenCode`
 - `Codex`
 
-Every target is generated from one canonical Melix server-session projection:
+Every target is generated from one canonical Melix provider projection:
 
 - listener base URL: `http://<host>:<port>/v1`
 - served model ID
@@ -34,17 +34,17 @@ Current fragment formats:
 - `OpenCode`: JSON
 - `Codex`: environment-variable block
 
-When the selected server session uses bearer auth, Melix renders a placeholder such as `<dev-token>` or `<smoke-token>`. When auth is disabled, Melix renders `not-required`.
+When the selected provider uses bearer auth, Melix renders a placeholder such as `<dev-token>` or `<smoke-token>`. When auth is disabled, Melix renders `not-required`.
 
 ## Desktop Operator Flow
 
 1. Open the Melix menu bar app.
-2. Select the server session whose listener and model should be exported.
+2. Select the provider whose listener and model should be exported.
 3. Open either the `Server` inspector or the `API` workspace.
 4. Choose the target integration from the shared export picker.
 5. Copy the generated config fragment or shell snippet.
 
-The exported content always rebinds to the currently selected server session. Changing host, port, model, or auth mode updates every target-specific export.
+The exported content always rebinds to the currently selected provider. Changing host, port, model, or auth mode updates every target-specific export.
 
 ## Deterministic Smoke
 
@@ -59,7 +59,7 @@ uv run --project services/mlx-worker-python python scripts/m9_agent_export_smoke
 The smoke command:
 
 - runs a Swift smoke test against `AgentIntegrationExport.exports(from:)`
-- validates that every supported target is rendered from the same fixture server session
+- validates that every supported target is rendered from the same fixture provider
 - reports deterministic setup metrics for the exported target count and setup success rate
 
 ## Metrics

--- a/docs/runbooks/phase-6-chat-panel.md
+++ b/docs/runbooks/phase-6-chat-panel.md
@@ -55,7 +55,7 @@ make swift-test
 MELIX_RUNTIME_DIR=.runtime/phase6 bash scripts/dev_app_up.sh
 ```
 
-5. Open the `Chat` tab, choose the intended Server Session from the chat header, and submit a prompt.
+5. Open the `Chat` tab, choose the intended Provider from the chat header, and submit a prompt.
    - Confirm the transcript records the user prompt and assistant output.
    - Confirm reasoning and tool-call sections appear when the runtime emits those deltas.
    - Confirm user and assistant bubbles do not expose internal model IDs or request IDs.
@@ -74,7 +74,7 @@ tail -n 50 .runtime/phase6/swift-text-worker.log
 
 - The local stack was started without the `MELIX_RUNTIME_DIR=.runtime/phase6` override, so the operator is reading the wrong logs.
 - The text model is not warm, so the control plane cannot route the desktop chat request.
-- The Chat session has not been bound to a Server Session yet; choose one from the chat header before submitting.
+- The Chat session has not been bound to a Provider yet; choose one from the chat header before submitting.
 - The desktop app was started before the control plane or workers were ready.
 - The local model snapshot does not expose multimodal capability classes, so the model capability section remains empty.
 

--- a/docs/runbooks/phase-8-product-acceptance.md
+++ b/docs/runbooks/phase-8-product-acceptance.md
@@ -158,12 +158,12 @@ Treat regressions in these flows as bugs, not as future roadmap work:
 - [x] Ordered registry-root management, including `list`, `add`, `remove`, `move`, `rescan`, and managed-root precedence.
 - [x] Registry-driven model library flows for `list`, `inspect`, `load`, and `unload`.
 - [x] Download-queue hydration, status rendering, and resumable download recovery.
-- [x] Serveable-model filtering for `Server Session` binding and start-time validation.
-- [x] `Server Session` create, update, remove, select, start, pause, resume, wake, stop, and unavailable-binding preservation.
-- [x] CLI-first server-session rebinding and `chat run` execution against managed base or derived models without `MELIX_DEV_TEXT_MODEL_PATH`.
+- [x] Serveable-model filtering for `Provider` binding and start-time validation.
+- [x] `Provider` create, update, remove, select, start, pause, resume, wake, stop, and unavailable-binding preservation.
+- [x] CLI-first provider rebinding and `chat run` execution against managed base or derived models without `MELIX_DEV_TEXT_MODEL_PATH`.
 - [x] Shared CLI-core execution for LoRA train, activate, remove-derived, benchmark, matrix benchmark, evaluation, evaluation compare, and export actions.
 - [x] Shared CLI-core execution for LoRA train, activate, remove-derived, benchmark, matrix benchmark, evaluation, evaluation compare, export, and acceptance-bundle orchestration.
-- [x] Window UI subprocess-backed CLI shell coverage for managed Hub download, local import, server-session mutation and start, LoRA train, activate, remove-derived, benchmark, matrix benchmark, evaluation, evaluation compare, and export.
+- [x] Window UI subprocess-backed CLI shell coverage for managed Hub download, local import, provider mutation and start, LoRA train, activate, remove-derived, benchmark, matrix benchmark, evaluation, evaluation compare, and export.
 - [x] Production Window UI uses the public `melix` subprocess path while test-only Window acceptance uses the shared CLI runner seam directly.
 - [x] Repository-owned deterministic LoRA CLI acceptance smoke exists at `scripts/phase8_lora_cli_smoke.py`.
 - [x] Repository-owned deterministic LoRA Window acceptance smoke exists at `scripts/phase8_lora_window_smoke.py`.
@@ -173,7 +173,7 @@ Treat regressions in these flows as bugs, not as future roadmap work:
 These flows exist in code, but still need fresh real-runtime acceptance evidence before
 release sign-off:
 
-- [x] Run one real desktop flow for `download -> registry refresh -> Server Session select -> server start` through the native Window UI CLI subprocess bridge using a downloaded Hugging Face text model without fallback environment model-path injection.
+- [x] Run one real desktop flow for `download -> registry refresh -> Provider select -> server start` through the native Window UI CLI subprocess bridge using a downloaded Hugging Face text model without fallback environment model-path injection.
 
 ### Live CLI Evidence Captured
 
@@ -189,7 +189,7 @@ release sign-off:
 - [x] The live Window UI evidence bundle is preserved at `/Users/ChenYu/Library/Application Support/Melix/acceptance/phase8/window-ui/2026-04-09T192003Z/bundle.json`.
 - [x] The live Window UI screenshot is preserved at `/Users/ChenYu/Library/Application Support/Melix/acceptance/phase8/window-ui/2026-04-09T192003Z/window-ui.png`.
 - [x] The live Window UI bundle chains back to the live CLI evidence bundle at `/Users/ChenYu/Library/Application Support/Melix/acceptance/phase8/cli/2026-04-09T162920Z/bundle.json`.
-- [x] The live Window UI bundle records `selected_surface=Server`, `selected_server_session_id=server-session-1`, `lora_train_job_id=model-ops-0137`, `lora_activate_job_id=model-ops-0141`, `bench_job_id=model-ops-0149`, `bench_matrix_job_id=model-ops-0154`, and `evaluation_job_id=eval-0004`; see `progress.md` for the exact measured timings.
+- [x] The live Window UI bundle records `selected_surface=Server`, `selected_provider_id=provider-1`, `lora_train_job_id=model-ops-0137`, `lora_activate_job_id=model-ops-0141`, `bench_job_id=model-ops-0149`, `bench_matrix_job_id=model-ops-0154`, and `evaluation_job_id=eval-0004`; see `progress.md` for the exact measured timings.
 
 ### Bucket 3: Open Product Gaps
 

--- a/docs/runbooks/serving-diagnostics-evidence.md
+++ b/docs/runbooks/serving-diagnostics-evidence.md
@@ -36,7 +36,7 @@ comparisons.
 
 Serving acceleration profiles are stable operator-facing intents that resolve
 before lower-level serving overrides. Use them when creating or updating a
-server session so reports, diagnostics, and benchmark artifacts can state the
+provider so reports, diagnostics, and benchmark artifacts can state the
 chosen serving intent instead of only listing individual knobs.
 
 Initial profiles:
@@ -51,14 +51,14 @@ Initial profiles:
 Examples:
 
 ```bash
-melix server session create \
+melix provider create \
   --title "Qwen low-memory" \
   --model-id mlx-community/Qwen3.5-0.8B-OptiQ-4bit \
   --acceleration-profile low-memory \
   --json
 
-melix server session update \
-  --server-session-id server-session-qwen \
+melix provider update \
+  --provider-id provider-qwen \
   --acceleration-profile throughput \
   --draft-model-id z-lab/Qwen3.5-27B-DFlash \
   --json

--- a/docs/runbooks/session-lifecycle.md
+++ b/docs/runbooks/session-lifecycle.md
@@ -4,7 +4,7 @@
 idle-power policy, desktop visibility, and reproducible smoke evidence.
 
 This runbook covers repository-local diagnosis and recovery for paused, sleeping, stopped, and
-failed server sessions.
+failed providers.
 
 ## Scope
 
@@ -107,7 +107,7 @@ swift run melix server wake --json
 swift run melix server start --json
 ```
 
-- To create or rebind a titled local server session and start it in one command, pass the session
+- To create or rebind a titled local provider and start it in one command, pass the session
   title plus the model and listener options:
 
 ```bash
@@ -118,7 +118,7 @@ swift run melix server start "Gemma 31B" \
 ```
 
 - The positional value is the session title. New sessions still receive generated identifiers such as
-  `server-session-1`; later shortcut starts reuse an existing session when its identifier or title
+  `provider-1`; later shortcut starts reuse an existing session when its identifier or title
   matches the supplied value.
 
 - If the restart path fails with a `conflict`, wait for in-flight requests to finish and retry.
@@ -138,5 +138,5 @@ swift run melix server start "Gemma 31B" \
 - Use `server snapshot` and the lifecycle smoke first for session-state faults.
 - Use [`connection-lifecycle.md`](./connection-lifecycle.md) for stream disconnects, resume grace,
   keepalive gaps, and client reconnect timing.
-- Do not treat a successful reconnect as proof that a paused or sleeping server session recovered;
+- Do not treat a successful reconnect as proof that a paused or sleeping provider recovered;
   lifecycle and connection evidence are separate.

--- a/docs/runbooks/shared-access.md
+++ b/docs/runbooks/shared-access.md
@@ -106,12 +106,12 @@ Browser CORS is default-denied. Requests with an `Origin` header return
 `403 origin_not_allowed` unless the origin is explicitly allowlisted. Melix does
 not emit wildcard `Access-Control-Allow-Origin`.
 
-For a trusted browser client, prefer durable server-session controls so the
+For a trusted browser client, prefer durable provider controls so the
 policy follows the operator session rather than a shell environment:
 
 ```bash
-melix server session update \
-  --server-session-id server-session-1 \
+melix provider update \
+  --provider-id provider-1 \
   --allowed-host operator.lan:12436 \
   --allowed-origin http://localhost:5173
 ```
@@ -127,12 +127,12 @@ melix server start "Local Workbench" \
   --allowed-origin http://localhost:5173
 ```
 
-`--allowed-host` and `--allowed-origin` are repeatable. `server session update`
+`--allowed-host` and `--allowed-origin` are repeatable. `provider update`
 can remove previously persisted browser access with:
 
 ```bash
-melix server session update \
-  --server-session-id server-session-1 \
+melix provider update \
+  --provider-id provider-1 \
   --clear-allowed-hosts \
   --clear-allowed-origins
 ```

--- a/scripts/phase8_acceptance_bundle.py
+++ b/scripts/phase8_acceptance_bundle.py
@@ -121,7 +121,7 @@ class AcceptanceBundleConfig:
     matrix_suites: list[str]
     evaluation_suites: list[str]
     evaluation_dataset: str
-    server_session_id: str
+    provider_id: str
     local_model_path: str
     live: bool
     timestamp: str
@@ -353,37 +353,36 @@ def run_acceptance_bundle(
     )
     _write_json(cli_receipts_root / "02-registry-rescan.json", registry_rescan_receipt)
 
-    server_update = _expect_mapping(
+    provider_update = _expect_mapping(
         executor.run_json(
             [
-                "server",
-                "session",
+                "provider",
                 "update",
-                "--server-session-id",
-                config.server_session_id,
+                "--provider-id",
+                config.provider_id,
                 "--model",
                 model_id,
                 "--json",
             ]
         ),
-        context="melix server session update",
+        context="melix provider update",
     )
-    _write_json(cli_receipts_root / "03-server-session-update.json", server_update)
+    _write_json(cli_receipts_root / "03-provider-update.json", provider_update)
 
     server_start = _expect_mapping(
         executor.run_json(
             [
                 "server",
                 "start",
-                "--server-session-id",
-                config.server_session_id,
+                "--provider-id",
+                config.provider_id,
                 "--json",
             ]
         ),
         context="melix server start",
     )
     _write_json(cli_receipts_root / "04-server-start.json", server_start)
-    timings["phase8.cli.session_rebind_ms"] = _elapsed_ms(rebind_started_at)
+    timings["phase8.cli.provider_rebind_ms"] = _elapsed_ms(rebind_started_at)
 
     base_chat_started_at = time.perf_counter()
     base_chat_receipt = _expect_mapping(
@@ -703,8 +702,8 @@ def run_acceptance_bundle(
             "manifest_path": str(lora_activate_receipt.get("manifest_path", "")),
         },
         "server": {
-            "server_session_id": config.server_session_id,
-            "update": server_update,
+            "provider_id": config.provider_id,
+            "update": provider_update,
             "start": server_start,
         },
         "datasets": {
@@ -815,9 +814,9 @@ def build_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("--evaluation-suite", action="append", default=[], help="Evaluation suite to execute.")
     parser.add_argument("--evaluation-dataset", required=True, help="Evaluation dataset identifier.")
     parser.add_argument(
-        "--server-session-id",
-        default="server-session-1",
-        help="Server session to rebind and start during acceptance.",
+        "--provider-id",
+        default="provider-1",
+        help="Provider to rebind and start during acceptance.",
     )
     parser.add_argument("--activation-mode", default="", help="Override melix lora activate mode.")
     parser.add_argument("--training-preset", default="", help="Override melix lora train preset.")
@@ -869,7 +868,7 @@ def parse_args(argv: list[str] | None = None) -> AcceptanceBundleConfig:
         matrix_suites=list(args.matrix_suite),
         evaluation_suites=list(args.evaluation_suite),
         evaluation_dataset=args.evaluation_dataset,
-        server_session_id=args.server_session_id,
+        provider_id=args.provider_id,
         local_model_path=local_model_path,
         live=live,
         timestamp=timestamp,
@@ -1083,8 +1082,8 @@ def _cli_step_label(args: list[str]) -> str:
         return f"bench matrix {args[2]}"
     if len(args) >= 3 and args[0] == "model" and args[1] in {"hub", "roots"}:
         return f"model {args[1]} {args[2]}"
-    if len(args) >= 3 and args[0] == "server" and args[1] == "session":
-        return f"server session {args[2]}"
+    if len(args) >= 2 and args[0] == "provider":
+        return f"provider {args[1]}"
     if len(args) >= 2:
         return f"{args[0]} {args[1]}"
     if args:

--- a/services/control-plane-swift/Sources/XPCService/ControlPlaneChatExecution.swift
+++ b/services/control-plane-swift/Sources/XPCService/ControlPlaneChatExecution.swift
@@ -71,6 +71,7 @@ public struct ControlPlaneChatRequest: Sendable, Equatable {
     public let topP: Double?
     public let maxTokens: UInt32?
     public let remoteTarget: RemoteTarget?
+    public let providerID: String
 
     public init(
         modelID: String,
@@ -82,7 +83,8 @@ public struct ControlPlaneChatRequest: Sendable, Equatable {
         temperature: Double? = nil,
         topP: Double? = nil,
         maxTokens: UInt32? = nil,
-        remoteTarget: RemoteTarget? = nil
+        remoteTarget: RemoteTarget? = nil,
+        providerID: String = ""
     ) {
         self.modelID = modelID
         self.messages = messages
@@ -94,6 +96,7 @@ public struct ControlPlaneChatRequest: Sendable, Equatable {
         self.topP = topP
         self.maxTokens = maxTokens
         self.remoteTarget = remoteTarget
+        self.providerID = providerID
     }
 }
 

--- a/services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift
+++ b/services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift
@@ -332,7 +332,8 @@ public actor ControlPlaneService {
             throw ControlPlaneChatExecutionError.unavailableReason("chat_unavailable: request coordinator is not configured")
         }
 
-        switch await prepareDefaultServerSessionForServingActivity() {
+        let chatProviderID = normalizedProviderID(request.providerID)
+        switch await prepareServerSessionForServingActivity(providerID: chatProviderID) {
         case .blocked(let code, let message):
             let detail = message.isEmpty ? code : "\(code): \(message)"
             throw ControlPlaneChatExecutionError.unavailableReason("chat_unavailable: \(detail)")
@@ -423,7 +424,7 @@ public actor ControlPlaneService {
             modelOCRPolicy: modelOCRPolicy,
             modelSamplingPolicy: modelSamplingPolicy,
             gatewayServingDefaults: await gatewayServingDefaultsStore.requestedDefaults(
-                serverSessionID: ServerSessionRuntimeStore.defaultServerSessionID
+                serverSessionID: chatProviderID
             ).resolvingAccelerationCompatibility(for: resolvedModel),
             mcpToolCatalog: mcpToolCatalog
         )
@@ -4792,13 +4793,17 @@ public actor ControlPlaneService {
         }
     }
 
-    private func prepareDefaultServerSessionForServingActivity() async -> ServingSessionPreparation {
+    private func prepareServerSessionForServingActivity(providerID: String) async -> ServingSessionPreparation {
+        let normalizedProviderID = normalizedProviderID(providerID)
         let runtimeSessions = await serverSessionRuntimeStore.snapshot(
             hasActiveRequests: await schedulerReadModel.hasActiveRequests()
         )
         let defaultSession = runtimeSessions.first(where: {
-            $0.providerID == ServerSessionRuntimeStore.defaultServerSessionID
-        }) ?? runtimeSessions.first ?? ServerSessionRuntimeStore.defaultRuntimeSession(updatedAtUnixMS: 0)
+            $0.providerID == normalizedProviderID
+        }) ?? ServerSessionRuntimeStore.defaultRuntimeSession(
+            serverSessionID: normalizedProviderID,
+            updatedAtUnixMS: 0
+        )
 
         switch defaultSession.lifecycleState {
         case .paused:
@@ -4829,6 +4834,15 @@ public actor ControlPlaneService {
             )
             return .ready(publishStateChanged: false)
         }
+    }
+
+    private func prepareDefaultServerSessionForServingActivity() async -> ServingSessionPreparation {
+        await prepareServerSessionForServingActivity(providerID: ServerSessionRuntimeStore.defaultServerSessionID)
+    }
+
+    private func normalizedProviderID(_ providerID: String) -> String {
+        let trimmedProviderID = providerID.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedProviderID.isEmpty ? ServerSessionRuntimeStore.defaultServerSessionID : trimmedProviderID
     }
 
     private func publishCurrentServerState(source: String) async {

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ControlPlaneServiceTests.swift
@@ -1509,6 +1509,100 @@ struct ControlPlaneServiceTests {
         #expect(snapshotAfterWake.server.snapshot.providers.first?.wakeReason == .requestActivity)
     }
 
+    @Test("startChat uses explicit provider target for local serving activity")
+    func startChatUsesExplicitProviderTargetForLocalServingActivity() async throws {
+        var defaultSession = ServerSessionRuntimeStore.defaultRuntimeSession(updatedAtUnixMS: 1_000)
+        defaultSession.lifecycleState = .sleeping
+        defaultSession.powerState = .deepSleep
+        var providerSession = ServerSessionRuntimeStore.defaultRuntimeSession(
+            serverSessionID: "provider-1",
+            updatedAtUnixMS: 1_000
+        )
+        providerSession.lifecycleState = .sleeping
+        providerSession.powerState = .lightSleep
+        let runtimeStore = ServerSessionRuntimeStore(
+            runtimeSessions: [defaultSession, providerSession],
+            nowUnixMS: { 3_000 }
+        )
+        let modelCatalog = ModelCatalog(seedModels: [ModelCatalog.devTextModel()])
+        _ = await modelCatalog.loadModel(id: "melix-dev-text", dispatchHandle: "melix-dev-text::local")
+        let textClient = ScriptedChatWorkerClient(events: [
+            makeQueuedExecuteEvent(requestID: "chat-provider-wake"),
+            makeCompletedExecuteEvent(
+                requestID: "chat-provider-wake",
+                finishReason: "stop",
+                assistant: "awake",
+                reasoning: ""
+            ),
+        ])
+        let service = ControlPlaneService(
+            modelCatalog: modelCatalog,
+            serverSessionRuntimeStore: runtimeStore,
+            workerRegistry: WorkerRegistry(defaultTextClient: textClient, modelCatalog: modelCatalog),
+            chatTranslator: ChatRequestTranslator(requestIDGenerator: { "chat-provider-wake" })
+        )
+
+        let execution = try await service.startChat(
+            ControlPlaneChatRequest(
+                modelID: "melix-dev-text",
+                messages: [.init(role: "user", content: "wake provider")],
+                providerID: "provider-1"
+            )
+        )
+        _ = try await Array(execution.stream)
+        let snapshotAfterWake = try await service.execute(makeServerSnapshotRequest())
+        let defaultAfterWake = try #require(
+            snapshotAfterWake.server.snapshot.providers.first { $0.providerID == "server-session-1" }
+        )
+        let providerAfterWake = try #require(
+            snapshotAfterWake.server.snapshot.providers.first { $0.providerID == "provider-1" }
+        )
+
+        #expect(defaultAfterWake.lifecycleState == .sleeping)
+        #expect(defaultAfterWake.powerState == .deepSleep)
+        #expect(providerAfterWake.lifecycleState == .ready)
+        #expect(providerAfterWake.powerState == .active)
+        #expect(providerAfterWake.wakeReason == .requestActivity)
+    }
+
+    @Test("startChat creates an explicit provider target when no runtime session exists")
+    func startChatCreatesExplicitProviderTargetWhenNoRuntimeSessionExists() async throws {
+        let runtimeStore = ServerSessionRuntimeStore(runtimeSessions: [], nowUnixMS: { 3_000 })
+        let modelCatalog = ModelCatalog(seedModels: [ModelCatalog.devTextModel()])
+        _ = await modelCatalog.loadModel(id: "melix-dev-text", dispatchHandle: "melix-dev-text::local")
+        let textClient = ScriptedChatWorkerClient(events: [
+            makeQueuedExecuteEvent(requestID: "chat-provider-create"),
+            makeCompletedExecuteEvent(
+                requestID: "chat-provider-create",
+                finishReason: "stop",
+                assistant: "created",
+                reasoning: ""
+            ),
+        ])
+        let service = ControlPlaneService(
+            modelCatalog: modelCatalog,
+            serverSessionRuntimeStore: runtimeStore,
+            workerRegistry: WorkerRegistry(defaultTextClient: textClient, modelCatalog: modelCatalog),
+            chatTranslator: ChatRequestTranslator(requestIDGenerator: { "chat-provider-create" })
+        )
+
+        let execution = try await service.startChat(
+            ControlPlaneChatRequest(
+                modelID: "melix-dev-text",
+                messages: [.init(role: "user", content: "create provider")],
+                providerID: "provider-1"
+            )
+        )
+        _ = try await Array(execution.stream)
+        let snapshotAfterCreate = try await service.execute(makeServerSnapshotRequest())
+        let providerAfterCreate = try #require(
+            snapshotAfterCreate.server.snapshot.providers.first { $0.providerID == "provider-1" }
+        )
+
+        #expect(providerAfterCreate.lifecycleState == .ready)
+        #expect(providerAfterCreate.powerState == .active)
+    }
+
     @Test("startChat syncs managed registry models before lazy load")
     func startChatSyncsManagedRegistryModelsBeforeLazyLoad() async throws {
         let importedModelID = "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"

--- a/tests/MelixCLITests/DiskStreamingSmokeRunnerTests.swift
+++ b/tests/MelixCLITests/DiskStreamingSmokeRunnerTests.swift
@@ -294,38 +294,38 @@ private actor DiskStreamingSmokeStubClient: ControlPlaneXPCClient {
         return snapshot
     }
 
-    func startServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        _ = serverSessionID
+    func startServerSession(providerID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
+        _ = providerID
         return try await serverSnapshot()
     }
 
-    func pauseServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        _ = serverSessionID
+    func pauseServerSession(providerID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
+        _ = providerID
         return try await serverSnapshot()
     }
 
-    func resumeServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        _ = serverSessionID
+    func resumeServerSession(providerID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
+        _ = providerID
         return try await serverSnapshot()
     }
 
-    func wakeServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        _ = serverSessionID
+    func wakeServerSession(providerID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
+        _ = providerID
         return try await serverSnapshot()
     }
 
-    func stopServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        _ = serverSessionID
+    func stopServerSession(providerID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
+        _ = providerID
         return try await serverSnapshot()
     }
 
     func updateServerIdlePolicy(
-        serverSessionID: String,
+        providerID: String,
         autoSleepEnabled: Bool,
         lightSleepAfterSeconds: UInt32,
         deepSleepAfterSeconds: UInt32
     ) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        _ = serverSessionID
+        _ = providerID
         _ = autoSleepEnabled
         _ = lightSleepAfterSeconds
         _ = deepSleepAfterSeconds
@@ -425,20 +425,20 @@ private actor DiskStreamingSmokeStubClient: ControlPlaneXPCClient {
     }
 
     func applyServerSessionGatewayAccess(
-        serverSessionID: String,
+        providerID: String,
         primaryKey: String,
         keyID: String,
         label: String,
         tokenHint: String
     ) async throws {
-        _ = serverSessionID
+        _ = providerID
         _ = primaryKey
         _ = keyID
         _ = label
         _ = tokenHint
     }
 
-    func clearServerSessionGatewayAccess(serverSessionID: String) async throws {
-        _ = serverSessionID
+    func clearServerSessionGatewayAccess(providerID: String) async throws {
+        _ = providerID
     }
 }

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -929,7 +929,7 @@ struct MelixCLIParserTests {
                 modelID: "melix-dev-text",
                 message: "Reply with OK",
                 systemPrompt: "Be concise.",
-                serverSessionID: "server-session-1",
+                providerID: "provider-1",
                 json: true
             )
         )
@@ -942,7 +942,7 @@ struct MelixCLIParserTests {
             "--model-id", "melix-dev-text",
             "--message", "Reply with OK",
             "--system", "Be concise.",
-            "--server-session-id", "server-session-1",
+            "--provider-id", "provider-1",
             "--json",
         ])
         #expect(try MelixCLIParser.parse(arguments) == command)
@@ -1179,25 +1179,25 @@ struct MelixCLIParserTests {
             (.modelRootsMove(.init(path: "/models", index: 1, json: true)), "model.roots.move"),
             (.modelRootsRescan(.init(json: true)), "model.roots.rescan"),
             (.serverSnapshot(.init(json: true)), "server.snapshot"),
-            (.serverSessionList(.init(json: true)), "server.session.list"),
-            (.serverSessionCreate(.init(title: "Server", servedModelIDs: ["model"], host: MelixGatewayDefaults.host, port: MelixGatewayDefaults.port, rateLimitPerMinute: 120, timeoutSeconds: 60, json: true)), "server.session.create"),
-            (.serverSessionUpdate(.init(serverSessionID: "server-session-1", title: "Server", servedModelIDs: ["model"], host: "127.0.0.1", port: 8081, rateLimitPerMinute: 60, timeoutSeconds: 30, json: true)), "server.session.update"),
-            (.serverSessionRemove(.init(serverSessionID: "server-session-1", json: true)), "server.session.remove"),
-            (.serverSessionSelect(.init(serverSessionID: "server-session-1", json: true)), "server.session.select"),
-            (.serverStart(.init(serverSessionID: "server-session-1", json: true)), "server.start"),
+            (.providerList(.init(json: true)), "provider.list"),
+            (.providerCreate(.init(title: "Server", servedModelIDs: ["model"], host: MelixGatewayDefaults.host, port: MelixGatewayDefaults.port, rateLimitPerMinute: 120, timeoutSeconds: 60, json: true)), "provider.create"),
+            (.providerUpdate(.init(providerID: "provider-1", title: "Server", servedModelIDs: ["model"], host: "127.0.0.1", port: 8081, rateLimitPerMinute: 60, timeoutSeconds: 30, json: true)), "provider.update"),
+            (.providerRemove(.init(providerID: "provider-1", json: true)), "provider.remove"),
+            (.providerSelect(.init(providerID: "provider-1", json: true)), "provider.select"),
+            (.serverStart(.init(providerID: "provider-1", json: true)), "server.start"),
             (.serverStart(.init(serverTitle: "Gemma 31B", servedModelIDs: ["mlx-community/gemma-4-31b-it-4bit"], host: "127.0.0.1", port: 12434, json: true)), "server.start"),
-            (.serverPause(.init(serverSessionID: "server-session-1", json: true)), "server.pause"),
-            (.serverResume(.init(serverSessionID: "server-session-1", json: true)), "server.resume"),
-            (.serverWake(.init(serverSessionID: "server-session-1", json: true)), "server.wake"),
-            (.serverStop(.init(serverSessionID: "server-session-1", json: true)), "server.stop"),
-            (.serverSetIdlePolicy(.init(serverSessionID: "server-session-1", autoSleepEnabled: true, lightSleepAfterSeconds: 30, deepSleepAfterSeconds: 60, json: true)), "server.set-idle-policy"),
+            (.serverPause(.init(providerID: "provider-1", json: true)), "server.pause"),
+            (.serverResume(.init(providerID: "provider-1", json: true)), "server.resume"),
+            (.serverWake(.init(providerID: "provider-1", json: true)), "server.wake"),
+            (.serverStop(.init(providerID: "provider-1", json: true)), "server.stop"),
+            (.serverSetIdlePolicy(.init(providerID: "provider-1", autoSleepEnabled: true, lightSleepAfterSeconds: 30, deepSleepAfterSeconds: 60, json: true)), "server.set-idle-policy"),
             (.remoteServerList(.init(json: true)), "remote-server.list"),
             (.remoteServerAdd(.init(remoteServerID: "custom", title: "Custom", providerPreset: .custom, providerKind: "openai-compatible", baseURL: "https://sub2api.example/v1", defaultModelID: "remote-model", apiKey: "sk-secret", timeoutSeconds: 60, rateLimitPerMinute: 10, json: true)), "remote-server.add"),
             (.remoteServerUpdate(.init(remoteServerID: "custom", title: "Custom Updated", providerPreset: .custom, providerKind: "openai-compatible", baseURL: "https://sub2api.example/updated/v1", defaultModelID: "remote-model-2", apiKey: "sk-new", timeoutSeconds: 90, rateLimitPerMinute: 20, toolSupportMode: .forceOff, json: true)), "remote-server.update"),
             (.remoteServerRemove(.init(remoteServerID: "custom", json: true)), "remote-server.remove"),
             (.remoteServerTest(.init(remoteServerID: "custom", remoteModelID: "remote-model", json: true)), "remote-server.test"),
-            (.chatRun(.init(modelID: "model", message: "hello", systemPrompt: "system", serverSessionID: "server-session-1", json: true)), "chat.run"),
-            (.chatRun(.init(remoteServerID: "custom", remoteModelID: "remote-model", message: "hello", systemPrompt: "system", serverSessionID: "server-session-1", json: true)), "chat.run"),
+            (.chatRun(.init(modelID: "model", message: "hello", systemPrompt: "system", providerID: "provider-1", json: true)), "chat.run"),
+            (.chatRun(.init(remoteServerID: "custom", remoteModelID: "remote-model", message: "hello", systemPrompt: "system", providerID: "provider-1", json: true)), "chat.run"),
             (.loraList(.init(modelID: "model", json: true)), "lora.list"),
             (.loraRun(.init(training: .init(modelID: "model-8bit", datasetSourceKind: "hf_dataset", datasetURI: "dataset/repo", adapterName: "adapter", targetRepo: "melix/adapter", trainingMode: "auto", parameters: ["derived_model_alias": "derived", "response_only": "true"], preflightFitCheck: true, allowMemoryRisk: true), evaluation: .init(modelID: "model-8bit", suites: ["event_extraction"], datasetID: "top200", sampleSize: 4, parameters: ["dataset_root": "evaluation"], json: false), outputDir: "/tmp/lora-run", json: true)), "lora.run"),
             (.loraTrain(.init(modelID: "model", datasetSourceKind: "huggingface", datasetURI: "dataset/repo", adapterName: "adapter", targetRepo: "melix/adapter", trainingMode: "qlora", parameters: ["derived_model_alias": "derived", "response_only": "true"], preflightFitCheck: true, allowMemoryRisk: true, json: true)), "lora.train"),
@@ -1276,23 +1276,23 @@ struct MelixCLIParserTests {
             .modelRootsRemove(.init(path: "/models", json: true)),
             .modelRootsMove(.init(path: "/models", index: 1, json: true)),
             .modelRootsRescan(.init(json: true)),
-            .serverSessionCreate(.init(title: "Server", servedModelIDs: ["model"], host: MelixGatewayDefaults.host, port: MelixGatewayDefaults.port, rateLimitPerMinute: 120, timeoutSeconds: 60, json: true)),
-            .serverSessionUpdate(.init(serverSessionID: "server-session-1", title: "Server", servedModelIDs: ["model"], host: "127.0.0.1", port: 8081, rateLimitPerMinute: 60, timeoutSeconds: 30, json: true)),
-            .serverSessionRemove(.init(serverSessionID: "server-session-1", json: true)),
-            .serverSessionSelect(.init(serverSessionID: "server-session-1", json: true)),
-            .serverStart(.init(serverSessionID: "server-session-1", json: true)),
-            .serverPause(.init(serverSessionID: "server-session-1", json: true)),
-            .serverResume(.init(serverSessionID: "server-session-1", json: true)),
-            .serverWake(.init(serverSessionID: "server-session-1", json: true)),
-            .serverStop(.init(serverSessionID: "server-session-1", json: true)),
-            .serverSetIdlePolicy(.init(serverSessionID: "server-session-1", autoSleepEnabled: false, lightSleepAfterSeconds: 30, deepSleepAfterSeconds: 60, json: true)),
+            .providerCreate(.init(title: "Server", servedModelIDs: ["model"], host: MelixGatewayDefaults.host, port: MelixGatewayDefaults.port, rateLimitPerMinute: 120, timeoutSeconds: 60, json: true)),
+            .providerUpdate(.init(providerID: "provider-1", title: "Server", servedModelIDs: ["model"], host: "127.0.0.1", port: 8081, rateLimitPerMinute: 60, timeoutSeconds: 30, json: true)),
+            .providerRemove(.init(providerID: "provider-1", json: true)),
+            .providerSelect(.init(providerID: "provider-1", json: true)),
+            .serverStart(.init(providerID: "provider-1", json: true)),
+            .serverPause(.init(providerID: "provider-1", json: true)),
+            .serverResume(.init(providerID: "provider-1", json: true)),
+            .serverWake(.init(providerID: "provider-1", json: true)),
+            .serverStop(.init(providerID: "provider-1", json: true)),
+            .serverSetIdlePolicy(.init(providerID: "provider-1", autoSleepEnabled: false, lightSleepAfterSeconds: 30, deepSleepAfterSeconds: 60, json: true)),
             .remoteServerList(.init(json: true)),
             .remoteServerAdd(.init(remoteServerID: "custom", title: "Custom", providerPreset: .custom, providerKind: "openai-compatible", baseURL: "https://sub2api.example/v1", defaultModelID: "remote-model", apiKey: "sk-secret", timeoutSeconds: 60, rateLimitPerMinute: 10, json: true)),
             .remoteServerUpdate(.init(remoteServerID: "custom", title: "Custom Updated", providerPreset: .custom, providerKind: "openai-compatible", baseURL: "https://sub2api.example/updated/v1", defaultModelID: "remote-model-2", apiKey: "sk-new", timeoutSeconds: 90, rateLimitPerMinute: 20, toolSupportMode: .forceOff, json: true)),
             .remoteServerRemove(.init(remoteServerID: "custom", json: true)),
             .remoteServerTest(.init(remoteServerID: "custom", remoteModelID: "remote-model", json: true)),
-            .chatRun(.init(modelID: "model", message: "hello", systemPrompt: "system", serverSessionID: "server-session-1", json: true)),
-            .chatRun(.init(remoteServerID: "custom", remoteModelID: "remote-model", message: "hello", systemPrompt: "system", serverSessionID: "server-session-1", json: true)),
+            .chatRun(.init(modelID: "model", message: "hello", systemPrompt: "system", providerID: "provider-1", json: true)),
+            .chatRun(.init(remoteServerID: "custom", remoteModelID: "remote-model", message: "hello", systemPrompt: "system", providerID: "provider-1", json: true)),
             .workspacePreflight(.init(manifestPath: "/tmp/workspace/workspace-manifest.json", outputPath: "/tmp/workspace/workspace-preflight-receipt.json", json: true)),
             .loraRun(.init(training: .init(modelID: "model-8bit", datasetSourceKind: "hf_dataset", datasetURI: "dataset/repo", adapterName: "adapter", targetRepo: "melix/adapter", trainingMode: "auto", parameters: ["derived_model_alias": "derived", "response_only": "true"], preflightFitCheck: true, allowMemoryRisk: true), evaluation: .init(modelID: "model-8bit", suites: ["event_extraction"], datasetID: "top200", sampleSize: 4, parameters: ["dataset_root": "evaluation"], json: false), outputDir: "/tmp/lora-run", json: true)),
             .loraTrain(.init(modelID: "model", datasetSourceKind: "huggingface", datasetURI: "dataset/repo", adapterName: "adapter", targetRepo: "melix/adapter", trainingMode: "qlora", parameters: ["derived_model_alias": "derived", "response_only": "true"], json: true)),
@@ -1492,7 +1492,7 @@ struct MelixCLIParserTests {
         }
 
         #expect(snapshotOptions.json)
-        #expect(pauseOptions.serverSessionID == ServerSessionRuntimeStore.defaultServerSessionID)
+        #expect(pauseOptions.providerID == "provider-1")
         #expect(!pauseOptions.json)
     }
 
@@ -2044,7 +2044,7 @@ struct MelixCLIParserTests {
             "--model-id", "melix-dev-qwen-local",
             "--message", "Reply with BASE_OK",
             "--system", "Be terse.",
-            "--server-session-id", "server-session-1",
+            "--provider-id", "provider-1",
             "--json",
         ])
 
@@ -2055,7 +2055,7 @@ struct MelixCLIParserTests {
                         modelID: "melix-dev-qwen-local",
                         message: "Reply with BASE_OK",
                         systemPrompt: "Be terse.",
-                        serverSessionID: "server-session-1",
+                        providerID: "provider-1",
                         json: true
                     )
                 )
@@ -2094,11 +2094,15 @@ struct MelixCLIParserTests {
         }
     }
 
-    @Test("parses server session create update remove and select commands")
-    func parsesServerSessionCRUDCommands() throws {
+    @Test("parses provider create update remove and select commands")
+    func parsesProviderCRUDCommands() throws {
+        let listCommand = try MelixCLIParser.parse([
+            "provider",
+            "list",
+            "--json",
+        ])
         let createCommand = try MelixCLIParser.parse([
-            "server",
-            "session",
+            "provider",
             "create",
             "--title", "Qwen Session",
             "--models", "mlx-community/Qwen3.5-0.8B-OptiQ-4bit,melix-secondary",
@@ -2114,10 +2118,9 @@ struct MelixCLIParserTests {
             "--json",
         ])
         let updateCommand = try MelixCLIParser.parse([
-            "server",
-            "session",
+            "provider",
             "update",
-            "--server-session-id", "server-session-qwen",
+            "--provider-id", "provider-qwen",
             "--model", "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
             "--model", "melix-secondary",
             "--default-model", "melix-secondary",
@@ -2132,35 +2135,38 @@ struct MelixCLIParserTests {
             "--num-draft-tokens", "8",
         ])
         let removeCommand = try MelixCLIParser.parse([
-            "server",
-            "session",
+            "provider",
             "remove",
-            "--server-session-id", "server-session-qwen",
+            "--provider-id", "provider-qwen",
         ])
         let selectCommand = try MelixCLIParser.parse([
-            "server",
-            "session",
+            "provider",
             "select",
-            "--server-session-id", "server-session-qwen",
+            "--provider-id", "provider-qwen",
         ])
 
-        guard case .serverSessionCreate(let createOptions) = createCommand else {
-            Issue.record("Expected serverSessionCreate command")
+        guard case .providerList(let listOptions) = listCommand else {
+            Issue.record("Expected providerList command")
             return
         }
-        guard case .serverSessionUpdate(let updateOptions) = updateCommand else {
-            Issue.record("Expected serverSessionUpdate command")
+        guard case .providerCreate(let createOptions) = createCommand else {
+            Issue.record("Expected providerCreate command")
             return
         }
-        guard case .serverSessionRemove(let removeOptions) = removeCommand else {
-            Issue.record("Expected serverSessionRemove command")
+        guard case .providerUpdate(let updateOptions) = updateCommand else {
+            Issue.record("Expected providerUpdate command")
             return
         }
-        guard case .serverSessionSelect(let selectOptions) = selectCommand else {
-            Issue.record("Expected serverSessionSelect command")
+        guard case .providerRemove(let removeOptions) = removeCommand else {
+            Issue.record("Expected providerRemove command")
+            return
+        }
+        guard case .providerSelect(let selectOptions) = selectCommand else {
+            Issue.record("Expected providerSelect command")
             return
         }
 
+        #expect(listOptions.json)
         #expect(createOptions.title == "Qwen Session")
         #expect(createOptions.defaultModelID == "melix-secondary")
         #expect(createOptions.servedModelIDs == [
@@ -2177,7 +2183,7 @@ struct MelixCLIParserTests {
         #expect(createOptions.draftModelID == "z-lab/Qwen3.5-27B-DFlash")
         #expect(createOptions.numDraftTokens == 4)
         #expect(createOptions.json)
-        #expect(updateOptions.serverSessionID == "server-session-qwen")
+        #expect(updateOptions.providerID == "provider-qwen")
         #expect(updateOptions.defaultModelID == "melix-secondary")
         #expect(updateOptions.servedModelIDs == [
             "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
@@ -2194,46 +2200,83 @@ struct MelixCLIParserTests {
         #expect(updateOptions.accelerationMode == "speculative_decode")
         #expect(updateOptions.draftModelID == "z-lab/Qwen3.5-27B-DFlash")
         #expect(updateOptions.numDraftTokens == 8)
-        #expect(removeOptions.serverSessionID == "server-session-qwen")
-        #expect(selectOptions.serverSessionID == "server-session-qwen")
+        #expect(removeOptions.providerID == "provider-qwen")
+        #expect(selectOptions.providerID == "provider-qwen")
     }
 
-    @Test("server session acceleration profiles resolve defaults and reject unknown profiles")
-    func serverSessionAccelerationProfilesResolveDefaultsAndRejectUnknownProfiles() throws {
+    @Test("provider parser rejects missing required fields")
+    func providerParserRejectsMissingRequiredFields() throws {
+        #expect(throws: MelixCLIError.missingRequired("--title is required for melix provider create.")) {
+            try MelixCLIParser.parse([
+                "provider",
+                "create",
+                "--model", "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+            ])
+        }
+
+        #expect(throws: MelixCLIError.missingRequired("--model or --models is required for melix provider create.")) {
+            try MelixCLIParser.parse([
+                "provider",
+                "create",
+                "--title", "Qwen Session",
+            ])
+        }
+
+        #expect(throws: MelixCLIError.missingRequired("--provider-id is required for melix provider update.")) {
+            try MelixCLIParser.parse([
+                "provider",
+                "update",
+                "--title", "Qwen Session",
+            ])
+        }
+
+        #expect(throws: MelixCLIError.missingRequired("--provider-id is required for melix provider remove.")) {
+            try MelixCLIParser.parse([
+                "provider",
+                "remove",
+            ])
+        }
+
+        #expect(throws: MelixCLIError.missingRequired("--provider-id is required for melix provider select.")) {
+            try MelixCLIParser.parse([
+                "provider",
+                "select",
+            ])
+        }
+    }
+
+    @Test("provider acceleration profiles resolve defaults and reject unknown profiles")
+    func providerAccelerationProfilesResolveDefaultsAndRejectUnknownProfiles() throws {
         let createCommand = try MelixCLIParser.parse([
-            "server",
-            "session",
+            "provider",
             "create",
             "--title", "Low Memory",
             "--model", "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
             "--acceleration-profile", "low_memory",
         ])
         let updateCommand = try MelixCLIParser.parse([
-            "server",
-            "session",
+            "provider",
             "update",
-            "--server-session-id", "server-session-qwen",
+            "--provider-id", "provider-qwen",
             "--acceleration-profile", "throughput",
             "--draft-model-id", "z-lab/Qwen3.5-27B-DFlash",
         ])
         let baselineUpdateCommand = try MelixCLIParser.parse([
-            "server",
-            "session",
+            "provider",
             "update",
-            "--server-session-id", "server-session-qwen",
+            "--provider-id", "provider-qwen",
             "--acceleration-profile", "low-memory",
         ])
         let noOpUpdateCommand = try MelixCLIParser.parse([
-            "server",
-            "session",
+            "provider",
             "update",
-            "--server-session-id", "server-session-qwen",
+            "--provider-id", "provider-qwen",
         ])
 
-        let createOptions = try #require(createCommand.serverSessionCreateOptions)
-        let updateOptions = try #require(updateCommand.serverSessionUpdateOptions)
-        let baselineUpdateOptions = try #require(baselineUpdateCommand.serverSessionUpdateOptions)
-        let noOpUpdateOptions = try #require(noOpUpdateCommand.serverSessionUpdateOptions)
+        let createOptions = try #require(createCommand.providerCreateOptions)
+        let updateOptions = try #require(updateCommand.providerUpdateOptions)
+        let baselineUpdateOptions = try #require(baselineUpdateCommand.providerUpdateOptions)
+        let noOpUpdateOptions = try #require(noOpUpdateCommand.providerUpdateOptions)
 
         #expect(createOptions.accelerationProfile == "low-memory")
         #expect(createOptions.accelerationMode == "baseline")
@@ -2252,9 +2295,8 @@ struct MelixCLIParserTests {
         #expect(noOpUpdateOptions.numDraftTokens == 0)
         #expect(throws: MelixCLIError.usage("Invalid value for --acceleration-profile. Expected balanced, throughput, low-memory, long-session.")) {
             try MelixCLIParser.parse([
-                "server",
-                "session",
-                "create",
+                "provider",
+            "create",
                 "--title", "Invalid",
                 "--model", "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
                 "--acceleration-profile", "fastest",
@@ -2262,9 +2304,8 @@ struct MelixCLIParserTests {
         }
         #expect(throws: MelixCLIError.usage("Invalid value for --acceleration-profile. Expected balanced, throughput, low-memory, long-session.")) {
             try MelixCLIParser.parse([
-                "server",
-                "session",
-                "create",
+                "provider",
+            "create",
                 "--title", "Invalid",
                 "--model", "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
                 "--acceleration-profile", " ",
@@ -2272,9 +2313,8 @@ struct MelixCLIParserTests {
         }
         #expect(throws: MelixCLIError.usage("Invalid value for --acceleration-mode. Expected baseline or speculative_decode.")) {
             try MelixCLIParser.parse([
-                "server",
-                "session",
-                "create",
+                "provider",
+            "create",
                 "--title", "Invalid",
                 "--model", "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
                 "--acceleration-mode", " ",
@@ -2282,20 +2322,19 @@ struct MelixCLIParserTests {
         }
     }
 
-    @Test("server session update parses allowlist clear flags and rejects mixed clear and set")
-    func serverSessionUpdateParsesAllowlistClearFlags() throws {
+    @Test("provider update parses allowlist clear flags and rejects mixed clear and set")
+    func providerUpdateParsesAllowlistClearFlags() throws {
         let command = try MelixCLIParser.parse([
-            "server",
-            "session",
+            "provider",
             "update",
-            "--server-session-id", "server-session-qwen",
+            "--provider-id", "provider-qwen",
             "--clear-allowed-hosts",
             "--clear-allowed-origins",
             "--json",
         ])
 
-        let options = try #require(command.serverSessionUpdateOptions)
-        #expect(options.serverSessionID == "server-session-qwen")
+        let options = try #require(command.providerUpdateOptions)
+        #expect(options.providerID == "provider-qwen")
         #expect(options.allowedHosts.isEmpty)
         #expect(options.allowedOrigins.isEmpty)
         #expect(options.clearAllowedHosts)
@@ -2310,31 +2349,28 @@ struct MelixCLIParserTests {
 
         #expect(throws: MelixCLIError.usage("--allowed-host and --clear-allowed-hosts are mutually exclusive.")) {
             _ = try MelixCLIParser.parse([
-                "server",
-                "session",
-                "update",
-                "--server-session-id", "server-session-qwen",
+                "provider",
+            "update",
+                "--provider-id", "provider-qwen",
                 "--allowed-host", "operator.lan",
                 "--clear-allowed-hosts",
             ])
         }
         #expect(throws: MelixCLIError.usage("--allowed-origin and --clear-allowed-origins are mutually exclusive.")) {
             _ = try MelixCLIParser.parse([
-                "server",
-                "session",
-                "update",
-                "--server-session-id", "server-session-qwen",
+                "provider",
+            "update",
+                "--provider-id", "provider-qwen",
                 "--allowed-origin", "http://localhost:5173",
                 "--clear-allowed-origins",
             ])
         }
     }
 
-    @Test("server session codec normalizes equals-form profile launch flags")
-    func serverSessionCodecNormalizesEqualsFormProfileLaunchFlags() throws {
+    @Test("provider codec normalizes equals-form profile launch flags")
+    func providerCodecNormalizesEqualsFormProfileLaunchFlags() throws {
         let createCommand = try MelixCLIParser.parse([
-            "server",
-            "session",
+            "provider",
             "create",
             "--title=Qwen Throughput",
             "--model=mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
@@ -2353,10 +2389,9 @@ struct MelixCLIParserTests {
             "--json",
         ])
         let updateCommand = try MelixCLIParser.parse([
-            "server",
-            "session",
+            "provider",
             "update",
-            "--server-session-id=server-session-qwen",
+            "--provider-id=provider-qwen",
             "--models=mlx-community/Qwen3.5-0.8B-OptiQ-4bit,melix-secondary",
             "--default-model=melix-secondary",
             "--allowed-host=dev.local",
@@ -2366,15 +2401,15 @@ struct MelixCLIParserTests {
             "--json",
         ])
 
-        let createOptions = try #require(createCommand.serverSessionCreateOptions)
-        let updateOptions = try #require(updateCommand.serverSessionUpdateOptions)
+        let createOptions = try #require(createCommand.providerCreateOptions)
+        let updateOptions = try #require(updateCommand.providerUpdateOptions)
         #expect(createOptions.accelerationProfile == "throughput")
         #expect(createOptions.allowedHosts == ["operator.lan:12436"])
         #expect(createOptions.allowedOrigins == ["http://localhost:5173/app"])
         #expect(createOptions.accelerationMode == "speculative_decode")
         #expect(createOptions.draftModelID == "z-lab/Qwen3.5-27B-DFlash")
         #expect(createOptions.numDraftTokens == 8)
-        #expect(updateOptions.serverSessionID == "server-session-qwen")
+        #expect(updateOptions.providerID == "provider-qwen")
         #expect(updateOptions.servedModelIDs == [
             "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
             "melix-secondary",
@@ -2404,10 +2439,9 @@ struct MelixCLIParserTests {
         #expect(Self.optionValue("--draft-model-id", in: updateArguments) == nil)
         #expect(throws: MelixCLIError.usage(MelixCLIParser.usageText)) {
             try MelixCLIParser.parse([
-                "server",
-                "session",
-                "update",
-                "--server-session-id=server-session-qwen",
+                "provider",
+            "update",
+                "--provider-id=provider-qwen",
                 "--json=true",
             ])
         }
@@ -2420,7 +2454,7 @@ struct MelixCLIParserTests {
         let startCommand = try MelixCLIParser.parse([
             "server",
             "start",
-            "--server-session-id", "server-session-2",
+            "--provider-id", "provider-2",
             "--json",
         ])
         let titledStartCommand = try MelixCLIParser.parse([
@@ -2448,17 +2482,17 @@ struct MelixCLIParserTests {
         let resumeCommand = try MelixCLIParser.parse([
             "server",
             "resume",
-            "--server-session-id", "server-session-3",
+            "--provider-id", "provider-3",
         ])
         let wakeCommand = try MelixCLIParser.parse([
             "server",
             "wake",
-            "--server-session-id", "server-session-4",
+            "--provider-id", "provider-4",
         ])
         let stopCommand = try MelixCLIParser.parse([
             "server",
             "stop",
-            "--server-session-id", "server-session-5",
+            "--provider-id", "provider-5",
         ])
 
         guard case .serverStart(let startOptions) = startCommand else {
@@ -2486,9 +2520,9 @@ struct MelixCLIParserTests {
             return
         }
 
-        #expect(startOptions.serverSessionID == "server-session-2")
+        #expect(startOptions.providerID == "provider-2")
         #expect(startOptions.json)
-        #expect(titledStartOptions.serverSessionID == "server-session-1")
+        #expect(titledStartOptions.providerID == "provider-1")
         #expect(titledStartOptions.serverTitle == "Gemma 31B")
         #expect(titledStartOptions.defaultModelID == "melix-secondary")
         #expect(titledStartOptions.servedModelIDs == [
@@ -2503,15 +2537,15 @@ struct MelixCLIParserTests {
         #expect(titledStartOptions.timeoutSeconds == 240)
         #expect(titledStartOptions.modelIdleTimeoutSeconds == 300)
         #expect(titledStartOptions.json)
-        #expect(namedStartOptions.serverSessionID == "gemma-31b")
+        #expect(namedStartOptions.providerID == "gemma-31b")
         #expect(namedStartOptions.serverTitle == "gemma-31b")
         #expect(namedStartOptions.defaultModelID == "mlx-community/gemma-4-31b-it-4bit")
         #expect(namedStartOptions.servedModelIDs == ["mlx-community/gemma-4-31b-it-4bit"])
         #expect(namedStartOptions.port == 12434)
-        #expect(resumeOptions.serverSessionID == "server-session-3")
+        #expect(resumeOptions.providerID == "provider-3")
         #expect(!resumeOptions.json)
-        #expect(wakeOptions.serverSessionID == "server-session-4")
-        #expect(stopOptions.serverSessionID == "server-session-5")
+        #expect(wakeOptions.providerID == "provider-4")
+        #expect(stopOptions.providerID == "provider-5")
     }
 
     @Test("parses server idle-policy command with explicit thresholds")
@@ -2519,7 +2553,7 @@ struct MelixCLIParserTests {
         let command = try MelixCLIParser.parse([
             "server",
             "set-idle-policy",
-            "--server-session-id", "server-session-2",
+            "--provider-id", "provider-2",
             "--auto-sleep", "true",
             "--light-sleep-after", "60",
             "--deep-sleep-after", "600",
@@ -2531,7 +2565,7 @@ struct MelixCLIParserTests {
             return
         }
 
-        #expect(options.serverSessionID == "server-session-2")
+        #expect(options.providerID == "provider-2")
         #expect(options.autoSleepEnabled)
         #expect(options.lightSleepAfterSeconds == 60)
         #expect(options.deepSleepAfterSeconds == 600)
@@ -2553,7 +2587,7 @@ struct MelixCLIParserTests {
             return
         }
 
-        #expect(options.serverSessionID == ServerSessionRuntimeStore.defaultServerSessionID)
+        #expect(options.providerID == MelixProviderDefaults.defaultProviderID)
         #expect(options.autoSleepEnabled == false)
         #expect(options.lightSleepAfterSeconds == 30)
         #expect(options.deepSleepAfterSeconds == 300)
@@ -4984,15 +5018,15 @@ private func assertSchemaUsageError(schemaPath: String, contains expectedText: S
 }
 
 private extension MelixCLICommand {
-    var serverSessionCreateOptions: ServerSessionCreateOptions? {
-        if case .serverSessionCreate(let options) = self {
+    var providerCreateOptions: ProviderCreateOptions? {
+        if case .providerCreate(let options) = self {
             return options
         }
         return nil
     }
 
-    var serverSessionUpdateOptions: ServerSessionUpdateOptions? {
-        if case .serverSessionUpdate(let options) = self {
+    var providerUpdateOptions: ProviderUpdateOptions? {
+        if case .providerUpdate(let options) = self {
             return options
         }
         return nil

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -15,7 +15,7 @@ struct MelixCLIRunnerTests {
         let output = try await MelixCLIRunner(client: client).run(.serverSnapshot(.init()))
 
         #expect(output.contains("server_state\tprovider_id\tlifecycle_state"))
-        #expect(output.contains("server_ready\tserver-session-1\tready\tactive\tinitial_boot"))
+        #expect(output.contains("server_ready\tprovider-1\tready\tactive\tinitial_boot"))
     }
 
     @Test("model hub search renders typed search results")
@@ -1554,10 +1554,10 @@ struct MelixCLIRunnerTests {
               "command": "model.roots.rescan"
             },
             {
-              "id": "update_session",
-              "command": "server.session.update",
+              "id": "update_provider",
+              "command": "provider.update",
               "args": {
-                "server_session_id": "server-session-1",
+                "provider_id": "provider-1",
                 "title": 123,
                 "default_model_id": "${inputs.model_id}",
                 "served_model_ids": ["${inputs.model_id}"],
@@ -1569,7 +1569,7 @@ struct MelixCLIRunnerTests {
             },
             {
               "id": "select_session",
-              "command": "server.session.select"
+              "command": "provider.select"
             },
             {
               "id": "start_server",
@@ -1903,8 +1903,8 @@ struct MelixCLIRunnerTests {
         #expect(quantizeArguments.contains("runtime_generate"))
     }
 
-    @Test("pipeline server session update accepts legacy model id alias")
-    func pipelineServerSessionUpdateAcceptsLegacyModelIDAlias() async throws {
+    @Test("pipeline provider update accepts legacy model id alias")
+    func pipelineProviderUpdateAcceptsModelIDAlias() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let pipelineURL = root.appendingPathComponent("legacy-model-id.pipeline.json")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -1919,10 +1919,10 @@ struct MelixCLIRunnerTests {
           },
           "steps": [
             {
-              "id": "update_session",
-              "command": "server.session.update",
+              "id": "update_provider",
+              "command": "provider.update",
               "args": {
-                "server_session_id": "server-session-1",
+                "provider_id": "provider-1",
                 "model_id": "${inputs.model_id}"
               }
             }
@@ -2124,7 +2124,7 @@ struct MelixCLIRunnerTests {
             "model_id": "melix-dev-text",
             "derived_model_alias": "melix-dev-text-derived",
             "model_path": "/tmp/melix-dev-text",
-            "server_session_id": "server-session-1",
+            "provider_id": "provider-1",
             "bench_job_id": "bench-1",
             "artifact_dir": "\#(artifactRoot.path)"
           },
@@ -2147,10 +2147,10 @@ struct MelixCLIRunnerTests {
               "args": {}
             },
             {
-              "id": "update_server_session",
-              "command": "server.session.update",
+              "id": "update_provider",
+              "command": "provider.update",
               "args": {
-                "server_session_id": "${inputs.server_session_id}",
+                "provider_id": "${inputs.provider_id}",
                 "title": "Fake Phase 8",
                 "default_model_id": "${inputs.model_id}",
                 "served_model_ids": ["${inputs.model_id}"],
@@ -2162,7 +2162,7 @@ struct MelixCLIRunnerTests {
               "id": "start_server",
               "command": "server.start",
               "args": {
-                "server_session_id": "${inputs.server_session_id}"
+                "provider_id": "${inputs.provider_id}"
               }
             },
             {
@@ -2170,7 +2170,7 @@ struct MelixCLIRunnerTests {
               "command": "chat.run",
               "args": {
                 "model_id": "${inputs.model_id}",
-                "server_session_id": "${inputs.server_session_id}",
+                "provider_id": "${inputs.provider_id}",
                 "message": "Reply with BASE_OK only."
               },
               "checks": {
@@ -2208,7 +2208,7 @@ struct MelixCLIRunnerTests {
               "command": "chat.run",
               "args": {
                 "model_id": "${inputs.derived_model_alias}",
-                "server_session_id": "${inputs.server_session_id}",
+                "provider_id": "${inputs.provider_id}",
                 "message": "Reply with DERIVED_OK only."
               },
               "checks": {
@@ -2376,10 +2376,10 @@ struct MelixCLIRunnerTests {
         )
         try await store.save(
             MelixOperatorSessionState(
-                selectedServerSessionID: "server-session-1",
-                serverSessions: [
+                selectedProviderID: "provider-1",
+                providers: [
                     .init(
-                        id: "server-session-1",
+                        id: "provider-1",
                         title: "Fake Phase 8",
                         defaultModelID: "melix-dev-text",
                         servedModelIDs: ["melix-dev-text"]
@@ -2433,7 +2433,7 @@ struct MelixCLIRunnerTests {
           "inputs": {
             "base_model_id": "melix-dev-text",
             "quantized_model_id": "melix-dev-text-aligned-q4",
-            "server_session_id": "server-session-issue365"
+            "provider_id": "provider-issue365"
           },
           "steps": [
             {
@@ -2530,7 +2530,7 @@ struct MelixCLIRunnerTests {
               "command": "chat.run",
               "args": {
                 "model_id": "${inputs.quantized_model_id}",
-                "server_session_id": "${inputs.server_session_id}",
+                "provider_id": "${inputs.provider_id}",
                 "message": "Reply with ISSUE365_OK only."
               },
               "checks": {
@@ -5113,7 +5113,7 @@ struct MelixCLIRunnerTests {
                     modelID: "melix-dev-qwen-local",
                     message: "Reply with BASE_OK",
                     systemPrompt: "Be terse.",
-                    serverSessionID: "server-session-1",
+                    providerID: "provider-1",
                     json: true
                 )
             )
@@ -5128,11 +5128,12 @@ struct MelixCLIRunnerTests {
                     messages: [
                         .init(role: "system", content: "Be terse."),
                         .init(role: "user", content: "Reply with BASE_OK"),
-                    ]
+                    ],
+                    providerID: "provider-1"
                 )
         )
         #expect(payload["model_id"] as? String == "melix-dev-qwen-local")
-        #expect(payload["server_session_id"] as? String == "server-session-1")
+        #expect(payload["provider_id"] as? String == "provider-1")
         #expect(payload["assistant_text"] as? String == "Echo: Reply with BASE_OK")
         #expect(payload["finish_reason"] as? String == "stop")
         #expect(payload["request_id"] as? String == "chat-run-1")
@@ -5681,18 +5682,18 @@ struct MelixCLIRunnerTests {
             requestID: "chat-run-failed",
             modelID: "melix-dev-qwen-local",
             events: [
-                .failed(code: "unavailable", message: "server session is not ready"),
+                .failed(code: "unavailable", message: "provider is not ready"),
             ]
         )
 
-        await #expect(throws: MelixCLIError.runtime("melix chat run failed [unavailable]: server session is not ready")) {
+        await #expect(throws: MelixCLIError.runtime("melix chat run failed [unavailable]: provider is not ready")) {
             try await MelixCLIRunner(client: client).run(
                 .chatRun(
                     .init(
                         modelID: "melix-dev-qwen-local",
                         message: "Reply with BASE_OK",
                         systemPrompt: "",
-                        serverSessionID: "server-session-1",
+                        providerID: "provider-1",
                         json: true
                     )
                 )
@@ -5718,7 +5719,7 @@ struct MelixCLIRunnerTests {
                     modelID: "melix-dev-qwen-local",
                     message: "Reply with BASE_OK",
                     systemPrompt: "",
-                    serverSessionID: "server-session-1",
+                    providerID: "provider-1",
                     json: false
                 )
             )
@@ -5745,7 +5746,7 @@ struct MelixCLIRunnerTests {
                     modelID: "melix-dev-qwen-local",
                     message: "Reply with BASE_OK",
                     systemPrompt: "",
-                    serverSessionID: "server-session-1",
+                    providerID: "provider-1",
                     json: false
                 )
             )
@@ -5772,7 +5773,7 @@ struct MelixCLIRunnerTests {
                         modelID: "melix-dev-qwen-local",
                         message: "Reply with BASE_OK",
                         systemPrompt: "",
-                        serverSessionID: "server-session-1",
+                        providerID: "provider-1",
                         json: true
                     )
                 )
@@ -5977,8 +5978,8 @@ struct MelixCLIRunnerTests {
         )
         try store.save(
             MelixOperatorSessionState(
-                selectedServerSessionID: "",
-                serverSessions: [],
+                selectedProviderID: "",
+                providers: [],
                 registryRoots: []
             )
         )
@@ -6121,8 +6122,8 @@ struct MelixCLIRunnerTests {
         )
         try store.save(
             MelixOperatorSessionState(
-                selectedServerSessionID: "",
-                serverSessions: [],
+                selectedProviderID: "",
+                providers: [],
                 registryRoots: ["/tmp/model-root-a"]
             )
         )
@@ -6339,27 +6340,27 @@ struct MelixCLIRunnerTests {
         await client.setServerSnapshot(makeServerSnapshot())
 
         let startOutput = try await MelixCLIRunner(client: client).run(
-            .serverStart(.init(serverSessionID: "server-session-2"))
+            .serverStart(.init(providerID: "provider-2"))
         )
         let resumeOutput = try await MelixCLIRunner(client: client).run(
-            .serverResume(.init(serverSessionID: "server-session-2", json: true))
+            .serverResume(.init(providerID: "provider-2", json: true))
         )
         let wakeOutput = try await MelixCLIRunner(client: client).run(
-            .serverWake(.init(serverSessionID: "server-session-2", json: true))
+            .serverWake(.init(providerID: "provider-2", json: true))
         )
         let stopOutput = try await MelixCLIRunner(client: client).run(
-            .serverStop(.init(serverSessionID: "server-session-2"))
+            .serverStop(.init(providerID: "provider-2"))
         )
 
         let wakePayload = try #require(parseJSONObject(wakeOutput))
         let wakeProviders = try #require(wakePayload["providers"] as? [[String: Any]])
         let wakeProvider = try #require(wakeProviders.first)
 
-        #expect(startOutput.contains("server_ready\tserver-session-2\tready\tactive\toperator_resume"))
+        #expect(startOutput.contains("server_ready\tprovider-2\tready\tactive\toperator_resume"))
         #expect(resumeOutput.contains(#""wake_reason" : "operator_resume""#))
         #expect(wakeProvider["wake_reason"] as? String == "request_activity")
-        #expect(stopOutput.contains("server_stopped\tserver-session-2\tstopped\tstopped\trequest_activity"))
-        #expect(await client.lastServerAction == .stop("server-session-2"))
+        #expect(stopOutput.contains("server_stopped\tprovider-2\tstopped\tstopped\trequest_activity"))
+        #expect(await client.lastServerAction == .stop("provider-2"))
     }
 
     @Test("server pause forwards the target session and returns json output")
@@ -6368,16 +6369,16 @@ struct MelixCLIRunnerTests {
         await client.setServerSnapshot(makeServerSnapshot(runtimeSessions: [makeRuntimeSession()]))
 
         let output = try await MelixCLIRunner(client: client).run(
-            .serverPause(.init(serverSessionID: "server-session-1", json: true))
+            .serverPause(.init(providerID: "provider-1", json: true))
         )
         let action = try #require(await client.lastServerAction)
         let payload = try #require(parseJSONObject(output))
         let providers = try #require(payload["providers"] as? [[String: Any]])
         let firstProvider = try #require(providers.first)
 
-        #expect(action == .pause("server-session-1"))
+        #expect(action == .pause("provider-1"))
         #expect(payload["server_state"] as? String == "server_degraded")
-        #expect(firstProvider["provider_id"] as? String == "server-session-1")
+        #expect(firstProvider["provider_id"] as? String == "provider-1")
         #expect(firstProvider["lifecycle_state"] as? String == "paused")
         #expect(firstProvider["power_state"] as? String == "active")
     }
@@ -6390,7 +6391,7 @@ struct MelixCLIRunnerTests {
         let output = try await MelixCLIRunner(client: client).run(
             .serverSetIdlePolicy(
                 .init(
-                    serverSessionID: "server-session-1",
+                    providerID: "provider-1",
                     autoSleepEnabled: true,
                     lightSleepAfterSeconds: 60,
                     deepSleepAfterSeconds: 600,
@@ -6403,7 +6404,7 @@ struct MelixCLIRunnerTests {
         let providers = try #require(payload["providers"] as? [[String: Any]])
         let firstProvider = try #require(providers.first)
 
-        #expect(call.serverSessionID == "server-session-1")
+        #expect(call.providerID == "provider-1")
         #expect(call.autoSleepEnabled)
         #expect(call.lightSleepAfterSeconds == 60)
         #expect(call.deepSleepAfterSeconds == 600)
@@ -6412,8 +6413,235 @@ struct MelixCLIRunnerTests {
         #expect(firstProvider["deep_sleep_after_seconds"] as? Int == 600)
     }
 
-    @Test("server session commands persist shared operator state and start validates serveable bindings")
-    func serverSessionCommandsPersistSharedOperatorStateAndStartValidatesServeableBindings() async throws {
+    @Test("operator session state encodes provider keys")
+    func operatorSessionStateEncodesProviderKeys() throws {
+        let state = MelixOperatorSessionState(
+            selectedSurfaceID: "server",
+            selectedToolSectionID: "modelsLibrary",
+            selectedProviderID: "provider-1",
+            providers: [
+                .init(
+                    id: "provider-1",
+                    title: "Qwen Provider",
+                    defaultModelID: "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                    servedModelIDs: ["mlx-community/Qwen3.5-0.8B-OptiQ-4bit"]
+                ),
+            ]
+        )
+
+        let data = try JSONEncoder().encode(state)
+        let payload = try #require(parseJSONObject(String(decoding: data, as: UTF8.self)))
+        let decoded = try JSONDecoder().decode(MelixOperatorSessionState.self, from: data)
+
+        #expect(payload["selected_provider_id"] as? String == "provider-1")
+        #expect(payload["providers"] as? [[String: Any]] != nil)
+        #expect(decoded.selectedProviderID == "provider-1")
+        #expect(decoded.providers.first?.id == "provider-1")
+    }
+
+    @Test("provider list renders empty state")
+    func providerListRendersEmptyState() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+
+        let store = MelixOperatorSessionStore(
+            melixHome: MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
+        )
+
+        let output = try await MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            operatorSessionStore: store
+        ).run(.providerList(.init(json: false)))
+
+        #expect(output == "No providers configured.\n")
+    }
+
+    @Test("provider remove and select render provider payloads")
+    func providerRemoveAndSelectRenderProviderPayloads() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+
+        let store = MelixOperatorSessionStore(
+            melixHome: MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
+        )
+        try store.save(
+            MelixOperatorSessionState(
+                selectedSurfaceID: "server",
+                selectedToolSectionID: "modelsLibrary",
+                selectedProviderID: "provider-1",
+                providers: [
+                    .init(
+                        id: "provider-1",
+                        title: "Qwen Provider",
+                        defaultModelID: "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                        servedModelIDs: ["mlx-community/Qwen3.5-0.8B-OptiQ-4bit"]
+                    ),
+                    .init(
+                        id: "provider-2",
+                        title: "Gemma Provider",
+                        defaultModelID: "mlx-community/gemma-4-31b-it-4bit",
+                        servedModelIDs: ["mlx-community/gemma-4-31b-it-4bit"]
+                    ),
+                ]
+            )
+        )
+        let runner = MelixCLIRunner(client: StubControlPlaneXPCClient(), operatorSessionStore: store)
+
+        let selectOutput = try await runner.run(.providerSelect(.init(providerID: "provider-2", json: true)))
+        let removeJSONOutput = try await runner.run(.providerRemove(.init(providerID: "provider-1", json: true)))
+        let removeTextOutput = try await runner.run(.providerRemove(.init(providerID: "provider-2", json: false)))
+        let selectPayload = try #require(parseJSONObject(selectOutput))
+        let removePayload = try #require(parseJSONObject(removeJSONOutput))
+
+        #expect(selectPayload["selected_provider_id"] as? String == "provider-2")
+        #expect(removePayload["removed_id"] as? String == "provider-1")
+        #expect(removePayload["selected_provider_id"] as? String == "provider-2")
+        #expect(removeTextOutput == "No providers configured.\n")
+    }
+
+    @Test("configured provider helpers apply persisted gateway and serving defaults")
+    func configuredProviderHelpersApplyPersistedGatewayAndServingDefaults() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+
+        let client = StubControlPlaneXPCClient()
+        let store = MelixOperatorSessionStore(
+            melixHome: MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
+        )
+        try store.save(
+            MelixOperatorSessionState(
+                selectedSurfaceID: "server",
+                selectedToolSectionID: "modelsLibrary",
+                selectedProviderID: "provider-1",
+                providers: [
+                    .init(
+                        id: "provider-1",
+                        title: "Qwen Provider",
+                        defaultModelID: "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                        servedModelIDs: [
+                            "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                            "mlx-community/Qwen3.5-27B-4bit",
+                        ],
+                        host: "0.0.0.0",
+                        port: 12434,
+                        allowedHosts: ["operator.lan"],
+                        allowedOrigins: ["http://localhost:5173"],
+                        rateLimitPerMinute: 42,
+                        timeoutSeconds: 90,
+                        modelIdleTimeoutSeconds: 300,
+                        servingDefaults: .init(
+                            temperature: 0.2,
+                            topP: 0.8,
+                            maxTokens: 512,
+                            streamIntervalTokens: 2,
+                            maxConcurrentRequests: 1,
+                            concurrentProcessingEnabled: false,
+                            prefillBatchSize: 1,
+                            completionBatchSize: 1,
+                            accelerationProfile: "low-memory",
+                            accelerationMode: "baseline"
+                        )
+                    ),
+                ]
+            )
+        )
+        let runner = MelixCLIRunner(client: client, operatorSessionStore: store)
+
+        _ = try await runner.applyConfiguredServerSessionGatewayConfig(providerID: "provider-1")
+        _ = try await runner.applyConfiguredServerSessionServingDefaults(providerID: "provider-1")
+        let gatewayConfigCall = try #require(await client.lastGatewayConfigApplyRequest)
+        let servingDefaultsCall = try #require(await client.lastServingDefaultsApplyRequest)
+
+        #expect(gatewayConfigCall.providerID == "provider-1")
+        #expect(gatewayConfigCall.host == "0.0.0.0")
+        #expect(gatewayConfigCall.port == 12434)
+        #expect(gatewayConfigCall.defaultModelID == "mlx-community/Qwen3.5-0.8B-OptiQ-4bit")
+        #expect(gatewayConfigCall.servedModelIDs == [
+            "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+            "mlx-community/Qwen3.5-27B-4bit",
+        ])
+        #expect(gatewayConfigCall.rateLimitPerMinute == 42)
+        #expect(gatewayConfigCall.timeoutSeconds == 90)
+        #expect(gatewayConfigCall.modelIdleTimeoutSeconds == 300)
+        #expect(gatewayConfigCall.allowedHosts == ["operator.lan"])
+        #expect(gatewayConfigCall.allowedOrigins == ["http://localhost:5173"])
+        #expect(servingDefaultsCall.providerID == "provider-1")
+        #expect(servingDefaultsCall.temperature == 0.2)
+        #expect(servingDefaultsCall.topP == 0.8)
+        #expect(servingDefaultsCall.maxTokens == 512)
+        #expect(servingDefaultsCall.streamIntervalTokens == 2)
+        #expect(servingDefaultsCall.maxConcurrentRequests == 1)
+        #expect(servingDefaultsCall.concurrentProcessingEnabled == false)
+        #expect(servingDefaultsCall.prefillBatchSize == 1)
+        #expect(servingDefaultsCall.completionBatchSize == 1)
+        #expect(servingDefaultsCall.accelerationMode == .baseline)
+        #expect(servingDefaultsCall.accelerationProfile == "low-memory")
+    }
+
+    @Test("server idle policy persists configured provider thresholds")
+    func serverIdlePolicyPersistsConfiguredProviderThresholds() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+
+        let client = StubControlPlaneXPCClient()
+        await client.setServerSnapshot(makeServerSnapshot(runtimeSessions: [makeRuntimeSession()]))
+        let store = MelixOperatorSessionStore(
+            melixHome: MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
+        )
+        try store.save(
+            MelixOperatorSessionState(
+                selectedSurfaceID: "server",
+                selectedToolSectionID: "modelsLibrary",
+                selectedProviderID: "provider-1",
+                providers: [
+                    .init(
+                        id: "provider-1",
+                        title: "Qwen Provider",
+                        defaultModelID: "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                        servedModelIDs: ["mlx-community/Qwen3.5-0.8B-OptiQ-4bit"]
+                    ),
+                ]
+            )
+        )
+
+        _ = try await MelixCLIRunner(client: client, operatorSessionStore: store).run(
+            .serverSetIdlePolicy(
+                .init(
+                    providerID: "provider-1",
+                    autoSleepEnabled: true,
+                    lightSleepAfterSeconds: 42,
+                    deepSleepAfterSeconds: 420,
+                    json: true
+                )
+            )
+        )
+        let state = try #require(try store.load())
+        let provider = try #require(state.providers.first)
+
+        #expect(provider.autoSleepEnabled)
+        #expect(provider.lightSleepAfterSeconds == 42)
+        #expect(provider.deepSleepAfterSeconds == 420)
+        #expect(provider.lifecycle == .draft)
+    }
+
+    @Test("provider commands persist shared operator state and start validates serveable bindings")
+    func serverProviderCommandsPersistSharedOperatorStateAndStartValidatesServeableBindings() async throws {
         let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
@@ -6432,7 +6660,7 @@ struct MelixCLIRunnerTests {
         let runner = MelixCLIRunner(client: client, operatorSessionStore: store)
 
         _ = try await runner.run(
-            .serverSessionCreate(
+            .providerCreate(
                 .init(
                     title: "Vision Session",
                     servedModelIDs: ["melix-dev-vlm"],
@@ -6447,15 +6675,15 @@ struct MelixCLIRunnerTests {
             )
         )
         _ = try await runner.run(
-            .serverSessionSelect(.init(serverSessionID: "server-session-1"))
+            .providerSelect(.init(providerID: "provider-1"))
         )
-        let listOutput = try await runner.run(.serverSessionList(.init(json: true)))
+        let listOutput = try await runner.run(.providerList(.init(json: true)))
 
         let payload = try #require(parseJSONObject(listOutput))
-        let selectedServerSessionID = try #require(payload["selected_server_session_id"] as? String)
-        let sessions = try #require(payload["server_sessions"] as? [[String: Any]])
+        let selectedProviderID = try #require(payload["selected_provider_id"] as? String)
+        let sessions = try #require(payload["providers"] as? [[String: Any]])
 
-        #expect(selectedServerSessionID == "server-session-1")
+        #expect(selectedProviderID == "provider-1")
         #expect(sessions.count == 1)
         #expect(sessions.first?["default_model_id"] as? String == "melix-dev-vlm")
         #expect(sessions.first?["served_model_ids"] as? [String] == ["melix-dev-vlm"])
@@ -6463,18 +6691,18 @@ struct MelixCLIRunnerTests {
         #expect(sessions.first?["allowed_origins"] as? [String] == ["http://localhost:5173/app"])
 
         _ = try await runner.run(
-            .serverStart(.init(serverSessionID: "server-session-1"))
+            .serverStart(.init(providerID: "provider-1"))
         )
 
         let gatewayConfigCall = try #require(await client.lastGatewayConfigApplyRequest)
         let servingDefaultsCall = try #require(await client.lastServingDefaultsApplyRequest)
 
-        #expect(gatewayConfigCall.serverSessionID == "server-session-1")
+        #expect(gatewayConfigCall.providerID == "provider-1")
         #expect(gatewayConfigCall.defaultModelID == "melix-dev-vlm")
         #expect(gatewayConfigCall.servedModelIDs == ["melix-dev-vlm"])
         #expect(gatewayConfigCall.allowedHosts == ["operator.lan:12436"])
         #expect(gatewayConfigCall.allowedOrigins == ["http://localhost:5173/app"])
-        #expect(servingDefaultsCall.serverSessionID == "server-session-1")
+        #expect(servingDefaultsCall.providerID == "provider-1")
         #expect(servingDefaultsCall.accelerationMode == .speculativeDecode)
         #expect(servingDefaultsCall.draftModelID == "z-lab/Qwen3.5-27B-DFlash")
         #expect(servingDefaultsCall.numDraftTokens == 4)
@@ -6483,10 +6711,10 @@ struct MelixCLIRunnerTests {
             MelixOperatorSessionState(
                 selectedSurfaceID: "server",
                 selectedToolSectionID: "modelsLibrary",
-                selectedServerSessionID: "server-session-1",
-                serverSessions: [
+                selectedProviderID: "provider-1",
+                providers: [
                     .init(
-                        id: "server-session-1",
+                        id: "provider-1",
                         title: "Broken Session",
                         defaultModelID: "melix-dev-ocr",
                         servedModelIDs: ["melix-dev-ocr"]
@@ -6499,12 +6727,61 @@ struct MelixCLIRunnerTests {
         ]))
 
         await #expect(throws: MelixCLIError.self) {
-            _ = try await runner.run(.serverStart(.init(serverSessionID: "server-session-1")))
+            _ = try await runner.run(.serverStart(.init(providerID: "provider-1")))
         }
     }
 
-    @Test("server session update persists draft serving defaults for start")
-    func serverSessionUpdatePersistsDraftServingDefaultsForStart() async throws {
+    @Test("server start marks configured provider unavailable when a bound model is missing")
+    func serverStartMarksConfiguredProviderUnavailableWhenBoundModelIsMissing() async throws {
+        let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: temporaryRoot)
+        }
+
+        let store = MelixOperatorSessionStore(
+            melixHome: MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
+        )
+        try store.save(
+            MelixOperatorSessionState(
+                selectedSurfaceID: "server",
+                selectedToolSectionID: "modelsLibrary",
+                selectedProviderID: "provider-1",
+                providers: [
+                    .init(
+                        id: "provider-1",
+                        title: "Missing Provider",
+                        defaultModelID: "missing-model",
+                        servedModelIDs: ["missing-model"]
+                    ),
+                ]
+            )
+        )
+        let client = StubControlPlaneXPCClient()
+        await client.setServerSnapshot(makeServerSnapshot(models: []))
+        await client.setModelInfoError(
+            modelID: "missing-model",
+            error: ControlPlaneXPCClientError.requestFailed(
+                code: "not_found",
+                message: "missing-model was not found"
+            )
+        )
+        let runner = MelixCLIRunner(client: client, operatorSessionStore: store)
+
+        await #expect(throws: MelixCLIError.runtime("Bound model missing-model is missing.")) {
+            _ = try await runner.run(.serverStart(.init(providerID: "provider-1")))
+        }
+        let state = try #require(try store.load())
+        let provider = try #require(state.providers.first)
+
+        #expect(provider.lifecycle == .unavailable)
+        #expect(provider.lastKnownModelStateText == "Unavailable")
+        #expect(provider.lastError == "Bound model missing-model is missing.")
+    }
+
+    @Test("provider update persists draft serving defaults for start")
+    func providerUpdatePersistsDraftServingDefaultsForStart() async throws {
         let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
@@ -6522,7 +6799,7 @@ struct MelixCLIRunnerTests {
         let runner = MelixCLIRunner(client: client, operatorSessionStore: store)
 
         _ = try await runner.run(
-            .serverSessionCreate(
+            .providerCreate(
                 .init(
                     title: "Qwen Session",
                     servedModelIDs: ["mlx-community/Qwen3.5-27B-4bit"]
@@ -6530,15 +6807,15 @@ struct MelixCLIRunnerTests {
             )
         )
         _ = try await runner.run(
-            .serverSessionUpdate(
+            .providerUpdate(
                 .init(
-                    serverSessionID: "server-session-1",
+                    providerID: "provider-1",
                     draftModelID: "z-lab/Qwen3.5-27B-DFlash"
                 )
             )
         )
         _ = try await runner.run(
-            .serverStart(.init(serverSessionID: "server-session-1"))
+            .serverStart(.init(providerID: "provider-1"))
         )
 
         let servingDefaultsCall = try #require(await client.lastServingDefaultsApplyRequest)
@@ -6547,8 +6824,8 @@ struct MelixCLIRunnerTests {
         #expect(servingDefaultsCall.numDraftTokens == 4)
     }
 
-    @Test("server session update clears persisted gateway allowlists before start")
-    func serverSessionUpdateClearsPersistedGatewayAllowlistsBeforeStart() async throws {
+    @Test("provider update clears persisted gateway allowlists before start")
+    func providerUpdateClearsPersistedGatewayAllowlistsBeforeStart() async throws {
         let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
@@ -6567,7 +6844,7 @@ struct MelixCLIRunnerTests {
         let runner = MelixCLIRunner(client: client, operatorSessionStore: store)
 
         _ = try await runner.run(
-            .serverSessionCreate(
+            .providerCreate(
                 .init(
                     title: "Qwen Session",
                     servedModelIDs: [modelID],
@@ -6577,20 +6854,20 @@ struct MelixCLIRunnerTests {
             )
         )
         _ = try await runner.run(
-            .serverSessionUpdate(
+            .providerUpdate(
                 .init(
-                    serverSessionID: "server-session-1",
+                    providerID: "provider-1",
                     clearAllowedHosts: true,
                     clearAllowedOrigins: true
                 )
             )
         )
         _ = try await runner.run(
-            .serverStart(.init(serverSessionID: "server-session-1"))
+            .serverStart(.init(providerID: "provider-1"))
         )
 
         let state = try #require(try store.load())
-        let session = try #require(state.serverSessions.first)
+        let session = try #require(state.providers.first)
         let gatewayConfigCall = try #require(await client.lastGatewayConfigApplyRequest)
 
         #expect(session.allowedHosts.isEmpty)
@@ -6599,8 +6876,8 @@ struct MelixCLIRunnerTests {
         #expect(gatewayConfigCall.allowedOrigins.isEmpty)
     }
 
-    @Test("server session update preserves roster when only default model changes")
-    func serverSessionUpdatePreservesRosterWhenOnlyDefaultModelChanges() async throws {
+    @Test("provider update preserves roster when only default model changes")
+    func providerUpdatePreservesRosterWhenOnlyDefaultModelChanges() async throws {
         let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
@@ -6616,7 +6893,7 @@ struct MelixCLIRunnerTests {
         let runner = MelixCLIRunner(client: StubControlPlaneXPCClient(), operatorSessionStore: store)
 
         _ = try await runner.run(
-            .serverSessionCreate(
+            .providerCreate(
                 .init(
                     title: "Qwen Session",
                     defaultModelID: primaryModelID,
@@ -6625,23 +6902,23 @@ struct MelixCLIRunnerTests {
             )
         )
         _ = try await runner.run(
-            .serverSessionUpdate(
+            .providerUpdate(
                 .init(
-                    serverSessionID: "server-session-1",
+                    providerID: "provider-1",
                     defaultModelID: secondaryModelID
                 )
             )
         )
 
         let state = try #require(try store.load())
-        let session = try #require(state.serverSessions.first)
+        let session = try #require(state.providers.first)
 
         #expect(session.defaultModelID == secondaryModelID)
         #expect(session.servedModelIDs == [primaryModelID, secondaryModelID])
     }
 
-    @Test("server session low memory profile persists serving defaults for start")
-    func serverSessionLowMemoryProfilePersistsServingDefaultsForStart() async throws {
+    @Test("provider low memory profile persists serving defaults for start")
+    func serverProviderLowMemoryProfilePersistsServingDefaultsForStart() async throws {
         let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
@@ -6659,7 +6936,7 @@ struct MelixCLIRunnerTests {
         let runner = MelixCLIRunner(client: client, operatorSessionStore: store)
 
         _ = try await runner.run(
-            .serverSessionCreate(
+            .providerCreate(
                 .init(
                     title: "Low Memory Session",
                     servedModelIDs: ["mlx-community/Qwen3.5-0.8B-OptiQ-4bit"],
@@ -6668,7 +6945,7 @@ struct MelixCLIRunnerTests {
             )
         )
         _ = try await runner.run(
-            .serverStart(.init(serverSessionID: "server-session-1"))
+            .serverStart(.init(providerID: "provider-1"))
         )
 
         let servingDefaultsCall = try #require(await client.lastServingDefaultsApplyRequest)
@@ -6717,13 +6994,13 @@ struct MelixCLIRunnerTests {
         )
 
         let state = try #require(try store.load())
-        let session = try #require(state.serverSessions.first)
+        let session = try #require(state.providers.first)
         let gatewayConfigCall = try #require(await client.lastGatewayConfigApplyRequest)
         let servingDefaultsCall = try #require(await client.lastServingDefaultsApplyRequest)
         let startedAction = try #require(await client.lastServerAction)
 
-        #expect(state.selectedServerSessionID == "server-session-1")
-        #expect(session.id == "server-session-1")
+        #expect(state.selectedProviderID == "provider-1")
+        #expect(session.id == "provider-1")
         #expect(session.title == "Gemma 31B")
         #expect(session.defaultModelID == modelID)
         #expect(session.servedModelIDs == [modelID])
@@ -6733,17 +7010,17 @@ struct MelixCLIRunnerTests {
         #expect(session.allowedOrigins == ["http://localhost:5173"])
         #expect(session.rateLimitPerMinute == 60)
         #expect(session.timeoutSeconds == 240)
-        #expect(gatewayConfigCall.serverSessionID == "server-session-1")
+        #expect(gatewayConfigCall.providerID == "provider-1")
         #expect(gatewayConfigCall.defaultModelID == modelID)
         #expect(gatewayConfigCall.servedModelIDs == [modelID])
         #expect(gatewayConfigCall.allowedHosts == ["operator.lan"])
         #expect(gatewayConfigCall.allowedOrigins == ["http://localhost:5173"])
         #expect(gatewayConfigCall.port == 12434)
-        #expect(servingDefaultsCall.serverSessionID == "server-session-1")
-        #expect(startedAction == .start("server-session-1"))
+        #expect(servingDefaultsCall.providerID == "provider-1")
+        #expect(startedAction == .start("provider-1"))
     }
 
-    @Test("server start shortcut uses slug title as the server session id")
+    @Test("server start shortcut uses slug title as the provider id")
     func serverStartShortcutUsesSlugTitleAsServerSessionID() async throws {
         let temporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("melix-cli-runner-\(UUID().uuidString)", isDirectory: true)
@@ -6773,16 +7050,16 @@ struct MelixCLIRunnerTests {
         )
 
         let state = try #require(try store.load())
-        let session = try #require(state.serverSessions.first(where: { $0.id == "gemma-31b" }))
+        let session = try #require(state.providers.first(where: { $0.id == "gemma-31b" }))
         let gatewayConfigCall = try #require(await client.lastGatewayConfigApplyRequest)
         let startedAction = try #require(await client.lastServerAction)
 
-        #expect(state.selectedServerSessionID == "gemma-31b")
+        #expect(state.selectedProviderID == "gemma-31b")
         #expect(session.title == "gemma-31b")
         #expect(session.defaultModelID == modelID)
         #expect(session.servedModelIDs == [modelID])
         #expect(session.port == 12434)
-        #expect(gatewayConfigCall.serverSessionID == "gemma-31b")
+        #expect(gatewayConfigCall.providerID == "gemma-31b")
         #expect(gatewayConfigCall.defaultModelID == modelID)
         #expect(gatewayConfigCall.servedModelIDs == [modelID])
         #expect(startedAction == .start("gemma-31b"))
@@ -6828,11 +7105,11 @@ struct MelixCLIRunnerTests {
         )
 
         let state = try #require(try store.load())
-        let session = try #require(state.serverSessions.first(where: { $0.id == "gemma-31b" }))
+        let session = try #require(state.providers.first(where: { $0.id == "gemma-31b" }))
         let startedAction = try #require(await client.lastServerAction)
 
-        #expect(state.serverSessions.count == 1)
-        #expect(state.selectedServerSessionID == "gemma-31b")
+        #expect(state.providers.count == 1)
+        #expect(state.selectedProviderID == "gemma-31b")
         #expect(session.title == "Gemma-31B")
         #expect(session.port == 12434)
         #expect(startedAction == .start("gemma-31b"))
@@ -6859,8 +7136,8 @@ struct MelixCLIRunnerTests {
             MelixOperatorSessionState(
                 selectedSurfaceID: "server",
                 selectedToolSectionID: "modelsLibrary",
-                selectedServerSessionID: "gemma-31b",
-                serverSessions: [
+                selectedProviderID: "gemma-31b",
+                providers: [
                     .init(
                         id: "gemma-31b",
                         title: "Existing Gemma",
@@ -6868,7 +7145,7 @@ struct MelixCLIRunnerTests {
                         servedModelIDs: [modelID]
                     ),
                     .init(
-                        id: "server-session-1",
+                        id: "provider-1",
                         title: "Existing One",
                         defaultModelID: modelID,
                         servedModelIDs: [modelID]
@@ -6880,7 +7157,7 @@ struct MelixCLIRunnerTests {
         _ = try await MelixCLIRunner(client: client, operatorSessionStore: store).run(
             .serverStart(
                 .init(
-                    serverSessionID: "gemma-31b",
+                    providerID: "gemma-31b",
                     serverTitle: "Gemma Archive",
                     servedModelIDs: [modelID],
                     port: 12434
@@ -6889,12 +7166,12 @@ struct MelixCLIRunnerTests {
         )
 
         let state = try #require(try store.load())
-        let created = try #require(state.serverSessions.first(where: { $0.title == "Gemma Archive" }))
+        let created = try #require(state.providers.first(where: { $0.title == "Gemma Archive" }))
         let startedAction = try #require(await client.lastServerAction)
 
-        #expect(created.id == "server-session-2")
-        #expect(state.selectedServerSessionID == "server-session-2")
-        #expect(startedAction == .start("server-session-2"))
+        #expect(created.id == "provider-2")
+        #expect(state.selectedProviderID == "provider-2")
+        #expect(startedAction == .start("provider-2"))
     }
 
     @Test("server start shortcut reuses an existing titled session")
@@ -6920,10 +7197,10 @@ struct MelixCLIRunnerTests {
             MelixOperatorSessionState(
                 selectedSurfaceID: "server",
                 selectedToolSectionID: "modelsLibrary",
-                selectedServerSessionID: "server-session-1",
-                serverSessions: [
+                selectedProviderID: "provider-1",
+                providers: [
                     .init(
-                        id: "server-session-1",
+                        id: "provider-1",
                         title: "Qwen Dev",
                         defaultModelID: originalModelID,
                         servedModelIDs: [originalModelID],
@@ -6948,13 +7225,13 @@ struct MelixCLIRunnerTests {
         )
 
         let state = try #require(try store.load())
-        let session = try #require(state.serverSessions.first)
+        let session = try #require(state.providers.first)
         let gatewayConfigCall = try #require(await client.lastGatewayConfigApplyRequest)
         let startedAction = try #require(await client.lastServerAction)
 
-        #expect(state.serverSessions.count == 1)
-        #expect(state.selectedServerSessionID == "server-session-1")
-        #expect(session.id == "server-session-1")
+        #expect(state.providers.count == 1)
+        #expect(state.selectedProviderID == "provider-1")
+        #expect(session.id == "provider-1")
         #expect(session.title == "Qwen Dev")
         #expect(session.defaultModelID == updatedModelID)
         #expect(session.servedModelIDs == [updatedModelID])
@@ -6962,11 +7239,11 @@ struct MelixCLIRunnerTests {
         #expect(session.port == 12435)
         #expect(session.rateLimitPerMinute == 90)
         #expect(session.timeoutSeconds == 300)
-        #expect(gatewayConfigCall.serverSessionID == "server-session-1")
+        #expect(gatewayConfigCall.providerID == "provider-1")
         #expect(gatewayConfigCall.defaultModelID == updatedModelID)
         #expect(gatewayConfigCall.servedModelIDs == [updatedModelID])
         #expect(gatewayConfigCall.port == 12435)
-        #expect(startedAction == .start("server-session-1"))
+        #expect(startedAction == .start("provider-1"))
     }
 
     @Test("server start shortcut preserves roster when only default model changes")
@@ -6992,10 +7269,10 @@ struct MelixCLIRunnerTests {
             MelixOperatorSessionState(
                 selectedSurfaceID: "server",
                 selectedToolSectionID: "modelsLibrary",
-                selectedServerSessionID: "server-session-1",
-                serverSessions: [
+                selectedProviderID: "provider-1",
+                providers: [
                     .init(
-                        id: "server-session-1",
+                        id: "provider-1",
                         title: "Qwen Dev",
                         defaultModelID: originalModelID,
                         servedModelIDs: [originalModelID, updatedDefaultID],
@@ -7017,7 +7294,7 @@ struct MelixCLIRunnerTests {
         )
 
         let state = try #require(try store.load())
-        let session = try #require(state.serverSessions.first)
+        let session = try #require(state.providers.first)
         let gatewayConfigCall = try #require(await client.lastGatewayConfigApplyRequest)
 
         #expect(session.defaultModelID == updatedDefaultID)
@@ -7047,16 +7324,16 @@ struct MelixCLIRunnerTests {
             MelixOperatorSessionState(
                 selectedSurfaceID: "server",
                 selectedToolSectionID: "modelsLibrary",
-                selectedServerSessionID: "server-session-3",
-                serverSessions: [
+                selectedProviderID: "provider-3",
+                providers: [
                     .init(
-                        id: "server-session-1",
+                        id: "provider-1",
                         title: "Existing One",
                         defaultModelID: modelID,
                         servedModelIDs: [modelID]
                     ),
                     .init(
-                        id: "server-session-3",
+                        id: "provider-3",
                         title: "Existing Three",
                         defaultModelID: modelID,
                         servedModelIDs: [modelID]
@@ -7076,12 +7353,12 @@ struct MelixCLIRunnerTests {
         )
 
         let state = try #require(try store.load())
-        let created = try #require(state.serverSessions.first(where: { $0.title == "Gemma 31B" }))
+        let created = try #require(state.providers.first(where: { $0.title == "Gemma 31B" }))
         let startedAction = try #require(await client.lastServerAction)
 
-        #expect(created.id == "server-session-2")
-        #expect(state.selectedServerSessionID == "server-session-2")
-        #expect(startedAction == .start("server-session-2"))
+        #expect(created.id == "provider-2")
+        #expect(state.selectedProviderID == "provider-2")
+        #expect(startedAction == .start("provider-2"))
     }
 
     @Test("server start shortcut requires title and model arguments")
@@ -7103,7 +7380,7 @@ struct MelixCLIRunnerTests {
         await #expect(throws: MelixCLIError.missingRequired("TITLE is required when passing --model, --models, --default-model, --host, --port, --allowed-host, --allowed-origin, --rate-limit-per-minute, --timeout-seconds, or --model-idle-timeout-seconds to melix server start.")) {
             _ = try await runner.run(.serverStart(.init(servedModelIDs: ["mlx-community/gemma-4-31b-it-4bit"])))
         }
-        await #expect(throws: MelixCLIError.missingRequired("--model or --models is required when starting a titled server session.")) {
+        await #expect(throws: MelixCLIError.missingRequired("--model or --models is required when starting a titled provider.")) {
             _ = try await runner.run(.serverStart(.init(serverTitle: "Gemma 31B")))
         }
     }
@@ -7139,10 +7416,10 @@ struct MelixCLIRunnerTests {
             MelixOperatorSessionState(
                 selectedSurfaceID: "server",
                 selectedToolSectionID: "modelsLibrary",
-                selectedServerSessionID: "server-session-1",
-                serverSessions: [
+                selectedProviderID: "provider-1",
+                providers: [
                     .init(
-                        id: "server-session-1",
+                        id: "provider-1",
                         title: "Imported Session",
                         defaultModelID: importedModelID,
                         servedModelIDs: [importedModelID]
@@ -7152,7 +7429,7 @@ struct MelixCLIRunnerTests {
         )
 
         _ = try await MelixCLIRunner(client: client, operatorSessionStore: store).run(
-            .serverStart(.init(serverSessionID: "server-session-1"))
+            .serverStart(.init(providerID: "provider-1"))
         )
 
         let gatewayConfigCall = try #require(await client.lastGatewayConfigApplyRequest)
@@ -7160,7 +7437,7 @@ struct MelixCLIRunnerTests {
 
         #expect(gatewayConfigCall.defaultModelID == importedModelID)
         #expect(gatewayConfigCall.servedModelIDs == [importedModelID])
-        #expect(startedAction == .start("server-session-1"))
+        #expect(startedAction == .start("provider-1"))
     }
 
     @Test("server snapshot renders empty sessions and fallback labels")
@@ -7172,19 +7449,19 @@ struct MelixCLIRunnerTests {
         await client.setServerSnapshot(emptySnapshot)
         let emptyOutput = try await MelixCLIRunner(client: client).run(.serverSnapshot(.init()))
 
-        var loadingSession = makeRuntimeSession(serverSessionID: "server-session-loading")
+        var loadingSession = makeRuntimeSession(providerID: "provider-loading")
         loadingSession.lifecycleState = .loading
         loadingSession.powerState = .lightSleep
         loadingSession.wakeReason = .toolActivity
-        var stoppedSession = makeRuntimeSession(serverSessionID: "server-session-stopped")
+        var stoppedSession = makeRuntimeSession(providerID: "provider-stopped")
         stoppedSession.lifecycleState = .stopped
         stoppedSession.powerState = .stopped
         stoppedSession.wakeReason = .policyApply
-        var failedSession = makeRuntimeSession(serverSessionID: "server-session-failed")
+        var failedSession = makeRuntimeSession(providerID: "provider-failed")
         failedSession.lifecycleState = .error
         failedSession.powerState = .deepSleep
         failedSession.wakeReason = .operatorResume
-        var unknownSession = makeRuntimeSession(serverSessionID: "server-session-unknown")
+        var unknownSession = makeRuntimeSession(providerID: "provider-unknown")
         unknownSession.lifecycleState = .UNRECOGNIZED(999)
         unknownSession.powerState = .UNRECOGNIZED(999)
         unknownSession.wakeReason = .UNRECOGNIZED(999)
@@ -7211,9 +7488,9 @@ struct MelixCLIRunnerTests {
         let unknownOutput = try await MelixCLIRunner(client: client).run(.serverSnapshot(.init(json: true)))
 
         #expect(emptyOutput == "server_state=server_booting\nNo providers found.\n")
-        #expect(loadingOutput.contains("server_draining\tserver-session-loading\tloading\tlight_sleep\ttool_activity"))
-        #expect(stoppedOutput.contains("server_stopped\tserver-session-stopped\tstopped\tstopped\tpolicy_apply"))
-        #expect(failedOutput.contains("server_failed\tserver-session-failed\terror\tdeep_sleep\toperator_resume"))
+        #expect(loadingOutput.contains("server_draining\tprovider-loading\tloading\tlight_sleep\ttool_activity"))
+        #expect(stoppedOutput.contains("server_stopped\tprovider-stopped\tstopped\tstopped\tpolicy_apply"))
+        #expect(failedOutput.contains("server_failed\tprovider-failed\terror\tdeep_sleep\toperator_resume"))
         #expect(unknownOutput.contains(#""server_state" : "server_state_unspecified""#))
         #expect(unknownOutput.contains(#""lifecycle_state" : "lifecycle_unspecified""#))
         #expect(unknownOutput.contains(#""power_state" : "power_unspecified""#))
@@ -13090,13 +13367,13 @@ struct MelixCLIRunnerTests {
         let doctor = try await client.runDoctor()
         let cancelled = try await client.cancelRequest(requestID: "request-1")
         try await client.applyServerSessionGatewayAccess(
-            serverSessionID: "session-1",
+            serverSessionID: "provider-1",
             primaryKey: "pk",
             keyID: "key",
             label: "demo",
             tokenHint: "***"
         )
-        try await client.clearServerSessionGatewayAccess(serverSessionID: "session-1")
+        try await client.clearServerSessionGatewayAccess(serverSessionID: "provider-1")
 
         #expect(handshake.protocolVersion.isEmpty)
         #expect(await iterator.next() == nil)
@@ -13491,7 +13768,7 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     struct IdlePolicyCall: Sendable, Equatable {
-        let serverSessionID: String
+        let providerID: String
         let autoSleepEnabled: Bool
         let lightSleepAfterSeconds: UInt32
         let deepSleepAfterSeconds: UInt32
@@ -13508,7 +13785,7 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     struct GatewayConfigApplyCall: Sendable, Equatable {
-        let serverSessionID: String
+        let providerID: String
         let host: String
         let port: Int
         let defaultModelID: String
@@ -13521,7 +13798,7 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     struct ServingDefaultsApplyCall: Sendable, Equatable {
-        let serverSessionID: String
+        let providerID: String
         let temperature: Double
         let topP: Double
         let maxTokens: Int
@@ -13567,6 +13844,7 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
     private(set) var maxConcurrentEvaluationCalls = 0
     private var exportResult = ControlPlaneExportResult(exportBundleJSON: #"{"export_schema_version":"melix.benchmark_export.v1","benchmark_jobs":[],"benchmark_results":[]}"#)
     private var modelInfoByID: [String: Melix_Controlplane_V1_ModelInfo] = [:]
+    private var modelInfoErrorsByID: [String: Error] = [:]
     private var loadError: Error?
     private var modelOperationError: Error?
     private var chatError: Error?
@@ -13637,6 +13915,10 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
         modelInfoByID[modelID] = info
     }
 
+    func setModelInfoError(modelID: String, error: Error) {
+        modelInfoErrorsByID[modelID] = error
+    }
+
     func setLoadError(_ error: Error?) {
         loadError = error
     }
@@ -13685,8 +13967,9 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     func startServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        lastServerAction = .start(serverSessionID)
-        mutateRuntimeSession(serverSessionID: serverSessionID) { session in
+        let providerID = serverSessionID
+        lastServerAction = .start(providerID)
+        mutateRuntimeSession(providerID: providerID) { session in
             session.lifecycleState = .ready
             session.powerState = .active
             session.wakeReason = .operatorResume
@@ -13696,8 +13979,9 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     func pauseServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        lastServerAction = .pause(serverSessionID)
-        mutateRuntimeSession(serverSessionID: serverSessionID) { session in
+        let providerID = serverSessionID
+        lastServerAction = .pause(providerID)
+        mutateRuntimeSession(providerID: providerID) { session in
             session.lifecycleState = .paused
             session.powerState = .active
         }
@@ -13706,8 +13990,9 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     func resumeServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        lastServerAction = .resume(serverSessionID)
-        mutateRuntimeSession(serverSessionID: serverSessionID) { session in
+        let providerID = serverSessionID
+        lastServerAction = .resume(providerID)
+        mutateRuntimeSession(providerID: providerID) { session in
             session.lifecycleState = .ready
             session.powerState = .active
             session.wakeReason = .operatorResume
@@ -13717,8 +14002,9 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     func wakeServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        lastServerAction = .wake(serverSessionID)
-        mutateRuntimeSession(serverSessionID: serverSessionID) { session in
+        let providerID = serverSessionID
+        lastServerAction = .wake(providerID)
+        mutateRuntimeSession(providerID: providerID) { session in
             session.lifecycleState = .ready
             session.powerState = .active
             session.wakeReason = .requestActivity
@@ -13728,8 +14014,9 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     func stopServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        lastServerAction = .stop(serverSessionID)
-        mutateRuntimeSession(serverSessionID: serverSessionID) { session in
+        let providerID = serverSessionID
+        lastServerAction = .stop(providerID)
+        mutateRuntimeSession(providerID: providerID) { session in
             session.lifecycleState = .stopped
             session.powerState = .stopped
         }
@@ -13743,13 +14030,14 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
         lightSleepAfterSeconds: UInt32,
         deepSleepAfterSeconds: UInt32
     ) async throws -> Melix_Controlplane_V1_ServerSnapshot {
+        let providerID = serverSessionID
         lastIdlePolicyCall = IdlePolicyCall(
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             autoSleepEnabled: autoSleepEnabled,
             lightSleepAfterSeconds: lightSleepAfterSeconds,
             deepSleepAfterSeconds: deepSleepAfterSeconds
         )
-        mutateRuntimeSession(serverSessionID: serverSessionID) { session in
+        mutateRuntimeSession(providerID: providerID) { session in
             session.autoSleepEnabled = autoSleepEnabled
             session.lightSleepAfterSeconds = lightSleepAfterSeconds
             session.deepSleepAfterSeconds = deepSleepAfterSeconds
@@ -13778,7 +14066,10 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     func modelInfo(modelID: String) async throws -> Melix_Controlplane_V1_ModelInfo {
-        modelInfoByID[modelID] ?? Melix_Controlplane_V1_ModelInfo()
+        if let error = modelInfoErrorsByID[modelID] {
+            throw error
+        }
+        return modelInfoByID[modelID] ?? Melix_Controlplane_V1_ModelInfo()
     }
 
     func runModelOperation(
@@ -13916,8 +14207,9 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
         allowedHosts: [String],
         allowedOrigins: [String]
     ) async throws -> Melix_Controlplane_V1_ServerSnapshot {
+        let providerID = serverSessionID
         lastGatewayConfigApplyRequest = GatewayConfigApplyCall(
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             host: host,
             port: port,
             defaultModelID: defaultModelID,
@@ -13946,8 +14238,9 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
         numDraftTokens: Int,
         accelerationProfile: String
     ) async throws -> Melix_Controlplane_V1_ServerSnapshot {
+        let providerID = serverSessionID
         lastServingDefaultsApplyRequest = ServingDefaultsApplyCall(
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             temperature: temperature,
             topP: topP,
             maxTokens: maxTokens,
@@ -13965,15 +14258,15 @@ private actor StubControlPlaneXPCClient: ControlPlaneXPCClient {
     }
 
     private func mutateRuntimeSession(
-        serverSessionID: String,
+        providerID: String,
         update: (inout Melix_Controlplane_V1_ProviderRuntimeState) -> Void
     ) {
-        if let index = snapshot.providers.firstIndex(where: { $0.providerID == serverSessionID }) {
+        if let index = snapshot.providers.firstIndex(where: { $0.providerID == providerID }) {
             update(&snapshot.providers[index])
             return
         }
 
-        var session = makeRuntimeSession(serverSessionID: serverSessionID)
+        var session = makeRuntimeSession(providerID: providerID)
         update(&session)
         snapshot.providers.append(session)
     }
@@ -13993,10 +14286,10 @@ private func makeServerSnapshot(
 }
 
 private func makeRuntimeSession(
-    serverSessionID: String = "server-session-1"
+    providerID: String = "provider-1"
 ) -> Melix_Controlplane_V1_ProviderRuntimeState {
     var session = Melix_Controlplane_V1_ProviderRuntimeState()
-    session.providerID = serverSessionID
+    session.providerID = providerID
     session.lifecycleState = .ready
     session.powerState = .active
     session.wakeReason = .initialBoot

--- a/tests/MelixCLITests/SessionLifecycleSmokeRunnerTests.swift
+++ b/tests/MelixCLITests/SessionLifecycleSmokeRunnerTests.swift
@@ -28,7 +28,7 @@ struct SessionLifecycleSmokeRunnerTests {
         let report = try await runner.run()
 
         #expect(report.ok)
-        #expect(report.serverSessionID == ServerSessionRuntimeStore.defaultServerSessionID)
+        #expect(report.providerID == MelixProviderDefaults.defaultProviderID)
         #expect(report.modelID == "melix-dev-text")
         #expect(report.metrics["control_plane.server_pause_ms"] == 4.5)
         #expect(report.metrics["lifecycle.pause_ack_ms"] != nil)
@@ -105,12 +105,12 @@ struct SessionLifecycleSmokeRunnerTests {
     @Test("command parser accepts explicit smoke arguments")
     func commandParserAcceptsExplicitArguments() throws {
         let options = try SessionLifecycleSmokeCommand.parseArguments([
-            "--server-session-id", "server-session-9",
+            "--provider-id", "provider-9",
             "--model-id", "melix-dev-text-alt",
             "--json",
         ])
 
-        #expect(options == .init(serverSessionID: "server-session-9", modelID: "melix-dev-text-alt"))
+        #expect(options == .init(providerID: "provider-9", modelID: "melix-dev-text-alt"))
     }
 
     @Test("command renderer prints machine-readable payload")
@@ -118,10 +118,10 @@ struct SessionLifecycleSmokeRunnerTests {
         let output = try await SessionLifecycleSmokeCommand.renderReport(
             arguments: ["--json"],
             environment: [:],
-            reportBuilder: { serverSessionID, modelID, _ in
+            reportBuilder: { providerID, modelID, _ in
                 SessionLifecycleSmokeReport(
                     ok: true,
-                    serverSessionID: serverSessionID,
+                    providerID: providerID,
                     modelID: modelID,
                     metrics: ["lifecycle.pause_ack_ms": 4.2],
                     scenarios: [
@@ -163,15 +163,15 @@ struct SessionLifecycleSmokeRunnerTests {
 
     @Test("command parser rejects missing values and unexpected arguments")
     func commandParserRejectsInvalidArguments() async throws {
-        #expect(throws: MelixCLIError.missingValue("--server-session-id")) {
-            _ = try SessionLifecycleSmokeCommand.parseArguments(["--server-session-id"])
+        #expect(throws: MelixCLIError.missingValue("--provider-id")) {
+            _ = try SessionLifecycleSmokeCommand.parseArguments(["--provider-id"])
         }
         #expect(throws: MelixCLIError.missingValue("--model-id")) {
             _ = try SessionLifecycleSmokeCommand.parseArguments(["--model-id"])
         }
         #expect(throws: MelixCLIError.usage("""
             Usage:
-              melix-session-lifecycle-smoke [--server-session-id ID] [--model-id MODEL] [--json]
+              melix-session-lifecycle-smoke [--provider-id ID] [--model-id MODEL] [--json]
             """)) {
             _ = try SessionLifecycleSmokeCommand.parseArguments(["--unexpected"])
         }
@@ -225,6 +225,30 @@ struct SessionLifecycleSmokeRunnerTests {
         #expect(report.scenarios["restart"]?.assistantText == "Echo: confirm restart recovery")
     }
 
+    @Test("runner surfaces stop conflict after retry deadline")
+    func runnerSurfacesStopConflictAfterRetryDeadline() async throws {
+        let clock = LifecycleSmokeFakeClock()
+        let runner = SessionLifecycleSmokeRunner(
+            client: LifecycleSmokeStubClient(stopConflictCount: 1000),
+            now: { clock.now() },
+            sleep: { seconds in
+                clock.sleep(seconds)
+            }
+        )
+
+        do {
+            _ = try await runner.run()
+            Issue.record("Expected stop conflict after retry deadline")
+        } catch let error as ControlPlaneXPCClientError {
+            guard case .requestFailed(let code, let message) = error else {
+                Issue.record("Expected requestFailed conflict, got \(error)")
+                return
+            }
+            #expect(code == "conflict")
+            #expect(message == "Cannot stop the provider while requests are active.")
+        }
+    }
+
     @Test("runner fails when the requested runtime session is missing")
     func runnerFailsWhenRequestedRuntimeSessionIsMissing() async throws {
         let runner = SessionLifecycleSmokeRunner(
@@ -232,8 +256,8 @@ struct SessionLifecycleSmokeRunnerTests {
             sleep: { _ in try await Task.sleep(for: .milliseconds(1)) }
         )
 
-        await #expect(throws: SessionLifecycleSmokeRunnerError.missingRuntimeSession("server-session-missing")) {
-            _ = try await runner.run(serverSessionID: "server-session-missing")
+        await #expect(throws: SessionLifecycleSmokeRunnerError.missingRuntimeSession("provider-missing")) {
+            _ = try await runner.run(providerID: "provider-missing")
         }
     }
 
@@ -259,9 +283,9 @@ struct SessionLifecycleSmokeRunnerTests {
             Issue.record("subscription stream should complete immediately")
         }
 
-        _ = try await client.wakeServerSession(serverSessionID: ServerSessionRuntimeStore.defaultServerSessionID)
+        _ = try await client.wakeServerSession(serverSessionID: MelixProviderDefaults.defaultProviderID)
         _ = try await client.updateServerIdlePolicy(
-            serverSessionID: ServerSessionRuntimeStore.defaultServerSessionID,
+            serverSessionID: MelixProviderDefaults.defaultProviderID,
             autoSleepEnabled: true,
             lightSleepAfterSeconds: 1,
             deepSleepAfterSeconds: 5
@@ -269,7 +293,7 @@ struct SessionLifecycleSmokeRunnerTests {
         _ = try await client.serverSnapshot()
         _ = try await client.serverSnapshot()
         let resumedSnapshot = try await client.updateServerIdlePolicy(
-            serverSessionID: ServerSessionRuntimeStore.defaultServerSessionID,
+            serverSessionID: MelixProviderDefaults.defaultProviderID,
             autoSleepEnabled: false,
             lightSleepAfterSeconds: 1,
             deepSleepAfterSeconds: 5
@@ -300,6 +324,25 @@ struct SessionLifecycleSmokeRunnerTests {
 
         #expect(output.contains("\"server_state\""))
         #expect(output.contains("\"providers\""))
+    }
+}
+
+private final class LifecycleSmokeFakeClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var currentTime: TimeInterval = 0
+
+    func now() -> TimeInterval {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return currentTime
+    }
+
+    func sleep(_ seconds: TimeInterval) {
+        lock.lock()
+        currentTime += seconds
+        lock.unlock()
     }
 }
 
@@ -334,7 +377,7 @@ private actor LifecycleMetricsExportDelay {
 }
 
 private actor LifecycleSmokeStubClient: ControlPlaneXPCClient {
-    nonisolated let serverSessionID: String
+    nonisolated let providerID: String
     private let allowSleepTransition: Bool
     private let chatModes: [String: LifecycleSmokeChatMode]
     private let pausedChatErrorReason: String?
@@ -346,21 +389,21 @@ private actor LifecycleSmokeStubClient: ControlPlaneXPCClient {
     private var remainingStopConflicts: Int
 
     init(
-        serverSessionID: String = ServerSessionRuntimeStore.defaultServerSessionID,
+        providerID: String = MelixProviderDefaults.defaultProviderID,
         allowSleepTransition: Bool = true,
         chatModes: [String: LifecycleSmokeChatMode] = [:],
         pausedChatErrorReason: String? = nil,
         deferWakeUntilStreamConsumption: Bool = false,
         stopConflictCount: Int = 0
     ) {
-        self.serverSessionID = serverSessionID
+        self.providerID = providerID
         self.allowSleepTransition = allowSleepTransition
         self.chatModes = chatModes
         self.pausedChatErrorReason = pausedChatErrorReason
         self.deferWakeUntilStreamConsumption = deferWakeUntilStreamConsumption
         self.remainingStopConflicts = stopConflictCount
         self.snapshot = LifecycleSmokeStubClient.makeSnapshot(
-            serverSessionID: serverSessionID,
+            providerID: providerID,
             lifecycleState: .ready,
             powerState: .active,
             wakeReason: .initialBoot
@@ -434,36 +477,36 @@ private actor LifecycleSmokeStubClient: ControlPlaneXPCClient {
     }
 
     func startServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        _ = serverSessionID
+        _ = providerID
         mutateSession(lifecycleState: .ready, powerState: .active, wakeReason: .operatorResume)
         return snapshot
     }
 
     func pauseServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        _ = serverSessionID
+        _ = providerID
         mutateSession(lifecycleState: .paused, powerState: .active, wakeReason: .operatorResume)
         return snapshot
     }
 
     func resumeServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        _ = serverSessionID
+        _ = providerID
         mutateSession(lifecycleState: .ready, powerState: .active, wakeReason: .operatorResume)
         return snapshot
     }
 
     func wakeServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        _ = serverSessionID
+        _ = providerID
         mutateSession(lifecycleState: .ready, powerState: .active, wakeReason: .operatorResume)
         return snapshot
     }
 
     func stopServerSession(serverSessionID: String) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        _ = serverSessionID
+        _ = providerID
         if remainingStopConflicts > 0 {
             remainingStopConflicts -= 1
             throw ControlPlaneXPCClientError.requestFailed(
                 code: "conflict",
-                message: "Cannot stop the server session while requests are active."
+                message: "Cannot stop the provider while requests are active."
             )
         }
         mutateSession(lifecycleState: .stopped, powerState: .stopped, wakeReason: .operatorResume)
@@ -476,7 +519,7 @@ private actor LifecycleSmokeStubClient: ControlPlaneXPCClient {
         lightSleepAfterSeconds: UInt32,
         deepSleepAfterSeconds: UInt32
     ) async throws -> Melix_Controlplane_V1_ServerSnapshot {
-        _ = serverSessionID
+        _ = providerID
         snapshot.providers[0].autoSleepEnabled = autoSleepEnabled
         snapshot.providers[0].lightSleepAfterSeconds = lightSleepAfterSeconds
         snapshot.providers[0].deepSleepAfterSeconds = deepSleepAfterSeconds
@@ -575,13 +618,13 @@ private actor LifecycleSmokeStubClient: ControlPlaneXPCClient {
     }
 
     private static func makeSnapshot(
-        serverSessionID: String,
+        providerID: String,
         lifecycleState: Melix_Controlplane_V1_ProviderLifecycleState,
         powerState: Melix_Controlplane_V1_ProviderPowerState,
         wakeReason: Melix_Controlplane_V1_ProviderWakeReason
     ) -> Melix_Controlplane_V1_ServerSnapshot {
         var session = Melix_Controlplane_V1_ProviderRuntimeState()
-        session.providerID = serverSessionID
+        session.providerID = providerID
         session.lifecycleState = lifecycleState
         session.powerState = powerState
         session.wakeReason = wakeReason

--- a/tests/integration/test_phase8_cli_acceptance.py
+++ b/tests/integration/test_phase8_cli_acceptance.py
@@ -379,18 +379,17 @@ def test_cli_chat_run_rebinds_primary_session_without_dev_text_model_path(tmp_pa
         created_state = run_cli_json(
             repo_root,
             [
-                "server",
-                "session",
+                "provider",
                 "create",
                 "--title",
-                "Primary Session",
+                "Primary Provider",
                 "--model",
                 "melix-dev-text",
                 "--json",
             ],
             env_overrides=env,
         )
-        assert created_state["id"] == "server-session-1"
+        assert created_state["id"] == "provider-1"
 
         run_cli_json(
             repo_root,
@@ -405,11 +404,10 @@ def test_cli_chat_run_rebinds_primary_session_without_dev_text_model_path(tmp_pa
         run_cli_json(
             repo_root,
             [
-                "server",
-                "session",
+                "provider",
                 "update",
-                "--server-session-id",
-                "server-session-1",
+                "--provider-id",
+                "provider-1",
                 "--model",
                 receipt["model_id"],
                 "--json",
@@ -419,24 +417,23 @@ def test_cli_chat_run_rebinds_primary_session_without_dev_text_model_path(tmp_pa
         selected_state = run_cli_json(
             repo_root,
             [
-                "server",
-                "session",
+                "provider",
                 "select",
-                "--server-session-id",
-                "server-session-1",
+                "--provider-id",
+                "provider-1",
                 "--json",
             ],
             env_overrides=env,
         )
-        assert selected_state["selected_server_session_id"] == "server-session-1"
+        assert selected_state["selected_provider_id"] == "provider-1"
 
         snapshot = run_cli_json(
             repo_root,
             [
                 "server",
                 "start",
-                "--server-session-id",
-                "server-session-1",
+                "--provider-id",
+                "provider-1",
                 "--json",
             ],
             env_overrides=env,
@@ -452,14 +449,14 @@ def test_cli_chat_run_rebinds_primary_session_without_dev_text_model_path(tmp_pa
                 receipt["model_id"],
                 "--message",
                 "Reply with BASE_OK",
-                "--server-session-id",
-                "server-session-1",
+                "--provider-id",
+                "provider-1",
                 "--json",
             ],
             env_overrides=env,
         )
         assert chat_receipt["model_id"] == receipt["model_id"]
-        assert chat_receipt["server_session_id"] == "server-session-1"
+        assert chat_receipt["provider_id"] == "provider-1"
         assert chat_receipt["finish_reason"] == "stop"
         assert chat_receipt["assistant_text"] == "Echo: Reply with BASE_OK"
         assert chat_receipt["request_id"]
@@ -494,18 +491,17 @@ def test_phase8_acceptance_bundle_closes_lora_bench_eval_and_export_paths(tmp_pa
         created_state = run_cli_json(
             repo_root,
             [
-                "server",
-                "session",
+                "provider",
                 "create",
                 "--title",
-                "Primary Session",
+                "Primary Provider",
                 "--model",
                 "melix-dev-text",
                 "--json",
             ],
             env_overrides=env,
         )
-        assert created_state["id"] == "server-session-1"
+        assert created_state["id"] == "provider-1"
 
         payload = run_python_script_json(
             repo_root,
@@ -527,8 +523,8 @@ def test_phase8_acceptance_bundle_closes_lora_bench_eval_and_export_paths(tmp_pa
                 "mmlu",
                 "--evaluation-dataset",
                 "mmlu.dev.v1",
-                "--server-session-id",
-                "server-session-1",
+                "--provider-id",
+                "provider-1",
                 "--timestamp",
                 "2026-04-09T120000Z",
                 "--json",
@@ -609,18 +605,17 @@ def test_phase8_acceptance_bundle_real_small_model_profile_closes_real_lora_chai
         created_state = run_cli_json(
             repo_root,
             [
-                "server",
-                "session",
+                "provider",
                 "create",
                 "--title",
-                "Real Small Model Session",
+                "Real Small Model Provider",
                 "--model",
                 _REAL_SMALL_MODEL_ID,
                 "--json",
             ],
             env_overrides=env,
         )
-        assert created_state["id"] == "server-session-1"
+        assert created_state["id"] == "provider-1"  # pragma: no cover - opt-in real model E2E.
 
         bundle_args = [
             "--execution-profile",
@@ -635,8 +630,8 @@ def test_phase8_acceptance_bundle_real_small_model_profile_closes_real_lora_chai
             "mmlu",
             "--evaluation-dataset",
             "mmlu.dev.v1",
-            "--server-session-id",
-            "server-session-1",
+            "--provider-id",
+            "provider-1",
             "--timestamp",
             "2026-04-16T000000Z",
             "--json",

--- a/tests/integration/test_session_lifecycle_integration.py
+++ b/tests/integration/test_session_lifecycle_integration.py
@@ -46,7 +46,7 @@ def test_session_lifecycle_smoke_records_live_pause_sleep_wake_and_restart_metri
         payload = json.loads(result.stdout)
 
         assert payload["ok"] is True
-        assert payload["serverSessionID"] == "server-session-1"
+        assert payload["providerID"] == "provider-1"
         assert payload["modelID"] == "melix-dev-text"
         assert payload["scenarios"]["pause"]["lifecycle"] == "paused"
         assert payload["scenarios"]["pause"]["blockedStatus"] == "unavailable"


### PR DESCRIPTION
## Summary
- Rename the operator-facing runtime target domain from server sessions to Providers across CLI commands, persisted operator state, AppMain labels/state, Phase 8 acceptance artifacts, and docs.
- Add explicit `providerID` targeting to chat start requests so `melix chat run --provider-id ...` and AppMain chat dispatch route local serving activity to the selected Provider.
- Keep server lifecycle verbs under `melix server ...` while switching target flags and receipts to Provider terminology.

## Plan or Spec
- `docs/runbooks/admin-surface-persistence.md`
- `docs/runbooks/session-lifecycle.md`
- `docs/runbooks/phase-8-product-acceptance.md`
- `docs/runbooks/phase-6-chat-panel.md`

## Commands Run
```text
python3 -m py_compile scripts/phase8_acceptance_bundle.py tests/integration/test_phase8_cli_acceptance.py tests/integration/test_session_lifecycle_integration.py
# passed

rg -n -- "ServerSessionAPIKeyStore|server-session-api-keys|server session|Server Session|server-session|selected_server_session_id|server_sessions|--server-session-id|server\.session" Sources/MelixCLICore tests/MelixCLITests tests/integration scripts/phase8_acceptance_bundle.py apps/macos-menubar/Sources/AppMain apps/macos-menubar/Tests/MenuBarTests docs/runbooks docs/examples/pipelines
# no matches

rg -n "server_session_id|serverSessionID|session_rebind|server-session" scripts/phase8_acceptance_bundle.py tests/integration/test_phase8_cli_acceptance.py tests/integration/test_session_lifecycle_integration.py
# no matches

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest tests/integration/test_phase8_cli_acceptance.py::test_cli_chat_run_rebinds_primary_session_without_dev_text_model_path tests/integration/test_phase8_cli_acceptance.py::test_phase8_acceptance_bundle_closes_lora_bench_eval_and_export_paths tests/integration/test_session_lifecycle_integration.py::test_session_lifecycle_smoke_records_live_pause_sleep_wake_and_restart_metrics -q
# 3 passed in 92.40s

env HOME="$PWD/.swift-home/control-provider-target" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/control-provider-target" xcrun swift test --package-path services/control-plane-swift --filter 'ControlPlaneServiceTests/startChatUsesExplicitProviderTargetForLocalServingActivity|ControlPlaneServiceTests/startChatBlocksPausedSessionsAndWakesSleepingSessionsBeforeDispatch'
# 2 tests passed

env HOME="$PWD/.swift-home/provider-chat-cli" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/provider-chat-cli" xcrun swift test --filter 'MelixCLIRunnerTests/chatRunCollectsStreamedAssistantTextAndReturnsATypedJSONReceipt'
# 1 test passed

git commit -m "refactor: rename operator provider domain"
# pre-commit passed: make swift-test, make py-test, make integration-test, PR scoped performance report
```

Full pre-commit gate:
```text
make swift-test
# passed; elapsed=664.7s; macOS menubar package: 797 tests in 25 suites passed

make py-test
# 3797 passed, 14 skipped, 2 warnings in 157.68s

make integration-test
# 117 passed, 1 skipped in 757.86s
```

## Coverage and Metrics
Changed-scope coverage:
```text
Root Swift changed-line coverage:
MelixCLI.swift 95.59% (130/136)
SessionLifecycleSmokeRunner.swift 100.00% (21/21)
MelixCLIRunnerTests.swift 100.00% (433/433)
SessionLifecycleSmokeRunnerTests.swift 94.92% (56/59)
TOTAL 98.61% (640/649)

Control-plane changed-line coverage:
ControlPlaneChatExecution.swift 100.00% (1/1)
ControlPlaneService.swift 100.00% (17/17)
ControlPlaneServiceTests.swift 100.00% (90/90)
TOTAL 100.00% (108/108)

macOS menubar changed-line coverage:
TOTAL 96.75% (804/831)

Python changed-line coverage:
TOTAL 100.00% (5/5)
```

PR scoped performance report:
```text
Report: .runtime/pre-commit-performance/20260610-133250-115fac0f/report/report.md
Status: ok
Changed files: 49
Selected probes: 1
Direct/gated probes: 1
Regressions: 0
Context regressions: 0
Verification failures: 0
Swift CLI JSON envelope encoding elapsed_ms_mean: base=151389.538 head=17024.663 delta=-134364.875 (-88.75%) status=improvement
```

Observability mode: minimal. This is a terminology and routing refactor; no new runtime observability plane was added. Probe overhead: N/A because the existing PR-scoped performance hook selected the direct CLI JSON probe.

## Known Gaps
- Control-plane backend internals still retain `ServerSessionRuntimeStore` and related internal naming. This PR removes the public/operator Provider leaks only; backend-domain naming can be handled in a later slice.
- The opt-in real-small-model Phase 8 E2E path remains opt-in and was not run in the default local gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
