### PR TITLE
Add runtime GRPO candidate receipt summaries

### DIFF
--- a/docs/plans/2026-06-14-issue-1761-runtime-grpo-candidate-receipts.md
+++ b/docs/plans/2026-06-14-issue-1761-runtime-grpo-candidate-receipts.md
@@ -1,0 +1,86 @@
+# Issue 1761 Runtime GRPO Candidate Receipt Summary Plan
+
+## Goal
+
+Preserve untrusted-context receipt evidence for every runtime-generated GRPO
+candidate that executes agentic tools, without copying full tool observations
+for non-selected candidates.
+
+## Scope
+
+This slice is limited to Python worker GRPO runtime-generation trace evidence in
+`worker.model_ops.rl_alignment_training`:
+
+- keep selected candidate rows unchanged: selected candidates still carry full
+  `agentic_tool_observations`;
+- add scalar receipt evidence to each generated candidate and candidate reward
+  trace row that has a tool run;
+- preserve the existing omission of full non-selected tool observations;
+- avoid copying tool payloads, retrieved text, page content, media refs, prompt
+  text, or receipt bodies into the new scalar fields;
+- update this plan and focused tests for the runtime GRPO tool trajectory path.
+
+Out of scope:
+
+- changing agentic tool execution, reward scoring, fatal-state masking, or
+  candidate selection;
+- storing full non-selected observations;
+- adding live RAG, skill, memory, MCP, workflow, or local-job execution wiring;
+- changing benchmark request-row receipt evidence.
+
+## Architecture
+
+`_attach_runtime_candidate_tool_evidence` already records candidate-local tool
+calls, tool metrics, and observation counts. It does not expose whether those
+observations carried untrusted-context receipts unless the candidate later
+becomes the selected trace row and receives full `agentic_tool_observations`.
+
+This slice derives a small receipt summary from the existing
+`tool_run.observations` payloads:
+
+- `agentic_tool_untrusted_context_receipt_schema`
+- `agentic_tool_untrusted_context_receipt_count`
+
+The schema is the first string `schema_version` found on a mapping-shaped
+receipt. The count is the total number of mapping-shaped receipts across all
+candidate observations. Malformed receipt values are ignored for the summary so
+they do not inflate evidence counts. The summary is attached to
+`generated_candidates` entries and copied into candidate reward trace rows.
+Selected rows still attach the full tool run through `_attach_agentic_tool_run`.
+
+## Performance Probes And Metrics
+
+The changed path adds a linear scan over already-materialized candidate tool
+observation receipt lists. It adds no model inference, filesystem access,
+network access, scheduler work, retrieval ranking, or persistent store access.
+
+Verification must include:
+
+- focused pytest for `test_rl_alignment_runtime_tool_trajectories.py`;
+- changed-line coverage for touched Python files at 95 percent or higher;
+- `git diff --check`;
+- scoped performance report with status `ok`, regressions `0`, context
+  regressions `0`, and verification failures `0`;
+- the required local gate before opening the PR.
+
+## Implementation Steps
+
+1. Add a failing regression test proving selected and non-selected runtime GRPO
+   candidates expose receipt schema/count summary fields while non-selected
+   candidate reward trace rows still omit full `agentic_tool_observations`.
+2. Implement a small summary helper in `rl_alignment_training.py` that scans
+   mapping-shaped `untrusted_context_receipts` values from tool observations.
+3. Attach the summary in `_attach_runtime_candidate_tool_evidence`.
+4. Copy the summary into `_runtime_candidate_reward_trace_rows`.
+5. Run focused tests, changed-line coverage, diff checks, scoped performance,
+   and the required local gate before opening the PR.
+
+## Success Criteria
+
+- Every runtime-generated candidate with a tool run exposes receipt schema and
+  receipt count summary evidence.
+- Candidate reward trace rows expose the same summary for selected and
+  non-selected candidates.
+- Non-selected trace rows still omit full `agentic_tool_observations`.
+- New scalar fields do not include tool payloads, retrieved text, page content,
+  media references, prompt text, or receipt bodies.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -875,6 +875,22 @@ The `model_final_answer` classification records the projection boundary for
 prior assistant output only; it does not mark generated text as trusted
 instructions and does not change assistant transcript storage.
 
+Runtime-generated GRPO candidate traces must preserve tool-observation receipt
+evidence for every candidate that executed tools. Selected candidates continue
+to include full `agentic_tool_observations` through the selected policy trace.
+Non-selected candidate reward trace rows intentionally omit full observations,
+but each generated candidate and each candidate reward trace row with a tool
+run must expose scalar receipt evidence:
+
+- `agentic_tool_untrusted_context_receipt_schema`
+- `agentic_tool_untrusted_context_receipt_count`
+
+The schema is the first string `schema_version` found on a mapping-shaped
+receipt from the candidate tool observations. The count is the total number of
+mapping-shaped receipts across those observations. These scalar fields must not
+copy tool payloads, retrieved text, page content, media references, prompt
+text, or receipt bodies into non-selected candidate rows.
+
 The v1 deterministic retrieval source slice lets callers attach
 source-specific untrusted-context receipts beside the generic tool-observation
 receipt without adding those receipts to the sanitized payload or replay hash.

--- a/services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
+++ b/services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
@@ -137,8 +137,16 @@ def test_mlx_lm_runner_runtime_grpo_executes_candidate_tool_trajectories(
     assert row["reward_components"]["tool_efficiency"] == 0.0
     assert row["generated_candidates"][0]["tool_calls"][0]["name"] == "visit"
     assert row["generated_candidates"][0]["agentic_tool_observation_count"] == 1
+    assert row["generated_candidates"][0]["agentic_tool_untrusted_context_receipt_schema"] == (
+        "melix.untrusted_context_receipt.v1"
+    )
+    assert row["generated_candidates"][0]["agentic_tool_untrusted_context_receipt_count"] == 2
     assert row["generated_candidates"][1]["tool_calls"][1]["name"] == "local_compute"
     assert row["generated_candidates"][1]["agentic_tool_metrics"]["agentic_tool.call_count"] == 2.0
+    assert row["generated_candidates"][1]["agentic_tool_untrusted_context_receipt_schema"] == (
+        "melix.untrusted_context_receipt.v1"
+    )
+    assert row["generated_candidates"][1]["agentic_tool_untrusted_context_receipt_count"] == 3
     assert row["generated_candidates"][1]["reward_components"]["tool_efficiency"] == -1.0
 
     candidate_trace_rows = [
@@ -168,12 +176,20 @@ def test_mlx_lm_runner_runtime_grpo_executes_candidate_tool_trajectories(
     assert selected_trace["agentic_tool_calls"][0]["id"] == "visit-selected"
     assert selected_trace["agentic_tool_observations"][0]["payload"]["text"] == "Selected source."
     assert selected_trace["agentic_tool_metrics"]["agentic_tool.call_count"] == 1.0
+    assert selected_trace["agentic_tool_untrusted_context_receipt_schema"] == (
+        "melix.untrusted_context_receipt.v1"
+    )
+    assert selected_trace["agentic_tool_untrusted_context_receipt_count"] == 2
     assert len(selected_trace["replay_fingerprint"]) == 64
     assert extra_trace["candidate_index"] == 1
     assert extra_trace["selected"] is False
     assert extra_trace["tool_call_count"] == 2
     assert extra_trace["agentic_tool_observation_count"] == 2
     assert extra_trace["tool_calls"][1]["name"] == "local_compute"
+    assert extra_trace["agentic_tool_untrusted_context_receipt_schema"] == (
+        "melix.untrusted_context_receipt.v1"
+    )
+    assert extra_trace["agentic_tool_untrusted_context_receipt_count"] == 3
     assert "agentic_tool_observations" not in extra_trace
 
 
@@ -412,6 +428,7 @@ def test_runtime_grpo_keeps_unselected_fatal_timeout_trace_penalized_without_cla
 def test_alignment_runtime_tool_helpers_cover_namespaces_and_invalid_events() -> None:
     from worker.model_ops.rl_alignment_training import (
         _agentic_tool_run_for_generated_candidate,
+        _agentic_tool_receipt_summary,
         _attach_runtime_candidate_tool_evidence,
         _runtime_tool_namespaces,
         _tool_call_from_runtime_event,
@@ -430,6 +447,33 @@ def test_alignment_runtime_tool_helpers_cover_namespaces_and_invalid_events() ->
         None,
     )
     assert candidate == {"tool_calls": [{"id": "call-1", "name": "visit", "arguments": {}}]}
+    assert _agentic_tool_receipt_summary(
+        type(
+            "ToolRun",
+            (),
+            {
+                "observations": (
+                    "not-an-observation",
+                    {"untrusted_context_receipts": "not-a-list"},
+                    {
+                        "untrusted_context_receipts": (
+                            "not-a-receipt",
+                            {
+                                "schema_version": "melix.untrusted_context_receipt.v1",
+                                "included": True,
+                            },
+                            {"included": False},
+                        )
+                    },
+                )
+            },
+        )()
+    ) == {
+        "agentic_tool_untrusted_context_receipt_schema": (
+            "melix.untrusted_context_receipt.v1"
+        ),
+        "agentic_tool_untrusted_context_receipt_count": 2,
+    }
 
     with pytest.raises(ModelOperationError) as invalid_json_exc:
         _tool_call_from_runtime_event(

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -1030,13 +1030,13 @@ def _runtime_candidate_reward_trace_rows(
         if isinstance(candidate.get("agentic_tool_metrics"), dict):
             row["agentic_tool_metrics"] = dict(candidate["agentic_tool_metrics"])
         if "agentic_tool_untrusted_context_receipt_schema" in candidate:
-            row["agentic_tool_untrusted_context_receipt_schema"] = str(
-                candidate["agentic_tool_untrusted_context_receipt_schema"]
-            )
+            row["agentic_tool_untrusted_context_receipt_schema"] = candidate[
+                "agentic_tool_untrusted_context_receipt_schema"
+            ]
         if "agentic_tool_untrusted_context_receipt_count" in candidate:
-            row["agentic_tool_untrusted_context_receipt_count"] = int(
-                candidate["agentic_tool_untrusted_context_receipt_count"]
-            )
+            row["agentic_tool_untrusted_context_receipt_count"] = candidate[
+                "agentic_tool_untrusted_context_receipt_count"
+            ]
         if reward_scorer is not None:
             row["reward_scoring_backend"] = reward_scorer.runtime_name
             row["reward_model_id"] = reward_scorer.reward_model_id

--- a/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
+++ b/services/mlx-worker-python/worker/model_ops/rl_alignment_training.py
@@ -958,6 +958,7 @@ def _attach_runtime_candidate_tool_evidence(
         return
     candidate["agentic_tool_metrics"] = dict(tool_run.metrics)
     candidate["agentic_tool_observation_count"] = len(tool_run.observations)
+    candidate.update(_agentic_tool_receipt_summary(tool_run))
 
 
 def _runtime_candidate_reward_trace_rows(
@@ -1028,6 +1029,14 @@ def _runtime_candidate_reward_trace_rows(
             row["tool_calls"] = [dict(call) for call in candidate["tool_calls"]]
         if isinstance(candidate.get("agentic_tool_metrics"), dict):
             row["agentic_tool_metrics"] = dict(candidate["agentic_tool_metrics"])
+        if "agentic_tool_untrusted_context_receipt_schema" in candidate:
+            row["agentic_tool_untrusted_context_receipt_schema"] = str(
+                candidate["agentic_tool_untrusted_context_receipt_schema"]
+            )
+        if "agentic_tool_untrusted_context_receipt_count" in candidate:
+            row["agentic_tool_untrusted_context_receipt_count"] = int(
+                candidate["agentic_tool_untrusted_context_receipt_count"]
+            )
         if reward_scorer is not None:
             row["reward_scoring_backend"] = reward_scorer.runtime_name
             row["reward_model_id"] = reward_scorer.reward_model_id
@@ -1035,6 +1044,29 @@ def _runtime_candidate_reward_trace_rows(
             _attach_agentic_tool_run(row, tool_run)
         rows.append(row)
     return rows
+
+
+def _agentic_tool_receipt_summary(tool_run: Any) -> dict[str, Any]:
+    receipt_schema = ""
+    receipt_count = 0
+    for observation in getattr(tool_run, "observations", ()):
+        if not isinstance(observation, dict):
+            continue
+        receipts = observation.get("untrusted_context_receipts", ())
+        if not isinstance(receipts, (list, tuple)):
+            continue
+        for receipt in receipts:
+            if not isinstance(receipt, dict):
+                continue
+            receipt_count += 1
+            if not receipt_schema:
+                schema_version = receipt.get("schema_version")
+                if isinstance(schema_version, str):
+                    receipt_schema = schema_version
+    return {
+        "agentic_tool_untrusted_context_receipt_schema": receipt_schema,
+        "agentic_tool_untrusted_context_receipt_count": receipt_count,
+    }
 
 
 def _candidate_replay_fingerprint(candidate: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- Add scalar untrusted-context receipt evidence to runtime-generated GRPO candidate traces.
- Preserve full tool observations only for the selected candidate while exposing `agentic_tool_untrusted_context_receipt_schema` and `agentic_tool_untrusted_context_receipt_count` for every tool-executing candidate.
- Update the runtime contract and add an issue-scoped plan for this #1761 slice.

## Plan or Spec
- Plan: `docs/plans/2026-06-14-issue-1761-runtime-grpo-candidate-receipts.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`
- Issue: #1761

## Commands Run
```text
make bootstrap && make proto
# pass; configured hooks, uv sync checked 79 packages, proto generation completed with no versioned diff

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py::test_mlx_lm_runner_runtime_grpo_executes_candidate_tool_trajectories
# red before implementation: failed with KeyError: 'agentic_tool_untrusted_context_receipt_schema'
# green after implementation: 1 passed in 0.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
# 4 passed in 0.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py && \
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python coverage json -o .runtime/coverage-rl-grpo-candidate-receipts-after-merge.json && \
UV_PYTHON=3.12 uv run python scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage-rl-grpo-candidate-receipts-after-merge.json --diff-from origin/main services/mlx-worker-python/worker/model_ops/rl_alignment_training.py services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
# 4 passed in 0.11s; changed-line coverage TOTAL 100.00% 32/32

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py services/mlx-worker-python/tests/test_tool_observation.py services/mlx-worker-python/tests/test_agentic_tools.py
# 113 passed in 0.12s

git diff --check origin/main...HEAD
# pass

UV_PYTHON=3.12 UV_CACHE_DIR="$PWD/.uv-cache" uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report
root = Path.cwd()
files = subprocess.check_output(["git", "diff", "--name-only", "origin/main...HEAD"], cwd=root, text=True).splitlines()
files = [f.strip() for f in files if f.strip()]
outcome = run_performance_report(root, files, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# pass; Status: ok, Changed files: 4, Selected probes: 1, Regressions: 0, Context regressions: 0, Verification failures: 0

make swift-test && make py-test && make integration-test
# pass after merging current origin/main
# make swift-test pass, including protocol package, text worker package, control-plane shards, worker clients, and macOS menubar package (796 tests)
# make py-test: 4014 passed, 14 skipped, 2 warnings in 165.68s
# make integration-test: 120 passed, 1 skipped in 679.75s
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 100.00% 32/32` for `rl_alignment_training.py` and `test_rl_alignment_runtime_tool_trajectories.py`.
- PR-scoped performance: `.runtime/pre-commit-performance/20260614-100220-b45ca880/report/report.md`
  - Status: ok
  - Changed files: 4
  - Selected probes: 1 (`local-job-followup-scan-scandir`, selected by contract doc watch glob)
  - Regressions: 0
  - Context regressions: 0
  - Verification failures: 0
  - `projection_elapsed_ms_mean`: base 97.101 ms, head 96.104 ms, delta -1.03%, neutral
- Observability mode: evidence; this records bounded scalar receipt schema/count metadata in existing runtime GRPO candidate trace rows and does not copy tool payloads or full receipt bodies into non-selected candidate rows.
- Probe overhead: scalar receipt summary scans in-memory observation receipt lists once per traced candidate; no new runtime I/O, model execution, or replay fingerprint work.

## Known Gaps
- This is one #1761 slice: it adds scalar receipt evidence for runtime-generated GRPO candidates.
- It does not copy full `agentic_tool_observations` into non-selected candidate rows.
- It does not complete the broader #1761 retrieved-doc, skill, memory, MCP, or local-job boundary rollout.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
