### PR TITLE
perf: fast-path flat code eval asserts

### DIFF
--- a/docs/plans/2026-05-16-code-eval-assert-node-loop.md
+++ b/docs/plans/2026-05-16-code-eval-assert-node-loop.md
@@ -26,6 +26,12 @@ The traversal order is not observable because the helper only counts
 `ast.Assert` nodes, and behavior stays unchanged for nested asserts and modules
 without asserts.
 
+2026-06-14 follow-up: the all-top-level-assert fast path now uses an explicit
+loop/`else` instead of `all(...)` with a generator expression. The probe's
+`assert_elapsed_ms_mean` path repeatedly counts a flat assert module, so this
+slice avoids generator overhead while preserving the nested traversal fallback
+for mixed or nested statement containers.
+
 ## Verification Plan
 
 - Run focused code-evaluation count tests, including the new no-assert helper

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -279,8 +279,12 @@ def _count_assert_nodes(
     _type=type,
 ) -> int:
     module_body = getattr(module, "body", ())
-    if module_body and all(_type(node) is _assert_type for node in module_body):
-        return len(module_body)
+    if module_body:
+        for node in module_body:
+            if _type(node) is not _assert_type:
+                break
+        else:
+            return len(module_body)
 
     count = 0
     stack: list[ast.AST] = []


### PR DESCRIPTION
## Summary
- Fast-path `_count_assert_nodes()` for flat modules that contain only top-level `assert` statements by replacing `all(...)` generator overhead with an explicit loop/`else`.
- Preserve the existing nested/mixed statement traversal fallback and code-evaluation test-count behavior.

## Plan or Spec
- `docs/plans/2026-05-16-code-eval-assert-node-loop.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_count_tests_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_count_tests_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 13 passed in 0.33s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_count_tests_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_count_tests_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_count_tests_probe.py
# 13 passed in 3.29s; changed-line coverage TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_count_tests_probe.py
# {"assert_elapsed_ms_mean": 3.615715474422489, "elapsed_ms_mean": 1.1333241792661803, "peak_bytes_mean": 76728.57142857143, ...}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/engine/code_eval_runner.py` changed lines 282, 283, 284, 285, 287 covered; aggregate `TOTAL 5 0 100%`.
- Registered probe: `code-eval-count-tests-line-scan` is present in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command`.
- Local Linux probe comparison (3 origin/main samples vs 4 branch samples): `assert_elapsed_ms_mean` old mean `6.786905539532502 ms`, new mean `3.6295514354216203 ms`, delta `-3.157354104110882 ms` (`46.52%` faster). Latest branch probe sample: `assert_elapsed_ms_mean=3.615715474422489 ms`, `elapsed_ms_mean=1.1333241792661803 ms`, `peak_bytes_mean=76728.57142857143`.
- CI PR-scoped performance is required as the merge gate after PR creation.

## Known Gaps
- Swift/macOS runtime effects are not involved; this is a Python-only slice verified locally on Linux.
- Broader `make py-test` was not run; this PR uses the registered focused command set for the touched probe scope.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability/debug mode changes.
- [x] Deferred work and known gaps are stated explicitly.
