### PR TITLE
perf: bind benchmark queue scan helpers locally

### DIFF
--- a/docs/plans/2026-06-11-benchmark-queue-local-bindings.md
+++ b/docs/plans/2026-06-11-benchmark-queue-local-bindings.md
@@ -1,0 +1,66 @@
+# Benchmark queue local binding scan slice
+
+## Scope
+
+This Python performance slice is limited to the benchmark queue record listing
+hot path in `services/mlx-worker-python/worker/productization/benchmark_queue.py`.
+It does not change queue record semantics, persistence format, or public return
+shape.
+
+## Linux verification boundary
+
+The path is Python-only and is locally verifiable on Linux. Focused tests,
+changed-scope coverage, and the registered PR-scoped probe must pass before the
+PR is merged.
+
+## Registered probe
+
+The affected path is covered by the existing `benchmark-queue-decoded-record-cache`
+entry in `infra/perf/pr_scoped_probes.json`. The registered entry includes
+focused `test_command`, `coverage_command`, and `probe_command` values, and it
+reports cold and warm queue scan timing plus JSON decode counts.
+
+## Optimization hypothesis
+
+`BenchmarkQueueStore.list_records()` executes a per-entry loop over queue JSON
+files. The current loop repeatedly resolves instance/static/module attributes for
+record loading, metadata-key construction, and regular-file checks. Binding these
+callables once before the loop should reduce Python attribute lookup overhead
+without weakening the existing stat reuse or decoded-record cache behavior.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_benchmark_queue.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_benchmark_queue.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/benchmark_queue.py \
+  services/mlx-worker-python/tests/test_benchmark_queue.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_benchmark_queue_probe.py
+
+git diff --check
+```
+
+## Success criteria
+
+- Focused behavior and PR-scoped registry tests pass.
+- Changed-scope coverage remains at least 95%.
+- Local registered probe reports `warm_json_loads_mean == 0.0` and a lower warm
+  scan mean than the baseline sample.
+- Hosted PR-scoped performance CI validates the same registered probe before merge.

--- a/services/mlx-worker-python/worker/productization/benchmark_queue.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_queue.py
@@ -85,6 +85,9 @@ class BenchmarkQueueStore:
             return []
 
         records = []
+        load_record = self._load_record
+        metadata_key_from_stat = self._metadata_key_from_stat
+        is_regular_file = stat.S_ISREG
         try:
             with os.scandir(queue_root) as entries:
                 for entry in entries:
@@ -94,12 +97,12 @@ class BenchmarkQueueStore:
                         stat_result = entry.stat()
                     except OSError:
                         continue
-                    if not stat.S_ISREG(stat_result.st_mode):
+                    if not is_regular_file(stat_result.st_mode):
                         continue
                     records.append(
-                        self._load_record(
+                        load_record(
                             entry.path,
-                            metadata_key=self._metadata_key_from_stat(stat_result),
+                            metadata_key=metadata_key_from_stat(stat_result),
                         )
                     )
         except OSError:


### PR DESCRIPTION
## Summary
- Bind benchmark queue scan helper callables once before the per-entry loop.
- Preserve the existing DirEntry stat reuse and decoded-record cache semantics.

## Plan or Spec
- `docs/plans/2026-06-11-benchmark-queue-local-bindings.md`
- Registered probe: `benchmark-queue-decoded-record-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
# 27 passed in 20.22s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
# 27 passed in 50.26s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_queue.py services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_benchmark_queue_probe.py
# baseline warm samples on origin/main: 0.660106, 0.679661, 0.711563 ms
# head warm samples: 0.662275, 0.657954, 0.649831 ms

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Registered local probe (`benchmark-queue-decoded-record-cache`):
  - `old_mean=0.683777 ms`, `new_mean=0.656687 ms`
  - `speedup=3.96%`, `delta_ms=-0.027090`
  - `warm_json_loads_mean=0.0` on all head probe samples.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full repository test matrix was not run locally; this Python slice used the focused registered commands.
- Hosted CI remains the merge gate for the registered PR-scoped probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no new probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
