### PR TITLE
perf: speed retrieval context receipt copies

### DIFF
--- a/docs/plans/2026-06-12-retrieval-context-projection-local-bindings.md
+++ b/docs/plans/2026-06-12-retrieval-context-projection-local-bindings.md
@@ -28,6 +28,8 @@ Bind loop-stable helpers (`_admit_entry`, `_duplicate_projection_receipt`, list 
 
 This follow-up slice keeps the same registered probe and adds a single-field payload fast path for the common `PromptContextAdmission` shape. Single-field admissions can check duplicate membership once and assign directly into the projected payload, while multi-field admissions continue to use the existing full duplicate-field scan and `dict.update()` path.
 
+This follow-up narrows receipt-copy overhead by binding `dict.copy` directly for projected receipt copies. The loop still produces a fresh shallow copy for each receipt, preserving the existing object isolation boundary while avoiding the generic `dict(receipt)` constructor path.
+
 ## Verification Plan
 
 Run the registered focused test command, changed-scope coverage command, and registered probe command locally on Linux before opening the PR. The PR-scoped performance workflow remains the authoritative CI validation source after push.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -114,7 +114,7 @@ def project_retrieval_contexts(
     receipts_extend = receipts.extend
     receipts_append = receipts.append
     user_payload_update = user_payload.update
-    copy_receipt = dict
+    copy_receipt = dict.copy
 
     for entry in entries:
         try:


### PR DESCRIPTION
## Summary
- Bind retrieval-context receipt copying to `dict.copy` in the projection loop.
- Keep shallow-copy isolation for projected/refusal receipts while avoiding the generic `dict(receipt)` constructor path.

## Plan or Spec
- Updated `docs/plans/2026-06-12-retrieval-context-projection-local-bindings.md` with this follow-up slice and probe boundary.
- Registered probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_isolates_refusals_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_malformed_entry_objects_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_preserves_multi_field_admission_duplicate_scan services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` (10 passed)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py` (10 passed; changed-line coverage 100%)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/retrieval_context_projection_probe.py"; python3 "$SCRIPT"'`
- `git diff --check`

## Coverage and Metrics
- Changed-line coverage: `TOTAL 1 0 100%`.
- Registered local probe: `baseline_elapsed_ms_mean=0.08242899452203087`, `optimized_elapsed_ms_mean=0.03677079005033842`, `delta_ms=-0.04565820447169245`, `speedup=2.2416976738652434`.
- Additional same-host comparison with 2000 iterations before/after this slice:
  - `origin/main`: `optimized_elapsed_ms_mean=0.03933681397964912`, `speedup=1.876297705476002`
  - this branch: `optimized_elapsed_ms_mean=0.03548096353188157`, `speedup=2.0590021779573404`

## Known Gaps
- Local validation is Linux/Python-only. The registered PR-scoped performance workflow is required as the CI merge gate.

## Evidence Checklist
- [x] Affected path has registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at 100% for changed lines.
- [x] Registered probe ran locally on Linux and showed lower elapsed time.
- [ ] PR-scoped performance CI report completed successfully.
