### PR TITLE
perf: avoid M9 metric split allocation

### DIFF
--- a/docs/plans/2026-06-13-release-gates-m9-metric-value-performance.md
+++ b/docs/plans/2026-06-13-release-gates-m9-metric-value-performance.md
@@ -1,0 +1,31 @@
+# Release Gates M9 Metric Lookup Performance Slice
+
+## Context
+
+The M9 release gate evaluator repeatedly resolves policy metric keys through
+`_metric_value()` while computing missing and threshold-failure counts. The path
+is covered by the registered PR-scoped probe
+`release-gates-m9-failure-count-single-pass` in
+`infra/perf/pr_scoped_probes.json`.
+
+## Slice
+
+Avoid allocating a `dotted_key.split(".")` list for every nested metric lookup.
+Keep the flat-key fast path and first-segment missing guard, then walk the dotted
+key with indexed `str.find()` slices.
+
+## Verification
+
+Use the registered probe commands for this path:
+
+- focused release-gate tests and PR-scoped probe registry tests;
+- changed-scope coverage for `release_gates.py`, `test_release_gates.py`,
+  `test_pr_scoped_performance.py`, and `release_gates_m9_failure_count_probe.py`;
+- `scripts/release_gates_m9_failure_count_probe.py` for local Linux metrics and
+  CI PR-scoped performance validation.
+
+## Expected Metrics
+
+The target metric is `elapsed_ms_mean` from
+`release_gates_m9_failure_count_probe.py`; `failure_count_mean` must remain
+stable and `endswith_checks_mean` must stay at zero.

--- a/services/mlx-worker-python/tests/test_release_gates.py
+++ b/services/mlx-worker-python/tests/test_release_gates.py
@@ -1175,6 +1175,8 @@ def test_metric_value_prefers_flat_keys_and_preserves_nested_lookup() -> None:
         {"other": {"section": {"metric": 5.0}}},
         "m9.section.metric",
     ) is missing
+    assert release_gates_module._metric_value({"other": 6.0}, "metric") is missing
+    assert release_gates_module._metric_value({"m9": {"section": {}}}, "m9.section.metric") is missing
 
 
 def test_run_python_json_script_sets_repo_pythonpath_entries(

--- a/services/mlx-worker-python/worker/productization/release_gates.py
+++ b/services/mlx-worker-python/worker/productization/release_gates.py
@@ -2181,17 +2181,30 @@ _MISSING = object()
 
 
 def _metric_value(values: dict[str, Any], dotted_key: str) -> Any:
-    if dotted_key in values:
-        return values[dotted_key]
+    missing = _MISSING
+    value = values.get(dotted_key, missing)
+    if value is not missing:
+        return value
     first_dot = dotted_key.find(".")
-    if first_dot != -1 and dotted_key[:first_dot] not in values:
-        return _MISSING
+    if first_dot == -1:
+        return missing
+    if dotted_key[:first_dot] not in values:
+        return missing
+
     current: Any = values
-    for segment in dotted_key.split("."):
+    start = 0
+    while True:
+        dot_index = dotted_key.find(".", start)
+        if dot_index == -1:
+            segment = dotted_key[start:]
+            if not isinstance(current, dict) or segment not in current:
+                return missing
+            return current[segment]
+        segment = dotted_key[start:dot_index]
         if not isinstance(current, dict) or segment not in current:
-            return _MISSING
+            return missing
         current = current[segment]
-    return current
+        start = dot_index + 1
 
 
 def _evaluate_section_metrics(


### PR DESCRIPTION
## Summary
- Optimizes M9 release-gate metric lookup by using a single flat-key `dict.get` probe before nested dotted-key traversal.
- Avoids allocating `dotted_key.split(".")` lists for nested metric fallback while preserving flat-key precedence and missing-key behavior.
- Adds focused regression assertions for bare missing keys and missing final nested segments.

## Plan or Spec
- `docs/plans/2026-06-13-release-gates-m9-metric-value-performance.md`
- Registered PR-scoped probe: `release-gates-m9-failure-count-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Focused registered test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_release_gates_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_release_gates_m9_failure_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
Result: 72 passed in 5.59s

# Changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_release_gates_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_release_gates_m9_failure_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/release_gates.py services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/release_gates_m9_failure_count_probe.py
Result: 72 passed in 6.48s; TOTAL 21 1 95%

# Registered local probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/release_gates_m9_failure_count_probe.py
Result: {"elapsed_ms_mean": 10.2488755248487, "endswith_checks_mean": 0.0, "failure_count_mean": 12800.0, "failures_per_section": 80.0, "sample_count": 5.0, "section_count": 160.0}

# Stability comparison with larger samples
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RELEASE_GATES_M9_PROBE_SAMPLES=30 uv run --project services/mlx-worker-python python3 scripts/release_gates_m9_failure_count_probe.py
origin/main result: {"elapsed_ms_mean": 8.779908949509263, "endswith_checks_mean": 0.0, "failure_count_mean": 12800.0, "failures_per_section": 80.0, "sample_count": 30.0, "section_count": 160.0}
PR branch result: {"elapsed_ms_mean": 8.64742382739981, "endswith_checks_mean": 0.0, "failure_count_mean": 12800.0, "failures_per_section": 80.0, "sample_count": 30.0, "section_count": 160.0}

python3 -m json.tool infra/perf/pr_scoped_probes.json >/dev/null
Result: passed

git diff --check
Result: passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 21 1 95%`.
- Local 30-sample probe delta: old_mean `8.779908949509263 ms`, new_mean `8.64742382739981 ms`, delta `-0.132485122109453 ms`, speedup about `1.0153x` / `1.51%`.
- Behavior parity: `failure_count_mean` stayed `12800.0`; `endswith_checks_mean` stayed `0.0`.
- CI PR-scoped performance workflow is required as the merge validation source for the registered probe.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this is a focused Python performance slice on Linux.
- The 5-sample local probe is noisy; the 30-sample comparison is included for stability, and the registered CI probe must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
