### PR TITLE
perf: slot model registry snapshots

### DIFF
--- a/docs/plans/2026-06-13-model-registry-snapshot-slots.md
+++ b/docs/plans/2026-06-13-model-registry-snapshot-slots.md
@@ -1,0 +1,28 @@
+# Model Registry Snapshot Slots Slice
+
+## Scope
+
+Reduce per-snapshot allocation overhead in `WorkerModelCatalog.registry_snapshot()` by
+slotting the two immutable snapshot container dataclasses:
+
+- `RegistryRootSnapshot`
+- `RegistrySnapshot`
+
+The affected path is covered by the registered PR-scoped performance probe
+`model-registry-plain-local-manifest-stat-elision` in
+`infra/perf/pr_scoped_probes.json`. The registry entry already includes focused
+`test_command`, `coverage_command`, and `probe_command` values for
+`worker/model_registry/catalog.py`.
+
+## Plan
+
+1. Keep the existing registry probe unchanged.
+2. Add `slots=True` to the immutable snapshot dataclasses only.
+3. Run the registered focused tests, changed-scope coverage, and local Linux
+   registered probe against `origin/main` and this branch.
+4. Accept only if behavior remains unchanged and the probe does not regress.
+
+## Validation Boundary
+
+This is a Python-only slice and is locally verifiable on Linux. GitHub Actions
+PR-scoped performance remains the merge gate after push.

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -62,7 +62,7 @@ _GEMMA4_QAT_DRAFT_COMPANION_RECOVERY_HINT = (
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RegistryRootSnapshot:
     root_id: str
     root_path: str
@@ -73,7 +73,7 @@ class RegistryRootSnapshot:
     discovered_model_ids: tuple[str, ...] = ()
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RegistrySnapshot:
     roots: tuple[RegistryRootSnapshot, ...]
     models: tuple[common_pb2.ModelSpec, ...]


### PR DESCRIPTION
## Summary
- Slot immutable model registry snapshot dataclasses to reduce per-snapshot allocation overhead.
- Keep the existing registered `model-registry-plain-local-manifest-stat-elision` probe and behavior unchanged.

## Plan or Spec
- `docs/plans/2026-06-13-model-registry-snapshot-slots.md`
- Registered probe: `model-registry-plain-local-manifest-stat-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_root_tree_records_plain_local_weight_presence_during_single_scandir_pass services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_root_tree_skips_hf_prune_relative_probe_for_plain_dirs services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_reuses_plain_local_tree_scan_and_config_payload services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_skips_runtime_rebuild_when_cached_snapshot_is_current services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_does_not_stat_missing_plain_local_generation_config_after_tree_scan services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_imports_plain_local_generation_config_when_seen_during_tree_scan services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_reuses_hf_cache_config_payload services/mlx-worker-python/tests/test_model_registry_catalog.py::test_raw_model_spec_loads_config_payload_when_not_supplied services/mlx-worker-python/tests/test_model_registry_catalog.py::test_has_mlx_signal_falls_back_to_config_text_for_empty_supplied_payload services/mlx-worker-python/tests/test_model_registry_catalog.py::test_has_mlx_signal_skips_config_text_fallback_for_nonempty_payload_without_mlx_signal services/mlx-worker-python/tests/test_model_registry_catalog.py::test_has_mlx_signal_falls_back_to_config_text_for_unserializable_nonempty_payload services/mlx-worker-python/tests/test_model_registry_catalog.py::test_metadata_payload_has_mlx_signal_does_not_request_sorted_json services/mlx-worker-python/tests/test_model_registry_catalog.py::test_has_mlx_signal_config_payload_fast_path_avoids_json_dump services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_does_not_stat_plain_local_manifest_after_tree_scan services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_skips_invalid_depth_manifests_without_parsing services/mlx-worker-python/tests/test_model_registry_catalog.py::test_load_json_dict_file_reads_json_bytes_without_text_decode services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_keeps_gemma4_qat_target_when_readme_mentions_assistant services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_registry_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_registry_catalog_probe_command_emits_metrics`
- Registered coverage command for `model-registry-plain-local-manifest-stat-elision`.
- Registered probe command x3 on detached `origin/main` baseline and this branch.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 20 passed.
- Changed-scope coverage: 2/2 measurable changed lines covered, 100%.
- Local Linux registered probe baseline (`origin/main`, 3 runs): mean of `elapsed_ms_mean` samples = `121.359374 ms`.
- Local Linux registered probe head (3 runs): mean of `elapsed_ms_mean` samples = `118.787242 ms`.
- Delta: `-2.572132 ms`, `2.12%` faster.
- Invariant metrics remained stable: `config_load_calls_mean=400.0`, `discovered_model_count_mean=400.0`, `generation_config_stat_calls_mean=0.0`, `manifest_is_file_calls_mean=0.0`, `manifest_parse_calls_mean=0.0`.

## Known Gaps
- Local validation covers the Python/Linux registered probe. GitHub Actions PR-scoped performance is still required as the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Local registered probe compared baseline and head.
- [ ] GitHub Actions PR-scoped performance completed successfully.
