### PR TITLE
perf: fast-path absent probe policy values

### DIFF
--- a/docs/plans/2026-05-23-probe-policy-invalid-string-cache.md
+++ b/docs/plans/2026-05-23-probe-policy-invalid-string-cache.md
@@ -17,3 +17,12 @@ This slice is limited to `worker.productization.probe_policy` and the existing r
 ## Verification
 
 Run the registered focused test command, changed-scope coverage command, and `probe-policy-noop-overhead` probe locally on Linux. CI remains the source of truth for the registered PR-scoped performance report.
+
+## 2026-06-13 follow-up: None fast path
+
+`ProbePolicy.from_value(None)` is part of the same fallback contract as empty
+probe-mode values. Add a direct `None` branch before the generic non-string
+normalization so repeated absent-value parsing returns the cached default policy
+without allocating and normalizing `str(None or "")`. The registered probe now
+also reports `mode_parse_none_call_ms_mean` alongside the existing empty, valid,
+and invalid parse metrics.

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -68,6 +68,8 @@ class ProbePolicy:
             return _probe_policy_from_uncached_string(value, default_mode)
         elif isinstance(value, ProbeMode):
             return _PROBE_POLICY_BY_MODE[value]
+        elif value is None:
+            return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
         elif isinstance(value, str):
             policy = _PROBE_POLICY_BY_VALUE_GET(value)
             if policy is not None:

--- a/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy_overhead.py
@@ -27,6 +27,7 @@ class ProbeOverheadMetrics:
     no_op_policy_check_call_ms_mean: float
     no_op_reason_call_ms_mean: float
     mode_parse_empty_call_ms_mean: float
+    mode_parse_none_call_ms_mean: float
     mode_parse_valid_call_ms_mean: float
     mode_parse_invalid_call_ms_mean: float
     env_parse_empty_call_ms_mean: float
@@ -57,6 +58,7 @@ class ProbeOverheadMetrics:
             "no_op_policy_check_call_ms_mean": self.no_op_policy_check_call_ms_mean,
             "no_op_reason_call_ms_mean": self.no_op_reason_call_ms_mean,
             "mode_parse_empty_call_ms_mean": self.mode_parse_empty_call_ms_mean,
+            "mode_parse_none_call_ms_mean": self.mode_parse_none_call_ms_mean,
             "mode_parse_valid_call_ms_mean": self.mode_parse_valid_call_ms_mean,
             "mode_parse_invalid_call_ms_mean": self.mode_parse_invalid_call_ms_mean,
             "env_parse_empty_call_ms_mean": self.env_parse_empty_call_ms_mean,
@@ -113,6 +115,11 @@ def measure_no_op_probe_policy_overhead(
         iterations=iteration_count,
         samples=sample_count,
     )
+    parse_none_samples = _sample_call_ms(
+        lambda: ProbePolicy.from_value(None),
+        iterations=iteration_count,
+        samples=sample_count,
+    )
     parse_valid_samples = _sample_call_ms(
         lambda: ProbePolicy.from_value("debug"),
         iterations=iteration_count,
@@ -144,6 +151,7 @@ def measure_no_op_probe_policy_overhead(
     policy_mean = _mean(policy_samples)
     reason_mean = _mean(reason_samples)
     parse_empty_mean = _mean(parse_empty_samples)
+    parse_none_mean = _mean(parse_none_samples)
     parse_valid_mean = _mean(parse_valid_samples)
     parse_invalid_mean = _mean(parse_invalid_samples)
     env_parse_empty_mean = _mean(env_parse_empty_samples)
@@ -169,6 +177,7 @@ def measure_no_op_probe_policy_overhead(
         no_op_policy_check_call_ms_mean=policy_mean,
         no_op_reason_call_ms_mean=reason_mean,
         mode_parse_empty_call_ms_mean=parse_empty_mean,
+        mode_parse_none_call_ms_mean=parse_none_mean,
         mode_parse_valid_call_ms_mean=parse_valid_mean,
         mode_parse_invalid_call_ms_mean=parse_invalid_mean,
         env_parse_empty_call_ms_mean=env_parse_empty_mean,


### PR DESCRIPTION
## Summary
- Add a direct `ProbePolicy.from_value(None)` branch so absent probe-mode values reuse the cached default policy without generic string normalization.
- Extend the probe-policy overhead metrics with `mode_parse_none_call_ms_mean` for the registered PR-scoped probe.
- Update the probe policy performance plan with the 2026-06-13 follow-up slice.

## Plan or Spec
- Updated `docs/plans/2026-05-23-probe-policy-invalid-string-cache.md` with the None fast-path follow-up and metric addition.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py`
- Baseline comparison command on `origin/main` and this branch: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY' ... _sample_call_ms(lambda: ProbePolicy.from_value(None), iterations=1000000, samples=5) ... PY`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 18 passed.
- Changed-scope coverage: 100.00% total (5/5 changed measurable lines covered).
- Registered local probe (this branch): `threshold_passed=1.0`, `mode_parse_none_call_ms_mean=0.000222683`, `mode_parse_empty_call_ms_mean=0.000145033`, `mode_parse_invalid_call_ms_mean=0.000216523`.
- Local baseline comparison for `ProbePolicy.from_value(None)`: `origin/main mean=0.000341946 ms/call`, this branch `mean=0.000227988 ms/call`, delta `-0.000113958 ms/call` (~1.50x faster for this absent-value parse slice).

## Known Gaps
- Local validation is Linux/Python only. The registered PR-scoped performance workflow in GitHub Actions remains the merge gate.

## Evidence Checklist
- [x] Registered probe exists for the affected path (`probe-policy-noop-overhead`) with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at 100%.
- [x] Registered probe ran locally and reports the new None metric.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
