### PR TITLE
perf: fast-path empty tool keyword matching

### DIFF
--- a/docs/plans/2026-06-11-tool-registry-keyword-empty-fastpath.md
+++ b/docs/plans/2026-06-11-tool-registry-keyword-empty-fastpath.md
@@ -1,0 +1,33 @@
+# Tool Registry Keyword Empty-Fastpath Slice
+
+## Scope
+
+This Python-only performance slice is limited to the agentic tool selector keyword matching helper in `services/mlx-worker-python/worker/runtime/tool_registry.py`.
+
+The selector calls `_keyword_tool_matches(...)` for the current turn and recent context during fallback keyword planning. Empty context should return immediately before case folding or boundary preparation. Whitespace-only context keeps the existing post-casefold strip guard so non-empty keyword traffic does not pay an added full-string scan.
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped performance probe `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`. That probe watches `tool_registry.py`, runs the focused tool registry regression tests, includes changed-scope coverage, and reports `selector_planning_elapsed_ms_mean` for `select_agentic_tools_for_turn(...)`.
+
+## Implementation Plan
+
+1. Keep behavior unchanged for empty, whitespace-only, literal, and boundary keyword matching inputs.
+2. Add a fast return before `casefold()` for empty keyword text while preserving the existing whitespace-only guard after case folding.
+3. Run the registered probe test command, coverage command, and probe command locally on Linux.
+4. Use the PR-scoped performance workflow as the merge gate after push.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
+```
+
+## Acceptance
+
+- Focused tool registry tests pass.
+- Changed-scope coverage is at least 95%.
+- The registered probe shows no selector planning regression; lower `selector_planning_elapsed_ms_mean` is the target metric.
+- CI PR-scoped performance completes successfully before merge.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -758,6 +758,20 @@ def test_agentic_tool_selection_records_fallback_when_no_keyword_matches() -> No
     ]
 
 
+def test_agentic_tool_selection_records_fallback_for_whitespace_only_turn() -> None:
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn=" \t\n ",
+            vector_available=False,
+            max_selected_tools=4,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute",)
+    assert result.receipt["selection_mode"] == "fallback"
+    assert result.receipt["fallback_reason"] == "no_keyword_match"
+
+
 def test_tool_registry_exports_worker_tool_config_metadata() -> None:
     config = built_in_tool_config(["image_crop", "local_compute"])
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -506,6 +506,8 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
 
 
 def _keyword_tool_matches(text: str) -> tuple[str, ...]:
+    if not text:
+        return ()
     normalized_text = text.casefold()
     if not normalized_text.strip():
         return ()


### PR DESCRIPTION
## Summary
- Fast-path empty tool keyword matching before case folding.
- Keeps whitespace-only, literal, and boundary keyword behavior unchanged while avoiding added scans on non-empty fallback selector traffic.
- Adds a whitespace-only regression test after CI showed the first empty-or-whitespace attempt could regress adjacent tool-registry probes.

## Plan or Spec
- `docs/plans/2026-06-11-tool-registry-keyword-empty-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 73 passed in 0.25s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# 73 passed in 0.40s; TOTAL 8 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# {"elapsed_ms_mean":22.0485,"selector_planning_elapsed_ms_mean":67.2381,...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py
# {"elapsed_ms_mean":4.1211,"schema_payload_elapsed_ms_mean":144.7273,...}

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 8 0 100%`).
- Registered probe: `tool-registry-select-name-index-cache`.
- Local 3-run base/head select probe comparison after narrowing the slice:
  - `selector_planning_elapsed_ms_mean`: base mean `69.535`, head mean `68.537` (delta `-0.998ms`, `-1.44%`).
  - `elapsed_ms_mean`: base mean `22.352`, head mean `22.587` (delta `+0.235ms`, `+1.05%`, neutral under the 5% gate).
  - `raw_single_config_elapsed_ms_mean`: base mean `16.336`, head mean `16.032` (delta `-0.304ms`, `-1.86%`).
- Local 3-run schema-bytes context probe comparison after narrowing the slice:
  - `elapsed_ms_mean`: base mean `4.424`, head mean `4.533` (delta `+0.110ms`, `+2.48%`, neutral under the 5% gate).
  - `schema_payload_elapsed_ms_mean`: base mean `147.257`, head mean `150.036` (delta `+2.779ms`, `+1.89%`, neutral under the 5% gate).
- CI PR-scoped performance is required before merge because GitHub Actions is the registered probe gate.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed.
- Final merge remains gated on GitHub Actions and the registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead is limited to CI/local synthetic probe execution.
- [x] Deferred work and known gaps are stated explicitly.
