### PR TITLE
perf: skip empty tool registry context scans

### DIFF
--- a/docs/plans/2026-06-11-tool-registry-empty-context-skip.md
+++ b/docs/plans/2026-06-11-tool-registry-empty-context-skip.md
@@ -1,0 +1,19 @@
+# Tool Registry Empty Context Keyword Scan Skip
+
+## Goal
+
+Avoid a redundant keyword matcher call in `select_agentic_tools_for_turn(...)` when no recent user turns are available. The default selector path is exercised for every agentic tool planning request, and the empty-context case is common for first-turn or vector-disabled requests.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`. The probe watches `services/mlx-worker-python/worker/runtime/tool_registry.py`, the focused tool registry tests, and `scripts/tool_registry_select_probe.py`; it includes `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Slice
+
+1. Add a focused regression test proving empty `recent_user_turns` does not invoke `_keyword_tool_matches("")`.
+2. Keep non-empty recent-turn behavior unchanged by joining and scanning context only when `recent_user_turns` is non-empty.
+3. Verify with the focused test suite, changed-scope coverage, and the registered probe locally on Linux.
+
+## Expected Metrics
+
+The primary expected metric is a lower `selector_planning_elapsed_ms_mean` in the registered `tool_registry_select_probe.py` workload. Other select/config metrics should remain stable because the slice only affects the selector planning branch.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -653,6 +653,35 @@ def test_agentic_tool_selection_uses_keyword_fallback_when_vector_unavailable() 
     ]
 
 
+def test_agentic_tool_selection_skips_empty_context_keyword_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanned_texts: list[str] = []
+    real_keyword_tool_matches = tool_registry_module._keyword_tool_matches
+
+    def record_keyword_tool_matches(text: str) -> tuple[str, ...]:
+        scanned_texts.append(text)
+        return real_keyword_tool_matches(text)
+
+    monkeypatch.setattr(
+        tool_registry_module,
+        "_keyword_tool_matches",
+        record_keyword_tool_matches,
+    )
+
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Open fixture://docs/provider-contract and summarize the page.",
+            vector_available=False,
+            recent_user_turns=(),
+            max_selected_tools=4,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute", "visit")
+    assert scanned_texts == ["Open fixture://docs/provider-contract and summarize the page."]
+
+
 @pytest.mark.parametrize(
     ("current_user_turn", "expected_tool"),
     [

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -455,8 +455,11 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
     max_selected_tools = max(1, selection_input.max_selected_tools)
     selected_sources: dict[str, str] = {}
     selected_names: list[str] = []
+    has_vector_selection = False
+    has_keyword_selection = False
 
     def add_tool(tool_name: str, source: str) -> None:
+        nonlocal has_keyword_selection, has_vector_selection
         if len(selected_names) >= max_selected_tools:
             return
         normalized_name = tool_name.strip()
@@ -466,6 +469,10 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
             return
         selected_sources[normalized_name] = source
         selected_names.append(normalized_name)
+        if source == "vector":
+            has_vector_selection = True
+        elif source == "keyword" or source == "keyword_context":
+            has_keyword_selection = True
 
     for tool_name in ALWAYS_AVAILABLE_AGENTIC_TOOL_NAMES:
         add_tool(tool_name, "always")
@@ -475,19 +482,21 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
     if selection_input.vector_available and selection_input.vector_selected_tool_ids:
         for tool_name in selection_input.vector_selected_tool_ids:
             add_tool(tool_name, "vector")
-        if any(source == "vector" for source in selected_sources.values()):
+        if has_vector_selection:
             selection_mode = "vector"
             fallback_reason = ""
 
     if selection_mode != "vector":
         current_matches = _keyword_tool_matches(selection_input.current_user_turn)
-        context_text = " ".join(selection_input.recent_user_turns)
-        context_matches = _keyword_tool_matches(context_text)
+        if selection_input.recent_user_turns:
+            context_matches = _keyword_tool_matches(" ".join(selection_input.recent_user_turns))
+        else:
+            context_matches = ()
         for tool_name in current_matches:
             add_tool(tool_name, "keyword")
         for tool_name in context_matches:
             add_tool(tool_name, "keyword_context")
-        if any(source in {"keyword", "keyword_context"} for source in selected_sources.values()):
+        if has_keyword_selection:
             selection_mode = "keyword"
             fallback_reason = "vector_unavailable" if not selection_input.vector_available else "vector_no_match"
 
@@ -518,18 +527,21 @@ def _keyword_tool_matches(text: str) -> tuple[str, ...]:
         return ()
     boundary_text = ""
     matches: list[str] = []
+    append_match = matches.append
+    keyword_hint_rules = _BUILTIN_TOOL_KEYWORD_HINT_RULES
+    keyword_boundary_text = _keyword_boundary_text
     for tool_name in _KEYWORD_MATCHABLE_TOOL_NAMES:
-        rules = _BUILTIN_TOOL_KEYWORD_HINT_RULES.get(tool_name, ())
+        rules = keyword_hint_rules.get(tool_name, ())
         for hint, literal in rules:
             if literal:
                 if hint in normalized_text:
-                    matches.append(tool_name)
+                    append_match(tool_name)
                     break
                 continue
             if not boundary_text:
-                boundary_text = _keyword_boundary_text(normalized_text)
+                boundary_text = keyword_boundary_text(normalized_text)
             if hint in boundary_text:
-                matches.append(tool_name)
+                append_match(tool_name)
                 break
     return tuple(matches)
 


### PR DESCRIPTION
## Summary
- Skip the empty recent-turn keyword scan in agentic tool selection.
- Track vector/keyword selection hits as booleans instead of rescanning selected source values.
- Localize keyword matcher hot-path callables for the registered selector probe.

## Plan or Spec
- Added `docs/plans/2026-06-11-tool-registry-empty-context-skip.md`.
- Registered PR-scoped probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_skips_empty_context_keyword_scan` (RED before implementation; failed because `_keyword_tool_matches("")` was called)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` (75 passed)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py && rm -f coverage.json` (TOTAL 28 1 96%)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`

## Coverage and Metrics
- Changed-scope coverage: 96% aggregate (27/28 covered changed lines).
- Registered local Linux probe baseline (`origin/main`): `selector_planning_elapsed_ms_mean=78.027902264148`, `elapsed_ms_mean=22.690367233008146`, `checksum=24399850.0`.
- Registered local Linux probe head: `selector_planning_elapsed_ms_mean=64.55450607463717`, `elapsed_ms_mean=21.83242402970791`, `checksum=24399850.0`.
- Delta: selector planning `-13.473396 ms` (`~17.27%` faster); overall select workload `-0.857943 ms` (`~3.78%` faster).

## Known Gaps
- Local validation is Linux/Python only. The registered PR-scoped performance workflow must validate the probe in CI before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Probe entry includes focused `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally with an improving metric.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
