### PR TITLE
perf: derive local job followup ids from filenames

### DIFF
--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -533,8 +533,9 @@ abort the whole scan; they emit `reason = record_unreadable`, and
 revision-guarded store conflicts keep their store-level receipt so the monitor
 can continue scanning other records. The registered PR-scoped performance probe
 for this path is `local-job-followup-scan-scandir`, which verifies the scandir
-scan and reports elapsed time plus `Path.exists`/`Path.glob`/`os.scandir` call
-counts.
+scan, derives job IDs directly from `.json` filenames without per-entry `Path`
+stem construction, and reports elapsed time plus `Path.exists`/`Path.glob`/
+`os.scandir` call counts.
 
 When a monitor already has redacted completion summaries for candidate records,
 it may compose discovery and guarded claiming through

--- a/services/mlx-worker-python/tests/test_local_job_continuation.py
+++ b/services/mlx-worker-python/tests/test_local_job_continuation.py
@@ -1191,6 +1191,14 @@ def test_store_scan_followup_candidates_uses_single_scandir_without_path_glob(
     )
     store.save_record(
         _record(
+            job_id="a.ready",
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/a.ready.json",),
+        )
+    )
+    store.save_record(
+        _record(
             job_id="a-ready",
             status="completed",
             exit_status=0,
@@ -1198,6 +1206,7 @@ def test_store_scan_followup_candidates_uses_single_scandir_without_path_glob(
         )
     )
     (tmp_path / "z-ignored.json.tmp").write_text("{}", encoding="utf-8")
+    (tmp_path / ".json").write_text("{}", encoding="utf-8")
     (tmp_path / "nested.json").mkdir()
 
     def fail_glob(self: Path, pattern: str):  # pragma: no cover - regression guard
@@ -1219,6 +1228,7 @@ def test_store_scan_followup_candidates_uses_single_scandir_without_path_glob(
 
     assert [candidate.record.job_id for candidate in scan.candidates] == [
         "a-ready",
+        "a.ready",
         "b-ready",
     ]
     assert scandir_calls == [os.fspath(tmp_path)]

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -357,16 +357,14 @@ class LocalJobContinuationStore:
         live_evidence_by_job_id = live_evidence_by_job_id or {}
         root = self.root
         try:
-            record_names = sorted(
-                entry.name
+            record_job_ids = sorted(
+                _record_job_id_from_filename(entry.name)
                 for entry in os.scandir(os.fspath(root))
                 if entry.name.endswith(".json") and entry.is_file()
             )
         except FileNotFoundError:
             return LocalJobContinuationFollowupScan(candidates=(), receipts=())
-        for record_name in record_names:
-            path = root / record_name
-            job_id = path.stem
+        for job_id in record_job_ids:
             try:
                 reconciliation = self.reconcile_record(
                     job_id,
@@ -1274,6 +1272,14 @@ def _optional_int(value: Any, field_name: str) -> int | None:
     if isinstance(value, bool) or not isinstance(value, int):
         raise ValueError(f"{field_name} must be an integer or null")
     return value
+
+
+def _record_job_id_from_filename(record_name: str) -> str:
+    # scan_followup_candidates has already filtered this to a .json file name.
+    # Avoid constructing a Path only to read .stem in large follow-up stores.
+    if record_name == ".json":
+        return ".json"
+    return record_name[:-5]
 
 
 def _safe_job_id(job_id: str) -> str:


### PR DESCRIPTION
## Summary
- Derive local-job follow-up scan job IDs directly from `.json` filenames instead of constructing a `Path` only to read `.stem` for every scanned record.
- Extend the focused scan regression test to cover dotted job IDs and the hidden `.json` edge case while preserving single-`os.scandir` behavior.
- Update the agentic tool runtime contract to document the filename-derived scan path.

## Plan or Spec
- Updated `docs/unified-agentic-tool-runtime-contract.md` for the `local-job-followup-scan-scandir` path.
- Registered PR-scoped probe coverage already exists in `infra/perf/pr_scoped_probes.json` as `local-job-followup-scan-scandir` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reconciles_and_filters_ready_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_uses_single_scandir_without_path_glob services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_returns_empty_for_missing_root services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_tolerates_root_deleted_during_scandir services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_skips_unreadable_records services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_local_job_followup_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` → 9 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...` → 9 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/local_job_followup_scan_probe.py` → TOTAL 8 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 8 0 100%`).
- Baseline registered probe from `origin/main`: `elapsed_ms_mean=33.670742`, `projection_elapsed_ms_mean=150.472050`, `scandir_calls_mean=1.0`, `path_glob_calls_mean=0.0`, `path_exists_calls_mean=0.0`.
- This branch registered probe: `elapsed_ms_mean=31.499566`, `projection_elapsed_ms_mean=146.134308`, `scandir_calls_mean=1.0`, `path_glob_calls_mean=0.0`, `path_exists_calls_mean=0.0`.
- Scan delta: `-2.171176 ms` mean, about `6.45%` faster on the local Linux probe.

## Known Gaps
- Local validation is Linux/Python only. No Swift runtime effect is involved in this slice.
- GitHub Actions PR-scoped performance validation must complete before merge.

## Evidence Checklist
- [x] Affected path has registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally and improved the target metric.
- [x] Governing documentation updated.
- [ ] GitHub Actions and registered PR-scoped performance report are green.
