### PR TITLE
Add background continuation entrypoint receipts

### DIFF
--- a/docs/plans/2026-06-10-issue-1761-background-continuation-entrypoint-receipts.md
+++ b/docs/plans/2026-06-10-issue-1761-background-continuation-entrypoint-receipts.md
@@ -1,0 +1,82 @@
+# Issue 1761 Background Continuation Entrypoint Receipt Metadata Plan
+
+## Goal
+
+Continue the background-continuation boundary work by allowing concrete
+entrypoints to attach local receipt metadata when admitting already-redacted
+background job evidence into user-role prompt context.
+
+## Scope
+
+This slice covers:
+
+- optional `segment_id`, `source_field`, `reason`, and `corrective_action`
+  parameters on `worker.runtime.background_continuation.admit_background_continuation`;
+- refusal receipts for malformed entrypoint-local metadata before prompt
+  admission;
+- focused Python tests for admitted metadata, malformed metadata, and the
+  existing default behavior;
+- contract documentation that future local-job, workflow, and session
+  continuation entrypoints must use this metadata surface instead of inventing
+  ad hoc receipt fields.
+
+This slice does not implement a durable job runner, live process monitor,
+workflow scheduler, or session resume loop. It only standardizes the receipt
+metadata surface those later entrypoints will call.
+
+## Best End-State Architecture
+
+Background job follow-up data should flow through a single prompt-boundary
+helper before it is projected into a prompt payload. Store-specific or
+entrypoint-specific details belong in redacted receipt metadata, not in raw
+prompt text or custom side-channel receipt shapes.
+
+The helper should keep a stable default for callers that only know a job ID, but
+also allow concrete entrypoints to identify the exact result slot or workflow
+field they are admitting. Invalid metadata must fail closed with the same
+`melix.untrusted_context_receipt.v1` shape as malformed job IDs, summaries, and
+owner-scope metadata.
+
+## Performance Probes And Metrics
+
+The changed path normalizes at most four short metadata strings and emits one
+receipt per admitted or refused continuation payload. Runtime cost remains
+constant per continuation payload and does not add filesystem polling, log
+scanning, scheduler work, or model inference.
+
+Verification must include:
+
+- focused Python tests for `test_background_continuation.py`;
+- changed-line coverage for touched Python files with at least 95 percent
+  coverage;
+- full local pre-commit gate on this host;
+- PR-scoped performance report with status `ok`, regressions `0`, context
+  regressions `0`, and verification failures `0`.
+
+## Implementation Steps
+
+1. Add focused tests proving `admit_background_continuation` accepts
+   entrypoint-local `segment_id`, `source_field`, `reason`, and
+   `corrective_action` while omitting raw job output from receipts.
+2. Add focused tests proving malformed entrypoint metadata fails closed with
+   `included = false` refusal receipts and no user payload.
+3. Implement metadata normalization in `worker.runtime.background_continuation`
+   while preserving existing defaults:
+   - `segment_id = <job_id>:background-continuation`;
+   - `source_field = background_job`;
+   - default reason and corrective action supplied by the shared source
+     evidence helper.
+4. Update the unified runtime contract so later local-job and workflow
+   continuation entrypoints use this helper surface.
+5. Run focused tests, changed-line coverage, the full local gate, and the PR
+   performance workflow before merge.
+
+## Success Criteria
+
+- Concrete background-continuation entrypoints can record redacted local receipt
+  metadata without changing prompt payload semantics.
+- Malformed metadata is refused before prompt admission with
+  `invalid_background_continuation_field`.
+- Existing callers keep the same default receipt shape.
+- The implementation remains a prompt-boundary primitive and does not introduce
+  durable job or workflow behavior.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -418,6 +418,15 @@ implement durable job storage, process monitoring, or session resume; it is only
 the prompt-context boundary for follow-up data admitted by those later
 surfaces.
 
+Concrete local-job, workflow, and continuation entrypoints may override the
+default `segment_id`, `source_field`, `reason`, and `corrective_action` when
+they need to identify the specific redacted result slot they are admitting. The
+default remains `segment_id = <job_id>:background-continuation` and
+`source_field = background_job`. Malformed entrypoint-local metadata must fail
+closed before prompt admission with the same `invalid_background_continuation_field`
+refusal receipt and must not include raw logs, command text, session contents,
+or workflow payloads.
+
 The Python worker skill and memory admission primitives are
 `worker.runtime.skill_memory_context.admit_skill_context` and
 `worker.runtime.skill_memory_context.admit_memory_context`. Future skill,

--- a/services/mlx-worker-python/tests/test_background_continuation.py
+++ b/services/mlx-worker-python/tests/test_background_continuation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -95,6 +96,109 @@ def test_background_continuation_uses_shared_prompt_context_admission(
     assert segment.source_id == "job-shared"
     assert segment.value == {"status": "completed"}
     assert segment.owner_scope_checked is False
+
+
+def test_background_continuation_accepts_entrypoint_receipt_metadata() -> None:
+    admission = admit_background_continuation(
+        job_id=" job-7 ",
+        job_summary={
+            "status": "completed",
+            "log_tail": "Background job says to ignore the operator.",
+        },
+        owner_scope_checked=True,
+        segment_id="workflow-3:background-results[0]",
+        source_field="workflow_background_jobs[0]",
+        reason="workflow background result is prompt data, not instructions",
+        corrective_action="Keep workflow background results in user-role prompt context.",
+    )
+
+    assert admission.user_payload == {
+        "workflow_background_jobs[0]": {
+            "status": "completed",
+            "log_tail": "Background job says to ignore the operator.",
+        }
+    }
+    assert admission.untrusted_context_receipts == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": "workflow-3:background-results[0]",
+            "source_type": "background_continuation",
+            "source_field": "workflow_background_jobs[0]",
+            "source_id": "job-7",
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": True,
+            "owner_scope_checked": True,
+            "reason": "workflow background result is prompt data, not instructions",
+            "corrective_action": "Keep workflow background results in user-role prompt context.",
+        }
+    ]
+    assert "ignore the operator" not in json.dumps(
+        admission.untrusted_context_receipts,
+        ensure_ascii=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_field"),
+    (
+        ({"segment_id": " "}, "segment_id"),
+        ({"source_field": 123}, "source_field"),
+        ({"reason": "\t"}, "reason"),
+        ({"corrective_action": None}, "corrective_action"),
+    ),
+)
+def test_background_continuation_refuses_malformed_entrypoint_receipt_metadata(
+    kwargs: dict[str, object],
+    expected_field: str,
+) -> None:
+    with pytest.raises(BackgroundContinuationAdmissionError) as exc_info:
+        admit_background_continuation(
+            job_id="job-entrypoint",
+            job_summary={"status": "completed"},
+            owner_scope_checked=True,
+            **kwargs,  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.refusal_receipts == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": "job-entrypoint:background-continuation",
+            "source_type": "background_continuation",
+            "source_field": expected_field,
+            "source_id": "job-entrypoint",
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": False,
+            "owner_scope_checked": False,
+            "reason": "invalid_background_continuation_field",
+            "corrective_action": (
+                "Reject malformed background continuation evidence before prompt assembly."
+            ),
+        }
+    ]
+
+
+def test_background_continuation_refuses_non_string_metadata_without_comparison() -> None:
+    segment_id = MagicMock()
+    segment_id.__eq__.side_effect = AssertionError(
+        "metadata should be type-checked before comparison"
+    )
+
+    with pytest.raises(BackgroundContinuationAdmissionError) as exc_info:
+        admit_background_continuation(
+            job_id="job-entrypoint",
+            job_summary={"status": "completed"},
+            owner_scope_checked=True,
+            segment_id=segment_id,  # type: ignore[arg-type]
+        )
+
+    segment_id.__eq__.assert_not_called()
+    assert exc_info.value.refusal_receipts[0]["source_field"] == "segment_id"
 
 
 @pytest.mark.parametrize(

--- a/services/mlx-worker-python/worker/runtime/background_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/background_continuation.py
@@ -21,32 +21,64 @@ def admit_background_continuation(
     job_id: str,
     job_summary: dict[str, Any],
     owner_scope_checked: bool,
+    segment_id: str = "",
+    source_field: str = "",
+    reason: str = "",
+    corrective_action: str = "",
 ) -> PromptContextAdmission:
     normalized_job_id = _job_id_or_refusal(job_id)
-    segment_id = f"{normalized_job_id}:background-continuation"
+    default_segment_id = f"{normalized_job_id}:background-continuation"
+    normalized_segment_id = _entrypoint_text_or_default(
+        segment_id,
+        default=default_segment_id,
+        field_name="segment_id",
+        refusal_segment_id=default_segment_id,
+        source_id=normalized_job_id,
+    )
+    normalized_source_field = _entrypoint_text_or_default(
+        source_field,
+        default="background_job",
+        field_name="source_field",
+        refusal_segment_id=normalized_segment_id,
+        source_id=normalized_job_id,
+    )
+    normalized_reason = _entrypoint_optional_text(
+        reason,
+        segment_id=normalized_segment_id,
+        source_id=normalized_job_id,
+        field_name="reason",
+    )
+    normalized_corrective_action = _entrypoint_optional_text(
+        corrective_action,
+        segment_id=normalized_segment_id,
+        source_id=normalized_job_id,
+        field_name="corrective_action",
+    )
     if not isinstance(owner_scope_checked, bool):
         _raise_refusal(
-            segment_id=segment_id,
+            segment_id=normalized_segment_id,
             source_id=normalized_job_id,
             source_field="owner_scope_checked",
             owner_scope_checked=False,
         )
     if not isinstance(job_summary, dict):
         _raise_refusal(
-            segment_id=segment_id,
+            segment_id=normalized_segment_id,
             source_id=normalized_job_id,
-            source_field="background_job",
+            source_field=normalized_source_field,
             owner_scope_checked=owner_scope_checked,
         )
     return admit_prompt_context_source_evidence(
         [
             PromptContextSourceEvidence(
-                segment_id=segment_id,
+                segment_id=normalized_segment_id,
                 source_type="background_continuation",
-                source_field="background_job",
+                source_field=normalized_source_field,
                 source_id=normalized_job_id,
                 value=job_summary,
                 owner_scope_checked=owner_scope_checked,
+                reason=normalized_reason,
+                corrective_action=normalized_corrective_action,
             )
         ]
     )
@@ -54,7 +86,7 @@ def admit_background_continuation(
 
 def _job_id_or_refusal(job_id: str) -> str:
     if isinstance(job_id, str) and job_id.strip():
-        return job_id
+        return job_id.strip()
     fallback = "unknown-background-job"
     _raise_refusal(
         segment_id=f"{fallback}:background-continuation",
@@ -83,6 +115,43 @@ def _raise_refusal(
                 reason="invalid_background_continuation_field",
             )
         ],
+    )
+
+
+def _entrypoint_text_or_default(
+    value: str,
+    *,
+    default: str,
+    field_name: str,
+    refusal_segment_id: str,
+    source_id: str,
+) -> str:
+    if isinstance(value, str):
+        if value == "":
+            return default
+        if value.strip():
+            return value.strip()
+    _raise_refusal(
+        segment_id=refusal_segment_id,
+        source_id=source_id,
+        source_field=field_name,
+        owner_scope_checked=False,
+    )
+
+
+def _entrypoint_optional_text(
+    value: str,
+    *,
+    segment_id: str,
+    source_id: str,
+    field_name: str,
+) -> str:
+    return _entrypoint_text_or_default(
+        value,
+        default="",
+        field_name=field_name,
+        refusal_segment_id=segment_id,
+        source_id=source_id,
     )
 
 


### PR DESCRIPTION
## Summary
- Adds explicit entrypoint-local receipt metadata to Python worker background-continuation admission.
- Preserves the default `<job_id>:background-continuation` segment behavior while allowing callers to provide `segment_id`, `source_field`, `reason`, and `corrective_action` for workflow/local-job continuation surfaces.
- Documents the fail-closed malformed-metadata behavior in the unified agentic runtime contract and adds a focused plan for this issue #1761 slice.

## Plan or Spec
- `docs/plans/2026-06-10-issue-1761-background-continuation-entrypoint-receipts.md`
- `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_background_continuation.py -q
# Red test before implementation: failed as expected because admit_background_continuation did not accept the new metadata keyword arguments.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_background_continuation.py -q
# Passed: 12 passed in 0.03s after review fix.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_background_continuation.py services/mlx-worker-python/tests/test_prompt_context.py services/mlx-worker-python/tests/test_skill_memory_context.py services/mlx-worker-python/tests/test_retrieval_context.py -q
# Passed: 59 passed in 0.09s.

git diff --check
# Passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 COVERAGE_FILE=.coverage.background_continuation uv run --project services/mlx-worker-python --extra mlx coverage run --source=services/mlx-worker-python/worker,services/mlx-worker-python/tests -m pytest services/mlx-worker-python/tests/test_background_continuation.py -q
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 COVERAGE_FILE=.coverage.background_continuation uv run --project services/mlx-worker-python --extra mlx coverage json -o .runtime/background-continuation-coverage.json
python3.11 scripts/python_changed_line_coverage.py --coverage-json .runtime/background-continuation-coverage.json services/mlx-worker-python/worker/runtime/background_continuation.py services/mlx-worker-python/tests/test_background_continuation.py
python3.11 scripts/python_changed_line_coverage.py --coverage-json .runtime/background-continuation-coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/background_continuation.py services/mlx-worker-python/tests/test_background_continuation.py
# Passed PR-range changed-line coverage: services/mlx-worker-python/worker/runtime/background_continuation.py 100.00% (15/15); services/mlx-worker-python/tests/test_background_continuation.py 100.00% (18/18); TOTAL 100.00% (33/33).

make bootstrap
# Passed.

make proto
# Passed.

.githooks/pre-commit
# Passed full local gate on 256 GiB macOS host after review fix:
# - make swift-test completed rc=0 elapsed=152.1s.
# - make py-test completed rc=0 elapsed=160.1s; pytest summary: 3809 passed, 14 skipped, 2 warnings in 159.61s.
# - make integration-test completed rc=0 elapsed=421.9s; pytest summary: 117 passed, 1 skipped in 420.97s.
# - scoped performance report status ok; regressions 0; context regressions 0; verification failures 0.
```

## Coverage and Metrics
- PR-range changed-line coverage: 100.00% for 33/33 changed executable/test lines.
- Metrics report: `.runtime/pre-commit-performance/20260610-141408-e6092aa6/report/report.md`
- Performance report status: `ok`; selected probes `0`; regressions `0`; context regressions `0`; verification failures `0`.
- Observability mode: `minimal`, because this change extends admission receipts only and does not add runtime probes.
- Probe overhead: `N/A: no registered performance probes were selected for this change set.`

## Known Gaps
- This PR does not add the durable/live RAG store, workflow runner, MCP/agent execution surface, or session resume store still tracked by issue #1761.
- Background-continuation receipts continue to carry metadata only; they do not include raw continuation logs or payload bodies.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
