### PR TITLE
perf: fast-path retrieval store records

### DIFF
--- a/docs/plans/2026-06-12-retrieval-context-projection-local-bindings.md
+++ b/docs/plans/2026-06-12-retrieval-context-projection-local-bindings.md
@@ -32,6 +32,10 @@ This follow-up narrows receipt-copy overhead by binding `dict.copy` directly for
 
 This slice adds a single-receipt append fast path for the common admission shape emitted by retrieval entries. Multi-receipt admissions still copy every receipt through the existing loop, while the one-receipt case avoids setting up a per-receipt loop iterator.
 
+This follow-up adds fast paths for valid store-record projection in `project_retrieval_store_records()`. The store bridge now skips the generic `Mapping` ABC check for exact `dict` records, binds loop-stable append/refusal helpers once, and returns the already isolated `project_retrieval_contexts()` projection directly when no malformed top-level records are present. Mapping subclasses and mixed valid/malformed records keep the existing defensive validation and refusal-copy path.
+
+The registered `retrieval-context-projection-fastpath` probe is extended with store-record projection metrics so the store bridge fast path is measured by the same PR-scoped performance gate.
+
 ## Verification Plan
 
 Run the registered focused test command, changed-scope coverage command, and registered probe command locally on Linux before opening the PR. The PR-scoped performance workflow remains the authoritative CI validation source after push.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5634,6 +5634,29 @@
         "warn_abs": 1.0
       },
       {
+        "key": "store_baseline_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "store_optimized_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "store_delta_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_abs": 0.0
+      },
+      {
+        "key": "store_speedup",
+        "unit": "x",
+        "direction": "higher_is_better",
+        "warn_abs": 1.0
+      },
+      {
         "key": "entry_count",
         "unit": "count",
         "direction": "informational"

--- a/scripts/retrieval_context_projection_probe.py
+++ b/scripts/retrieval_context_projection_probe.py
@@ -6,7 +6,7 @@ import os
 import statistics
 import sys
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -58,6 +58,22 @@ def _build_entries(count: int) -> list[rc.RetrievalContextEntry]:
             corrective_action="Keep retrieved results in user-role prompt context.",
         )
         for index in range(count)
+    ]
+
+
+def _build_store_records(entries: Iterable[rc.RetrievalContextEntry]) -> list[dict[str, Any]]:
+    return [
+        {
+            "context_kind": entry.context_kind,
+            "source_id": entry.source_id,
+            "payload": entry.payload,
+            "owner_scope_checked": entry.owner_scope_checked,
+            "segment_id": entry.segment_id,
+            "source_field": entry.source_field,
+            "reason": entry.reason,
+            "corrective_action": entry.corrective_action,
+        }
+        for entry in entries
     ]
 
 
@@ -118,6 +134,58 @@ def _baseline_project_retrieval_contexts(
     )
 
 
+def _baseline_project_retrieval_store_records(records: list[dict[str, Any]]) -> rc.RetrievalContextProjection:
+    entries: list[rc.RetrievalContextEntry] = []
+    refusal_receipts: list[dict[str, object]] = []
+
+    for record in records:
+        if not isinstance(record, Mapping):  # pragma: no cover - defensive baseline fallback
+            refusal_receipts.append(
+                rc._store_record_refusal(  # type: ignore[attr-defined]
+                    source_field="record",
+                    source_id="unknown-retrieved-document",
+                    context_kind="retrieved_document",
+                )
+            )
+            continue
+
+        context_kind = record.get("context_kind")
+        if context_kind not in ("retrieved_document", "retrieved_image"):  # pragma: no cover - defensive baseline fallback
+            source_id = rc._store_record_source_id(record)  # type: ignore[attr-defined]
+            refusal_context_kind = rc._store_record_refusal_context_kind(source_id)  # type: ignore[attr-defined]
+            refusal_receipts.append(
+                rc._store_record_refusal(  # type: ignore[attr-defined]
+                    source_field="context_kind",
+                    source_id=source_id,
+                    context_kind=refusal_context_kind,
+                )
+            )
+            continue
+
+        entries.append(
+            rc.RetrievalContextEntry(
+                context_kind=context_kind,
+                source_id=record.get("source_id"),
+                payload=record.get("payload"),
+                owner_scope_checked=record.get("owner_scope_checked"),
+                segment_id=record.get("segment_id", ""),
+                source_field=record.get("source_field", ""),
+                reason=record.get("reason", ""),
+                corrective_action=record.get("corrective_action", ""),
+            )
+        )
+
+    projection = rc.project_retrieval_contexts(entries)
+    return rc.RetrievalContextProjection(
+        user_payload=projection.user_payload,
+        untrusted_context_receipts=projection.untrusted_context_receipts,
+        refusal_receipts=[
+            *(dict(receipt) for receipt in refusal_receipts),
+            *(dict(receipt) for receipt in projection.refusal_receipts),
+        ],
+    )
+
+
 def _measure(func: Any, entries: list[rc.RetrievalContextEntry], iterations: int) -> float:
     start = time.perf_counter()
     projected_count = 0
@@ -135,6 +203,23 @@ def _measure(func: Any, entries: list[rc.RetrievalContextEntry], iterations: int
     return elapsed_ms / iterations
 
 
+def _measure_store(func: Any, records: list[dict[str, Any]], iterations: int) -> float:
+    start = time.perf_counter()
+    projected_count = 0
+    receipt_count = 0
+    for _ in range(iterations):
+        projection = func(records)
+        projected_count += len(projection.user_payload)
+        receipt_count += projection.untrusted_context_receipt_count
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    expected = len(records) * iterations
+    if projected_count != expected or receipt_count != expected:  # pragma: no cover - probe integrity guard
+        raise AssertionError(
+            f"store projection drift: projected={projected_count} receipts={receipt_count} expected={expected}"
+        )
+    return elapsed_ms / iterations
+
+
 def _mean(values: list[float]) -> float:
     return float(statistics.fmean(values))
 
@@ -144,6 +229,7 @@ def main() -> int:
     sample_count = _samples()
     iteration_count = _iterations()
     entries = _build_entries(entry_count)
+    records = _build_store_records(entries)
     admissions = _build_admissions(entries)
     original_admit_entry = rc._admit_entry  # type: ignore[attr-defined]
 
@@ -155,6 +241,8 @@ def main() -> int:
         # Warm both variants once before sampling.
         _measure(_baseline_project_retrieval_contexts, entries, 1)
         _measure(rc.project_retrieval_contexts, entries, 1)
+        _measure_store(_baseline_project_retrieval_store_records, records, 1)
+        _measure_store(rc.project_retrieval_store_records, records, 1)
         baseline = [
             _measure(_baseline_project_retrieval_contexts, entries, iteration_count)
             for _ in range(sample_count)
@@ -163,18 +251,34 @@ def main() -> int:
             _measure(rc.project_retrieval_contexts, entries, iteration_count)
             for _ in range(sample_count)
         ]
+        store_baseline = [
+            _measure_store(_baseline_project_retrieval_store_records, records, iteration_count)
+            for _ in range(sample_count)
+        ]
+        store_optimized = [
+            _measure_store(rc.project_retrieval_store_records, records, iteration_count)
+            for _ in range(sample_count)
+        ]
     finally:
         rc._admit_entry = original_admit_entry  # type: ignore[attr-defined]
 
     baseline_mean = _mean(baseline)
     optimized_mean = _mean(optimized)
+    store_baseline_mean = _mean(store_baseline)
+    store_optimized_mean = _mean(store_optimized)
     delta_ms = optimized_mean - baseline_mean
+    store_delta_ms = store_optimized_mean - store_baseline_mean
     speedup = baseline_mean / optimized_mean if optimized_mean > 0.0 else 0.0
+    store_speedup = store_baseline_mean / store_optimized_mean if store_optimized_mean > 0.0 else 0.0
     payload = {
         "baseline_elapsed_ms_mean": baseline_mean,
         "optimized_elapsed_ms_mean": optimized_mean,
         "delta_ms": delta_ms,
         "speedup": speedup,
+        "store_baseline_elapsed_ms_mean": store_baseline_mean,
+        "store_optimized_elapsed_ms_mean": store_optimized_mean,
+        "store_delta_ms": store_delta_ms,
+        "store_speedup": store_speedup,
         "entry_count": float(entry_count),
         "sample_count": float(sample_count),
         "iteration_count": float(iteration_count),

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -195,11 +195,16 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
 
     entries: list[RetrievalContextEntry] = []
     refusal_receipts: list[dict[str, object]] = []
+    entries_append = entries.append
+    refusal_receipts_append = refusal_receipts.append
+    store_record_refusal = _store_record_refusal
+    store_record_source_id = _store_record_source_id
+    store_record_refusal_context_kind = _store_record_refusal_context_kind
 
     for record in records:
-        if not isinstance(record, Mapping):
-            refusal_receipts.append(
-                _store_record_refusal(
+        if type(record) is not dict and not isinstance(record, Mapping):
+            refusal_receipts_append(
+                store_record_refusal(
                     source_field="record",
                     source_id="unknown-retrieved-document",
                     context_kind="retrieved_document",
@@ -207,12 +212,13 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
             )
             continue
 
-        context_kind = record.get("context_kind")
+        record_get = record.get
+        context_kind = record_get("context_kind")
         if context_kind not in ("retrieved_document", "retrieved_image"):
-            source_id = _store_record_source_id(record)
-            refusal_context_kind = _store_record_refusal_context_kind(source_id)
-            refusal_receipts.append(
-                _store_record_refusal(
+            source_id = store_record_source_id(record)
+            refusal_context_kind = store_record_refusal_context_kind(source_id)
+            refusal_receipts_append(
+                store_record_refusal(
                     source_field="context_kind",
                     source_id=source_id,
                     context_kind=refusal_context_kind,
@@ -220,7 +226,7 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
             )
             continue
 
-        entries.append(
+        entries_append(
             RetrievalContextEntry(
                 context_kind=context_kind,
                 source_id=record.get("source_id"),
@@ -234,6 +240,8 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
         )
 
     projection = project_retrieval_contexts(entries)
+    if not refusal_receipts:
+        return projection
     return RetrievalContextProjection(
         user_payload=projection.user_payload,
         untrusted_context_receipts=projection.untrusted_context_receipts,


### PR DESCRIPTION
## Summary
- Add exact-dict fast paths in `project_retrieval_store_records()` so valid store-record projections skip the generic `Mapping` ABC check and reuse loop-stable helper bindings.
- Return the already isolated `project_retrieval_contexts()` projection directly when no malformed top-level store records add refusal receipts.
- Extend the registered `retrieval-context-projection-fastpath` probe metrics with store-record projection base-vs-head timing.

## Plan or Spec
- `docs/plans/2026-06-12-retrieval-context-projection-local-bindings.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <registered retrieval-context projection tests>
# 11 passed in 0.20s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered retrieval-context projection tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
# 11 passed in 0.27s; TOTAL 0 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
# {"baseline_elapsed_ms_mean": 0.08167214824685029, "optimized_elapsed_ms_mean": 0.034851977335555215, "delta_ms": -0.046820170911295075, "speedup": 2.3434007046575855, "store_baseline_elapsed_ms_mean": 0.22609053728436784, "store_optimized_elapsed_ms_mean": 0.22311611217446625, "store_delta_ms": -0.0029744251099015906, "store_speedup": 1.0133312878254876, "entry_count": 96.0, "iteration_count": 400.0, "sample_count": 7.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 0 0 100%` from `scripts/changed_scope_coverage.py` for the changed retrieval-context/probe scope.
- Registered local probe: `retrieval-context-projection-fastpath`.
- Local context projection metrics: `baseline_elapsed_ms_mean=0.08167214824685029`, `optimized_elapsed_ms_mean=0.034851977335555215`, `delta_ms=-0.046820170911295075`, `speedup=2.3434007046575855`.
- Local store-record metrics: `store_baseline_elapsed_ms_mean=0.22609053728436784`, `store_optimized_elapsed_ms_mean=0.22311611217446625`, `store_delta_ms=-0.0029744251099015906`, `store_speedup=1.0133312878254876`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- No Swift runtime validation is involved; this is a Python-only Linux-verified slice.
- GitHub Actions and the registered PR-scoped performance workflow must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
