### PR TITLE
perf: bind serving diagnostics finite check

### DIFF
--- a/docs/plans/2026-06-14-serving-diagnostics-finite-fastpath.md
+++ b/docs/plans/2026-06-14-serving-diagnostics-finite-fastpath.md
@@ -1,0 +1,45 @@
+# Serving diagnostics bound finite check fast path
+
+## Summary
+
+This Python-only performance slice is limited to the empty-attribute serving
+diagnostics JSONL fast path in
+`services/mlx-worker-python/worker/productization/serving_diagnostics.py`.
+The behavior stays unchanged while avoiding repeated `math.isfinite` attribute
+lookups for each retained debug event row.
+
+## Registered PR-scoped probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`serving-diagnostics-debug-queue-bounds` in
+`infra/perf/pr_scoped_probes.json`. The probe has focused `test_command`,
+`coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/serving_diagnostics.py`
+- `services/mlx-worker-python/tests/test_serving_diagnostics.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/serving_diagnostics_queue_probe.py`
+
+No registry change is required for this slice.
+
+## Optimization slice
+
+The JSONL writer already has a specialized bytearray extension path for
+empty-attribute events. This slice binds `math.isfinite` once at module import
+as `_IS_FINITE` and uses that bound callable in the direct and bytearray fast
+helpers. This keeps the finite-duration guard in place for invalid values while
+reducing per-event global attribute lookup overhead on the hot serialization
+path.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and the
+registered probe locally on Linux. The PR-scoped performance workflow remains
+the merge gate for base-vs-head validation.
+
+## Success criteria
+
+- Focused Python tests pass.
+- Changed-scope coverage for touched files remains at or above 95%.
+- Registered probe shows non-regressing or improved queue/serialization metrics.
+- GitHub Actions and the PR-scoped performance workflow are green before merge.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -636,6 +636,32 @@ def test_serving_diagnostics_jsonl_fast_path_builds_direct_bytes() -> None:
     assert json.loads(line)["request_id"] == "req-direct-bytes"
 
 
+def test_serving_diagnostics_jsonl_fast_path_uses_bound_finite_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[float] = []
+    original_is_finite = serving_diagnostics_module._IS_FINITE
+
+    def counting_is_finite(value: float) -> bool:
+        calls.append(value)
+        return original_is_finite(value)
+
+    monkeypatch.setattr(serving_diagnostics_module, "_IS_FINITE", counting_is_finite)
+    event = ServingDiagnosticsEvent(
+        request_id="req-bound-finite",
+        phase="decode",
+        event_index=10,
+        status="completed",
+        duration_ms=0.001,
+    )
+
+    line = serving_diagnostics_module._empty_attribute_event_json_line_bytes(event)
+
+    assert line is not None
+    assert json.loads(line)["duration_ms"] == 0.001
+    assert calls == [0.001]
+
+
 def test_serving_diagnostics_jsonl_fast_path_reuses_duration_literal_cache() -> None:
     serving_diagnostics_module._ascii_float_literal.cache_clear()
     rows = tuple(

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -34,6 +34,7 @@ _EMPTY_EVENT_ATTRIBUTES: Mapping[str, object] = MappingProxyType({})
 _JSON_COMPACT_SEPARATORS = (",", ":")
 _JSONL_ENCODER = json.JSONEncoder(sort_keys=True, separators=_JSON_COMPACT_SEPARATORS)
 _JSON_STRING_ENCODER = json.encoder.encode_basestring_ascii
+_IS_FINITE = math.isfinite
 _SET_FROZEN_ATTR = object.__setattr__
 _EMPTY_EVENT_JSON_DECODE_COMPLETED_PREFIX = b'{"attributes":{},"duration_ms":'
 _EMPTY_EVENT_JSON_DECODE_COMPLETED_MID = b',"event_index":'
@@ -622,7 +623,7 @@ def _extend_empty_attribute_event_json_line_bytes(
     duration_ms = event.duration_ms
     if type(event_index) is not int or type(duration_ms) is not float:
         return False
-    if not math.isfinite(duration_ms):
+    if not _IS_FINITE(duration_ms):
         return False
     phase = event.phase
     request_id = event.request_id
@@ -666,7 +667,7 @@ def _empty_attribute_event_json_line_bytes(
     duration_ms = event.duration_ms
     if type(event_index) is not int or type(duration_ms) is not float:
         return None
-    if not math.isfinite(duration_ms):
+    if not _IS_FINITE(duration_ms):
         return None
     phase = event.phase
     request_id = event.request_id


### PR DESCRIPTION
## Summary
- Bind `math.isfinite` once for the serving diagnostics empty-attribute JSONL fast path.
- Add a focused regression test proving the fast path uses the bound finite guard.
- Document the single-slice plan and registered probe coverage.

## Plan or Spec
- `docs/plans/2026-06-14-serving-diagnostics-finite-fastpath.md`
- Registered probe: `serving-diagnostics-debug-queue-bounds`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py`
- `MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py`
- `uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id serving-diagnostics-debug-queue-bounds --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/serving_diag_pr_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 51 passed.
- Changed-scope coverage: 100% (`TOTAL 15 0 100%`).
- Local registered probe comparison:
  - `elapsed_ms_mean`: base `5.347605`, head `5.349710` ms (`+0.002105` ms, +0.04%).
  - `serialization_elapsed_ms_mean`: base `0.964159`, head `0.925228` ms (`-0.038931` ms, ~4.04% faster).
  - `serialized_bytes`: base/head `10944`.
  - `dropped_count`: base/head `4032`; `retained_count`: base/head `64`.

## Known Gaps
- Local validation is Linux-only for this Python slice; GitHub Actions PR-scoped performance remains the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally against base and head.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
