### PR TITLE
Harden local job continuation records

### DIFF
--- a/docs/plans/2026-06-10-issue-1756-local-job-continuation-records.md
+++ b/docs/plans/2026-06-10-issue-1756-local-job-continuation-records.md
@@ -14,7 +14,8 @@ This slice covers:
 - `worker.runtime.local_job_continuation` with a versioned local-job
   continuation record;
 - JSON persistence for one record per job ID, with atomic replacement,
-  per-record write locks, and revision guards for concurrent writer detection;
+  cross-platform-safe record filenames, per-record write locks, bounded stale
+  lock recovery, and revision guards for concurrent writer detection;
 - live-session reconciliation for stale `completed` records without success or
   artifact evidence;
 - typed receipts for `live_session_reused`, `stale_done_revived`,
@@ -52,7 +53,8 @@ start subprocesses, or invoke model inference.
 Success metrics:
 
 - reconciliation remains O(1) in record size and live-evidence size;
-- atomic store writes touch one temporary JSON file and one lock file per write;
+- atomic store writes touch one temporary JSON file and one lock file per write,
+  with at most one liveness probe when a stale lock candidate exists;
 - changed-line Python coverage for the touched runtime module and tests is at
   least 95 percent;
 - local and hosted PR-scoped performance reports are `Status: ok` with zero
@@ -68,7 +70,8 @@ Success metrics:
      same session is already active;
    - completed records being accepted only after success marker or artifact path
      evidence is present;
-   - store lock and revision mismatch write guards.
+   - store lock, stale-lock recovery, unsafe job ID rejection, and revision
+     mismatch write guards.
 2. Implement `LocalJobContinuationRecord`, `LocalJobLiveEvidence`,
    `LocalJobContinuationStore`, and `reconcile_local_job_continuation`.
 3. Record the contract in the unified agentic runtime document beside the
@@ -84,6 +87,8 @@ Success metrics:
 - A stale `completed` record without completion evidence cannot be accepted as
   final.
 - A live matching session is reused instead of duplicated, with a typed receipt.
-- Concurrent record writes are rejected before silent overwrite.
+- Concurrent record writes are rejected before silent overwrite, while stale
+  lock files left by dead writer processes may be recovered without human
+  cleanup.
 - The PR stays focused on the state/reconciliation primitive and leaves runner,
   monitor, and chat follow-up side effects to later slices.

--- a/docs/plans/2026-06-10-issue-1756-local-job-continuation-records.md
+++ b/docs/plans/2026-06-10-issue-1756-local-job-continuation-records.md
@@ -14,8 +14,8 @@ This slice covers:
 - `worker.runtime.local_job_continuation` with a versioned local-job
   continuation record;
 - JSON persistence for one record per job ID, with atomic replacement,
-  cross-platform-safe record filenames, per-record write locks, bounded stale
-  lock recovery, and revision guards for concurrent writer detection;
+  cross-platform-safe record filenames, per-record write locks, identity-checked
+  stale lock recovery, and revision guards for concurrent writer detection;
 - live-session reconciliation for stale `completed` records without success or
   artifact evidence;
 - typed receipts for `live_session_reused`, `stale_done_revived`,
@@ -54,7 +54,8 @@ Success metrics:
 
 - reconciliation remains O(1) in record size and live-evidence size;
 - atomic store writes touch one temporary JSON file and one lock file per write,
-  with at most one liveness probe when a stale lock candidate exists;
+  with one liveness probe and one short-lived recovery guard when a stale lock
+  candidate exists;
 - changed-line Python coverage for the touched runtime module and tests is at
   least 95 percent;
 - local and hosted PR-scoped performance reports are `Status: ok` with zero
@@ -70,8 +71,8 @@ Success metrics:
      same session is already active;
    - completed records being accepted only after success marker or artifact path
      evidence is present;
-   - store lock, stale-lock recovery, unsafe job ID rejection, and revision
-     mismatch write guards.
+   - store lock, identity-checked stale-lock recovery, unsafe job ID rejection,
+     and revision mismatch write guards.
 2. Implement `LocalJobContinuationRecord`, `LocalJobLiveEvidence`,
    `LocalJobContinuationStore`, and `reconcile_local_job_continuation`.
 3. Record the contract in the unified agentic runtime document beside the
@@ -89,6 +90,6 @@ Success metrics:
 - A live matching session is reused instead of duplicated, with a typed receipt.
 - Concurrent record writes are rejected before silent overwrite, while stale
   lock files left by dead writer processes may be recovered without human
-  cleanup.
+  cleanup after the stale file is guarded, renamed, and revalidated.
 - The PR stays focused on the state/reconciliation primitive and leaves runner,
   monitor, and chat follow-up side effects to later slices.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -439,7 +439,11 @@ job ID, command vector, working directory, log path, exit status, timeout,
 originating session ID, follow-up status, follow-up session ID,
 `followed_up_at`, and explicit completion evidence paths. Store writes use
 atomic JSON replacement plus per-record write locks and revision checks so
-concurrent writers fail closed instead of silently overwriting each other.
+concurrent writers fail closed instead of silently overwriting each other. Job
+IDs must be cross-platform-safe record filenames. If a lock file belongs to a
+dead writer PID, the store may remove it before retrying the write; malformed
+lock files, permission-protected active processes, and failed lock cleanup all
+preserve the lock and emit a write-refusal receipt instead.
 
 Persisted local-job state is advisory. A record marked `completed` is accepted
 as final only when a success marker path or artifact path is present on the

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -441,9 +441,13 @@ originating session ID, follow-up status, follow-up session ID,
 atomic JSON replacement plus per-record write locks and revision checks so
 concurrent writers fail closed instead of silently overwriting each other. Job
 IDs must be cross-platform-safe record filenames. If a lock file belongs to a
-dead writer PID, the store may remove it before retrying the write; malformed
-lock files, permission-protected active processes, and failed lock cleanup all
-preserve the lock and emit a write-refusal receipt instead.
+dead writer PID, the store may recover it only after acquiring a short-lived
+recovery guard, renaming the stale file, and revalidating the lock identity
+before deletion. Windows process IDs are treated as active because
+`os.kill(pid, 0)` is not a portable liveness probe there. Malformed lock files,
+permission-protected active processes, active recovery guards, concurrent lock
+reacquisition, and failed lock cleanup all preserve the lock or refuse the write
+instead of deleting a possibly active writer lock.
 
 Persisted local-job state is advisory. A record marked `completed` is accepted
 as final only when a success marker path or artifact path is present on the

--- a/services/mlx-worker-python/tests/test_local_job_continuation.py
+++ b/services/mlx-worker-python/tests/test_local_job_continuation.py
@@ -264,22 +264,210 @@ def test_store_recovers_stale_lock_for_dead_writer_pid(tmp_path: Path) -> None:
     assert not lock_path.exists()
 
 
+def test_record_lock_cleanup_failure_is_non_fatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    lock_path = tmp_path / "job-7.json.lock"
+    original_unlink = Path.unlink
+
+    def fail_lock_cleanup(path: Path, *args: object, **kwargs: object) -> None:
+        if path == lock_path:
+            raise OSError("cleanup denied")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_lock_cleanup)
+
+    saved = store.save_record(_record(status="running"))
+
+    assert saved.status == "running"
+    monkeypatch.undo()
+    lock_path.unlink(missing_ok=True)
+
+
 def test_stale_lock_cleanup_tolerates_concurrent_lock_removal(tmp_path: Path) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("999999\n", encoding="utf-8")
+    original_rename = os.rename
+
+    def remove_before_rename(src: Path | str, dst: Path | str) -> None:
+        if Path(src) == lock_path and lock_path.exists():
+            lock_path.unlink()
+            raise FileNotFoundError(src)
+        original_rename(src, dst)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(os, "rename", remove_before_rename)
+        saved = store.save_record(_record(status="running"))
+
+    assert saved.status == "running"
+    assert not lock_path.exists()
+
+
+def test_stale_lock_recovery_blocks_when_guard_is_active(tmp_path: Path) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    guard_path = tmp_path / "job-7.json.lock.recovery"
+    lock_path.write_text("999999\n", encoding="utf-8")
+    guard_path.write_text(f"{os.getpid()}\n", encoding="utf-8")
+
+    try:
+        with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+            store.save_record(_record(status="running"))
+    finally:
+        lock_path.unlink(missing_ok=True)
+        guard_path.unlink(missing_ok=True)
+
+    assert exc_info.value.receipt["reason"] == "record_write_locked"
+
+
+def test_stale_lock_recovery_reclaims_dead_recovery_guard(tmp_path: Path) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    guard_path = tmp_path / "job-7.json.lock.recovery"
+    lock_path.write_text("999999\n", encoding="utf-8")
+    guard_path.write_text("999998\n", encoding="utf-8")
+
+    saved = store.save_record(_record(status="running"))
+
+    assert saved.status == "running"
+    assert not guard_path.exists()
+
+
+def test_stale_lock_recovery_blocks_when_recovery_guard_reacquired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    guard_path = tmp_path / "job-7.json.lock.recovery"
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    guard_path.write_text("999998\n", encoding="utf-8")
+    original_open = os.open
+
+    def race_reacquire_guard(path: Path | str, flags: int, mode: int = 0o777) -> int:
+        if Path(path) == guard_path and not guard_path.exists():
+            raise FileExistsError(path)
+        return original_open(path, flags, mode)
+
+    monkeypatch.setattr(os, "open", race_reacquire_guard)
+
+    assert store._open_record_lock_recovery_guard(guard_path) is None
+
+
+def test_stale_lock_recovery_blocks_when_lock_rename_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("999999\n", encoding="utf-8")
+
+    def fail_rename(src: Path | str, dst: Path | str) -> None:
+        if Path(src) == lock_path:
+            raise OSError("rename denied")
+        os.rename(src, dst)
+
+    monkeypatch.setattr(os, "rename", fail_rename)
+
+    with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+        store.save_record(_record(status="running"))
+
+    assert exc_info.value.receipt["reason"] == "record_write_locked"
+    assert lock_path.read_text(encoding="utf-8") == "999999\n"
+
+
+def test_stale_lock_recovery_restores_lock_when_renamed_pid_is_invalid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("999999\n", encoding="utf-8")
+    original_rename = os.rename
+
+    def corrupt_temp_after_rename(src: Path | str, dst: Path | str) -> None:
+        original_rename(src, dst)
+        if Path(src) == lock_path:
+            Path(dst).write_text("not-a-pid\n", encoding="utf-8")
+
+    monkeypatch.setattr(os, "rename", corrupt_temp_after_rename)
+
+    with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+        store.save_record(_record(status="running"))
+
+    assert exc_info.value.receipt["reason"] == "record_write_locked"
+    assert lock_path.read_text(encoding="utf-8") == "not-a-pid\n"
+
+
+def test_stale_lock_recovery_preserves_new_lock_acquired_after_rename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     store = LocalJobContinuationStore(tmp_path)
     tmp_path.mkdir(parents=True, exist_ok=True)
     lock_path = tmp_path / "job-7.json.lock"
     lock_path.write_text("999999\n", encoding="utf-8")
     original_unlink = Path.unlink
 
-    def remove_before_unlink(path: Path, *args: object, **kwargs: object) -> None:
-        if path == lock_path and path.exists():
+    def acquire_new_lock_before_stale_temp_unlink(
+        path: Path, *args: object, **kwargs: object
+    ) -> None:
+        if path.name.startswith(f"{lock_path.name}.stale."):
+            lock_path.write_text(f"{os.getpid()}\n", encoding="utf-8")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", acquire_new_lock_before_stale_temp_unlink)
+
+    with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+        store.save_record(_record(status="running"))
+
+    assert exc_info.value.receipt["reason"] == "record_write_locked"
+    assert lock_path.read_text(encoding="utf-8") == f"{os.getpid()}\n"
+
+
+def test_stale_lock_recovery_restores_lock_when_renamed_pid_is_active(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("999999\n", encoding="utf-8")
+    original_rename = os.rename
+
+    def rewrite_temp_to_active_pid(src: Path | str, dst: Path | str) -> None:
+        original_rename(src, dst)
+        if Path(src) == lock_path:
+            Path(dst).write_text(f"{os.getpid()}\n", encoding="utf-8")
+
+    monkeypatch.setattr(os, "rename", rewrite_temp_to_active_pid)
+
+    with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+        store.save_record(_record(status="running"))
+
+    assert exc_info.value.receipt["reason"] == "record_write_locked"
+    assert lock_path.read_text(encoding="utf-8") == f"{os.getpid()}\n"
+
+
+def test_stale_lock_recovery_tolerates_temp_removed_before_unlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("999999\n", encoding="utf-8")
+    original_unlink = Path.unlink
+
+    def remove_temp_before_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        if path.name.startswith(f"{lock_path.name}.stale."):
             original_unlink(path)
             raise FileNotFoundError(path)
         return original_unlink(path, *args, **kwargs)
 
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setattr(Path, "unlink", remove_before_unlink)
-        saved = store.save_record(_record(status="running"))
+    monkeypatch.setattr(Path, "unlink", remove_temp_before_unlink)
+
+    saved = store.save_record(_record(status="running"))
 
     assert saved.status == "running"
     assert not lock_path.exists()
@@ -292,11 +480,12 @@ def test_stale_lock_cleanup_preserves_lock_when_unlink_fails(
     tmp_path.mkdir(parents=True, exist_ok=True)
     lock_path = tmp_path / "job-7.json.lock"
     lock_path.write_text("999999\n", encoding="utf-8")
+    original_unlink = Path.unlink
 
     def fail_unlink(path: Path, *args: object, **kwargs: object) -> None:
-        if path == lock_path:
+        if path.name.startswith(f"{lock_path.name}.stale."):
             raise OSError("permission denied")
-        path.unlink(*args, **kwargs)
+        return original_unlink(path, *args, **kwargs)
 
     monkeypatch.setattr(Path, "unlink", fail_unlink)
 
@@ -304,6 +493,125 @@ def test_stale_lock_cleanup_preserves_lock_when_unlink_fails(
         store.save_record(_record(status="running"))
 
     assert exc_info.value.receipt["reason"] == "record_write_locked"
+    assert lock_path.read_text(encoding="utf-8") == "999999\n"
+
+
+def test_stale_lock_recovery_tolerates_recovery_guard_cleanup_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    guard_path = tmp_path / "job-7.json.lock.recovery"
+    lock_path.write_text("999999\n", encoding="utf-8")
+    original_unlink = Path.unlink
+
+    def fail_guard_cleanup(path: Path, *args: object, **kwargs: object) -> None:
+        if path == guard_path:
+            raise OSError("guard cleanup denied")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_guard_cleanup)
+
+    saved = store.save_record(_record(status="running"))
+
+    assert saved.status == "running"
+    monkeypatch.undo()
+    guard_path.unlink(missing_ok=True)
+
+
+def test_recovery_guard_refuses_unparseable_and_active_pids(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    guard_path = tmp_path / "job-7.json.lock.recovery"
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    guard_path.write_text("not-a-pid\n", encoding="utf-8")
+
+    assert store._remove_stale_record_lock_recovery_guard(guard_path) is False
+
+    guard_path.write_text("42\n", encoding="utf-8")
+
+    def deny_signal(pid: int, signal: int) -> None:
+        raise PermissionError("not owned")
+
+    monkeypatch.setattr(os, "kill", deny_signal)
+
+    assert store._remove_stale_record_lock_recovery_guard(guard_path) is False
+
+
+def test_recovery_guard_cleanup_handles_missing_and_failed_unlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    guard_path = tmp_path / "job-7.json.lock.recovery"
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    guard_path.write_text("999998\n", encoding="utf-8")
+    original_unlink = Path.unlink
+
+    def remove_before_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        if path == guard_path:
+            original_unlink(path)
+            raise FileNotFoundError(path)
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", remove_before_unlink)
+
+    assert store._remove_stale_record_lock_recovery_guard(guard_path) is True
+
+    monkeypatch.undo()
+    guard_path.write_text("999998\n", encoding="utf-8")
+
+    def fail_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        if path == guard_path:
+            raise OSError("cleanup denied")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_unlink)
+
+    assert store._remove_stale_record_lock_recovery_guard(guard_path) is False
+
+
+def test_restore_renamed_lock_handles_restore_races(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    lock_path = tmp_path / "job-7.json.lock"
+    temp_path = tmp_path / "job-7.json.lock.stale.test"
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(f"{os.getpid()}\n", encoding="utf-8")
+    temp_path.write_text("999998\n", encoding="utf-8")
+
+    store._restore_renamed_record_lock(temp_path, lock_path)
+
+    assert lock_path.read_text(encoding="utf-8") == f"{os.getpid()}\n"
+    assert not temp_path.exists()
+
+    temp_path.write_text("999998\n", encoding="utf-8")
+
+    def fail_link(src: Path | str, dst: Path | str) -> None:
+        raise OSError("link denied")
+
+    monkeypatch.setattr(os, "link", fail_link)
+
+    store._restore_renamed_record_lock(temp_path, lock_path)
+
+    assert temp_path.exists()
+
+    monkeypatch.undo()
+    lock_path.unlink()
+    original_unlink = Path.unlink
+
+    def fail_temp_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        if path == temp_path:
+            raise OSError("unlink denied")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_temp_unlink)
+
+    store._restore_renamed_record_lock(temp_path, lock_path)
+
+    assert lock_path.read_text(encoding="utf-8") == "999998\n"
 
 
 def test_lock_cleanup_treats_permission_errors_as_active_process(
@@ -344,6 +652,46 @@ def test_lock_cleanup_treats_eperm_oserror_as_active_process(
         store.save_record(_record(status="running"))
 
     assert exc_info.value.receipt["reason"] == "record_write_locked"
+
+
+def test_lock_cleanup_treats_signal_value_error_as_active_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("42\n", encoding="utf-8")
+
+    def reject_signal(pid: int, signal: int) -> None:
+        raise ValueError("unsupported signal")
+
+    monkeypatch.setattr(os, "kill", reject_signal)
+
+    with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+        store.save_record(_record(status="running"))
+
+    assert exc_info.value.receipt["reason"] == "record_write_locked"
+
+
+def test_lock_cleanup_treats_windows_process_ids_as_active_without_signal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("999999\n", encoding="utf-8")
+
+    def fail_if_signalled(pid: int, signal: int) -> None:
+        raise AssertionError("os.kill(pid, 0) must not run on Windows")
+
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(os, "kill", fail_if_signalled)
+
+    with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+        store.save_record(_record(status="running"))
+
+    assert exc_info.value.receipt["reason"] == "record_write_locked"
+    assert lock_path.read_text(encoding="utf-8") == "999999\n"
 
 
 def test_with_revision_rejects_negative_revision() -> None:

--- a/services/mlx-worker-python/tests/test_local_job_continuation.py
+++ b/services/mlx-worker-python/tests/test_local_job_continuation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -192,11 +193,28 @@ def test_store_revision_guard_rejects_concurrent_stale_update(tmp_path: Path) ->
     assert store.load_record("job-7") == second
 
 
+def test_load_record_tolerates_record_deleted_between_path_resolution_and_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    saved = store.save_record(_record(status="running"))
+    original_read_text = Path.read_text
+
+    def delete_before_read(path: Path, *args: object, **kwargs: object) -> str:
+        if path == tmp_path / "job-7.json":
+            path.unlink()
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", delete_before_read)
+
+    assert store.load_record(saved.job_id) is None
+
+
 def test_store_lock_guard_rejects_active_writer(tmp_path: Path) -> None:
     store = LocalJobContinuationStore(tmp_path)
     tmp_path.mkdir(parents=True, exist_ok=True)
     lock_path = tmp_path / "job-7.json.lock"
-    lock_path.write_text("other-writer\n", encoding="utf-8")
+    lock_path.write_text(f"{os.getpid()}\n", encoding="utf-8")
 
     try:
         with pytest.raises(LocalJobContinuationStoreError) as exc_info:
@@ -216,6 +234,145 @@ def test_store_lock_guard_rejects_active_writer(tmp_path: Path) -> None:
         "completion_evidence_available": False,
         "corrective_action": "Retry after the active local job record writer finishes.",
     }
+
+
+def test_store_lock_guard_preserves_unparseable_lock_file(tmp_path: Path) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("other-writer\n", encoding="utf-8")
+
+    try:
+        with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+            store.save_record(_record(status="running"))
+    finally:
+        lock_path.unlink(missing_ok=True)
+
+    assert exc_info.value.receipt["reason"] == "record_write_locked"
+
+
+def test_store_recovers_stale_lock_for_dead_writer_pid(tmp_path: Path) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("999999\n", encoding="utf-8")
+
+    saved = store.save_record(_record(status="running"))
+
+    assert saved.revision == 0
+    assert store.load_record("job-7") == saved
+    assert not lock_path.exists()
+
+
+def test_stale_lock_cleanup_tolerates_concurrent_lock_removal(tmp_path: Path) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("999999\n", encoding="utf-8")
+    original_unlink = Path.unlink
+
+    def remove_before_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        if path == lock_path and path.exists():
+            original_unlink(path)
+            raise FileNotFoundError(path)
+        return original_unlink(path, *args, **kwargs)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(Path, "unlink", remove_before_unlink)
+        saved = store.save_record(_record(status="running"))
+
+    assert saved.status == "running"
+    assert not lock_path.exists()
+
+
+def test_stale_lock_cleanup_preserves_lock_when_unlink_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("999999\n", encoding="utf-8")
+
+    def fail_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        if path == lock_path:
+            raise OSError("permission denied")
+        path.unlink(*args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_unlink)
+
+    with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+        store.save_record(_record(status="running"))
+
+    assert exc_info.value.receipt["reason"] == "record_write_locked"
+
+
+def test_lock_cleanup_treats_permission_errors_as_active_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("42\n", encoding="utf-8")
+
+    def deny_signal(pid: int, signal: int) -> None:
+        raise PermissionError("not owned")
+
+    monkeypatch.setattr(os, "kill", deny_signal)
+
+    with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+        store.save_record(_record(status="running"))
+
+    assert exc_info.value.receipt["reason"] == "record_write_locked"
+
+
+def test_lock_cleanup_treats_eperm_oserror_as_active_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("42\n", encoding="utf-8")
+
+    def deny_signal(pid: int, signal: int) -> None:
+        error = OSError("not owned")
+        error.errno = 1
+        raise error
+
+    monkeypatch.setattr(os, "kill", deny_signal)
+
+    with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+        store.save_record(_record(status="running"))
+
+    assert exc_info.value.receipt["reason"] == "record_write_locked"
+
+
+def test_with_revision_rejects_negative_revision() -> None:
+    with pytest.raises(ValueError, match="revision must be non-negative"):
+        _record().with_revision(-1)
+
+
+def test_with_revision_rejects_null_revision() -> None:
+    with pytest.raises(ValueError, match="revision must be an integer"):
+        _record().with_revision(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "job_id",
+    (
+        "bad:name",
+        "bad*name",
+        "bad?name",
+        'bad"name',
+        "bad<name",
+        "bad>name",
+        "bad|name",
+        "bad\x00name",
+        "bad\nname",
+    ),
+)
+def test_record_validation_rejects_cross_platform_unsafe_job_ids(job_id: str) -> None:
+    with pytest.raises(ValueError):
+        _record(job_id=job_id).to_dict()
 
 
 @pytest.mark.parametrize(

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
+from errno import EPERM
 from pathlib import Path
 from typing import Any, Iterator, Sequence
 
@@ -13,6 +15,7 @@ RECEIPT_SCHEMA_VERSION = "melix.local_job_continuation_receipt.v1"
 
 JOB_STATUSES = frozenset({"pending", "running", "completed", "failed", "timeout", "blocked"})
 FOLLOWUP_STATUSES = frozenset({"not_started", "pending", "in_progress", "completed", "blocked"})
+JOB_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 class LocalJobContinuationStoreError(RuntimeError):
@@ -85,7 +88,9 @@ class LocalJobContinuationRecord:
         parsed_revision = _optional_int(revision, "revision")
         if parsed_revision is None:
             raise ValueError("revision must be an integer")
-        return replace(self, revision=max(0, parsed_revision))
+        if parsed_revision < 0:
+            raise ValueError("local job continuation revision must be non-negative")
+        return replace(self, revision=parsed_revision)
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,9 +115,11 @@ class LocalJobContinuationStore:
 
     def load_record(self, job_id: str) -> LocalJobContinuationRecord | None:
         path = self._record_path(job_id)
-        if not path.exists():
+        try:
+            content = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
             return None
-        return LocalJobContinuationRecord.from_dict(json.loads(path.read_text(encoding="utf-8")))
+        return LocalJobContinuationRecord.from_dict(json.loads(content))
 
     def save_record(
         self,
@@ -162,7 +169,7 @@ class LocalJobContinuationStore:
         lock_path = path.with_suffix(path.suffix + ".lock")
         fd: int | None = None
         try:
-            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            fd = self._open_record_lock(lock_path)
             os.write(fd, f"{os.getpid()}\n".encode("utf-8"))
             yield
         except FileExistsError as exc:
@@ -185,8 +192,32 @@ class LocalJobContinuationStore:
                 os.close(fd)
                 try:
                     lock_path.unlink()
-                except FileNotFoundError:
+                except OSError:
                     pass
+
+    def _open_record_lock(self, lock_path: Path) -> int:
+        try:
+            return os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            if self._remove_stale_record_lock(lock_path):
+                return os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            raise
+
+    def _remove_stale_record_lock(self, lock_path: Path) -> bool:
+        try:
+            raw_pid = lock_path.read_text(encoding="utf-8").strip()
+            pid = int(raw_pid)
+        except (OSError, ValueError):
+            return False
+        if pid <= 0 or _process_is_active(pid):
+            return False
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            return True
+        except OSError:
+            return False
+        return True
 
 
 def reconcile_local_job_continuation(
@@ -415,9 +446,21 @@ def _safe_job_id(job_id: str) -> str:
     if not isinstance(job_id, str) or not job_id.strip():
         raise ValueError("local job continuation job_id is required")
     normalized = job_id.strip()
-    if normalized in {".", ".."} or any(character in normalized for character in ("/", "\\")):
+    if normalized in {".", ".."} or JOB_ID_PATTERN.fullmatch(normalized) is None:
         raise ValueError("local job continuation job_id must be path-safe")
     return normalized
+
+
+def _process_is_active(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError as exc:
+        return exc.errno == EPERM
+    return True
 
 
 __all__ = [

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, replace
 from errno import EPERM
 from pathlib import Path
 from typing import Any, Iterator, Sequence
+from uuid import uuid4
 
 
 RECORD_SCHEMA_VERSION = "melix.local_job_continuation_record.v1"
@@ -200,24 +201,97 @@ class LocalJobContinuationStore:
             return os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
         except FileExistsError:
             if self._remove_stale_record_lock(lock_path):
-                return os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                try:
+                    return os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                except FileExistsError:
+                    pass
             raise
 
     def _remove_stale_record_lock(self, lock_path: Path) -> bool:
+        guard_path = lock_path.with_name(f"{lock_path.name}.recovery")
+        guard_fd = self._open_record_lock_recovery_guard(guard_path)
+        if guard_fd is None:
+            return False
         try:
-            raw_pid = lock_path.read_text(encoding="utf-8").strip()
+            try:
+                raw_pid = lock_path.read_text(encoding="utf-8").strip()
+                pid = int(raw_pid)
+            except (OSError, ValueError):
+                return False
+            if pid <= 0 or _process_is_active(pid):
+                return False
+
+            temp_path = lock_path.with_name(f"{lock_path.name}.stale.{os.getpid()}.{uuid4().hex}")
+            try:
+                os.rename(lock_path, temp_path)
+            except FileNotFoundError:
+                return True
+            except OSError:
+                return False
+
+            try:
+                current_pid = int(temp_path.read_text(encoding="utf-8").strip())
+            except (OSError, ValueError):
+                self._restore_renamed_record_lock(temp_path, lock_path)
+                return False
+            if current_pid != pid or _process_is_active(current_pid):
+                self._restore_renamed_record_lock(temp_path, lock_path)
+                return False
+            try:
+                temp_path.unlink()
+            except FileNotFoundError:
+                return True
+            except OSError:
+                self._restore_renamed_record_lock(temp_path, lock_path)
+                return False
+            return True
+        finally:
+            os.close(guard_fd)
+            try:
+                guard_path.unlink()
+            except OSError:
+                pass
+
+    def _open_record_lock_recovery_guard(self, guard_path: Path) -> int | None:
+        try:
+            fd = os.open(guard_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            if not self._remove_stale_record_lock_recovery_guard(guard_path):
+                return None
+            try:
+                fd = os.open(guard_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            except FileExistsError:
+                return None
+        os.write(fd, f"{os.getpid()}\n".encode("utf-8"))
+        return fd
+
+    def _remove_stale_record_lock_recovery_guard(self, guard_path: Path) -> bool:
+        try:
+            raw_pid = guard_path.read_text(encoding="utf-8").strip()
             pid = int(raw_pid)
         except (OSError, ValueError):
             return False
         if pid <= 0 or _process_is_active(pid):
             return False
         try:
-            lock_path.unlink()
+            guard_path.unlink()
         except FileNotFoundError:
             return True
         except OSError:
             return False
         return True
+
+    def _restore_renamed_record_lock(self, temp_path: Path, lock_path: Path) -> None:
+        try:
+            os.link(temp_path, lock_path)
+        except FileExistsError:
+            pass
+        except OSError:
+            return
+        try:
+            temp_path.unlink()
+        except OSError:
+            pass
 
 
 def reconcile_local_job_continuation(
@@ -452,8 +526,12 @@ def _safe_job_id(job_id: str) -> str:
 
 
 def _process_is_active(pid: int) -> bool:
+    if os.name == "nt":
+        return True
     try:
         os.kill(pid, 0)
+    except ValueError:
+        return True
     except ProcessLookupError:
         return False
     except PermissionError:


### PR DESCRIPTION
## Summary
- Harden local job continuation records after the #1992/#1994 review by validating job ids with a cross-platform safe pattern and rejecting `.`/`..`.
- Make record loading resilient to delete-after-lookup races and make negative continuation revisions explicit validation errors.
- Replace unsafe stale writer-lock deletion with guarded stale lock recovery: dead PID locks are recovery-guarded, atomically renamed, revalidated, and restored or preserved on races.
- Treat Windows PID liveness as conservatively active instead of calling `os.kill(pid, 0)`.
- Update the governing #1756 plan and unified agentic tool runtime contract with the tightened record contract.

## Plan or Spec
- Issue: #1756
- Follow-up to review feedback on #1992 and #1994.
- Plan: `docs/plans/2026-06-10-issue-1756-local-job-continuation-records.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py
# 68 passed in 0.08s

mkdir -p .runtime/coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file=.runtime/coverage/local_job_continuation.coverage -m pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py
# 68 passed in 0.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file=.runtime/coverage/local_job_continuation.coverage -o .runtime/coverage/local_job_continuation.json
# Wrote JSON report to .runtime/coverage/local_job_continuation.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json .runtime/coverage/local_job_continuation.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py
# services/mlx-worker-python/worker/runtime/local_job_continuation.py 100.00% 117/117
# services/mlx-worker-python/tests/test_local_job_continuation.py 97.78% 309/316
# TOTAL 98.38% 426/433

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts import pre_commit_gate
root = Path.cwd()
changed = pre_commit_gate.staged_changed_files(root, base_ref="origin/main")
outcome = pre_commit_gate.run_performance_report(root, changed, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# Melix PR Scoped Performance Report: Status ok; changed files 4; selected probes 0; regressions 0; context regressions 0; verification failures 0
# Report: .runtime/pre-commit-performance/20260610-173001-b0fd9934/report/report.md

.githooks/pre-commit
# enforced: macOS host memory is 256.0 GiB
# make swift-test: rc=0, elapsed=412.0s
# make py-test: rc=0, 3865 passed, 14 skipped, 2 warnings in 159.64s, elapsed=160.2s
# make integration-test: rc=0, 117 passed, 1 skipped in 463.14s, elapsed=464.1s
# Melix PR Scoped Performance Report: Status ok; changed files 4; selected probes 0; direct/gated probes 0; regressions 0; context regressions 0; verification failures 0
# Report: .runtime/pre-commit-performance/20260610-180039-b0fd9934/report/report.md

git merge --no-edit origin/main
# merged origin/main commit 60ec347b without conflicts

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py
# 68 passed in 0.06s

mkdir -p .runtime/coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file=.runtime/coverage/local_job_continuation.coverage -m pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py
# 68 passed in 0.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file=.runtime/coverage/local_job_continuation.coverage -o .runtime/coverage/local_job_continuation.json
# Wrote JSON report to .runtime/coverage/local_job_continuation.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json .runtime/coverage/local_job_continuation.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py
# services/mlx-worker-python/worker/runtime/local_job_continuation.py 100.00% 117/117
# services/mlx-worker-python/tests/test_local_job_continuation.py 97.78% 309/316
# TOTAL 98.38% 426/433

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts import pre_commit_gate
root = Path.cwd()
changed = pre_commit_gate.staged_changed_files(root, base_ref="origin/main")
outcome = pre_commit_gate.run_performance_report(root, changed, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# Melix PR Scoped Performance Report: Status ok; changed files 4; selected probes 0; regressions 0; context regressions 0; verification failures 0
# Report: .runtime/pre-commit-performance/20260610-180512-7e678788/report/report.md

git merge-base --is-ancestor origin/main HEAD
# passed
```

## Coverage and Metrics
- Changed-line coverage: 98.38% total, 426/433 changed lines covered.
- Runtime changed-line coverage: 100.00%, 117/117 changed lines covered in `services/mlx-worker-python/worker/runtime/local_job_continuation.py`.
- Test changed-line coverage: 97.78%, 309/316 changed lines covered in `services/mlx-worker-python/tests/test_local_job_continuation.py`.
- Local scoped performance report: status `ok`, selected probes `0`, regressions `0`, context regressions `0`, verification failures `0`.
- Full pre-commit performance report: status `ok`, selected probes `0`, direct/gated probes `0`, regressions `0`, context regressions `0`, verification failures `0`.
- Post-merge scoped performance report: status `ok`, selected probes `0`, regressions `0`, context regressions `0`, verification failures `0`.
- Observability mode: `evidence`; this change only hardens persisted local continuation-record behavior and tests.
- Probe overhead: N/A, no observability probe behavior changed and no registered performance probes were selected.

## Known Gaps
- Runner scheduling, monitor replay side effects, and higher-level follow-up actions remain deferred to later #1756 slices.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
