### PR TITLE
perf: skip HF fallback snapshot resolve

### DIFF
--- a/docs/plans/2026-05-04-real-model-support-hf-cache-latest-snapshot.md
+++ b/docs/plans/2026-05-04-real-model-support-hf-cache-latest-snapshot.md
@@ -29,6 +29,14 @@ Register `real-model-support-hf-cache-latest-snapshot` in the PR-scoped performa
 - `snapshot_count` (guardrail)
 - `selected_latest_snapshot` (guardrail)
 
+2026-06-14 follow-up slice: after the single-pass scan has selected the latest
+snapshot name, the fallback now returns the already-absolute `snapshots_root /
+latest_snapshot_name` path directly instead of resolving that snapshot path a
+second time. The registered script now reports the HF-cache fallback metrics as
+`hf_cache_elapsed_ms_mean` and `hf_cache_peak_bytes_mean` alongside the existing
+weight-file scan metric, so the PR-scoped report gates this fallback path
+directly.
+
 ## Success metrics
 
 - Focused pytest for the real-model support fallback and PR-scoped probe registration passes.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2685,6 +2685,18 @@
     "coverage_replays_tests": true,
     "metrics": [
       {
+        "key": "hf_cache_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "hf_cache_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 10.0
+      },
+      {
         "key": "weight_scan_elapsed_ms_mean",
         "unit": "ms",
         "direction": "lower_is_better",

--- a/scripts/real_model_support.py
+++ b/scripts/real_model_support.py
@@ -301,7 +301,7 @@ def _huggingface_cache_model_path(
                 latest_snapshot_name = entry.name
     if latest_snapshot_name is None:
         return None
-    fallback = (snapshots_root / latest_snapshot_name).resolve()
+    fallback = snapshots_root / latest_snapshot_name
     return _HuggingFaceCacheModelPath(
         path=fallback,
         warnings=(

--- a/scripts/real_model_support_hf_cache_probe.py
+++ b/scripts/real_model_support_hf_cache_probe.py
@@ -108,6 +108,8 @@ def _measure() -> dict[str, float]:
         )
 
     return {
+        "hf_cache_elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+        "hf_cache_peak_bytes_mean": round(statistics.fmean(peak_samples), 1),
         "sample_count": float(SAMPLE_COUNT),
         "snapshot_count": float(SNAPSHOT_COUNT),
         "selected_latest_snapshot": float(SNAPSHOT_COUNT - 1),

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -4660,6 +4660,8 @@ def test_real_model_support_hf_cache_probe_script_emits_metrics(
     assert payload["sample_count"] == 7.0
     assert payload["snapshot_count"] == 6000.0
     assert payload["selected_latest_snapshot"] == 5999.0
+    assert payload["hf_cache_elapsed_ms_mean"] > 0
+    assert payload["hf_cache_peak_bytes_mean"] > 0
     assert payload["weight_scan_elapsed_ms_mean"] > 0
     assert payload["weight_file_count"] == 20_000.0
 


### PR DESCRIPTION
## Summary
- Skip the extra `Path.resolve()` call after the HF cache fallback has selected the latest snapshot directory.
- Extend the registered real-model support probe to report HF-cache fallback elapsed/peak metrics directly.
- Document the follow-up slice in the existing real-model HF cache optimization plan.

## Plan or Spec
- Updated `docs/plans/2026-05-04-real-model-support-hf-cache-latest-snapshot.md` with the 2026-06-14 follow-up slice and probe metric coverage.

## Commands Run
- `git fetch origin main && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_does_not_follow_symlinked_directories tests/test_real_model_support.py::test_runtime_model_preflight_short_circuits_common_exact_weight_file services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_does_not_follow_symlinked_directories tests/test_real_model_support.py::test_runtime_model_preflight_short_circuits_common_exact_weight_file services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/real_model_support.py tests/test_real_model_support.py scripts/real_model_support_hf_cache_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/real_model_support_hf_cache_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 7 passed.
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Registered local probe (head): `hf_cache_elapsed_ms_mean=18.881518`, `hf_cache_peak_bytes_mean=4121.0`, `weight_scan_elapsed_ms_mean=0.029404`, `snapshot_count=6000`, `selected_latest_snapshot=5999`.
- Local baseline micro comparison for the HF fallback path over three synthetic-cache runs: `old_mean=21.172927ms`, `new_mean=20.276562ms`, `speedup=1.0442x`, `delta_ms=-0.896365`.

## Known Gaps
- Linux validates the Python helper and registered probe locally. GitHub Actions remains the merge gate for the registered PR-scoped performance report.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe emitted metrics.
- [ ] PR-scoped performance workflow completed successfully in CI.
