### PR TITLE
perf: stream macOS app package pruning

### DIFF
--- a/docs/plans/2026-06-11-macos-app-package-prune-scandir.md
+++ b/docs/plans/2026-06-11-macos-app-package-prune-scandir.md
@@ -1,0 +1,20 @@
+# macOS app package-prune scandir slice
+
+This Python performance slice is limited to `worker.productization.macos_app_bundle._prune_python_package_baggage`.
+
+## Slice
+
+- Replace the package baggage pruning `os.walk` pass with an explicit `os.scandir` stack so app bundle packaging can stream package directories while deleting prunable `tests`, `docs`, and `__pycache__` subtrees.
+- Preserve existing semantics: directory symlinks with prunable names are unlinked instead of traversed, non-prunable symlinks are not followed, metadata and deletion errors are ignored, and byte accounting still uses `_path_size_bytes` before deletion.
+- Register the focused PR-scoped probe `macos-app-package-prune-scandir` because adjacent macOS app bundle probes cover resource bundle, native binary, path-size, and signing-target scans but did not directly measure package pruning.
+
+## Verification
+
+- Focused regression tests for package-prune behavior and a guard that fails if `_prune_python_package_baggage` returns to `os.walk`.
+- `test_pr_scoped_performance` registry checks proving the macOS app bundle path selects the new probe and that the probe script emits JSON metrics.
+- Changed-scope coverage via the registered probe `coverage_command`.
+- Local Linux probe execution for `_prune_python_package_baggage`; GitHub Actions PR-scoped performance remains the base-vs-head merge gate.
+
+## Expected outcome
+
+The packaging prune pass should reduce traversal overhead on synthetic package trees while keeping package slimming output and byte accounting stable.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2296,6 +2296,42 @@
     ]
   },
   {
+    "id": "macos-app-package-prune-scandir",
+    "name": "macOS app Python package prune scandir",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/macos_app_bundle.py",
+      "services/mlx-worker-python/tests/test_macos_app_bundle.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/macos_app_package_prune_probe.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_bundle_slimming_helpers_cover_runtime_edge_cases services/mlx-worker-python/tests/test_macos_app_bundle.py::test_prune_python_package_baggage_uses_scandir_without_os_walk services/mlx-worker-python/tests/test_macos_app_bundle.py::test_prune_python_package_baggage_tolerates_scan_and_delete_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_package_prune_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_bundle_slimming_helpers_cover_runtime_edge_cases services/mlx-worker-python/tests/test_macos_app_bundle.py::test_prune_python_package_baggage_uses_scandir_without_os_walk services/mlx-worker-python/tests/test_macos_app_bundle.py::test_prune_python_package_baggage_tolerates_scan_and_delete_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_package_prune_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/macos_app_bundle.py services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/macos_app_package_prune_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/macos_app_package_prune_probe.py\"; for CANDIDATE in \"${MELIX_PR_SCOPED_PERFORMANCE_HEAD_REPO:-}/$SCRIPT\" \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "pruned_count",
+        "unit": "directories",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "package-macos-resolve-fallback-scandir",
     "name": "Package macOS fallback build product scandir",
     "runner": "ubuntu-latest",

--- a/scripts/macos_app_package_prune_probe.py
+++ b/scripts/macos_app_package_prune_probe.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import statistics
+import tempfile
+import time
+from pathlib import Path
+
+from worker.productization.macos_app_bundle import _prune_python_package_baggage
+
+
+PACKAGE_COUNT = 400
+PRUNABLE_DIR_NAMES = ("tests", "test", "testing", "docs", "doc", "__pycache__")
+KEPT_FILE_COUNT = 3
+SAMPLE_COUNT = 9
+
+
+def _build_site_packages(root: Path) -> None:
+    root.mkdir()
+    for index in range(PACKAGE_COUNT):
+        package = root / f"package_{index:04d}"
+        package.mkdir()
+        for dirname in PRUNABLE_DIR_NAMES:
+            prunable = package / dirname
+            prunable.mkdir()
+            (prunable / "fixture.txt").write_text("x" * 64, encoding="utf-8")
+        for file_index in range(KEPT_FILE_COUNT):
+            (package / f"module_{file_index}.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+
+def main() -> None:
+    elapsed_samples: list[float] = []
+    pruned_count = 0
+    bytes_saved = 0
+    for _ in range(SAMPLE_COUNT):
+        with tempfile.TemporaryDirectory() as tmp:
+            site_packages = Path(tmp) / "site-packages"
+            _build_site_packages(site_packages)
+            started_at = time.perf_counter()
+            result = _prune_python_package_baggage(site_packages)
+            elapsed_samples.append((time.perf_counter() - started_at) * 1000.0)
+            pruned_count = result["directories_pruned"]
+            bytes_saved = result["bytes_saved"]
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.mean(elapsed_samples),
+                "elapsed_ms_min": min(elapsed_samples),
+                "elapsed_ms_p95": statistics.quantiles(elapsed_samples, n=20)[18],
+                "sample_count": float(SAMPLE_COUNT),
+                "package_count": float(PACKAGE_COUNT),
+                "pruned_count": float(pruned_count),
+                "bytes_saved": float(bytes_saved),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mlx-worker-python/tests/test_macos_app_bundle.py
+++ b/services/mlx-worker-python/tests/test_macos_app_bundle.py
@@ -652,6 +652,92 @@ def test_bundle_slimming_helpers_cover_runtime_edge_cases(
     assert unavailable_result["attempted"] == 0
 
 
+def test_prune_python_package_baggage_uses_scandir_without_os_walk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    package = site_packages / "package"
+    nested = package / "nested"
+    docs = nested / "docs"
+    retained = nested / "runtime.py"
+    docs.mkdir(parents=True)
+    retained.write_text("VALUE = 1\n", encoding="utf-8")
+    (docs / "fixture.txt").write_text("not shipped\n", encoding="utf-8")
+
+    def fail_os_walk(*args: object, **kwargs: object):  # pragma: no cover - regression guard
+        raise AssertionError("_prune_python_package_baggage() should stream os.scandir entries")
+
+    monkeypatch.setattr(macos_app_bundle_module.os, "walk", fail_os_walk)
+
+    result = _prune_python_package_baggage(site_packages)
+
+    assert result["directories_pruned"] == 1
+    assert result["bytes_saved"] > 0
+    assert docs.exists() is False
+    assert retained.is_file()
+
+
+def test_prune_python_package_baggage_tolerates_scan_and_delete_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    package = site_packages / "package"
+    docs = package / "docs"
+    unreadable = package / "unreadable"
+    docs.mkdir(parents=True)
+    unreadable.mkdir()
+    (docs / "fixture.txt").write_text("not shipped\n", encoding="utf-8")
+
+    original_scandir = macos_app_bundle_module.os.scandir
+    original_rmtree = macos_app_bundle_module.shutil.rmtree
+
+    class BrokenEntry:
+        name = "broken"
+        path = str(package / "broken")
+
+        def is_dir(self, *, follow_symlinks: bool) -> bool:
+            assert follow_symlinks is False
+            raise OSError("synthetic entry metadata failure")
+
+    class FakeScandir:
+        def __init__(self, entries: list[object]) -> None:
+            self._entries = entries
+
+        def __enter__(self) -> "FakeScandir":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def __iter__(self):
+            return iter(self._entries)
+
+    def fake_scandir(path: Path | str):
+        path = Path(path)
+        if path == package:
+            real_entries = list(original_scandir(path))
+            return FakeScandir([BrokenEntry(), *real_entries])
+        if path == unreadable:
+            raise OSError("synthetic scandir failure")
+        return original_scandir(path)
+
+    def flaky_rmtree(path: Path) -> None:
+        if path == docs:
+            raise OSError("synthetic delete failure")
+        original_rmtree(path)
+
+    monkeypatch.setattr(macos_app_bundle_module.os, "scandir", fake_scandir)
+    monkeypatch.setattr(macos_app_bundle_module.shutil, "rmtree", flaky_rmtree)
+
+    assert _prune_python_package_baggage(site_packages) == {
+        "directories_pruned": 0,
+        "bytes_saved": 0,
+    }
+    assert docs.is_dir()
+
+
 def test_iter_python_native_binary_candidates_tolerates_scandir_metadata_errors(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1506,12 +1506,13 @@ def test_scope_report_selects_macos_app_bundle_probes() -> None:
         changed_files=["services/mlx-worker-python/worker/productization/macos_app_bundle.py"],
     )
 
-    assert scope["selected_count"] == 4
+    assert scope["selected_count"] == 5
     assert _selected_probe_ids(scope) == [
         "macos-app-resource-bundle-scandir",
         "macos-app-native-binary-scandir",
         "macos-app-path-size-scandir",
         "macos-app-signing-targets-scandir",
+        "macos-app-package-prune-scandir",
     ]
 
 
@@ -1523,6 +1524,19 @@ def test_macos_app_path_size_probe_script_emits_metrics(
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["file_count"] == 2500.0
     assert metrics["measured_size_bytes"] > 0.0
+    assert metrics["elapsed_ms_mean"] > 0.0
+    assert metrics["sample_count"] == 9.0
+
+
+def test_macos_app_package_prune_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runpy.run_path(str(REPO_ROOT / "scripts/macos_app_package_prune_probe.py"), run_name="__main__")
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["package_count"] == 400.0
+    assert metrics["pruned_count"] == 2400.0
+    assert metrics["bytes_saved"] > 0.0
     assert metrics["elapsed_ms_mean"] > 0.0
     assert metrics["sample_count"] == 9.0
 
@@ -3324,6 +3338,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "macos-app-native-binary-scandir",
         "macos-app-path-size-scandir",
         "macos-app-signing-targets-scandir",
+        "macos-app-package-prune-scandir",
         "package-macos-resolve-fallback-scandir",
         "melix-metrics-snapshot-runtime-scandir",
         "pr-scoped-performance-scope-json-read-bytes",

--- a/services/mlx-worker-python/worker/productization/macos_app_bundle.py
+++ b/services/mlx-worker-python/worker/productization/macos_app_bundle.py
@@ -367,24 +367,35 @@ def _prune_python_package_baggage(site_packages: Path) -> dict[str, int]:
         "directories_pruned": 0,
         "bytes_saved": 0,
     }
-    for root, dirnames, _filenames in os.walk(site_packages, followlinks=False):
-        root_path = Path(root)
-        for dirname in list(dirnames):
-            if dirname not in _PRUNABLE_PYTHON_PACKAGE_DIR_NAMES:
-                continue
-            target = root_path / dirname
-            try:
-                bytes_saved = _path_size_bytes(target)
-                if target.is_symlink():
-                    target.unlink()
-                else:
-                    shutil.rmtree(target)
-            except OSError:
-                dirnames.remove(dirname)
-                continue
-            result["bytes_saved"] += bytes_saved
-            result["directories_pruned"] += 1
-            dirnames.remove(dirname)
+    stack = [site_packages]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as entries:
+                for entry in entries:
+                    try:
+                        is_directory = entry.is_dir(follow_symlinks=False)
+                    except OSError:
+                        continue
+
+                    if entry.name in _PRUNABLE_PYTHON_PACKAGE_DIR_NAMES:
+                        target = Path(entry.path)
+                        try:
+                            bytes_saved = _path_size_bytes(target)
+                            if entry.is_symlink():
+                                target.unlink()
+                            else:
+                                shutil.rmtree(target)
+                        except OSError:
+                            continue
+                        result["bytes_saved"] += bytes_saved
+                        result["directories_pruned"] += 1
+                        continue
+
+                    if is_directory:
+                        stack.append(Path(entry.path))
+        except OSError:
+            continue
     return result
 
 


### PR DESCRIPTION
## Summary
- Stream `_prune_python_package_baggage` with an explicit `os.scandir` stack instead of `os.walk` while preserving symlink, deletion-error, and metadata-error behavior.
- Add the registered PR-scoped probe `macos-app-package-prune-scandir` and a focused synthetic probe script for package-prune traversal.
- Document the slice in `docs/plans/2026-06-11-macos-app-package-prune-scandir.md`.

## Plan or Spec
- `docs/plans/2026-06-11-macos-app-package-prune-scandir.md`

## Commands Run
```text
# Baseline old implementation local probe (before code change): exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
# synthetic 400-package package-prune probe
PY
=> old elapsed_ms_mean=245.01981819048524, elapsed_ms_min=216.16107877343893, pruned_count=2400

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_bundle_slimming_helpers_cover_runtime_edge_cases services/mlx-worker-python/tests/test_macos_app_bundle.py::test_prune_python_package_baggage_uses_scandir_without_os_walk services/mlx-worker-python/tests/test_macos_app_bundle.py::test_prune_python_package_baggage_tolerates_scan_and_delete_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_package_prune_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
=> 6 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_bundle_slimming_helpers_cover_runtime_edge_cases services/mlx-worker-python/tests/test_macos_app_bundle.py::test_prune_python_package_baggage_uses_scandir_without_os_walk services/mlx-worker-python/tests/test_macos_app_bundle.py::test_prune_python_package_baggage_tolerates_scan_and_delete_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_package_prune_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
=> 6 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/macos_app_bundle.py services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/macos_app_package_prune_probe.py
=> TOTAL 91 1 99%

# Registered probe command loaded from infra/perf/pr_scoped_probes.json: exit 0
macos-app-package-prune-scandir
=> elapsed_ms_mean=235.98082741308542, elapsed_ms_min=217.31468802317977, elapsed_ms_p95=253.40909510850906, pruned_count=2400

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.json.validated
=> exit 0

git diff --check
=> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 91 1 99%`.
- Local Linux synthetic probe: old_mean=245.01981819048524ms, new_mean=235.98082741308542ms, delta=-9.038990777399817ms, speedup=3.689085578527633%.
- Registered PR-scoped performance CI is required as the base-vs-head merge gate before merging.

## Known Gaps
- Local validation is Linux-only. This slice touches Python packaging code and was locally verified on Linux; CI remains required for the registered PR-scoped performance workflow and broader gates.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
