### PR TITLE
perf: map dataset source path materialization

### DIFF
--- a/docs/plans/2026-06-13-dataset-source-records-path-map.md
+++ b/docs/plans/2026-06-13-dataset-source-records-path-map.md
@@ -1,0 +1,13 @@
+# Dataset source records Path materialization map slice
+
+This Python-only performance slice is limited to `worker.productization.dataset_preparation._iter_source_file_paths`.
+
+## Scope
+
+- Preserve the existing `os.scandir` directory walk, sorted path order, OSError handling, and `Path` return values.
+- Change only the final string-to-`Path` materialization step from a Python list comprehension to `list(map(Path, ...))` so the registered dataset source records probe can measure whether the conversion loop is cheaper at the same file count.
+- Keep the registered PR-scoped probe `dataset-source-records-scandir` as the validation source for tests, changed-scope coverage, and metrics.
+
+## Validation
+
+Run the focused dataset ingest tests, changed-scope coverage command, and `scripts/dataset_source_records_probe.py` locally on Linux before opening the PR. The same registered probe must pass in GitHub Actions before merge.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -49,6 +49,7 @@ def test_dataset_ingest_source_file_paths_use_scandir_without_rglob(
         "b/b.txt",
         "z.txt",
     ]
+    assert all(isinstance(path, Path) for path in _iter_source_file_paths(input_root))
 
 
 def test_dataset_ingest_source_kind_uses_single_suffix_fast_path() -> None:

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -588,7 +588,7 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
         except OSError:
             continue
     file_paths.sort()
-    return [path_cls(file_path) for file_path in file_paths]
+    return list(map(path_cls, file_paths))
 
 
 def _classify_source_kind_name(name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Switch dataset source path materialization from a Python list comprehension to `list(map(Path, ...))` after the existing sorted `os.scandir` walk.
- Add a regression assertion that the helper still returns `Path` objects.
- Document this focused performance slice under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-06-13-dataset-source-records-path-map.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_reuses_cached_basename_classification services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_returns_cached_none_without_reclassifying services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_name_cache_clears_at_bound services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 13 passed in 1.00s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same registered dataset-source-records-scandir focused test set>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# TOTAL 2 0 100%; 13 passed in 0.35s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# repeated 3x locally; outputs recorded below

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%` for `dataset_preparation.py`, `test_dataset_preparation_ingest.py`, `test_pr_scoped_performance.py`, and `scripts/dataset_source_records_probe.py`.
- Registered probe: `dataset-source-records-scandir`.
- Local Linux baseline before patch: `elapsed_ms_mean=12.882`, `source_kind_elapsed_ms_mean=16.839`.
- Local Linux head probe repeated 3x:
  - run 1: `elapsed_ms_mean=12.027`, `source_kind_elapsed_ms_mean=15.618`
  - run 2: `elapsed_ms_mean=11.265`, `source_kind_elapsed_ms_mean=14.966`
  - run 3: `elapsed_ms_mean=11.501`, `source_kind_elapsed_ms_mean=15.328`
- Local aggregate: `elapsed_ms_mean=11.597` (`-1.285ms`, `-9.97%`, `1.111x`); `source_kind_elapsed_ms_mean=15.304` (`-1.535ms`, `-9.12%`, `1.100x`).
- CI required: PR-scoped performance must rerun `dataset-source-records-scandir` before merge.

## Known Gaps
- Full repository `make py-test` / `make integration-test` were not run locally; this is a focused Python performance slice and CI is the merge gate.
- No Swift runtime validation needed; this slice only changes Python code.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing registered PR-scoped probe; no new runtime observability overhead.
- [x] Deferred work and known gaps are stated explicitly.
