### PR TITLE
Add companion read-only status endpoint

### DIFF
--- a/docs/plans/2026-06-14-issue-1759-companion-status-endpoint.md
+++ b/docs/plans/2026-06-14-issue-1759-companion-status-endpoint.md
@@ -1,0 +1,205 @@
+# Issue 1759 Companion Status Endpoint
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a scoped, read-only companion status endpoint that returns a redacted mobile-friendly runtime summary for issue #1759.
+
+**Architecture:** Build on the companion auth scope delivered in PR #2068. The HTTP gateway owns route admission, collects already-available runtime read models, and emits a dedicated companion payload that excludes prompt text, raw logs, artifact URIs, local paths, and request bodies.
+
+**Tech Stack:** Swift control plane HTTP gateway, `PersistentAuthSessionStore`, `SchedulerReadModel`, `ImageJobReadModel`, `CacheMetadataStore`, Swift Testing.
+
+---
+
+## Context
+
+Issue #1759 asks for a paired read-only companion/mobile surface. PR #2068 already delivered durable `companion_read_only` sessions, read-only route enforcement, mutation denial, and self-revocation. The next safe server-side slice is a single aggregate status endpoint that future QR/mobile UI can call without stitching several operator routes together.
+
+The best end-state architecture is a companion API layer with deliberately narrow DTOs. It should not reuse internal operator payloads if those payloads include raw prompts, recipes, local artifact URIs, request bodies, or logs. Later UI slices can render this endpoint directly, and later receipt/log work can add redacted read models behind the same endpoint without expanding companion permissions.
+
+## Slice Boundary
+
+This transaction adds `GET /v1/melix/companion/status` only. It includes:
+
+- runtime health route readiness;
+- loaded model summary with model id, state, and supported modalities;
+- cache summary numeric counters;
+- scheduler queue summary;
+- redacted image job summaries;
+- current session status for the presented companion token;
+- browser preflight support for the `x-melix-session` header used by companion clients;
+- a redaction policy block documenting intentionally omitted private surfaces.
+
+This transaction does not add QR pairing UI, desktop token management UI, mobile HTML/CSS, receipt history, or log tail UI. Receipt and log-tail content stay omitted until a redacted read model exists.
+
+## Performance Probes and Metrics
+
+- Runtime metric: `companion.status_latency_ms` records endpoint assembly latency.
+- The endpoint reads in-memory control-plane models only and does not call model workers.
+- Observability mode: `minimal`, one latency metric on the HTTP gateway path.
+- Success metric: focused Swift tests cover the new route and redaction contract; changed-line coverage for touched Swift files remains at least 95 percent.
+- PR merge gate: scoped performance report must stay `Status: ok` with zero regressions.
+
+## Implementation Plan
+
+### Task 1: Add the Failing Companion Status Contract Test
+
+**Files:**
+- Modify: `services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift`
+
+- [x] **Step 1: Write the failing test**
+
+Add a Swift test near the existing companion auth session test:
+
+```swift
+@Test("companion status endpoint returns redacted runtime queue job and session summary")
+func companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary() async throws {
+    // Create a companion_read_only session, seed queue and image job state with
+    // private prompt material, call GET /v1/melix/companion/status, then assert:
+    // - status code is 200;
+    // - schema_version is melix.companion.status.v1;
+    // - authorization.scope is companion_read_only;
+    // - runtime/model/cache/queue/job summaries are present;
+    // - private prompt text, negative prompts, artifact URIs, and local paths are absent;
+    // - companion.status_latency_ms is recorded.
+}
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary'
+```
+
+Expected: FAIL because `GET /v1/melix/companion/status` is not implemented or not allowlisted for companion sessions.
+
+### Task 2: Implement the Companion Status Route
+
+**Files:**
+- Modify: `services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift`
+
+- [x] **Step 1: Allow the route for companion read-only sessions**
+
+Add `GET /v1/melix/companion/status` to `authorizationRoute(for:)` under `.companionReadOnly`.
+
+- [x] **Step 2: Route requests to a new handler**
+
+Add a route case in `handle(_:)`:
+
+```swift
+case (.get, "/v1/melix/companion/status"):
+    response = try await handleCompanionStatus(authorization: authorizationContext)
+```
+
+- [x] **Step 3: Assemble a redacted companion payload**
+
+Add `handleCompanionStatus(authorization:)` that gathers:
+
+- `healthRoutes()`;
+- user-visible model summaries;
+- `CacheMetadataStore` summary or empty summary;
+- `schedulerReadModel?.snapshot()`;
+- `imageJobReadModel?.snapshot()`.
+
+Use new `Codable` DTOs instead of reusing `OpenAIImageJobPayload`, because the existing image job payload includes recipe prompts, prompt deltas, and artifact URIs.
+
+- [x] **Step 4: Record the latency metric**
+
+Set `companion.status_latency_ms` before returning the encoded JSON response.
+
+- [x] **Step 5: Admit browser companion session headers**
+
+Add `x-melix-session` to the local-server-security CORS preflight
+`access-control-allow-headers` value so paired browser/mobile clients can call
+the companion status endpoint from an allowed origin.
+
+### Task 3: Verify Green and Adjacent Auth Behavior
+
+**Files:**
+- Test: `services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift`
+
+- [x] **Step 1: Run focused green test**
+
+Run:
+
+```bash
+HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary'
+```
+
+Expected: PASS.
+
+- [x] **Step 2: Run adjacent auth and health tests**
+
+Run:
+
+```bash
+HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companion|gatewayAuthSession|HealthDiagnostics|CacheStats)'
+```
+
+Expected: PASS.
+
+### Task 4: Coverage, Metrics, Commit, and PR
+
+**Files:**
+- Modify: `.github/pull_request_template.md` only if the template itself changed, which is not expected.
+
+- [x] **Step 1: Run changed-scope coverage**
+
+Use the repository Swift coverage tooling for the touched control-plane gateway scope. Record the changed-line percentage and keep it at least 95 percent.
+
+- [x] **Step 2: Run full local gate**
+
+Run:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```
+
+Expected: all pass.
+
+- [x] **Step 3: Commit and use the pre-commit performance report**
+
+Run `make git-hooks-install` if needed, commit the plan/test/code changes, and let the pre-commit hook produce the scoped performance report. The report must show no performance regressions before pushing.
+
+- [ ] **Step 4: Open and monitor the PR**
+
+Fill `.github/pull_request_template.md` exactly. Include `docs/plans/2026-06-14-issue-1759-companion-status-endpoint.md` under `## Plan or Spec`, all command results under `## Commands Run`, coverage/performance under `## Coverage and Metrics`, and deferred UI/receipt/log work under `## Known Gaps`.
+
+Monitor CI, review threads, conflicts, and the PR performance report. Fix any in-scope failure or regression before squash merging.
+
+## Verification Results
+
+- Red contract test:
+  - `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary'`
+  - Result before implementation: expected failure because `GET /v1/melix/companion/status` did not yet return the `authorization` status payload.
+- Red CORS contract test:
+  - `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/localServerSecurityAllowsExplicitBrowserPreflightWithExactCORSEcho'`
+  - Result before implementation: expected failure because `access-control-allow-headers` did not yet include `x-melix-session`.
+- Focused green tests:
+  - `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary|localServerSecurityAllowsExplicitBrowserPreflightWithExactCORSEcho)'` passed 2 tests.
+  - `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companion|gatewayAuthSession|HealthDiagnostics|CacheStats|localServerSecurityAllowsExplicitBrowserPreflightWithExactCORSEcho)'` passed 6 tests.
+  - `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(getHealthDiagnostics|getCacheStats)'` passed 6 tests.
+  - `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering'` passed.
+  - `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering'` passed.
+  - `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests|PersistentAuthSessionStoreTests'` passed 219 tests.
+- Changed-line coverage:
+  - `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIHandlerTests/(companionStatusEndpoint|companionAuthSessionsCanReadStatusAndRevokeThemselvesButCannotMutateRuntime|localServerSecurityAllowsExplicitBrowserPreflightWithExactCORSEcho|getHealthDiagnostics|getCacheStats)'` passed.
+  - `UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift` reported `TOTAL 99.75% (395/396)`, production `OpenAIHandler.swift 99.30% (141/142)`, and tests `OpenAIHandlerTests.swift 100.00% (254/254)`.
+- Full local gate and pre-commit performance report:
+  - `make swift-test` passed.
+  - `make py-test` passed with `4005 passed, 14 skipped, 2 warnings`.
+  - `make integration-test` passed with `120 passed, 1 skipped`.
+  - Pre-commit hook passed `make swift-test`, `make py-test`, and `make integration-test`.
+  - Pre-commit performance report reported `Status: ok`, `Regressions: 0`,
+    `Context regressions: 0`, `Verification failures: 0`, and `Selected probes: 0`.
+
+## Deferred Work
+
+- QR/code pairing UX.
+- Desktop companion-token issuance and revocation controls.
+- Mobile/narrow viewport dashboard smoke.
+- Redacted recent receipt read model.
+- Redacted log-tail read model and UI.

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -984,11 +984,12 @@ public struct OpenAIHandler: Sendable {
         let summary = await cacheSummaryTask
         let queueSnapshot = await queueSnapshotTask
         let imageJobsSnapshot = await imageJobsSnapshotTask
+        let status = routes.values.allSatisfy { $0 } ? "ok" : "degraded"
         let response = CompanionStatusResponse(
             readOnly: true,
-            status: routes.values.allSatisfy { $0 } ? "ok" : "degraded",
+            status: status,
             runtime: CompanionRuntimeStatusPayload(
-                status: routes.values.allSatisfy { $0 } ? "ok" : "degraded",
+                status: status,
                 routes: routes
             ),
             authorization: CompanionAuthorizationStatusPayload(authorization: authorization),
@@ -5727,6 +5728,8 @@ private struct CompanionQueueLanePayload: Codable {
     }
 }
 
+private let companionImageJobVisibleLimit = 10
+
 private struct CompanionImageJobStatusPayload: Codable {
     let active: Int
     let total: Int
@@ -5739,7 +5742,7 @@ private struct CompanionImageJobStatusPayload: Codable {
             }
             return lhs.updatedAtUnixMs > rhs.updatedAtUnixMs
         }
-        let visibleJobs = Array(sortedJobs.prefix(10))
+        let visibleJobs = Array(sortedJobs.prefix(companionImageJobVisibleLimit))
         active = jobs.filter { $0.state == .imageJobQueued || $0.state == .imageJobRunning }.count
         total = jobs.count
         self.jobs = visibleJobs.map(CompanionImageJobPayload.init(job:))

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -973,13 +973,9 @@ public struct OpenAIHandler: Sendable {
         let startedAt = Date()
         async let routesTask = healthRoutes()
         async let modelsTask = modelCatalog.listModels()
-        async let cacheSummaryTask: Melix_Controlplane_V1_CacheSummary = if let cacheMetadataStore {
-            await cacheMetadataStore.cacheSummary()
-        } else {
-            CacheMetadataStore.emptySummary()
-        }
-        async let queueSnapshotTask = schedulerReadModel?.snapshot()
-        async let imageJobsSnapshotTask = imageJobReadModel?.snapshot()
+        async let cacheSummaryTask = companionCacheSummary()
+        async let queueSnapshotTask = companionQueueSnapshot()
+        async let imageJobsSnapshotTask = companionImageJobsSnapshot()
 
         let routes = await routesTask
         let models = await modelsTask
@@ -987,7 +983,7 @@ public struct OpenAIHandler: Sendable {
         let readyCount = visibleModels.filter { $0.state == .modelWarm || $0.state == .modelPinned }.count
         let summary = await cacheSummaryTask
         let queueSnapshot = await queueSnapshotTask
-        let imageJobsSnapshot = await imageJobsSnapshotTask ?? []
+        let imageJobsSnapshot = await imageJobsSnapshotTask
         let response = CompanionStatusResponse(
             readOnly: true,
             status: routes.values.allSatisfy { $0 } ? "ok" : "degraded",
@@ -1011,6 +1007,21 @@ public struct OpenAIHandler: Sendable {
             forKey: "companion.status_latency_ms"
         )
         return try encodedJSONResponse(response)
+    }
+
+    private func companionCacheSummary() async -> Melix_Controlplane_V1_CacheSummary {
+        guard let store = cacheMetadataStore else {
+            return CacheMetadataStore.emptySummary()
+        }
+        return await store.cacheSummary()
+    }
+
+    private func companionQueueSnapshot() async -> Melix_Controlplane_V1_QueueSummary? {
+        await schedulerReadModel?.snapshot()
+    }
+
+    private func companionImageJobsSnapshot() async -> [Melix_Controlplane_V1_ImageJobSummary] {
+        await imageJobReadModel?.snapshot() ?? []
     }
 
     private func handleCacheStats() async throws -> HTTPResponse {

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -971,15 +971,23 @@ public struct OpenAIHandler: Sendable {
         authorization: GatewayAuthorizationContext
     ) async throws -> HTTPResponse {
         let startedAt = Date()
-        let routes = await healthRoutes()
-        let models = await modelCatalog.listModels()
-        let visibleModels = models.filter(ModelCatalogPresentation.isUserVisible)
-        let readyCount = visibleModels.filter { $0.state == .modelWarm || $0.state == .modelPinned }.count
-        let summary = if let cacheMetadataStore {
+        async let routesTask = healthRoutes()
+        async let modelsTask = modelCatalog.listModels()
+        async let cacheSummaryTask: Melix_Controlplane_V1_CacheSummary = if let cacheMetadataStore {
             await cacheMetadataStore.cacheSummary()
         } else {
             CacheMetadataStore.emptySummary()
         }
+        async let queueSnapshotTask = schedulerReadModel?.snapshot()
+        async let imageJobsSnapshotTask = imageJobReadModel?.snapshot()
+
+        let routes = await routesTask
+        let models = await modelsTask
+        let visibleModels = models.filter(ModelCatalogPresentation.isUserVisible)
+        let readyCount = visibleModels.filter { $0.state == .modelWarm || $0.state == .modelPinned }.count
+        let summary = await cacheSummaryTask
+        let queueSnapshot = await queueSnapshotTask
+        let imageJobsSnapshot = await imageJobsSnapshotTask ?? []
         let response = CompanionStatusResponse(
             readOnly: true,
             status: routes.values.allSatisfy { $0 } ? "ok" : "degraded",
@@ -994,8 +1002,8 @@ public struct OpenAIHandler: Sendable {
                 items: visibleModels.map(CompanionModelPayload.init(model:))
             ),
             cache: CompanionCacheStatusPayload(summary: summary),
-            queue: CompanionQueueStatusPayload(summary: await schedulerReadModel?.snapshot()),
-            imageJobs: CompanionImageJobStatusPayload(jobs: await imageJobReadModel?.snapshot() ?? []),
+            queue: CompanionQueueStatusPayload(summary: queueSnapshot),
+            imageJobs: CompanionImageJobStatusPayload(jobs: imageJobsSnapshot),
             redaction: CompanionRedactionStatusPayload()
         )
         await metricsStore.set(

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -733,6 +733,8 @@ public struct OpenAIHandler: Sendable {
                 response = try await handleHealthDiagnostics()
             case (.get, "/v1/cache/stats"):
                 response = try await handleCacheStats()
+            case (.get, "/v1/melix/companion/status"):
+                response = try await handleCompanionStatus(authorization: authorizationContext)
             case (.post, "/v1/melix/auth/session"):
                 response = try await handleCreateAuthSession(request, authorization: authorizationContext)
             case (.get, "/v1/melix/auth/session"):
@@ -784,7 +786,7 @@ public struct OpenAIHandler: Sendable {
         return HTTPResponse(
             statusCode: 204,
             headers: [
-                "access-control-allow-headers": "authorization, content-type, x-api-key, x-melix-auth-session",
+                "access-control-allow-headers": "authorization, content-type, x-api-key, x-melix-auth-session, x-melix-session",
                 "access-control-allow-methods": "GET, POST, DELETE, OPTIONS",
                 "access-control-max-age": "600",
             ],
@@ -961,6 +963,44 @@ public struct OpenAIHandler: Sendable {
         await metricsStore.set(
             Date().timeIntervalSince(startedAt) * 1000,
             forKey: "operator.health_diagnostics_latency_ms"
+        )
+        return try encodedJSONResponse(response)
+    }
+
+    private func handleCompanionStatus(
+        authorization: GatewayAuthorizationContext
+    ) async throws -> HTTPResponse {
+        let startedAt = Date()
+        let routes = await healthRoutes()
+        let models = await modelCatalog.listModels()
+        let visibleModels = models.filter(ModelCatalogPresentation.isUserVisible)
+        let readyCount = visibleModels.filter { $0.state == .modelWarm || $0.state == .modelPinned }.count
+        let summary = if let cacheMetadataStore {
+            await cacheMetadataStore.cacheSummary()
+        } else {
+            CacheMetadataStore.emptySummary()
+        }
+        let response = CompanionStatusResponse(
+            readOnly: true,
+            status: routes.values.allSatisfy { $0 } ? "ok" : "degraded",
+            runtime: CompanionRuntimeStatusPayload(
+                status: routes.values.allSatisfy { $0 } ? "ok" : "degraded",
+                routes: routes
+            ),
+            authorization: CompanionAuthorizationStatusPayload(authorization: authorization),
+            models: CompanionModelStatusPayload(
+                ready: readyCount,
+                total: visibleModels.count,
+                items: visibleModels.map(CompanionModelPayload.init(model:))
+            ),
+            cache: CompanionCacheStatusPayload(summary: summary),
+            queue: CompanionQueueStatusPayload(summary: await schedulerReadModel?.snapshot()),
+            imageJobs: CompanionImageJobStatusPayload(jobs: await imageJobReadModel?.snapshot() ?? []),
+            redaction: CompanionRedactionStatusPayload()
+        )
+        await metricsStore.set(
+            Date().timeIntervalSince(startedAt) * 1000,
+            forKey: "companion.status_latency_ms"
         )
         return try encodedJSONResponse(response)
     }
@@ -4470,7 +4510,8 @@ public struct OpenAIHandler: Sendable {
              (.get, "/api/config-metadata"),
              (.get, "/v1/models"),
              (.get, "/v1/melix/health"),
-             (.get, "/v1/cache/stats"):
+             (.get, "/v1/cache/stats"),
+             (.get, "/v1/melix/companion/status"):
             return .companionReadOnly
         case (.post, "/v1/melix/auth/session"):
             return .createSession
@@ -5450,6 +5491,305 @@ private struct HealthDiagnosticsModelResponse: Codable {
         case modelID = "model_id"
         case supportedModalities = "supported_modalities"
         case mediaRouteReceipt = "media_route_receipt"
+    }
+}
+
+private struct CompanionStatusResponse: Codable {
+    let schemaVersion = "melix.companion.status.v1"
+    let readOnly: Bool
+    let status: String
+    let runtime: CompanionRuntimeStatusPayload
+    let authorization: CompanionAuthorizationStatusPayload
+    let models: CompanionModelStatusPayload
+    let cache: CompanionCacheStatusPayload
+    let queue: CompanionQueueStatusPayload
+    let imageJobs: CompanionImageJobStatusPayload
+    let redaction: CompanionRedactionStatusPayload
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case readOnly = "read_only"
+        case status
+        case runtime
+        case authorization
+        case models
+        case cache
+        case queue
+        case imageJobs = "image_jobs"
+        case redaction
+    }
+}
+
+private struct CompanionRuntimeStatusPayload: Codable {
+    let status: String
+    let routes: [String: Bool]
+}
+
+private struct CompanionAuthorizationStatusPayload: Codable {
+    let mode: String
+    let scope: String
+    let state: String
+    let sessionID: String?
+    let keyID: String?
+    let rememberMe: Bool?
+    let expiresAtUnixMs: Int64?
+
+    init(authorization: GatewayAuthorizationContext) {
+        switch authorization {
+        case .localTrusted:
+            mode = "local_trusted"
+            scope = "operator_control"
+            state = "active"
+            sessionID = nil
+            keyID = nil
+            rememberMe = nil
+            expiresAtUnixMs = nil
+        case let .credential(keyID, _):
+            mode = "credential"
+            scope = "operator_control"
+            state = "active"
+            sessionID = nil
+            self.keyID = keyID
+            rememberMe = nil
+            expiresAtUnixMs = nil
+        case let .session(_, metadata):
+            mode = "session"
+            scope = metadata.scope.rawValue
+            state = metadata.state
+            sessionID = metadata.sessionID
+            keyID = metadata.keyID
+            rememberMe = metadata.rememberMe
+            expiresAtUnixMs = metadata.expiresAtUnixMs
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case mode
+        case scope
+        case state
+        case sessionID = "session_id"
+        case keyID = "key_id"
+        case rememberMe = "remember_me"
+        case expiresAtUnixMs = "expires_at_unix_ms"
+    }
+}
+
+private struct CompanionModelStatusPayload: Codable {
+    let ready: Int
+    let total: Int
+    let items: [CompanionModelPayload]
+}
+
+private struct CompanionModelPayload: Codable {
+    let modelID: String
+    let state: String
+    let kind: String
+    let supportedModalities: [String]
+
+    init(model: Melix_Controlplane_V1_ModelSummary) {
+        let receipt = ModelCatalogPresentation.publicMediaRouteReceipt(for: model)
+        modelID = model.modelID
+        state = model.state.melixString
+        kind = model.kind
+        supportedModalities = receipt.effectiveSupportedModalities
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case modelID = "model_id"
+        case state
+        case kind
+        case supportedModalities = "supported_modalities"
+    }
+}
+
+private struct CompanionCacheStatusPayload: Codable {
+    let l1Bytes: UInt64
+    let l2Bytes: UInt64
+    let l1HitRate: Double
+    let l2HitRate: Double
+    let checkpointCount: UInt64
+    let blockCount: UInt64
+    let quantizedBytes: UInt64
+    let compressionRatio: Double
+    let l2RestoreHitRate: Double
+    let activeCacheMode: String
+
+    init(summary: Melix_Controlplane_V1_CacheSummary) {
+        l1Bytes = summary.l1Bytes
+        l2Bytes = summary.l2Bytes
+        l1HitRate = summary.l1HitRate
+        l2HitRate = summary.l2HitRate
+        checkpointCount = summary.checkpointCount
+        blockCount = summary.blockCount
+        quantizedBytes = summary.quantizedBytes
+        compressionRatio = summary.compressionRatio
+        l2RestoreHitRate = summary.l2RestoreHitRate
+        activeCacheMode = cacheModeLabel(summary.activeMode)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case l1Bytes = "l1_bytes"
+        case l2Bytes = "l2_bytes"
+        case l1HitRate = "l1_hit_rate"
+        case l2HitRate = "l2_hit_rate"
+        case checkpointCount = "checkpoint_count"
+        case blockCount = "block_count"
+        case quantizedBytes = "quantized_bytes"
+        case compressionRatio = "compression_ratio"
+        case l2RestoreHitRate = "l2_restore_hit_rate"
+        case activeCacheMode = "active_cache_mode"
+    }
+}
+
+private struct CompanionQueueStatusPayload: Codable {
+    let queuedRequests: UInt32
+    let activeRequests: UInt32
+    let admissionLatencyMs: Double
+    let backpressure: Double
+    let admittedRequests: UInt32
+    let rejectedRequests: UInt32
+    let lanes: [CompanionQueueLanePayload]
+
+    init(summary: Melix_Controlplane_V1_QueueSummary?) {
+        let summary = summary ?? Melix_Controlplane_V1_QueueSummary()
+        queuedRequests = summary.queuedRequests
+        activeRequests = summary.activeRequests
+        admissionLatencyMs = summary.admissionLatencyMs
+        backpressure = summary.backpressure
+        admittedRequests = summary.admittedRequests
+        rejectedRequests = summary.rejectedRequests
+        lanes = summary.lanes.map(CompanionQueueLanePayload.init(lane:))
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case queuedRequests = "queued_requests"
+        case activeRequests = "active_requests"
+        case admissionLatencyMs = "admission_latency_ms"
+        case backpressure
+        case admittedRequests = "admitted_requests"
+        case rejectedRequests = "rejected_requests"
+        case lanes
+    }
+}
+
+private struct CompanionQueueLanePayload: Codable {
+    let laneID: String
+    let laneClass: String
+    let queuedRequests: UInt32
+    let activeRequests: UInt32
+    let queueDelayMsP50: Double
+    let queueDelayMsP95: Double
+    let admissionRate: Double
+    let backpressure: Double
+    let priorityScore: Double
+
+    init(lane: Melix_Controlplane_V1_QueueLaneSummary) {
+        laneID = lane.laneID
+        laneClass = lane.laneClass
+        queuedRequests = lane.queuedRequests
+        activeRequests = lane.activeRequests
+        queueDelayMsP50 = lane.queueDelayMsP50
+        queueDelayMsP95 = lane.queueDelayMsP95
+        admissionRate = lane.admissionRate
+        backpressure = lane.backpressure
+        priorityScore = lane.priorityScore
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case laneID = "lane_id"
+        case laneClass = "lane_class"
+        case queuedRequests = "queued_requests"
+        case activeRequests = "active_requests"
+        case queueDelayMsP50 = "queue_delay_ms_p50"
+        case queueDelayMsP95 = "queue_delay_ms_p95"
+        case admissionRate = "admission_rate"
+        case backpressure
+        case priorityScore = "priority_score"
+    }
+}
+
+private struct CompanionImageJobStatusPayload: Codable {
+    let active: Int
+    let total: Int
+    let jobs: [CompanionImageJobPayload]
+
+    init(jobs: [Melix_Controlplane_V1_ImageJobSummary]) {
+        let sortedJobs = jobs.sorted { lhs, rhs in
+            if lhs.updatedAtUnixMs == rhs.updatedAtUnixMs {
+                return lhs.jobID < rhs.jobID
+            }
+            return lhs.updatedAtUnixMs > rhs.updatedAtUnixMs
+        }
+        let visibleJobs = Array(sortedJobs.prefix(10))
+        active = jobs.filter { $0.state == .imageJobQueued || $0.state == .imageJobRunning }.count
+        total = jobs.count
+        self.jobs = visibleJobs.map(CompanionImageJobPayload.init(job:))
+    }
+}
+
+private struct CompanionImageJobPayload: Codable {
+    let jobID: String
+    let requestID: String
+    let modelID: String
+    let operation: String
+    let state: String
+    let lane: String
+    let workerID: String
+    let progress: OpenAIImageJobProgressPayload
+    let cancelable: Bool
+    let createdAtUnixMs: Int64
+    let updatedAtUnixMs: Int64
+    let promptDigest: String
+    let editMode: String
+
+    init(job: Melix_Controlplane_V1_ImageJobSummary) {
+        jobID = job.jobID
+        requestID = job.requestID
+        modelID = job.modelID
+        operation = job.operation
+        state = job.state.melixString
+        lane = job.lane
+        workerID = job.workerID
+        progress = OpenAIImageJobProgressPayload(progress: job.progress)
+        cancelable = job.cancelable
+        createdAtUnixMs = job.createdAtUnixMs
+        updatedAtUnixMs = job.updatedAtUnixMs
+        promptDigest = job.promptDigest
+        editMode = job.editMode.melixString
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case jobID = "job_id"
+        case requestID = "request_id"
+        case modelID = "model_id"
+        case operation
+        case state
+        case lane
+        case workerID = "worker_id"
+        case progress
+        case cancelable
+        case createdAtUnixMs = "created_at_unix_ms"
+        case updatedAtUnixMs = "updated_at_unix_ms"
+        case promptDigest = "prompt_digest"
+        case editMode = "edit_mode"
+    }
+}
+
+private struct CompanionRedactionStatusPayload: Codable {
+    let rawPrompts = "omitted"
+    let rawRequestBodies = "omitted"
+    let localPaths = "omitted"
+    let artifactURIs = "omitted"
+    let logs = "omitted"
+    let recentReceipts = "omitted"
+
+    enum CodingKeys: String, CodingKey {
+        case rawPrompts = "raw_prompts"
+        case rawRequestBodies = "raw_request_bodies"
+        case localPaths = "local_paths"
+        case artifactURIs = "artifact_uris"
+        case logs
+        case recentReceipts = "recent_receipts"
     }
 }
 

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -162,6 +162,7 @@ struct OpenAIHandlerTests {
         #expect(response.headers["access-control-allow-origin"] == "http://localhost:5173")
         #expect(response.headers["access-control-allow-methods"] == "GET, POST, DELETE, OPTIONS")
         #expect(response.headers["access-control-allow-headers"]?.contains("x-api-key") == true)
+        #expect(response.headers["access-control-allow-headers"]?.contains("x-melix-session") == true)
         #expect(response.headers["vary"] == "Origin")
         #expect(response.headers.values.contains("*") == false)
         #expect(await metricsStore.value(forKey: "local_server_security.accepted_origin_count") == 1)
@@ -884,6 +885,265 @@ struct OpenAIHandlerTests {
         #expect(revokedModelsResponse.statusCode == 401)
         #expect(revokedError["code"] as? String == "revoked_session")
         #expect(await metricsStore.value(forKey: "companion_auth.rejected_request_count") == 1)
+    }
+
+    @Test("companion status endpoint returns redacted runtime queue job and session summary")
+    func companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary() async throws {
+        let metricsStore = MetricsStore()
+        let schedulerReadModel = SchedulerReadModel(metricsStore: metricsStore)
+        let imageJobReadModel = ImageJobReadModel(now: { Date(timeIntervalSince1970: 1_700) })
+        let temporaryRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-companion-status-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        var snapshot = CacheMetadataStore.emptySnapshot()
+        snapshot.summary.l1Bytes = 2048
+        snapshot.summary.l2Bytes = 4096
+        snapshot.summary.activeMode = .rotating
+
+        let privatePrompt = "PRIVATE COMPANION STATUS PROMPT"
+        let privateNegativePrompt = "PRIVATE NEGATIVE PROMPT"
+        let privateArtifactURI = "file:///Users/chenyu/private/status-image.png"
+        var recipe = Melix_Controlplane_V1_ImageJobRecipeSummary()
+        recipe.prompt = privatePrompt
+        recipe.negativePrompt = privateNegativePrompt
+        recipe.sourceImageUri = privateArtifactURI
+
+        await schedulerReadModel.recordQueued(
+            requestID: "req-companion-status",
+            laneHint: "multimodal.vision.background",
+            priority: 30,
+            queuePosition: 2,
+            workerID: "vision-worker"
+        )
+        await imageJobReadModel.recordQueued(
+            requestID: "req-companion-status",
+            jobID: "img-companion-status",
+            modelID: "melix-dev-image",
+            operation: "image.generation",
+            lane: "multimodal.vision.background",
+            promptDigest: "sha256:prompt-digest",
+            recipe: recipe,
+            sourceArtifactID: "artifact-private-source",
+            promptDelta: privatePrompt,
+            editMode: .iterate
+        )
+        await imageJobReadModel.recordRunning(
+            jobID: "img-companion-status",
+            workerID: "vision-worker",
+            stage: "sampling",
+            pct: 0.5,
+            completedSteps: 2,
+            totalSteps: 4
+        )
+
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel(), warmEmbeddingModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                abortRegistry: AbortRegistry()
+            ),
+            workerRegistry: WorkerRegistry(
+                defaultTextClient: ScriptedWorkerClient(events: []),
+                embeddingClient: ScriptedWorkerClient(events: [])
+            ),
+            metricsStore: metricsStore,
+            schedulerReadModel: schedulerReadModel,
+            imageJobReadModel: imageJobReadModel,
+            cacheMetadataStore: CacheMetadataStore(snapshot: snapshot),
+            gatewayAccessPolicy: GatewayAccessPolicy(
+                mode: .apiKeys,
+                sharedAccessEnabled: true,
+                keys: [
+                    .init(keyID: "codex", label: "Codex", tokenHint: "codex", token: "sk-codex"),
+                ]
+            ),
+            persistentAuthSessionStore: PersistentAuthSessionStore(
+                storeURL: temporaryRoot.appendingPathComponent("persistent-auth-sessions.json"),
+                metricsStore: metricsStore,
+                retentionTTLSeconds: 3600,
+                nowUnixMs: { 1_000 }
+            )
+        )
+
+        let createResponse = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/melix/auth/session",
+                headers: [
+                    "content-type": "application/json",
+                    "x-api-key": "sk-codex",
+                ],
+                body: Data("""
+                {
+                  "remember_me": true,
+                  "scope": "companion_read_only"
+                }
+                """.utf8)
+            )
+        )
+        let createPayload = try await jsonPayload(from: createResponse.body)
+        let sessionToken = try #require((createPayload["resume"] as? [String: Any])?["token"] as? String)
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .get,
+                path: "/v1/melix/companion/status",
+                headers: ["X-Melix-Session": sessionToken],
+                body: Data()
+            )
+        )
+        let body = try await collectBody(response.body)
+        let payload = try #require(JSONSerialization.jsonObject(with: Data(body.utf8)) as? [String: Any])
+        let authorization = try #require(payload["authorization"] as? [String: Any])
+        let runtime = try #require(payload["runtime"] as? [String: Any])
+        let models = try #require(payload["models"] as? [String: Any])
+        let cache = try #require(payload["cache"] as? [String: Any])
+        let queue = try #require(payload["queue"] as? [String: Any])
+        let imageJobs = try #require(payload["image_jobs"] as? [String: Any])
+        let jobs = try #require(imageJobs["jobs"] as? [[String: Any]])
+        let firstJob = try #require(jobs.first)
+        let redaction = try #require(payload["redaction"] as? [String: Any])
+
+        #expect(response.statusCode == 200)
+        #expect(payload["schema_version"] as? String == "melix.companion.status.v1")
+        #expect(payload["read_only"] as? Bool == true)
+        #expect(authorization["scope"] as? String == "companion_read_only")
+        #expect(authorization["state"] as? String == "active")
+        #expect(runtime["status"] as? String == "degraded")
+        #expect((runtime["routes"] as? [String: Any])?["swift_text"] as? Bool == true)
+        #expect(models["ready"] as? Int == 2)
+        #expect(models["total"] as? Int == 2)
+        #expect(cache["l1_bytes"] as? Int == 2048)
+        #expect(cache["l2_bytes"] as? Int == 4096)
+        #expect(cache["active_cache_mode"] as? String == "rotating")
+        #expect(queue["queued_requests"] as? Int == 1)
+        #expect(firstJob["job_id"] as? String == "img-companion-status")
+        #expect(firstJob["state"] as? String == "running")
+        #expect(firstJob["prompt_digest"] as? String == "sha256:prompt-digest")
+        #expect(redaction["raw_prompts"] as? String == "omitted")
+        #expect(redaction["logs"] as? String == "omitted")
+        #expect(body.contains(privatePrompt) == false)
+        #expect(body.contains(privateNegativePrompt) == false)
+        #expect(body.contains(privateArtifactURI) == false)
+        #expect(body.contains("source_image_uri") == false)
+        #expect(body.contains("prompt_delta") == false)
+        #expect(await metricsStore.value(forKey: "companion.status_latency_ms") >= 0)
+    }
+
+    @Test("companion status endpoint supports local trusted empty stores and deterministic job ordering")
+    func companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering() async throws {
+        let imageJobReadModel = ImageJobReadModel(now: { Date(timeIntervalSince1970: 1_800) })
+        await imageJobReadModel.recordQueued(
+            requestID: "req-z",
+            jobID: "job-z",
+            modelID: "melix-dev-image",
+            operation: "image.generation",
+            lane: "multimodal.vision.background"
+        )
+        await imageJobReadModel.recordQueued(
+            requestID: "req-a",
+            jobID: "job-a",
+            modelID: "melix-dev-image",
+            operation: "image.generation",
+            lane: "multimodal.vision.background"
+        )
+
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: []),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                abortRegistry: AbortRegistry()
+            ),
+            imageJobReadModel: imageJobReadModel
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .get,
+                path: "/v1/melix/companion/status",
+                headers: [:],
+                body: Data()
+            )
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let authorization = try #require(payload["authorization"] as? [String: Any])
+        let cache = try #require(payload["cache"] as? [String: Any])
+        let queue = try #require(payload["queue"] as? [String: Any])
+        let imageJobs = try #require(payload["image_jobs"] as? [String: Any])
+        let jobs = try #require(imageJobs["jobs"] as? [[String: Any]])
+
+        #expect(response.statusCode == 200)
+        #expect(authorization["mode"] as? String == "local_trusted")
+        #expect(authorization["scope"] as? String == "operator_control")
+        #expect(cache["active_cache_mode"] as? String == "tiered")
+        #expect(queue["queued_requests"] as? Int == 0)
+        #expect(imageJobs["active"] as? Int == 2)
+        #expect(jobs.map { $0["job_id"] as? String } == ["job-a", "job-z"])
+    }
+
+    @Test("companion status endpoint supports credential auth and newest job ordering")
+    func companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering() async throws {
+        final class Clock: @unchecked Sendable {
+            var date: Date
+
+            init(date: Date) {
+                self.date = date
+            }
+        }
+
+        let clock = Clock(date: Date(timeIntervalSince1970: 1_900))
+        let imageJobReadModel = ImageJobReadModel(now: { clock.date })
+        await imageJobReadModel.recordQueued(
+            requestID: "req-older",
+            jobID: "job-older",
+            modelID: "melix-dev-image",
+            operation: "image.generation",
+            lane: "multimodal.vision.background"
+        )
+        clock.date = Date(timeIntervalSince1970: 1_901)
+        await imageJobReadModel.recordQueued(
+            requestID: "req-newer",
+            jobID: "job-newer",
+            modelID: "melix-dev-image",
+            operation: "image.generation",
+            lane: "multimodal.vision.background"
+        )
+
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: []),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                abortRegistry: AbortRegistry()
+            ),
+            imageJobReadModel: imageJobReadModel,
+            gatewayAccessPolicy: GatewayAccessPolicy(
+                mode: .apiKeys,
+                sharedAccessEnabled: true,
+                keys: [
+                    .init(keyID: "browser-client", label: "Browser Client", tokenHint: "browser-client", token: "sk-browser"),
+                ]
+            )
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .get,
+                path: "/v1/melix/companion/status",
+                headers: ["x-api-key": "sk-browser"],
+                body: Data()
+            )
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let authorization = try #require(payload["authorization"] as? [String: Any])
+        let imageJobs = try #require(payload["image_jobs"] as? [String: Any])
+        let jobs = try #require(imageJobs["jobs"] as? [[String: Any]])
+
+        #expect(response.statusCode == 200)
+        #expect(authorization["mode"] as? String == "credential")
+        #expect(authorization["key_id"] as? String == "browser-client")
+        #expect(jobs.map { $0["job_id"] as? String } == ["job-newer", "job-older"])
     }
 
     @Test("gateway auth session responses sanitize rich output in encoded and manual json payloads")


### PR DESCRIPTION
## Summary
- Add `GET /v1/melix/companion/status` as a scoped, read-only companion status endpoint for the next issue #1759 server-side slice.
- Return a dedicated redacted companion DTO with runtime health, visible models, cache counters, scheduler queues, image job progress, current auth status, and an explicit redaction policy.
- Admit the `x-melix-session` browser preflight header and cover companion session, local trusted, credential auth, ordering, redaction, and latency metric behavior.

Refs #1759.

## Plan or Spec
- `docs/plans/2026-06-14-issue-1759-companion-status-endpoint.md`
- Governing issue: #1759

## Commands Run
```text
make bootstrap
# passed: configured .githooks, uv sync resolved 121 packages and checked 79 packages

make proto
# passed: ./scripts/proto_gen.sh; no generated artifact diff

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary'
# red before implementation: expected failure because /v1/melix/companion/status did not yet return the authorization payload

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/localServerSecurityAllowsExplicitBrowserPreflightWithExactCORSEcho'
# red before implementation: expected failure because access-control-allow-headers omitted x-melix-session

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary|localServerSecurityAllowsExplicitBrowserPreflightWithExactCORSEcho)'
# passed: 2 tests

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companion|gatewayAuthSession|HealthDiagnostics|CacheStats|localServerSecurityAllowsExplicitBrowserPreflightWithExactCORSEcho)'
# passed: 6 tests

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(getHealthDiagnostics|getCacheStats)'
# passed: 6 tests

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering'
# passed

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering'
# passed

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests|PersistentAuthSessionStoreTests'
# passed: 219 tests

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary|companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering|companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering)'
# passed after review fix: 3 tests

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --no-parallel --package-path services/control-plane-swift --filter 'HTTPGatewayTests.RequestCoordinatorTests/emptyModelIdentifiersAreRejectedBeforeDispatch()'
# passed after CI compiler compatibility fix: 1 test; verifies the previously failing request-coordinator compile path

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary|companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering|companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering)'
# passed after CI compiler compatibility fix: 3 tests

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary|companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering|companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering)'
# passed after review cleanup: 3 tests

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIHandlerTests/(companionStatusEndpoint|companionAuthSessionsCanReadStatusAndRevokeThemselvesButCannotMutateRuntime|localServerSecurityAllowsExplicitBrowserPreflightWithExactCORSEcho|getHealthDiagnostics|getCacheStats)'
# passed after review cleanup: 11 tests

UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
# passed after review cleanup: TOTAL 99.76% (412/413); OpenAIHandler.swift 99.37% (158/159); OpenAIHandlerTests.swift 100.00% (254/254)

make swift-test
# passed in pre-commit after review cleanup: rc=0, elapsed=325.9s

make py-test
# passed in pre-commit after review cleanup: 4005 passed, 14 skipped, 2 warnings in 161.97s; rc=0

make integration-test
# passed in pre-commit after review cleanup: 120 passed, 1 skipped in 526.50s; rc=0
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 99.76% (412/413)` for touched Swift gateway/test files.
- Production changed-line coverage: `OpenAIHandler.swift 99.37% (158/159)`.
- Test changed-line coverage: `OpenAIHandlerTests.swift 100.00% (254/254)`.
- Runtime metric added: `companion.status_latency_ms`.
- Observability mode: `minimal`; endpoint records one latency metric and does not call model workers.
- Probe overhead: in-memory read-model assembly plus one latency metric; no worker/model execution in the endpoint path.
- Pre-commit performance report: `.runtime/pre-commit-performance/20260614-004819-05c0f05b/report/report.md`
- Performance report status: `ok`; `Regressions: 0`; `Context regressions: 0`; `Verification failures: 0`; `Selected probes: 0`.

## Known Gaps
- QR/code pairing UX remains deferred.
- Desktop companion-token issuance and revocation controls remain deferred.
- Mobile/narrow viewport dashboard smoke remains deferred.
- Redacted recent receipt and log-tail read models remain deferred.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes; `make proto` produced no diff.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes; lockfiles unchanged.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
