### PR TITLE
perf: fast-path equal json score lists

### DIFF
--- a/docs/plans/2026-06-11-evaluation-final-result-json-score-local-bindings.md
+++ b/docs/plans/2026-06-11-evaluation-final-result-json-score-local-bindings.md
@@ -1,0 +1,35 @@
+# Evaluation Final Result JSON Score Local Bindings
+
+## Goal
+
+Reduce per-node overhead in `services/mlx-worker-python/worker/productization/evaluation_final_result.py` JSON typed scoring by keeping the recursive scoring semantics unchanged while binding repeated lookups locally inside the recursive walker.
+
+## Scope
+
+Touched files:
+
+- `services/mlx-worker-python/worker/productization/evaluation_final_result.py`
+- `services/mlx-worker-python/tests/test_evaluation_final_result.py`
+- `docs/plans/2026-06-11-evaluation-final-result-json-score-local-bindings.md`
+
+## Registered probe coverage
+
+The affected production file is covered by the registered PR-scoped probe `evaluation-final-result-json-typed-score-aggregate` in `infra/perf/pr_scoped_probes.json`. The probe already has focused `test_command`, `coverage_command`, and `probe_command` entries and reports:
+
+- `elapsed_ms_mean` (lower is better)
+- `peak_bytes_mean` (lower is better)
+- `score_checksum` (higher is better / parity guard)
+
+## Planned change
+
+1. Keep `_json_typed_score` output identical for dictionaries, lists, primitive values, ignored paths, and missing actual values.
+2. Replace repeated global/function/member lookups in hot recursive branches with local bindings (`actual_get`, `ignored_contains`, and `score_child`).
+3. Inline the small child-path join at the call site to avoid the helper call in the per-key loop.
+4. Return immediately for equal list payloads, which preserves scoring semantics because every element would otherwise score `1.0` even when ignored paths are present.
+
+## Verification commands
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_json_typed_score_probe.py`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_json_typed_score_probe.py`
+- `git diff --check`

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -585,6 +585,24 @@ def test_score_final_result_aggregates_wide_json_without_losing_ignored_paths() 
     assert score.typed_score == pytest.approx(0.75)
 
 
+def test_score_final_result_recurses_into_partially_different_json_lists() -> None:
+    score = score_final_result(
+        extracted_result=json.dumps({"scores": [1, 99, 3]}),
+        target=json.dumps({"scores": [1, 2, 3]}),
+        profile=EvaluationProfileDefinition(
+            profile_type="final_result",
+            result_kind="json",
+            extraction_mode="strict_full_response",
+            scoring_mode="json_field_match",
+            threshold=1.0,
+        ),
+    )
+
+    assert score.validation_status == "validated"
+    assert score.failure_reason == ""
+    assert score.typed_score == pytest.approx(0.6667)
+
+
 def test_score_final_result_treats_fully_ignored_json_object_as_match() -> None:
     score = score_final_result(
         extracted_result=json.dumps({"metadata": {"confidence": 0.0}}),

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -493,13 +493,16 @@ def _json_typed_score(*, expected: Any, actual: Any, ignored_paths: Collection[s
         total = 0.0
         count = 0
         actual_dict = actual if isinstance(actual, dict) else None
+        actual_get = actual_dict.get if actual_dict is not None else None
+        ignored_contains = ignored_paths.__contains__
+        score_child = _json_typed_score
         for key, expected_value in expected.items():
-            child_path = _joined_path(path, key)
-            if child_path in ignored_paths:
+            child_path = f"{path}.{key}" if path else key
+            if ignored_contains(child_path):
                 continue
-            total += _json_typed_score(
+            total += score_child(
                 expected=expected_value,
-                actual=actual_dict.get(key) if actual_dict is not None else None,
+                actual=actual_get(key) if actual_get is not None else None,
                 ignored_paths=ignored_paths,
                 path=child_path,
             )
@@ -510,11 +513,12 @@ def _json_typed_score(*, expected: Any, actual: Any, ignored_paths: Collection[s
     if isinstance(expected, list):
         if not isinstance(actual, list) or len(expected) != len(actual):
             return 0.0
-        if not expected:
+        if not expected or expected == actual:
             return 1.0
         total = 0.0
+        score_child = _json_typed_score
         for index, item in enumerate(expected):
-            total += _json_typed_score(
+            total += score_child(
                 expected=item,
                 actual=actual[index],
                 ignored_paths=ignored_paths,


### PR DESCRIPTION
## Summary
- Optimizes final-result JSON typed scoring by avoiding recursive descent for list values that are already equal.
- Keeps hot recursive lookups local in the dict/list scorer path while preserving ignored-path semantics.
- Adds a regression test covering partially different JSON lists so the non-fast-path list recursion remains exercised.

## Plan or Spec
- `docs/plans/2026-06-11-evaluation-final-result-json-score-local-bindings.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 41 passed in 0.24s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_json_typed_score_probe.py
# 41 passed in 0.35s; changed-scope coverage TOTAL 14 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_json_typed_score_probe.py
# base repeated locally from origin/main: 18.175196554511786, 17.51210791990161, 17.943412624299526 ms
# head repeated locally: 13.727067317813635, 13.318691123276949, 12.551050819456577 ms

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Registered probe: `evaluation-final-result-json-typed-score-aggregate` covers `services/mlx-worker-python/worker/productization/evaluation_final_result.py` with focused test, coverage, and probe commands.
- Local Linux probe result: `old_mean=17.876906 ms`, `new_mean=13.198936 ms`, `delta_ms=-4.677969`, `speedup=26.17%`; `peak_bytes_mean` unchanged at `713702.6`; `score_checksum=35.0` unchanged.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed.
- Full `make py-test` / integration suite not run locally; CI is expected to cover broader gates.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe; runtime observability unchanged.
- [x] Deferred work and known gaps are stated explicitly.
