### PR TITLE
perf: fast-path single maintenance capability splits

### DIFF
--- a/docs/plans/2026-06-12-maintenance-capability-single-value-fastpath.md
+++ b/docs/plans/2026-06-12-maintenance-capability-single-value-fastpath.md
@@ -1,0 +1,31 @@
+# Maintenance capability single-value fast path
+
+This Python-only performance slice is limited to capability metadata splitting in
+`worker.engine.maintenance_core._split_capability_values`.
+
+## Scope
+
+- Preserve comma-separated capability parsing behavior, including whitespace
+  trimming and empty segment dropping.
+- Add a no-comma fast path for the common single capability value case so callers
+  avoid allocating and iterating over a one-element `split(",")` list.
+- Extend the registered PR-scoped probe to report both the existing multi-segment
+  comparison and the new single-value scenario.
+
+## Registered probe
+
+The affected path is covered by `maintenance-capability-split-single-strip` in
+`infra/perf/pr_scoped_probes.json`, including focused `test_command`,
+`coverage_command`, and `probe_command` entries.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and
+registered probe locally on Linux. GitHub Actions remains the merge gate for the
+PR-scoped performance report after push.
+
+## Expected metrics
+
+The existing multi-segment metrics should remain neutral to improved. The new
+single-value metrics should show lower elapsed time versus the baseline helper
+that always calls `split(",")`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -1648,6 +1648,24 @@
         "warn_pct": 5.0
       },
       {
+        "key": "single_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "single_delta_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_abs": 0.02
+      },
+      {
+        "key": "single_speedup",
+        "unit": "ratio",
+        "direction": "higher_is_better",
+        "warn_pct": 5.0
+      },
+      {
         "key": "peak_bytes_mean",
         "unit": "bytes",
         "direction": "informational"

--- a/scripts/maintenance_capability_split_probe.py
+++ b/scripts/maintenance_capability_split_probe.py
@@ -28,6 +28,17 @@ def _payload(segment_count: int) -> str:
     return ",".join(values[index % len(values)] for index in range(segment_count))
 
 
+def _run_single_value(splitter, iterations: int) -> tuple[float, int]:
+    checksum = 0
+    started = time.perf_counter()
+    for _ in range(iterations):
+        values = splitter(" qwen ")
+        if values != ["qwen"]:
+            raise SystemExit(f"unexpected single capability split: {values!r}")
+        checksum += len(values[0])
+    return (time.perf_counter() - started) * 1000.0, checksum
+
+
 def _run_split(splitter, raw_value: str, iterations: int) -> tuple[float, int, int]:
     checksum = 0
     segment_count = 0
@@ -54,8 +65,11 @@ def main() -> int:
 
     baseline_elapsed: list[float] = []
     optimized_elapsed: list[float] = []
+    single_baseline_elapsed: list[float] = []
+    single_optimized_elapsed: list[float] = []
     peak_bytes: list[float] = []
     checksum = 0
+    single_checksum = 0
     segment_total = 0
     for _ in range(sample_count):
         elapsed_ms, checksum, segment_total = _run_split(
@@ -65,12 +79,18 @@ def main() -> int:
         )
         baseline_elapsed.append(elapsed_ms)
 
+        elapsed_ms, single_checksum = _run_single_value(_baseline_split, iterations)
+        single_baseline_elapsed.append(elapsed_ms)
+
         elapsed_ms, checksum, segment_total = _run_split(
             _split_capability_values,
             raw_value,
             iterations,
         )
         optimized_elapsed.append(elapsed_ms)
+
+        elapsed_ms, single_checksum = _run_single_value(_split_capability_values, iterations)
+        single_optimized_elapsed.append(elapsed_ms)
 
         tracemalloc.start()
         _run_split(
@@ -84,18 +104,27 @@ def main() -> int:
 
     baseline_mean = statistics.fmean(baseline_elapsed)
     optimized_mean = statistics.fmean(optimized_elapsed)
+    single_baseline_mean = statistics.fmean(single_baseline_elapsed)
+    single_optimized_mean = statistics.fmean(single_optimized_elapsed)
     metrics = {
         "baseline_elapsed_ms_mean": baseline_mean,
         "optimized_elapsed_ms_mean": optimized_mean,
         "elapsed_ms_mean": optimized_mean,
         "delta_ms_mean": optimized_mean - baseline_mean,
         "speedup": baseline_mean / optimized_mean if optimized_mean > 0 else 0.0,
+        "single_baseline_elapsed_ms_mean": single_baseline_mean,
+        "single_elapsed_ms_mean": single_optimized_mean,
+        "single_delta_ms_mean": single_optimized_mean - single_baseline_mean,
+        "single_speedup": single_baseline_mean / single_optimized_mean
+        if single_optimized_mean > 0
+        else 0.0,
         "peak_bytes_mean": statistics.fmean(peak_bytes),
         "segment_count": float(value_segments),
         "iteration_count": float(iterations),
         "sample_count": float(sample_count),
         "split_values_per_sample": float(segment_total),
         "checksum": float(checksum),
+        "single_checksum": float(single_checksum),
     }
     print(json.dumps(metrics, sort_keys=True))
     return 0

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -4875,6 +4875,8 @@ def test_split_capability_values_strips_once_and_drops_empty_segments() -> None:
     assert maintenance_core_module._split_capability_values(
         " text, image ,, qwen ,\ttool\n, "
     ) == ["text", "image", "qwen", "tool"]
+    assert maintenance_core_module._split_capability_values(" qwen ") == ["qwen"]
+    assert maintenance_core_module._split_capability_values(" \t\n ") == []
 
 
 def test_get_model_info_appends_tool_parser_when_capability_parser_metadata_is_absent(

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -202,6 +202,9 @@ class BenchmarkLoadedModelResolution:
 
 
 def _split_capability_values(raw_value: str) -> list[str]:
+    if "," not in raw_value:
+        stripped = raw_value.strip()
+        return [stripped] if stripped else []
     return [
         stripped
         for part in raw_value.split(",")


### PR DESCRIPTION
## Summary
- Add a no-comma fast path for `_split_capability_values` so single capability metadata values avoid `split(",")` allocation and iteration.
- Extend the maintenance capability probe with single-value metrics while keeping the existing multi-segment comparison.
- Add focused regression assertions for single non-empty and whitespace-only capability strings.

## Plan or Spec
- `docs/plans/2026-06-12-maintenance-capability-single-value-fastpath.md`
- Registered probe: `maintenance-capability-split-single-strip` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/maintenance_capability_split_probe.py
# before change: exit 0; elapsed_ms_mean=345.41931254789233; delta_ms_mean=-50.689277332276106; speedup=1.1467470853276278

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_split_capability_values_strips_once_and_drops_empty_segments services/mlx-worker-python/tests/test_maintenance_service.py::test_get_model_info_appends_tool_parser_when_capability_parser_metadata_is_absent services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_capability_split_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_capability_split_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 5 passed in 2.57s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_split_capability_values_strips_once_and_drops_empty_segments services/mlx-worker-python/tests/test_maintenance_service.py::test_get_model_info_appends_tool_parser_when_capability_parser_metadata_is_absent services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_capability_split_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_capability_split_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/maintenance_capability_split_probe.py
# exit 0; aggregate changed-line coverage 96% (22/23); maintenance_core.py 100%; test_maintenance_service.py 100%; test_pr_scoped_performance.py 100%; maintenance_capability_split_probe.py 94.44% due to defensive error branch

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/maintenance_capability_split_probe.py
# exit 0; elapsed_ms_mean=349.54744316637516; delta_ms_mean=-53.6268625408411; speedup=1.1534179797027329; single_elapsed_ms_mean=12.53677411004901; single_delta_ms_mean=-5.587899871170521; single_speedup=1.4457207110951666

bash /tmp/maintenance_capability_probe_cmd.sh
# exit 0; registered probe command emitted JSON; elapsed_ms_mean=346.80827585980296; delta_ms_mean=-48.01222672685981; speedup=1.1384402566744651; single_elapsed_ms_mean=11.928997281938791; single_delta_ms_mean=-5.866616778075695; single_speedup=1.4917946277813392

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: aggregate 96% (22/23 changed measurable lines).
- Local registered probe metrics after change:
  - multi-segment: `elapsed_ms_mean=346.80827585980296`, `delta_ms_mean=-48.01222672685981`, `speedup=1.1384402566744651`
  - single-value: `single_elapsed_ms_mean=11.928997281938791`, `single_delta_ms_mean=-5.866616778075695`, `single_speedup=1.4917946277813392`
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this is a focused Python performance slice and GitHub Actions remains the merge gate.
- No Swift runtime validation is involved in this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
