### PR TITLE
perf: extend embedding cycle vector copies

### DIFF
--- a/docs/plans/2026-05-05-deterministic-embedding-duplicate-input-cache.md
+++ b/docs/plans/2026-05-05-deterministic-embedding-duplicate-input-cache.md
@@ -47,3 +47,13 @@ lookups in duplicate-heavy deterministic embedding requests.
 - Changed-scope coverage for touched Python/tests with at least 95% automated coverage
 - Local registered probe run through `scripts/pr_scoped_performance_run.py`
 - `git diff --check`
+
+## 2026-06-12 Cycle Copy Extension Slice
+
+This follow-up keeps the same registered probe and narrows only the repeated-cycle
+materialization path in `DeterministicEmbeddingRuntime.embed_inputs()`. Once the
+first cycle's vectors are embedded, each repeated cycle is now extended from a
+generator of `vector.copy()` results instead of appending one copied vector at a
+time in Python. The slice preserves per-position list independence and duplicate
+embedding-call elision while reducing hot-loop append overhead on cycle-shaped
+duplicate requests.

--- a/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
@@ -70,8 +70,7 @@ class DeterministicEmbeddingRuntime:
                 append_vector(vector)
             cycle_vectors = tuple(vectors)
             for _ in range(len(inputs) // cycle_length - 1):
-                for vector in cycle_vectors:
-                    append_vector(vector.copy())
+                vectors.extend(vector.copy() for vector in cycle_vectors)
             return vectors
 
         vector_cache: dict[str, list[float]] = {}


### PR DESCRIPTION
## Summary
- Optimizes the deterministic embedding repeated-cycle path by extending each repeated cycle from copied vectors instead of appending one vector copy at a time.
- Keeps duplicate embedding-call elision and per-position list independence unchanged.

## Plan or Spec
- `docs/plans/2026-05-05-deterministic-embedding-duplicate-input-cache.md` documents the 2026-06-12 cycle copy extension slice.

## Commands Run
```text
# baseline probe on origin/main before changes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_duplicate_probe.py
# exit 0; {"elapsed_ms_mean": 22.276023, "peak_bytes_mean": 3016335.2, "embed_text_calls_mean": 512.0, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics
# exit 0; 18 passed in 2.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_duplicate_probe.py
# exit 0; changed-scope coverage TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_duplicate_probe.py
# exit 0; {"elapsed_ms_mean": 17.586004, "peak_bytes_mean": 3016951.2, "embed_text_calls_mean": 512.0, ...}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 1 0 100%`).
- Registered local probe: `deterministic-embedding-duplicate-input-cache` via `scripts/deterministic_embedding_duplicate_probe.py`.
- Local Linux probe delta: `elapsed_ms_mean` 22.276023 ms → 17.586004 ms (`-4.690019 ms`, ~21.05% faster); `embed_text_calls_mean` stayed 512.0; `peak_bytes_mean` 3016335.2 → 3016951.2 bytes (+616 bytes, informational).
- CI PR-scoped performance workflow remains the merge gate for registered probe validation.

## Known Gaps
- Local validation was Linux-only for this Python worker path; GitHub Actions PR-scoped performance report is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe; probe overhead N/A because this is not a runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
