### PR TITLE
Refresh window shell titlebar navigation

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift
@@ -69,18 +69,33 @@ public struct AppScreenshotCaptureConfig: Equatable, Sendable {
 }
 
 public enum AppScreenshotCaptureCase: Equatable, Sendable {
+    public enum ChatState: String, Equatable, Sendable {
+        case ready = "ready"
+        case noProvider = "no-provider"
+        case noModel = "no-model"
+    }
+
+    case chat(ChatState)
     case workspace(DesktopSurface)
     case toolSection(DesktopToolSection)
     case commandCenter
 
     public static var defaultCases: [AppScreenshotCaptureCase] {
-        DesktopSurface.visibleNavigationCases.map(AppScreenshotCaptureCase.workspace)
-            + DesktopToolSection.allCases.map(AppScreenshotCaptureCase.toolSection)
-            + [.commandCenter]
+        [
+            .chat(.ready),
+            .chat(.noProvider),
+            .chat(.noModel),
+            .workspace(.server),
+            .workspace(.models),
+            .workspace(.workflows),
+            .workspace(.settings),
+        ]
     }
 
     public var id: String {
         switch self {
+        case .chat(let state):
+            return "workspace-chat-\(state.rawValue)"
         case .workspace(let surface):
             return "workspace-\(Self.slug(surface.rawValue))"
         case .toolSection(let section):
@@ -92,6 +107,8 @@ public enum AppScreenshotCaptureCase: Equatable, Sendable {
 
     var kind: String {
         switch self {
+        case .chat:
+            return "chat_state"
         case .workspace:
             return "workspace"
         case .toolSection:
@@ -103,6 +120,8 @@ public enum AppScreenshotCaptureCase: Equatable, Sendable {
 
     var surface: DesktopSurface? {
         switch self {
+        case .chat:
+            return .chat
         case .workspace(let surface):
             return surface
         case .toolSection(let section):
@@ -116,7 +135,16 @@ public enum AppScreenshotCaptureCase: Equatable, Sendable {
         switch self {
         case .toolSection(let section):
             return section
-        case .workspace, .commandCenter:
+        case .chat, .workspace, .commandCenter:
+            return nil
+        }
+    }
+
+    var chatState: ChatState? {
+        switch self {
+        case .chat(let state):
+            return state
+        case .workspace, .toolSection, .commandCenter:
             return nil
         }
     }
@@ -161,7 +189,7 @@ public struct AppScreenshotCaptureManifest: Codable, Equatable, Sendable {
 @MainActor
 public final class AppScreenshotCaptureRunner {
     private let config: AppScreenshotCaptureConfig
-    private let viewModel: RuntimeViewModel
+    private let makeViewModel: @MainActor () -> RuntimeViewModel
     private let renderer: MelixSwiftUIScreenshotRenderer
     private let fileManager: FileManager
     private let cases: [AppScreenshotCaptureCase]
@@ -174,7 +202,9 @@ public final class AppScreenshotCaptureRunner {
         cases: [AppScreenshotCaptureCase] = AppScreenshotCaptureCase.defaultCases
     ) {
         self.config = config
-        self.viewModel = viewModel ?? RuntimeViewModel(client: AppScreenshotCaptureControlPlaneClient())
+        self.makeViewModel = {
+            viewModel ?? RuntimeViewModel(client: AppScreenshotCaptureControlPlaneClient())
+        }
         self.renderer = renderer
         self.fileManager = fileManager
         self.cases = cases
@@ -191,11 +221,12 @@ public final class AppScreenshotCaptureRunner {
         let size = CGSize(width: config.width, height: config.height)
 
         try fileManager.createDirectory(at: screenshotRoot, withIntermediateDirectories: true)
-        await viewModel.start()
 
         var entries: [AppScreenshotCaptureEntry] = []
         for captureCase in cases {
-            apply(captureCase)
+            let viewModel = makeViewModel()
+            await viewModel.start()
+            apply(captureCase, to: viewModel)
             let screenshotURL = screenshotRoot.appendingPathComponent("\(captureCase.id).png")
             let startedAt = Date()
             do {
@@ -206,9 +237,9 @@ public final class AppScreenshotCaptureRunner {
                         to: screenshotURL,
                         size: size
                     )
-                case .workspace, .toolSection:
+                case .chat, .workspace, .toolSection:
                     try renderer.render(
-                        DesktopFoundationRootView(viewModel: viewModel),
+                        AppScreenshotCaptureWindowShellView(viewModel: viewModel),
                         to: screenshotURL,
                         size: size
                     )
@@ -246,8 +277,10 @@ public final class AppScreenshotCaptureRunner {
         return manifest
     }
 
-    private func apply(_ captureCase: AppScreenshotCaptureCase) {
+    private func apply(_ captureCase: AppScreenshotCaptureCase, to viewModel: RuntimeViewModel) {
         switch captureCase {
+        case .chat(let state):
+            applyChatState(state, to: viewModel)
         case .workspace(let surface):
             viewModel.selectSurface(surface)
         case .toolSection(let section):
@@ -255,6 +288,38 @@ public final class AppScreenshotCaptureRunner {
         case .commandCenter:
             break
         }
+    }
+
+    private func applyChatState(_ state: AppScreenshotCaptureCase.ChatState, to viewModel: RuntimeViewModel) {
+        viewModel.applyAppScreenshotChatState(state)
+    }
+}
+
+private struct AppScreenshotCaptureWindowShellView: View {
+    let viewModel: RuntimeViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                Spacer(minLength: 92)
+                DesktopWorkspaceTitleBarTabsView(viewModel: viewModel)
+                Spacer(minLength: 12)
+                DesktopWorkspaceTitleBarActionsView(viewModel: viewModel)
+            }
+            .frame(height: 44)
+            .padding(.horizontal, 14)
+            .background(MelixDesignTokens.Palette.backgroundSurface.color)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(Color.primary.opacity(MelixDesignTokens.StrokeOpacity.hairline))
+                    .frame(height: 1)
+            }
+
+            DesktopWorkspaceShellView(viewModel: viewModel)
+        }
+        .frame(minWidth: 980, minHeight: 680)
+        .background(MelixDesignTokens.Palette.backgroundBase.color)
+        .tint(MelixDesignTokens.accent)
     }
 }
 

--- a/apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift
@@ -301,7 +301,7 @@ private struct AppScreenshotCaptureWindowShellView: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 12) {
-                Spacer(minLength: 92)
+                Spacer(minLength: DesktopShellChromeMetrics.windowTrafficLightAreaWidth)
                 DesktopWorkspaceTitleBarTabsView(viewModel: viewModel)
                 Spacer(minLength: 12)
                 DesktopWorkspaceTitleBarActionsView(viewModel: viewModel)

--- a/apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift
+++ b/apps/macos-menubar/Sources/AppMain/Acceptance/AppScreenshotCaptureRunner.swift
@@ -196,14 +196,14 @@ public final class AppScreenshotCaptureRunner {
 
     public init(
         config: AppScreenshotCaptureConfig,
-        viewModel: RuntimeViewModel? = nil,
+        makeViewModel: (@MainActor () -> RuntimeViewModel)? = nil,
         renderer: MelixSwiftUIScreenshotRenderer = MelixSwiftUIScreenshotRenderer(),
         fileManager: FileManager = .default,
         cases: [AppScreenshotCaptureCase] = AppScreenshotCaptureCase.defaultCases
     ) {
         self.config = config
-        self.makeViewModel = {
-            viewModel ?? RuntimeViewModel(client: AppScreenshotCaptureControlPlaneClient())
+        self.makeViewModel = makeViewModel ?? {
+            RuntimeViewModel(client: AppScreenshotCaptureControlPlaneClient())
         }
         self.renderer = renderer
         self.fileManager = fileManager

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
@@ -252,7 +252,7 @@ struct DesktopShellTabStripView: View {
                 }
                 .buttonStyle(.plain)
                 .keyboardShortcut(shortcutKey(for: surface), modifiers: .command)
-                .accessibilityLabel(surface.rawValue)
+                .accessibilityLabel(LocalizedStringKey(surface.rawValue))
                 .focusable(false)
                 .fixedSize(horizontal: true, vertical: false)
             }

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 enum DesktopShellChromeMetrics {
-    static let workspaceTitleBarContentTopInset: CGFloat = 72
+    static let workspaceTitleBarContentTopInset: CGFloat = 0
     static let titleBarTabHeightBudget: CGFloat = 30
     static let titleBarTabHorizontalPadding: CGFloat = 9
     static let titleBarTabVerticalPadding: CGFloat = 4
@@ -141,14 +141,6 @@ struct DesktopWorkspaceTitleBarActionsView: View {
     var body: some View {
         HStack(spacing: 4) {
             DesktopPaneToggleButton(
-                role: .sidebar,
-                isVisible: viewModel.isDesktopPaneVisible(.sidebar)
-            ) {
-                withAnimation(DesktopWorkspacePaneAnimation.animation) {
-                    viewModel.toggleDesktopPane(.sidebar)
-                }
-            }
-            DesktopPaneToggleButton(
                 role: .inspector,
                 isVisible: viewModel.isDesktopPaneVisible(.inspector)
             ) {
@@ -260,13 +252,14 @@ struct DesktopShellTabStripView: View {
                 }
                 .buttonStyle(.plain)
                 .keyboardShortcut(shortcutKey(for: surface), modifiers: .command)
+                .accessibilityLabel(surface.rawValue)
                 .focusable(false)
                 .fixedSize(horizontal: true, vertical: false)
             }
         }
         .padding(DesktopShellChromeMetrics.titleBarTabContainerInset)
         .frame(height: DesktopShellChromeMetrics.titleBarTabHeightBudget)
-        .background(Color(nsColor: .windowBackgroundColor), in: Capsule())
+        .background(MelixDesignTokens.Palette.backgroundSurface.color, in: Capsule())
         .overlay(
             Capsule()
                 .stroke(Color.primary.opacity(MelixDesignTokens.StrokeOpacity.hairline), lineWidth: 1)
@@ -278,12 +271,14 @@ struct DesktopShellTabStripView: View {
         case .chat:
             return "1"
         case .commandCenter:
-            return "2"
+            return "0"
         case .server:
-            return "3"
+            return "2"
         case .models:
-            return "4"
+            return "3"
         case .workflows:
+            return "4"
+        case .settings:
             return "5"
         case .jobs:
             return "6"
@@ -293,8 +288,6 @@ struct DesktopShellTabStripView: View {
             return "8"
         case .image:
             return "9"
-        case .settings:
-            return "0"
         case .tools:
             return "0"
         }

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 enum DesktopShellChromeMetrics {
     static let workspaceTitleBarContentTopInset: CGFloat = 0
+    // Approximate macOS traffic-light button and leading margin reservation for screenshot chrome.
     static let windowTrafficLightAreaWidth: CGFloat = 92
     static let titleBarTabHeightBudget: CGFloat = 30
     static let titleBarTabHorizontalPadding: CGFloat = 9

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 enum DesktopShellChromeMetrics {
     static let workspaceTitleBarContentTopInset: CGFloat = 0
+    static let windowTrafficLightAreaWidth: CGFloat = 92
     static let titleBarTabHeightBudget: CGFloat = 30
     static let titleBarTabHorizontalPadding: CGFloat = 9
     static let titleBarTabVerticalPadding: CGFloat = 4
@@ -289,7 +290,7 @@ struct DesktopShellTabStripView: View {
         case .image:
             return "9"
         case .tools:
-            return "0"
+            return "t"
         }
     }
 }

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -121,7 +121,7 @@ struct DesktopWorkspaceShellView: View {
                 }
             )
         }
-        .background(Color(nsColor: .windowBackgroundColor))
+        .background(MelixDesignTokens.Palette.backgroundBase.color.ignoresSafeArea())
     }
 
     private func paneVisibilityBinding(

--- a/apps/macos-menubar/Sources/AppMain/Models/DesktopShellState.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/DesktopShellState.swift
@@ -47,7 +47,7 @@ public enum DesktopSurface: String, CaseIterable, Identifiable, Codable, Sendabl
     }
 
     public static var visibleNavigationCases: [DesktopSurface] {
-        [.chat, .commandCenter, .server, .models, .workflows, .jobs, .diagnostics, .api, .image, .settings]
+        [.chat, .server, .models, .workflows, .settings]
     }
 
     public var routeDomainID: String {

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -4251,6 +4251,46 @@ public final class RuntimeViewModel {
         notifyStateChanged()
     }
 
+    func applyAppScreenshotChatState(_ state: AppScreenshotCaptureCase.ChatState) {
+        selectedSurface = .chat
+        switch state {
+        case .ready:
+            ensureChatSessionsBoundToServerSessions()
+            if let selectedServerSession {
+                bindSelectedChatSessionToServer(providerID: selectedServerSession.id)
+            }
+            if selectedChatServerSession == nil,
+               let readyProvider = providers.first(where: { $0.isInteractiveReady }) ?? providers.first {
+                bindSelectedChatSessionToServer(providerID: readyProvider.id)
+            }
+        case .noProvider:
+            selectedProviderID = ""
+            providers = []
+            chatSessions = [
+                DesktopChatSessionState(
+                    id: "chat-screenshot-no-provider",
+                    title: "Chat",
+                    providerID: "",
+                    statusText: "Choose Provider"
+                ),
+            ]
+            loadChatSession(chatSessions[0])
+        case .noModel:
+            ensureChatSessionsBoundToServerSessions()
+            guard let provider = selectedServerSession ?? providers.first else {
+                return applyAppScreenshotChatState(.noProvider)
+            }
+            selectedProviderID = provider.id
+            replaceServerSession(id: provider.id) { session in
+                session.modelID = ""
+                session.lifecycle = .running
+                session.powerState = .active
+            }
+            bindSelectedChatSessionToServer(providerID: provider.id)
+        }
+        notifyStateChanged()
+    }
+
     private func selectToolSectionWithoutNotifying(_ section: DesktopToolSection) {
         selectedSurface = section.domain.surface
         selectedToolSection = section

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -4278,6 +4278,9 @@ public final class RuntimeViewModel {
         case .noModel:
             ensureChatSessionsBoundToServerSessions()
             guard let provider = selectedServerSession ?? providers.first else {
+                assertionFailure(
+                    "applyAppScreenshotChatState(.noModel) called with no providers; falling back to no-provider screenshot state."
+                )
                 return applyAppScreenshotChatState(.noProvider)
             }
             selectedProviderID = provider.id

--- a/apps/macos-menubar/Tests/MenuBarTests/AppMainBootstrapTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/AppMainBootstrapTests.swift
@@ -466,9 +466,10 @@ struct AppMainBootstrapTests {
         #expect(outputJSON["app_path"] as? String == "/tmp/Melix.app")
         #expect(outputJSON["width"] as? Int == 360)
         #expect(outputJSON["height"] as? Int == 240)
-        #expect(screenshots.count == DesktopSurface.visibleNavigationCases.count + DesktopToolSection.allCases.count + 1)
+        #expect(screenshots.count == AppScreenshotCaptureCase.defaultCases.count)
         #expect(fileManager.fileExists(atPath: tempRoot.appendingPathComponent("screenshot_manifest.json").path))
-        #expect(fileManager.fileExists(atPath: tempRoot.appendingPathComponent("screenshots/command-center.png").path))
+        #expect(fileManager.fileExists(atPath: tempRoot.appendingPathComponent("screenshots/workspace-chat-ready.png").path))
+        #expect(fileManager.fileExists(atPath: tempRoot.appendingPathComponent("screenshots/workspace-settings.png").path))
     }
 
     @Test("app screenshot capture entry supports default output flushing and scheduling")

--- a/apps/macos-menubar/Tests/MenuBarTests/AppScreenshotCaptureTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/AppScreenshotCaptureTests.swift
@@ -60,10 +60,6 @@ struct AppScreenshotCaptureTests {
         noProviderViewModel.applyAppScreenshotChatState(.noProvider)
         #expect(noProviderViewModel.providers.isEmpty)
         #expect(noProviderViewModel.selectedChatSession?.statusText == "Choose Provider")
-
-        noProviderViewModel.applyAppScreenshotChatState(.noModel)
-        #expect(noProviderViewModel.providers.isEmpty)
-        #expect(noProviderViewModel.selectedChatSession?.statusText == "Choose Provider")
     }
 
     @Test("config environment normalizes overrides and falls back to deterministic defaults")

--- a/apps/macos-menubar/Tests/MenuBarTests/AppScreenshotCaptureTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/AppScreenshotCaptureTests.swift
@@ -6,31 +6,64 @@ import Testing
 
 @Suite("App Screenshot Capture", .serialized)
 struct AppScreenshotCaptureTests {
-    @Test("default cases cover all workspace surfaces, tool sections, and command center")
+    @Test("default cases cover shell titlebar acceptance surfaces")
     func defaultCasesCoverAllAppSurfaces() {
         let cases = AppScreenshotCaptureCase.defaultCases
+        let chatStates = cases.compactMap { captureCase -> AppScreenshotCaptureCase.ChatState? in
+            guard case .chat(let state) = captureCase else {
+                return nil
+            }
+            return state
+        }
         let workspaceSurfaces = cases.compactMap { captureCase -> String? in
             guard case .workspace(let surface) = captureCase else {
                 return nil
             }
             return surface.rawValue
         }
-        let toolSections = cases.compactMap { captureCase -> String? in
-            guard case .toolSection(let section) = captureCase else {
-                return nil
-            }
-            return section.rawValue
-        }
-        let commandCenterCount = cases.filter {
-            if case .commandCenter = $0 {
-                return true
-            }
-            return false
-        }.count
 
-        #expect(workspaceSurfaces.sorted() == DesktopSurface.visibleNavigationCases.map(\.rawValue).sorted())
-        #expect(toolSections.sorted() == DesktopToolSection.allCases.map(\.rawValue).sorted())
-        #expect(commandCenterCount == 1)
+        #expect(chatStates == [.ready, .noProvider, .noModel])
+        #expect(AppScreenshotCaptureCase.chat(.ready).chatState == .ready)
+        #expect(AppScreenshotCaptureCase.workspace(.chat).chatState == nil)
+        #expect(workspaceSurfaces == ["Servers", "Models", "Workflows", "Settings"])
+        #expect(cases.map(\.id) == [
+            "workspace-chat-ready",
+            "workspace-chat-no-provider",
+            "workspace-chat-no-model",
+            "workspace-servers",
+            "workspace-models",
+            "workspace-workflows",
+            "workspace-settings",
+        ])
+    }
+
+    @Test("chat state fixtures model ready, no provider, and no model states")
+    @MainActor
+    func chatStateFixturesModelChatSetupStates() async throws {
+        let readyViewModel = RuntimeViewModel(client: AppScreenshotCaptureControlPlaneClient())
+        await readyViewModel.start()
+        readyViewModel.applyAppScreenshotChatState(.ready)
+        #expect(readyViewModel.selectedSurface == .chat)
+        #expect(readyViewModel.selectedChatServerSession != nil)
+
+        let noModelViewModel = RuntimeViewModel(client: AppScreenshotCaptureControlPlaneClient())
+        await noModelViewModel.start()
+        noModelViewModel.applyAppScreenshotChatState(.noModel)
+        #expect(noModelViewModel.selectedSurface == .chat)
+        let noModelProvider = try #require(noModelViewModel.selectedChatServerSession)
+        #expect(noModelProvider.modelID.isEmpty)
+        #expect(noModelProvider.lifecycle == .running)
+        #expect(noModelProvider.powerState == .active)
+
+        let noProviderViewModel = RuntimeViewModel(client: AppScreenshotCaptureControlPlaneClient())
+        await noProviderViewModel.start()
+        noProviderViewModel.applyAppScreenshotChatState(.noProvider)
+        #expect(noProviderViewModel.providers.isEmpty)
+        #expect(noProviderViewModel.selectedChatSession?.statusText == "Choose Provider")
+
+        noProviderViewModel.applyAppScreenshotChatState(.noModel)
+        #expect(noProviderViewModel.providers.isEmpty)
+        #expect(noProviderViewModel.selectedChatSession?.statusText == "Choose Provider")
     }
 
     @Test("config environment normalizes overrides and falls back to deterministic defaults")

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -41,11 +41,6 @@ struct DesktopFoundationViewTests {
     @Test("titlebar navigation exposes only the five product domains")
     @MainActor
     func titlebarNavigationExposesOnlyFiveProductDomains() async throws {
-        let root = try repositoryRootForDesktopFoundationTests()
-        let chromeSourceURL = root.appendingPathComponent(
-            "apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift"
-        )
-        let chromeSource = try String(contentsOf: chromeSourceURL, encoding: .utf8)
         let viewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
         await viewModel.start()
 
@@ -64,9 +59,8 @@ struct DesktopFoundationViewTests {
         #expect(visibleLabels.contains("Jobs") == false)
         #expect(visibleLabels.contains("Diagnostics") == false)
         #expect(visibleLabels.contains("Image") == false)
+        #expect(Set(visibleLabels).count == visibleLabels.count)
         #expect(hosted.fittingSize.height <= DesktopShellChromeMetrics.titleBarTabHeightBudget)
-        #expect(chromeSource.contains("ForEach(DesktopSurface.visibleNavigationCases)"))
-        #expect(chromeSource.contains(".accessibilityLabel(surface.rawValue)"))
     }
 
     @Test("shared pane chrome exposes labeled icon controls")

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -38,6 +38,37 @@ struct DesktopFoundationViewTests {
         #expect(viewModel.selectedSurface == .chat)
     }
 
+    @Test("titlebar navigation exposes only the five product domains")
+    @MainActor
+    func titlebarNavigationExposesOnlyFiveProductDomains() async throws {
+        let root = try repositoryRootForDesktopFoundationTests()
+        let chromeSourceURL = root.appendingPathComponent(
+            "apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift"
+        )
+        let chromeSource = try String(contentsOf: chromeSourceURL, encoding: .utf8)
+        let viewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        await viewModel.start()
+
+        let hosted = hostView(DesktopWorkspaceTitleBarTabsView(viewModel: viewModel))
+        let visibleLabels = DesktopSurface.visibleNavigationCases.map(\.rawValue)
+
+        #expect(visibleLabels == [
+            "Chat",
+            "Servers",
+            "Models",
+            "Workflows",
+            "Settings",
+        ])
+        #expect(visibleLabels.contains("Command Center") == false)
+        #expect(visibleLabels.contains("API") == false)
+        #expect(visibleLabels.contains("Jobs") == false)
+        #expect(visibleLabels.contains("Diagnostics") == false)
+        #expect(visibleLabels.contains("Image") == false)
+        #expect(hosted.fittingSize.height <= DesktopShellChromeMetrics.titleBarTabHeightBudget)
+        #expect(chromeSource.contains("ForEach(DesktopSurface.visibleNavigationCases)"))
+        #expect(chromeSource.contains(".accessibilityLabel(surface.rawValue)"))
+    }
+
     @Test("shared pane chrome exposes labeled icon controls")
     @MainActor
     func sharedPaneChromeExposesLabeledIconControls() {
@@ -266,9 +297,9 @@ struct DesktopFoundationViewTests {
         #expect(commandCenter.wasOpened)
     }
 
-    @Test("titlebar exposes pane toggles and command center entry")
+    @Test("titlebar exposes inspector toggle and command center entry")
     @MainActor
-    func titlebarExposesPaneTogglesAndCommandCenterEntry() async throws {
+    func titlebarExposesInspectorToggleAndCommandCenterEntry() async throws {
         let viewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
         let commandCenter = CommandCenterOpenRecorder()
         viewModel.openCommandCenterAction = { commandCenter.open() }
@@ -280,6 +311,7 @@ struct DesktopFoundationViewTests {
 
         let hosted = hostView(DesktopWorkspaceTitleBarActionsView(viewModel: viewModel))
         #expect(hosted.subviews.isEmpty == false)
+        #expect(renderedTextValues(in: hosted).contains("Hide Sidebar") == false)
 
         viewModel.toggleDesktopPane(.inspector)
         #expect(viewModel.isDesktopPaneVisible(.inspector, for: .chat) == false)
@@ -1731,8 +1763,8 @@ struct DesktopFoundationViewTests {
         #expect(registrySource.contains("Run Suitability"))
     }
 
-    @Test("desktop workspace reserves titlebar chrome space")
-    func desktopWorkspaceReservesTitlebarChromeSpace() throws {
+    @Test("desktop workspace removes the artificial titlebar content gap")
+    func desktopWorkspaceRemovesArtificialTitlebarContentGap() throws {
         let root = try repositoryRootForDesktopFoundationTests()
         let chromeSourceURL = root.appendingPathComponent(
             "apps/macos-menubar/Sources/AppMain/Dashboard/DesktopShellChromeView.swift"
@@ -1745,10 +1777,7 @@ struct DesktopFoundationViewTests {
 
         #expect(chromeSource.contains("workspaceTitleBarContentTopInset"))
         #expect(shellSource.contains(".padding(.top, DesktopShellChromeMetrics.workspaceTitleBarContentTopInset)"))
-        #expect(
-            DesktopShellChromeMetrics.workspaceTitleBarContentTopInset
-            >= DesktopShellChromeMetrics.titleBarTabHeightBudget + 24
-        )
+        #expect(DesktopShellChromeMetrics.workspaceTitleBarContentTopInset == 0)
     }
 
     @Test("server sidebar rows opt out of appkit focus rings")

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopShellStateTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopShellStateTests.swift
@@ -21,6 +21,10 @@ struct DesktopShellStateTests {
             "Workflows",
             "Settings",
         ])
+        #expect(DesktopSurface.visibleNavigationCases.contains(.jobs) == false)
+        #expect(DesktopSurface.visibleNavigationCases.contains(.diagnostics) == false)
+        #expect(DesktopSurface.visibleNavigationCases.contains(.api) == false)
+        #expect(DesktopSurface.visibleNavigationCases.contains(.image) == false)
 
         let metadata = DesktopRouteMetadata.acceptedWindowIA
         #expect(metadata.domains.map(\.domain.routeDomainID) == [

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopShellStateTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopShellStateTests.swift
@@ -9,26 +9,16 @@ struct DesktopShellStateTests {
     func desktopRouteMetadataEncodesAcceptedProductIA() throws {
         #expect(DesktopSurface.visibleNavigationCases == [
             .chat,
-            .commandCenter,
             .server,
             .models,
             .workflows,
-            .jobs,
-            .diagnostics,
-            .api,
-            .image,
             .settings,
         ])
         #expect(DesktopSurface.visibleNavigationCases.map(\.rawValue) == [
             "Chat",
-            "Command Center",
             "Servers",
             "Models",
             "Workflows",
-            "Jobs",
-            "Diagnostics",
-            "API",
-            "Image",
             "Settings",
         ])
 

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -1357,6 +1357,7 @@ struct RuntimeViewModelTests {
         await viewModel.start()
 
         #expect(viewModel.selectedSurface == .api)
+        #expect(DesktopSurface.visibleNavigationCases.contains(viewModel.selectedSurface) == false)
         #expect(viewModel.selectedServerSession?.id == restoredServerSession.id)
     }
 

--- a/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
+++ b/services/mlx-text-worker-swift/Tests/CoreTests/WorkerScaffoldTests.swift
@@ -3189,7 +3189,10 @@ final class WorkerScaffoldTests: XCTestCase {
             modelCatalog: WorkerModelCatalog(environment: [
                 "MELIX_DEV_TEXT_MODEL_PATH": "mlx-community/melix-dev-text-4bit"
             ]),
-            runtime: TextRuntime(backend: FakeRuntimeBackend())
+            runtime: TextRuntime(
+                backend: FakeRuntimeBackend(),
+                residentMemoryReader: { 0 }
+            )
         )
 
         var loadRequest = Melix_Worker_V1_ModelSpec()


### PR DESCRIPTION
## Summary
- Move the desktop shell's visible top-level navigation to the titlebar with five product domains: Chat, Servers, Models, Workflows, and Settings.
- Remove the artificial workspace/titlebar gap and keep provider, model, queue, and runtime metrics out of the titlebar.
- Expand screenshot acceptance coverage for Chat ready/no-provider/no-model plus Servers, Models, Workflows, and Settings.

## Plan or Spec
- `docs/plans/2026-06-08-window-ui-chat-first-refresh.md` (Slice PR C)
- `docs/window-ui-product-spec.md`

## Commands Run
```text
env HOME="$PWD/.runtime/test-home-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-menubar" xcrun swift test --package-path apps/macos-menubar --no-parallel -Xswiftc -gnone --filter 'AppScreenshotCaptureTests|AppMainBootstrapTests/app screenshot capture execution supports the default runner factory path|AppMainBootstrapTests/app screenshot capture entry supports default output flushing and scheduling' -> PASS (8 App Screenshot Capture tests)
rm -rf .runtime/app-screenshots/window-ui-shell-titlebar && env MELIX_APP_SCREENSHOT_CAPTURE=1 MELIX_APP_SCREENSHOT_OUTPUT_DIR="$PWD/.runtime/app-screenshots/window-ui-shell-titlebar" MELIX_APP_SCREENSHOT_APP_PATH="/tmp/Melix.app" MELIX_APP_SCREENSHOT_WIDTH=1440 MELIX_APP_SCREENSHOT_HEIGHT=960 apps/macos-menubar/.build/arm64-apple-macosx/debug/melix-menubar > .runtime/app-screenshots/window-ui-shell-titlebar-output.json -> PASS (7 screenshots)
env HOME="$PWD/.runtime/test-home-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-menubar" xcrun swift test --package-path apps/macos-menubar --enable-code-coverage --no-parallel -Xswiftc -gnone -> PASS (799 tests in 25 suites)
git diff --check -> PASS
git commit -m "Refresh window shell titlebar navigation" -> PASS (pre-commit hook ran make swift-test, make py-test, make integration-test, and PR-scoped performance report)
env HOME="$PWD/.runtime/test-home-text-worker" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-text-worker" xcrun swift test --package-path services/mlx-text-worker-swift --filter 'WorkerScaffoldTests/testRuntimeRegistryRejectsPrefillRequestsThatExceedProcessBudget' -> PASS
env HOME="$PWD/.runtime/test-home-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-menubar" xcrun swift test --package-path apps/macos-menubar --no-parallel -Xswiftc -gnone --filter 'titlebarNavigationExposesOnlyFiveProductDomains|AppScreenshotCaptureTests' -> PASS (9 tests in 2 suites)
git commit -m "Address shell titlebar review feedback" -> PASS (pre-commit hook ran make swift-test, make py-test, make integration-test, and PR-scoped performance report)
git merge origin/feat/window-ui-provider-refresh -> PASS (base sync after feature branch was updated to latest origin/main)
git diff --check HEAD~1..HEAD && git diff --check origin/feat/window-ui-provider-refresh...HEAD -> PASS
env HOME="$PWD/.runtime/test-home-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-menubar" xcrun swift test --package-path apps/macos-menubar --no-parallel -Xswiftc -gnone --filter 'titlebarNavigationExposesOnlyFiveProductDomains|AppScreenshotCaptureTests' -> PASS after base sync (9 tests in 2 suites)
env HOME="$PWD/.runtime/test-home-text-worker" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-text-worker" xcrun swift test --package-path services/mlx-text-worker-swift --filter 'WorkerScaffoldTests/testRuntimeRegistryRejectsPrefillRequestsThatExceedProcessBudget' -> PASS after base sync
pre-commit make swift-test -> PASS (includes macOS menubar package: 799 tests in 25 suites)
pre-commit make py-test -> PASS (3886 passed, 14 skipped, 2 warnings)
pre-commit make integration-test -> PASS (117 passed, 1 skipped)
env HOME="$PWD/.runtime/test-home-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-menubar" xcrun swift test --package-path apps/macos-menubar --no-parallel -Xswiftc -gnone --filter 'titlebarNavigationExposesOnlyFiveProductDomains|AppScreenshotCaptureTests' -> PASS for titlebar chrome review fix (9 tests in 2 suites)
git commit -m "Address titlebar chrome review comments" -> PASS (pre-commit hook ran make swift-test, make py-test, make integration-test, and PR-scoped performance report)
git merge --no-edit origin/main on feat/window-ui-provider-refresh -> PASS (base sync to latest origin/main)
git merge --no-edit origin/feat/window-ui-provider-refresh on codex/window-ui-shell-titlebar -> PASS (PR branch base sync)
git diff --check HEAD~1..HEAD && git diff --check origin/feat/window-ui-provider-refresh...HEAD -> PASS after latest base sync
env HOME="$PWD/.runtime/test-home-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-menubar" xcrun swift test --package-path apps/macos-menubar --no-parallel -Xswiftc -gnone --filter 'titlebarNavigationExposesOnlyFiveProductDomains|AppScreenshotCaptureTests' -> PASS after latest base sync (9 tests in 2 suites)
env HOME="$PWD/.runtime/test-home-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-menubar" xcrun swift test --package-path apps/macos-menubar --no-parallel -Xswiftc -gnone --filter 'AppScreenshotCaptureTests|DesktopShellStateTests|RuntimeViewModelTests/restoresSelectedSurfaceAndServerSessionFromOperatorSessionState' -> PASS for screenshot fixture review fix (18 tests in 3 suites)
git diff --check -> PASS
git commit -m "Address screenshot fixture review comments" -> PASS (pre-commit hook ran make swift-test, make py-test, make integration-test, and PR-scoped performance report)
pre-commit make swift-test -> PASS (includes macOS menubar package: 799 tests in 25 suites)
pre-commit make py-test -> PASS (3898 passed, 14 skipped, 2 warnings)
pre-commit make integration-test -> PASS (117 passed, 1 skipped)
git merge --no-edit origin/main on feat/window-ui-provider-refresh -> PASS (base sync to latest origin/main f5d2b1da)
git merge --no-edit origin/feat/window-ui-provider-refresh on codex/window-ui-shell-titlebar -> PASS (PR branch base sync after review-fix commit)
git diff --check HEAD~1..HEAD && git diff --check origin/feat/window-ui-provider-refresh...HEAD -> PASS after review-fix base sync
env HOME="$PWD/.runtime/test-home-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-menubar" xcrun swift test --package-path apps/macos-menubar --no-parallel -Xswiftc -gnone --filter 'AppScreenshotCaptureTests|DesktopShellStateTests|RuntimeViewModelTests/restoresSelectedSurfaceAndServerSessionFromOperatorSessionState' -> PASS after review-fix base sync (18 tests in 3 suites)
git merge --no-edit origin/main on feat/window-ui-provider-refresh -> PASS (base sync to latest origin/main 6975a423)
git merge --no-edit origin/feat/window-ui-provider-refresh on codex/window-ui-shell-titlebar -> PASS (PR branch base sync after latest Python worker performance update)
git diff --check HEAD~1..HEAD && git diff --check origin/feat/window-ui-provider-refresh...HEAD -> PASS after latest main base sync
env HOME="$PWD/.runtime/test-home-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-menubar" xcrun swift test --package-path apps/macos-menubar --no-parallel -Xswiftc -gnone --filter 'AppScreenshotCaptureTests|DesktopShellStateTests|RuntimeViewModelTests/restoresSelectedSurfaceAndServerSessionFromOperatorSessionState' -> PASS after latest main base sync (18 tests in 3 suites)
git merge --no-edit origin/main on feat/window-ui-provider-refresh -> PASS (base sync to latest origin/main f34852b9)
git merge --no-edit origin/feat/window-ui-provider-refresh on codex/window-ui-shell-titlebar -> PASS (PR branch base sync after latest Python worker evaluation fast-path update)
git diff --check HEAD~1..HEAD && git diff --check origin/feat/window-ui-provider-refresh...HEAD -> PASS after second latest main base sync
env HOME="$PWD/.runtime/test-home-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-menubar" xcrun swift test --package-path apps/macos-menubar --no-parallel -Xswiftc -gnone --filter 'AppScreenshotCaptureTests|DesktopShellStateTests|RuntimeViewModelTests/restoresSelectedSurfaceAndServerSessionFromOperatorSessionState' -> PASS after second latest main base sync (18 tests in 3 suites)
git diff --check -> PASS for traffic-light chrome metric comment
env HOME="$PWD/.runtime/test-home-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-menubar" xcrun swift test --package-path apps/macos-menubar --no-parallel -Xswiftc -gnone --filter 'AppScreenshotCaptureTests|DesktopShellStateTests|RuntimeViewModelTests/restoresSelectedSurfaceAndServerSessionFromOperatorSessionState' -> PASS for traffic-light chrome metric comment (18 tests in 3 suites)
git commit -m "Document shell traffic light chrome metric" -> PASS (pre-commit hook ran make swift-test, make py-test, make integration-test, and PR-scoped performance report)
pre-commit make swift-test -> PASS (includes macOS menubar package: 799 tests in 25 suites)
pre-commit make py-test -> PASS (3900 passed, 14 skipped, 2 warnings)
pre-commit make integration-test -> PASS (117 passed, 1 skipped)
git merge --no-edit origin/main on feat/window-ui-provider-refresh -> PASS (base sync to latest origin/main ceb79b4f)
git merge --no-edit origin/feat/window-ui-provider-refresh on codex/window-ui-shell-titlebar -> PASS (PR branch base sync after local job follow-up candidate scan)
git diff --check HEAD~1..HEAD && git diff --check origin/feat/window-ui-provider-refresh...HEAD -> PASS after latest local-job base sync
env HOME="$PWD/.runtime/test-home-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.runtime/clang-module-cache-menubar" xcrun swift test --package-path apps/macos-menubar --no-parallel -Xswiftc -gnone --filter 'AppScreenshotCaptureTests|DesktopShellStateTests|RuntimeViewModelTests/restoresSelectedSurfaceAndServerSessionFromOperatorSessionState' -> PASS after latest local-job base sync (18 tests in 3 suites)
```

## Coverage and Metrics
- Changed executable scope coverage: 99% (153/154 lines).
- Touched-file aggregate coverage: 95.75% (62103/64859 lines).
- AppMain source total coverage: 94.64% (68429/72308 lines); this is a historical package total, not the changed-scope gate.
- Screenshot render metrics: workspace-chat-ready 133.612ms; workspace-chat-no-provider 63.529ms; workspace-chat-no-model 85.099ms; workspace-servers 49.451ms; workspace-models 191.450ms; workspace-workflows 161.476ms; workspace-settings 38.644ms.
- Initial PR-scoped performance report: Status ok; 9 changed files; 0 selected probes; 0 regressions; 0 verification failures.
- Follow-up PR-scoped performance report: Status ok; 4 changed files; 1 selected direct probe; targeted tests pass; coverage pass (100.0%); 0 regressions; 0 verification failures.
- Titlebar chrome review-fix PR-scoped performance report: Status ok; 2 changed files; 0 selected probes; 0 regressions; 0 verification failures.
- Screenshot fixture review-fix PR-scoped performance report: Status ok; 4 changed files; 0 selected probes; 0 regressions; 0 verification failures.
- Traffic-light metric comment PR-scoped performance report: Status ok; 1 changed file; 0 selected probes; 0 regressions; 0 verification failures.
- Observability mode: N/A; this is a UI shell and screenshot acceptance slice with no production observability changes.
- Probe overhead: N/A for production code; the follow-up only stabilized an existing text-worker guard test by injecting a deterministic resident-memory reader.

## Known Gaps
- None for Slice PR C.
- Later slices still cover chat composer polish, setup wizard, thinking UI, and broader provider-domain surfaces.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
