### PR TITLE
perf: reduce report evidence release matrix lookups

### DIFF
--- a/docs/plans/2026-06-14-report-evidence-release-matrix-bindings.md
+++ b/docs/plans/2026-06-14-report-evidence-release-matrix-bindings.md
@@ -1,0 +1,45 @@
+# Report Evidence Release Matrix Local Bindings
+
+## Slice
+
+Optimize one Python hot path in `worker.productization.report_evidence_gate`:
+`_release_matrix_rows(...)` aggregates evidence IDs by release-matrix role for
+PR evidence reports. The current loop repeatedly performs global method lookup
+for matrix membership and evidence-map lookup while processing many synthetic
+reports in the registered probe.
+
+This slice binds those lookups locally inside `_release_matrix_rows(...)` and
+avoids allocating an unused empty `set()` for matrix roles that have no evidence.
+It does not change release matrix semantics, report validation, probe registry
+shape, or output schemas.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `report-evidence-gate-run-kind-set-membership` in
+`infra/perf/pr_scoped_probes.json`. The probe has focused `test_command`,
+`coverage_command`, and `probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/productization/report_evidence_gate.py`
+- `services/mlx-worker-python/tests/test_report_evidence_gate.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/report_evidence_gate_run_kind_probe.py`
+
+## Verification Plan
+
+1. Run the registered probe on `origin/main` before the edit and record the
+   release-matrix baseline.
+2. Apply the local-binding optimization in `_release_matrix_rows(...)` only.
+3. Run focused pytest from the registered probe.
+4. Run changed-scope coverage from the registered probe.
+5. Run the registered probe locally on Linux and require an improvement or a
+   clear no-merge decision.
+6. Use PR-scoped performance CI as the merge gate.
+
+## Metrics
+
+Primary metric: `release_matrix_elapsed_ms_mean` from
+`report-evidence-gate-run-kind-set-membership`.
+
+Secondary guard metrics: `elapsed_ms_mean`, `matrix_roles_elapsed_ms_mean`, and
+existing informational role/report counts must remain valid.

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -243,6 +243,7 @@ def _release_matrix_rows(
 ) -> list[dict[str, object]]:
     evidence_by_role: dict[str, set[str]] = {}
     to_string = str
+    evidence_by_role_get = evidence_by_role.get
     for report in reports:
         roles = report.get("release_matrix_roles")
         source_evidence_ids = report.get("source_evidence_ids", [])
@@ -255,7 +256,7 @@ def _release_matrix_rows(
         if len(roles) == 1:
             role = roles[0]
             if role in matrix:
-                evidence_ids_for_role = evidence_by_role.get(role)
+                evidence_ids_for_role = evidence_by_role_get(role)
                 if evidence_ids_for_role is None:
                     evidence_ids_for_role = set()
                     evidence_by_role[role] = evidence_ids_for_role
@@ -266,7 +267,7 @@ def _release_matrix_rows(
         for role in roles:
             if role not in matrix:
                 continue
-            evidence_ids_for_role = evidence_by_role.get(role)
+            evidence_ids_for_role = evidence_by_role_get(role)
             if evidence_ids_for_role is None:
                 evidence_ids_for_role = set()
                 evidence_by_role[role] = evidence_ids_for_role
@@ -274,13 +275,13 @@ def _release_matrix_rows(
 
     rows: list[dict[str, object]] = []
     for role, rule in matrix.items():
-        evidence_ids = evidence_by_role.get(role, set())
+        evidence_ids = evidence_by_role_get(role)
         rows.append(
             {
                 "role": role,
                 "required": bool(rule.get("required", True)),
                 "present": bool(evidence_ids),
-                "evidence_ids": sorted(evidence_ids),
+                "evidence_ids": sorted(evidence_ids) if evidence_ids else [],
                 "description": str(rule.get("description", "")),
             }
         )


### PR DESCRIPTION
## Summary
- Optimize the report evidence release-matrix aggregation loop by reusing the evidence map lookup binding.
- Avoid allocating an unused empty `set()` for release-matrix roles without evidence while preserving emitted empty evidence lists.
- Add a focused plan for this Python performance slice.

## Plan or Spec
- `docs/plans/2026-06-14-report-evidence-release-matrix-bindings.md`
- Registered probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py` on `origin/main` baseline.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (registered focused test command; 22 tests).
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json && python3 scripts/changed_scope_coverage.py ...`.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py` on the candidate branch.
- `git diff --check`.

## Coverage and Metrics
- Focused tests: `22 passed`.
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Registered local Linux probe (`report-evidence-gate-run-kind-set-membership`):
  - warmed `origin/main`: `release_matrix_elapsed_ms_mean=30.413322150707245`, `elapsed_ms_mean=932.4019006453454`.
  - candidate: `release_matrix_elapsed_ms_mean=27.59284358471632`, `elapsed_ms_mean=909.9230815656483`.
  - local delta: `release_matrix_elapsed_ms_mean` improved by `-2.820478565990925 ms` (`~9.27%` lower); `elapsed_ms_mean` improved by `-22.478819079697132 ms` (`~2.41%` lower).
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Linux local validation covers the Python slice only; no Swift runtime effect is claimed.
- Microbenchmark timing has normal host noise, so the registered PR-scoped performance workflow remains authoritative before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux and showed an improvement on the targeted release-matrix metric.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
