### PR TITLE
perf: bind dataset version manifest getters

### DIFF
--- a/docs/plans/2026-06-05-dataset-version-listing-local-bindings.md
+++ b/docs/plans/2026-06-05-dataset-version-listing-local-bindings.md
@@ -20,9 +20,13 @@ entries and reports listing elapsed time plus version count.
 2. Reuse local loop bindings for version append/read operations and avoid a
    redundant `str()` conversion for manifest paths that are already yielded as
    strings.
-3. Run the registered focused tests, changed-scope coverage, and the registered
+3. 2026-06-12 follow-up: bind each loaded manifest's `dict.get` method once
+   before copying the summary fields into the listing row. This keeps the same
+   missing-field defaults and ordering while removing repeated bound-method
+   lookups across large version directories.
+4. Run the registered focused tests, changed-scope coverage, and the registered
    probe locally on Linux.
-4. Use GitHub Actions PR-scoped performance as the merge gate after opening the
+5. Use GitHub Actions PR-scoped performance as the merge gate after opening the
    PR.
 
 ## Validation

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -482,16 +482,17 @@ def list_dataset_versions(
     read_json_file = _read_json_file
     for manifest_path in _iter_dataset_version_manifest_paths(versions_root):
         version = read_json_file(manifest_path)
+        version_get = version.get
         versions_append(
             {
-                "dataset_id": version.get("dataset_id", ""),
-                "version_id": version.get("version_id", ""),
-                "created_at": version.get("created_at", ""),
-                "status": version.get("status", ""),
-                "train_count": version.get("train_count", 0),
-                "validation_count": version.get("validation_count", 0),
-                "failed_count": version.get("failed_count", 0),
-                "quality_summary_path": version.get("quality_summary_path", ""),
+                "dataset_id": version_get("dataset_id", ""),
+                "version_id": version_get("version_id", ""),
+                "created_at": version_get("created_at", ""),
+                "status": version_get("status", ""),
+                "train_count": version_get("train_count", 0),
+                "validation_count": version_get("validation_count", 0),
+                "failed_count": version_get("failed_count", 0),
+                "quality_summary_path": version_get("quality_summary_path", ""),
                 "dataset_version_path": manifest_path,
             }
         )


### PR DESCRIPTION
## Summary
- Bind each loaded dataset-version manifest's `dict.get` method once before copying listing fields.
- Keep the existing `os.scandir()` manifest discovery, missing-field defaults, sorting, and output schema unchanged.

## Plan or Spec
- Updated `docs/plans/2026-06-05-dataset-version-listing-local-bindings.md` with the 2026-06-12 getter-binding follow-up.
- Registered PR-scoped probe: `dataset-version-listing-scandir`.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-version-listing-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/dataset_version_listing_probe_compare.json`
- `git diff --check`

## Coverage and Metrics
- Focused coverage command (via registered PR-scoped runner): 7 passed, changed-line coverage 100% for `services/mlx-worker-python/worker/productization/dataset_preparation.py`.
- Local Linux registered probe comparison:
  - base `elapsed_ms_mean=45.647283`, head `elapsed_ms_mean=43.476577`, delta `-2.170706 ms` (~4.75% faster)
  - base `elapsed_ms_min=39.298791`, head `elapsed_ms_min=39.004129`, delta `-0.294662 ms`
  - base `elapsed_ms_p95=51.381515`, head `elapsed_ms_p95=50.355803`, delta `-1.025712 ms`
  - `version_count=2500`, `sample_count=7`

## Known Gaps
- This is a Python-only Linux-verified slice; no Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance remains the merge gate before squash merge.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path is covered by registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests and changed-scope coverage passed locally on Linux.
- [x] Registered probe was run locally against base and head worktrees.
- [ ] GitHub Actions and PR-scoped performance report are green.
