### PR TITLE
perf: direct-parse single README size hints

### DIFF
--- a/docs/plans/2026-06-13-hub-catalog-single-readme-size-hint-direct.md
+++ b/docs/plans/2026-06-13-hub-catalog-single-readme-size-hint-direct.md
@@ -1,0 +1,30 @@
+# Hub catalog single-readme size hint direct parse
+
+## Scope
+
+This Python performance slice is limited to the Hub catalog model-size hint parser in `services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+
+The change preserves model-size hint semantics while reusing the existing direct explicit-marker parser for payloads that only provide one marked text field, such as a README containing `MODEL SIZE | <value> <unit>`. Before this slice, those single-field branches skipped the direct parser and immediately used the regex fallback.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry already provides focused `test_command`, `coverage_command`, and `probe_command` entries for `hub_catalog.py`, `test_hub_catalog.py`, `test_pr_scoped_performance.py`, and `scripts/hub_catalog_size_hint_probe.py`. This slice relies on the probe's `size_hint_calls_mean` and `elapsed_ms_mean` metrics to validate reduced regex fallback work.
+
+## Plan
+
+1. Add a regression test proving a single README `MODEL SIZE | ...` payload is parsed without calling the regex fallback helper.
+2. Route single marked text fields through a small direct-then-regex helper.
+3. Run focused Hub catalog tests, changed-scope coverage, and the registered Hub catalog probe locally on Linux.
+4. Use GitHub Actions and the registered PR-scoped performance report as the merge gate.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
+```

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -360,6 +360,34 @@ def test_repo_id_mlx_substring_match_preserves_ascii_case_insensitivity() -> Non
     ) is True
 
 
+def test_size_hint_single_readme_uses_direct_explicit_marker_before_regex(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parser = Mock(return_value=0)
+    monkeypatch.setattr(hub_catalog_module, "_size_hint_from_text", parser)
+
+    assert (
+        hub_catalog_module._size_hint_bytes(
+            {
+                "cardData": {},
+                "readme": "README\nMODEL SIZE | 130 kb\nother metadata",
+            }
+        )
+        == 130 * KB
+    )
+    parser.assert_not_called()
+
+
+def test_size_hint_single_readme_falls_back_to_regex_when_direct_parse_misses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parser = Mock(return_value=5 * MB)
+    monkeypatch.setattr(hub_catalog_module, "_size_hint_from_text", parser)
+
+    assert hub_catalog_module._size_hint_bytes({"cardData": {}, "readme": "Model size:"}) == 5 * MB
+    parser.assert_called_once_with("Model size:", allow_bare=False)
+
+
 def test_direct_size_hint_rejects_extra_tokens_without_full_split() -> None:
     assert _direct_size_hint_from_text("12 GB extra") == 0
     assert _direct_size_hint_from_text("12 GB") == 12 * 1024 * 1024 * 1024
@@ -1247,7 +1275,7 @@ def test_size_hint_bytes_skips_explicit_parser_when_model_marker_absent(
     parser.assert_not_called()
 
 
-def test_size_hint_bytes_skips_direct_hint_parser_when_card_model_size_missing(
+def test_size_hint_bytes_uses_direct_marker_parser_when_card_model_size_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[tuple[str, bool]] = []
@@ -1261,8 +1289,8 @@ def test_size_hint_bytes_skips_direct_hint_parser_when_card_model_size_missing(
     assert hub_catalog_module._size_hint_bytes({"cardData": {}}) == 0
     assert calls == []
 
-    assert hub_catalog_module._size_hint_bytes({"cardData": {}, "readme": "Model size: 7 MB"}) == 0
-    assert calls == [("Model size: 7 MB", False)]
+    assert hub_catalog_module._size_hint_bytes({"cardData": {}, "readme": "Model size: 7 MB"}) == 7 * MB
+    assert calls == []
 
 
 def test_size_hint_bytes_reuses_marker_checks_before_hint_parsing(
@@ -1394,16 +1422,12 @@ def test_size_hint_bytes_uses_single_payload_text_without_join(
     payload: dict[str, object],
     expected_text: str,
 ) -> None:
-    calls: list[tuple[str, bool]] = []
+    parser = Mock(return_value=1)
+    monkeypatch.setattr(hub_catalog_module, "_size_hint_from_text", parser)
 
-    def tracked(text: str, *, allow_bare: bool) -> int:
-        calls.append((text, allow_bare))
-        return 1
-
-    monkeypatch.setattr(hub_catalog_module, "_size_hint_from_text", tracked)
-
-    assert hub_catalog_module._size_hint_bytes(payload) == 1
-    assert calls == [(expected_text, False)]
+    expected_value = 6 * MB if expected_text == "Model size: 6 MB" else 8 * MB
+    assert hub_catalog_module._size_hint_bytes(payload) == expected_value
+    parser.assert_not_called()
 
 
 def test_search_models_ignores_sibling_sizes_without_weight_or_config_filenames() -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -2536,7 +2536,7 @@ def test_hub_catalog_size_hint_probe_script_emits_metrics(
     assert exc_info.value.code == 0
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["sample_count"] == 1.0
-    assert metrics["size_hint_calls_mean"] == 2.0
+    assert metrics["size_hint_calls_mean"] == 0.0
     assert metrics["matched_hint_count"] == 5.0
     assert metrics["payload_compatibility_calls_mean"] == 8.0
     assert metrics["payload_compatibility_matched_count"] == 7.0

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -776,23 +776,11 @@ def _size_hint_bytes(payload: dict[str, Any], *, card_data: dict[str, Any] | Non
     readme_text = _string(payload.get("readme"))
     card_description_text = _string(card_data.get("description"))
     if not readme_text and not card_description_text:
-        return (
-            _size_hint_from_text(description_text, allow_bare=False)
-            if description_text and _may_contain_model_marker(description_text)
-            else 0
-        )
+        return _size_hint_from_marked_text(description_text) if description_text else 0
     if not description_text and not card_description_text:
-        return (
-            _size_hint_from_text(readme_text, allow_bare=False)
-            if readme_text and _may_contain_model_marker(readme_text)
-            else 0
-        )
+        return _size_hint_from_marked_text(readme_text) if readme_text else 0
     if not description_text and not readme_text:
-        return (
-            _size_hint_from_text(card_description_text, allow_bare=False)
-            if card_description_text and _may_contain_model_marker(card_description_text)
-            else 0
-        )
+        return _size_hint_from_marked_text(card_description_text) if card_description_text else 0
 
     found_model_marker = False
     for text in (description_text, readme_text, card_description_text):
@@ -812,6 +800,15 @@ def _size_hint_bytes(payload: dict[str, Any], *, card_data: dict[str, Any] | Non
         for text in (description_text, readme_text, card_description_text)
         if text
     )
+    return _size_hint_from_text(text, allow_bare=False)
+
+
+def _size_hint_from_marked_text(text: str) -> int:
+    if not _may_contain_model_marker(text):
+        return 0
+    direct_hint = _direct_explicit_size_hint_from_text(text)
+    if direct_hint > 0:
+        return direct_hint
     return _size_hint_from_text(text, allow_bare=False)
 
 


### PR DESCRIPTION
## Summary
- Reuse the direct explicit model-size parser for single marked Hub catalog text fields before falling back to the regex helper.
- Add regression coverage for single-README direct parsing and fallback behavior.
- Update the registered probe smoke expectation now that the synthetic README path avoids regex fallback calls.

## Plan or Spec
- `docs/plans/2026-06-13-hub-catalog-single-readme-size-hint-direct.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 84 passed in 0.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 84 passed in 0.50s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# TOTAL 29 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# {"elapsed_ms_mean": 1793.545823264867, "size_hint_calls_mean": 0.0, ...}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (29/29 changed measurable lines).
- Registered local probe: `hub-catalog-size-hint-regex-precompile` via `scripts/hub_catalog_size_hint_probe.py`.
- Baseline local probe on `origin/main` before change: `elapsed_ms_mean=1815.5126319266856`, `size_hint_calls_mean=40000.0`, `peak_bytes_mean=1833.0`.
- New local probe: `elapsed_ms_mean=1793.545823264867`, `size_hint_calls_mean=0.0`, `peak_bytes_mean=819.0`.
- Delta: `elapsed_ms_mean` -21.966808661818504 ms (~1.21% faster); regex fallback calls reduced by 40000/sample to zero for the synthetic single-README path.
- CI is required for the registered PR-scoped performance report before merge.

## Known Gaps
- None for the Python slice. Swift runtime effects are not applicable.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
