### PR TITLE
Add companion read-only auth sessions

### DIFF
--- a/docs/plans/2026-06-13-issue-1759-companion-readonly-auth-scope.md
+++ b/docs/plans/2026-06-13-issue-1759-companion-readonly-auth-scope.md
@@ -1,0 +1,97 @@
+# Issue 1759 Companion Read-Only Auth Scope
+
+## Goal
+
+Land the first executable server-side slice for issue #1759 by giving paired
+companion/mobile clients a durable read-only session scope before building the
+mobile dashboard surface.
+
+## Best End-State Architecture
+
+Companion access should be a scoped gateway session, not another shared API key
+family. The operator should create or revoke companion sessions through trusted
+local UI/CLI pairing, while the HTTP gateway enforces a narrow read-only
+allowlist regardless of which browser or LAN client presents the token.
+
+The durable model is:
+
+- gateway credentials remain the authority that can issue sessions;
+- session metadata records an explicit `operator_control` or
+  `companion_read_only` scope;
+- companion sessions can read status-oriented endpoints and inspect/revoke their
+  own session;
+- companion sessions cannot start inference, mutate runtime state, run jobs, or
+  receive raw request bodies in denial responses;
+- later slices can add QR/code pairing and a mobile viewport without changing
+  the authorization contract.
+
+## Slice Boundary
+
+This transaction implements the auth and route-enforcement foundation only.
+It does not add a production companion UI, QR-code pairing, LAN discovery, or a
+new protocol message.
+
+## Implementation Plan
+
+1. Extend `PersistentAuthSessionStore` metadata and persistence with a
+   backwards-compatible session scope.
+2. Allow `POST /v1/melix/auth/session` to request
+   `{ "scope": "companion_read_only" }`, defaulting omitted scope to
+   `operator_control`.
+3. Teach `OpenAIHandler` to allow companion sessions only on status/discovery
+   GET routes plus self-inspection and self-revocation.
+4. Return a structured 403 for companion scope violations and increment a
+   gateway metric.
+5. Cover token creation, read access, mutation rejection, private-prompt
+   non-echoing, and revocation with focused Swift tests.
+
+## Performance Probes and Metrics
+
+- Authorization overhead remains on the existing HTTP gateway route admission
+  path; no new worker or model runtime path is introduced.
+- Runtime metric: `companion_auth.rejected_request_count` records rejected
+  companion-scope requests.
+- Success metric: companion read-only requests preserve existing
+  `operator.health_diagnostics_latency_ms`, `operator.cache_stats_latency_ms`,
+  and gateway rate-limit metrics for allowed status routes.
+- PR merge gate: the scoped performance report must stay `Status: ok` with zero
+  regressions. This slice does not add a synthetic PR-scoped probe because the
+  changed path is Swift gateway authorization logic, not a repeated Python
+  performance workload.
+
+## Verification
+
+Run focused Swift tests first:
+
+```bash
+HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'PersistentAuthSessionStoreTests|OpenAIHandlerTests'
+```
+
+Before commit and PR:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```
+
+The pre-commit hook must also produce a scoped performance report with no
+regressions before the branch is pushed.
+
+## Verification Results
+
+- `PersistentAuthSessionStoreTests|OpenAIHandlerTests`: passed, 216 tests.
+- Swift changed-line coverage for the changed gateway files: 99.34 percent
+  total, 301/303 changed lines covered.
+- `PersistentAuthSessionStoreTests|OpenAIHandlerTests|ControlPlaneServiceTests`:
+  passed, 430 tests.
+- `make swift-test`: passed.
+- `make py-test`: passed, 3999 tests, 14 skipped.
+- `make integration-test`: passed, 120 tests, 1 skipped.
+
+## Deferred Work
+
+- QR/code pairing UX.
+- Mobile/narrow viewport dashboard smoke.
+- Status cards for active jobs, recent receipts, and log-tail redaction.
+- Companion-token issuance and revocation controls in the desktop UI.

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -456,6 +456,7 @@ private enum GatewayAuthorizationContext: Sendable {
 private enum GatewayAuthorizationRoute {
     case health
     case standard
+    case companionReadOnly
     case createSession
     case currentSession
 }
@@ -807,6 +808,13 @@ public struct OpenAIHandler: Sendable {
         {
             switch await persistentAuthSessionStore.validateSessionToken(sessionToken, policy: gatewayAccessPolicy) {
             case .success(let metadata):
+                if let failure = await companionScopeFailureResponse(
+                    route: route,
+                    request: request,
+                    metadata: metadata
+                ) {
+                    return .failure(failure)
+                }
                 return .success(.session(token: sessionToken, metadata: metadata))
             case .failure(let failure):
                 return .failure(await authSessionFailureResponse(for: failure))
@@ -1060,7 +1068,8 @@ public struct OpenAIHandler: Sendable {
         let createRequest = try decoder.decode(OpenAICreateAuthSessionRequest.self, from: request.body)
         let issued = try await persistentAuthSessionStore.issueSession(
             keyID: keyID,
-            rememberMe: createRequest.rememberMe
+            rememberMe: createRequest.rememberMe,
+            scope: createRequest.scope
         )
         let response = OpenAIAuthSessionResponse(
             session: OpenAIAuthSessionPayload(metadata: issued.metadata),
@@ -4458,14 +4467,52 @@ public struct OpenAIHandler: Sendable {
         case (.get, "/.well-known/melix.json"),
              (.get, "/api/capabilities"),
              (.get, "/api/instructions"),
-             (.get, "/api/config-metadata"):
-            return .standard
+             (.get, "/api/config-metadata"),
+             (.get, "/v1/models"),
+             (.get, "/v1/melix/health"),
+             (.get, "/v1/cache/stats"):
+            return .companionReadOnly
         case (.post, "/v1/melix/auth/session"):
             return .createSession
         case (.get, "/v1/melix/auth/session"), (.delete, "/v1/melix/auth/session"):
             return .currentSession
         default:
             return .standard
+        }
+    }
+
+    private func companionScopeFailureResponse(
+        route: GatewayAuthorizationRoute,
+        request: HTTPRequest,
+        metadata: PersistentAuthSessionMetadata
+    ) async -> HTTPResponse? {
+        guard metadata.scope == .companionReadOnly else {
+            return nil
+        }
+        switch route {
+        case .health, .companionReadOnly, .currentSession:
+            return nil
+        case .standard, .createSession:
+            await metricsStore.increment("companion_auth.rejected_request_count")
+            return jsonResponse(
+                statusCode: 403,
+                payload: [
+                    "error": [
+                        "code": "companion_read_only_scope_violation",
+                        "message": "Companion sessions are read-only and cannot call this route.",
+                        "session_state": [
+                            "state": metadata.state,
+                            "session_id": metadata.sessionID,
+                            "key_id": metadata.keyID,
+                            "scope": metadata.scope.rawValue,
+                        ],
+                        "route": [
+                            "method": request.method.rawValue,
+                            "path": request.path,
+                        ],
+                    ]
+                ]
+            )
         }
     }
 
@@ -5432,11 +5479,19 @@ private struct CacheStatsResponse: Codable {
     }
 }
 
-private struct OpenAICreateAuthSessionRequest: Codable {
+private struct OpenAICreateAuthSessionRequest: Decodable {
     let rememberMe: Bool
+    let scope: PersistentAuthSessionScope
 
     enum CodingKeys: String, CodingKey {
         case rememberMe = "remember_me"
+        case scope
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        rememberMe = try container.decode(Bool.self, forKey: .rememberMe)
+        scope = try container.decodeIfPresent(PersistentAuthSessionScope.self, forKey: .scope) ?? .operatorControl
     }
 }
 
@@ -5449,6 +5504,7 @@ private struct OpenAIAuthSessionPayload: Codable {
     let sessionID: String
     let keyID: String
     let rememberMe: Bool
+    let scope: PersistentAuthSessionScope
     let createdAtUnixMs: Int64
     let expiresAtUnixMs: Int64
     let revokedAtUnixMs: Int64
@@ -5459,6 +5515,7 @@ private struct OpenAIAuthSessionPayload: Codable {
         sessionID = metadata.sessionID
         keyID = metadata.keyID
         rememberMe = metadata.rememberMe
+        scope = metadata.scope
         createdAtUnixMs = metadata.createdAtUnixMs
         expiresAtUnixMs = metadata.expiresAtUnixMs
         revokedAtUnixMs = metadata.revokedAtUnixMs
@@ -5470,6 +5527,7 @@ private struct OpenAIAuthSessionPayload: Codable {
         case sessionID = "session_id"
         case keyID = "key_id"
         case rememberMe = "remember_me"
+        case scope
         case createdAtUnixMs = "created_at_unix_ms"
         case expiresAtUnixMs = "expires_at_unix_ms"
         case revokedAtUnixMs = "revoked_at_unix_ms"

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/PersistentAuthSessionStore.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/PersistentAuthSessionStore.swift
@@ -1,10 +1,16 @@
 import CryptoKit
 import Foundation
 
+public enum PersistentAuthSessionScope: String, Codable, Equatable, Sendable {
+    case operatorControl = "operator_control"
+    case companionReadOnly = "companion_read_only"
+}
+
 public struct PersistentAuthSessionMetadata: Equatable, Sendable {
     public let sessionID: String
     public let keyID: String
     public let rememberMe: Bool
+    public let scope: PersistentAuthSessionScope
     public let createdAtUnixMs: Int64
     public let expiresAtUnixMs: Int64
     public let revokedAtUnixMs: Int64
@@ -39,6 +45,7 @@ private struct PersistentAuthSessionRecord: Codable, Equatable, Sendable {
     let sessionID: String
     let keyID: String
     let rememberMe: Bool
+    let scope: PersistentAuthSessionScope
     let tokenHash: String
     let createdAtUnixMs: Int64
     let expiresAtUnixMs: Int64
@@ -49,6 +56,7 @@ private struct PersistentAuthSessionRecord: Codable, Equatable, Sendable {
         case sessionID = "session_id"
         case keyID = "key_id"
         case rememberMe = "remember_me"
+        case scope
         case tokenHash = "token_hash"
         case createdAtUnixMs = "created_at_unix_ms"
         case expiresAtUnixMs = "expires_at_unix_ms"
@@ -56,11 +64,47 @@ private struct PersistentAuthSessionRecord: Codable, Equatable, Sendable {
         case lastRestoredAtUnixMs = "last_restored_at_unix_ms"
     }
 
+    init(
+        sessionID: String,
+        keyID: String,
+        rememberMe: Bool,
+        scope: PersistentAuthSessionScope,
+        tokenHash: String,
+        createdAtUnixMs: Int64,
+        expiresAtUnixMs: Int64,
+        revokedAtUnixMs: Int64,
+        lastRestoredAtUnixMs: Int64
+    ) {
+        self.sessionID = sessionID
+        self.keyID = keyID
+        self.rememberMe = rememberMe
+        self.scope = scope
+        self.tokenHash = tokenHash
+        self.createdAtUnixMs = createdAtUnixMs
+        self.expiresAtUnixMs = expiresAtUnixMs
+        self.revokedAtUnixMs = revokedAtUnixMs
+        self.lastRestoredAtUnixMs = lastRestoredAtUnixMs
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessionID = try container.decode(String.self, forKey: .sessionID)
+        keyID = try container.decode(String.self, forKey: .keyID)
+        rememberMe = try container.decode(Bool.self, forKey: .rememberMe)
+        scope = try container.decodeIfPresent(PersistentAuthSessionScope.self, forKey: .scope) ?? .operatorControl
+        tokenHash = try container.decode(String.self, forKey: .tokenHash)
+        createdAtUnixMs = try container.decode(Int64.self, forKey: .createdAtUnixMs)
+        expiresAtUnixMs = try container.decode(Int64.self, forKey: .expiresAtUnixMs)
+        revokedAtUnixMs = try container.decode(Int64.self, forKey: .revokedAtUnixMs)
+        lastRestoredAtUnixMs = try container.decode(Int64.self, forKey: .lastRestoredAtUnixMs)
+    }
+
     var metadata: PersistentAuthSessionMetadata {
         PersistentAuthSessionMetadata(
             sessionID: sessionID,
             keyID: keyID,
             rememberMe: rememberMe,
+            scope: scope,
             createdAtUnixMs: createdAtUnixMs,
             expiresAtUnixMs: expiresAtUnixMs,
             revokedAtUnixMs: revokedAtUnixMs,
@@ -151,7 +195,8 @@ public actor PersistentAuthSessionStore {
 
     public func issueSession(
         keyID: String,
-        rememberMe: Bool
+        rememberMe: Bool,
+        scope: PersistentAuthSessionScope = .operatorControl
     ) async throws -> PersistentAuthSessionIssue {
         let createdAtUnixMs = nowUnixMs()
         let token = "melix_sess_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
@@ -159,6 +204,7 @@ public actor PersistentAuthSessionStore {
             sessionID: "auth-session-\(UUID().uuidString)",
             keyID: keyID,
             rememberMe: rememberMe,
+            scope: scope,
             tokenHash: Self.hash(token),
             createdAtUnixMs: createdAtUnixMs,
             expiresAtUnixMs: createdAtUnixMs + Int64(retentionTTLSeconds * 1_000),

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -750,6 +750,142 @@ struct OpenAIHandlerTests {
         #expect(await metricsStore.value(forKey: "persistent_session.active_session_count") == 0)
     }
 
+    @Test("companion auth sessions can read status and revoke themselves but cannot mutate runtime")
+    func companionAuthSessionsCanReadStatusAndRevokeThemselvesButCannotMutateRuntime() async throws {
+        let metricsStore = MetricsStore()
+        let temporaryRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-companion-auth-session-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                abortRegistry: AbortRegistry()
+            ),
+            metricsStore: metricsStore,
+            gatewayAccessPolicy: GatewayAccessPolicy(
+                mode: .apiKeys,
+                sharedAccessEnabled: true,
+                keys: [
+                    .init(keyID: "codex", label: "Codex", tokenHint: "codex", token: "sk-codex"),
+                ]
+            ),
+            persistentAuthSessionStore: PersistentAuthSessionStore(
+                storeURL: temporaryRoot.appendingPathComponent("persistent-auth-sessions.json"),
+                metricsStore: metricsStore,
+                retentionTTLSeconds: 3600,
+                nowUnixMs: { 1_000 }
+            )
+        )
+
+        let createResponse = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/melix/auth/session",
+                headers: [
+                    "content-type": "application/json",
+                    "x-api-key": "sk-codex",
+                ],
+                body: try #require("""
+                {
+                  "remember_me": true,
+                  "scope": "companion_read_only"
+                }
+                """.data(using: .utf8))
+            )
+        )
+        let createPayload = try await jsonPayload(from: createResponse.body)
+        let createSession = try #require(createPayload["session"] as? [String: Any])
+        let sessionToken = try #require((createPayload["resume"] as? [String: Any])?["token"] as? String)
+
+        let modelsResponse = try await handler.handle(
+            HTTPRequest(
+                method: .get,
+                path: "/v1/models",
+                headers: ["X-Melix-Session": sessionToken],
+                body: Data()
+            )
+        )
+        let diagnosticsResponse = try await handler.handle(
+            HTTPRequest(
+                method: .get,
+                path: "/v1/melix/health",
+                headers: ["X-Melix-Session": sessionToken],
+                body: Data()
+            )
+        )
+        let inspectResponse = try await handler.handle(
+            HTTPRequest(
+                method: .get,
+                path: "/v1/melix/auth/session",
+                headers: ["X-Melix-Session": sessionToken],
+                body: Data()
+            )
+        )
+        let inspectPayload = try await jsonPayload(from: inspectResponse.body)
+        let inspectSession = try #require(inspectPayload["session"] as? [String: Any])
+
+        let privatePrompt = "PRIVATE PROMPT: do not expose this companion secret"
+        let mutationResponse = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: [
+                    "content-type": "application/json",
+                    "X-Melix-Session": sessionToken,
+                ],
+                body: Data("""
+                {
+                  "model": "melix-dev-text",
+                  "messages": [
+                    { "role": "user", "content": "\(privatePrompt)" }
+                  ]
+                }
+                """.utf8)
+            )
+        )
+        let mutationBody = try await collectBody(mutationResponse.body)
+        let mutationPayload = try #require(
+            JSONSerialization.jsonObject(with: Data(mutationBody.utf8)) as? [String: Any]
+        )
+        let mutationError = try #require(mutationPayload["error"] as? [String: Any])
+
+        let signOutResponse = try await handler.handle(
+            HTTPRequest(
+                method: .delete,
+                path: "/v1/melix/auth/session",
+                headers: ["X-Melix-Session": sessionToken],
+                body: Data()
+            )
+        )
+        let revokedModelsResponse = try await handler.handle(
+            HTTPRequest(
+                method: .get,
+                path: "/v1/models",
+                headers: ["X-Melix-Session": sessionToken],
+                body: Data()
+            )
+        )
+        let revokedPayload = try await jsonPayload(from: revokedModelsResponse.body)
+        let revokedError = try #require(revokedPayload["error"] as? [String: Any])
+
+        #expect(createResponse.statusCode == 200)
+        #expect(createSession["scope"] as? String == "companion_read_only")
+        #expect(modelsResponse.statusCode == 200)
+        #expect(diagnosticsResponse.statusCode == 200)
+        #expect(inspectResponse.statusCode == 200)
+        #expect(inspectSession["scope"] as? String == "companion_read_only")
+        #expect(mutationResponse.statusCode == 403)
+        #expect(mutationError["code"] as? String == "companion_read_only_scope_violation")
+        #expect(mutationBody.contains(privatePrompt) == false)
+        #expect(signOutResponse.statusCode == 200)
+        #expect(revokedModelsResponse.statusCode == 401)
+        #expect(revokedError["code"] as? String == "revoked_session")
+        #expect(await metricsStore.value(forKey: "companion_auth.rejected_request_count") == 1)
+    }
+
     @Test("gateway auth session responses sanitize rich output in encoded and manual json payloads")
     func gatewayAuthSessionResponsesSanitizeRichOutputAcrossResponsePaths() async throws {
         let metricsStore = MetricsStore()

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/PersistentAuthSessionStoreTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/PersistentAuthSessionStoreTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import Testing
 
@@ -106,6 +107,105 @@ struct PersistentAuthSessionStoreTests {
         try await store.reconcile(with: unsupportedPolicy)
         #expect(await metricsStore.value(forKey: "persistent_session.active_session_count") == 0)
         #expect(await metricsStore.value(forKey: "persistent_session.remembered_session_count") == 0)
+    }
+
+    @Test("store records companion read-only session scope")
+    func storeRecordsCompanionReadOnlySessionScope() async throws {
+        let temporaryRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-persistent-session-scope-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let metricsStore = MetricsStore()
+        let store = PersistentAuthSessionStore(
+            storeURL: temporaryRoot.appendingPathComponent("persistent-auth-sessions.json"),
+            metricsStore: metricsStore,
+            retentionTTLSeconds: 3600,
+            nowUnixMs: { 10_000 }
+        )
+
+        let issued = try await store.issueSession(
+            keyID: "desktop-agent",
+            rememberMe: true,
+            scope: .companionReadOnly
+        )
+        let validation = await store.validateSessionToken(
+            issued.token,
+            policy: GatewayAccessPolicy(
+                mode: .apiKeys,
+                sharedAccessEnabled: true,
+                keys: [
+                    .init(keyID: "desktop-agent", label: "Desktop Agent", tokenHint: "desktop-agent", token: "sk-desktop"),
+                ]
+            )
+        )
+
+        #expect(issued.metadata.scope == .companionReadOnly)
+        #expect(validation == .success(issued.metadata))
+
+        let persistedObject = try persistedSessionDocument(
+            at: temporaryRoot.appendingPathComponent("persistent-auth-sessions.json")
+        )
+        let sessions = try #require(persistedObject["sessions"] as? [[String: Any]])
+        let session = try #require(sessions.first)
+        #expect(session["scope"] as? String == "companion_read_only")
+    }
+
+    @Test("store restores legacy sessions without scope as operator control")
+    func storeRestoresLegacySessionsWithoutScopeAsOperatorControl() async throws {
+        let temporaryRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-persistent-session-legacy-scope-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let token = "melix_sess_legacy"
+        let tokenHash = SHA256.hash(data: Data(token.utf8)).map { String(format: "%02x", $0) }.joined()
+        let storeURL = temporaryRoot.appendingPathComponent("persistent-auth-sessions.json")
+        try #require("""
+        {
+          "schema_version": 1,
+          "sessions": [
+            {
+              "session_id": "auth-session-legacy",
+              "key_id": "desktop-agent",
+              "remember_me": true,
+              "token_hash": "\(tokenHash)",
+              "created_at_unix_ms": 1000,
+              "expires_at_unix_ms": 20000,
+              "revoked_at_unix_ms": 0,
+              "last_restored_at_unix_ms": 0
+            }
+          ]
+        }
+        """.data(using: .utf8)).write(to: storeURL)
+
+        let metricsStore = MetricsStore()
+        let store = PersistentAuthSessionStore(
+            storeURL: storeURL,
+            metricsStore: metricsStore,
+            retentionTTLSeconds: 3600,
+            nowUnixMs: { 10_000 }
+        )
+        let restoreResult = try await store.restorePersistedSessions()
+        let validation = await store.validateSessionToken(
+            token,
+            policy: GatewayAccessPolicy(
+                mode: .apiKeys,
+                sharedAccessEnabled: true,
+                keys: [
+                    .init(keyID: "desktop-agent", label: "Desktop Agent", tokenHint: "desktop-agent", token: "sk-desktop"),
+                ]
+            )
+        )
+
+        #expect(restoreResult.restoredSessionCount == 1)
+        #expect(restoreResult.malformedRecordCount == 0)
+        guard case .success(let metadata) = validation else {
+            Issue.record("Expected legacy session validation to succeed.")
+            return
+        }
+        #expect(metadata.scope == .operatorControl)
+        #expect(metadata.lastRestoredAtUnixMs == 10_000)
     }
 
     @Test("store consumes session revocation atomically")


### PR DESCRIPTION
## Summary
- Adds persistent auth session scopes for `operator_control` and `companion_read_only`, preserving legacy persisted sessions as operator-control sessions.
- Allows companion read-only sessions to use status, discovery, health, current-session, and self-revocation routes while rejecting runtime mutation and auth-session creation.
- Returns a structured `403` scope-violation response without echoing request bodies or private prompt content, and records `companion_auth.rejected_request_count`.

## Plan or Spec
- Governing plan: `docs/plans/2026-06-13-issue-1759-companion-readonly-auth-scope.md`
- Issue: Refs #1759

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'PersistentAuthSessionStoreTests|OpenAIHandlerTests'
# Passed: 216 tests.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'PersistentAuthSessionStoreTests|OpenAIHandlerTests'
# Passed: 216 tests.

UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/PersistentAuthSessionStore.swift services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/HTTPGatewayTests/PersistentAuthSessionStoreTests.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
# Passed: TOTAL 99.34% (301/303 changed lines).

make swift-test
# Passed.

make py-test
# Passed: 3999 passed, 14 skipped, 2 warnings.

make integration-test
# Passed: 120 passed, 1 skipped.

git diff --check
# Passed.

UV_PYTHON=3.12 uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report

root = Path.cwd()
changed_files = [
    line
    for line in subprocess.check_output(
        ["git", "diff", "--name-only", "origin/main...HEAD"],
        cwd=root,
        text=True,
    ).splitlines()
    if line.strip()
]
outcome = run_performance_report(root, changed_files, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# Passed: Status ok, Selected probes 0, Regressions 0, Context regressions 0, Verification failures 0.
# Report: .runtime/pre-commit-performance/20260613-162931-3cb990bd/report/report.md

After merging latest origin/main e1cc12aa:

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'PersistentAuthSessionStoreTests|OpenAIHandlerTests'
# Passed: 216 tests.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'PersistentAuthSessionStoreTests|OpenAIHandlerTests'
# Passed: 216 tests.

UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/PersistentAuthSessionStore.swift services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/HTTPGatewayTests/PersistentAuthSessionStoreTests.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
# Passed: TOTAL 99.34% (301/303 changed lines).

UV_PYTHON=3.12 uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report

root = Path.cwd()
changed_files = [
    line
    for line in subprocess.check_output(
        ["git", "diff", "--name-only", "origin/main...HEAD"],
        cwd=root,
        text=True,
    ).splitlines()
    if line.strip()
]
outcome = run_performance_report(root, changed_files, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# Passed: Status ok, Selected probes 0, Regressions 0, Context regressions 0, Verification failures 0.
# Report: .runtime/pre-commit-performance/20260613-170923-54494e50/report/report.md
```

## Coverage and Metrics
- Changed-line coverage: `99.34%` overall (`301/303`).
- Source changed-line coverage: `PersistentAuthSessionStore.swift` `100.00%` (`25/25`), `OpenAIHandler.swift` `100.00%` (`49/49`).
- Test changed-line coverage: `PersistentAuthSessionStoreTests.swift` `97.89%` (`93/95`), `OpenAIHandlerTests.swift` `100.00%` (`134/134`).
- Metrics report: `.runtime/pre-commit-performance/20260613-170923-54494e50/report/report.md`; status `ok`, selected probes `0`, regressions `0`.
- Observability mode: `minimal`; the runtime path adds the bounded counter `companion_auth.rejected_request_count`.
- Probe overhead: `N/A`; no new performance, evidence-mode, or debug probe was added, and no existing registered probe matched this change set.

## Known Gaps
- This PR is the server-side authorization foundation for #1759; it does not close the full companion/mobile surface issue.
- Deferred: QR/pairing UX, desktop token issuance and revocation controls, mobile/narrow viewport status smoke, active-job/recent-receipt cards, and log-tail redaction UI.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
