### PR TITLE
perf: fast-path hub size hint markers

### DIFF
--- a/docs/plans/2026-06-12-hub-size-direct-marker-performance.md
+++ b/docs/plans/2026-06-12-hub-size-direct-marker-performance.md
@@ -1,0 +1,44 @@
+# Hub Catalog Size Hint Direct Marker Performance Slice
+
+## Status
+
+Accepted for the 2026-06-12 performance slice.
+
+## Scope
+
+Optimize the Python hub catalog size-hint path in
+`services/mlx-worker-python/worker/model_ops/hub_catalog.py` by adding a direct
+common-case parser for explicit `Model size` README/card lines before falling
+back to the registered regex path.
+
+## Registered Probe
+
+This slice is covered by the existing PR-scoped performance probe:
+
+- `hub-catalog-size-hint-regex-precompile`
+- watched path: `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- focused tests: `services/mlx-worker-python/tests/test_hub_catalog.py`
+- coverage command: registered `coverage_command` in
+  `infra/perf/pr_scoped_probes.json`
+- probe command: registered `probe_command` in
+  `infra/perf/pr_scoped_probes.json`
+
+## Behavior
+
+The direct parser handles high-frequency explicit marker forms such as:
+
+- `Model size: 12 GB`
+- `MODEL SIZE | 7 kb`
+- `model size 1.5 MB`
+
+Mixed-case marker variants that are not covered by the direct fast path still
+fall back to the existing case-insensitive regex parser, preserving behavior.
+
+## Verification Plan
+
+1. Run the focused hub catalog tests and PR-scoped registry tests.
+2. Run changed-scope coverage using the registered coverage command.
+3. Run `scripts/hub_catalog_size_hint_probe.py` locally on Linux and compare the
+   metrics against the pre-change baseline.
+4. Let GitHub Actions run the registered PR-scoped performance workflow before
+   merge.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -415,9 +415,26 @@ def test_size_hint_scans_multiple_text_fields_before_joining(monkeypatch: pytest
         )
         == 12 * GB
     )
-    assert scanned_texts == [
-        "README\nModel size: 12 GB\nother metadata",
-    ]
+    assert scanned_texts == []
+
+
+def test_direct_explicit_size_hint_handles_common_readme_lines() -> None:
+    assert (
+        hub_catalog_module._direct_explicit_size_hint_from_text(
+            "README\nModel size: 12 GB\nother metadata"
+        )
+        == 12 * GB
+    )
+    assert (
+        hub_catalog_module._direct_explicit_size_hint_from_text(
+            "README\nMODEL SIZE | 7 kb\nother metadata"
+        )
+        == 7 * KB
+    )
+    assert hub_catalog_module._direct_explicit_size_hint_from_text("model size 1.5 MB") == int(
+        1.5 * MB
+    )
+    assert hub_catalog_module._direct_explicit_size_hint_from_text("mOdel size: 12 GB") == 0
 
 
 def test_weight_or_config_file_preserves_case_insensitive_matches() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2536,7 +2536,7 @@ def test_hub_catalog_size_hint_probe_script_emits_metrics(
     assert exc_info.value.code == 0
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["sample_count"] == 1.0
-    assert metrics["size_hint_calls_mean"] == 3.0
+    assert metrics["size_hint_calls_mean"] == 2.0
     assert metrics["matched_hint_count"] == 5.0
     assert metrics["payload_compatibility_calls_mean"] == 8.0
     assert metrics["payload_compatibility_matched_count"] == 7.0

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -799,6 +799,9 @@ def _size_hint_bytes(payload: dict[str, Any], *, card_data: dict[str, Any] | Non
         if not text or not _may_contain_model_marker(text):
             continue
         found_model_marker = True
+        direct_hint = _direct_explicit_size_hint_from_text(text)
+        if direct_hint > 0:
+            return direct_hint
         hint = _size_hint_from_text(text, allow_bare=False)
         if hint > 0:
             return hint
@@ -854,6 +857,33 @@ def _direct_card_size_hint_from_text(text: str) -> int:
     if stripped_text:
         return _direct_size_hint_from_text(stripped_text)
     return _direct_size_hint_from_text(text)
+
+
+def _direct_explicit_size_hint_from_text(text: str) -> int:
+    marker_index = text.find("Model size")
+    if marker_index < 0:
+        marker_index = text.find("MODEL SIZE")
+    if marker_index < 0:
+        marker_index = text.find("model size")
+    if marker_index < 0:
+        return 0
+
+    value_start = marker_index + 10
+    text_length = len(text)
+    while value_start < text_length and text[value_start].isspace():
+        value_start += 1
+    if value_start < text_length and (text[value_start] == ":" or text[value_start] == "|"):
+        value_start += 1
+    while value_start < text_length and text[value_start].isspace():
+        value_start += 1
+
+    value_end = value_start
+    while (
+        value_end < text_length
+        and text[value_end] not in "\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029"
+    ):
+        value_end += 1
+    return _direct_size_hint_from_text(text[value_start:value_end])
 
 
 def _strip_model_size_label(text: str) -> str:


### PR DESCRIPTION
## Summary
- Add a direct common-case parser for explicit `Model size` README/card lines before falling back to the existing regex size-hint parser.
- Keep mixed-case/uncommon marker behavior on the existing case-insensitive regex fallback.
- Update focused hub catalog tests, PR-scoped probe expectations, and the governing performance plan.

## Plan or Spec
- `docs/plans/2026-06-12-hub-size-direct-marker-performance.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py` (baseline before change)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py` (after change)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 82 passed.
- Changed-scope coverage: `TOTAL 30 0 100%`.
- Local Linux probe baseline: `elapsed_ms_mean=1874.5254115201533`, `size_hint_calls_mean=80000.0`, `payload_compatibility_elapsed_ms_mean=198.8621797412634`.
- Local Linux probe after change: `elapsed_ms_mean=1825.7910064421594`, `size_hint_calls_mean=40000.0`, `payload_compatibility_elapsed_ms_mean=195.88929610326886`.
- Delta: `elapsed_ms_mean -48.73440507799387 ms` (~2.60% faster), `size_hint_calls_mean -40000.0` (50% fewer regex fallback calls in the probe).

## Known Gaps
- Local validation is Linux/Python-only. The registered PR-scoped performance workflow must complete successfully in CI before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows an improvement.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
