### PR TITLE
Handle disappearing stale continuation locks

### DIFF
--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -447,7 +447,9 @@ before deletion. Windows process IDs are treated as active because
 `os.kill(pid, 0)` is not a portable liveness probe there. Malformed lock files,
 permission-protected active processes, active recovery guards, concurrent lock
 reacquisition, and failed lock cleanup all preserve the lock or refuse the write
-instead of deleting a possibly active writer lock.
+instead of deleting a possibly active writer lock. If the stale candidate
+disappears before its writer PID can be read, the store treats the lock as
+already cleared and retries acquisition instead of reporting a blocked write.
 
 Persisted local-job state is advisory. A record marked `completed` is accepted
 as final only when a success marker path or artifact path is present on the

--- a/services/mlx-worker-python/tests/test_local_job_continuation.py
+++ b/services/mlx-worker-python/tests/test_local_job_continuation.py
@@ -306,6 +306,29 @@ def test_stale_lock_cleanup_tolerates_concurrent_lock_removal(tmp_path: Path) ->
     assert not lock_path.exists()
 
 
+def test_stale_lock_cleanup_retries_when_lock_disappears_before_pid_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    lock_path = tmp_path / "job-7.json.lock"
+    lock_path.write_text("999999\n", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def remove_before_pid_read(path: Path, *args: object, **kwargs: object) -> str:
+        if path == lock_path and lock_path.exists():
+            lock_path.unlink()
+            raise FileNotFoundError(path)
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", remove_before_pid_read)
+
+    saved = store.save_record(_record(status="running"))
+
+    assert saved.status == "running"
+    assert not lock_path.exists()
+
+
 def test_stale_lock_recovery_blocks_when_guard_is_active(tmp_path: Path) -> None:
     store = LocalJobContinuationStore(tmp_path)
     tmp_path.mkdir(parents=True, exist_ok=True)

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -216,6 +216,8 @@ class LocalJobContinuationStore:
             try:
                 raw_pid = lock_path.read_text(encoding="utf-8").strip()
                 pid = int(raw_pid)
+            except FileNotFoundError:
+                return True
             except (OSError, ValueError):
                 return False
             if pid <= 0 or _process_is_active(pid):


### PR DESCRIPTION
## Summary
- Fix the #1994 stale-lock recovery edge case where another writer removes the lock between the initial `FileExistsError` and PID read.
- Treat that `FileNotFoundError` as an already-cleared stale candidate so `_open_record_lock` retries acquisition instead of surfacing a spurious `record_write_locked` receipt.
- Add a focused regression test for the lock-disappears-before-PID-read race and document the retry behavior in the unified agentic runtime contract.

## Plan or Spec
- Issue: #1756
- Follow-up to merged PR #1994 review thread: https://github.com/Keith-CY/melix/pull/1994#discussion_r3390511031
- Plan: `docs/plans/2026-06-10-issue-1756-local-job-continuation-records.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_stale_lock_cleanup_retries_when_lock_disappears_before_pid_read
# before fix: failed with LocalJobContinuationStoreError / record_write_locked
# after fix: 1 passed in 0.02s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py
# 69 passed in 0.10s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py
# 69 passed in 0.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage report -m services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py
# TOTAL 783 statements, 11 missed, 99% coverage
# services/mlx-worker-python/worker/runtime/local_job_continuation.py: 99%
# services/mlx-worker-python/tests/test_local_job_continuation.py: 98%
# services/mlx-worker-python/tests/test_background_continuation.py: 98%

git diff --cached --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts import pre_commit_gate
root = Path.cwd()
changed = pre_commit_gate.staged_changed_files(root, base_ref="origin/main")
outcome = pre_commit_gate.run_performance_report(root, changed, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# Melix PR Scoped Performance Report: Status ok; changed files 3; selected probes 0; direct/gated probes 0; regressions 0; context regressions 0; verification failures 0
# Report: .runtime/pre-commit-performance/20260610-184338-c176e7d7/report/report.md

.githooks/pre-commit
# make swift-test: rc=0, elapsed=502.9s
# make py-test: rc=0, 3866 passed, 14 skipped, 2 warnings in 189.00s, elapsed=189.6s
# make integration-test: rc=0, 117 passed, 1 skipped in 690.86s, elapsed=691.1s
# Melix PR Scoped Performance Report: Status ok; changed files 3; selected probes 0; direct/gated probes 0; regressions 0; context regressions 0; verification failures 0
# Report: .runtime/pre-commit-performance/20260610-190654-c176e7d7/report/report.md
```

## Coverage and Metrics
- Changed-scope coverage: 99% total, 783 statements, 11 missed.
- Runtime continuation module coverage: 99% for `services/mlx-worker-python/worker/runtime/local_job_continuation.py`.
- Local continuation tests coverage: 98% for `services/mlx-worker-python/tests/test_local_job_continuation.py`.
- Background continuation tests coverage: 98% for `services/mlx-worker-python/tests/test_background_continuation.py`.
- Local scoped performance report: status `ok`, changed files `3`, selected probes `0`, direct/gated probes `0`, regressions `0`, context regressions `0`, verification failures `0`.
- Full pre-commit performance report: status `ok`, changed files `3`, selected probes `0`, direct/gated probes `0`, regressions `0`, context regressions `0`, verification failures `0`.
- Observability mode: `evidence`; this change only hardens persisted local continuation-record lock behavior and tests.
- Probe overhead: N/A, no observability probe behavior changed and no registered performance probes were selected.

## Known Gaps
- Runner scheduling, monitor replay side effects, and higher-level follow-up actions remain deferred to later #1756 slices.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
