### PR TITLE
perf: gate hub MLX tag comparisons by type

### DIFF
--- a/docs/plans/2026-06-11-hub-size-marker-cache.md
+++ b/docs/plans/2026-06-11-hub-size-marker-cache.md
@@ -1,9 +1,9 @@
-# Hub catalog size-hint marker cache
+# Hub catalog MLX tag atom type gate
 
 ## Scope
 
-This Python-only performance slice is limited to the Hub catalog size-hint path in
-`services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+This Python-only performance slice is limited to the Hub catalog MLX tag
+compatibility path in `services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
 
 ## Registered probe
 
@@ -15,17 +15,17 @@ focused `test_command`, `coverage_command`, and `probe_command` entries.
 
 ## Change
 
-When the size-hint parser must inspect `description`, `readme`, and
-`cardData.description`, reuse each `_may_contain_model_marker(...)` result as the
-parser walks the fields. The loop stops once a valid size hint is found, keeps
-behavior identical, and avoids a second marker scan for fields that proceed to
-regex parsing.
+When `_tag_payload_contains_mlx(...)` scans list payloads, it now gates the
+existing exact/atom checks with `isinstance(item, str)` before comparing tag
+values. This preserves exact three-character MLX semantics and the existing
+short-circuit for `"MLX"`/`"mlx"` while skipping unnecessary string comparisons
+for non-string tag values.
 
 ## Verification plan
 
 - Run the registered focused test command for `hub-catalog-size-hint-regex-precompile`.
 - Run the registered changed-scope coverage command and require at least 95% coverage.
-- Run the registered probe locally on Linux against `origin/main` and the slice, then compare `elapsed_ms_mean`.
+- Run the registered probe locally on Linux against `origin/main` and the slice, then compare `payload_compatibility_elapsed_ms_mean`.
 - Use the PR-scoped performance workflow as the CI merge gate.
 
 ## Linux boundary

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -420,8 +420,8 @@ def _is_mlx_atom(value: str) -> bool:
 def _tag_payload_contains_mlx(value: Any) -> bool:
     if isinstance(value, list):
         for item in value:
-            if item == "MLX" or item == "mlx" or (
-                isinstance(item, str) and len(item) == 3 and _is_mlx_atom(item)
+            if isinstance(item, str) and (
+                item == "MLX" or item == "mlx" or (len(item) == 3 and _is_mlx_atom(item))
             ):
                 return True
         return False


### PR DESCRIPTION
## Summary
- Gate Hub catalog MLX tag comparisons with `isinstance(item, str)` before exact string checks.
- Preserve exact `MLX`/`mlx` short-circuit and three-character case-insensitive atom behavior.
- Update the governing plan for this Python-only compatibility-path slice.

## Plan or Spec
- `docs/plans/2026-06-11-hub-size-marker-cache.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics` → 79 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py` → TOTAL 1 0 100%
- Baseline probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- Slice probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`services/mlx-worker-python/worker/model_ops/hub_catalog.py` changed line covered).
- Baseline `payload_compatibility_elapsed_ms_mean`: 209.90135418251157 ms.
- Slice `payload_compatibility_elapsed_ms_mean`: 207.47270956635475 ms.
- Delta: -2.4286446161568165 ms (~1.16% faster) for the registered compatibility metric.
- Compatibility call count unchanged: 200000.0; matched count unchanged: 160000.0; checksum unchanged: 1545732096.0.
- Overall size-hint `elapsed_ms_mean` was effectively flat locally (baseline 1907.7289167791605 ms, slice 1907.5525233522058 ms).

## Known Gaps
- Local validation is Linux-only Python validation; no Swift runtime claims are made.
- Registered PR-scoped performance CI must complete successfully before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe shows improvement on the targeted compatibility metric.
- [ ] GitHub Actions / PR-scoped performance workflow completed successfully.
