### PR TITLE
perf: fast-path single retrieval receipt copies

### DIFF
--- a/docs/plans/2026-06-12-retrieval-context-projection-local-bindings.md
+++ b/docs/plans/2026-06-12-retrieval-context-projection-local-bindings.md
@@ -30,6 +30,8 @@ This follow-up slice keeps the same registered probe and adds a single-field pay
 
 This follow-up narrows receipt-copy overhead by binding `dict.copy` directly for projected receipt copies. The loop still produces a fresh shallow copy for each receipt, preserving the existing object isolation boundary while avoiding the generic `dict(receipt)` constructor path.
 
+This slice adds a single-receipt append fast path for the common admission shape emitted by retrieval entries. Multi-receipt admissions still copy every receipt through the existing loop, while the one-receipt case avoids setting up a per-receipt loop iterator.
+
 ## Verification Plan
 
 Run the registered focused test command, changed-scope coverage command, and registered probe command locally on Linux before opening the PR. The PR-scoped performance workflow remains the authoritative CI validation source after push.

--- a/services/mlx-worker-python/tests/test_retrieval_context.py
+++ b/services/mlx-worker-python/tests/test_retrieval_context.py
@@ -588,6 +588,53 @@ def test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receip
     assert "system instruction" not in store_receipt_json
 
 
+def test_project_retrieval_contexts_copies_multi_receipt_admissions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Admission:
+        user_payload = {"retrieved_document": {"title": "Local note"}}
+        untrusted_context_receipts = [
+            {
+                "source_type": "retrieved_document",
+                "source_field": "retrieved_document",
+                "source_id": "doc:local-7",
+                "segment_id": "text-search:result-0",
+                "owner_scope_checked": True,
+            },
+            {
+                "source_type": "retrieved_document",
+                "source_field": "retrieved_document_metadata",
+                "source_id": "doc:local-7",
+                "segment_id": "text-search:result-0:metadata",
+                "owner_scope_checked": True,
+            },
+        ]
+
+    monkeypatch.setattr(
+        retrieval_context_module,
+        "_admit_entry",
+        lambda _entry: Admission(),
+    )
+
+    projection = project_retrieval_contexts(
+        [
+            RetrievalContextEntry(
+                context_kind="retrieved_document",
+                source_id="doc:local-7",
+                payload={"title": "Local note"},
+                owner_scope_checked=True,
+                source_field="retrieved_document",
+            )
+        ]
+    )
+
+    assert projection.user_payload == {"retrieved_document": {"title": "Local note"}}
+    assert projection.refusal_receipts == []
+    assert projection.untrusted_context_receipts == Admission.untrusted_context_receipts
+    assert projection.untrusted_context_receipts[0] is not Admission.untrusted_context_receipts[0]
+    assert projection.untrusted_context_receipts[1] is not Admission.untrusted_context_receipts[1]
+
+
 def test_project_retrieval_contexts_isolates_refusals_without_dropping_valid_entries() -> None:
     projection = project_retrieval_contexts(
         [

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -153,8 +153,12 @@ def project_retrieval_contexts(
                 )
                 continue
             user_payload_update(admission_payload)
-        for receipt in admission.untrusted_context_receipts:
-            receipts_append(copy_receipt(receipt))
+        admission_receipts = admission.untrusted_context_receipts
+        if len(admission_receipts) == 1:
+            receipts_append(copy_receipt(admission_receipts[0]))
+        else:
+            for receipt in admission_receipts:
+                receipts_append(copy_receipt(receipt))
 
     return RetrievalContextProjection(
         user_payload=user_payload,


### PR DESCRIPTION
## Summary
- Adds a single-receipt append fast path in `project_retrieval_contexts()` while preserving fresh shallow receipt copies.
- Adds a regression test for multi-receipt admissions so the fallback path remains covered.
- Updates the retrieval-context performance slice plan with the new receipt-copy optimization.

## Plan or Spec
- `docs/plans/2026-06-12-retrieval-context-projection-local-bindings.md`
- Registered PR-scoped probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_copies_multi_receipt_admissions services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 30 passed.
- Changed-scope coverage: 100.00% (16/16 measurable changed lines covered).
- Local registered probe output: `baseline_elapsed_ms_mean=0.07503576393771384`, `optimized_elapsed_ms_mean=0.03443672604459737`, `delta_ms=-0.040599037893116474`, `speedup=2.1789459265244493`, `entry_count=96`, `sample_count=7`, `iteration_count=400`.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Linux local validation covers the Python retrieval-context path only; no Swift runtime effect is claimed.
- Full repository gates are left to GitHub Actions for this scheduled performance slice.

## Evidence Checklist
- [x] Branch started from current `origin/main`.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally and showed improvement.
- [ ] GitHub Actions completed successfully.
- [ ] PR-scoped performance workflow completed successfully.
