### PR TITLE
perf: fast-path local job follow-up claim inputs

### DIFF
--- a/docs/plans/2026-06-12-local-job-followup-claim-input-fastpath.md
+++ b/docs/plans/2026-06-12-local-job-followup-claim-input-fastpath.md
@@ -1,0 +1,32 @@
+# Local Job Follow-Up Claim Input Fast Path
+
+## Goal
+
+Reduce per-candidate overhead in the local-job follow-up batch claim path while preserving the existing store scan, reconciliation, prompt-admission, and receipt semantics.
+
+## Scope
+
+This Python-only performance slice is limited to `LocalJobContinuationStore.claim_scanned_followup_prompt_contexts(...)` and the registered local-job follow-up scan probe. It keeps the existing `os.scandir()` store scan, guarded record writes, prompt-context admission, projection copying, and receipt shapes unchanged.
+
+The affected path is covered by the registered PR-scoped probe `local-job-followup-scan-scandir` in `infra/perf/pr_scoped_probes.json`. This slice extends that registered probe with batch projection metrics so CI and local runs measure the newly added multi-candidate follow-up path, not only the file scan.
+
+## Optimization
+
+The prior claim loop rebuilt a three-entry tuple and a list comprehension for every scanned candidate just to discover missing claim-input maps. This slice replaces that per-candidate tuple/list-comprehension setup with direct membership checks against the normalized mappings, appending missing field names only when a field is absent.
+
+This keeps exception mapping behavior unchanged: mapping membership errors still become `followup_claim_input_invalid`, and missing fields still emit `followup_claim_input_missing` with the same ordered field names.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_project_local_job_session_followup_returns_user_message_projection services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_project_local_job_session_followup_returns_user_message_projection services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/local_job_followup_scan_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py
+```
+
+## Success Criteria
+
+- Focused local-job follow-up tests and registry validation tests pass.
+- Changed-scope coverage remains at or above 95 percent for the touched scope.
+- The registered probe emits `projection_elapsed_ms_mean` and related projection count metrics.
+- `projection_elapsed_ms_mean` improves against the base implementation in the local probe and registered CI report without changing candidate, receipt, or follow-up message counts.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5553,6 +5553,32 @@
         "key": "receipt_count_mean",
         "unit": "count",
         "direction": "informational"
+      },
+      {
+        "key": "projection_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "projection_elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better"
+      },
+      {
+        "key": "projection_count_mean",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
+        "key": "projection_followup_message_count_mean",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
+        "key": "projection_receipt_count_mean",
+        "unit": "count",
+        "direction": "informational"
       }
     ]
   },

--- a/scripts/local_job_followup_scan_probe.py
+++ b/scripts/local_job_followup_scan_probe.py
@@ -106,10 +106,60 @@ def run_probe(*, record_count: int = 500, samples: int = 5) -> dict[str, float]:
     }
 
 
+def run_projection_probe(*, record_count: int = 250, samples: int = 5) -> dict[str, float]:
+    elapsed_samples: list[float] = []
+    projection_samples: list[float] = []
+    followup_message_samples: list[float] = []
+    receipt_samples: list[float] = []
+
+    for _ in range(samples):
+        with tempfile.TemporaryDirectory(prefix="melix-local-job-projection-") as tmp:
+            store = _prepare_store(Path(tmp), record_count=record_count)
+            followup_session_ids = {
+                f"job-{index:05d}": f"followup-job-{index:05d}"
+                for index in range(record_count)
+            }
+            completion_summaries = {
+                f"job-{index:05d}": {
+                    "status": "completed",
+                    "summary": f"Redacted completion summary {index}",
+                }
+                for index in range(record_count)
+            }
+            owner_scope_checked = {f"job-{index:05d}": True for index in range(record_count)}
+
+            started = time.perf_counter()
+            projection_batch = target.project_local_job_session_followups(
+                store,
+                followup_session_ids_by_job_id=followup_session_ids,
+                completion_summaries_by_job_id=completion_summaries,
+                owner_scope_checked_by_job_id=owner_scope_checked,
+            )
+            elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+            projection_samples.append(float(len(projection_batch.projections)))
+            followup_message_samples.append(float(len(projection_batch.followup_messages)))
+            receipt_samples.append(float(len(projection_batch.receipts)))
+
+    return {
+        "projection_elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+        "projection_elapsed_ms_min": round(min(elapsed_samples), 6),
+        "projection_count_mean": statistics.fmean(projection_samples),
+        "projection_followup_message_count_mean": statistics.fmean(followup_message_samples),
+        "projection_receipt_count_mean": statistics.fmean(receipt_samples),
+    }
+
+
 def main() -> int:
     record_count = int(os.environ.get("MELIX_LOCAL_JOB_SCAN_RECORDS", "500"))
     samples = int(os.environ.get("MELIX_LOCAL_JOB_SCAN_SAMPLES", "5"))
-    print(json.dumps(run_probe(record_count=record_count, samples=samples), sort_keys=True))
+    projection_record_count = int(
+        os.environ.get("MELIX_LOCAL_JOB_PROJECTION_RECORDS", "250")
+    )
+    metrics = run_probe(record_count=record_count, samples=samples)
+    metrics.update(
+        run_projection_probe(record_count=projection_record_count, samples=samples)
+    )
+    print(json.dumps(metrics, sort_keys=True))
     return 0
 
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -329,6 +329,7 @@ def test_local_job_followup_scan_probe_script_emits_metrics(
 ) -> None:
     monkeypatch.setenv("MELIX_LOCAL_JOB_SCAN_RECORDS", "5")
     monkeypatch.setenv("MELIX_LOCAL_JOB_SCAN_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_LOCAL_JOB_PROJECTION_RECORDS", "3")
     probe_script = runpy.run_path(str(REPO_ROOT / "scripts/local_job_followup_scan_probe.py"))
 
     assert probe_script["main"]() == 0
@@ -340,6 +341,10 @@ def test_local_job_followup_scan_probe_script_emits_metrics(
     assert metrics["scandir_calls_mean"] == 1.0
     assert metrics["path_glob_calls_mean"] == 0.0
     assert metrics["path_exists_calls_mean"] == 0.0
+    assert metrics["projection_elapsed_ms_mean"] >= 0.0
+    assert metrics["projection_count_mean"] == 3.0
+    assert metrics["projection_followup_message_count_mean"] == 3.0
+    assert metrics["projection_receipt_count_mean"] == 6.0
 
 
 

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -413,21 +413,21 @@ class LocalJobContinuationStore:
     ) -> LocalJobContinuationFollowupClaimBatch:
         live_evidence_by_job_id = live_evidence_by_job_id or {}
         (
-            followup_session_ids_by_job_id,
+            followup_session_ids,
             followup_session_ids_input_error,
         ) = _claim_input_mapping_or_error(
             followup_session_ids_by_job_id,
             "followup_session_ids_by_job_id",
         )
         (
-            completion_summaries_by_job_id,
+            completion_summaries,
             completion_summaries_input_error,
         ) = _claim_input_mapping_or_error(
             completion_summaries_by_job_id,
             "completion_summaries_by_job_id",
         )
         (
-            owner_scope_checked_by_job_id,
+            owner_scope_checked,
             owner_scope_checked_input_error,
         ) = _claim_input_mapping_or_error(
             owner_scope_checked_by_job_id,
@@ -456,15 +456,13 @@ class LocalJobContinuationStore:
                 )
                 continue
             try:
-                missing_fields = [
-                    field_name
-                    for field_name, values in (
-                        ("followup_session_id", followup_session_ids_by_job_id),
-                        ("completion_summary", completion_summaries_by_job_id),
-                        ("owner_scope_checked", owner_scope_checked_by_job_id),
-                    )
-                    if job_id not in values
-                ]
+                missing_fields: list[str] = []
+                if job_id not in followup_session_ids:
+                    missing_fields.append("followup_session_id")
+                if job_id not in completion_summaries:
+                    missing_fields.append("completion_summary")
+                if job_id not in owner_scope_checked:
+                    missing_fields.append("owner_scope_checked")
             except (LookupError, TypeError, ValueError) as exc:
                 receipts.append(
                     _followup_claim_input_invalid_receipt(
@@ -487,15 +485,15 @@ class LocalJobContinuationStore:
                 claim = self.claim_followup_prompt_context(
                     job_id,
                     followup_session_id=_claim_input_value(
-                        followup_session_ids_by_job_id,
+                        followup_session_ids,
                         job_id,
                     ),
                     completion_summary=_claim_input_value(
-                        completion_summaries_by_job_id,
+                        completion_summaries,
                         job_id,
                     ),
                     owner_scope_checked=_claim_input_value(
-                        owner_scope_checked_by_job_id,
+                        owner_scope_checked,
                         job_id,
                     ),
                     live_evidence=live_evidence_by_job_id.get(job_id),


### PR DESCRIPTION
## Summary
- Fast-path local-job follow-up claim input checks by avoiding the per-candidate tuple/list-comprehension setup for the three required claim maps.
- Extend the registered `local-job-followup-scan-scandir` PR-scoped probe with batch projection timing/count metrics.
- Add a focused plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-12-local-job-followup-claim-input-fastpath.md`
- Affected path is covered by registered probe `local-job-followup-scan-scandir` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_project_local_job_session_followup_returns_user_message_projection services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` → 4 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_project_local_job_session_followup_returns_user_message_projection services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_claim_scanned_followups_reports_missing_claim_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/local_job_followup_scan_probe.py` → 5 passed; changed-scope coverage 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py` → emitted registered scan and projection metrics
- Base/head comparison with `MELIX_LOCAL_JOB_SCAN_RECORDS=300 MELIX_LOCAL_JOB_PROJECTION_RECORDS=400 MELIX_LOCAL_JOB_SCAN_SAMPLES=11` using the head probe script against `origin/main` and this branch.

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 34 0 100%`.
- Default local registered probe (head): `elapsed_ms_mean=33.936912`, `projection_elapsed_ms_mean=150.905958`, `projection_count_mean=250.0`, `projection_followup_message_count_mean=250.0`, `projection_receipt_count_mean=500.0`.
- Local base/head projection comparison: `base projection_elapsed_ms_mean=245.73987`, `head projection_elapsed_ms_mean=237.860012`, `delta_ms=-7.879858`, `speedup=1.033128x`.
- Local base/head scan metric stayed stable in repeat comparison: `base elapsed_ms_mean=19.417842`, `head elapsed_ms_mean=19.391701`, `delta_ms=-0.026141`, `speedup=1.001348x`.

## Known Gaps
- Linux local validation covers the Python worker path only.
- The registered PR-scoped performance workflow remains the merge gate for CI-side base/head validation.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Registered probe covers the affected path and includes focused `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe emitted projection metrics and showed a positive base/head projection delta.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
