### PR TITLE
perf: speed up retrieval payload copies

### DIFF
--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -329,23 +329,26 @@ def project_retrieval_lookup_result(lookup_result: Any) -> RetrievalLookupResult
     )
 
 
-_JSON_IMMUTABLE_TYPES = (str, int, float, bool, type(None))
-
-
 def _copy_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
     return {key: _copy_payload_value(value) for key, value in payload.items()}
 
 
 def _copy_payload_value(value: Any) -> Any:
     value_type = type(value)
-    if value_type in _JSON_IMMUTABLE_TYPES:
+    if (
+        value_type is str
+        or value_type is int
+        or value_type is float
+        or value_type is bool
+        or value is None
+    ):
         return value
     if value_type is dict:
         return {key: _copy_payload_value(item) for key, item in value.items()}
     if value_type is list:
         return [_copy_payload_value(item) for item in value]
     if value_type is tuple:
-        return tuple(_copy_payload_value(item) for item in value)
+        return tuple([_copy_payload_value(item) for item in value])
     return deepcopy(value)
 
 


### PR DESCRIPTION
## Summary
- Speeds up retrieval lookup payload copying by replacing immutable-type tuple membership with direct exact-type checks.
- Copies tuple payload values through a list-backed tuple construction to avoid generator overhead in the recursive hot path.

## Plan or Spec
- Governing spec: `docs/unified-agentic-tool-runtime-contract.md` (retrieval prompt-context admission and projection contract).
- No doc update required: this is behavior-preserving internal copy-path optimization for an already registered probe.

## Commands Run
```text
# Registered focused test command for retrieval-context-projection-fastpath
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_isolates_refusals_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_malformed_entry_objects_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_preserves_multi_field_admission_duplicate_scan services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_copies_multi_receipt_admissions services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_projects_records_without_entry_reentry services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_copies_store_projection_outputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
Result: 13 passed in 0.16s

# Changed-scope coverage for registered probe scope (pre-commit run before committing this diff)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
Result: 13 passed; changed_line_coverage=100.00% (2/2 changed measurable lines covered)

# Registered probe script for retrieval-context-projection-fastpath
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
Result: pass; JSON metrics emitted (see Coverage and Metrics)
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` for changed measurable lines in `services/mlx-worker-python/worker/runtime/retrieval_context.py` (2/2) from the pre-commit coverage run.
- Registered probe (`scripts/retrieval_context_projection_probe.py`, local Linux):
  - `baseline_elapsed_ms_mean=0.07574254663528077`
  - `optimized_elapsed_ms_mean=0.037004064402676055`
  - `delta_ms=-0.03873848223260471`
  - `speedup=2.046871008845267x`
  - `store_baseline_elapsed_ms_mean=0.23013653000816703`
  - `store_optimized_elapsed_ms_mean=0.22598789821911072`
  - `store_delta_ms=-0.004148631789056306`
  - `store_speedup=1.0183577608436092x`
  - `lookup_copy_baseline_elapsed_ms_mean=0.8104626069377575`
  - `lookup_copy_optimized_elapsed_ms_mean=0.20233456677358067`
  - `lookup_copy_delta_ms=-0.6081280401641769`
  - `lookup_copy_speedup=4.005556835203018x`
- CI registered PR-scoped performance validation is required before merge.

## Known Gaps
- None for the Python retrieval-context slice. CI is still required as the authoritative registered PR-scoped probe gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated: N/A, behavior-preserving optimization only.
- [x] Protocol changes include regenerated generated artifacts, or N/A is stated: N/A, no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A is stated: N/A, no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason: registered probe is local/CI command_json; no deferred debug work.
- [x] Deferred work and known gaps are stated explicitly.
