### PR TITLE
perf: fast-path report evidence run-kind values

### DIFF
--- a/docs/plans/2026-06-11-report-evidence-run-kind-values-fastpath.md
+++ b/docs/plans/2026-06-11-report-evidence-run-kind-values-fastpath.md
@@ -1,0 +1,27 @@
+# Report Evidence Run-kind Value Fast Path
+
+This Python-only performance slice is limited to the report evidence gate's
+release-matrix run-kind value normalization path in
+`services/mlx-worker-python/worker/productization/report_evidence_gate.py`.
+
+Registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership` in
+`infra/perf/pr_scoped_probes.json`. The probe already includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for this path.
+
+## Slice
+
+`_report_matrix_roles()` builds a normalized run-kind set once when the release
+matrix contains run-kind-only rules. The current helper normalizes through a
+`str(...)` generator for every run value, even though production benchmark and
+evaluation reports normally store `run_kind` as an exact `str`.
+
+This slice keeps the same non-string fallback behavior while adding a direct
+string fast path inside `_report_run_kind_values()`.
+
+## Validation
+
+- Focused report evidence gate tests.
+- Changed-scope coverage for the touched report evidence gate files.
+- Registered PR-scoped probe locally on Linux.
+- GitHub Actions remains the merge gate for the registered PR-scoped performance
+  report.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -272,6 +272,15 @@ def test_report_evidence_gate_run_kind_non_string_values_still_match_by_string()
     )
 
 
+def test_report_evidence_gate_matrix_roles_keep_non_string_run_kind_match() -> None:
+    roles = report_evidence_gate_module._report_matrix_roles(
+        {"runs": [{"run_kind": 42}]},
+        {"numeric_run": {"run_kinds": ("42",)}},
+    )
+
+    assert roles == ["numeric_run"]
+
+
 def test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple() -> None:
     report_evidence_gate_module._string_prefix_tuple_from_tuple.cache_clear()
     rule = {"metric_prefixes": ("adapter.", "runtime.")}

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -321,7 +321,16 @@ def _run_kind_only_rule(rule: dict[str, object]) -> bool:
 
 def _report_run_kind_values(runs: list[dict[str, object]]) -> frozenset[str]:
     run_kind_key = "run_kind"
-    return frozenset(str(run.get(run_kind_key, "")) for run in runs)
+    values: set[str] = set()
+    values_add = values.add
+    to_string = str
+    for run in runs:
+        run_kind = run.get(run_kind_key, "")
+        if type(run_kind) is str:
+            values_add(run_kind)
+        else:
+            values_add(to_string(run_kind))
+    return frozenset(values)
 
 
 def _rule_matches_report(


### PR DESCRIPTION
## Summary
- Fast-path report evidence release-matrix run-kind normalization for the common exact-string `run_kind` case.
- Preserve non-string run-kind fallback matching by string with a focused regression test.
- Document the slice and registered probe coverage.

## Plan or Spec
- `docs/plans/2026-06-11-report-evidence-run-kind-values-fastpath.md`
- Registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_matrix_roles_keep_non_string_run_kind_match services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_matrix_roles_skip_probe_phase_scan_without_phase_rules services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# 4 passed in 0.98s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <registered report-evidence-gate-run-kind-set-membership focused tests plus the new non-string matrix-role regression>
# 23 passed in 0.28s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused test list>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
# TOTAL 12 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# baseline before change: elapsed_ms_mean=1261.207031365484, run_kind_elapsed_ms_mean=235.43750699609518, matrix_roles_elapsed_ms_mean=5.300277471542358
# after change sample 1: elapsed_ms_mean=935.6014433316886, run_kind_elapsed_ms_mean=220.69910550490022, matrix_roles_elapsed_ms_mean=4.760462138801813
# after change sample 2: elapsed_ms_mean=958.1445810385048, run_kind_elapsed_ms_mean=230.4802388884127, matrix_roles_elapsed_ms_mean=5.202449765056372
# after change sample 3: elapsed_ms_mean=939.5988493226469, run_kind_elapsed_ms_mean=226.17678921669722, matrix_roles_elapsed_ms_mean=5.159843806177378

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 12 0 100%`).
- Local Linux registered probe evidence:
  - Baseline: `elapsed_ms_mean=1261.2070`, `run_kind_elapsed_ms_mean=235.4375`, `matrix_roles_elapsed_ms_mean=5.3003`.
  - New 3-sample mean of probe runs: `elapsed_ms_mean=944.4483`, `run_kind_elapsed_ms_mean=225.7854`, `matrix_roles_elapsed_ms_mean=5.0409`.
  - Delta: `elapsed_ms_mean=-316.7587 ms` (~25.1% lower), `run_kind_elapsed_ms_mean=-9.6521 ms` (~4.1% lower), `matrix_roles_elapsed_ms_mean=-0.2594 ms` (~4.9% lower).
- CI is required for the registered PR-scoped performance report before merge.

## Known Gaps
- Full repository test suite was not run locally; this PR is limited to the registered focused Python performance slice.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance evidence; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
