### PR TITLE
Add local job follow-up candidate scan

### DIFF
--- a/docs/plans/2026-06-11-issue-1756-local-job-followup-candidate-scan.md
+++ b/docs/plans/2026-06-11-issue-1756-local-job-followup-candidate-scan.md
@@ -1,0 +1,78 @@
+# Issue 1756 Local Job Follow-Up Candidate Scan Plan
+
+## Goal
+
+Add a side-effect-free store scan that lets a future local-job monitor discover
+which durable local-job records are ready for exactly one follow-up, while still
+reconciling stale persisted state against live evidence before returning
+candidates.
+
+## Scope
+
+This slice covers:
+
+- a store-level scan result that contains follow-up candidates and scan
+  receipts;
+- deterministic one-level scanning of local-job continuation record files;
+- per-record reconciliation before candidate classification, so stale
+  `completed` records can self-heal to `running` and missing completion evidence
+  can block before a monitor attempts a follow-up claim;
+- candidate receipts for evidence-backed completed records whose follow-up has
+  not yet been claimed;
+- skip/block receipts for already-claimed follow-ups and non-ready records;
+- focused Python worker tests for ready, already-claimed, stale, missing
+  evidence, live-evidence, running, and missing-root scan cases;
+- contract documentation for future side-effecting monitor wiring.
+
+This slice does not start local processes, poll process tables, tail logs, claim
+follow-ups, inject prompt context, or resume sessions. Future monitors must
+still call `claim_followup_prompt_context` before projecting any completed job
+summary into prompt context.
+
+## Best End-State Architecture
+
+The local-job monitor should not decide readiness from stale JSON state alone.
+It should ask the worker-owned store to reconcile every persisted record first,
+then consume only records that are completed, have explicit completion evidence,
+and have no existing follow-up claim. The scan therefore acts as the monitor's
+read model, not as a side-effecting runner or session writer.
+
+## Performance Probes And Metrics
+
+The changed path performs a bounded one-level scan of `*.json` record files,
+loads each record once, reconciles it with at most one caller-provided
+`LocalJobLiveEvidence` value, and writes only records whose reconciliation
+changes persisted state. It does not scan logs, enumerate process tables, start
+subprocesses, or call model inference.
+
+Success metrics:
+
+- scan cost is O(record count) and O(1) per record beyond JSON load/optional
+  reconciliation write;
+- lock, temporary, and unrelated files are ignored by suffix;
+- changed-line Python coverage for touched runtime and tests is at least
+  95 percent;
+- local and hosted PR-scoped performance reports are `Status: ok` with zero
+  direct/gated regressions and zero verification failures.
+
+## Implementation Steps
+
+1. Add failing focused tests for store-level follow-up candidate scanning across
+   ready, already-claimed, stale, missing-evidence, running, live-evidence, and
+   missing-root records.
+2. Add a frozen scan result type and `LocalJobContinuationStore.scan_followup_candidates`.
+3. Reuse existing reconciliation and receipt helpers instead of introducing a
+   separate local-job status vocabulary.
+4. Document the scanner contract in the unified agentic runtime contract.
+5. Run focused tests, changed-line coverage, diff checks, scoped performance,
+   and the relevant full gates before PR merge.
+
+## Success Criteria
+
+- A future monitor can discover ready follow-up records without claiming them.
+- Every scanned record is reconciled before candidate classification.
+- Stale done records revive to running, missing-evidence completions block, and
+  live completion evidence is persisted before a record appears as ready.
+- Already-claimed records are never returned as candidates.
+- The scanner remains a small runtime primitive with no runner, prompt, or
+  session side effects.

--- a/docs/plans/2026-06-11-issue-1756-local-job-followup-candidate-scan.md
+++ b/docs/plans/2026-06-11-issue-1756-local-job-followup-candidate-scan.md
@@ -17,6 +17,9 @@ This slice covers:
 - per-record reconciliation before candidate classification, so stale
   `completed` records can self-heal to `running` and missing completion evidence
   can block before a monitor attempts a follow-up claim;
+- per-record scan isolation for unreadable record files and store-level
+  reconciliation conflicts, so one bad durable record does not stop discovery of
+  other ready follow-ups;
 - candidate receipts for evidence-backed completed records whose follow-up has
   not yet been claimed;
 - skip/block receipts for already-claimed follow-ups and non-ready records;
@@ -50,6 +53,8 @@ Success metrics:
 - scan cost is O(record count) and O(1) per record beyond JSON load/optional
   reconciliation write;
 - lock, temporary, and unrelated files are ignored by suffix;
+- unreadable record files and store-level reconciliation conflicts are surfaced
+  as per-record receipts and do not abort the scan;
 - changed-line Python coverage for touched runtime and tests is at least
   95 percent;
 - local and hosted PR-scoped performance reports are `Status: ok` with zero

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -511,6 +511,21 @@ Malformed completion summaries or owner-scope metadata must fail closed with a
 `in_progress` follow-up claim. Store-level blockers such as missing completion
 evidence or an already claimed follow-up must not emit prompt-context payloads.
 
+Future local-job monitor loops should discover follow-up work through
+`LocalJobContinuationStore.scan_followup_candidates`. The scanner performs a
+one-level scan of persisted local-job record files, reconciles each loaded
+record with optional caller-provided live evidence, persists any reconciliation
+state changes through the same revision-guarded store path, and returns only
+evidence-backed `completed` records whose follow-up has not already been
+claimed. The scan is a read model for monitors: it must not start jobs, tail
+logs, claim follow-ups, inject prompt context, or resume sessions. Already
+claimed records emit `reason = followup_already_claimed`; stale completed
+records, missing completion evidence, and live completion evidence keep the
+same reconciliation receipts defined above. Ready records emit
+`reason = followup_candidate_ready`, indicating that a monitor may next call
+`claim_followup_prompt_context` to perform the single guarded claim and
+prompt-context admission.
+
 When a local-job follow-up claim succeeds, the
 `melix.local_job_continuation_receipt.v1` receipt must also expose the redacted
 background-continuation prompt-boundary evidence for that claim:

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -524,7 +524,10 @@ records, missing completion evidence, and live completion evidence keep the
 same reconciliation receipts defined above. Ready records emit
 `reason = followup_candidate_ready`, indicating that a monitor may next call
 `claim_followup_prompt_context` to perform the single guarded claim and
-prompt-context admission.
+prompt-context admission. Unreadable record files must not abort the whole
+scan; they emit `reason = record_unreadable`, and revision-guarded store
+conflicts keep their store-level receipt so the monitor can continue scanning
+other records.
 
 When a local-job follow-up claim succeeds, the
 `melix.local_job_continuation_receipt.v1` receipt must also expose the redacted

--- a/services/mlx-worker-python/tests/test_local_job_continuation.py
+++ b/services/mlx-worker-python/tests/test_local_job_continuation.py
@@ -622,6 +622,132 @@ def test_store_claim_followup_preserves_non_completed_records(tmp_path: Path) ->
     assert store.load_record("job-7") == running
 
 
+def test_store_scan_followup_candidates_reconciles_and_filters_ready_records(
+    tmp_path: Path,
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    claimed = store.save_record(
+        _record(
+            job_id="claimed",
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/claimed.json",),
+            followup_status="in_progress",
+            followup_session_id="followup-claimed",
+        )
+    )
+    live_done = store.save_record(
+        _record(job_id="live-done", status="completed", exit_status=0)
+    )
+    missing = store.save_record(
+        _record(job_id="missing", status="completed", exit_status=0)
+    )
+    ready = store.save_record(
+        _record(
+            job_id="ready",
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/ready.json",),
+        )
+    )
+    running = store.save_record(_record(job_id="running", status="running"))
+    stale = store.save_record(_record(job_id="stale", status="completed", exit_status=0))
+    (tmp_path / "ready.json.lock").write_text(f"{os.getpid()}\n", encoding="utf-8")
+    (tmp_path / "ready.json.tmp").write_text("{}", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("not a record", encoding="utf-8")
+
+    scan = store.scan_followup_candidates(
+        live_evidence_by_job_id={
+            "live-done": LocalJobLiveEvidence(
+                session_id="session-7",
+                active=False,
+                progress_excerpt="done",
+                artifact_paths=("/workspace/out/live-done.json",),
+            ),
+            "stale": LocalJobLiveEvidence(
+                session_id="session-7",
+                active=True,
+                progress_excerpt="shard 3/12 still running",
+            ),
+        }
+    )
+
+    assert [candidate.record.job_id for candidate in scan.candidates] == [
+        "live-done",
+        "ready",
+    ]
+    assert [candidate.receipt["reason"] for candidate in scan.candidates] == [
+        "followup_candidate_ready",
+        "followup_candidate_ready",
+    ]
+    receipts_by_job = {receipt["job_id"]: receipt for receipt in scan.receipts}
+    assert set(receipts_by_job) == {
+        "claimed",
+        "live-done",
+        "missing",
+        "ready",
+        "running",
+        "stale",
+    }
+    assert receipts_by_job["claimed"]["reason"] == "followup_already_claimed"
+    assert receipts_by_job["claimed"]["followup_session_id"] == "followup-claimed"
+    assert receipts_by_job["live-done"]["reason"] == "followup_candidate_ready"
+    assert receipts_by_job["missing"]["reason"] == "missing_completion_evidence"
+    assert receipts_by_job["ready"]["reason"] == "followup_candidate_ready"
+    assert receipts_by_job["running"]["reason"] == "followup_not_ready"
+    assert receipts_by_job["stale"]["reason"] == "stale_done_revived"
+    assert store.load_record("claimed") == claimed
+    assert store.load_record("live-done") == replace(
+        live_done,
+        artifact_paths=("/workspace/out/live-done.json",),
+        revision=1,
+    )
+    assert store.load_record("missing") == replace(missing, status="blocked", revision=1)
+    assert store.load_record("ready") == ready
+    assert store.load_record("running") == running
+    assert store.load_record("stale") == replace(
+        stale,
+        status="running",
+        exit_status=None,
+        revision=1,
+    )
+
+
+def test_store_scan_followup_candidates_returns_empty_for_missing_root(
+    tmp_path: Path,
+) -> None:
+    scan = LocalJobContinuationStore(tmp_path / "missing").scan_followup_candidates()
+
+    assert scan.candidates == ()
+    assert scan.receipts == ()
+
+
+def test_store_scan_followup_candidates_tolerates_record_deleted_during_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    store.save_record(
+        _record(
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/ready.json",),
+        )
+    )
+    original_load_record = store.load_record
+
+    def delete_before_load(job_id: str) -> LocalJobContinuationRecord | None:
+        if job_id == "job-7":
+            (tmp_path / "job-7.json").unlink()
+        return original_load_record(job_id)
+
+    monkeypatch.setattr(store, "load_record", delete_before_load)
+
+    scan = store.scan_followup_candidates()
+
+    assert scan.candidates == ()
+    assert scan.receipts == ()
+
+
 def test_store_claim_followup_uses_revision_guard_for_concurrent_claim(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/services/mlx-worker-python/tests/test_local_job_continuation.py
+++ b/services/mlx-worker-python/tests/test_local_job_continuation.py
@@ -748,6 +748,92 @@ def test_store_scan_followup_candidates_tolerates_record_deleted_during_scan(
     assert scan.receipts == ()
 
 
+def test_store_scan_followup_candidates_skips_unreadable_records(
+    tmp_path: Path,
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    ready = store.save_record(
+        _record(
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/ready.json",),
+        )
+    )
+    (tmp_path / "corrupt.json").write_text("{", encoding="utf-8")
+    (tmp_path / "metadata.json").write_text(
+        json.dumps({"schema_version": "metadata.v1"}) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "nested.json").mkdir()
+
+    scan = store.scan_followup_candidates()
+
+    assert [candidate.record.job_id for candidate in scan.candidates] == ["job-7"]
+    receipts_by_job = {receipt["job_id"]: receipt for receipt in scan.receipts}
+    assert receipts_by_job["job-7"]["reason"] == "followup_candidate_ready"
+    assert receipts_by_job["corrupt"]["reason"] == "record_unreadable"
+    assert receipts_by_job["metadata"]["reason"] == "record_unreadable"
+    assert "nested" not in receipts_by_job
+    assert store.load_record("job-7") == ready
+
+
+def test_store_scan_followup_candidates_preserves_store_error_receipts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    ready = store.save_record(
+        _record(
+            job_id="ready",
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/ready.json",),
+        )
+    )
+    stale_done = store.save_record(
+        _record(job_id="stale", status="completed", exit_status=0)
+    )
+    original_save_record = store.save_record
+    injected_race = False
+
+    def race_before_reconcile_write(
+        record: LocalJobContinuationRecord,
+        *,
+        expected_revision: int | None = None,
+    ) -> LocalJobContinuationRecord:
+        nonlocal injected_race
+        if record.job_id == "stale" and not injected_race and expected_revision == stale_done.revision:
+            injected_race = True
+            original_save_record(
+                replace(stale_done, status="running", exit_status=None),
+                expected_revision=stale_done.revision,
+            )
+        return original_save_record(record, expected_revision=expected_revision)
+
+    monkeypatch.setattr(store, "save_record", race_before_reconcile_write)
+
+    scan = store.scan_followup_candidates(
+        live_evidence_by_job_id={
+            "stale": LocalJobLiveEvidence(
+                session_id="session-7",
+                active=True,
+                progress_excerpt="shard 3/12 still running",
+            ),
+        }
+    )
+
+    assert [candidate.record.job_id for candidate in scan.candidates] == ["ready"]
+    receipts_by_job = {receipt["job_id"]: receipt for receipt in scan.receipts}
+    assert receipts_by_job["ready"]["reason"] == "followup_candidate_ready"
+    assert receipts_by_job["stale"]["reason"] == "record_revision_mismatch"
+    assert store.load_record("ready") == ready
+    assert store.load_record("stale") == replace(
+        stale_done,
+        status="running",
+        exit_status=None,
+        revision=1,
+    )
+
+
 def test_store_claim_followup_uses_revision_guard_for_concurrent_claim(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -136,6 +136,18 @@ class LocalJobContinuationFollowupClaim:
     prompt_context: PromptContextAdmission
 
 
+@dataclass(frozen=True, slots=True)
+class LocalJobContinuationFollowupCandidate:
+    record: LocalJobContinuationRecord
+    receipt: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class LocalJobContinuationFollowupScan:
+    candidates: tuple[LocalJobContinuationFollowupCandidate, ...]
+    receipts: tuple[dict[str, Any], ...]
+
+
 class LocalJobContinuationStore:
     def __init__(self, root: Path | str) -> None:
         self.root = Path(root)
@@ -306,6 +318,46 @@ class LocalJobContinuationStore:
         return LocalJobContinuationFollowupClaim(
             reconciliation=replace(result, record=saved),
             prompt_context=prompt_context,
+        )
+
+    def scan_followup_candidates(
+        self,
+        *,
+        live_evidence_by_job_id: dict[str, LocalJobLiveEvidence] | None = None,
+    ) -> LocalJobContinuationFollowupScan:
+        candidates: list[LocalJobContinuationFollowupCandidate] = []
+        receipts: list[dict[str, Any]] = []
+        if not self.root.exists():
+            return LocalJobContinuationFollowupScan(candidates=(), receipts=())
+
+        live_evidence_by_job_id = live_evidence_by_job_id or {}
+        for path in sorted(self.root.glob("*.json")):
+            job_id = path.stem
+            reconciliation = self.reconcile_record(
+                job_id,
+                live_evidence=live_evidence_by_job_id.get(job_id),
+            )
+            if reconciliation is None:
+                continue
+            receipt = _followup_candidate_scan_receipt(reconciliation.record)
+            if receipt["reason"] == "followup_candidate_ready":
+                receipts.append(receipt)
+                candidates.append(
+                    LocalJobContinuationFollowupCandidate(
+                        record=reconciliation.record,
+                        receipt=receipt,
+                    )
+                )
+            elif receipt["reason"] == "followup_already_claimed":
+                receipts.append(receipt)
+            elif reconciliation.receipt.get("reason") != "record_state_preserved":
+                receipts.append(reconciliation.receipt)
+            else:
+                receipts.append(receipt)
+
+        return LocalJobContinuationFollowupScan(
+            candidates=tuple(candidates),
+            receipts=tuple(receipts),
         )
 
     def _record_path(self, job_id: str) -> Path:
@@ -657,6 +709,53 @@ def _receipt(
     return receipt
 
 
+def _followup_candidate_scan_receipt(
+    record: LocalJobContinuationRecord,
+) -> dict[str, Any]:
+    evidence_available = _has_completion_evidence(record)
+    if record.followup_status in {"pending", "in_progress", "completed"}:
+        return _receipt(
+            job_id=record.job_id,
+            status=record.status,
+            reason="followup_already_claimed",
+            session_id=record.session_id,
+            exit_status=record.exit_status,
+            followup_status=record.followup_status,
+            duplicate_launch_refused=False,
+            completion_evidence_available=evidence_available,
+            corrective_action="Do not enqueue another local job follow-up for this record.",
+            followup_session_id=record.followup_session_id,
+        )
+    if record.status == "completed" and evidence_available:
+        return _receipt(
+            job_id=record.job_id,
+            status=record.status,
+            reason="followup_candidate_ready",
+            session_id=record.session_id,
+            exit_status=record.exit_status,
+            followup_status=record.followup_status,
+            duplicate_launch_refused=False,
+            completion_evidence_available=True,
+            corrective_action=(
+                "A monitor may claim this local job follow-up after prompt-context admission."
+            ),
+        )
+    return _receipt(
+        job_id=record.job_id,
+        status=record.status,
+        reason="followup_not_ready",
+        session_id=record.session_id,
+        exit_status=record.exit_status,
+        followup_status=record.followup_status,
+        duplicate_launch_refused=False,
+        completion_evidence_available=evidence_available,
+        corrective_action=(
+            "Wait until the local job is completed with explicit evidence before follow-up."
+        ),
+        followup_session_id=record.followup_session_id,
+    )
+
+
 def _local_job_followup_prompt_context_receipts(
     record: LocalJobContinuationRecord,
 ) -> list[dict[str, object]]:
@@ -840,7 +939,9 @@ __all__ = [
     "RECEIPT_SCHEMA_VERSION",
     "RECORD_SCHEMA_VERSION",
     "LocalJobContinuationAdmissionError",
+    "LocalJobContinuationFollowupCandidate",
     "LocalJobContinuationFollowupClaim",
+    "LocalJobContinuationFollowupScan",
     "LocalJobContinuationRecord",
     "LocalJobContinuationReconciliation",
     "LocalJobContinuationStore",

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -332,11 +332,20 @@ class LocalJobContinuationStore:
 
         live_evidence_by_job_id = live_evidence_by_job_id or {}
         for path in sorted(self.root.glob("*.json")):
+            if not path.is_file():
+                continue
             job_id = path.stem
-            reconciliation = self.reconcile_record(
-                job_id,
-                live_evidence=live_evidence_by_job_id.get(job_id),
-            )
+            try:
+                reconciliation = self.reconcile_record(
+                    job_id,
+                    live_evidence=live_evidence_by_job_id.get(job_id),
+                )
+            except LocalJobContinuationStoreError as exc:
+                receipts.append(exc.receipt)
+                continue
+            except (json.JSONDecodeError, OSError, ValueError):
+                receipts.append(_unreadable_record_scan_receipt(job_id=job_id))
+                continue
             if reconciliation is None:
                 continue
             receipt = _followup_candidate_scan_receipt(reconciliation.record)
@@ -753,6 +762,23 @@ def _followup_candidate_scan_receipt(
             "Wait until the local job is completed with explicit evidence before follow-up."
         ),
         followup_session_id=record.followup_session_id,
+    )
+
+
+def _unreadable_record_scan_receipt(*, job_id: str) -> dict[str, Any]:
+    return _receipt(
+        job_id=job_id,
+        status="blocked",
+        reason="record_unreadable",
+        session_id="",
+        exit_status=None,
+        followup_status="blocked",
+        duplicate_launch_refused=False,
+        completion_evidence_available=False,
+        corrective_action=(
+            "Repair or remove the unreadable local job continuation record before "
+            "it can be considered for follow-up."
+        ),
     )
 
 

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -349,6 +349,8 @@ class LocalJobContinuationStore:
             if reconciliation is None:
                 continue
             receipt = _followup_candidate_scan_receipt(reconciliation.record)
+            # Scan-level follow-up state wins for ready or already-claimed records.
+            # Otherwise surface reconciliation changes before the generic scan result.
             if receipt["reason"] == "followup_candidate_ready":
                 receipts.append(receipt)
                 candidates.append(
@@ -749,6 +751,8 @@ def _followup_candidate_scan_receipt(
                 "A monitor may claim this local job follow-up after prompt-context admission."
             ),
         )
+    # A non-ready record only means the monitor may not claim it yet; callers
+    # that need running-vs-blocked detail should inspect the status field.
     return _receipt(
         job_id=record.job_id,
         status=record.status,


### PR DESCRIPTION
## Summary
- Adds a side-effect-free local-job follow-up candidate scan to `LocalJobContinuationStore`.
- Reconciles durable records before classification, returns ready follow-up candidates, and records per-record receipts without claiming prompts or starting/resuming worker sessions.
- Isolates malformed/unrelated record files, `*.json` directories, and revision-conflict store errors so one bad record cannot abort the scan.
- Documents this issue #1756 slice as the read-model boundary that future monitor wiring can call before `claim_followup_prompt_context`.

## Plan or Spec
- Issue: https://github.com/Keith-CY/melix/issues/1756
- Plan: `docs/plans/2026-06-11-issue-1756-local-job-followup-candidate-scan.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
# Red check before implementation:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_local_job_continuation.py -q
# Expected red result: 2 failed, 74 passed; AttributeError for missing scan_followup_candidates.

# Focused local-job continuation tests:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_local_job_continuation.py -q
# Result: 77 passed in 0.12s.

# Adjacent continuation tests:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py -q
# Result: 100 passed in 0.10s.

# Syntax and diff hygiene:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python -m py_compile services/mlx-worker-python/worker/runtime/local_job_continuation.py
# Result: pass.
git diff --check
# Result: pass.

# Changed-line coverage:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest services/mlx-worker-python/tests/test_local_job_continuation.py -q
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o /tmp/issue1756-followup-scan-coverage.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json /tmp/issue1756-followup-scan-coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py
# Result: TOTAL 100.00% (81/81 changed lines).

# Historical scoped performance report before commit:
UV_PYTHON=3.12 MELIX_PERF_BASE_REF=52a491bf ./scripts/pre_commit_performance_report.py
# Result: Status ok; changed files 4; selected probes 0; regressions 0; verification failures 0.
# Report: .runtime/pre-commit-performance/20260611-062041-52a491bf/report/report.md

# Full local gates before commit:
make bootstrap
# Result: pass; git hooks path configured to .githooks; uv sync checked 79 packages.
make proto
# Result: pass; ./scripts/proto_gen.sh completed with no protocol diff.
make swift-test
# Result: pass; protocol package rc=0, text worker 241 tests/0 failures, control-plane core 495 tests passed, worker clients 127 tests passed, macOS menubar 796 tests passed.
make py-test
# Result: pass; 3901 passed, 14 skipped, 2 warnings in 191.01s.
make integration-test
# Result: pass; 117 passed, 1 skipped in 702.02s.

# Versioned pre-commit hook for commit 69123e03 on 256 GiB macOS host:
git commit -m "feat: add local job follow-up candidate scan"
# Result: pass.
# Hook reran make swift-test, make py-test, make integration-test, and scoped performance report.
# Hook py-test result: 3901 passed, 14 skipped, 2 warnings in 167.79s.
# Hook integration-test result: 117 passed, 1 skipped in 763.03s.
# Hook performance result: Status ok; changed files 4; selected probes 0; regressions 0; verification failures 0.
# Hook report: .runtime/pre-commit-performance/20260611-071535-52a491bf/report/report.md

# Branch refresh after origin/main advanced to f5d2b1da:
git merge --no-edit origin/main
# Result: pass; merged f5d2b1da without conflicts.

# Post-merge focused tests and PR body validation:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py -q
# Result: 100 passed in 0.10s.
python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-issue-1756-followup-scan.md
# Result: PR evidence looks valid.

# Post-merge full local gates:
make bootstrap
# Result: pass; git hooks path configured to .githooks; uv sync checked 79 packages.
make proto
# Result: pass; ./scripts/proto_gen.sh completed with no protocol diff.
make swift-test
# Result: pass; all Swift targets completed; macOS menubar package reported 796 tests in 25 suites passed.
make py-test
# Result: pass; 3902 passed, 14 skipped, 2 warnings in 159.19s.
make integration-test
# Result: pass; 117 passed, 1 skipped in 667.68s.

# Post-merge changed-line coverage against origin/main:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest services/mlx-worker-python/tests/test_local_job_continuation.py -q
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o /tmp/issue1756-followup-scan-coverage-after-merge.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json /tmp/issue1756-followup-scan-coverage-after-merge.json --diff-from origin/main services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py
# Result: TOTAL 100.00% (81/81 changed lines).

# Post-merge scoped performance report against origin/main:
git diff --name-only origin/main...HEAD | jq -R -s 'split("\n")[:-1]' > .runtime/pr-issue-1756-after-merge-perf/changed-files.json
UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-issue-1756-after-merge-perf/changed-files.json --output .runtime/pr-issue-1756-after-merge-perf/scope.json
UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/pr-issue-1756-after-merge-perf/scope.json --results-dir .runtime/pr-issue-1756-after-merge-perf/results --format terminal --output-dir .runtime/pr-issue-1756-after-merge-perf/report --sticky-comment
# Result: Status ok; changed files 4; selected probes 0; regressions 0; verification failures 0.
# Report: .runtime/pr-issue-1756-after-merge-perf/report/report.md

# Review-fix red checks for per-record scan isolation:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_local_job_continuation.py -q
# Expected red result before the fix: 2 failed; corrupt JSON aborted the scan with JSONDecodeError and revision-conflict store errors aborted the scan with LocalJobContinuationStoreError.

# Review-fix focused local-job continuation tests:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_local_job_continuation.py -q
# Result: 79 passed in 0.08s.

# Review-fix adjacent continuation tests:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py -q
# Result: 102 passed in 0.10s.

# Review-fix syntax and diff hygiene:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python -m py_compile services/mlx-worker-python/worker/runtime/local_job_continuation.py
# Result: pass.
git diff --check origin/main...HEAD
# Result: pass.

# Review-fix changed-line coverage against origin/main:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest services/mlx-worker-python/tests/test_local_job_continuation.py -q
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o /tmp/issue1756-followup-scan-review-fix-coverage.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json /tmp/issue1756-followup-scan-review-fix-coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py
# Result: TOTAL 100.00% (125/125 changed lines).

# Review-fix scoped performance report against origin/main:
git diff --name-only origin/main...HEAD | jq -R -s 'split("\n")[:-1]' > .runtime/pr-issue-1756-review-fix-perf/changed-files.json
UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-issue-1756-review-fix-perf/changed-files.json --output .runtime/pr-issue-1756-review-fix-perf/scope.json
UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/pr-issue-1756-review-fix-perf/scope.json --results-dir .runtime/pr-issue-1756-review-fix-perf/results --format terminal --output-dir .runtime/pr-issue-1756-review-fix-perf/report --sticky-comment
# Result: Status ok; changed files 4; selected probes 0; regressions 0; verification failures 0.
# Report: .runtime/pr-issue-1756-review-fix-perf/report/report.md

# Versioned pre-commit hook for review-fix commit ec790b6b on 256 GiB macOS host:
git commit -m "fix: isolate local job scan record failures"
# Result: pass.
# Hook reran make swift-test, make py-test, make integration-test, and scoped performance report.
# Hook swift-test result: pass; completed in 473.2s.
# Hook py-test result: 3904 passed, 14 skipped, 2 warnings in 176.48s.
# Hook integration-test result: 117 passed, 1 skipped in 651.17s.
# Hook performance result: Status ok; changed files 4; selected probes 0; regressions 0; verification failures 0.
# Hook report: .runtime/pre-commit-performance/20260611-084850-29b4b9ff/report/report.md

# Branch refresh after origin/main advanced to 6975a423:
git fetch origin main
git merge --no-edit origin/main
# Result: pass; merged 6975a423 without conflicts.

# Post-main-refresh focused and adjacent tests:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_local_job_continuation.py -q
# Result: 79 passed in 0.08s.
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py -q
# Result: 102 passed in 0.10s.

# Post-main-refresh syntax, diff hygiene, and changed-line coverage:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python -m py_compile services/mlx-worker-python/worker/runtime/local_job_continuation.py
# Result: pass.
git diff --check origin/main...HEAD
# Result: pass.
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest services/mlx-worker-python/tests/test_local_job_continuation.py -q
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o /tmp/issue1756-followup-scan-after-main-refresh-coverage.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json /tmp/issue1756-followup-scan-after-main-refresh-coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py
# Result: TOTAL 100.00% (125/125 changed lines).

# Post-main-refresh scoped performance report against origin/main:
git diff --name-only origin/main...HEAD | jq -R -s 'split("\n")[:-1]' > .runtime/pr-issue-1756-after-main-refresh-perf/changed-files.json
UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-issue-1756-after-main-refresh-perf/changed-files.json --output .runtime/pr-issue-1756-after-main-refresh-perf/scope.json
UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/pr-issue-1756-after-main-refresh-perf/scope.json --results-dir .runtime/pr-issue-1756-after-main-refresh-perf/results --format terminal --output-dir .runtime/pr-issue-1756-after-main-refresh-perf/report --sticky-comment
# Result: Status ok; changed files 4; selected probes 0; regressions 0; verification failures 0.
# Report: .runtime/pr-issue-1756-after-main-refresh-perf/report/report.md

# Post-main-refresh full local gates:
make bootstrap
# Result: pass; git hooks path configured to .githooks; uv sync checked 79 packages.
make proto
# Result: pass; ./scripts/proto_gen.sh completed with no protocol diff.
make swift-test
# Result: pass; protocol package rc=0, text worker 241 tests/0 failures, control-plane core 495 tests passed, OpenAI handler 209 tests passed, REST compatibility 40 tests passed, worker clients 127 tests passed, macOS menubar 796 tests passed.
make py-test
# Result: pass; 3904 passed, 14 skipped, 2 warnings in 159.48s.
make integration-test
# Result: pass; 117 passed, 1 skipped in 643.55s.

# Branch refresh after origin/main advanced to f34852b9:
git fetch origin main
git merge --no-edit origin/main
# Result: pass; merged f34852b9 without conflicts. The origin/main changes touched evaluation final-result files and did not overlap the local-job follow-up scanner.

# Post-second-main-refresh focused and adjacent tests:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_local_job_continuation.py -q
# Result: 79 passed in 0.08s.
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py -q
# Result: 102 passed in 0.10s.

# Post-second-main-refresh syntax, diff hygiene, and changed-line coverage:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python -m py_compile services/mlx-worker-python/worker/runtime/local_job_continuation.py
# Result: pass.
git diff --check origin/main...HEAD
# Result: pass.
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest services/mlx-worker-python/tests/test_local_job_continuation.py -q
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o /tmp/issue1756-followup-scan-after-main-refresh-2-coverage.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json /tmp/issue1756-followup-scan-after-main-refresh-2-coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py
# Result: TOTAL 100.00% (125/125 changed lines).

# Post-second-main-refresh scoped performance report against origin/main:
git diff --name-only origin/main...HEAD | jq -R -s 'split("\n")[:-1]' > .runtime/pr-issue-1756-after-main-refresh-2-perf/changed-files.json
UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-issue-1756-after-main-refresh-2-perf/changed-files.json --output .runtime/pr-issue-1756-after-main-refresh-2-perf/scope.json
UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/pr-issue-1756-after-main-refresh-2-perf/scope.json --results-dir .runtime/pr-issue-1756-after-main-refresh-2-perf/results --format terminal --output-dir .runtime/pr-issue-1756-after-main-refresh-2-perf/report --sticky-comment
# Result: Status ok; changed files 4; selected probes 0; regressions 0; verification failures 0.
# Report: .runtime/pr-issue-1756-after-main-refresh-2-perf/report/report.md

# Post-second-main-refresh full local gates:
make bootstrap
# Result: pass; git hooks path configured to .githooks; uv sync checked 79 packages.
make proto
# Result: pass; ./scripts/proto_gen.sh completed with no protocol diff.
make swift-test
# Result: pass; all Swift targets completed; macOS menubar package reported 796 tests in 25 suites passed.
make py-test
# Result: pass; 3905 passed, 14 skipped, 2 warnings in 161.44s.
make integration-test
# Result: pass; 117 passed, 1 skipped in 432.97s.

# Review-comment clarification for scan receipt precedence/status docs:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_local_job_continuation.py -q
# Result: 79 passed in 0.08s.
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python -m py_compile services/mlx-worker-python/worker/runtime/local_job_continuation.py
# Result: pass.
git diff --check origin/main...HEAD
# Result: pass.

# Review-comment changed-line coverage against origin/main:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest services/mlx-worker-python/tests/test_local_job_continuation.py -q
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o /tmp/issue1756-followup-scan-review-comment-coverage.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json /tmp/issue1756-followup-scan-review-comment-coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py
# Result: TOTAL 100.00% (125/125 changed lines).

# Review-comment scoped performance report against origin/main:
git diff --name-only origin/main...HEAD | jq -R -s 'split("\n")[:-1]' > .runtime/pr-issue-1756-review-comment-perf/changed-files.json
UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-issue-1756-review-comment-perf/changed-files.json --output .runtime/pr-issue-1756-review-comment-perf/scope.json
UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/pr-issue-1756-review-comment-perf/scope.json --results-dir .runtime/pr-issue-1756-review-comment-perf/results --format terminal --output-dir .runtime/pr-issue-1756-review-comment-perf/report --sticky-comment
# Result: Status ok; changed files 4; selected probes 0; regressions 0; verification failures 0.
# Report: .runtime/pr-issue-1756-review-comment-perf/report/report.md

# Versioned pre-commit hook for review-comment clarification commit 8df10e15 on 256 GiB macOS host:
git commit -m "docs: clarify local job scan receipts"
# Result: pass.
# Hook reran make swift-test, make py-test, make integration-test, and scoped performance report.
# Hook swift-test result: pass; completed in 421.4s.
# Hook py-test result: 3905 passed, 14 skipped, 2 warnings in 157.58s.
# Hook integration-test result: 117 passed, 1 skipped in 630.79s.
# Hook performance result: Status ok; changed files 1; selected probes 0; regressions 0; verification failures 0.
# Hook report: .runtime/pre-commit-performance/20260611-104727-0409abd1/report/report.md
```

## Coverage and Metrics
- Changed-line coverage: `100.00%` (`125/125` changed lines).
- Scoped performance report: `.runtime/pr-issue-1756-review-comment-perf/report/report.md`
- Pre-commit performance report: `.runtime/pre-commit-performance/20260611-104727-0409abd1/report/report.md`
- Performance status: `ok`; selected probes `0`; regressions `0`; context regressions `0`; verification failures `0`.
- Observability mode: `minimal`; this slice emits durable scan receipts only and adds no runtime metrics, no evidence-mode probes, and no debug artifacts.
- Probe overhead: `N/A`; no PR-scoped probes were selected because this is a bounded one-level store scan with no registered synthetic benchmark in `infra/perf/pr_scoped_probes.json`.

## Known Gaps
- The side-effecting monitor loop, prompt injection, session resume, and local process continuation remain deferred to later issue #1756 slices.
- This PR intentionally adds only the store-level discovery/read-model boundary.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
