### PR TITLE
perf: skip single recent tool context join

### DIFF
--- a/docs/plans/2026-06-12-tool-registry-single-recent-context.md
+++ b/docs/plans/2026-06-12-tool-registry-single-recent-context.md
@@ -1,0 +1,32 @@
+# Tool registry single recent context fast path
+
+This Python-only performance slice is limited to agentic tool keyword planning in
+`worker.runtime.tool_registry.select_agentic_tools_for_turn`.
+
+## Scope
+
+- Preserve keyword fallback behavior for current and recent user turns.
+- Avoid allocating a joined context string when there is exactly one recent user
+  turn; the selector can scan that existing string directly.
+- Keep multi-recent-turn behavior unchanged by continuing to join entries with a
+  single space separator.
+
+## Registered probe
+
+The affected path is covered by `tool-registry-select-name-index-cache` in
+`infra/perf/pr_scoped_probes.json`. The registered probe includes focused
+`test_command`, `coverage_command`, and `probe_command` entries, and its
+selector-planning sample includes the single-recent-turn keyword fallback case
+this slice optimizes.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and
+registered probe locally on Linux. GitHub Actions remains the merge gate for the
+PR-scoped performance report after push.
+
+## Expected metrics
+
+`selector_planning_elapsed_ms_mean` should improve or remain neutral while the
+overall select probe metrics stay neutral. The optimization removes one short
+string join allocation from the common single-recent-context fallback path.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -682,6 +682,43 @@ def test_agentic_tool_selection_skips_empty_context_keyword_scan(
     assert scanned_texts == ["Open fixture://docs/provider-contract and summarize the page."]
 
 
+def test_agentic_tool_selection_reuses_single_recent_context_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanned_text_ids: list[int] = []
+    recent_context = "Search the local text evidence."
+    real_keyword_tool_matches = tool_registry_module._keyword_tool_matches
+
+    def record_keyword_tool_matches(text: str) -> tuple[str, ...]:
+        scanned_text_ids.append(id(text))
+        return real_keyword_tool_matches(text)
+
+    monkeypatch.setattr(
+        tool_registry_module,
+        "_keyword_tool_matches",
+        record_keyword_tool_matches,
+    )
+
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Use two results this time.",
+            vector_available=False,
+            recent_user_turns=(recent_context,),
+            max_selected_tools=4,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute", "text_search")
+    assert len(scanned_text_ids) == 2
+    assert scanned_text_ids[1] == id(recent_context)
+
+
+def test_agentic_tool_selection_joins_multiple_recent_context_turns() -> None:
+    assert tool_registry_module._recent_user_turns_keyword_context(
+        ("Search the local text evidence.", "Visit fixture://docs/provider-contract.")
+    ) == "Search the local text evidence. Visit fixture://docs/provider-contract."
+
+
 @pytest.mark.parametrize(
     ("current_user_turn", "expected_tool"),
     [

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -490,7 +490,9 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
     if selection_mode != "vector":
         current_matches = _keyword_tool_matches(selection_input.current_user_turn)
         if selection_input.recent_user_turns:
-            context_matches = _keyword_tool_matches(" ".join(selection_input.recent_user_turns))
+            context_matches = _keyword_tool_matches(
+                _recent_user_turns_keyword_context(selection_input.recent_user_turns)
+            )
         else:
             context_matches = ()
         for tool_name in current_matches:
@@ -518,6 +520,12 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
         "selected_schema_bytes": selected_registry.metrics().schema_bytes,
     }
     return ToolSelectionResult(registry=selected_registry, receipt=receipt)
+
+
+def _recent_user_turns_keyword_context(recent_user_turns: tuple[str, ...]) -> str:
+    if len(recent_user_turns) == 1:
+        return recent_user_turns[0]
+    return " ".join(recent_user_turns)
 
 
 @lru_cache(maxsize=128)


### PR DESCRIPTION
## Summary
- Add a single-recent-turn fast path for agentic tool keyword fallback context scanning.
- Preserve multi-recent-turn behavior by continuing to join multiple context turns with a single space separator.
- Add regression coverage for the single-turn no-join path and multi-turn join fallback.

## Plan or Spec
- `docs/plans/2026-06-12-tool-registry-single-recent-context.md`
- Registered PR-scoped probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# Baseline probe before the change (origin/main worktree)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
exit 0; elapsed_ms_mean=23.70008220896125; selector_planning_elapsed_ms_mean=34.52263390645385

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
exit 0; 77 passed in 1.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
exit 0; 78 passed in 0.76s; changed-scope coverage TOTAL 19 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
exit 0; elapsed_ms_mean=21.661630552262068; selector_planning_elapsed_ms_mean=32.939397264271975

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 19 0 100%`.
- Registered local probe (`tool_registry_select_probe.py`):
  - baseline `elapsed_ms_mean=23.70008220896125`, new `elapsed_ms_mean=21.661630552262068`, delta `-2.0384516566991806 ms` (~8.60% faster).
  - baseline `selector_planning_elapsed_ms_mean=34.52263390645385`, new `selector_planning_elapsed_ms_mean=32.939397264271975`, delta `-1.5832366421818733 ms` (~4.59% faster).
- CI PR-scoped performance report is required as the merge gate after push.

## Known Gaps
- Local verification is Linux/Python-only for this Python slice.
- GitHub Actions PR-scoped performance report still needs to complete before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability/debug mode changes.
- [x] Deferred work and known gaps are stated explicitly.
