### PR TITLE
perf: split changed-scope diff on newline

### DIFF
--- a/docs/plans/2026-06-12-changed-scope-diff-split-newline.md
+++ b/docs/plans/2026-06-12-changed-scope-diff-split-newline.md
@@ -1,0 +1,33 @@
+# Changed-scope diff split newline performance slice
+
+## Scope
+
+This Python-only performance slice is limited to the hot unified-diff parser in
+`scripts/changed_scope_coverage.py`.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `changed-scope-coverage-diff-parser` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries, and selects the
+synthetic parser workload in `scripts/changed_scope_coverage_parse_probe.py`.
+
+## Plan
+
+1. Preserve parser behavior for malformed headers, no-newline markers, blank
+   context lines, and trailing newline inputs.
+2. Parse the hot loop over UTF-8 bytes split on explicit newlines so the parser
+   avoids universal line-boundary handling and string-character dispatch for the
+   ASCII-only diff grammar markers emitted by `git diff`.
+3. Run the registered focused tests, changed-scope coverage command, and
+   registered parser probe locally on Linux.
+4. Use GitHub Actions and the PR-scoped performance workflow as the merge gate.
+
+## Validation commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+python3 scripts/changed_scope_coverage_parse_probe.py
+```

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -14,10 +14,17 @@ import sys
 
 _DIFF_HEADER_PREFIX = "diff --git a/"
 _DIFF_HEADER_SEPARATOR = " b/"
+_DIFF_HEADER_PREFIX_BYTES = b"diff --git a/"
+_DIFF_HEADER_SEPARATOR_BYTES = b" b/"
 _ASCII_ZERO = ord("0")
 _ASCII_NINE = ord("9")
 _ASCII_COMMA = ord(",")
 _ASCII_SPACE = ord(" ")
+_ASCII_BACKSLASH = ord("\\")
+_ASCII_PLUS = ord("+")
+_ASCII_MINUS = ord("-")
+_ASCII_AT = ord("@")
+_ASCII_LOWER_D = ord("d")
 
 
 def _is_diff_file_marker(line: str) -> bool:
@@ -50,6 +57,22 @@ def _parse_hunk_new_start_from_digit(line: str, digit_index: int) -> int | None:
     return None
 
 
+def _parse_hunk_new_start_from_digit_bytes(line: bytes, digit_index: int) -> int | None:
+    value = 0
+    index = digit_index
+    line_length = len(line)
+    while index < line_length:
+        character_code = line[index]
+        if _ASCII_ZERO <= character_code <= _ASCII_NINE:
+            value = value * 10 + (character_code - _ASCII_ZERO)
+            index += 1
+            continue
+        if character_code == _ASCII_COMMA or character_code == _ASCII_SPACE:
+            return value if index > digit_index else None
+        return None
+    return None
+
+
 def _parse_hunk_new_start(line: str) -> int | None:
     new_range_index = line.find(" +")
     if new_range_index < 0:
@@ -60,29 +83,29 @@ def _parse_hunk_new_start(line: str) -> int | None:
 def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     changed_by_path: dict[str, set[int]] = {}
     changed_by_path_setdefault = changed_by_path.setdefault
-    header_prefix = _DIFF_HEADER_PREFIX
-    header_separator = _DIFF_HEADER_SEPARATOR
+    header_prefix = _DIFF_HEADER_PREFIX_BYTES
+    header_separator = _DIFF_HEADER_SEPARATOR_BYTES
     header_prefix_len = len(header_prefix)
     header_separator_len = len(header_separator)
-    parse_hunk_new_start_from_digit = _parse_hunk_new_start_from_digit
+    parse_hunk_new_start_from_digit = _parse_hunk_new_start_from_digit_bytes
     add_changed_line = None
     new_line: int | None = None
-    for line in diff_text.splitlines():
+    for line in diff_text.encode().split(b"\n"):
         if not line:
             if add_changed_line is not None and new_line is not None:
                 new_line += 1
             continue
         first_char = line[0]
-        if first_char == "d" and line.startswith(header_prefix):
+        if first_char == _ASCII_LOWER_D and line.startswith(header_prefix):
             separator_index = line.find(header_separator, header_prefix_len)
             add_changed_line = None
             if separator_index >= 0:
-                current_path = line[separator_index + header_separator_len :]
+                current_path = line[separator_index + header_separator_len :].decode()
                 add_changed_line = changed_by_path_setdefault(current_path, set()).add
             new_line = None
             continue
-        if first_char == "@" and len(line) > 1 and line[1] == "@":
-            new_range_index = line.find(" +")
+        if first_char == _ASCII_AT and len(line) > 1 and line[1] == _ASCII_AT:
+            new_range_index = line.find(b" +")
             if new_range_index < 0:
                 new_line = None
                 continue
@@ -90,12 +113,12 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
             continue
         if add_changed_line is None or new_line is None:
             continue
-        if first_char == "\\":
+        if first_char == _ASCII_BACKSLASH:
             continue
-        if first_char == "+":
+        if first_char == _ASCII_PLUS:
             add_changed_line(new_line)
             new_line += 1
-        elif first_char == "-":
+        elif first_char == _ASCII_MINUS:
             continue
         else:
             new_line += 1


### PR DESCRIPTION
## Summary
- Optimize the changed-scope coverage unified diff parser by parsing the hot loop over UTF-8 bytes split on explicit newlines.
- Keep parser semantics unchanged for malformed hunks, no-newline markers, blank context lines, and trailing newline inputs.

## Plan or Spec
- Added `docs/plans/2026-06-12-changed-scope-diff-split-newline.md` for this Python-only performance slice.
- Registered probe coverage already exists via `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`, including focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `python3 scripts/changed_scope_coverage_parse_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `40 passed in 0.21s` and `40 passed in 0.59s` under coverage.
- Changed-scope coverage: `TOTAL 32 0 100%`.
- Local base-vs-head parser probe (200 samples): baseline mean `3.0101 ms`, head mean `2.8647 ms`, delta `-0.1454 ms`, speedup `1.0508x`.
- Registered head probe: `elapsed_ms_mean=3.0888`, `elapsed_ms_min=2.9101`, `file_count=240`, `changed_line_count=7680`, `line_count=16080`.

## Known Gaps
- Local verification is Linux/Python-only. The registered PR-scoped performance workflow remains the merge gate for CI validation.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage passed locally at or above 95%.
- [x] Registered probe ran locally and showed improvement.
- [ ] GitHub Actions completed successfully after the latest push.
- [ ] PR-scoped performance workflow completed successfully after the latest push.
