### PR TITLE
Claim local job follow-ups once

### DIFF
--- a/docs/plans/2026-06-10-issue-1756-local-job-continuation-records.md
+++ b/docs/plans/2026-06-10-issue-1756-local-job-continuation-records.md
@@ -21,9 +21,13 @@ This slice covers:
 - a store-backed reconciliation entrypoint that loads the latest persisted
   record, applies live evidence, and writes revived or evidence-enriched state
   back with the record revision guard;
+- a store-backed follow-up claim primitive that marks an evidence-backed
+  completed job as `in_progress` exactly once before a later monitor projects
+  prompt follow-up data;
 - typed receipts for `live_session_reused`, `stale_done_revived`,
-  `completion_evidence_accepted`, `missing_completion_evidence`, and store
-  write refusal cases;
+  `completion_evidence_accepted`, `missing_completion_evidence`,
+  `followup_claimed`, `followup_already_claimed`, `followup_not_ready`, and
+  store write refusal cases;
 - focused Python tests for record round-trip, stale-state self-healing,
   duplicate-launch refusal through live-session reuse, completion evidence
   gating, and write guards;
@@ -31,7 +35,9 @@ This slice covers:
 
 This slice does not start shell commands, poll processes, tail logs, inject chat
 follow-ups, or resume a workflow session. Future runner and monitor slices will
-use this primitive before adding side effects.
+use this primitive before adding side effects. The follow-up claim primitive is
+the monitor-side state transition that future side-effecting monitors must
+perform before prompt projection.
 
 ## Best End-State Architecture
 
@@ -61,6 +67,9 @@ Success metrics:
   candidate exists;
 - store-backed reconciliation performs one bounded record read and, only when
   state changes, one guarded atomic record write;
+- follow-up claiming performs one bounded record read and, only when a
+  completed evidence-backed record is claimable or blocked by missing evidence,
+  one guarded atomic record write;
 - changed-line Python coverage for the touched runtime module and tests is at
   least 95 percent;
 - local and hosted PR-scoped performance reports are `Status: ok` with zero
@@ -82,9 +91,12 @@ Success metrics:
    `LocalJobContinuationStore`, and `reconcile_local_job_continuation`.
 3. Add store-backed reconciliation so future monitors can self-heal stale
    persisted state in place without bypassing revision guards.
-4. Record the contract in the unified agentic runtime document beside the
+4. Add store-backed follow-up claiming so a future monitor can reserve exactly
+   one prompt follow-up for an evidence-backed completed job while preserving
+   duplicate-claim and missing-evidence receipts.
+5. Record the contract in the unified agentic runtime document beside the
    existing background-continuation prompt-boundary primitive.
-5. Run focused tests, changed-line coverage, full local pre-commit, and the PR
+6. Run focused tests, changed-line coverage, full local pre-commit, and the PR
    performance gate before merge.
 
 ## Success Criteria
@@ -97,6 +109,9 @@ Success metrics:
 - A live matching session is reused instead of duplicated, with a typed receipt.
 - Store-backed reconciliation persists revived running state and live completion
   evidence with optimistic revision protection.
+- Store-backed follow-up claiming marks an evidence-backed completed record
+  `in_progress` exactly once, persists live completion evidence before claiming
+  when needed, and rejects duplicate or premature claims with typed receipts.
 - Concurrent record writes are rejected before silent overwrite, while stale
   lock files left by dead writer processes may be recovered without human
   cleanup after the stale file is guarded, renamed, and revalidated.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -471,10 +471,20 @@ running state or live completion evidence with the same optimistic revision
 guard used by normal writes, and returns `None` when no record exists for the
 job ID. If another writer changes the record during reconciliation, the write
 must fail closed with the existing `record_revision_mismatch` receipt. The
-primitive does not start processes, tail logs, inject prompt follow-ups, or
-resume workflows; those later surfaces must first call the reconciliation
-primitive and then pass any already-redacted completion summary through
-`admit_background_continuation` before prompt projection.
+same store owns follow-up claiming through `LocalJobContinuationStore.claim_followup`.
+Claiming first reconciles the latest persisted record with optional live
+completion evidence, then marks an evidence-backed completed record
+`followup_status = in_progress` with the claiming follow-up session ID. Duplicate
+claims must return `reason = followup_already_claimed` without changing the
+record. Non-completed records return `reason = followup_not_ready`, and
+completed records without success or artifact evidence keep the existing
+`missing_completion_evidence` blocker. Claim writes use the record revision
+guard so two monitor loops cannot silently enqueue two follow-ups.
+
+The primitive does not start processes, tail logs, inject prompt follow-ups, or
+resume workflows; those later surfaces must first call reconciliation and
+follow-up claiming, and then pass any already-redacted completion summary
+through `admit_background_continuation` before prompt projection.
 
 The Python worker skill and memory admission primitives are
 `worker.runtime.skill_memory_context.admit_skill_context` and

--- a/services/mlx-worker-python/tests/test_local_job_continuation.py
+++ b/services/mlx-worker-python/tests/test_local_job_continuation.py
@@ -89,6 +89,7 @@ def test_stale_completed_record_with_live_progress_is_revived() -> None:
         "session_id": "session-7",
         "exit_status": None,
         "followup_status": "not_started",
+        "followup_session_id": "",
         "duplicate_launch_refused": True,
         "completion_evidence_available": False,
         "corrective_action": (
@@ -247,6 +248,144 @@ def test_store_reconcile_persists_stale_done_self_heal_and_completion_evidence(
     assert store.load_record("job-7") == accepted.record
 
 
+def test_store_claim_followup_marks_completed_job_in_progress_once(tmp_path: Path) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    completed = store.save_record(
+        _record(
+            status="completed",
+            exit_status=0,
+            success_marker_path="/workspace/.runtime/jobs/job-7.success",
+        )
+    )
+
+    claimed = store.claim_followup("job-7", followup_session_id=" followup-session-7 ")
+
+    assert claimed is not None
+    assert claimed.record == replace(
+        completed,
+        followup_status="in_progress",
+        followup_session_id="followup-session-7",
+        revision=1,
+    )
+    assert claimed.receipt["reason"] == "followup_claimed"
+    assert claimed.receipt["followup_status"] == "in_progress"
+    assert claimed.receipt["followup_session_id"] == "followup-session-7"
+    assert claimed.receipt["completion_evidence_available"] is True
+    assert store.load_record("job-7") == claimed.record
+
+    duplicate = store.claim_followup("job-7", followup_session_id="other-followup")
+
+    assert duplicate is not None
+    assert duplicate.record == claimed.record
+    assert duplicate.receipt["reason"] == "followup_already_claimed"
+    assert duplicate.receipt["followup_session_id"] == "followup-session-7"
+    assert store.load_record("job-7") == claimed.record
+
+
+def test_store_claim_followup_blocks_completed_record_without_evidence(tmp_path: Path) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    completed = store.save_record(_record(status="completed", exit_status=0))
+
+    blocked = store.claim_followup("job-7", followup_session_id="followup-session-7")
+
+    assert blocked is not None
+    assert blocked.record == replace(completed, status="blocked", revision=1)
+    assert blocked.receipt["reason"] == "missing_completion_evidence"
+    assert blocked.receipt["completion_evidence_available"] is False
+    assert blocked.receipt["followup_status"] == "not_started"
+    assert blocked.receipt["followup_session_id"] == ""
+    assert store.load_record("job-7") == blocked.record
+
+
+def test_store_claim_followup_persists_live_completion_evidence_before_claim(
+    tmp_path: Path,
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    completed = store.save_record(_record(status="completed", exit_status=0))
+
+    claimed = store.claim_followup(
+        "job-7",
+        followup_session_id="followup-session-7",
+        live_evidence=LocalJobLiveEvidence(
+            session_id="session-7",
+            active=False,
+            progress_excerpt="completed",
+            artifact_paths=(" /workspace/out/final.json ",),
+        ),
+    )
+
+    assert claimed is not None
+    assert claimed.record == replace(
+        completed,
+        followup_status="in_progress",
+        followup_session_id="followup-session-7",
+        artifact_paths=("/workspace/out/final.json",),
+        revision=1,
+    )
+    assert claimed.receipt["reason"] == "followup_claimed"
+    assert claimed.receipt["completion_evidence_available"] is True
+    assert store.load_record("job-7") == claimed.record
+
+
+def test_store_claim_followup_preserves_non_completed_records(tmp_path: Path) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    running = store.save_record(_record(status="running"))
+
+    result = store.claim_followup("job-7", followup_session_id="followup-session-7")
+
+    assert result is not None
+    assert result.record == running
+    assert result.receipt["reason"] == "followup_not_ready"
+    assert result.receipt["followup_status"] == "not_started"
+    assert store.load_record("job-7") == running
+
+
+def test_store_claim_followup_uses_revision_guard_for_concurrent_claim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    completed = store.save_record(
+        _record(
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/final.json",),
+        )
+    )
+    original_save_record = store.save_record
+    injected_race = False
+
+    def race_before_claim_write(
+        record: LocalJobContinuationRecord,
+        *,
+        expected_revision: int | None = None,
+    ) -> LocalJobContinuationRecord:
+        nonlocal injected_race
+        if not injected_race and expected_revision == completed.revision:
+            injected_race = True
+            original_save_record(
+                replace(
+                    completed,
+                    followup_status="in_progress",
+                    followup_session_id="other-followup",
+                ),
+                expected_revision=completed.revision,
+            )
+        return original_save_record(record, expected_revision=expected_revision)
+
+    monkeypatch.setattr(store, "save_record", race_before_claim_write)
+
+    with pytest.raises(LocalJobContinuationStoreError) as exc_info:
+        store.claim_followup("job-7", followup_session_id="followup-session-7")
+
+    assert exc_info.value.receipt["reason"] == "record_revision_mismatch"
+    assert store.load_record("job-7") == replace(
+        completed,
+        followup_status="in_progress",
+        followup_session_id="other-followup",
+        revision=1,
+    )
+
+
 def test_store_reconcile_returns_none_for_missing_record(tmp_path: Path) -> None:
     store = LocalJobContinuationStore(tmp_path)
 
@@ -368,6 +507,7 @@ def test_store_lock_guard_rejects_active_writer(tmp_path: Path) -> None:
         "session_id": "",
         "exit_status": None,
         "followup_status": "blocked",
+        "followup_session_id": "",
         "duplicate_launch_refused": False,
         "completion_evidence_available": False,
         "corrective_action": "Retry after the active local job record writer finishes.",

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -178,6 +178,28 @@ class LocalJobContinuationStore:
         saved = self.save_record(result.record, expected_revision=record.revision)
         return LocalJobContinuationReconciliation(record=saved, receipt=result.receipt)
 
+    def claim_followup(
+        self,
+        job_id: str,
+        *,
+        followup_session_id: str,
+        live_evidence: LocalJobLiveEvidence | None = None,
+    ) -> LocalJobContinuationReconciliation | None:
+        record = self.load_record(job_id)
+        if record is None:
+            return None
+
+        result = claim_local_job_followup(
+            record,
+            followup_session_id=followup_session_id,
+            live_evidence=live_evidence,
+        )
+        if result.record == record:
+            return result
+
+        saved = self.save_record(result.record, expected_revision=record.revision)
+        return LocalJobContinuationReconciliation(record=saved, receipt=result.receipt)
+
     def _record_path(self, job_id: str) -> Path:
         safe_job_id = _safe_job_id(job_id)
         return self.root / f"{safe_job_id}.json"
@@ -412,6 +434,86 @@ def reconcile_local_job_continuation(
     )
 
 
+def claim_local_job_followup(
+    record: LocalJobContinuationRecord,
+    *,
+    followup_session_id: str,
+    live_evidence: LocalJobLiveEvidence | None = None,
+) -> LocalJobContinuationReconciliation:
+    _validate_record(record)
+    normalized_followup_session_id = _required_runtime_text(
+        followup_session_id,
+        "followup_session_id",
+    )
+    reconciled = reconcile_local_job_continuation(record, live_evidence=live_evidence)
+    record = reconciled.record
+    evidence_available = _has_completion_evidence(record, live_evidence)
+
+    if reconciled.receipt.get("reason") == "missing_completion_evidence":
+        return reconciled
+
+    if record.followup_status in {"pending", "in_progress", "completed"}:
+        return LocalJobContinuationReconciliation(
+            record=record,
+            receipt=_receipt(
+                job_id=record.job_id,
+                status=record.status,
+                reason="followup_already_claimed",
+                session_id=record.session_id,
+                exit_status=record.exit_status,
+                followup_status=record.followup_status,
+                duplicate_launch_refused=False,
+                completion_evidence_available=evidence_available,
+                corrective_action=(
+                    "Do not enqueue another local job follow-up for this record."
+                ),
+                followup_session_id=record.followup_session_id,
+            ),
+        )
+
+    if record.status != "completed":
+        return LocalJobContinuationReconciliation(
+            record=record,
+            receipt=_receipt(
+                job_id=record.job_id,
+                status=record.status,
+                reason="followup_not_ready",
+                session_id=record.session_id,
+                exit_status=record.exit_status,
+                followup_status=record.followup_status,
+                duplicate_launch_refused=False,
+                completion_evidence_available=evidence_available,
+                corrective_action=(
+                    "Wait until the local job is completed with explicit evidence before follow-up."
+                ),
+                followup_session_id=record.followup_session_id,
+            ),
+        )
+
+    claimed = replace(
+        record,
+        followup_status="in_progress",
+        followup_session_id=normalized_followup_session_id,
+    )
+    return LocalJobContinuationReconciliation(
+        record=claimed,
+        receipt=_receipt(
+            job_id=record.job_id,
+            status=claimed.status,
+            reason="followup_claimed",
+            session_id=claimed.session_id,
+            exit_status=claimed.exit_status,
+            followup_status=claimed.followup_status,
+            duplicate_launch_refused=False,
+            completion_evidence_available=True,
+            corrective_action=(
+                "The monitor may project exactly one admitted background continuation."
+            ),
+            followup_session_id=claimed.followup_session_id,
+        ),
+    )
+
+
 def _receipt(
     *,
     job_id: str,
@@ -423,6 +525,7 @@ def _receipt(
     duplicate_launch_refused: bool,
     completion_evidence_available: bool,
     corrective_action: str,
+    followup_session_id: str = "",
 ) -> dict[str, Any]:
     return {
         "schema_version": RECEIPT_SCHEMA_VERSION,
@@ -432,6 +535,7 @@ def _receipt(
         "session_id": session_id,
         "exit_status": exit_status,
         "followup_status": followup_status,
+        "followup_session_id": followup_session_id,
         "duplicate_launch_refused": duplicate_launch_refused,
         "completion_evidence_available": completion_evidence_available,
         "corrective_action": corrective_action,
@@ -526,6 +630,12 @@ def _required_text(payload: dict[str, Any], field_name: str) -> str:
     return value
 
 
+def _required_runtime_text(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value.strip()
+
+
 def _required_list(payload: dict[str, Any], field_name: str) -> Sequence[Any]:
     value = payload.get(field_name)
     if not isinstance(value, list) or not value:
@@ -599,5 +709,6 @@ __all__ = [
     "LocalJobContinuationStore",
     "LocalJobContinuationStoreError",
     "LocalJobLiveEvidence",
+    "claim_local_job_followup",
     "reconcile_local_job_continuation",
 ]


### PR DESCRIPTION
## Summary
- Refs #1756.
- Adds a store-backed local job follow-up claim primitive that reconciles live evidence and marks completed jobs `in_progress` exactly once before a future monitor projects prompt follow-up data.
- Adds tests for first claim, duplicate claim, missing completion evidence, live evidence persistence before claim, non-completed records, and revision races.
- Updates the issue #1756 plan and unified agentic runtime contract with the claim semantics and typed receipt reasons.

## Plan or Spec
- `docs/plans/2026-06-10-issue-1756-local-job-continuation-records.md`
- `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py
# Red run before implementation: failed 5 tests with AttributeError for missing LocalJobContinuationStore.claim_followup.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py
# 66 passed in 0.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py
# 78 passed in 0.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage report -m services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/worker/runtime/background_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py
# 78 passed in 0.14s
# TOTAL 98%

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts import pre_commit_gate
root = Path.cwd()
changed = pre_commit_gate.staged_changed_files(root, base_ref='origin/main')
print('changed_files=')
for path in changed:
    print(path)
outcome = pre_commit_gate.run_performance_report(root, changed, base_ref='origin/main')
print(f'status={outcome.status}')
print(f'selected_probe_count={outcome.selected_probe_count}')
print(f'report_dir={outcome.report_dir}')
raise SystemExit(0 if outcome.status == 'ok' else 1)
PY
# Status: ok; Changed files: 4; Selected probes: 0; Regressions: 0; Verification failures: 0
# Report: .runtime/pre-commit-performance/20260610-205638-ae7348db/report/report.md

.githooks/pre-commit
# completed rc=0 elapsed=529.3s: make swift-test
# 3875 passed, 14 skipped, 2 warnings in 185.78s (0:03:05)
# completed rc=0 elapsed=186.4s: make py-test
# 117 passed, 1 skipped in 696.70s (0:11:36)
# completed rc=0 elapsed=697.6s: make integration-test
# Performance report: Status: ok; Changed files: 4; Selected probes: 0; Regressions: 0; Verification failures: 0
# Report: .runtime/pre-commit-performance/20260610-212020-ae7348db/report/report.md

.githooks/pre-commit
# Review-thread fix rerun after removing unreachable missing-evidence branch.
# completed rc=0 elapsed=193.4s: make swift-test
# 3875 passed, 14 skipped, 2 warnings in 161.19s (0:02:41)
# completed rc=0 elapsed=161.7s: make py-test
# 117 passed, 1 skipped in 446.95s (0:07:26)
# completed rc=0 elapsed=447.2s: make integration-test
# Performance report: Status: ok; Changed files: 4; Selected probes: 0; Regressions: 0; Verification failures: 0
# Report: .runtime/pre-commit-performance/20260610-214832-c3ef2e40/report/report.md
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 98%`.
- Runtime module coverage: `services/mlx-worker-python/worker/runtime/local_job_continuation.py` 98%; `services/mlx-worker-python/worker/runtime/background_continuation.py` 100%.
- Test coverage: `services/mlx-worker-python/tests/test_local_job_continuation.py` 99%; `services/mlx-worker-python/tests/test_background_continuation.py` 98%.
- Local scoped performance report: `.runtime/pre-commit-performance/20260610-212020-ae7348db/report/report.md`.
- Performance status: `ok`; changed files: 4; selected probes: 0; regressions: 0; verification failures: 0.
- Review-thread fix full-gate scoped performance report: `.runtime/pre-commit-performance/20260610-214832-c3ef2e40/report/report.md`; status `ok`; regressions: 0; verification failures: 0.
- Earlier direct scoped performance report: `.runtime/pre-commit-performance/20260610-205638-ae7348db/report/report.md`; status `ok`; regressions: 0; verification failures: 0.
- Performance probes: no registered PR-scoped probes selected for this Python store primitive. The claim path performs one bounded record read and one guarded atomic write only when a completed evidence-backed record is claimable or a completed record must be blocked for missing evidence.
- Observability mode: `evidence`; the existing `melix.local_job_continuation_receipt.v1` receipt now also carries `followup_session_id`. Probe overhead is `N/A` because this adds no new runtime probe loop or sampling path.
- Protocol changes: `N/A`; no protobuf schema changed.
- Dependency changes: `N/A`; no dependency or lockfile changed.

## Known Gaps
- This slice does not start shell jobs, poll processes, tail logs, project background prompt data, inject session messages, or resume workflows.
- A later monitor slice still needs to call reconciliation plus follow-up claiming before passing redacted completion summaries through `admit_background_continuation`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
