### PR TITLE
Add companion recent receipt summaries

### DIFF
--- a/docs/plans/2026-06-14-issue-1759-companion-recent-receipts.md
+++ b/docs/plans/2026-06-14-issue-1759-companion-recent-receipts.md
@@ -1,0 +1,177 @@
+# Issue 1759 Companion Recent Receipts
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a redacted recent-receipts summary to the read-only companion status endpoint for issue #1759.
+
+**Architecture:** Keep companion status as a narrow HTTP DTO owned by `OpenAIHandler`. Derive recent receipt rows from the existing `ImageJobReadModel` snapshot, expose only identifiers, state, timing, digest, progress, artifact count, and failure code, and keep raw prompts, request bodies, local paths, artifact URIs, error messages, and log text out of the companion payload.
+
+**Tech Stack:** Swift control plane HTTP gateway, `ImageJobReadModel`, Swift Testing, changed-line coverage tooling, pre-commit performance report.
+
+---
+
+## Context
+
+Issue #1759 still needs read-only companion views for active jobs, recent receipts, and redacted log tail. PR #2074 added `GET /v1/melix/companion/status` with runtime, model, queue, cache, image-job, and authorization summaries, but intentionally kept receipt and log content omitted until a redacted read model existed.
+
+This slice adds the first redacted receipt read model to the existing status endpoint. It intentionally derives from image jobs only because that read model already exists and already tracks long-running companion-relevant operations. It does not introduce a general log-tail reader.
+
+## Slice Boundary
+
+This transaction adds:
+
+- a top-level `recent_receipts` object in `melix.companion.status.v1`;
+- newest-first image-job receipt summaries with deterministic tie-breaking;
+- per-receipt redaction metadata;
+- redaction status `recent_receipts: "redacted_summary"`;
+- tests proving private prompts, prompt deltas, source artifact IDs, storage URIs, local paths, and error messages do not appear.
+
+This transaction does not add:
+
+- QR/code pairing UX;
+- desktop companion-token issuance or revocation controls;
+- mobile/narrow viewport UI smoke;
+- a generic receipt store for non-image operations;
+- redacted log-tail read models or UI.
+
+## Performance Probes and Metrics
+
+- Runtime metric remains `companion.status_latency_ms` on the aggregate endpoint.
+- The new receipt section reuses the already-loaded `ImageJobReadModel` snapshot and performs one in-memory sort with a visible limit of 10 rows.
+- Success metric: focused Swift tests cover the new receipt payload and redaction contract; changed-line coverage for touched Swift files remains at least 95 percent.
+- PR merge gate: scoped performance report must stay `Status: ok` with zero regressions.
+
+## Implementation Plan
+
+### Task 1: Add the Failing Recent Receipts Contract Test
+
+**Files:**
+- Modify: `services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift`
+
+- [x] **Step 1: Write the failing test**
+
+Add a Swift test near the companion status endpoint tests:
+
+```swift
+@Test("companion status endpoint returns redacted recent receipt summaries")
+func companionStatusEndpointReturnsRedactedRecentReceiptSummaries() async throws {
+    // Seed two image jobs with private prompts, prompt deltas, local artifact
+    // URIs, and a private error message.
+    // Call GET /v1/melix/companion/status.
+    // Assert recent_receipts exists, orders newest first, includes only safe
+    // receipt fields, marks raw fields as omitted, and excludes private text.
+}
+```
+
+- [x] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/companionStatusEndpointReturnsRedactedRecentReceiptSummaries'
+```
+
+Expected: FAIL because the companion status response has no top-level `recent_receipts` object yet.
+
+### Task 2: Implement the Recent Receipts DTO
+
+**Files:**
+- Modify: `services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift`
+
+- [x] **Step 1: Add `recentReceipts` to `CompanionStatusResponse`**
+
+Populate it from the same `imageJobsSnapshot` already read by `handleCompanionStatus`.
+
+- [x] **Step 2: Add receipt payload types**
+
+Add `CompanionRecentReceiptStatusPayload`, `CompanionRecentReceiptPayload`, and `CompanionRecentReceiptRedactionPayload`. Sort by `updated_at_unix_ms` descending, then `job_id` ascending, and cap visible rows at 10.
+
+- [x] **Step 3: Keep fields redacted by construction**
+
+Expose only:
+
+- `receipt_type`
+- `source`
+- `job_id`
+- `request_id`
+- `model_id`
+- `operation`
+- `state`
+- `lane`
+- `worker_id`
+- `progress`
+- `created_at_unix_ms`
+- `updated_at_unix_ms`
+- `prompt_digest`
+- `artifact_count`
+- `failure_code`
+- `redaction`
+
+Do not expose recipe fields, raw error messages, prompt deltas, artifact IDs, artifact storage URIs, local paths, request bodies, or log lines.
+
+- [x] **Step 4: Update the redaction block**
+
+Change `recent_receipts` from `omitted` to `redacted_summary`; keep `logs` as `omitted` until a log-tail read model exists.
+
+### Task 3: Verify Green, Coverage, Metrics, Commit, and PR
+
+**Files:**
+- Test: `services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift`
+
+- [x] **Step 1: Run focused green tests**
+
+Run:
+
+```bash
+HOME="$(pwd)/.swift-home" CLANG_MODULE_CACHE_PATH="$(pwd)/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedRecentReceiptSummaries|companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary|companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering|companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering)'
+```
+
+Expected: PASS.
+
+- [x] **Step 2: Run changed-line coverage**
+
+Run Swift coverage for the touched companion status tests, then:
+
+```bash
+UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+```
+
+Expected: changed-line coverage is at least 95 percent.
+
+- [x] **Step 3: Run full local gate**
+
+Run:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit and use the pre-commit performance report**
+
+Run `make git-hooks-install` if needed, commit the plan/test/code changes, and let the pre-commit hook produce the scoped performance report. The report must show no performance regressions before pushing.
+
+- [ ] **Step 5: Open and monitor the PR**
+
+Fill `.github/pull_request_template.md` exactly. Include this plan under `## Plan or Spec`, all command results under `## Commands Run`, coverage/performance under `## Coverage and Metrics`, and deferred QR/UI/log-tail work under `## Known Gaps`.
+
+Monitor CI, review threads, conflicts, and the PR performance report. Fix any in-scope failure or regression before squash merging.
+
+## Verification Results
+
+- Red contract test:
+  - `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/companionStatusEndpointReturnsRedactedRecentReceiptSummaries'`
+  - Result before implementation: expected failure because `payload["recent_receipts"]` was `nil`.
+- Focused green tests:
+  - `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/companionStatusEndpointReturnsRedactedRecentReceiptSummaries'` passed 1 test.
+  - `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedRecentReceiptSummaries|companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary|companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering|companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering)'` passed 4 tests.
+- Changed-line coverage:
+  - `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedRecentReceiptSummaries|companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary|companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering|companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering)'` passed 4 tests.
+  - `UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift` reported `TOTAL 100.00% (162/162)`.
+- Full local gate:
+  - `make swift-test` passed. The final macOS menubar stage reported `796 tests in 25 suites passed`.
+  - `make py-test` passed with `4014 passed, 14 skipped, 2 warnings`.
+  - `make integration-test` passed with `120 passed, 1 skipped`.

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -1001,6 +1001,7 @@ public struct OpenAIHandler: Sendable {
             cache: CompanionCacheStatusPayload(summary: summary),
             queue: CompanionQueueStatusPayload(summary: queueSnapshot),
             imageJobs: CompanionImageJobStatusPayload(jobs: imageJobsSnapshot),
+            recentReceipts: CompanionRecentReceiptStatusPayload(jobs: imageJobsSnapshot),
             redaction: CompanionRedactionStatusPayload()
         )
         await metricsStore.set(
@@ -5514,7 +5515,7 @@ private struct HealthDiagnosticsModelResponse: Codable {
     }
 }
 
-private struct CompanionStatusResponse: Codable {
+private struct CompanionStatusResponse: Encodable {
     let schemaVersion = "melix.companion.status.v1"
     let readOnly: Bool
     let status: String
@@ -5524,6 +5525,7 @@ private struct CompanionStatusResponse: Codable {
     let cache: CompanionCacheStatusPayload
     let queue: CompanionQueueStatusPayload
     let imageJobs: CompanionImageJobStatusPayload
+    let recentReceipts: CompanionRecentReceiptStatusPayload
     let redaction: CompanionRedactionStatusPayload
 
     enum CodingKeys: String, CodingKey {
@@ -5536,6 +5538,7 @@ private struct CompanionStatusResponse: Codable {
         case cache
         case queue
         case imageJobs = "image_jobs"
+        case recentReceipts = "recent_receipts"
         case redaction
     }
 }
@@ -5797,13 +5800,111 @@ private struct CompanionImageJobPayload: Codable {
     }
 }
 
+private let companionRecentReceiptVisibleLimit = 10
+
+private struct CompanionRecentReceiptStatusPayload: Encodable {
+    let source: String
+    let visible: Int
+    let total: Int
+    let items: [CompanionRecentReceiptPayload]
+
+    init(jobs: [Melix_Controlplane_V1_ImageJobSummary]) {
+        let sortedJobs = jobs.sorted { lhs, rhs in
+            if lhs.updatedAtUnixMs == rhs.updatedAtUnixMs {
+                return lhs.jobID < rhs.jobID
+            }
+            return lhs.updatedAtUnixMs > rhs.updatedAtUnixMs
+        }
+        let visibleJobs = Array(sortedJobs.prefix(companionRecentReceiptVisibleLimit))
+        source = "image_jobs"
+        visible = visibleJobs.count
+        total = jobs.count
+        items = visibleJobs.map(CompanionRecentReceiptPayload.init(job:))
+    }
+}
+
+private struct CompanionRecentReceiptPayload: Encodable {
+    let receiptType = "image_job"
+    let source = "image_jobs"
+    let jobID: String
+    let requestID: String
+    let modelID: String
+    let operation: String
+    let state: String
+    let lane: String
+    let workerID: String
+    let progress: OpenAIImageJobProgressPayload
+    let createdAtUnixMs: Int64
+    let updatedAtUnixMs: Int64
+    let promptDigest: String
+    let artifactCount: Int
+    let failureCode: String
+    let redaction: CompanionRecentReceiptRedactionPayload
+
+    init(job: Melix_Controlplane_V1_ImageJobSummary) {
+        jobID = job.jobID
+        requestID = job.requestID
+        modelID = job.modelID
+        operation = job.operation
+        state = job.state.melixString
+        lane = job.lane
+        workerID = job.workerID
+        progress = OpenAIImageJobProgressPayload(progress: job.progress)
+        createdAtUnixMs = job.createdAtUnixMs
+        updatedAtUnixMs = job.updatedAtUnixMs
+        promptDigest = job.promptDigest
+        artifactCount = job.artifacts.count
+        failureCode = job.error.code
+        redaction = CompanionRecentReceiptRedactionPayload()
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case receiptType = "receipt_type"
+        case source
+        case jobID = "job_id"
+        case requestID = "request_id"
+        case modelID = "model_id"
+        case operation
+        case state
+        case lane
+        case workerID = "worker_id"
+        case progress
+        case createdAtUnixMs = "created_at_unix_ms"
+        case updatedAtUnixMs = "updated_at_unix_ms"
+        case promptDigest = "prompt_digest"
+        case artifactCount = "artifact_count"
+        case failureCode = "failure_code"
+        case redaction
+    }
+}
+
+private struct CompanionRecentReceiptRedactionPayload: Encodable {
+    let rawPrompt = "omitted"
+    let promptDelta = "omitted"
+    let requestBody = "omitted"
+    let artifactURIs = "omitted"
+    let localPaths = "omitted"
+    let errorMessage = "omitted"
+    let logs = "omitted"
+
+    enum CodingKeys: String, CodingKey {
+        case rawPrompt = "raw_prompt"
+        case promptDelta = "prompt_delta"
+        case requestBody = "request_body"
+        case artifactURIs = "artifact_uris"
+        case localPaths = "local_paths"
+        case errorMessage = "error_message"
+        case logs
+    }
+}
+
 private struct CompanionRedactionStatusPayload: Codable {
     let rawPrompts = "omitted"
     let rawRequestBodies = "omitted"
     let localPaths = "omitted"
     let artifactURIs = "omitted"
     let logs = "omitted"
-    let recentReceipts = "omitted"
+    let recentReceipts = "redacted_summary"
 
     enum CodingKeys: String, CodingKey {
         case rawPrompts = "raw_prompts"

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -1028,7 +1028,6 @@ struct OpenAIHandlerTests {
         #expect(body.contains(privateNegativePrompt) == false)
         #expect(body.contains(privateArtifactURI) == false)
         #expect(body.contains("source_image_uri") == false)
-        #expect(body.contains("prompt_delta") == false)
         #expect(await metricsStore.value(forKey: "companion.status_latency_ms") >= 0)
     }
 
@@ -1086,10 +1085,22 @@ struct OpenAIHandlerTests {
     @Test("companion status endpoint supports credential auth and newest job ordering")
     func companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering() async throws {
         final class Clock: @unchecked Sendable {
-            var date: Date
+            private var lockedDate: Date
+            private let lock = NSLock()
+
+            var date: Date {
+                get {
+                    lock.withLock { lockedDate }
+                }
+                set {
+                    lock.withLock {
+                        lockedDate = newValue
+                    }
+                }
+            }
 
             init(date: Date) {
-                self.date = date
+                self.lockedDate = date
             }
         }
 
@@ -1144,6 +1155,142 @@ struct OpenAIHandlerTests {
         #expect(authorization["mode"] as? String == "credential")
         #expect(authorization["key_id"] as? String == "browser-client")
         #expect(jobs.map { $0["job_id"] as? String } == ["job-newer", "job-older"])
+    }
+
+    @Test("companion status endpoint returns redacted recent receipt summaries")
+    func companionStatusEndpointReturnsRedactedRecentReceiptSummaries() async throws {
+        final class Clock: @unchecked Sendable {
+            private var lockedDate: Date
+            private let lock = NSLock()
+
+            var date: Date {
+                get {
+                    lock.withLock { lockedDate }
+                }
+                set {
+                    lock.withLock {
+                        lockedDate = newValue
+                    }
+                }
+            }
+
+            init(date: Date) {
+                self.lockedDate = date
+            }
+        }
+
+        let clock = Clock(date: Date(timeIntervalSince1970: 2_000))
+        let imageJobReadModel = ImageJobReadModel(now: { clock.date })
+
+        let privatePrompt = "PRIVATE RECENT RECEIPT PROMPT"
+        let privatePromptDelta = "PRIVATE RECENT RECEIPT DELTA"
+        let privateNegativePrompt = "PRIVATE RECENT RECEIPT NEGATIVE"
+        let privateSourceURI = "file:///Users/chenyu/private/recent-source.png"
+        let privateStorageURI = "file:///Users/chenyu/private/recent-output.png"
+        let privateErrorMessage = "PRIVATE RECENT RECEIPT ERROR"
+        let privateSourceArtifactID = "private-source-artifact"
+
+        var recipe = Melix_Controlplane_V1_ImageJobRecipeSummary()
+        recipe.prompt = privatePrompt
+        recipe.negativePrompt = privateNegativePrompt
+        recipe.sourceImageUri = privateSourceURI
+
+        await imageJobReadModel.recordQueued(
+            requestID: "req-receipt-old",
+            jobID: "job-receipt-old",
+            modelID: "melix-dev-image",
+            operation: "image.generation",
+            lane: "multimodal.vision.background",
+            promptDigest: "sha256:old",
+            recipe: recipe,
+            sourceArtifactID: privateSourceArtifactID,
+            promptDelta: privatePromptDelta
+        )
+
+        var artifact = Melix_Controlplane_V1_ImageArtifactRef()
+        artifact.artifactID = "private-output-artifact"
+        artifact.jobID = "job-receipt-old"
+        artifact.role = .imageArtifactGenerated
+        artifact.mimeType = "image/png"
+        artifact.format = "png"
+        artifact.width = 1024
+        artifact.height = 1024
+        artifact.byteLength = 4096
+        artifact.storageUri = privateStorageURI
+        artifact.variantIndex = 0
+        await imageJobReadModel.recordCompleted(jobID: "job-receipt-old", artifacts: [artifact])
+
+        clock.date = Date(timeIntervalSince1970: 2_001)
+        await imageJobReadModel.recordQueued(
+            requestID: "req-receipt-new",
+            jobID: "job-receipt-new",
+            modelID: "melix-dev-image",
+            operation: "image.edit",
+            lane: "multimodal.vision.background",
+            promptDigest: "sha256:new",
+            recipe: recipe,
+            sourceArtifactID: privateSourceArtifactID,
+            promptDelta: privatePromptDelta,
+            editMode: .iterate
+        )
+        var error = Melix_Controlplane_V1_ErrorStatus()
+        error.code = "worker_failed"
+        error.message = privateErrorMessage
+        await imageJobReadModel.recordFailed(jobID: "job-receipt-new", error: error)
+
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: []),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                abortRegistry: AbortRegistry()
+            ),
+            imageJobReadModel: imageJobReadModel
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .get,
+                path: "/v1/melix/companion/status",
+                headers: [:],
+                body: Data()
+            )
+        )
+        let body = try await collectBody(response.body)
+        let payload = try #require(JSONSerialization.jsonObject(with: Data(body.utf8)) as? [String: Any])
+        let recentReceipts = try #require(payload["recent_receipts"] as? [String: Any])
+        let items = try #require(recentReceipts["items"] as? [[String: Any]])
+        let first = try #require(items.first)
+        let firstRedaction = try #require(first["redaction"] as? [String: Any])
+        let redaction = try #require(payload["redaction"] as? [String: Any])
+
+        #expect(response.statusCode == 200)
+        #expect(recentReceipts["total"] as? Int == 2)
+        #expect(recentReceipts["visible"] as? Int == 2)
+        #expect(recentReceipts["source"] as? String == "image_jobs")
+        #expect(items.map { $0["job_id"] as? String } == ["job-receipt-new", "job-receipt-old"])
+        #expect(first["receipt_type"] as? String == "image_job")
+        #expect(first["source"] as? String == "image_jobs")
+        #expect(first["request_id"] as? String == "req-receipt-new")
+        #expect(first["state"] as? String == "failed")
+        #expect(first["prompt_digest"] as? String == "sha256:new")
+        #expect(first["artifact_count"] as? Int == 0)
+        #expect(first["failure_code"] as? String == "worker_failed")
+        #expect(firstRedaction["raw_prompt"] as? String == "omitted")
+        #expect(firstRedaction["prompt_delta"] as? String == "omitted")
+        #expect(firstRedaction["artifact_uris"] as? String == "omitted")
+        #expect(firstRedaction["local_paths"] as? String == "omitted")
+        #expect(firstRedaction["error_message"] as? String == "omitted")
+        #expect(redaction["recent_receipts"] as? String == "redacted_summary")
+        #expect(redaction["logs"] as? String == "omitted")
+        #expect(body.contains(privatePrompt) == false)
+        #expect(body.contains(privatePromptDelta) == false)
+        #expect(body.contains(privateNegativePrompt) == false)
+        #expect(body.contains(privateSourceURI) == false)
+        #expect(body.contains(privateStorageURI) == false)
+        #expect(body.contains(privateSourceArtifactID) == false)
+        #expect(body.contains(privateErrorMessage) == false)
+        #expect(body.contains("storage_uri") == false)
+        #expect(body.contains("source_artifact_id") == false)
     }
 
     @Test("gateway auth session responses sanitize rich output in encoded and manual json payloads")


### PR DESCRIPTION
## Summary
- Adds a redacted `recent_receipts` summary to `GET /v1/melix/companion/status` for read-only companion clients.
- Derives rows from the existing image job read model, caps visible rows at 10, orders newest first with deterministic tie-breaking, and exposes only safe identifiers, state, timing, digest, progress, artifact count, failure code, and explicit redaction metadata.

## Plan or Spec
- `docs/plans/2026-06-14-issue-1759-companion-recent-receipts.md`
- Governing issue: #1759

## Commands Run
```text
make bootstrap
PASS: configured hooks and checked the locked Python environment.

make proto
PASS: regenerated protocol artifacts; git status stayed clean.

git diff --check
PASS: no whitespace errors.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/companionStatusEndpointReturnsRedactedRecentReceiptSummaries'
EXPECTED FAIL before implementation: companion status had no recent_receipts payload.
PASS after implementation: 1 test passed.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedRecentReceiptSummaries|companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary|companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering|companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering)'
PASS: 4 tests passed.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companion|gatewayAuthSession|HealthDiagnostics|CacheStats)'
PASS: 8 tests passed.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedRecentReceiptSummaries|companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary|companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering|companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering)'
PASS before and after review fix: 4 tests passed with coverage data.

gh api repos/Keith-CY/melix/pulls/2080/comments/<comment-id>/replies ...
PASS: replied to all inline review threads with either the fix made or no-change rationale, then resolved the threads.

UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
PASS before review fix: TOTAL 100.00% (162/162) changed-line coverage.
PASS after review fix: TOTAL 100.00% (188/188) changed-line coverage.

make swift-test
PASS: full Swift gate passed, including macOS menubar stage with 796 tests in 25 suites.

make py-test
PASS: 4014 passed, 14 skipped, 2 warnings.

make integration-test
PASS: 120 passed, 1 skipped.

make git-hooks-install
PASS: configured git hooks path .githooks.

git commit -m "feat: add companion recent receipt summaries"
PASS: pre-commit reran make swift-test, make py-test, make integration-test, and scoped performance reporting successfully.

git commit --amend --no-edit
PASS after review fix: pre-commit reran make swift-test, make py-test, make integration-test, and scoped performance reporting successfully.
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 100.00% (188/188)` for `OpenAIHandler.swift` and `OpenAIHandlerTests.swift` after review fixes.
- Runtime metric: existing `companion.status_latency_ms` remains the status endpoint latency metric.
- Observability mode: minimal. This adds no debug/evidence-mode probes and no new production metric cardinality.
- Probe overhead: new receipt summary reuses the already-loaded image job snapshot, performs one in-memory sort, and caps visible rows at 10.
- Initial pre-commit scoped performance report: `.runtime/pre-commit-performance/20260614-075452-b0a8e8de/report/report.md` reported `Status: ok`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`.
- Post-review pre-commit scoped performance report: `.runtime/pre-commit-performance/20260614-082751-13286b60/report/report.md` reported `Status: ok`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`.
- Remote PR scoped performance workflow for head `d1d124d8` passed: `Status: ok`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`; no registered probes were selected for this change set.

## Known Gaps
- QR/code pairing UX remains deferred.
- Desktop companion-token issuance/revocation controls remain deferred.
- Mobile/narrow viewport smoke remains deferred.
- Generic non-image receipt storage remains deferred.
- Redacted log-tail read model and UI remain deferred.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.


