### PR TITLE
perf: cache rounded event matching ties

### DIFF
--- a/services/mlx-worker-python/tests/test_event_extraction.py
+++ b/services/mlx-worker-python/tests/test_event_extraction.py
@@ -2067,9 +2067,11 @@ def test_event_alignment_precomputes_only_accepted_sparse_edges(monkeypatch) -> 
 
     edges = event_extraction_module._accepted_event_matching_edges(scores, accepted)
     precomputed_round_calls = len(round_calls)
+    round_calls.clear()
     matches = event_extraction_module._maximum_weight_event_matching(scores, accepted)
 
-    assert precomputed_round_calls == 0
+    assert precomputed_round_calls == 5
+    assert len(round_calls) == 5
     assert edges == (
         ((0, 0.91), (3, 0.77)),
         ((1, 0.82),),

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -15,6 +15,8 @@ from urllib.request import Request, urlopen
 
 
 FIELD_NAMES = ("actor", "time", "location", "action")
+_EventMatchingPairs = tuple[tuple[int, int, float], ...]
+_EventMatchingState = tuple[float, _EventMatchingPairs]
 FIELD_WEIGHTS = {
     "actor": 0.30,
     "time": 0.25,
@@ -2243,7 +2245,7 @@ def _accepted_event_matching_edges(
     accepted: list[list[bool]],
 ) -> tuple[tuple[tuple[int, float], ...], ...]:
     return tuple(
-        tuple((pred_index, score) for pred_index, _pred_mask, score in edge_row)
+        tuple((pred_index, score) for pred_index, _pred_mask, score, _rounded_score in edge_row)
         for edge_row in _accepted_event_matching_edge_states(scores, accepted)
     )
 
@@ -2251,10 +2253,10 @@ def _accepted_event_matching_edges(
 def _accepted_event_matching_edge_states(
     scores: list[list[float]],
     accepted: list[list[bool]],
-) -> tuple[tuple[tuple[int, int, float], ...], ...]:
+) -> tuple[tuple[tuple[int, int, float, float], ...], ...]:
     return tuple(
         tuple(
-            (pred_index, 1 << pred_index, float(score))
+            (pred_index, 1 << pred_index, float(score), _round_metric(float(score)))
             for pred_index, score in enumerate(score_row)
             if pred_index < len(accepted_row) and accepted_row[pred_index]
         )
@@ -2268,22 +2270,19 @@ def _maximum_weight_event_matching(
 ) -> list[tuple[int, int, float]]:
     gold_count = len(scores)
     accepted_edges = _accepted_event_matching_edge_states(scores, accepted)
-    memo: dict[tuple[int, int], tuple[float, tuple[tuple[int, int, float], ...]]] = {}
-
-    def rounded_pairs(pairs: tuple[tuple[int, int, float], ...]) -> tuple[tuple[int, int, float], ...]:
-        return tuple((gold_index, pred_index, _round_metric(score)) for gold_index, pred_index, score in pairs)
+    memo: dict[tuple[int, int], _EventMatchingState] = {}
 
     def better(
-        candidate: tuple[float, tuple[tuple[int, int, float], ...]],
-        current: tuple[float, tuple[tuple[int, int, float], ...]],
+        candidate: _EventMatchingState,
+        current: _EventMatchingState,
     ) -> bool:
         if candidate[0] > current[0] + 1e-12:
             return True
         if abs(candidate[0] - current[0]) <= 1e-12:
-            return rounded_pairs(candidate[1]) < rounded_pairs(current[1])
+            return candidate[1] < current[1]
         return False
 
-    def solve(gold_index: int, used_pred_mask: int) -> tuple[float, tuple[tuple[int, int, float], ...]]:
+    def solve(gold_index: int, used_pred_mask: int) -> _EventMatchingState:
         key = (gold_index, used_pred_mask)
         cached = memo.get(key)
         if cached is not None:
@@ -2292,18 +2291,18 @@ def _maximum_weight_event_matching(
             return (0.0, ())
 
         best = solve(gold_index + 1, used_pred_mask)
-        for pred_index, pred_mask, score in accepted_edges[gold_index]:
+        for pred_index, pred_mask, score, rounded_score in accepted_edges[gold_index]:
             if used_pred_mask & pred_mask:
                 continue
-            next_score, next_pairs = solve(gold_index + 1, used_pred_mask | pred_mask)
-            pair = (gold_index, pred_index, score)
-            candidate = (score + next_score, (pair,) + next_pairs)
+            next_score, next_rounded_pairs = solve(gold_index + 1, used_pred_mask | pred_mask)
+            rounded_pair = (gold_index, pred_index, rounded_score)
+            candidate = (score + next_score, (rounded_pair,) + next_rounded_pairs)
             if better(candidate, best):
                 best = candidate
         memo[key] = best
         return best
 
-    return list(rounded_pairs(solve(0, 0)[1]))
+    return list(solve(0, 0)[1])
 
 
 def _build_row_alignment_audit(


### PR DESCRIPTION
## Summary
- Cache rounded event-matching tie-break tuples in `_maximum_weight_event_matching` instead of re-rounding full candidate/current pair chains during each tie comparison.
- Keep accepted-edge filtering sparse and preserve deterministic optimal matching output.
- Update the focused regression to assert rounding is bounded to accepted edges for both helper edge extraction and matching.

## Plan or Spec
- Existing registered PR-scoped probe: `event-extraction-alignment-accepted-edge-cache` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/productization/event_extraction.py`, the focused tests, and `scripts/event_extraction_alignment_probe.py` with test, coverage, and probe commands.
- No docs/spec behavior change: public matching semantics are unchanged; this is an internal tie-break cache optimization.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_event_extraction.py -k 'event_alignment_precomputes_only_accepted_sparse_edges or event_alignment_tie_breaks_on_rounded_match_tuples or event_alignment_uses_global_optimum_not_greedy' -q`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_uses_global_optimum_not_greedy services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_precomputes_only_accepted_sparse_edges services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_tie_breaks_on_rounded_match_tuples services/mlx-worker-python/tests/test_event_extraction.py::test_string_similarity_reuses_normalized_text_and_bigram_counts services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_reuses_alignment_payloads_for_matched_details services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_alignment_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_uses_global_optimum_not_greedy services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_precomputes_only_accepted_sparse_edges services/mlx-worker-python/tests/test_event_extraction.py::test_event_alignment_tie_breaks_on_rounded_match_tuples services/mlx-worker-python/tests/test_event_extraction.py::test_string_similarity_reuses_normalized_text_and_bigram_counts services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_reuses_alignment_payloads_for_matched_details services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_alignment_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_alignment_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_alignment_probe.py`
- Baseline/current probe repeated 3x each against `origin/main` and this branch.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 8 passed.
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Registered local probe single run on this branch: `elapsed_ms_mean=2050.832552090287`, `elapsed_ms_min=1966.2763830274343`, `accepted_edges=28.0`, `match_count_mean=280.0`, `checksum=10605974.000000017`.
- Repeated local probe comparison:
  - `origin/main` elapsed mean samples: `2173.5194717533886`, `2117.798531986773`, `2095.167684368789`; average `2128.8285627029836 ms`.
  - Branch elapsed mean samples: `2100.949545018375`, `2086.4887460134923`, `2118.085969146341`; average `2101.841420059403 ms`.
  - Delta: `-26.987142643580682 ms` (`1.2676991992870943%` faster); checksum and accepted-edge counts unchanged.
- CI PR-scoped registered probe validation is required before merge.

## Known Gaps
- The local Linux probe shows a modest improvement with normal runtime variance; GitHub Actions registered probe report is the merge gate.
- No Swift runtime validation is involved in this Python-only slice.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before this isolated slice.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage run locally.
- [x] Registered probe run locally with baseline/current comparison.
- [ ] GitHub Actions and PR-scoped performance workflow complete successfully.
