### PR TITLE
Add local job continuation records

### DIFF
--- a/docs/plans/2026-06-10-issue-1756-local-job-continuation-records.md
+++ b/docs/plans/2026-06-10-issue-1756-local-job-continuation-records.md
@@ -1,0 +1,89 @@
+# Issue 1756 Local Job Continuation Records Plan
+
+## Goal
+
+Add the first durable local-job continuation primitive for long-running Melix
+workflows: a persistent record schema, an optimistic and locked JSON store, and
+side-effect-free reconciliation receipts that reject stale completion state
+unless explicit completion evidence is present.
+
+## Scope
+
+This slice covers:
+
+- `worker.runtime.local_job_continuation` with a versioned local-job
+  continuation record;
+- JSON persistence for one record per job ID, with atomic replacement,
+  per-record write locks, and revision guards for concurrent writer detection;
+- live-session reconciliation for stale `completed` records without success or
+  artifact evidence;
+- typed receipts for `live_session_reused`, `stale_done_revived`,
+  `completion_evidence_accepted`, `missing_completion_evidence`, and store
+  write refusal cases;
+- focused Python tests for record round-trip, stale-state self-healing,
+  duplicate-launch refusal through live-session reuse, completion evidence
+  gating, and write guards;
+- contract documentation for later runner and monitor wiring.
+
+This slice does not start shell commands, poll processes, tail logs, inject chat
+follow-ups, or resume a workflow session. Future runner and monitor slices will
+use this primitive before adding side effects.
+
+## Best End-State Architecture
+
+Durable background local jobs should have one persisted source of local truth
+that is reconciled against live process or session evidence before Melix starts
+duplicates or declares completion. Persisted state is advisory: a record marked
+`completed` is not final until the monitor can also point to a success marker or
+artifact path. If a live session with matching progress is still active, the
+record should self-heal back to `running` and report why.
+
+The Python worker owns the local execution evidence surface for this first
+slice. The Swift control plane and chat/session monitor should later treat the
+record and receipts as worker-owned evidence rather than inventing separate job
+status semantics.
+
+## Performance Probes And Metrics
+
+The changed path reads or writes one bounded JSON record per job ID and compares
+small metadata fields. It does not scan job logs, enumerate process tables,
+start subprocesses, or invoke model inference.
+
+Success metrics:
+
+- reconciliation remains O(1) in record size and live-evidence size;
+- atomic store writes touch one temporary JSON file and one lock file per write;
+- changed-line Python coverage for the touched runtime module and tests is at
+  least 95 percent;
+- local and hosted PR-scoped performance reports are `Status: ok` with zero
+  direct/gated regressions and zero verification failures.
+
+## Implementation Steps
+
+1. Add focused tests for:
+   - versioned record serialization and JSON store round-trip;
+   - stale `completed` state without evidence self-healing to `running` when
+     live progress is observed;
+   - duplicate launch refusal through a `live_session_reused` receipt when the
+     same session is already active;
+   - completed records being accepted only after success marker or artifact path
+     evidence is present;
+   - store lock and revision mismatch write guards.
+2. Implement `LocalJobContinuationRecord`, `LocalJobLiveEvidence`,
+   `LocalJobContinuationStore`, and `reconcile_local_job_continuation`.
+3. Record the contract in the unified agentic runtime document beside the
+   existing background-continuation prompt-boundary primitive.
+4. Run focused tests, changed-line coverage, full local pre-commit, and the PR
+   performance gate before merge.
+
+## Success Criteria
+
+- A future runner can persist command, cwd, log path, exit status, timeout,
+  session ID, follow-up status, follow-up session ID, and completion evidence in
+  a stable record shape.
+- A stale `completed` record without completion evidence cannot be accepted as
+  final.
+- A live matching session is reused instead of duplicated, with a typed receipt.
+- Concurrent record writes are rejected before silent overwrite.
+- The PR stays focused on the state/reconciliation primitive and leaves runner,
+  monitor, and chat follow-up side effects to later slices.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -427,6 +427,31 @@ closed before prompt admission with the same `invalid_background_continuation_fi
 refusal receipt and must not include raw logs, command text, session contents,
 or workflow payloads.
 
+The Python worker local-job continuation primitive is
+`worker.runtime.local_job_continuation`. It defines a versioned
+`melix.local_job_continuation_record.v1` record for durable background local
+jobs before runner and monitor side effects are added. The record persists the
+job ID, command vector, working directory, log path, exit status, timeout,
+originating session ID, follow-up status, follow-up session ID,
+`followed_up_at`, and explicit completion evidence paths. Store writes use
+atomic JSON replacement plus per-record write locks and revision checks so
+concurrent writers fail closed instead of silently overwriting each other.
+
+Persisted local-job state is advisory. A record marked `completed` is accepted
+as final only when a success marker path or artifact path is present on the
+record or matching live evidence. A stale `completed` record without completion
+evidence must reconcile back to `running` when a matching live session still
+shows progress, emitting a `melix.local_job_continuation_receipt.v1` receipt
+with `reason = stale_done_revived`. A pending or running record with matching
+active live progress must emit `reason = live_session_reused` and
+`duplicate_launch_refused = true` so future runners reattach instead of
+launching duplicate local work. Completed records without evidence emit
+`reason = missing_completion_evidence` and remain blocked until explicit
+completion evidence appears. The primitive does not start processes, tail logs,
+inject prompt follow-ups, or resume workflows; those later surfaces must first
+call the reconciliation primitive and then pass any already-redacted completion
+summary through `admit_background_continuation` before prompt projection.
+
 The Python worker skill and memory admission primitives are
 `worker.runtime.skill_memory_context.admit_skill_context` and
 `worker.runtime.skill_memory_context.admit_memory_context`. Future skill,

--- a/services/mlx-worker-python/tests/test_local_job_continuation.py
+++ b/services/mlx-worker-python/tests/test_local_job_continuation.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from worker.runtime.local_job_continuation import (
+    RECEIPT_SCHEMA_VERSION,
+    RECORD_SCHEMA_VERSION,
+    LocalJobContinuationRecord,
+    LocalJobContinuationStore,
+    LocalJobContinuationStoreError,
+    LocalJobLiveEvidence,
+    reconcile_local_job_continuation,
+)
+
+
+def _record(**overrides: object) -> LocalJobContinuationRecord:
+    values: dict[str, object] = {
+        "job_id": "job-7",
+        "command": ("melix", "bench", "--suite", "smoke"),
+        "cwd": "/workspace",
+        "log_path": "/workspace/.runtime/jobs/job-7.log",
+        "session_id": "session-7",
+        "timeout_seconds": 120,
+    }
+    values.update(overrides)
+    return LocalJobContinuationRecord(**values)  # type: ignore[arg-type]
+
+
+def test_local_job_continuation_record_round_trips_through_store(tmp_path: Path) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+
+    saved = store.save_record(
+        _record(
+            status="running",
+            exit_status=None,
+            followup_status="pending",
+            followup_session_id="followup-1",
+            followed_up_at="",
+            success_marker_path="",
+            artifact_paths=("/workspace/out/report.md",),
+        )
+    )
+    loaded = store.load_record("job-7")
+
+    assert saved.revision == 0
+    assert loaded == saved
+    payload = json.loads((tmp_path / "job-7.json").read_text(encoding="utf-8"))
+    assert payload == {
+        "schema_version": RECORD_SCHEMA_VERSION,
+        "job_id": "job-7",
+        "command": ["melix", "bench", "--suite", "smoke"],
+        "cwd": "/workspace",
+        "log_path": "/workspace/.runtime/jobs/job-7.log",
+        "session_id": "session-7",
+        "status": "running",
+        "exit_status": None,
+        "timeout_seconds": 120,
+        "followup_status": "pending",
+        "followup_session_id": "followup-1",
+        "followed_up_at": "",
+        "success_marker_path": "",
+        "artifact_paths": ["/workspace/out/report.md"],
+        "revision": 0,
+    }
+
+
+def test_stale_completed_record_with_live_progress_is_revived() -> None:
+    result = reconcile_local_job_continuation(
+        _record(status="completed", exit_status=0),
+        live_evidence=LocalJobLiveEvidence(
+            session_id="session-7",
+            active=True,
+            progress_excerpt="shard 3/12 still running",
+        ),
+    )
+
+    assert result.record.status == "running"
+    assert result.record.exit_status is None
+    assert result.receipt == {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "job_id": "job-7",
+        "status": "running",
+        "reason": "stale_done_revived",
+        "session_id": "session-7",
+        "exit_status": None,
+        "followup_status": "not_started",
+        "duplicate_launch_refused": True,
+        "completion_evidence_available": False,
+        "corrective_action": (
+            "Reattach to the live local job session and wait for explicit "
+            "success marker or artifact evidence before completing."
+        ),
+    }
+
+
+def test_live_session_reuse_refuses_duplicate_launch_for_running_job() -> None:
+    result = reconcile_local_job_continuation(
+        _record(status="pending"),
+        live_evidence=LocalJobLiveEvidence(
+            session_id="session-7",
+            active=True,
+            progress_excerpt="download 81%",
+            exit_status=None,
+        ),
+    )
+
+    assert result.record.status == "running"
+    assert result.receipt["reason"] == "live_session_reused"
+    assert result.receipt["duplicate_launch_refused"] is True
+    assert result.receipt["corrective_action"] == (
+        "Reuse the active local job session instead of launching duplicate work."
+    )
+
+
+def test_completed_record_requires_success_or_artifact_evidence() -> None:
+    missing = reconcile_local_job_continuation(_record(status="completed", exit_status=0))
+    marker = reconcile_local_job_continuation(
+        _record(
+            status="completed",
+            exit_status=0,
+            success_marker_path="/workspace/.runtime/jobs/job-7.success",
+        )
+    )
+    artifact = reconcile_local_job_continuation(
+        _record(
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/report.md",),
+        )
+    )
+
+    assert missing.record.status == "blocked"
+    assert missing.receipt["reason"] == "missing_completion_evidence"
+    assert missing.receipt["completion_evidence_available"] is False
+    assert marker.record.status == "completed"
+    assert marker.receipt["reason"] == "completion_evidence_accepted"
+    assert marker.receipt["completion_evidence_available"] is True
+    assert artifact.receipt["reason"] == "completion_evidence_accepted"
+
+
+def test_live_completion_evidence_accepts_completed_record() -> None:
+    result = reconcile_local_job_continuation(
+        _record(status="completed", exit_status=0),
+        live_evidence=LocalJobLiveEvidence(
+            session_id="session-7",
+            active=False,
+            progress_excerpt="done",
+            artifact_paths=("/workspace/out/final.json",),
+        ),
+    )
+
+    assert result.record.status == "completed"
+    assert result.receipt["reason"] == "completion_evidence_accepted"
+    assert result.receipt["completion_evidence_available"] is True
+
+
+def test_non_completed_record_without_matching_live_evidence_is_preserved() -> None:
+    result = reconcile_local_job_continuation(
+        _record(
+            status="failed",
+            exit_status=2,
+            success_marker_path="/workspace/.runtime/jobs/job-7.success",
+        ),
+        live_evidence=LocalJobLiveEvidence(
+            session_id="other-session",
+            active=True,
+            progress_excerpt="unrelated progress",
+        ),
+    )
+
+    assert result.record.status == "failed"
+    assert result.record.exit_status == 2
+    assert result.receipt["reason"] == "record_state_preserved"
+    assert result.receipt["completion_evidence_available"] is True
+    assert result.receipt["duplicate_launch_refused"] is False
+
+
+def test_store_revision_guard_rejects_concurrent_stale_update(tmp_path: Path) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    first = store.save_record(_record(status="pending"))
+    second = store.save_record(_record(status="running"), expected_revision=first.revision)
+
+    with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+        store.save_record(_record(status="completed", exit_status=0), expected_revision=first.revision)
+
+    assert second.revision == 1
+    assert exc_info.value.receipt["schema_version"] == RECEIPT_SCHEMA_VERSION
+    assert exc_info.value.receipt["reason"] == "record_revision_mismatch"
+    assert store.load_record("job-7") == second
+
+
+def test_store_lock_guard_rejects_active_writer(tmp_path: Path) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("other-writer\n", encoding="utf-8")
+
+    try:
+        with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+            store.save_record(_record(status="running"))
+    finally:
+        lock_path.unlink(missing_ok=True)
+
+    assert exc_info.value.receipt == {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "job_id": "job-7",
+        "status": "blocked",
+        "reason": "record_write_locked",
+        "session_id": "",
+        "exit_status": None,
+        "followup_status": "blocked",
+        "duplicate_launch_refused": False,
+        "completion_evidence_available": False,
+        "corrective_action": "Retry after the active local job record writer finishes.",
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {"schema_version": "old", "job_id": "job-7"},
+        {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": "../job-7",
+            "command": ["melix"],
+            "cwd": "/workspace",
+            "log_path": "/tmp/job.log",
+            "session_id": "session-7",
+            "status": "pending",
+            "followup_status": "not_started",
+        },
+        {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": "job-7",
+            "command": ["melix", 7],
+            "cwd": "/workspace",
+            "log_path": "/tmp/job.log",
+            "session_id": "session-7",
+            "status": "pending",
+            "followup_status": "not_started",
+        },
+        {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": "job-7",
+            "command": ["melix"],
+            "cwd": "",
+            "log_path": "/tmp/job.log",
+            "session_id": "session-7",
+            "status": "pending",
+            "followup_status": "not_started",
+        },
+        {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": "job-7",
+            "command": ["melix"],
+            "cwd": "/workspace",
+            "log_path": "/tmp/job.log",
+            "session_id": "session-7",
+            "status": "done",
+            "followup_status": "not_started",
+        },
+        {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": "job-7",
+            "command": ["melix"],
+            "cwd": "/workspace",
+            "log_path": "/tmp/job.log",
+            "session_id": "session-7",
+            "status": "pending",
+            "followup_status": "later",
+        },
+        {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": "job-7",
+            "command": ["melix"],
+            "cwd": "/workspace",
+            "log_path": "/tmp/job.log",
+            "session_id": "session-7",
+            "status": "pending",
+            "followup_status": "not_started",
+            "revision": -1,
+        },
+        {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": "job-7",
+            "command": ["melix"],
+            "cwd": "/workspace",
+            "log_path": "/tmp/job.log",
+            "session_id": "session-7",
+            "status": "pending",
+            "followup_status": "not_started",
+            "timeout_seconds": -1,
+        },
+        {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": "job-7",
+            "command": ["melix"],
+            "cwd": "/workspace",
+            "log_path": "/tmp/job.log",
+            "session_id": "session-7",
+            "status": "pending",
+            "followup_status": "not_started",
+            "exit_status": True,
+        },
+        {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": "job-7",
+            "command": ["melix"],
+            "cwd": "/workspace",
+            "log_path": "/tmp/job.log",
+            "session_id": "session-7",
+            "status": "pending",
+            "followup_status": "not_started",
+            "revision": True,
+        },
+        {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": "job-7",
+            "command": ["melix"],
+            "cwd": "/workspace",
+            "log_path": "/tmp/job.log",
+            "session_id": "session-7",
+            "status": "pending",
+            "followup_status": "not_started",
+            "followup_session_id": 7,
+        },
+        {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": "job-7",
+            "command": ["melix"],
+            "cwd": "/workspace",
+            "log_path": "/tmp/job.log",
+            "session_id": "session-7",
+            "status": "pending",
+            "followup_status": "not_started",
+            "artifact_paths": "/tmp/artifact.json",
+        },
+        {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": "job-7",
+            "command": ["melix"],
+            "cwd": "/workspace",
+            "log_path": "/tmp/job.log",
+            "session_id": "session-7",
+            "status": "pending",
+            "followup_status": "not_started",
+            "artifact_paths": [7],
+        },
+        {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": "",
+            "command": ["melix"],
+            "cwd": "/workspace",
+            "log_path": "/tmp/job.log",
+            "session_id": "session-7",
+            "status": "pending",
+            "followup_status": "not_started",
+        },
+    ),
+)
+def test_record_from_dict_rejects_malformed_persisted_state(payload: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        LocalJobContinuationRecord.from_dict(payload)
+
+
+def test_record_validation_rejects_malformed_dataclass_fields() -> None:
+    with pytest.raises(ValueError):
+        _record(command=("",)).to_dict()
+    with pytest.raises(ValueError):
+        _record(exit_status=True).to_dict()
+    with pytest.raises(ValueError):
+        _record(timeout_seconds=True).to_dict()
+    with pytest.raises(ValueError):
+        _record(followup_session_id=7).to_dict()
+    with pytest.raises(ValueError):
+        _record(artifact_paths=(7,)).to_dict()

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+
+
+RECORD_SCHEMA_VERSION = "melix.local_job_continuation_record.v1"
+RECEIPT_SCHEMA_VERSION = "melix.local_job_continuation_receipt.v1"
+
+JOB_STATUSES = frozenset({"pending", "running", "completed", "failed", "timeout", "blocked"})
+FOLLOWUP_STATUSES = frozenset({"not_started", "pending", "in_progress", "completed", "blocked"})
+
+
+class LocalJobContinuationStoreError(RuntimeError):
+    def __init__(self, message: str, *, receipt: dict[str, Any]) -> None:
+        super().__init__(message)
+        self.receipt = receipt
+
+
+@dataclass(frozen=True, slots=True)
+class LocalJobContinuationRecord:
+    job_id: str
+    command: tuple[str, ...]
+    cwd: str
+    log_path: str
+    session_id: str
+    status: str = "pending"
+    exit_status: int | None = None
+    timeout_seconds: int | None = None
+    followup_status: str = "not_started"
+    followup_session_id: str = ""
+    followed_up_at: str = ""
+    success_marker_path: str = ""
+    artifact_paths: tuple[str, ...] = ()
+    revision: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        _validate_record(self)
+        return {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "job_id": self.job_id,
+            "command": list(self.command),
+            "cwd": self.cwd,
+            "log_path": self.log_path,
+            "session_id": self.session_id,
+            "status": self.status,
+            "exit_status": self.exit_status,
+            "timeout_seconds": self.timeout_seconds,
+            "followup_status": self.followup_status,
+            "followup_session_id": self.followup_session_id,
+            "followed_up_at": self.followed_up_at,
+            "success_marker_path": self.success_marker_path,
+            "artifact_paths": list(self.artifact_paths),
+            "revision": self.revision,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> LocalJobContinuationRecord:
+        if payload.get("schema_version") != RECORD_SCHEMA_VERSION:
+            raise ValueError("unsupported local job continuation record schema")
+        record = cls(
+            job_id=_required_text(payload, "job_id"),
+            command=tuple(_required_text_list(payload, "command")),
+            cwd=_required_text(payload, "cwd"),
+            log_path=_required_text(payload, "log_path"),
+            session_id=_required_text(payload, "session_id"),
+            status=_required_text(payload, "status"),
+            exit_status=_optional_int(payload.get("exit_status"), "exit_status"),
+            timeout_seconds=_optional_int(payload.get("timeout_seconds"), "timeout_seconds"),
+            followup_status=_required_text(payload, "followup_status"),
+            followup_session_id=_optional_text(payload, "followup_session_id"),
+            followed_up_at=_optional_text(payload, "followed_up_at"),
+            success_marker_path=_optional_text(payload, "success_marker_path"),
+            artifact_paths=tuple(_optional_text_list(payload, "artifact_paths")),
+            revision=_optional_int(payload.get("revision", 0), "revision") or 0,
+        )
+        _validate_record(record)
+        return record
+
+    def with_revision(self, revision: int) -> LocalJobContinuationRecord:
+        parsed_revision = _optional_int(revision, "revision")
+        if parsed_revision is None:
+            raise ValueError("revision must be an integer")
+        return replace(self, revision=max(0, parsed_revision))
+
+
+@dataclass(frozen=True, slots=True)
+class LocalJobLiveEvidence:
+    session_id: str
+    active: bool
+    progress_excerpt: str = ""
+    exit_status: int | None = None
+    success_marker_path: str = ""
+    artifact_paths: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class LocalJobContinuationReconciliation:
+    record: LocalJobContinuationRecord
+    receipt: dict[str, Any]
+
+
+class LocalJobContinuationStore:
+    def __init__(self, root: Path | str) -> None:
+        self.root = Path(root)
+
+    def load_record(self, job_id: str) -> LocalJobContinuationRecord | None:
+        path = self._record_path(job_id)
+        if not path.exists():
+            return None
+        return LocalJobContinuationRecord.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+    def save_record(
+        self,
+        record: LocalJobContinuationRecord,
+        *,
+        expected_revision: int | None = None,
+    ) -> LocalJobContinuationRecord:
+        _validate_record(record)
+        path = self._record_path(record.job_id)
+        self.root.mkdir(parents=True, exist_ok=True)
+        with self._record_write_lock(path):
+            current = self.load_record(record.job_id)
+            current_revision = current.revision if current is not None else None
+            if expected_revision is not None and current_revision != expected_revision:
+                raise LocalJobContinuationStoreError(
+                    "local job continuation record revision changed",
+                    receipt=_receipt(
+                        job_id=record.job_id,
+                        status="blocked",
+                        reason="record_revision_mismatch",
+                        session_id=record.session_id,
+                        exit_status=record.exit_status,
+                        followup_status=record.followup_status,
+                        duplicate_launch_refused=False,
+                        completion_evidence_available=_has_completion_evidence(record),
+                        corrective_action=(
+                            "Reload the local job continuation record before writing a new update."
+                        ),
+                    ),
+                )
+            next_revision = 0 if current_revision is None else current_revision + 1
+            next_record = record.with_revision(next_revision)
+            tmp_path = path.with_suffix(path.suffix + ".tmp")
+            tmp_path.write_text(
+                json.dumps(next_record.to_dict(), indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            tmp_path.replace(path)
+            return next_record
+
+    def _record_path(self, job_id: str) -> Path:
+        safe_job_id = _safe_job_id(job_id)
+        return self.root / f"{safe_job_id}.json"
+
+    @contextmanager
+    def _record_write_lock(self, path: Path) -> Iterator[None]:
+        lock_path = path.with_suffix(path.suffix + ".lock")
+        fd: int | None = None
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            os.write(fd, f"{os.getpid()}\n".encode("utf-8"))
+            yield
+        except FileExistsError as exc:
+            raise LocalJobContinuationStoreError(
+                "local job continuation record is locked by another writer",
+                receipt=_receipt(
+                    job_id=path.stem,
+                    status="blocked",
+                    reason="record_write_locked",
+                    session_id="",
+                    exit_status=None,
+                    followup_status="blocked",
+                    duplicate_launch_refused=False,
+                    completion_evidence_available=False,
+                    corrective_action="Retry after the active local job record writer finishes.",
+                ),
+            ) from exc
+        finally:
+            if fd is not None:
+                os.close(fd)
+                try:
+                    lock_path.unlink()
+                except FileNotFoundError:
+                    pass
+
+
+def reconcile_local_job_continuation(
+    record: LocalJobContinuationRecord,
+    *,
+    live_evidence: LocalJobLiveEvidence | None = None,
+) -> LocalJobContinuationReconciliation:
+    _validate_record(record)
+    evidence_available = _has_completion_evidence(record, live_evidence)
+    live_matches = _live_session_matches(record, live_evidence)
+
+    if live_matches and live_evidence is not None and live_evidence.active:
+        if record.status == "completed" and not evidence_available:
+            revived = replace(record, status="running", exit_status=None)
+            return LocalJobContinuationReconciliation(
+                record=revived,
+                receipt=_receipt(
+                    job_id=record.job_id,
+                    status="running",
+                    reason="stale_done_revived",
+                    session_id=record.session_id,
+                    exit_status=None,
+                    followup_status=record.followup_status,
+                    duplicate_launch_refused=True,
+                    completion_evidence_available=False,
+                    corrective_action=(
+                        "Reattach to the live local job session and wait for explicit "
+                        "success marker or artifact evidence before completing."
+                    ),
+                ),
+            )
+        if record.status in {"pending", "running"}:
+            running = replace(record, status="running", exit_status=live_evidence.exit_status)
+            return LocalJobContinuationReconciliation(
+                record=running,
+                receipt=_receipt(
+                    job_id=record.job_id,
+                    status="running",
+                    reason="live_session_reused",
+                    session_id=record.session_id,
+                    exit_status=live_evidence.exit_status,
+                    followup_status=record.followup_status,
+                    duplicate_launch_refused=True,
+                    completion_evidence_available=evidence_available,
+                    corrective_action=(
+                        "Reuse the active local job session instead of launching duplicate work."
+                    ),
+                ),
+            )
+
+    if record.status == "completed":
+        if evidence_available:
+            return LocalJobContinuationReconciliation(
+                record=record,
+                receipt=_receipt(
+                    job_id=record.job_id,
+                    status="completed",
+                    reason="completion_evidence_accepted",
+                    session_id=record.session_id,
+                    exit_status=record.exit_status,
+                    followup_status=record.followup_status,
+                    duplicate_launch_refused=False,
+                    completion_evidence_available=True,
+                    corrective_action="The monitor may enqueue exactly one follow-up for this job.",
+                ),
+            )
+        blocked = replace(record, status="blocked")
+        return LocalJobContinuationReconciliation(
+            record=blocked,
+            receipt=_receipt(
+                job_id=record.job_id,
+                status="blocked",
+                reason="missing_completion_evidence",
+                session_id=record.session_id,
+                exit_status=record.exit_status,
+                followup_status=record.followup_status,
+                duplicate_launch_refused=False,
+                completion_evidence_available=False,
+                corrective_action=(
+                    "Require a success marker or artifact path before treating the local job as complete."
+                ),
+            ),
+        )
+
+    return LocalJobContinuationReconciliation(
+        record=record,
+        receipt=_receipt(
+            job_id=record.job_id,
+            status=record.status,
+            reason="record_state_preserved",
+            session_id=record.session_id,
+            exit_status=record.exit_status,
+            followup_status=record.followup_status,
+            duplicate_launch_refused=False,
+            completion_evidence_available=evidence_available,
+            corrective_action="No reconciliation change was required for this local job record.",
+        ),
+    )
+
+
+def _receipt(
+    *,
+    job_id: str,
+    status: str,
+    reason: str,
+    session_id: str,
+    exit_status: int | None,
+    followup_status: str,
+    duplicate_launch_refused: bool,
+    completion_evidence_available: bool,
+    corrective_action: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "job_id": job_id,
+        "status": status,
+        "reason": reason,
+        "session_id": session_id,
+        "exit_status": exit_status,
+        "followup_status": followup_status,
+        "duplicate_launch_refused": duplicate_launch_refused,
+        "completion_evidence_available": completion_evidence_available,
+        "corrective_action": corrective_action,
+    }
+
+
+def _has_completion_evidence(
+    record: LocalJobContinuationRecord,
+    live_evidence: LocalJobLiveEvidence | None = None,
+) -> bool:
+    if record.success_marker_path.strip() or any(path.strip() for path in record.artifact_paths):
+        return True
+    if live_evidence is None:
+        return False
+    return bool(
+        live_evidence.success_marker_path.strip()
+        or any(path.strip() for path in live_evidence.artifact_paths)
+    )
+
+
+def _live_session_matches(
+    record: LocalJobContinuationRecord,
+    live_evidence: LocalJobLiveEvidence | None,
+) -> bool:
+    if live_evidence is None:
+        return False
+    return (
+        bool(live_evidence.session_id.strip())
+        and live_evidence.session_id == record.session_id
+        and bool(live_evidence.progress_excerpt.strip())
+    )
+
+
+def _validate_record(record: LocalJobContinuationRecord) -> None:
+    _safe_job_id(record.job_id)
+    if not record.command or any(not isinstance(part, str) or not part for part in record.command):
+        raise ValueError("local job continuation command is required")
+    for field_name in ("cwd", "log_path", "session_id"):
+        value = getattr(record, field_name)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"local job continuation {field_name} is required")
+    if record.status not in JOB_STATUSES:
+        raise ValueError("unsupported local job continuation status")
+    if record.followup_status not in FOLLOWUP_STATUSES:
+        raise ValueError("unsupported local job continuation followup status")
+    _optional_int(record.exit_status, "exit_status")
+    _optional_int(record.timeout_seconds, "timeout_seconds")
+    _optional_int(record.revision, "revision")
+    if record.revision < 0:
+        raise ValueError("local job continuation revision must be non-negative")
+    if record.timeout_seconds is not None and record.timeout_seconds < 0:
+        raise ValueError("local job continuation timeout must be non-negative")
+    for field_name in ("followup_session_id", "followed_up_at", "success_marker_path"):
+        if not isinstance(getattr(record, field_name), str):
+            raise ValueError(f"local job continuation {field_name} must be a string")
+    if any(not isinstance(path, str) for path in record.artifact_paths):
+        raise ValueError("local job continuation artifact paths must be strings")
+
+
+def _required_text(payload: dict[str, Any], field_name: str) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value
+
+
+def _required_list(payload: dict[str, Any], field_name: str) -> Sequence[Any]:
+    value = payload.get(field_name)
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{field_name} must be a non-empty list")
+    return value
+
+
+def _required_text_list(payload: dict[str, Any], field_name: str) -> list[str]:
+    values = _required_list(payload, field_name)
+    if any(not isinstance(value, str) or not value for value in values):
+        raise ValueError(f"{field_name} must be a non-empty list of strings")
+    return list(values)
+
+
+def _optional_text_list(payload: dict[str, Any], field_name: str) -> list[str]:
+    value = payload.get(field_name, [])
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list")
+    if any(not isinstance(part, str) for part in value):
+        raise ValueError(f"{field_name} must be a list of strings")
+    return list(value)
+
+
+def _optional_text(payload: dict[str, Any], field_name: str) -> str:
+    value = payload.get(field_name, "")
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    return value
+
+
+def _optional_int(value: Any, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field_name} must be an integer or null")
+    return value
+
+
+def _safe_job_id(job_id: str) -> str:
+    if not isinstance(job_id, str) or not job_id.strip():
+        raise ValueError("local job continuation job_id is required")
+    normalized = job_id.strip()
+    if normalized in {".", ".."} or any(character in normalized for character in ("/", "\\")):
+        raise ValueError("local job continuation job_id must be path-safe")
+    return normalized
+
+
+__all__ = [
+    "FOLLOWUP_STATUSES",
+    "JOB_STATUSES",
+    "RECEIPT_SCHEMA_VERSION",
+    "RECORD_SCHEMA_VERSION",
+    "LocalJobContinuationRecord",
+    "LocalJobContinuationReconciliation",
+    "LocalJobContinuationStore",
+    "LocalJobContinuationStoreError",
+    "LocalJobLiveEvidence",
+    "reconcile_local_job_continuation",
+]


### PR DESCRIPTION
## Summary
- Adds `worker.runtime.local_job_continuation` as the first durable background local-job continuation primitive for issue #1756.
- Persists versioned job records with atomic JSON replacement, per-record write locks, revision guards, completion evidence fields, and typed reconciliation receipts.
- Hardens local record admission after review with cross-platform-safe job IDs, race-tolerant record loading, PID-owned stale lock recovery, and explicit negative-revision rejection.
- Documents the runner/monitor contract in the unified agentic runtime contract and records the slice plan under `docs/plans/`.

## Plan or Spec
- Issue: #1756
- Plan: `docs/plans/2026-06-10-issue-1756-local-job-continuation-records.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py
# 53 passed in 0.06s

mkdir -p .runtime/coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file=.runtime/coverage/local_job_continuation.coverage -m pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file=.runtime/coverage/local_job_continuation.coverage -o .runtime/coverage/local_job_continuation.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json .runtime/coverage/local_job_continuation.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py
# TOTAL 98.79% 407/412

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts import pre_commit_gate
root = Path.cwd()
changed = pre_commit_gate.staged_changed_files(root, base_ref="origin/main")
outcome = pre_commit_gate.run_performance_report(root, changed, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# Melix PR Scoped Performance Report: Status ok, Changed files 4, Selected probes 0, Regressions 0, Context regressions 0, Verification failures 0
# Report: .runtime/pre-commit-performance/20260610-161426-792c7e83/report/report.md

git diff --check
# passed

.githooks/pre-commit
# make swift-test: rc=0 elapsed=177.8s
# make py-test: 3850 passed, 14 skipped, 2 warnings in 158.90s; rc=0 elapsed=159.4s
# make integration-test: 117 passed, 1 skipped in 473.62s; rc=0 elapsed=474.5s
# Melix PR Scoped Performance Report: Status ok, Changed files 4, Selected probes 0, Regressions 0, Context regressions 0, Verification failures 0
# Report: .runtime/pre-commit-performance/20260610-164149-792c7e83/report/report.md
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 98.79% 407/412`.
- Runtime module changed-line coverage: `services/mlx-worker-python/worker/runtime/local_job_continuation.py 98.71% 230/233`.
- Test changed-line coverage: `services/mlx-worker-python/tests/test_local_job_continuation.py 98.88% 177/179`.
- Local PR-scoped performance report: `Status: ok`; selected probes `0`; direct/gated regressions `0`; context regressions `0`; verification failures `0`.
- Latest local full-gate performance report: `.runtime/pre-commit-performance/20260610-164149-792c7e83/report/report.md`.
- Observability mode: `evidence`; the primitive emits typed receipts and does not add production metrics yet.
- Probe overhead: `N/A`; no registered performance probes were selected because the slice only adds bounded O(1) JSON record serialization/reconciliation and docs.

## Known Gaps
- Runner, monitor, and chat follow-up side effects are intentionally deferred to later slices of #1756.
- This PR does not start shell commands, poll processes, tail logs, inject prompt follow-ups, or resume workflow sessions.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
