### PR TITLE
Harden local job batch claim inputs

### DIFF
--- a/docs/plans/2026-06-12-issue-1761-local-job-batch-claim-input-boundary.md
+++ b/docs/plans/2026-06-12-issue-1761-local-job-batch-claim-input-boundary.md
@@ -1,0 +1,72 @@
+# Issue 1761 Local Job Batch Claim Input Boundary Plan
+
+## Goal
+
+Harden the durable local-job batch follow-up claim entrypoint so malformed
+caller-provided claim input maps fail closed per candidate instead of raising an
+unstructured Python exception before prompt-context admission.
+
+## Scope
+
+This slice covers:
+
+- the `LocalJobContinuationStore.claim_scanned_followup_prompt_contexts`
+  wrapper inputs for follow-up session IDs, redacted completion summaries, and
+  owner-scope decisions;
+- deterministic per-candidate receipts when those wrapper inputs are malformed;
+- focused Python tests proving malformed wrappers do not claim or drop sibling
+  ready records;
+- unified runtime contract documentation for future local-job monitor callers.
+
+This slice does not change local-job record schema, reconciliation semantics,
+prompt-admission receipts, live-evidence behavior, session projection, process
+launch, log reading, artifact reading, or owner-scope inference.
+
+## Best End-State Architecture
+
+The best end-state keeps the monitor batch bridge as a typed boundary between
+external monitor state and durable local-job claims. Candidate discovery remains
+store-owned, prompt-context admission remains background-continuation-owned, and
+the batch bridge is responsible for refusing malformed claim-input wrappers
+before it indexes or trusts them.
+
+Malformed wrapper inputs should therefore produce local-job continuation
+receipts, not crashes. The bridge should continue processing other ready
+candidates whose wrappers are valid, and it should leave refused candidates
+unclaimed so a monitor can retry with corrected inputs.
+
+## Performance Probes And Metrics
+
+The changed path adds constant-time type checks for three caller-provided
+wrapper values after the existing scandir-based candidate scan. It does not add
+filesystem scans, file reads, process polling, network calls, model inference,
+or additional prompt assembly work.
+
+Verification must include:
+
+- focused Python tests for `test_local_job_continuation.py`;
+- changed-scope coverage for touched Python files with at least 95 percent
+  coverage;
+- PR-scoped performance report with status `ok`, regressions `0`, context
+  regressions `0`, and verification failures `0`;
+- the full local pre-commit gate before PR merge.
+
+## Implementation Steps
+
+1. Add failing tests proving non-mapping batch input wrappers emit
+   `followup_claim_input_invalid` receipts without claiming the candidate.
+2. Add a sibling-candidate test proving a malformed wrapper for one input source
+   does not prevent another ready job with valid wrappers from being claimed.
+3. Add a small wrapper validation helper used by
+   `claim_scanned_followup_prompt_contexts` before candidate indexing.
+4. Update the unified runtime contract with the wrapper fail-closed behavior.
+5. Run focused tests, changed-scope coverage, scoped performance, full
+   pre-commit gate, and PR evidence validation.
+
+## Success Criteria
+
+- Non-mapping follow-up session ID, completion summary, or owner-scope wrapper
+  inputs return per-candidate `followup_claim_input_invalid` receipts instead
+  of unstructured exceptions.
+- Malformed wrapper inputs do not persist an `in_progress` claim.
+- Valid sibling candidates can still be claimed in the same batch.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -543,12 +543,15 @@ emit `reason = followup_claim_input_missing`; malformed claim inputs emit
 `reason = followup_claim_input_invalid`; prompt-admission refusals emit
 `reason = followup_prompt_context_refused` plus background-continuation refusal
 receipts, including a fallback refusal receipt if prompt admission fails before
-reconciliation evidence is available; store revision races keep the store-level receipt such as
-`record_revision_mismatch`. These per-candidate failures must not abort claims
-for other ready records, and admission-refused candidates must not persist an
-`in_progress` follow-up claim. The batch bridge still must not start jobs, tail
-logs, write to session stores, inject prompt context into an agent loop, or
-resume workflows.
+reconciliation evidence is available; malformed non-mapping wrapper inputs for
+the follow-up session IDs, completion summaries, or owner-scope decisions also
+emit per-candidate `followup_claim_input_invalid` receipts instead of raising
+unstructured exceptions; store revision races keep the store-level receipt such
+as `record_revision_mismatch`. These per-candidate failures must not abort
+claims for other ready records, and admission-refused or wrapper-refused
+candidates must not persist an `in_progress` follow-up claim. The batch bridge
+still must not start jobs, tail logs, write to session stores, inject prompt
+context into an agent loop, or resume workflows.
 
 When a local-job follow-up claim succeeds, the
 `melix.local_job_continuation_receipt.v1` receipt must also expose the redacted

--- a/services/mlx-worker-python/tests/test_local_job_continuation.py
+++ b/services/mlx-worker-python/tests/test_local_job_continuation.py
@@ -837,6 +837,143 @@ def test_store_scan_followup_candidates_reconciles_and_filters_ready_records(
         revision=1,
     )
 
+    none_store = LocalJobContinuationStore(tmp_path / "claim-none")
+    none_ready = none_store.save_record(
+        _record(
+            job_id="none-ready",
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/none-ready.json",),
+        )
+    )
+
+    none_batch = none_store.claim_scanned_followup_prompt_contexts(
+        followup_session_ids_by_job_id=None,
+        completion_summaries_by_job_id=None,
+        owner_scope_checked_by_job_id=None,
+    )
+
+    assert none_batch.claims == ()
+    assert none_batch.refusal_receipts == ()
+    assert [receipt["reason"] for receipt in none_batch.receipts] == [
+        "followup_candidate_ready",
+        "followup_claim_input_missing",
+    ]
+    assert store.load_record("ready") == ready
+    assert none_store.load_record("none-ready") == none_ready
+
+    wrapper_store = LocalJobContinuationStore(tmp_path / "claim-wrapper")
+    wrapper_ready = wrapper_store.save_record(
+        _record(
+            job_id="wrapper-ready",
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/wrapper-ready.json",),
+        )
+    )
+
+    wrapper_batch = wrapper_store.claim_scanned_followup_prompt_contexts(
+        followup_session_ids_by_job_id=["not", "a", "mapping"],
+        completion_summaries_by_job_id={
+            "wrapper-ready": {"status": "completed"},
+        },
+        owner_scope_checked_by_job_id={"wrapper-ready": True},
+    )
+
+    assert wrapper_batch.claims == ()
+    assert wrapper_batch.refusal_receipts == ()
+    assert [receipt["reason"] for receipt in wrapper_batch.receipts] == [
+        "followup_candidate_ready",
+        "followup_claim_input_invalid",
+    ]
+    assert wrapper_batch.receipts[1]["input_error"] == (
+        "followup_session_ids_by_job_id must be a mapping when provided"
+    )
+    assert wrapper_store.load_record("wrapper-ready") == wrapper_ready
+
+    claim_store = LocalJobContinuationStore(tmp_path / "claim-siblings")
+    refused = claim_store.save_record(
+        _record(
+            job_id="refused",
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/refused.json",),
+        )
+    )
+    lookup_refused = claim_store.save_record(
+        _record(
+            job_id="lookup-refused",
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/lookup-refused.json",),
+        )
+    )
+    valid = claim_store.save_record(
+        _record(
+            job_id="valid",
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/valid.json",),
+        )
+    )
+
+    class FollowupSessionIdsByJobId(dict[str, str]):
+        def __contains__(self, key: object) -> bool:
+            if key == "refused":
+                raise TypeError("followup session lookup refused")
+            return super().__contains__(key)
+
+    class CompletionSummariesByJobId(dict[str, dict[str, str]]):
+        def __getitem__(self, key: str) -> dict[str, str]:
+            if key == "lookup-refused":
+                raise TypeError("completion summary lookup refused")
+            return super().__getitem__(key)
+
+    claim_batch = claim_store.claim_scanned_followup_prompt_contexts(
+        followup_session_ids_by_job_id=FollowupSessionIdsByJobId(
+            {
+                "lookup-refused": "followup-lookup-refused",
+                "valid": "followup-valid",
+            }
+        ),
+        completion_summaries_by_job_id=CompletionSummariesByJobId(
+            {
+                "lookup-refused": {"status": "completed"},
+                "valid": {"status": "completed"},
+            }
+        ),
+        owner_scope_checked_by_job_id={
+            "lookup-refused": True,
+            "refused": True,
+            "valid": True,
+        },
+    )
+
+    assert [claim.reconciliation.record.job_id for claim in claim_batch.claims] == ["valid"]
+    sibling_receipts_by_job = {
+        receipt["job_id"]: receipt for receipt in claim_batch.receipts
+    }
+    assert sibling_receipts_by_job["refused"]["reason"] == "followup_claim_input_invalid"
+    assert sibling_receipts_by_job["refused"]["input_error"] == (
+        "followup session lookup refused"
+    )
+    assert sibling_receipts_by_job["lookup-refused"]["reason"] == (
+        "followup_claim_input_invalid"
+    )
+    assert sibling_receipts_by_job["lookup-refused"]["input_error"] == (
+        "completion summary lookup refused"
+    )
+    assert sibling_receipts_by_job["valid"]["reason"] == "followup_claimed"
+    assert claim_batch.refusal_receipts == ()
+    assert claim_store.load_record("refused") == refused
+    assert claim_store.load_record("lookup-refused") == lookup_refused
+    assert claim_store.load_record("valid") == replace(
+        valid,
+        followup_status="in_progress",
+        followup_session_id="followup-valid",
+        revision=1,
+    )
+
 
 def test_store_scan_followup_candidates_uses_single_scandir_without_path_glob(
     tmp_path: Path,

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
+from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from errno import EPERM
@@ -404,9 +405,18 @@ class LocalJobContinuationStore:
         live_evidence_by_job_id: dict[str, LocalJobLiveEvidence] | None = None,
     ) -> LocalJobContinuationFollowupClaimBatch:
         live_evidence_by_job_id = live_evidence_by_job_id or {}
-        followup_session_ids_by_job_id = followup_session_ids_by_job_id or {}
-        completion_summaries_by_job_id = completion_summaries_by_job_id or {}
-        owner_scope_checked_by_job_id = owner_scope_checked_by_job_id or {}
+        followup_session_ids_by_job_id = _claim_input_mapping_or_invalid(
+            followup_session_ids_by_job_id,
+            "followup_session_ids_by_job_id",
+        )
+        completion_summaries_by_job_id = _claim_input_mapping_or_invalid(
+            completion_summaries_by_job_id,
+            "completion_summaries_by_job_id",
+        )
+        owner_scope_checked_by_job_id = _claim_input_mapping_or_invalid(
+            owner_scope_checked_by_job_id,
+            "owner_scope_checked_by_job_id",
+        )
         scan = self.scan_followup_candidates(
             live_evidence_by_job_id=live_evidence_by_job_id,
         )
@@ -416,15 +426,24 @@ class LocalJobContinuationStore:
 
         for candidate in scan.candidates:
             job_id = candidate.record.job_id
-            missing_fields = [
-                field_name
-                for field_name, values in (
-                    ("followup_session_id", followup_session_ids_by_job_id),
-                    ("completion_summary", completion_summaries_by_job_id),
-                    ("owner_scope_checked", owner_scope_checked_by_job_id),
+            try:
+                missing_fields = [
+                    field_name
+                    for field_name, values in (
+                        ("followup_session_id", followup_session_ids_by_job_id),
+                        ("completion_summary", completion_summaries_by_job_id),
+                        ("owner_scope_checked", owner_scope_checked_by_job_id),
+                    )
+                    if job_id not in values
+                ]
+            except (LookupError, TypeError, ValueError) as exc:
+                receipts.append(
+                    _followup_claim_input_invalid_receipt(
+                        candidate.record,
+                        error=str(exc),
+                    )
                 )
-                if job_id not in values
-            ]
+                continue
             if missing_fields:
                 receipts.append(
                     _followup_claim_input_missing_receipt(
@@ -438,9 +457,18 @@ class LocalJobContinuationStore:
                 # Keep this try block scoped to the claim call so ValueError maps only claim-input validation.
                 claim = self.claim_followup_prompt_context(
                     job_id,
-                    followup_session_id=followup_session_ids_by_job_id[job_id],
-                    completion_summary=completion_summaries_by_job_id[job_id],
-                    owner_scope_checked=owner_scope_checked_by_job_id[job_id],
+                    followup_session_id=_claim_input_value(
+                        followup_session_ids_by_job_id,
+                        job_id,
+                    ),
+                    completion_summary=_claim_input_value(
+                        completion_summaries_by_job_id,
+                        job_id,
+                    ),
+                    owner_scope_checked=_claim_input_value(
+                        owner_scope_checked_by_job_id,
+                        job_id,
+                    ),
                     live_evidence=live_evidence_by_job_id.get(job_id),
                 )
             except LocalJobContinuationAdmissionError as exc:
@@ -825,6 +853,35 @@ def project_local_job_session_followup(
         untrusted_context_receipts=receipts,
         followup_message=followup_message,
     )
+
+
+class _InvalidClaimInputMapping:
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    def __contains__(self, key: object) -> bool:
+        raise TypeError(self.message)
+
+    def __getitem__(self, key: str) -> Any:
+        raise TypeError(self.message)
+
+
+def _claim_input_mapping_or_invalid(
+    value: Mapping[str, Any] | None,
+    field_name: str,
+) -> Mapping[str, Any] | _InvalidClaimInputMapping:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return value
+    return _InvalidClaimInputMapping(f"{field_name} must be a mapping when provided")
+
+
+def _claim_input_value(values: Mapping[str, Any] | _InvalidClaimInputMapping, job_id: str) -> Any:
+    try:
+        return values[job_id]
+    except (LookupError, TypeError, ValueError) as exc:
+        raise ValueError(str(exc)) from exc
 
 
 def _receipt(


### PR DESCRIPTION
## Summary
- Harden `LocalJobContinuationStore.claim_scanned_followup_prompt_contexts` so malformed batch claim input wrappers produce per-candidate `followup_claim_input_invalid` receipts instead of unstructured exceptions.
- Keep malformed candidates unclaimed while allowing valid sibling candidates in the same scan batch to proceed.
- Document the wrapper fail-closed contract for future local-job monitor callers.

## Plan or Spec
- Plan: `docs/plans/2026-06-12-issue-1761-local-job-batch-claim-input-boundary.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`
- Issue: Refs #1761

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py -k 'malformed_claim_input_wrappers or malformed_wrapper_from_valid_siblings'
# Red before implementation: 4 failed, 93 deselected.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py -k 'malformed_claim_input_wrappers or malformed_wrapper_from_valid_siblings'
# Green after implementation: 4 passed, 93 deselected.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py
# 98 passed in 0.17s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_background_continuation.py services/mlx-worker-python/tests/test_prompt_context.py
# 35 passed.

git diff --check
# Passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py services/mlx-worker-python/tests/test_prompt_context.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py
# local_job_continuation.py 96.30%, test_local_job_continuation.py 100.00%, aggregate 99%.

make git-hooks-install && git commit -m "Harden local job batch claim inputs"
# Pre-commit passed: make swift-test, make py-test, make integration-test, scoped performance report.

git merge --no-edit origin/main
# Merged latest origin/main after it advanced to 4c568ce5.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_background_continuation.py services/mlx-worker-python/tests/test_prompt_context.py
# 128 passed in 0.13s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts.pre_commit_gate import run_performance_report
changed_files = [
    'docs/plans/2026-06-12-issue-1761-local-job-batch-claim-input-boundary.md',
    'docs/unified-agentic-tool-runtime-contract.md',
    'services/mlx-worker-python/tests/test_local_job_continuation.py',
    'services/mlx-worker-python/worker/runtime/local_job_continuation.py',
]
outcome = run_performance_report(Path.cwd(), changed_files, base_ref='origin/main')
print(f'STATUS={outcome.status}')
print(f'REPORT_DIR={outcome.report_dir}')
print(f'SELECTED_PROBES={outcome.selected_probe_count}')
PY
# STATUS=ok; SELECTED_PROBES=1.
```

## Coverage and Metrics
- Changed-scope coverage before commit: `services/mlx-worker-python/worker/runtime/local_job_continuation.py` 96.30%, `services/mlx-worker-python/tests/test_local_job_continuation.py` 100.00%, aggregate 99%.
- Pre-commit hook full gate passed on macOS 256 GiB host:
  - `make swift-test`: passed.
  - `make py-test`: 3940 passed, 14 skipped, 2 warnings.
  - `make integration-test`: 120 passed, 1 skipped.
- Pre-commit scoped performance report: `.runtime/pre-commit-performance/20260611-230838-2bdaa50f/report/report.md`
  - Status `ok`, regressions `0`, context regressions `0`, verification failures `0`.
  - Local job follow-up scan scandir: targeted tests pass, coverage 99.0%.
  - `elapsed_ms_mean` base 16.184 ms, head 16.339 ms, delta +0.95%, neutral.
  - `scandir_calls_mean` unchanged at 1.000; `path_glob_calls_mean` unchanged at 0.000.
- Post-merge scoped performance report against latest `origin/main`: `.runtime/pre-commit-performance/20260611-231008-1b3273ef/report/report.md`
  - Status `ok`, regressions `0`, context regressions `0`, verification failures `0`.
  - Local job follow-up scan scandir: targeted tests pass, coverage 99.0%.
  - `elapsed_ms_mean` base 16.475 ms, head 15.832 ms, delta -3.90%, neutral.
  - `scandir_calls_mean` unchanged at 1.000; `path_glob_calls_mean` unchanged at 0.000.
- Observability mode: minimal receipt-path behavior only; no new runtime metrics, debug mode, sampled evidence, or probe overhead beyond the existing PR-scoped probe. Probe overhead change: N/A, no observability probe was added or expanded.

## Known Gaps
- This slice does not implement live owner-scope inference, process launching, log or artifact reading, session enqueueing, or workflow resume behavior.
- Remaining untrusted-context boundary work for retrieved docs, skills, memories, and tool output stays under #1761.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A because this PR does not change protobuf schemas.
- [x] Dependency changes include updated lockfiles, or N/A because this PR does not change dependencies.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
