### PR TITLE
perf: cache tool registry keyword matches

### DIFF
--- a/docs/plans/2026-06-11-tool-registry-keyword-match-cache.md
+++ b/docs/plans/2026-06-11-tool-registry-keyword-match-cache.md
@@ -1,0 +1,36 @@
+# Tool registry keyword match cache
+
+This Python-only performance slice keeps the agentic tool keyword-selection
+behavior unchanged while avoiding repeated keyword scans for repeated prompts in
+selector planning.
+
+Registered PR-scoped probe: `tool-registry-select-name-index-cache` in
+`infra/perf/pr_scoped_probes.json`. The probe covers
+`services/mlx-worker-python/worker/runtime/tool_registry.py`, includes focused
+`test_command`, `coverage_command`, and `probe_command` entries, and reports the
+`selector_planning_elapsed_ms_mean` metric for `select_agentic_tools_for_turn`.
+
+## Slice
+
+1. Add a bounded `lru_cache(maxsize=128)` to `_keyword_tool_matches`, keyed by
+   the original prompt/context string.
+2. Preserve existing keyword semantics: empty text, whitespace-only text,
+   literal hints, and boundary-token hints still return the same matches.
+3. Add a regression test proving repeated keyword matching reuses the bounded
+   cache without changing returned matches.
+
+## Verification plan
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
+```
+
+## Expected metrics
+
+The primary metric is `selector_planning_elapsed_ms_mean` from
+`scripts/tool_registry_select_probe.py`; repeated selector prompts in the probe
+should hit the keyword-match cache after the first sample. General
+`elapsed_ms_mean` registry-selection metrics may remain within noise because the
+`ToolRegistry.select()` code path is unchanged.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -757,6 +757,20 @@ def test_agentic_tool_selection_keyword_matcher_covers_literal_and_boundary_bran
     )
 
 
+def test_agentic_tool_selection_keyword_matches_reuse_bounded_cache() -> None:
+    matcher = tool_registry_module._keyword_tool_matches
+    matcher.cache_clear()
+
+    assert matcher("Search, then crop-region.") == ("image_crop", "text_search")
+    first_info = matcher.cache_info()
+    assert matcher("Search, then crop-region.") == ("image_crop", "text_search")
+    second_info = matcher.cache_info()
+
+    assert first_info.maxsize == 128
+    assert first_info.misses == 1
+    assert second_info.hits == first_info.hits + 1
+
+
 def test_agentic_tool_selection_keyword_rule_compiler_filters_empty_hints() -> None:
     rules = tool_registry_module._compile_keyword_hint_rules(
         {

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import Any, cast
 
 from packages.protocol.python.worker.v1 import common_pb2
@@ -519,6 +520,7 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
     return ToolSelectionResult(registry=selected_registry, receipt=receipt)
 
 
+@lru_cache(maxsize=128)
 def _keyword_tool_matches(text: str) -> tuple[str, ...]:
     if not text:
         return ()


### PR DESCRIPTION
## Summary
- Add a bounded cache for agentic tool keyword-match results so repeated selector prompts avoid rescanning keyword hints.
- Add focused regression coverage for cache reuse while preserving literal/boundary keyword behavior.
- Document the slice and registered probe in `docs/plans/2026-06-11-tool-registry-keyword-match-cache.md`.

## Plan or Spec
- Plan: `docs/plans/2026-06-11-tool-registry-keyword-match-cache.md`
- Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 76 passed.
- Changed-scope coverage: 100.00% (12/12 changed measurable lines).
- Baseline probe on `origin/main`: `selector_planning_elapsed_ms_mean=64.60544439032674`, `elapsed_ms_mean=21.185588464140892`.
- Candidate probe on this branch: `selector_planning_elapsed_ms_mean=36.09675485640764`, `elapsed_ms_mean=21.91478619351983`.
- Primary selector-planning delta: -28.5086895339191 ms (-44.13%). General registry selection elapsed is within the registered 5% warning threshold and is not the targeted path for this slice.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed.
- Probe timing may vary by runner; the registered CI probe report is the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe command ran locally.
- [ ] GitHub Actions completed successfully.
- [ ] Registered PR-scoped performance report completed successfully.
