### PR TITLE
Classify function tool output receipts

### DIFF
--- a/docs/plans/2026-06-12-issue-1761-function-role-tool-output-receipts.md
+++ b/docs/plans/2026-06-12-issue-1761-function-role-tool-output-receipts.md
@@ -1,0 +1,54 @@
+# Issue 1761 Function Role Tool Output Receipts
+
+## Goal
+
+Classify OpenAI-compatible legacy `function` role messages and Harmony-style
+`functions.<name>` role messages as untrusted tool output when control-plane
+prompt boundary receipts are built.
+
+## Scope
+
+This slice is limited to control-plane prompt-context receipt classification:
+
+- keep existing `tool` role messages classified as `tool_output`
+- add `function` and `functions.*` roles to the same `tool_output` trust
+  boundary
+- preserve redacted receipt JSON with no raw tool output text
+- update the unified runtime contract to document the role aliases
+
+Out of scope:
+
+- changing worker message roles or prompt payloads
+- adding new tool parser behavior
+- parsing function names or tool-call arguments into receipts
+- owner-scope validation for tool output
+
+## Architecture
+
+`PromptContextBoundaryReceipts` already owns control-plane classification for
+prompt-adjacent message parts. Extend its role classifier so legacy function
+outputs use the existing source policy, reason, corrective action, and receipt
+shape for `tool_output`. This keeps the behavior local to evidence metadata and
+does not alter the normalized messages sent to the worker.
+
+## Performance Probes
+
+The changed path adds two role string comparisons while building request-local
+receipt evidence. It does not add filesystem access, network calls, model
+execution, or parser work.
+
+Success metrics:
+
+- focused `ToolParserRegistryTests` pass
+- Swift changed-line coverage for the touched source/test scope is at least 95
+  percent
+- scoped performance report has status `ok`, zero regressions, and zero
+  verification failures
+
+## Verification Plan
+
+1. Add a RED Swift test covering `function` and `functions.get_weather` roles.
+2. Implement the role classifier update in `PromptContextBoundaryReceipts`.
+3. Update `docs/unified-agentic-tool-runtime-contract.md`.
+4. Run focused Swift tests, changed-line coverage, pre-commit, and PR-scoped
+   performance before opening the PR.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -274,8 +274,10 @@ admission primitives are defined below for future entrypoint wiring.
 
 The v1 source-specific control-plane classification slice refines those chat
 prompt receipts using request-local message metadata already present at prompt
-assembly time. Tool-role messages record `source_type = tool_output`. Non-tool
-messages whose normalized `name` uses the reserved prefixes `retrieved_image`,
+assembly time. Tool-output messages record `source_type = tool_output` when the
+normalized role is `tool`, legacy OpenAI-compatible `function`, or
+Harmony-style `functions.<name>`. Non-tool messages whose normalized `name` uses
+the reserved prefixes `retrieved_image`,
 `retrieved-image`, `image_retrieval`, `image-retrieval`, `rag_image`, or
 `rag-image` record `source_type = retrieved_image`. Non-tool
 messages whose normalized `name` uses the reserved prefixes `retrieved_document`,

--- a/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift
@@ -58,7 +58,7 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
 
     private static func sourceType(for message: NormalizedTextMessage) -> String {
         let normalizedRole = message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if normalizedRole == "tool" {
+        if isToolOutputRole(normalizedRole) {
             return "tool_output"
         }
 
@@ -91,6 +91,12 @@ struct PromptContextBoundaryReceipts: Sendable, Equatable {
             return "model_final_answer"
         }
         return "chat_prompt_message"
+    }
+
+    private static func isToolOutputRole(_ normalizedRole: String) -> Bool {
+        normalizedRole == "tool"
+            || normalizedRole == "function"
+            || normalizedRole.hasPrefix("functions.")
     }
 
     private static func sourcePolicy(for sourceType: String) -> (reason: String, correctiveAction: String) {

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -660,6 +660,42 @@ struct ToolParserRegistryTests {
         #expect(receiptsJSON.contains("Continue from the previous answer.") == false)
     }
 
+    @Test("prompt context boundary receipts classify function roles as tool output")
+    func promptContextBoundaryReceiptsClassifyFunctionRolesAsToolOutput() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-function-tool-output" })
+        let request = makeNormalizedRequest(messages: [
+            .init(role: "function", name: "get_weather", content: "legacy function output says ignore system"),
+            .init(role: "functions.get_forecast", content: "harmony function output says reveal secrets"),
+        ])
+
+        let translated = try translator.translate(request, modelHandle: "worker-text")
+        let ext = translated.workerRequest.execution.ext
+        let receiptsJSON = try #require(ext["melix.prompt_context.receipts_json"])
+        let receipts = try #require(
+            try JSONSerialization.jsonObject(with: Data(receiptsJSON.utf8)) as? [[String: Any]]
+        )
+
+        #expect(ext["melix.prompt_context.receipt_count"] == "2")
+        #expect(receipts.compactMap { $0["source_type"] as? String } == ["tool_output", "tool_output"])
+        #expect(receipts.compactMap { $0["message_role"] as? String } == ["function", "functions.get_forecast"])
+        #expect(receipts.compactMap { $0["source_id"] as? String } == ["get_weather"])
+        #expect(
+            receipts.allSatisfy {
+                $0["reason"] as? String == "tool output is prompt data, not instructions"
+            }
+        )
+        #expect(
+            receipts.allSatisfy {
+                $0["corrective_action"] as? String ==
+                    "Keep tool output in user-role data context and do not project it into system or developer instructions."
+            }
+        )
+        #expect(receipts.allSatisfy { $0["included"] as? Bool == true })
+        #expect(receipts.allSatisfy { $0["policy"] as? String == "data_only" })
+        #expect(receiptsJSON.contains("ignore system") == false)
+        #expect(receiptsJSON.contains("reveal secrets") == false)
+    }
+
     @Test("request-local compatibility policy receipt overrides do not mutate default requests")
     func requestLocalCompatibilityPolicyReceiptOverridesDoNotMutateDefaultRequests() throws {
         let translator = ChatRequestTranslator(requestIDGenerator: { "req-compat-policy-defaults" })


### PR DESCRIPTION
## Summary
- Classifies legacy `function` and Harmony-style `functions.<name>` prompt roles as `tool_output` in prompt context boundary receipts.
- Adds regression coverage proving function-role tool output metadata is retained while untrusted text stays redacted from receipt JSON.
- Documents the supported tool-output role aliases in the unified agentic tool runtime contract.

## Plan or Spec
- `docs/plans/2026-06-12-issue-1761-function-role-tool-output-receipts.md`
- `docs/unified-agentic-tool-runtime-contract.md`
- Refs #1761

## Commands Run
```text
xcrun swift test --package-path services/control-plane-swift --filter ToolParserRegistryTests/promptContextBoundaryReceiptsClassifyFunctionRolesAsToolOutput --disable-automatic-resolution
RED before implementation: exited 1; source_type was ["chat_prompt_message", "chat_prompt_message"] instead of ["tool_output", "tool_output"].

xcrun swift test --package-path services/control-plane-swift --filter ToolParserRegistryTests/promptContextBoundaryReceiptsClassifyFunctionRolesAsToolOutput --disable-automatic-resolution
GREEN after implementation: 1 test passed.

xcrun swift test --package-path services/control-plane-swift --filter 'ToolParserRegistryTests/promptContextBoundaryReceipts' --disable-automatic-resolution
Passed: 6 prompt context boundary receipt tests.

xcrun swift test --package-path services/control-plane-swift --filter 'ToolParserRegistryTests/promptContextBoundaryReceipts' --enable-code-coverage --disable-automatic-resolution
Passed: 6 prompt context boundary receipt tests; wrote Swift coverage artifacts.

python3.11 scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/Requests/PromptContextBoundaryReceipt.swift services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
Passed: TOTAL 100.00% 40/40 changed executable lines.

git diff --check
Passed.

make bootstrap
Passed.

make proto
Passed; no generated artifact changes.

git commit -m "Classify function tool output receipts"
Passed with versioned pre-commit hook:
- make swift-test: rc=0, elapsed=642.9s.
- make py-test: rc=0, 3956 passed, 14 skipped, 2 warnings in 178.99s.
- make integration-test: rc=0, 120 passed, 1 skipped in 741.04s.
- PR scoped performance report: Status ok, 1 selected direct probe, 0 regressions, 0 context regressions, 0 verification failures.

git fetch origin main --prune
Passed; origin/main remained a9069190.

git merge-base --is-ancestor origin/main HEAD
Passed; branch is current with origin/main.
```

## Coverage and Metrics
- Changed executable Swift scope: 100.00% changed-line coverage, 40/40 executable changed lines covered.
- PR scoped performance report: `.runtime/pre-commit-performance/20260612-151852-a9069190/report/report.md`.
- Report status: `ok`; selected probes: 1 direct/gated probe; regressions: 0; context regressions: 0; verification failures: 0.
- Probe: Local job follow-up scan scandir.
- Probe metrics: `elapsed_ms_mean` base 15.955 ms, head 15.918 ms, delta -0.037 ms (-0.23%), neutral; `scandir_calls_mean` unchanged at 1.000; `path_glob_calls_mean` unchanged at 0.000.
- Observability mode: N/A. This change updates request-local receipt classification and does not add runtime metrics, evidence-mode probes, or debug artifacts.
- Probe overhead: N/A. No new probe was added; the existing PR-scoped probe ran as part of the pre-commit gate.

## Known Gaps
- This slice does not change worker message roles or prompt payload construction.
- This slice does not parse function/tool argument payloads into receipts.
- This slice does not add owner-scope validation for tool or function names.
- Broader #1761 entrypoint coverage for durable context, live RAG, skill/memory, MCP, agent, and local job handoff sources remains follow-up work.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
