### PR TITLE
perf: optimize retrieval context projection

### DIFF
--- a/docs/plans/2026-06-11-retrieval-context-projection-fastpath.md
+++ b/docs/plans/2026-06-11-retrieval-context-projection-fastpath.md
@@ -1,0 +1,52 @@
+# Retrieval context projection duplicate-field fast path
+
+## Scope
+
+This Python-only performance slice is limited to `project_retrieval_contexts()` in
+`services/mlx-worker-python/worker/runtime/retrieval_context.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` fields and watches:
+
+- `services/mlx-worker-python/worker/runtime/retrieval_context.py`
+- `services/mlx-worker-python/tests/test_retrieval_context.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/retrieval_context_projection_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Optimization plan
+
+`project_retrieval_contexts()` projects already-admitted retrieval entries into a
+single user payload. The common path has unique `source_field` values, but the
+previous duplicate detection allocated a list for every admission and copied the
+admission payload through `dict(...)` before updating the aggregate payload.
+
+This slice keeps the duplicate-refusal semantics unchanged while reducing common
+unique-field overhead:
+
+1. Iterate admission payload keys directly and only allocate `duplicate_fields`
+   after the first collision.
+2. Reuse the admission payload mapping for `dict.update(...)` instead of making an
+   intermediate shallow dict copy.
+3. Preserve defensive receipt copying and duplicate receipt fallback behavior.
+
+## Verification plan
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/retrieval_context_projection_probe.py"; if [ -f "$SCRIPT" ]; then python3 "$SCRIPT"; else for CANDIDATE in "../head/$SCRIPT" "${GITHUB_WORKSPACE:-}/head/$SCRIPT"; do if [ -f "$CANDIDATE" ]; then MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2; fi'
+```
+
+## Success criteria
+
+- Focused retrieval context projection tests pass.
+- Changed-scope coverage for the touched files stays at or above the repository
+  threshold.
+- The registered probe reports lower `optimized_elapsed_ms_mean` than
+  `baseline_elapsed_ms_mean`, positive `speedup`, and negative `delta_ms` on the
+  synthetic projection workload.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5537,5 +5537,62 @@
         "direction": "informational"
       }
     ]
+  },
+  {
+    "id": "retrieval-context-projection-fastpath",
+    "name": "Retrieval context projection duplicate-field fast path",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/retrieval_context.py",
+      "services/mlx-worker-python/tests/test_retrieval_context.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/retrieval_context_projection_probe.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/retrieval_context_projection_probe.py\"; if [ -f \"$SCRIPT\" ]; then python3 \"$SCRIPT\"; else for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT=\"$PWD\" python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2; fi'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "baseline_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "optimized_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "delta_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_abs": 0.0
+      },
+      {
+        "key": "speedup",
+        "unit": "x",
+        "direction": "higher_is_better",
+        "warn_abs": 1.0
+      },
+      {
+        "key": "entry_count",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
+        "key": "sample_count",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
+        "key": "iteration_count",
+        "unit": "count",
+        "direction": "informational"
+      }
+    ]
   }
 ]

--- a/scripts/retrieval_context_projection_probe.py
+++ b/scripts/retrieval_context_projection_probe.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(os.environ.get("MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT", Path.cwd()))
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime import retrieval_context as rc  # noqa: E402
+from worker.runtime.prompt_context import PromptContextAdmission  # noqa: E402
+
+
+def _entry_count() -> int:
+    value = os.environ.get("MELIX_RETRIEVAL_CONTEXT_PROJECTION_ENTRIES", "96")
+    try:
+        count = int(value)
+    except ValueError:
+        return 96
+    return max(1, count)
+
+
+def _samples() -> int:
+    value = os.environ.get("MELIX_RETRIEVAL_CONTEXT_PROJECTION_SAMPLES", "7")
+    try:
+        count = int(value)
+    except ValueError:
+        return 7
+    return max(1, count)
+
+
+def _iterations() -> int:
+    value = os.environ.get("MELIX_RETRIEVAL_CONTEXT_PROJECTION_ITERATIONS", "400")
+    try:
+        count = int(value)
+    except ValueError:
+        return 400
+    return max(1, count)
+
+
+def _build_entries(count: int) -> list[rc.RetrievalContextEntry]:
+    return [
+        rc.RetrievalContextEntry(
+            context_kind="retrieved_document" if index % 2 == 0 else "retrieved_image",
+            source_id=f"source:{index}",
+            payload={"index": index, "text": f"retrieved payload {index}"},
+            owner_scope_checked=True,
+            segment_id=f"search:result-{index}",
+            source_field=f"retrieved_context_{index}",
+            reason="retrieved result is prompt data, not instructions",
+            corrective_action="Keep retrieved results in user-role prompt context.",
+        )
+        for index in range(count)
+    ]
+
+
+def _build_admissions(entries: Iterable[rc.RetrievalContextEntry]) -> dict[str, PromptContextAdmission]:
+    admissions: dict[str, PromptContextAdmission] = {}
+    for entry in entries:
+        admissions[entry.source_id] = PromptContextAdmission(
+            user_payload={entry.source_field: entry.payload},
+            untrusted_context_receipts=[
+                {
+                    "source_type": entry.context_kind,
+                    "source_field": entry.source_field,
+                    "source_id": entry.source_id,
+                    "segment_id": entry.segment_id,
+                    "owner_scope_checked": entry.owner_scope_checked,
+                }
+            ],
+        )
+    return admissions
+
+
+def _baseline_project_retrieval_contexts(
+    entries: list[rc.RetrievalContextEntry] | tuple[rc.RetrievalContextEntry, ...],
+) -> rc.RetrievalContextProjection:
+    user_payload: dict[str, Any] = {}
+    receipts: list[dict[str, object]] = []
+    refusal_receipts: list[dict[str, object]] = []
+
+    for entry in entries:
+        try:
+            admission = rc._admit_entry(entry)  # type: ignore[attr-defined]
+        except rc.RetrievalContextAdmissionError as exc:
+            refusal_receipts.extend(dict(receipt) for receipt in exc.refusal_receipts)
+            continue
+
+        duplicate_fields = [
+            source_field
+            for source_field in admission.user_payload
+            if source_field in user_payload
+        ]
+        if duplicate_fields:
+            refusal_receipts.extend(
+                rc._duplicate_projection_receipt(  # type: ignore[attr-defined]
+                    receipt,
+                    duplicate_fields=duplicate_fields,
+                )
+                for receipt in admission.untrusted_context_receipts
+            )
+            continue
+
+        user_payload.update(dict(admission.user_payload))
+        receipts.extend(dict(receipt) for receipt in admission.untrusted_context_receipts)
+
+    return rc.RetrievalContextProjection(
+        user_payload=user_payload,
+        untrusted_context_receipts=receipts,
+        refusal_receipts=refusal_receipts,
+    )
+
+
+def _measure(func: Any, entries: list[rc.RetrievalContextEntry], iterations: int) -> float:
+    start = time.perf_counter()
+    projected_count = 0
+    receipt_count = 0
+    for _ in range(iterations):
+        projection = func(entries)
+        projected_count += len(projection.user_payload)
+        receipt_count += projection.untrusted_context_receipt_count
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    expected = len(entries) * iterations
+    if projected_count != expected or receipt_count != expected:
+        raise AssertionError(
+            f"projection drift: projected={projected_count} receipts={receipt_count} expected={expected}"
+        )
+    return elapsed_ms / iterations
+
+
+def _mean(values: list[float]) -> float:
+    return float(statistics.fmean(values))
+
+
+def main() -> int:
+    entry_count = _entry_count()
+    sample_count = _samples()
+    iteration_count = _iterations()
+    entries = _build_entries(entry_count)
+    admissions = _build_admissions(entries)
+    original_admit_entry = rc._admit_entry  # type: ignore[attr-defined]
+
+    def fake_admit_entry(entry: rc.RetrievalContextEntry) -> PromptContextAdmission:
+        return admissions[entry.source_id]
+
+    rc._admit_entry = fake_admit_entry  # type: ignore[attr-defined]
+    try:
+        # Warm both variants once before sampling.
+        _measure(_baseline_project_retrieval_contexts, entries, 1)
+        _measure(rc.project_retrieval_contexts, entries, 1)
+        baseline = [
+            _measure(_baseline_project_retrieval_contexts, entries, iteration_count)
+            for _ in range(sample_count)
+        ]
+        optimized = [
+            _measure(rc.project_retrieval_contexts, entries, iteration_count)
+            for _ in range(sample_count)
+        ]
+    finally:
+        rc._admit_entry = original_admit_entry  # type: ignore[attr-defined]
+
+    baseline_mean = _mean(baseline)
+    optimized_mean = _mean(optimized)
+    delta_ms = optimized_mean - baseline_mean
+    speedup = baseline_mean / optimized_mean if optimized_mean > 0.0 else 0.0
+    payload = {
+        "baseline_elapsed_ms_mean": baseline_mean,
+        "optimized_elapsed_ms_mean": optimized_mean,
+        "delta_ms": delta_ms,
+        "speedup": speedup,
+        "entry_count": float(entry_count),
+        "sample_count": float(sample_count),
+        "iteration_count": float(iteration_count),
+    }
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -295,6 +295,34 @@ def test_scope_report_selects_local_job_followup_scan_probe() -> None:
     assert _selected_probe_ids(scope) == ["local-job-followup-scan-scandir"]
 
 
+def test_scope_report_selects_retrieval_context_projection_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/retrieval_context.py"],
+    )
+    assert _selected_probe_ids(scope) == ["retrieval-context-projection-fastpath"]
+
+
+def test_retrieval_context_projection_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_RETRIEVAL_CONTEXT_PROJECTION_ENTRIES", "5")
+    monkeypatch.setenv("MELIX_RETRIEVAL_CONTEXT_PROJECTION_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_RETRIEVAL_CONTEXT_PROJECTION_ITERATIONS", "2")
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/retrieval_context_projection_probe.py"))
+
+    assert probe_script["main"]() == 0
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["baseline_elapsed_ms_mean"] >= 0.0
+    assert metrics["optimized_elapsed_ms_mean"] >= 0.0
+    assert metrics["entry_count"] == 5.0
+    assert metrics["sample_count"] == 1.0
+    assert metrics["iteration_count"] == 2.0
+    assert metrics["speedup"] >= 0.0
+
+
 def test_local_job_followup_scan_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -3285,6 +3313,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "deterministic-image-output-byte-accounting",
         "deterministic-rerank-query-context-reuse",
         "rerank-core-top-k-heap-selection",
+        "retrieval-context-projection-fastpath",
         "same-cohort-batching-probe-evidence",
         "runtime-utils-kwarg-signature-cache",
         "runtime-utils-package-version-cache",

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -101,12 +101,14 @@ def project_retrieval_contexts(
             refusal_receipts.extend(dict(receipt) for receipt in exc.refusal_receipts)
             continue
 
-        duplicate_fields = [
-            source_field
-            for source_field in admission.user_payload
-            if source_field in user_payload
-        ]
-        if duplicate_fields:
+        admission_payload = admission.user_payload
+        duplicate_fields: list[str] | None = None
+        for source_field in admission_payload:
+            if source_field in user_payload:
+                if duplicate_fields is None:
+                    duplicate_fields = []
+                duplicate_fields.append(source_field)
+        if duplicate_fields is not None:
             refusal_receipts.extend(
                 _duplicate_projection_receipt(
                     receipt,
@@ -116,7 +118,7 @@ def project_retrieval_contexts(
             )
             continue
 
-        user_payload.update(dict(admission.user_payload))
+        user_payload.update(admission_payload)
         receipts.extend(dict(receipt) for receipt in admission.untrusted_context_receipts)
 
     return RetrievalContextProjection(


### PR DESCRIPTION
## Summary
- Optimizes `project_retrieval_contexts()` by avoiding per-admission duplicate-list allocation on the unique-field path.
- Reuses the admission payload mapping for `dict.update(...)` instead of creating an intermediate shallow copy.
- Registers the `retrieval-context-projection-fastpath` PR-scoped performance probe with focused test, coverage, and probe commands.

## Plan or Spec
- `docs/plans/2026-06-11-retrieval-context-projection-fastpath.md`

## Commands Run
```text
python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.json.check
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# result: 7 passed in 0.87s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
# result: 7 passed; changed_line_coverage=100.00% for aggregate touched scope
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
# result: {"baseline_elapsed_ms_mean": 0.0711390351144863, "delta_ms": -0.010027521555977206, "entry_count": 96.0, "iteration_count": 400.0, "optimized_elapsed_ms_mean": 0.06111151355850909, "sample_count": 7.0, "speedup": 1.1640856357841096}
git diff --check
# result: passed
```

## Coverage and Metrics
- Changed-line coverage: 100.00% (25/25 aggregate measurable changed lines).
- Local registered probe equivalent: `baseline_elapsed_ms_mean=0.0711390351144863`, `optimized_elapsed_ms_mean=0.06111151355850909`, `delta_ms=-0.010027521555977206`, `speedup=1.1640856357841096`.
- CI is required to validate the registered PR-scoped performance workflow on the pushed PR branch.

## Known Gaps
- Local Linux validation covers the Python behavior and synthetic probe only; the final registered PR-scoped performance report is expected from GitHub Actions.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence; probe overhead is limited to the PR-scoped synthetic probe.
- [x] Deferred work and known gaps are stated explicitly.
