### PR TITLE
Add retrieved image prompt receipt classification

### DIFF
--- a/docs/plans/2026-06-10-issue-1761-retrieved-image-prompt-receipts.md
+++ b/docs/plans/2026-06-10-issue-1761-retrieved-image-prompt-receipts.md
@@ -1,0 +1,87 @@
+# Issue 1761 Retrieved Image Prompt Receipt Classification Plan
+
+## Goal
+
+Continue #1761 by making the live control-plane prompt-context receipt path
+classify retrieved image and RAG image message sources with source-specific
+`retrieved_image` boundary evidence.
+
+## Scope
+
+This slice covers the existing Swift `PromptContextBoundaryReceipts` helper
+used by `ChatRequestTranslator` before `Melix_Worker_V1_GenerateRequest`
+messages are sent to a worker.
+
+In scope:
+
+- classify request-local message names such as `retrieved_image-*`,
+  `retrieved-image-*`, `image_retrieval-*`, `rag_image-*`, and
+  `rag-image-*` as `source_type = retrieved_image`;
+- emit retrieved-image-specific `reason` and `corrective_action` text;
+- keep raw image captions, media URIs, byte payloads, prompt text, and private
+  source payloads out of receipt JSON;
+- update the unified runtime contract to document the live retrieved-image
+  classification.
+
+Out of scope:
+
+- implementing a RAG store, image index, image retrieval ranking, or owner
+  lookup;
+- changing prompt message roles, names, parts, cache fingerprints, or worker
+  protobuf schema;
+- changing deterministic Python retrieval-source receipts.
+
+## Best End-State Architecture
+
+Prompt receipt classification should cover both textual and visual retrieved
+context before prompt messages cross into the worker. Live image retrieval
+stores can later perform owner-scope and admission/refusal checks before
+constructing messages, while this control-plane receipt remains the final
+request-translation evidence that retrieved image prompt data is untrusted.
+
+The classification must be based only on request-local metadata already present
+at prompt assembly time: message role and normalized message `name`. It must
+not parse message content or inspect image payloads.
+
+## Performance Probes And Metrics
+
+The changed path remains a single linear pass over already-shaped messages and
+parts. The new classification adds a constant-time prefix check per named
+message and no filesystem IO, model inference, vector search, hashing, or
+scheduler work.
+
+Verification must include:
+
+- focused Swift test coverage for retrieved-image prompt receipt
+  classification;
+- changed-line coverage for the touched Swift source and test file with at
+  least 95 percent coverage;
+- full local pre-commit gate before commit on this host;
+- PR-scoped performance report with status `ok`, regressions `0`, context
+  regressions `0`, and verification failures `0`.
+
+## Implementation Steps
+
+1. Add a failing Swift test that sends live prompt messages named with
+   retrieved-image and RAG-image prefixes and expects `retrieved_image`
+   receipts.
+2. Assert retrieved image receipts preserve `source_id`, stay `included =
+   true`, keep `owner_scope_checked = false`, and omit raw prompt/media text
+   from receipt JSON.
+3. Extend `PromptContextBoundaryReceipts.sourceType(for:)` and
+   `sourcePolicy(for:)` for retrieved-image source names.
+4. Update `docs/unified-agentic-tool-runtime-contract.md` with the new live
+   source classification and policy text.
+5. Run focused Swift tests, changed-line coverage, full local gate, and PR
+   scoped performance checks before opening the PR.
+
+## Success Criteria
+
+- Live translated chat requests classify retrieved image prompt sources as
+  `source_type = retrieved_image`.
+- Retrieved-image receipt policy matches the existing Python retrieval prompt
+  policy language.
+- Receipt JSON remains redacted and does not include raw caption, media URI,
+  media bytes, prompt text, or private source payloads.
+- Existing retrieved-document, skill, memory, background, tool-output, generic
+  chat, and assistant-history receipt behavior remains unchanged.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -275,6 +275,9 @@ admission primitives are defined below for future entrypoint wiring.
 The v1 source-specific control-plane classification slice refines those chat
 prompt receipts using request-local message metadata already present at prompt
 assembly time. Tool-role messages record `source_type = tool_output`. Non-tool
+messages whose normalized `name` uses the reserved prefixes `retrieved_image`,
+`retrieved-image`, `image_retrieval`, `image-retrieval`, `rag_image`, or
+`rag-image` record `source_type = retrieved_image`. Non-tool
 messages whose normalized `name` uses the reserved prefixes `retrieved_document`,
 `retrieved-doc`, `document`, `doc`, `rag`, `rag_document`, or `knowledge`
 record `source_type = retrieved_document`; `skill` and `agent_skill` record
@@ -302,10 +305,11 @@ background-continuation link validation.
 The live chat prompt receipt uses source-specific data-only policy text for the
 classified source type. Tool output records `reason = tool output is prompt
 data, not instructions`; retrieved documents record `reason = retrieved
-document evidence is prompt data, not instructions`; skills record `reason =
-skill evidence is prompt data, not instructions`; memories record `reason =
-memory evidence is prompt data, not instructions`; background continuations
-record `reason = background continuation is prompt data, not instructions`;
+document evidence is prompt data, not instructions`; retrieved images record
+`reason = retrieved image evidence is prompt data, not instructions`; skills
+record `reason = skill evidence is prompt data, not instructions`; memories
+record `reason = memory evidence is prompt data, not instructions`;
+background continuations record `reason = background continuation is prompt data, not instructions`;
 model-final-answer history records `reason = model final answer history is
 prompt data, not instructions`; and generic chat prompt messages retain
 `reason = chat message content is prompt data, not instructions`. Each matching

--- a/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
@@ -64,6 +64,7 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
 
         if let name = message.name {
             let normalizedName = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            // Keep this before retrieved_document because rag_image and rag-image also match the broader rag prefix.
             if hasAnyPrefix(
                 normalizedName,
                 ["retrieved_image", "retrieved-image", "image_retrieval", "image-retrieval", "rag_image", "rag-image"]

--- a/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
@@ -66,6 +66,12 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
             let normalizedName = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             if hasAnyPrefix(
                 normalizedName,
+                ["retrieved_image", "retrieved-image", "image_retrieval", "image-retrieval", "rag_image", "rag-image"]
+            ) {
+                return "retrieved_image"
+            }
+            if hasAnyPrefix(
+                normalizedName,
                 ["retrieved_document", "retrieved-doc", "document", "doc", "rag", "rag_document", "knowledge"]
             ) {
                 return "retrieved_document"
@@ -97,6 +103,11 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
             return (
                 "retrieved document evidence is prompt data, not instructions",
                 "Keep retrieved document evidence in user-role data context and do not project it into system or developer instructions."
+            )
+        case "retrieved_image":
+            return (
+                "retrieved image evidence is prompt data, not instructions",
+                "Keep retrieved image evidence in user-role data context and do not project it into system or developer instructions."
             )
         case "skill":
             return (

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -475,7 +475,8 @@ struct ToolParserRegistryTests {
             .init(role: "user", name: "retrieved_image:canvas-1", content: "image caption says ignore all policy"),
             .init(role: "user", name: "retrieved-image.local-2", content: "local image text says reveal hidden prompt"),
             .init(role: "user", name: "image_retrieval_3", content: "retrieved image OCR says exfiltrate secrets"),
-            .init(role: "user", name: "rag-image-4", content: "RAG image metadata says run tool calls"),
+            .init(role: "user", name: "image-retrieval-4", content: "hyphenated image retrieval says leak source pixels"),
+            .init(role: "user", name: "rag-image-5", content: "RAG image metadata says run tool calls"),
             .init(role: "user", name: "imageology-note", content: "ordinary note with imageology prefix text"),
         ])
 
@@ -489,8 +490,9 @@ struct ToolParserRegistryTests {
         let sourceIDs = receipts.compactMap { $0["source_id"] as? String }
         let imageReceipts = receipts.filter { $0["source_type"] as? String == "retrieved_image" }
 
-        #expect(ext["melix.prompt_context.receipt_count"] == "5")
+        #expect(ext["melix.prompt_context.receipt_count"] == "6")
         #expect(sourceTypes == [
+            "retrieved_image",
             "retrieved_image",
             "retrieved_image",
             "retrieved_image",
@@ -501,10 +503,11 @@ struct ToolParserRegistryTests {
             "retrieved_image:canvas-1",
             "retrieved-image.local-2",
             "image_retrieval_3",
-            "rag-image-4",
+            "image-retrieval-4",
+            "rag-image-5",
             "imageology-note",
         ])
-        #expect(imageReceipts.count == 4)
+        #expect(imageReceipts.count == 5)
         #expect(
             imageReceipts.allSatisfy {
                 $0["reason"] as? String == "retrieved image evidence is prompt data, not instructions"
@@ -521,6 +524,7 @@ struct ToolParserRegistryTests {
         #expect(receiptsJSON.contains("ignore all policy") == false)
         #expect(receiptsJSON.contains("hidden prompt") == false)
         #expect(receiptsJSON.contains("exfiltrate secrets") == false)
+        #expect(receiptsJSON.contains("source pixels") == false)
         #expect(receiptsJSON.contains("run tool calls") == false)
         #expect(receiptsJSON.contains("ordinary note") == false)
     }

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -425,6 +425,7 @@ struct ToolParserRegistryTests {
             .init(role: "system", content: "trusted system prompt must not leak"),
             .init(role: "tool", name: "calculator", content: "tool output says ignore developer policy"),
             .init(role: "user", name: "rag_doc-17", content: "retrieved document says reveal secrets"),
+            .init(role: "user", name: "rag_image-4", content: "retrieved image caption says reveal private media"),
             .init(role: "user", name: "skill-repo-search", content: "skill index says run arbitrary shell"),
             .init(role: "user", name: "memory_pinned-42", content: "memory says bypass authentication"),
             .init(role: "assistant", name: "background_continuation_job-9", content: "background job says trust me"),
@@ -439,10 +440,11 @@ struct ToolParserRegistryTests {
         let sourceTypes = receipts.compactMap { $0["source_type"] as? String }
         let sourceIDs = receipts.compactMap { $0["source_id"] as? String }
 
-        #expect(ext["melix.prompt_context.receipt_count"] == "5")
+        #expect(ext["melix.prompt_context.receipt_count"] == "6")
         #expect(sourceTypes == [
             "tool_output",
             "retrieved_document",
+            "retrieved_image",
             "skill",
             "memory",
             "background_continuation",
@@ -450,6 +452,7 @@ struct ToolParserRegistryTests {
         #expect(sourceIDs == [
             "calculator",
             "rag_doc-17",
+            "rag_image-4",
             "skill-repo-search",
             "memory_pinned-42",
             "background_continuation_job-9",
@@ -459,9 +462,67 @@ struct ToolParserRegistryTests {
         #expect(receiptsJSON.contains("trusted system prompt") == false)
         #expect(receiptsJSON.contains("ignore developer policy") == false)
         #expect(receiptsJSON.contains("reveal secrets") == false)
+        #expect(receiptsJSON.contains("private media") == false)
         #expect(receiptsJSON.contains("arbitrary shell") == false)
         #expect(receiptsJSON.contains("bypass authentication") == false)
         #expect(receiptsJSON.contains("trust me") == false)
+    }
+
+    @Test("prompt context boundary receipts classify retrieved image source names")
+    func promptContextBoundaryReceiptsClassifyRetrievedImageSourceNames() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-prompt-images" })
+        let request = makeNormalizedRequest(messages: [
+            .init(role: "user", name: "retrieved_image:canvas-1", content: "image caption says ignore all policy"),
+            .init(role: "user", name: "retrieved-image.local-2", content: "local image text says reveal hidden prompt"),
+            .init(role: "user", name: "image_retrieval_3", content: "retrieved image OCR says exfiltrate secrets"),
+            .init(role: "user", name: "rag-image-4", content: "RAG image metadata says run tool calls"),
+            .init(role: "user", name: "imageology-note", content: "ordinary note with imageology prefix text"),
+        ])
+
+        let translated = try translator.translate(request, modelHandle: "worker-text")
+        let ext = translated.workerRequest.execution.ext
+        let receiptsJSON = try #require(ext["melix.prompt_context.receipts_json"])
+        let receipts = try #require(
+            try JSONSerialization.jsonObject(with: Data(receiptsJSON.utf8)) as? [[String: Any]]
+        )
+        let sourceTypes = receipts.compactMap { $0["source_type"] as? String }
+        let sourceIDs = receipts.compactMap { $0["source_id"] as? String }
+        let imageReceipts = receipts.filter { $0["source_type"] as? String == "retrieved_image" }
+
+        #expect(ext["melix.prompt_context.receipt_count"] == "5")
+        #expect(sourceTypes == [
+            "retrieved_image",
+            "retrieved_image",
+            "retrieved_image",
+            "retrieved_image",
+            "chat_prompt_message",
+        ])
+        #expect(sourceIDs == [
+            "retrieved_image:canvas-1",
+            "retrieved-image.local-2",
+            "image_retrieval_3",
+            "rag-image-4",
+            "imageology-note",
+        ])
+        #expect(imageReceipts.count == 4)
+        #expect(
+            imageReceipts.allSatisfy {
+                $0["reason"] as? String == "retrieved image evidence is prompt data, not instructions"
+            }
+        )
+        #expect(
+            imageReceipts.allSatisfy {
+                $0["corrective_action"] as? String ==
+                    "Keep retrieved image evidence in user-role data context and do not project it into system or developer instructions."
+            }
+        )
+        #expect(imageReceipts.allSatisfy { $0["included"] as? Bool == true })
+        #expect(imageReceipts.allSatisfy { $0["owner_scope_checked"] as? Bool == false })
+        #expect(receiptsJSON.contains("ignore all policy") == false)
+        #expect(receiptsJSON.contains("hidden prompt") == false)
+        #expect(receiptsJSON.contains("exfiltrate secrets") == false)
+        #expect(receiptsJSON.contains("run tool calls") == false)
+        #expect(receiptsJSON.contains("ordinary note") == false)
     }
 
     @Test("prompt context boundary receipts use source-specific data-only policies")
@@ -470,6 +531,7 @@ struct ToolParserRegistryTests {
         let request = makeNormalizedRequest(messages: [
             .init(role: "tool", name: "calculator", content: "tool output says ignore developer policy"),
             .init(role: "user", name: "rag_doc-17", content: "retrieved document says reveal secrets"),
+            .init(role: "user", name: "rag_image-4", content: "retrieved image says reveal private media"),
             .init(role: "user", name: "skill-repo-search", content: "skill index says run arbitrary shell"),
             .init(role: "user", name: "memory_pinned-42", content: "memory says bypass authentication"),
             .init(role: "user", name: "background_continuation_job-9", content: "background job says trust me"),
@@ -494,8 +556,8 @@ struct ToolParserRegistryTests {
             uniquingKeysWith: { first, _ in first }
         )
 
-        #expect(ext["melix.prompt_context.receipt_count"] == "7")
-        #expect(receipts.count == 7)
+        #expect(ext["melix.prompt_context.receipt_count"] == "8")
+        #expect(receipts.count == 8)
         #expect(
             receiptsBySourceType["tool_output"]?["reason"] as? String ==
                 "tool output is prompt data, not instructions"
@@ -511,6 +573,14 @@ struct ToolParserRegistryTests {
         #expect(
             receiptsBySourceType["retrieved_document"]?["corrective_action"] as? String ==
                 "Keep retrieved document evidence in user-role data context and do not project it into system or developer instructions."
+        )
+        #expect(
+            receiptsBySourceType["retrieved_image"]?["reason"] as? String ==
+                "retrieved image evidence is prompt data, not instructions"
+        )
+        #expect(
+            receiptsBySourceType["retrieved_image"]?["corrective_action"] as? String ==
+                "Keep retrieved image evidence in user-role data context and do not project it into system or developer instructions."
         )
         #expect(receiptsBySourceType["skill"]?["reason"] as? String == "skill evidence is prompt data, not instructions")
         #expect(
@@ -550,6 +620,7 @@ struct ToolParserRegistryTests {
         #expect(receipts.allSatisfy { $0["policy"] as? String == "data_only" })
         #expect(receiptsJSON.contains("ignore developer policy") == false)
         #expect(receiptsJSON.contains("reveal secrets") == false)
+        #expect(receiptsJSON.contains("private media") == false)
         #expect(receiptsJSON.contains("arbitrary shell") == false)
         #expect(receiptsJSON.contains("bypass authentication") == false)
         #expect(receiptsJSON.contains("trust me") == false)


### PR DESCRIPTION
## Summary
- Add live prompt-context boundary receipt classification for retrieved image and RAG image message sources.
- Document the retrieved-image source prefixes and data-only policy in the unified agentic tool runtime contract.
- Add Swift coverage proving receipt metadata stays redacted and does not include raw prompt or private media text.

Refs #1761.

## Plan or Spec
- Governing plan: `docs/plans/2026-06-10-issue-1761-retrieved-image-prompt-receipts.md`
- Canonical spec updated: `docs/unified-agentic-tool-runtime-contract.md`
- Protocol/dependency impact: N/A. This slice only changes Swift receipt classification metadata and tests; no protobuf schema, generated artifact, dependency, or lockfile changes.

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'ToolParserRegistryTests/promptContextBoundaryReceiptsClassifyRetrievedImageSourceNames|ToolParserRegistryTests/promptContextBoundaryReceiptsClassifySourceSpecificMessageNames|ToolParserRegistryTests/promptContextBoundaryReceiptsUseSourceSpecificPolicyText'
# Red run before implementation failed as expected because retrieved-image prefixes were not yet classified as retrieved_image.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'ToolParserRegistryTests/promptContextBoundaryReceiptsClassifyRetrievedImageSourceNames|ToolParserRegistryTests/promptContextBoundaryReceiptsClassifySourceSpecificMessageNames|ToolParserRegistryTests/promptContextBoundaryReceiptsUseSourceSpecificPolicyText'
# Passed: 3 selected tests.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'ToolParserRegistryTests'
# Passed: 25 tests.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --enable-code-coverage --package-path services/control-plane-swift --filter 'ToolParserRegistryTests'
# Passed: 25 tests.

python3.11 scripts/swift_changed_line_coverage.py --diff-from origin/main --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
# Passed: TOTAL 100.00% changed-line coverage, 83/83 covered executable changed lines.

git diff --check
# Passed.

MELIX_PRE_COMMIT_FORCE=1 .githooks/pre-commit
# Passed: make swift-test rc=0 elapsed=529.2s.
# Passed: make py-test, 3803 passed, 14 skipped, 2 warnings in 189.57s.
# Passed: make integration-test, 117 passed, 1 skipped in 693.93s.
# Passed: scoped performance report status ok, regressions 0, context regressions 0, verification failures 0.

git merge origin/main --no-edit
# Passed: merged current origin/main before addressing review feedback.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'ToolParserRegistryTests/promptContextBoundaryReceiptsClassifyRetrievedImageSourceNames|ToolParserRegistryTests/promptContextBoundaryReceiptsClassifySourceSpecificMessageNames|ToolParserRegistryTests/promptContextBoundaryReceiptsUseSourceSpecificPolicyText'
# Passed: 3 selected tests after review feedback.

git diff --check
# Passed after review feedback.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --enable-code-coverage --package-path services/control-plane-swift --filter 'ToolParserRegistryTests'
# Passed: 25 tests after review feedback.

python3.11 scripts/swift_changed_line_coverage.py --diff-from origin/main --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
# Passed: TOTAL 100.00% changed-line coverage, 88/88 covered executable changed lines after review feedback.

MELIX_PRE_COMMIT_FORCE=1 .githooks/pre-commit
# Passed after review feedback: make swift-test rc=0 elapsed=215.1s.
# Passed after review feedback: make py-test, 3809 passed, 14 skipped, 2 warnings in 159.43s.
# Passed after review feedback: make integration-test, 117 passed, 1 skipped in 456.68s.
# Passed after review feedback: scoped performance report status ok, regressions 0, context regressions 0, verification failures 0.
```

## Coverage and Metrics
- Changed-line coverage: 100.00% for the touched Swift source and test lines (`88/88` covered executable changed lines after review feedback).
- Initial local scoped performance report: `.runtime/pre-commit-performance/20260610-135745-a6781b74/report/report.md`
- Post-review local scoped performance report: `.runtime/pre-commit-performance/20260610-152323-a43e2fb8/report/report.md`
- Performance status: `ok`
- Selected probes: `0`; no registered performance probes were selected for this metadata-only receipt classification change.
- Regressions: `0`
- Context regressions: `0`
- Verification failures: `0`
- Observability mode: `minimal`; this adds request-local receipt metadata only.
- Probe overhead: N/A. No runtime probe, benchmark probe, filesystem IO, model inference, vector search, or scheduler work was added.

## Known Gaps
- This PR does not implement a RAG store, image index, image retrieval ranking, or owner lookup.
- Retrieved-image receipts still report `owner_scope_checked = false`, matching the current live prompt receipt helper until a durable retrieval store performs owner-scope checks.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
