### PR TITLE
perf: scan evaluation sample metrics by row items

### DIFF
--- a/docs/plans/2026-06-14-benchmark-evaluation-sample-row-scan-performance.md
+++ b/docs/plans/2026-06-14-benchmark-evaluation-sample-row-scan-performance.md
@@ -1,0 +1,45 @@
+# Benchmark Evaluation Sample Row Scan Performance
+
+## Status
+
+Accepted for the 2026-06-14 performance slice.
+
+## Context
+
+The PR-scoped benchmark evaluation report probe exercises
+`worker.productization.benchmark_evaluation_report` with large synthetic
+benchmark and evaluation bundles. The evaluation sample collector walks every
+sample row and previously checked each fixed sample probe key with membership
+lookups before reading the value.
+
+Sparse rows are common in report payloads: each row usually contains a small
+subset of the known probe keys plus metadata. Repeating fixed-key membership
+checks for every row adds unnecessary dictionary lookups in the report build
+path.
+
+## Slice
+
+Change only the evaluation sample metric collector to iterate row items once and
+filter keys through a precomputed probe-key set. This keeps the emitted metric
+names and aggregation semantics unchanged while avoiding fixed-key membership
+and index lookups on sparse rows.
+
+## Validation
+
+The affected path is covered by the registered PR-scoped probe
+`benchmark-evaluation-report-running-aggregates` in
+`infra/perf/pr_scoped_probes.json`. The probe includes focused test, coverage,
+and probe commands for:
+
+- `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`
+- `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+
+Local Linux validation should run the registered focused tests, changed-scope
+coverage command, and registered probe. CI remains the source of truth for the
+PR-scoped performance workflow report.
+
+## Expected Metrics
+
+The probe should show a lower or neutral `elapsed_ms_mean` for benchmark report
+construction. `load_input_ms_mean` is not expected to change because this slice
+only changes report aggregation after input loading.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -1468,9 +1468,11 @@ def test_probe_collectors_use_expected_sparse_row_scan_strategy() -> None:
                 raise AssertionError("benchmark collector should scan actual row items")
             return super().__contains__(key)
 
-    class NoItemsDict(dict[str, object]):
-        def items(self):  # type: ignore[override]
-            raise AssertionError("evaluation collector should scan registered probe keys directly")
+    class NoEvaluationContainsDict(dict[str, object]):
+        def __contains__(self, key: object) -> bool:
+            if key in {"sample_render_ms", "inference_ms", "raw_response_chars"}:
+                raise AssertionError("evaluation collector should scan actual row items")
+            return super().__contains__(key)
 
     benchmark_metrics: dict[str, object] = {}
     _collect_benchmark_probe_metrics(
@@ -1495,7 +1497,7 @@ def test_probe_collectors_use_expected_sparse_row_scan_strategy() -> None:
     _collect_evaluation_sample_probe_metrics(
         evaluation_metrics,
         [
-            NoItemsDict(
+            NoEvaluationContainsDict(
                 {
                     "suite_id": "smoke",
                     "sample_render_ms": 3.0,
@@ -2437,6 +2439,7 @@ def test_report_builder_uses_sparse_evaluation_sample_rows_without_fixed_key_sca
             "raw_response_chars",
             "extracted_result_chars",
         },
+        forbid_contains=True,
     )
 
     report = build_benchmark_evaluation_report(

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -87,6 +87,7 @@ _EVALUATION_SAMPLE_PROBE_KEYS = (
     "raw_response_chars",
     "extracted_result_chars",
 )
+_EVALUATION_SAMPLE_PROBE_KEY_SET = frozenset(_EVALUATION_SAMPLE_PROBE_KEYS)
 _AGENTIC_TOOL_METRIC_KEYS = (
     "agentic_tool.call_count",
     "agentic_tool.observation_count",
@@ -2666,10 +2667,9 @@ def _collect_evaluation_sample_probe_metrics(
     failure_stage_counts: dict[tuple[str, str], int] = {}
     for row in _dict_rows(rows):
         suite_id = str(row.get("suite_id", "")).strip() or "suite"
-        for key in _EVALUATION_SAMPLE_PROBE_KEYS:
-            if key not in row:
+        for key, raw_value in row.items():
+            if key not in _EVALUATION_SAMPLE_PROBE_KEY_SET:
                 continue
-            raw_value = row[key]
             raw_value_type = type(raw_value)
             if raw_value_type is float:
                 value = raw_value


### PR DESCRIPTION
## Summary
- Optimize benchmark evaluation sample metric collection by scanning each row's actual items once.
- Add a regression guard that rejects fixed-key membership scans for sparse evaluation sample rows.
- Document the slice and registered PR-scoped probe expectations.

## Plan or Spec
- `docs/plans/2026-06-14-benchmark-evaluation-sample-row-scan-performance.md`

## Commands Run
```text
# Baseline registered probe on origin/main (3 runs, exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_benchmark_probe.py
old elapsed_ms_mean samples: 297.540766, 298.526690, 289.298629

# Focused regression tests (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py::test_report_builder_uses_sparse_evaluation_sample_rows_without_fixed_key_scans services/mlx-worker-python/tests/test_benchmark_evaluation_report.py::test_evaluation_sample_collector_finalizes_mean_metrics_directly services/mlx-worker-python/tests/test_benchmark_evaluation_report.py::test_report_builder_aggregates_evaluation_sample_probes
3 passed in 0.35s

# Registered focused test command (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
65 passed in 0.33s

# Registered coverage command (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
TOTAL 2046 47 98%
benchmark_evaluation_report.py: 97%; test_benchmark_evaluation_report.py: 99%

# Registered probe on this branch (3 runs, exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_benchmark_probe.py
new elapsed_ms_mean samples: 288.676026, 300.958851, 290.133373
```

## Coverage and Metrics
- Registered probe: `benchmark-evaluation-report-running-aggregates`.
- Local Linux probe comparison: old_mean=295.122028 ms, new_mean=293.256083 ms, delta_ms=-1.865945, speedup=0.632%.
- `load_input_ms_mean` is expected to be neutral because this slice only changes post-load metric aggregation.
- CI PR-scoped performance workflow is required as the repository source of truth for the registered probe report.

## Known Gaps
- None for Python local validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
