### PR TITLE
perf: bind retrieval store record accessors

### DIFF
--- a/docs/plans/2026-06-11-retrieval-context-projection-fastpath.md
+++ b/docs/plans/2026-06-11-retrieval-context-projection-fastpath.md
@@ -1,9 +1,9 @@
-# Retrieval context projection duplicate-field fast path
+# Retrieval context projection and store-record local binding fast paths
 
 ## Scope
 
-This Python-only performance slice is limited to `project_retrieval_contexts()` in
-`services/mlx-worker-python/worker/runtime/retrieval_context.py`.
+This Python-only performance slice is limited to retrieval context projection and
+store-record projection in `services/mlx-worker-python/worker/runtime/retrieval_context.py`.
 
 ## Registered probe
 
@@ -34,6 +34,13 @@ unique-field overhead:
    intermediate shallow dict copy.
 3. Preserve defensive receipt copying and duplicate receipt fallback behavior.
 
+The 2026-06-13 follow-up keeps the same registered probe and narrows the next
+change to `project_retrieval_store_records()`: bind `RetrievalContextEntry` and
+each record's `.get` method once per valid record, then reuse those local
+bindings while building the entry descriptor. This preserves all validation and
+refusal behavior while trimming repeated attribute lookup overhead in the
+registered store-record projection workload.
+
 ## Verification plan
 
 ```bash
@@ -49,4 +56,6 @@ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJEC
   threshold.
 - The registered probe reports lower `optimized_elapsed_ms_mean` than
   `baseline_elapsed_ms_mean`, positive `speedup`, and negative `delta_ms` on the
-  synthetic projection workload.
+  synthetic projection workload. For the store-record follow-up, the same probe
+  must also keep `store_optimized_elapsed_ms_mean` below
+  `store_baseline_elapsed_ms_mean` with negative `store_delta_ms`.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -200,6 +200,7 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
     store_record_refusal = _store_record_refusal
     store_record_source_id = _store_record_source_id
     store_record_refusal_context_kind = _store_record_refusal_context_kind
+    entry_type = RetrievalContextEntry
 
     for record in records:
         if type(record) is not dict and not isinstance(record, Mapping):
@@ -212,7 +213,7 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
             )
             continue
 
-        record_get = record.get
+        record_get: Any = record.get
         context_kind = record_get("context_kind")
         if context_kind not in ("retrieved_document", "retrieved_image"):
             source_id = store_record_source_id(record)
@@ -227,15 +228,15 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
             continue
 
         entries_append(
-            RetrievalContextEntry(
+            entry_type(
                 context_kind=context_kind,
-                source_id=record.get("source_id"),
-                payload=record.get("payload"),
-                owner_scope_checked=record.get("owner_scope_checked"),
-                segment_id=record.get("segment_id", ""),
-                source_field=record.get("source_field", ""),
-                reason=record.get("reason", ""),
-                corrective_action=record.get("corrective_action", ""),
+                source_id=record_get("source_id"),
+                payload=record_get("payload"),
+                owner_scope_checked=record_get("owner_scope_checked"),
+                segment_id=record_get("segment_id", ""),
+                source_field=record_get("source_field", ""),
+                reason=record_get("reason", ""),
+                corrective_action=record_get("corrective_action", ""),
             )
         )
 


### PR DESCRIPTION
## Summary
- Bind `RetrievalContextEntry` and per-record `.get` once in `project_retrieval_store_records()` to reduce repeated attribute lookups in the registered retrieval-context store-record workload.
- Update the retrieval context projection plan with the store-record local-binding follow-up and required metrics gate.

## Plan or Spec
- `docs/plans/2026-06-11-retrieval-context-projection-fastpath.md`

## Commands Run
```text
# branch/context
pwd && git status --short && git branch --show-current && git rev-parse --short HEAD && git merge-base --is-ancestor origin/main HEAD
exit 0: /root/.hermes/profiles/coder/workspace/worktrees/melix-retrieval-context-hash-fastpath-20260613; branch perf/retrieval-context-hash-fastpath-20260613; HEAD 6ecf888d; origin/main is ancestor

# focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_isolates_refusals_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_malformed_entry_objects_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_preserves_multi_field_admission_duplicate_scan services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_copies_multi_receipt_admissions services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
exit 0: 11 passed in 0.13s

# changed-scope coverage using registered coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same 11 tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py && rm -f coverage.json
exit 0: 11 passed in 0.26s; TOTAL 0 0 100%

# registered probe, direct script form of probe_command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
exit 0: see metrics below

git diff --check origin/main...HEAD
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 0 0 100%` from `scripts/changed_scope_coverage.py`.
- Registered probe: `retrieval-context-projection-fastpath` already covers `services/mlx-worker-python/worker/runtime/retrieval_context.py` and includes focused `test_command`, `coverage_command`, and `probe_command` entries.
- Local Linux probe JSON:
```json
{"baseline_elapsed_ms_mean": 0.08812075497449509, "delta_ms": -0.0515607070909547, "entry_count": 96.0, "iteration_count": 400.0, "optimized_elapsed_ms_mean": 0.03656004788354039, "sample_count": 7.0, "speedup": 2.4103019573496707, "store_baseline_elapsed_ms_mean": 0.21733172603749804, "store_delta_ms": -0.01067075080105237, "store_optimized_elapsed_ms_mean": 0.20666097523644567, "store_speedup": 1.051634087126724}
```

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not rerun locally for this narrow Python slice; CI is required for full gate validation and the registered PR-scoped performance report.
- Observability/probe overhead: N/A; this changes Python projection internals and does not add runtime observability.
- Protocol/dependency changes: N/A; no protobuf, generated artifact, lockfile, or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
