### PR TITLE
Fix MLX-only model registry search

### DIFF
--- a/docs/plans/2026-06-12-model-registry-mlx-only-search-pagination.md
+++ b/docs/plans/2026-06-12-model-registry-mlx-only-search-pagination.md
@@ -1,0 +1,43 @@
+# Model Registry MLX-Only Search Pagination
+
+## Goal
+
+The Models Library registry search should visibly surface Hugging Face discovery
+results for common model-family queries such as `Gemma` when the operator keeps
+the default `MLX Only` filter enabled.
+
+## Root Cause
+
+Model Registry already refreshes its unified local, managed-download, and Hub
+discovery list after Hub search completes. The failure mode is in the worker
+Hub catalog search path: `mlx_only=true` fetched a single Hugging Face page
+without asking the Hub to constrain results to MLX, then filtered that page
+locally for MLX compatibility. For broad model-family queries, the first Hub
+page can contain non-MLX or unsupported runtime formats while later pages
+contain compatible MLX repositories. Filtering only the first page can
+therefore return no Hub discovery rows, leaving the registry list visibly
+unchanged.
+
+## Implementation Slice
+
+- Keep non-MLX-only search as a single Hub API request.
+- For `mlx_only=true`, request the Hub API with `filter=mlx` and retain the
+  local MLX-compatibility filter as a correctness guard.
+- Continue following the Hub `rel="next"` cursor while the locally filtered
+  MLX-compatible results are still under the requested page size.
+- Bound the continuation to a small maximum page count so broad queries cannot
+  produce unbounded network work.
+- Preserve the current `next_cursor` contract so the UI can continue paginating
+  from the last fetched Hub cursor.
+
+## Verification And Metrics
+
+- Add a regression test where the first Hub page for `Gemma` contains no
+  MLX-compatible payloads, the `Link` header points to a second page, and the
+  second page contains an MLX Gemma repository.
+- Run focused Hub catalog tests and the maintenance service search test that
+  exercises `mlx_only` propagation.
+- Measure changed-line Python coverage for the touched worker catalog path.
+- Metrics report: no runtime performance baseline is expected for this narrow
+  correctness fix; the bounded page count is the performance guardrail. Report
+  the selected test/coverage commands and mark broader product metrics as N/A.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -806,6 +806,93 @@ def test_search_models_uses_next_cursor_from_link_header() -> None:
     assert page.next_cursor == "page+2"
 
 
+def test_search_models_with_mlx_only_fetches_next_page_when_first_page_has_no_mlx_results() -> None:
+    first_response = FakeHTTPResponse(
+        [
+            {
+                "id": "google/gemma-4-12B-it",
+                "author": "google",
+                "pipeline_tag": "image-text-to-text",
+                "tags": ["gemma4", "transformers", "safetensors"],
+                "siblings": [],
+                "cardData": {},
+            },
+            {
+                "id": "unsloth/gemma-4-12b-it-GGUF",
+                "author": "unsloth",
+                "pipeline_tag": "text-generation",
+                "tags": ["gguf", "gemma4"],
+                "siblings": [],
+                "cardData": {},
+            },
+        ]
+    )
+    first_response.headers["Link"] = '<https://huggingface.co/api/models?limit=2&cursor=page%2B2>; rel="next"'
+    second_response = FakeHTTPResponse(
+        [
+            {
+                "id": "mlx-community/gemma-4-E4B-it-qat-4bit",
+                "author": "mlx-community",
+                "pipeline_tag": "image-text-to-text",
+                "tags": ["mlx", "gemma4", "qat", "4-bit"],
+                "siblings": [{"rfilename": "model.safetensors", "size": 2 * GB}],
+                "cardData": {"base_model": "google/gemma-4-E4B-it-qat-q4_0-unquantized"},
+            }
+        ]
+    )
+    responses = [first_response, second_response]
+    requested_urls: list[str] = []
+
+    def opener(request: Request):
+        requested_urls.append(request.full_url)
+        return responses.pop(0)
+
+    catalog = HubCatalog(opener=opener, local_memory_gb=32)
+    page = catalog.search_models(query="Gemma", page_size=2, cursor="", mlx_only=True)
+
+    assert [item.repo_id for item in page.items] == ["mlx-community/gemma-4-E4B-it-qat-4bit"]
+    assert page.next_cursor == ""
+    assert len(requested_urls) == 2
+    assert "search=Gemma" in requested_urls[0]
+    assert "filter=mlx" in requested_urls[0]
+    assert "cursor=page%2B2" in requested_urls[1]
+    assert "filter=mlx" in requested_urls[1]
+
+
+def test_search_models_with_mlx_only_keeps_all_compatible_results_from_fetched_pages() -> None:
+    response = FakeHTTPResponse(
+        [
+            {
+                "id": "mlx-community/gemma-4-E4B-it-qat-4bit",
+                "author": "mlx-community",
+                "pipeline_tag": "image-text-to-text",
+                "tags": ["mlx", "gemma4", "4-bit"],
+                "siblings": [],
+                "cardData": {},
+            },
+            {
+                "id": "mlx-community/gemma-4-12B-it-qat-4bit",
+                "author": "mlx-community",
+                "pipeline_tag": "image-text-to-text",
+                "tags": ["mlx", "gemma4", "4-bit"],
+                "siblings": [],
+                "cardData": {},
+            },
+        ]
+    )
+
+    def opener(_request: Request):
+        return response
+
+    catalog = HubCatalog(opener=opener, local_memory_gb=32)
+    page = catalog.search_models(query="Gemma", page_size=1, cursor="", mlx_only=True)
+
+    assert [item.repo_id for item in page.items] == [
+        "mlx-community/gemma-4-E4B-it-qat-4bit",
+        "mlx-community/gemma-4-12B-it-qat-4bit",
+    ]
+
+
 def test_search_models_with_mlx_only_false_returns_all_results() -> None:
     payload = [
         {
@@ -827,7 +914,10 @@ def test_search_models_with_mlx_only_false_returns_all_results() -> None:
         },
     ]
 
-    def opener(_request: Request):
+    requested_urls: list[str] = []
+
+    def opener(request: Request):
+        requested_urls.append(request.full_url)
         return FakeHTTPResponse(payload)
 
     catalog = HubCatalog(opener=opener)
@@ -836,6 +926,7 @@ def test_search_models_with_mlx_only_false_returns_all_results() -> None:
     assert len(page.items) == 2
     assert page.items[0].mlx_compatible is True
     assert page.items[1].mlx_compatible is False
+    assert "filter=mlx" not in requested_urls[0]
 
 
 def test_search_models_marks_small_mlx_model_as_good_local_fit() -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -15,6 +15,7 @@ from worker.productization.device_identity import collect_device_identity
 MEMORY_COMFORT_BUDGET_FACTOR = 0.60
 RESIDENT_MEMORY_OVERHEAD_FACTOR = 1.35
 GEMMA4_QAT_AUTOMATIC_ORG = "mlx-community"
+MLX_ONLY_SEARCH_MAX_PAGES = 4
 
 _SIZE_HINT_KB = 1024
 _SIZE_HINT_MB = _SIZE_HINT_KB * 1024
@@ -141,13 +142,38 @@ class HubCatalog:
         cursor: str,
         mlx_only: bool,
     ) -> HubSearchPage:
-        payloads, next_cursor = self._fetch_models(
-            search=query,
-            page_size=page_size,
-            cursor=cursor,
-        )
-        if mlx_only:
-            payloads = [payload for payload in payloads if _payload_is_mlx_compatible(payload)]
+        normalized_page_size = max(1, page_size or 20)
+        if not mlx_only:
+            payloads, next_cursor = self._fetch_models(
+                search=query,
+                page_size=normalized_page_size,
+                cursor=cursor,
+                hub_filter="",
+            )
+            items = [self._summary_record(payload) for payload in payloads]
+            return HubSearchPage(items=items, next_cursor=next_cursor)
+
+        payloads: list[dict[str, Any]] = []
+        next_cursor = ""
+        current_cursor = cursor
+        pages_fetched = 0
+        while pages_fetched < MLX_ONLY_SEARCH_MAX_PAGES:
+            page_payloads, next_cursor = self._fetch_models(
+                search=query,
+                page_size=normalized_page_size,
+                cursor=current_cursor,
+                hub_filter="mlx",
+            )
+            payloads.extend(
+                payload
+                for payload in page_payloads
+                if _payload_is_mlx_compatible(payload)
+            )
+            pages_fetched += 1
+            if len(payloads) >= normalized_page_size or not next_cursor:
+                break
+            current_cursor = next_cursor
+
         items = [self._summary_record(payload) for payload in payloads]
         return HubSearchPage(items=items, next_cursor=next_cursor)
 
@@ -155,7 +181,7 @@ class HubCatalog:
         if not repo_id.strip():
             raise HubCatalogError("invalid_argument", "Hub repo_id is required.")
 
-        payloads, _ = self._fetch_models(search=repo_id, page_size=10, cursor="")
+        payloads, _ = self._fetch_models(search=repo_id, page_size=10, cursor="", hub_filter="")
         payload = next(
             (
                 item
@@ -174,6 +200,7 @@ class HubCatalog:
         search: str,
         page_size: int,
         cursor: str,
+        hub_filter: str,
     ) -> tuple[list[dict[str, Any]], str]:
         normalized_page_size = max(1, page_size or 20)
         params: list[tuple[str, str]] = [
@@ -184,6 +211,8 @@ class HubCatalog:
         ]
         if search:
             params.append(("search", search))
+        if hub_filter:
+            params.append(("filter", hub_filter))
         if cursor:
             params.append(("cursor", cursor))
 


### PR DESCRIPTION
## Summary

- Fix MLX-only Model Registry search so broad queries such as `Gemma` send the Hugging Face `filter=mlx` parameter and keep paging until compatible results are found.
- Preserve non-MLX search behavior while keeping the MLX-only fetch bounded to four Hub pages.
- Add regression coverage for first-page non-compatible results, same-page compatible result retention, and non-MLX search URL behavior.

## Plan or Spec

- `docs/plans/2026-06-12-model-registry-mlx-only-search-pagination.md`
- Related model registry behavior: `docs/plans/2026-05-01-model-registry-local-fit.md`

## Commands Run

- `.githooks/pre-commit` via `git commit -m "Fix MLX-only model registry search"`: passed
  - `make swift-test`: passed
  - `make py-test`: `3949 passed, 14 skipped, 2 warnings`
  - `make integration-test`: `120 passed, 1 skipped`
  - PR scoped performance report: `Status: ok`, `Regressions: 0`, `Verification failures: 0`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_maintenance_service.py::test_search_hub_models_passes_cursor_and_filters_to_mlx_results`: `79 passed`
- `SWIFTPM_DISABLE_SANDBOX=1 swift test --package-path apps/macos-menubar --filter 'RuntimeViewModelTests/(modelRegistryEntriesMergeLocalManagedDownloadAndHubFitState|modelRegistryGroupsReadyLocalModelsAndExcludesDuplicateHubDiscoveries|blockedHubDownloadIsPreventedWhileHeavyRemainsAllowed)'`: `3 passed`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 COVERAGE_FILE=.runtime/coverage/model-registry-mlx-only-search.coverage uv run --project services/mlx-worker-python coverage run --source=services/mlx-worker-python/worker,services/mlx-worker-python/tests -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_maintenance_service.py::test_search_hub_models_passes_cursor_and_filters_to_mlx_results`: `79 passed`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 COVERAGE_FILE=.runtime/coverage/model-registry-mlx-only-search.coverage uv run --project services/mlx-worker-python coverage json -o .runtime/coverage/model-registry-mlx-only-search.json`: passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/model-registry-mlx-only-search.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py`: `TOTAL 49 0 100%`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python python - <<'PY' ... catalog.search_models(query="Gemma", page_size=10, cursor="", mlx_only=True) ... PY`: returned 10 MLX-compatible Gemma results and a next cursor
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics`: `3 passed`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 MELIX_HUB_CATALOG_CURSOR_ITERATIONS=1000 MELIX_HUB_CATALOG_CURSOR_SAMPLES=1 uv run --project services/mlx-worker-python python scripts/hub_catalog_next_cursor_probe.py`: passed
- `git diff --check`: passed
- After merging current `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_maintenance_service.py::test_search_hub_models_passes_cursor_and_filters_to_mlx_results`: `79 passed`
- After merging current `origin/main`: `git diff --check`: passed
- After merging current `origin/main`: `git merge-base --is-ancestor origin/main HEAD`: passed

## Coverage and Metrics

- Changed-line coverage: `49/49`, `100%`
  - `services/mlx-worker-python/worker/model_ops/hub_catalog.py`: `20/20`, `100%`
  - `services/mlx-worker-python/tests/test_hub_catalog.py`: `29/29`, `100%`
- PR scoped performance report: `Status: ok`, `Selected probes: 3`, `Regressions: 0`, `Verification failures: 0`
  - Hub catalog tag normalization single pass: head `93.406 ms` vs base `94.887 ms`, neutral
  - Hub catalog next cursor fast parse: head `355.595 ms` vs base `358.533 ms`, neutral; peak bytes unchanged at `832`
  - Hub catalog size hint regex precompile: head `949.669 ms` vs base `971.107 ms`, neutral
- Runtime performance guardrail: MLX-only search pagination is bounded by `MLX_ONLY_SEARCH_MAX_PAGES = 4` and stops early once the requested page has enough compatible results.
- Observability mode: N/A. This is a worker search correctness fix with no new telemetry surface.

## Known Gaps

- `make bootstrap` and `make proto` were not rerun. No dependency or protobuf schema changes were made.

## Evidence Checklist

- [x] Behavior change is tied to a governing plan/spec.
- [x] Relevant focused tests pass.
- [x] Full pre-commit gate passed on this macOS host.
- [x] Coverage and scoped performance metrics are reported.
- [x] Branch is current with `origin/main`.
- [x] Known gaps are documented.
