### PR TITLE
perf: tighten report evidence duration parsing

### DIFF
--- a/docs/plans/2026-06-13-report-evidence-slowest-phase-exact-str.md
+++ b/docs/plans/2026-06-13-report-evidence-slowest-phase-exact-str.md
@@ -1,0 +1,29 @@
+# Report evidence slowest-phase exact string duration fast path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.productization.report_evidence_gate._slowest_probe_phases`.
+
+The report evidence gate consumes JSON-like report payloads. Slowest-phase duration values are expected as plain `float`, `int`, or `str` values from decoded report JSON. This slice keeps those accepted types and narrows the hot string branch to the exact `str` type used by decoded JSON payloads.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry provides focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/report_evidence_gate.py`
+- `services/mlx-worker-python/tests/test_report_evidence_gate.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/report_evidence_gate_run_kind_probe.py`
+
+## Implementation plan
+
+1. Preserve existing tests for top-five slowest-phase ordering and typed duration conversion.
+2. Replace the `isinstance(duration, str)` hot-path check with `type(duration) is str`, matching JSON-decoded payload types and avoiding subclass checks in the probe loop.
+3. Run the registered focused tests, changed-scope coverage command, and local registered probe on Linux.
+4. Use GitHub Actions PR-scoped performance as the merge gate before merging.
+
+## Expected performance signal
+
+The primary metric is `slowest_probe_phase_elapsed_ms_mean`; it should decrease because each slowest-phase row avoids the broader `isinstance(..., str)` check. The aggregate `elapsed_ms_mean` may also improve slightly, while unrelated sub-metrics may vary with local runtime noise.

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -480,7 +480,7 @@ def _slowest_probe_phases(report: dict[str, object]) -> list[dict[str, object]]:
                 duration_ms = duration
             elif type(duration) is int:
                 duration_ms = float(duration)
-            elif isinstance(duration, str):
+            elif type(duration) is str:
                 duration_ms = float(duration or 0.0)
             else:
                 duration_ms = 0.0


### PR DESCRIPTION
## Summary
- Tighten the report evidence slowest-phase duration parsing hot path to use the exact JSON-decoded `str` type check.
- Add a governing plan for this focused Python performance slice.

## Plan or Spec
- `docs/plans/2026-06-13-report-evidence-slowest-phase-exact-str.md`
- Registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe on origin/main before the accepted change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# exit 0; elapsed_ms_mean=943.7748053111136; slowest_probe_phase_elapsed_ms_mean=40.23155132308602

# Rejected candidate evidence: single-pass run-kind scan was tested and reverted because it regressed run_kind_elapsed_ms_mean to 290.92569751664996.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_keeps_top_five_order services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_accepts_typed_durations services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_fast_reject_preserves_empty_prefix services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_sparse_match_scans_row_items services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_preserves_stringified_presence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_matrix_roles_skip_probe_phase_scan_without_phase_rules services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_matrix_roles_scans_probe_phases_once_for_phase_rules services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_matrix_roles_select_multiple_run_kind_rules services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_dedupes_evidence_ids services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_single_role_keeps_stringified_evidence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_ignores_invalid_cached_roles services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# exit 0; 22 passed in 0.14s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
# exit 0; changed_line_coverage=100.00%; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# exit 0; elapsed_ms_mean=909.6934503875673; slowest_probe_phase_elapsed_ms_mean=35.898786038160324

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 1 0 100%`).
- Local registered probe baseline vs candidate:
  - `elapsed_ms_mean`: 943.7748053111136 ms -> 909.6934503875673 ms (delta -34.08135492354634 ms, speedup ~1.037x)
  - `slowest_probe_phase_elapsed_ms_mean`: 40.23155132308602 ms -> 35.898786038160324 ms (delta -4.332765284925699 ms, speedup ~1.121x)
- CI PR-scoped performance must validate the registered probe report before merge.

## Known Gaps
- Local Linux probe results can vary with runner noise; GitHub Actions PR-scoped performance is the merge gate.
- Swift/macOS runtime effects are not involved in this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
