### PR TITLE
perf: speed up PR scope command summaries

### DIFF
--- a/docs/plans/2026-06-14-prscope-command-summary-tail-scan.md
+++ b/docs/plans/2026-06-14-prscope-command-summary-tail-scan.md
@@ -1,0 +1,48 @@
+# PR-scoped performance command-summary partition fast path
+
+## Scope
+
+This Python-only performance slice is limited to `_summarize_command` in
+`services/mlx-worker-python/worker/productization/pr_scoped_performance.py`.
+
+The previous implementation found the first newline and then sliced the first
+line manually. This slice keeps command-summary output unchanged while switching
+to `str.partition("\n")`, which lets CPython split the first line and remainder
+in one C-level operation for the long here-doc command payloads emitted by
+PR-scoped performance command heartbeats.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `pr-scoped-performance-scope-matcher` in
+`infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused:
+
+- `test_command` for scope selection, glob matching, command-summary behavior,
+  and probe dispatch.
+- `coverage_command` for changed-scope coverage on `pr_scoped_performance.py`
+  and its tests.
+- `probe_command` that reports `build_scope_report_ms_*` and
+  `command_summary_ms_mean`.
+
+## Verification plan
+
+Run on Linux before pushing:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_prscope_scope_probe.py
+```
+
+GitHub Actions PR-scoped performance remains the final merge gate.
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage is at or above the repository threshold for the touched
+  scope.
+- Local registered probe shows lower `command_summary_ms_mean` with unchanged
+  scope-selection counts.
+- PR-scoped performance CI completes successfully before merge.

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -5150,6 +5150,7 @@ def test_command_summary_keeps_ci_heartbeats_compact() -> None:
     assert _summarize_command("python3 - <<'PY'\nprint('x')\nPY") == "python3 - <<'PY' ..."
     assert _summarize_command(" \n  python3 - <<'PY'  \nprint('x')") == "python3 - <<'PY' ..."
     assert _summarize_command(" \n ") == "<empty command>"
+    assert _summarize_command("python3 -m pytest\n \t\n") == "python3 -m pytest"
 
     long_summary = _summarize_command("python3 -c " + "x" * 300, max_length=80)
     assert len(long_summary) <= 80

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -78,13 +78,9 @@ def _summarize_command(command: str, *, max_length: int = 180) -> str:
     if not command:
         return "<empty command>"
 
-    line_end = command.find("\n")
-    if line_end == -1:
-        summary = command.rstrip()
-        has_more_lines = False
-    else:
-        summary = command[:line_end].rstrip()
-        has_more_lines = bool(command[line_end + 1 :].lstrip())
+    first_line, separator, remaining_lines = command.partition("\n")
+    summary = first_line.rstrip()
+    has_more_lines = bool(separator and remaining_lines.lstrip())
 
     if has_more_lines:
         summary = f"{summary} ..."


### PR DESCRIPTION
## Summary
- Use `str.partition("\n")` in PR-scoped performance command summaries to split the first command line in one C-level operation.
- Preserve existing heartbeat summary behavior for multi-line here-doc commands and whitespace-only tails.
- Document the Python-only performance slice and registered probe gate.

## Plan or Spec
- `docs/plans/2026-06-14-prscope-command-summary-tail-scan.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` — 3 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py` — TOTAL 4 0 100%
- Baseline local registered probe via `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_prscope_scope_probe.py` before the change.
- Head local registered probe via `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_prscope_scope_probe.py` after the change.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 3 passed.
- Changed-scope coverage: 100% aggregate changed-line coverage.
- Local registered probe (Linux): `command_summary_ms_mean` improved from `14.041352` to `12.03772` ms over 20,000 iterations (`delta_ms=-2.003632`, `speedup=1.166446`, `delta_pct=-14.2695%`).
- Scope selection parity held locally: `changed_file_count=3205.0`, `selected_probe_count_mean=7.0`, `force_all_selected_mean=0.0`.

## Known Gaps
- Python-only slice validated locally on Linux. CI is still required for the PR-scoped registered performance workflow and repository check suite.

## Evidence Checklist
- [x] Branch synced from `origin/main` before starting.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage command passed.
- [x] Registered probe ran locally and reported improved command-summary metrics.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
