### PR TITLE
perf: precompute keyword-matchable tool names

### DIFF
--- a/docs/plans/2026-06-11-tool-registry-keyword-matchable-names.md
+++ b/docs/plans/2026-06-11-tool-registry-keyword-matchable-names.md
@@ -1,0 +1,48 @@
+# Tool registry keyword matchable names tuple
+
+## Summary
+
+This Python-only performance slice keeps agentic tool selection behavior unchanged
+while reducing per-call work in `_keyword_tool_matches(...)`. The current keyword
+matcher loops over every built-in tool name and skips always-available tools with
+a membership test on each call. This slice precomputes the keyword-matchable tool
+names once at module import and iterates only over that tuple.
+
+## Registered PR-scoped probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+The entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_select_probe.py`
+
+No probe registry change is required for this slice because the registered probe
+already measures selector planning through `selector_planning_elapsed_ms_mean`.
+
+## Optimization slice
+
+Scope is limited to the keyword matcher inside
+`worker.runtime.tool_registry.select_agentic_tools_for_turn(...)`:
+
+- precompute `_KEYWORD_MATCHABLE_TOOL_NAMES` from built-in names excluding
+  `ALWAYS_AVAILABLE_AGENTIC_TOOL_NAMES`;
+- iterate the precomputed tuple in `_keyword_tool_matches(...)`;
+- preserve keyword matching, literal/boundary hint behavior, always-available
+  tool admission, receipt ordering, and fallback semantics.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and the
+registered probe locally on Linux. The PR-scoped performance workflow remains the
+merge gate for base-vs-head validation.
+
+## Success criteria
+
+- Focused Python tests pass.
+- Changed-scope coverage for touched files remains at or above 95%.
+- Registered probe shows non-regressing or improved selector planning metrics.
+- GitHub Actions and the PR-scoped performance workflow are green before merge.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -615,6 +615,25 @@ def test_agentic_tool_selection_uses_builtin_name_set_for_membership() -> None:
     ]
 
 
+def test_agentic_tool_selection_keyword_matchable_names_omit_always_available_tool() -> None:
+    assert tool_registry_module._KEYWORD_MATCHABLE_TOOL_NAMES == tuple(
+        tool_name
+        for tool_name in BUILTIN_AGENTIC_TOOL_NAMES
+        if tool_name not in tool_registry_module.ALWAYS_AVAILABLE_AGENTIC_TOOL_NAMES
+    )
+
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Run deterministic local compute for this answer.",
+            vector_available=False,
+            max_selected_tools=4,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute",)
+    assert result.receipt["selection_mode"] == "fallback"
+
+
 def test_agentic_tool_selection_uses_keyword_fallback_when_vector_unavailable() -> None:
     result = select_agentic_tools_for_turn(
         ToolSelectionInput(

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -59,6 +59,11 @@ BUILTIN_AGENTIC_TOOL_NAMES = (
 )
 _BUILTIN_AGENTIC_TOOL_NAME_SET = frozenset(BUILTIN_AGENTIC_TOOL_NAMES)
 ALWAYS_AVAILABLE_AGENTIC_TOOL_NAMES = ("local_compute",)
+_KEYWORD_MATCHABLE_TOOL_NAMES = tuple(
+    tool_name
+    for tool_name in BUILTIN_AGENTIC_TOOL_NAMES
+    if tool_name not in ALWAYS_AVAILABLE_AGENTIC_TOOL_NAMES
+)
 
 
 class ToolRegistryError(ValueError):
@@ -513,9 +518,7 @@ def _keyword_tool_matches(text: str) -> tuple[str, ...]:
         return ()
     boundary_text = ""
     matches: list[str] = []
-    for tool_name in BUILTIN_AGENTIC_TOOL_NAMES:
-        if tool_name in ALWAYS_AVAILABLE_AGENTIC_TOOL_NAMES:
-            continue
+    for tool_name in _KEYWORD_MATCHABLE_TOOL_NAMES:
         rules = _BUILTIN_TOOL_KEYWORD_HINT_RULES.get(tool_name, ())
         for hint, literal in rules:
             if literal:


### PR DESCRIPTION
## Summary
- Precompute keyword-matchable agentic tool names so keyword fallback no longer checks always-available tools on every `_keyword_tool_matches(...)` call.
- Add a regression test proving the precomputed tuple omits always-available tools while preserving fallback behavior.
- Add the governing performance-slice plan for this tool-registry keyword matcher slice.

## Plan or Spec
- `docs/plans/2026-06-11-tool-registry-keyword-matchable-names.md`
- Existing registered PR-scoped probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 74 passed.
- Changed-scope coverage: 100.00% (`TOTAL 7 0 100%`).
- Local registered probe (`tool_registry_select_probe.py`):
  - baseline `selector_planning_elapsed_ms_mean=77.21734307706356`
  - head `selector_planning_elapsed_ms_mean=66.42137905582786`
  - delta `-10.7959640219997 ms` (~13.98% faster)
  - baseline `elapsed_ms_mean=22.998048830777407`
  - head `elapsed_ms_mean=22.081777919083834`

## Known Gaps
- Linux local validation covers the Python slice only. CI PR-scoped performance remains the required base-vs-head validation source before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before branch creation.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused Python tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally with improved selector planning metric.
- [ ] GitHub Actions and PR-scoped performance workflow completed successfully.
