### PR TITLE
perf: skip empty benchmark tool-turn aggregation

### DIFF
--- a/services/mlx-worker-python/worker/productization/benchmark_store.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_store.py
@@ -643,22 +643,27 @@ class BenchmarkStore:
         if not all(isinstance(row, BenchmarkMatrixSummaryRow) for row in summary_rows):
             return summary_rows
 
-        aggregates_by_cell_key: dict[
-            tuple[str, int, int, int, str, str, str, int],
-            tuple[int, int, float, int, int, int],
-        ] = {}
         has_tool_turn_fields = False
         for row in request_rows:
             if not isinstance(row, BenchmarkMatrixRequestRow):
                 return summary_rows
-            row_has_tool_turn_fields = (
+            if (
                 row.tool_call_count
                 or row.tool_latency_ms
                 or row.observation_bytes
                 or row.fatal_rate
                 or row.turn_count
-            )
-            has_tool_turn_fields = has_tool_turn_fields or bool(row_has_tool_turn_fields)
+            ):
+                has_tool_turn_fields = True
+                break
+        if not has_tool_turn_fields:
+            return summary_rows
+
+        aggregates_by_cell_key: dict[
+            tuple[str, int, int, int, str, str, str, int],
+            tuple[int, int, float, int, int, int],
+        ] = {}
+        for row in request_rows:
             key = (
                 row.suite_id,
                 row.context_length,
@@ -685,8 +690,6 @@ class BenchmarkStore:
                 fatal_count + (1 if row.fatal_rate > 0.0 else 0),
                 turn_count + row.turn_count,
             )
-        if not has_tool_turn_fields:
-            return summary_rows
 
         hydrated_rows: list[BenchmarkMatrixSummaryRow] = []
         for row in summary_rows:


### PR DESCRIPTION
## Summary
- Short-circuit benchmark matrix tool-turn summary hydration when request rows contain no tool-turn fields.
- Avoid building the per-cell aggregate dictionary for the common zero-tool-turn matrix path while preserving schema validation and hydration behavior when tool fields are present.

## Plan or Spec
- Governing standard: `docs/engineering-standards.md` and the registered PR-scoped performance probe `benchmark-store-matrix-streaming` in `infra/perf/pr_scoped_probes.json`.
- No product behavior or workflow contract changed; docs/spec update is not required for this implementation-only performance slice.

## Commands Run
```text
# Baseline from origin/main (3 probe invocations)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/benchmark_store_probe.py
old elapsed_ms_mean samples: 1469.227236, 1383.501722, 1407.619384
old peak_bytes_mean samples: 181580.7, 181580.7, 181541.3

# Focused tests + probe smoke before edit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_store.py::test_attach_matrix_tool_turn_summary_fields_skips_zero_tool_turn_requests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_script_emits_metrics
2 passed in 7.26s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/benchmark_store_probe.py
{"elapsed_ms_mean": 1380.467646, "peak_bytes_mean": 181580.7, "request_csv_line_count": 6001.0, "request_row_count": 6000.0, "sample_count": 3.0, "summary_row_count": 750.0}

# Focused behavior tests after edit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_store.py::test_attach_matrix_tool_turn_summary_fields_ignores_non_schema_request_rows services/mlx-worker-python/tests/test_benchmark_store.py::test_attach_matrix_tool_turn_summary_fields_hydrates_matching_summary_rows services/mlx-worker-python/tests/test_benchmark_store.py::test_attach_matrix_tool_turn_summary_fields_preserves_explicit_and_unmatched_rows services/mlx-worker-python/tests/test_benchmark_store.py::test_attach_matrix_tool_turn_summary_fields_skips_zero_tool_turn_requests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_script_emits_metrics
5 passed in 5.46s

# Registered changed-scope coverage command for benchmark-store-matrix-streaming
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_counts_lines_without_read_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_script_emits_metrics
28 passed in 25.17s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
Wrote JSON report to coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_store.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/benchmark_store_probe.py
TOTAL 7 0 100%
rm -f coverage.json

# Registered probe after edit (3 probe invocations)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/benchmark_store_probe.py
new elapsed_ms_mean samples: 1347.623818, 1386.610752, 1453.825634
new peak_bytes_mean samples: 179972.7, 179953.0, 179972.7

git diff --check
passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 7 0 100%`).
- Registered probe: `benchmark-store-matrix-streaming` (`scripts/benchmark_store_probe.py`, `probe_impl: command_json`).
- Local Linux probe comparison across 3 invocations:
  - `elapsed_ms_mean`: old_mean=1420.116114 ms, new_mean=1396.020068 ms, delta=-24.096046 ms (-1.6968%).
  - `peak_bytes_mean`: old_mean=181567.566667 bytes, new_mean=179966.133333 bytes, delta=-1601.433333 bytes (-0.8820%).
- CI PR-scoped performance workflow is required as the merge validation source for the registered probe report.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this slice used the registered benchmark-store focused test/coverage/probe commands.
- Local validation was Linux/Python only; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated: N/A, implementation-only performance shortcut with no behavior/workflow contract change.
- [x] Protocol changes include regenerated generated artifacts, or N/A is stated: N/A, no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A is stated: N/A, no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason: evidence mode via registered PR-scoped probe; no observability behavior changed.
- [x] Deferred work and known gaps are stated explicitly.
