### PR TITLE
perf: compile tool keyword rules in one pass

### DIFF
--- a/docs/plans/2026-06-13-tool-registry-keyword-rule-single-any.md
+++ b/docs/plans/2026-06-13-tool-registry-keyword-rule-single-any.md
@@ -1,0 +1,50 @@
+# Tool registry keyword rule literal classification single pass
+
+## Summary
+
+This Python-only performance slice keeps agentic tool selection behavior unchanged
+while reducing import-time setup work for the built-in keyword routing rules. The
+keyword-rule compiler classified literal hints with `any(...)` twice for hints
+that contain literal marker characters. This slice classifies each hint once,
+keeps the existing compiled `(hint, literal)` contract, and leaves runtime
+selection semantics unchanged.
+
+## Registered PR-scoped probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+The entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_select_probe.py`
+
+No probe registry change is required for this slice because the existing probe
+imports the built-in registry and measures selector planning through
+`selector_planning_elapsed_ms_mean`.
+
+## Optimization slice
+
+Scope is limited to `_compile_keyword_hint_rules(...)` in
+`worker.runtime.tool_registry`:
+
+- convert the comprehension into an explicit loop;
+- bind the literal marker set and boundary text helper locally;
+- compute the literal flag once per non-empty hint;
+- preserve casefolding, boundary normalization, literal matching behavior, and
+  the compiled rule shape consumed by `_keyword_tool_matches(...)`.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and the
+registered probe locally on Linux. The PR-scoped performance workflow remains the
+merge gate for base-vs-head validation.
+
+## Success criteria
+
+- Focused Python tests pass.
+- Changed-scope coverage for touched files remains at or above 95%.
+- Registered probe shows non-regressing or improved selector planning metrics.
+- GitHub Actions and the PR-scoped performance workflow are green before merge.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -634,6 +634,30 @@ def test_agentic_tool_selection_keyword_matchable_names_omit_always_available_to
     assert result.receipt["selection_mode"] == "fallback"
 
 
+def test_agentic_tool_selection_compiles_keyword_hint_rules_once_per_hint() -> None:
+    compiled_rules = tool_registry_module._compile_keyword_hint_rules(
+        {
+            "visit": ("fixture://docs", "Visit", ""),
+            "text_search": ("local evidence",),
+        }
+    )
+
+    assert compiled_rules == {
+        "visit": (("fixture://docs", True), (" visit ", False)),
+        "text_search": ((" local evidence ", False),),
+    }
+    assert tool_registry_module._keyword_hint_matches(
+        "Open fixture://docs/provider-contract.",
+        compiled_rules["visit"][0][0],
+        literal=compiled_rules["visit"][0][1],
+    )
+    assert tool_registry_module._keyword_hint_matches(
+        "Please VISIT the cited page.",
+        compiled_rules["visit"][1][0],
+        literal=compiled_rules["visit"][1][1],
+    )
+
+
 def test_agentic_tool_selection_max_always_only_skips_optional_routing_scans(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -612,16 +612,24 @@ def _keyword_boundary_text(text: str) -> str:
 def _compile_keyword_hint_rules(
     hints_by_tool: dict[str, tuple[str, ...]],
 ) -> dict[str, tuple[_KeywordHintRule, ...]]:
-    return {
-        tool_name: tuple(
-            (hint.casefold(), any(character in hint for character in _KEYWORD_LITERAL_HINT_CHARACTERS))
-            if any(character in hint for character in _KEYWORD_LITERAL_HINT_CHARACTERS)
-            else (_keyword_boundary_text(hint.casefold()), False)
-            for hint in hints
-            if hint
-        )
-        for tool_name, hints in hints_by_tool.items()
-    }
+    literal_hint_characters = _KEYWORD_LITERAL_HINT_CHARACTERS
+    keyword_boundary_text = _keyword_boundary_text
+    compiled_rules: dict[str, tuple[_KeywordHintRule, ...]] = {}
+    for tool_name, hints in hints_by_tool.items():
+        rules: list[_KeywordHintRule] = []
+        append_rule = rules.append
+        for hint in hints:
+            if not hint:
+                continue
+            casefolded_hint = hint.casefold()
+            is_literal = any(character in hint for character in literal_hint_characters)
+            append_rule(
+                (casefolded_hint, True)
+                if is_literal
+                else (keyword_boundary_text(casefolded_hint), False)
+            )
+        compiled_rules[tool_name] = tuple(rules)
+    return compiled_rules
 
 
 def _arg(


### PR DESCRIPTION
## Summary
- Compile tool-registry keyword hint rules with one literal-classification pass per hint.
- Preserve the existing compiled `(hint, literal)` rule shape and runtime selection behavior.
- Add a focused regression test for literal and boundary compiled rule behavior.

## Plan or Spec
- `docs/plans/2026-06-13-tool-registry-keyword-rule-single-any.md`
- Registered PR-scoped probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# baseline on origin/main: exit 0; elapsed_ms_mean=22.511090897023678; selector_planning_elapsed_ms_mean=34.10004731267691; always_only_planning_elapsed_ms_mean=30.389133375138044

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_compiles_keyword_hint_rules_once_per_hint
# exit 0; 1 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 80 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# exit 0; 80 passed; TOTAL 19 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# head: exit 0; elapsed_ms_mean=21.267093438655138; selector_planning_elapsed_ms_mean=33.60337084159255; always_only_planning_elapsed_ms_mean=29.006165079772472

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 19 0 100%`.
- Registered local probe (`tool_registry_select_probe.py`, 80k iterations, 5 samples):
  - `elapsed_ms_mean`: 22.511090897023678 ms -> 21.267093438655138 ms (delta -1.2439974583685398 ms, 5.526153592729777% faster)
  - `selector_planning_elapsed_ms_mean`: 34.10004731267691 ms -> 33.60337084159255 ms (delta -0.4966764710843563 ms, 1.4565272198309054% faster)
  - `always_only_planning_elapsed_ms_mean`: 30.389133375138044 ms -> 29.006165079772472 ms (delta -1.382968295365572 ms, 4.550864541918809% faster)
- CI PR-scoped performance report is required for base-vs-head validation before merge.

## Known Gaps
- Local verification is Linux/Python-only. No Swift runtime effect is claimed for this Python slice.
- CI registered probe validation is pending after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
