### PR TITLE
perf: cache hub size hint marker scans

### DIFF
--- a/docs/plans/2026-06-11-hub-size-marker-cache.md
+++ b/docs/plans/2026-06-11-hub-size-marker-cache.md
@@ -1,0 +1,34 @@
+# Hub catalog size-hint marker cache
+
+## Scope
+
+This Python-only performance slice is limited to the Hub catalog size-hint path in
+`services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.
+The registry entry watches the Hub catalog module, focused tests, the PR-scoped
+performance tests, and `scripts/hub_catalog_size_hint_probe.py`; it also includes
+focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Change
+
+When the size-hint parser must inspect `description`, `readme`, and
+`cardData.description`, reuse each `_may_contain_model_marker(...)` result as the
+parser walks the fields. The loop stops once a valid size hint is found, keeps
+behavior identical, and avoids a second marker scan for fields that proceed to
+regex parsing.
+
+## Verification plan
+
+- Run the registered focused test command for `hub-catalog-size-hint-regex-precompile`.
+- Run the registered changed-scope coverage command and require at least 95% coverage.
+- Run the registered probe locally on Linux against `origin/main` and the slice, then compare `elapsed_ms_mean`.
+- Use the PR-scoped performance workflow as the CI merge gate.
+
+## Linux boundary
+
+This slice changes Python code and is locally verifiable on Linux. No Swift
+runtime performance claims are made.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -1157,6 +1157,34 @@ def test_size_hint_bytes_skips_direct_hint_parser_when_card_model_size_missing(
     assert calls == [("Model size: 7 MB", False)]
 
 
+def test_size_hint_bytes_reuses_marker_checks_before_hint_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    marker_calls: list[str] = []
+    original_marker = hub_catalog_module._may_contain_model_marker
+
+    def tracked_marker(text: str) -> bool:
+        marker_calls.append(text)
+        return original_marker(text)
+
+    monkeypatch.setattr(hub_catalog_module, "_may_contain_model_marker", tracked_marker)
+
+    assert (
+        hub_catalog_module._size_hint_bytes(
+            {
+                "description": "Model size appears in docs without value",
+                "readme": "Model size: 5 MB",
+                "cardData": {"description": "operator note"},
+            }
+        )
+        == 5 * MB
+    )
+    assert marker_calls == [
+        "Model size appears in docs without value",
+        "Model size: 5 MB",
+    ]
+
+
 def test_size_hint_bytes_preserves_combined_marker_parsing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -765,18 +765,16 @@ def _size_hint_bytes(payload: dict[str, Any], *, card_data: dict[str, Any] | Non
             else 0
         )
 
-    if not (
-        _may_contain_model_marker(description_text)
-        or _may_contain_model_marker(readme_text)
-        or _may_contain_model_marker(card_description_text)
-    ):
-        return 0
+    found_model_marker = False
     for text in (description_text, readme_text, card_description_text):
         if not text or not _may_contain_model_marker(text):
             continue
+        found_model_marker = True
         hint = _size_hint_from_text(text, allow_bare=False)
         if hint > 0:
             return hint
+    if not found_model_marker:
+        return 0
     text = "\n".join(
         text
         for text in (description_text, readme_text, card_description_text)


### PR DESCRIPTION
## Summary
- Reuse `_may_contain_model_marker(...)` results as the Hub catalog size-hint parser walks multi-field text.
- Stop scanning later fields once a valid size hint is found.
- Add regression coverage proving marker checks are reused before per-field hint parsing.
- Document the slice and registered probe gate.

## Plan or Spec
- `docs/plans/2026-06-11-hub-size-marker-cache.md`
- Registered PR-scoped probe: `hub-catalog-size-hint-regex-precompile`

## Commands Run
```text
# Baseline probe on origin/main before edits
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
=> exit 0; elapsed_ms_mean=1519.160505; payload_compatibility_elapsed_ms_mean=208.825536; peak_bytes_mean=1833.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py::test_size_hint_bytes_reuses_marker_checks_before_hint_parsing services/mlx-worker-python/tests/test_hub_catalog.py::test_size_hint_bytes_preserves_combined_marker_parsing
=> exit 0; 2 passed

# Registered focused test command for hub-catalog-size-hint-regex-precompile
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
=> exit 0; 79 passed

# Registered coverage command for hub-catalog-size-hint-regex-precompile
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
=> exit 0; 79 passed; TOTAL 6 0 100%

# Head probe after final edits
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
=> exit 0; elapsed_ms_mean=1510.652843; payload_compatibility_elapsed_ms_mean=209.960651; peak_bytes_mean=1833.0

git diff --check
=> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 6 0 100%`).
- Registered local probe (`hub-catalog-size-hint-regex-precompile`, Linux):
  - `elapsed_ms_mean`: 1519.160505 ms -> 1510.652843 ms (`-8.507662 ms`, `-0.560%`, lower is better)
  - `payload_compatibility_elapsed_ms_mean`: 208.825536 ms -> 209.960651 ms (`+1.135116 ms`, `+0.544%`, secondary payload path unchanged by this slice)
  - `peak_bytes_mean`: 1833.0 -> 1833.0 (`0.0`)
- CI PR-scoped performance report remains the merge gate for registered probe validation.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally; this is a focused Python performance slice and GitHub Actions remains the full gate.
- No Swift runtime performance claims; this slice is Python-only and locally verified on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
