### PR TITLE
Add companion status log tail

### DIFF
--- a/docs/plans/2026-06-14-issue-1759-companion-log-tail.md
+++ b/docs/plans/2026-06-14-issue-1759-companion-log-tail.md
@@ -45,7 +45,9 @@ This transaction does not add:
 - Runtime metric remains `companion.status_latency_ms` on the aggregate endpoint.
 - The new read model appends one small value per image-job state update and caps
   retained entries at 50.
-- The companion status endpoint sorts and returns at most 20 visible log entries.
+- The companion status endpoint sorts and returns at most 20 visible log entries;
+  `logs.total` reports the retained read-model tail count while `logs.visible`
+  reports the number of entries returned in the payload.
 - Success metric: focused Swift tests cover the log-tail payload and redaction
   contract; changed-line coverage for touched Swift files remains at least 95
   percent.
@@ -121,7 +123,8 @@ descending.
 
 - [x] **Step 3: Expose companion logs**
 
-Read `logTailSnapshot(limit: 20)` in `handleCompanionStatus`, add a
+Read the retained log tail in `handleCompanionStatus`, expose at most 20
+visible entries, report the retained count in `logs.total`, add a
 `CompanionLogTailStatusPayload`, and change `CompanionRedactionStatusPayload`
 `logs` to `redacted_tail`.
 
@@ -143,9 +146,9 @@ Run Swift coverage for the focused tests, then:
 UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/ImageJobs/ImageJobReadModel.swift services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/ControlPlaneTests/ImageJobReadModelTests.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
 ```
 
-Result: changed-line coverage is 99.27 percent total for touched Swift files;
-`ImageJobReadModel.swift` is 96.15 percent, with only defensive enum fallback
-branches uncovered.
+Result after review-thread fix: changed-line coverage is 99.37 percent total
+for touched Swift files; `ImageJobReadModel.swift` is 96.15 percent, with only
+defensive enum fallback branches uncovered.
 
 - [ ] **Step 3: Run full local gate and PR lifecycle**
 

--- a/docs/plans/2026-06-14-issue-1759-companion-log-tail.md
+++ b/docs/plans/2026-06-14-issue-1759-companion-log-tail.md
@@ -1,0 +1,154 @@
+# Issue 1759 Companion Log Tail
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans or inline TDD execution to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a redacted companion log-tail summary to the read-only companion status endpoint for issue #1759.
+
+**Architecture:** Extend `ImageJobReadModel` with a small in-memory, redacted state-event tail, then expose it through the existing companion status DTO. The HTTP payload carries safe event metadata only and keeps prompts, prompt deltas, request bodies, artifact URIs, local paths, and error messages omitted by construction.
+
+**Tech Stack:** Swift control plane HTTP gateway, `ImageJobReadModel`, Swift Testing, changed-line coverage tooling, pre-commit performance report.
+
+---
+
+## Context
+
+Issue #1759 asks for a read-only companion/mobile surface with runtime status,
+recent receipts, and log-tail redaction. Previous slices added companion
+read-only auth, `GET /v1/melix/companion/status`, and redacted recent image-job
+receipt summaries. The remaining safe server-side slice is a redacted log tail
+that future mobile UI can render without reading raw log files or exposing
+private prompt/session content.
+
+## Slice Boundary
+
+This transaction adds:
+
+- a bounded in-memory image-job state event tail on `ImageJobReadModel`;
+- a top-level `logs` object in `melix.companion.status.v1`;
+- safe log fields: source, event type, job id, request id, model id, operation,
+  state, lane, worker id, progress stage, timestamp, and failure code;
+- redaction metadata for raw log line, prompt text, request body, artifact URIs,
+  local paths, and error messages;
+- tests proving private prompts, prompt deltas, artifact URIs, local paths, and
+  error messages do not appear in companion log payloads.
+
+This transaction does not add:
+
+- QR/code pairing UX;
+- desktop companion-token issuance or revocation controls;
+- mobile/narrow viewport UI smoke;
+- generic filesystem log tailing;
+- raw OSLog, worker stdout/stderr, or arbitrary runtime log reads.
+
+## Performance Probes And Metrics
+
+- Runtime metric remains `companion.status_latency_ms` on the aggregate endpoint.
+- The new read model appends one small value per image-job state update and caps
+  retained entries at 50.
+- The companion status endpoint sorts and returns at most 20 visible log entries.
+- Success metric: focused Swift tests cover the log-tail payload and redaction
+  contract; changed-line coverage for touched Swift files remains at least 95
+  percent.
+- PR merge gate: scoped performance report must stay `Status: ok` with zero
+  regressions.
+
+## Implementation Plan
+
+### Task 1: Add RED Tests
+
+**Files:**
+- Modify: `services/control-plane-swift/Tests/ControlPlaneTests/ImageJobReadModelTests.swift`
+- Modify: `services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift`
+
+- [x] **Step 1: Add image job log-tail read model test**
+
+Assert that queued/running/failed state updates append bounded redacted entries,
+newest-first ordering is deterministic, and only failure code, not failure
+message, is exposed.
+
+- [x] **Step 2: Add companion status payload test**
+
+Seed image jobs with private prompt, prompt delta, artifact URI, local path, and
+private error message. Call `GET /v1/melix/companion/status` and assert:
+
+- `logs.source == "image_jobs"`;
+- visible entries are newest-first;
+- each entry contains safe metadata and redaction flags;
+- raw private fields are absent from the JSON body;
+- `redaction.logs == "redacted_tail"`.
+
+- [x] **Step 3: Run focused tests to verify RED**
+
+Run:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'ImageJobReadModelTests/imageJobLogTailPreservesRedactedStateEvents|OpenAIHandlerTests/companionStatusEndpointReturnsRedactedLogTail'
+```
+
+Result: failed as expected because `ImageJobReadModel` had no
+`logTailSnapshot` member.
+
+### Task 2: Implement The Read Model And DTO
+
+**Files:**
+- Modify: `services/control-plane-swift/Sources/ImageJobs/ImageJobReadModel.swift`
+- Modify: `services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift`
+
+- [x] **Step 1: Add `ImageJobLogEntry`**
+
+Add a public value type with safe fields only:
+
+- `eventType`
+- `source`
+- `jobID`
+- `requestID`
+- `modelID`
+- `operation`
+- `state`
+- `lane`
+- `workerID`
+- `progressStage`
+- `createdAtUnixMs`
+- `updatedAtUnixMs`
+- `failureCode`
+
+- [x] **Step 2: Record bounded entries**
+
+Append one entry after each successful image-job state mutation. Retain the most
+recent 50 entries, and expose `logTailSnapshot(limit:)` newest-first with
+`updatedAtUnixMs` descending, then `jobID` ascending, then insertion order
+descending.
+
+- [x] **Step 3: Expose companion logs**
+
+Read `logTailSnapshot(limit: 20)` in `handleCompanionStatus`, add a
+`CompanionLogTailStatusPayload`, and change `CompanionRedactionStatusPayload`
+`logs` to `redacted_tail`.
+
+### Task 3: Verify Green, Coverage, Metrics, Commit, And PR
+
+- [x] **Step 1: Run focused green tests**
+
+Run the RED command again and then the adjacent companion status tests:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedLogTail|companionStatusEndpointReturnsRedactedRecentReceiptSummaries|companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary|companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering|companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering)'
+```
+
+- [x] **Step 2: Run changed-line coverage**
+
+Run Swift coverage for the focused tests, then:
+
+```bash
+UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/ImageJobs/ImageJobReadModel.swift services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/ControlPlaneTests/ImageJobReadModelTests.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+```
+
+Result: changed-line coverage is 99.27 percent total for touched Swift files;
+`ImageJobReadModel.swift` is 96.15 percent, with only defensive enum fallback
+branches uncovered.
+
+- [ ] **Step 3: Run full local gate and PR lifecycle**
+
+Run `make swift-test`, `make py-test`, `make integration-test`, commit with the
+pre-commit hook enabled, open the PR with the repository template, monitor CI,
+performance report, review threads, and merge only after all gates are green.

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -976,6 +976,7 @@ public struct OpenAIHandler: Sendable {
         async let cacheSummaryTask = companionCacheSummary()
         async let queueSnapshotTask = companionQueueSnapshot()
         async let imageJobsSnapshotTask = companionImageJobsSnapshot()
+        async let imageJobLogsTask = companionImageJobLogTail()
 
         let routes = await routesTask
         let models = await modelsTask
@@ -984,6 +985,7 @@ public struct OpenAIHandler: Sendable {
         let summary = await cacheSummaryTask
         let queueSnapshot = await queueSnapshotTask
         let imageJobsSnapshot = await imageJobsSnapshotTask
+        let imageJobLogs = await imageJobLogsTask
         let status = routes.values.allSatisfy { $0 } ? "ok" : "degraded"
         let response = CompanionStatusResponse(
             readOnly: true,
@@ -1002,6 +1004,7 @@ public struct OpenAIHandler: Sendable {
             queue: CompanionQueueStatusPayload(summary: queueSnapshot),
             imageJobs: CompanionImageJobStatusPayload(jobs: imageJobsSnapshot),
             recentReceipts: CompanionRecentReceiptStatusPayload(jobs: imageJobsSnapshot),
+            logs: CompanionLogTailStatusPayload(entries: imageJobLogs),
             redaction: CompanionRedactionStatusPayload()
         )
         await metricsStore.set(
@@ -1024,6 +1027,10 @@ public struct OpenAIHandler: Sendable {
 
     private func companionImageJobsSnapshot() async -> [Melix_Controlplane_V1_ImageJobSummary] {
         await imageJobReadModel?.snapshot() ?? []
+    }
+
+    private func companionImageJobLogTail() async -> [ImageJobLogEntry] {
+        await imageJobReadModel?.logTailSnapshot(limit: companionLogTailVisibleLimit) ?? []
     }
 
     private func handleCacheStats() async throws -> HTTPResponse {
@@ -5526,6 +5533,7 @@ private struct CompanionStatusResponse: Encodable {
     let queue: CompanionQueueStatusPayload
     let imageJobs: CompanionImageJobStatusPayload
     let recentReceipts: CompanionRecentReceiptStatusPayload
+    let logs: CompanionLogTailStatusPayload
     let redaction: CompanionRedactionStatusPayload
 
     enum CodingKeys: String, CodingKey {
@@ -5539,6 +5547,7 @@ private struct CompanionStatusResponse: Encodable {
         case queue
         case imageJobs = "image_jobs"
         case recentReceipts = "recent_receipts"
+        case logs
         case redaction
     }
 }
@@ -5898,12 +5907,97 @@ private struct CompanionRecentReceiptRedactionPayload: Encodable {
     }
 }
 
+private let companionLogTailVisibleLimit = 20
+
+private struct CompanionLogTailStatusPayload: Encodable {
+    let source: String
+    let visible: Int
+    let total: Int
+    let entries: [CompanionLogTailEntryPayload]
+
+    init(entries: [ImageJobLogEntry]) {
+        source = "image_jobs"
+        visible = entries.count
+        total = entries.count
+        self.entries = entries.map(CompanionLogTailEntryPayload.init(entry:))
+    }
+}
+
+private struct CompanionLogTailEntryPayload: Encodable {
+    let eventType: String
+    let source: String
+    let jobID: String
+    let requestID: String
+    let modelID: String
+    let operation: String
+    let state: String
+    let lane: String
+    let workerID: String
+    let progressStage: String
+    let createdAtUnixMs: Int64
+    let updatedAtUnixMs: Int64
+    let failureCode: String
+    let redaction: CompanionLogTailRedactionPayload
+
+    init(entry: ImageJobLogEntry) {
+        eventType = entry.eventType
+        source = entry.source
+        jobID = entry.jobID
+        requestID = entry.requestID
+        modelID = entry.modelID
+        operation = entry.operation
+        state = entry.state
+        lane = entry.lane
+        workerID = entry.workerID
+        progressStage = entry.progressStage
+        createdAtUnixMs = entry.createdAtUnixMs
+        updatedAtUnixMs = entry.updatedAtUnixMs
+        failureCode = entry.failureCode
+        redaction = CompanionLogTailRedactionPayload()
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case eventType = "event_type"
+        case source
+        case jobID = "job_id"
+        case requestID = "request_id"
+        case modelID = "model_id"
+        case operation
+        case state
+        case lane
+        case workerID = "worker_id"
+        case progressStage = "progress_stage"
+        case createdAtUnixMs = "created_at_unix_ms"
+        case updatedAtUnixMs = "updated_at_unix_ms"
+        case failureCode = "failure_code"
+        case redaction
+    }
+}
+
+private struct CompanionLogTailRedactionPayload: Encodable {
+    let rawLogLine = "omitted"
+    let rawPrompt = "omitted"
+    let requestBody = "omitted"
+    let artifactURIs = "omitted"
+    let localPaths = "omitted"
+    let errorMessage = "omitted"
+
+    enum CodingKeys: String, CodingKey {
+        case rawLogLine = "raw_log_line"
+        case rawPrompt = "raw_prompt"
+        case requestBody = "request_body"
+        case artifactURIs = "artifact_uris"
+        case localPaths = "local_paths"
+        case errorMessage = "error_message"
+    }
+}
+
 private struct CompanionRedactionStatusPayload: Codable {
     let rawPrompts = "omitted"
     let rawRequestBodies = "omitted"
     let localPaths = "omitted"
     let artifactURIs = "omitted"
-    let logs = "omitted"
+    let logs = "redacted_tail"
     let recentReceipts = "redacted_summary"
 
     enum CodingKeys: String, CodingKey {

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -1004,7 +1004,7 @@ public struct OpenAIHandler: Sendable {
             queue: CompanionQueueStatusPayload(summary: queueSnapshot),
             imageJobs: CompanionImageJobStatusPayload(jobs: imageJobsSnapshot),
             recentReceipts: CompanionRecentReceiptStatusPayload(jobs: imageJobsSnapshot),
-            logs: CompanionLogTailStatusPayload(entries: imageJobLogs),
+            logs: CompanionLogTailStatusPayload(entries: imageJobLogs.entries, total: imageJobLogs.total),
             redaction: CompanionRedactionStatusPayload()
         )
         await metricsStore.set(
@@ -1029,8 +1029,12 @@ public struct OpenAIHandler: Sendable {
         await imageJobReadModel?.snapshot() ?? []
     }
 
-    private func companionImageJobLogTail() async -> [ImageJobLogEntry] {
-        await imageJobReadModel?.logTailSnapshot(limit: companionLogTailVisibleLimit) ?? []
+    private func companionImageJobLogTail() async -> (entries: [ImageJobLogEntry], total: Int) {
+        guard let imageJobReadModel else {
+            return ([], 0)
+        }
+        let available = await imageJobReadModel.logTailSnapshot(limit: ImageJobReadModel.logTailRetainedLimit)
+        return (Array(available.prefix(companionLogTailVisibleLimit)), available.count)
     }
 
     private func handleCacheStats() async throws -> HTTPResponse {
@@ -5915,10 +5919,10 @@ private struct CompanionLogTailStatusPayload: Encodable {
     let total: Int
     let entries: [CompanionLogTailEntryPayload]
 
-    init(entries: [ImageJobLogEntry]) {
+    init(entries: [ImageJobLogEntry], total: Int) {
         source = "image_jobs"
         visible = entries.count
-        total = entries.count
+        self.total = total
         self.entries = entries.map(CompanionLogTailEntryPayload.init(entry:))
     }
 }

--- a/services/control-plane-swift/Sources/ImageJobs/ImageJobReadModel.swift
+++ b/services/control-plane-swift/Sources/ImageJobs/ImageJobReadModel.swift
@@ -1,14 +1,33 @@
 import Foundation
 import MelixControlPlaneProtocol
 
+public struct ImageJobLogEntry: Sendable, Equatable {
+    public let eventType: String
+    public let source: String
+    public let jobID: String
+    public let requestID: String
+    public let modelID: String
+    public let operation: String
+    public let state: String
+    public let lane: String
+    public let workerID: String
+    public let progressStage: String
+    public let createdAtUnixMs: Int64
+    public let updatedAtUnixMs: Int64
+    public let failureCode: String
+}
+
 public actor ImageJobReadModel {
     public typealias EventPublisher = @Sendable (Melix_Controlplane_V1_ControlPlaneEvent) async -> Void
+
+    private static let logTailRetainedLimit = 50
 
     private let eventPublisher: EventPublisher?
     private let now: @Sendable () -> Date
 
     private var jobsByID: [String: Melix_Controlplane_V1_ImageJobSummary]
     private var requestToJobID: [String: String]
+    private var logEntries: [ImageJobLogEntry]
 
     public init(
         eventPublisher: EventPublisher? = nil,
@@ -18,6 +37,7 @@ public actor ImageJobReadModel {
         self.now = now
         self.jobsByID = [:]
         self.requestToJobID = [:]
+        self.logEntries = []
     }
 
     public func recordQueued(
@@ -141,6 +161,24 @@ public actor ImageJobReadModel {
         }
     }
 
+    public func logTailSnapshot(limit: Int) -> [ImageJobLogEntry] {
+        let boundedLimit = max(0, limit)
+        guard boundedLimit > 0 else {
+            return []
+        }
+        return logEntries.enumerated().sorted { lhs, rhs in
+            let left = lhs.element
+            let right = rhs.element
+            if left.updatedAtUnixMs != right.updatedAtUnixMs {
+                return left.updatedAtUnixMs > right.updatedAtUnixMs
+            }
+            if left.jobID != right.jobID {
+                return left.jobID < right.jobID
+            }
+            return lhs.offset > rhs.offset
+        }.prefix(boundedLimit).map(\.element)
+    }
+
     public func job(jobID: String) -> Melix_Controlplane_V1_ImageJobSummary? {
         jobsByID[jobID]
     }
@@ -162,6 +200,7 @@ public actor ImageJobReadModel {
     }
 
     private func publish(_ job: Melix_Controlplane_V1_ImageJobSummary) async {
+        appendLogEntry(job)
         guard let eventPublisher else {
             return
         }
@@ -177,8 +216,50 @@ public actor ImageJobReadModel {
         await eventPublisher(event)
     }
 
+    private func appendLogEntry(_ job: Melix_Controlplane_V1_ImageJobSummary) {
+        logEntries.append(
+            ImageJobLogEntry(
+                eventType: "image.job.state_changed",
+                source: "image_jobs",
+                jobID: job.jobID,
+                requestID: job.requestID,
+                modelID: job.modelID,
+                operation: job.operation,
+                state: Self.imageJobStateLabel(job.state),
+                lane: job.lane,
+                workerID: job.workerID,
+                progressStage: job.progress.stage,
+                createdAtUnixMs: job.createdAtUnixMs,
+                updatedAtUnixMs: job.updatedAtUnixMs,
+                failureCode: job.error.code
+            )
+        )
+        if logEntries.count > Self.logTailRetainedLimit {
+            logEntries.removeFirst(logEntries.count - Self.logTailRetainedLimit)
+        }
+    }
+
     private func unixMilliseconds() -> Int64 {
         Int64((now().timeIntervalSince1970 * 1000).rounded())
+    }
+
+    private static func imageJobStateLabel(_ state: Melix_Controlplane_V1_ImageJobState) -> String {
+        switch state {
+        case .unspecified:
+            return "unknown"
+        case .imageJobQueued:
+            return "queued"
+        case .imageJobRunning:
+            return "running"
+        case .imageJobCanceled:
+            return "canceled"
+        case .imageJobFailed:
+            return "failed"
+        case .imageJobCompleted:
+            return "completed"
+        case .UNRECOGNIZED(let value):
+            return "unrecognized_\(value)"
+        }
     }
 
     private func progress(

--- a/services/control-plane-swift/Sources/ImageJobs/ImageJobReadModel.swift
+++ b/services/control-plane-swift/Sources/ImageJobs/ImageJobReadModel.swift
@@ -20,7 +20,7 @@ public struct ImageJobLogEntry: Sendable, Equatable {
 public actor ImageJobReadModel {
     public typealias EventPublisher = @Sendable (Melix_Controlplane_V1_ControlPlaneEvent) async -> Void
 
-    private static let logTailRetainedLimit = 50
+    public static let logTailRetainedLimit = 50
 
     private let eventPublisher: EventPublisher?
     private let now: @Sendable () -> Date

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ImageJobReadModelTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ImageJobReadModelTests.swift
@@ -178,6 +178,74 @@ struct ImageJobReadModelTests {
         #expect(events.last?.imageJob.job.progress.stage == "decode")
     }
 
+    @Test("image job log tail preserves redacted state events")
+    func imageJobLogTailPreservesRedactedStateEvents() async throws {
+        let clock = ImageJobTestClock()
+        let readModel = ImageJobReadModel(now: clock.now)
+
+        await readModel.recordQueued(
+            requestID: "req-log-tail",
+            jobID: "job-log-tail",
+            modelID: "melix-dev-image",
+            operation: "image_generate",
+            lane: "image.generate.background",
+            promptDigest: "sha256:private-prompt"
+        )
+        await readModel.recordRunning(
+            jobID: "job-log-tail",
+            workerID: "python-image-worker",
+            stage: "decode",
+            pct: 0.5,
+            completedSteps: 1,
+            totalSteps: 2
+        )
+        var error = Melix_Controlplane_V1_ErrorStatus()
+        error.code = "worker_failed"
+        error.message = "PRIVATE IMAGE JOB ERROR MESSAGE"
+        await readModel.recordFailed(jobID: "job-log-tail", error: error)
+
+        let entries = await readModel.logTailSnapshot(limit: 10)
+
+        #expect(entries.map(\.state) == ["failed", "running", "queued"])
+        #expect(entries.map(\.eventType).allSatisfy { $0 == "image.job.state_changed" })
+        #expect(entries.map(\.source).allSatisfy { $0 == "image_jobs" })
+        #expect(entries.first?.jobID == "job-log-tail")
+        #expect(entries.first?.requestID == "req-log-tail")
+        #expect(entries.first?.modelID == "melix-dev-image")
+        #expect(entries.first?.operation == "image_generate")
+        #expect(entries.first?.lane == "image.generate.background")
+        #expect(entries.first?.workerID == "python-image-worker")
+        #expect(entries.first?.progressStage == "failed")
+        #expect(entries.first?.failureCode == "worker_failed")
+        #expect(await readModel.logTailSnapshot(limit: 0).isEmpty)
+
+        await readModel.recordQueued(
+            requestID: "req-log-tail-cancel",
+            jobID: "job-log-tail-cancel",
+            modelID: "melix-dev-image",
+            operation: "image_generate",
+            lane: "image.generate.background"
+        )
+        await readModel.recordCanceled(jobID: "job-log-tail-cancel")
+        let canceledEntry = try #require(await readModel.logTailSnapshot(limit: 1).first)
+        #expect(canceledEntry.state == "canceled")
+
+        for index in 0..<55 {
+            await readModel.recordQueued(
+                requestID: "req-log-tail-\(index)",
+                jobID: "job-log-tail-\(index)",
+                modelID: "melix-dev-image",
+                operation: "image_generate",
+                lane: "image.generate.background"
+            )
+        }
+
+        let retainedEntries = await readModel.logTailSnapshot(limit: 100)
+        #expect(retainedEntries.count == 50)
+        #expect(retainedEntries.first?.jobID == "job-log-tail-54")
+        #expect(retainedEntries.contains { $0.jobID == "job-log-tail" } == false)
+    }
+
     @Test("server snapshot builder carries image job summaries")
     func serverSnapshotBuilderCarriesImageJobSummaries() async throws {
         var job = Melix_Controlplane_V1_ImageJobSummary()

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -1082,6 +1082,35 @@ struct OpenAIHandlerTests {
         #expect(jobs.map { $0["job_id"] as? String } == ["job-a", "job-z"])
     }
 
+    @Test("companion status endpoint returns empty logs without image job read model")
+    func companionStatusEndpointReturnsEmptyLogsWithoutImageJobReadModel() async throws {
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: []),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                abortRegistry: AbortRegistry()
+            )
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .get,
+                path: "/v1/melix/companion/status",
+                headers: [:],
+                body: Data()
+            )
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let logs = try #require(payload["logs"] as? [String: Any])
+        let entries = try #require(logs["entries"] as? [[String: Any]])
+
+        #expect(response.statusCode == 200)
+        #expect(logs["source"] as? String == "image_jobs")
+        #expect(logs["total"] as? Int == 0)
+        #expect(logs["visible"] as? Int == 0)
+        #expect(entries.isEmpty)
+    }
+
     @Test("companion status endpoint supports credential auth and newest job ordering")
     func companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering() async throws {
         final class Clock: @unchecked Sendable {
@@ -1355,6 +1384,18 @@ struct OpenAIHandlerTests {
         error.message = privateErrorMessage
         clock.date = Date(timeIntervalSince1970: 2_101)
         await imageJobReadModel.recordFailed(jobID: "job-log-tail", error: error)
+        for index in 0..<55 {
+            clock.date = Date(timeIntervalSince1970: 2_102 + TimeInterval(index))
+            await imageJobReadModel.recordQueued(
+                requestID: "req-log-tail-\(index)",
+                jobID: "job-log-tail-\(String(format: "%02d", index))",
+                modelID: "melix-dev-image",
+                operation: "image.generation",
+                lane: "multimodal.vision.background",
+                promptDigest: "sha256:log-tail-\(index)",
+                recipe: recipe
+            )
+        }
 
         let handler = OpenAIHandler(
             modelCatalog: ModelCatalog(seedModels: []),
@@ -1383,18 +1424,19 @@ struct OpenAIHandlerTests {
 
         #expect(response.statusCode == 200)
         #expect(logs["source"] as? String == "image_jobs")
-        #expect(logs["total"] as? Int == 3)
-        #expect(logs["visible"] as? Int == 3)
-        #expect(entries.map { $0["state"] as? String } == ["failed", "running", "queued"])
+        #expect(logs["total"] as? Int == 50)
+        #expect(logs["visible"] as? Int == 20)
+        #expect(entries.count == 20)
+        #expect(entries.map { $0["state"] as? String } == Array(repeating: "queued", count: 20))
         #expect(first["event_type"] as? String == "image.job.state_changed")
-        #expect(first["job_id"] as? String == "job-log-tail")
-        #expect(first["request_id"] as? String == "req-log-tail")
+        #expect(first["job_id"] as? String == "job-log-tail-54")
+        #expect(first["request_id"] as? String == "req-log-tail-54")
         #expect(first["model_id"] as? String == "melix-dev-image")
         #expect(first["operation"] as? String == "image.generation")
         #expect(first["lane"] as? String == "multimodal.vision.background")
-        #expect(first["worker_id"] as? String == "vision-worker")
-        #expect(first["progress_stage"] as? String == "failed")
-        #expect(first["failure_code"] as? String == "worker_failed")
+        #expect(first["worker_id"] as? String == "")
+        #expect(first["progress_stage"] as? String == "queued")
+        #expect(first["failure_code"] as? String == "")
         #expect(firstRedaction["raw_log_line"] as? String == "omitted")
         #expect(firstRedaction["raw_prompt"] as? String == "omitted")
         #expect(firstRedaction["request_body"] as? String == "omitted")

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -1023,7 +1023,7 @@ struct OpenAIHandlerTests {
         #expect(firstJob["state"] as? String == "running")
         #expect(firstJob["prompt_digest"] as? String == "sha256:prompt-digest")
         #expect(redaction["raw_prompts"] as? String == "omitted")
-        #expect(redaction["logs"] as? String == "omitted")
+        #expect(redaction["logs"] as? String == "redacted_tail")
         #expect(body.contains(privatePrompt) == false)
         #expect(body.contains(privateNegativePrompt) == false)
         #expect(body.contains(privateArtifactURI) == false)
@@ -1194,6 +1194,7 @@ struct OpenAIHandlerTests {
         recipe.prompt = privatePrompt
         recipe.negativePrompt = privateNegativePrompt
         recipe.sourceImageUri = privateSourceURI
+        recipe.maskUri = privateStorageURI
 
         await imageJobReadModel.recordQueued(
             requestID: "req-receipt-old",
@@ -1281,7 +1282,7 @@ struct OpenAIHandlerTests {
         #expect(firstRedaction["local_paths"] as? String == "omitted")
         #expect(firstRedaction["error_message"] as? String == "omitted")
         #expect(redaction["recent_receipts"] as? String == "redacted_summary")
-        #expect(redaction["logs"] as? String == "omitted")
+        #expect(redaction["logs"] as? String == "redacted_tail")
         #expect(body.contains(privatePrompt) == false)
         #expect(body.contains(privatePromptDelta) == false)
         #expect(body.contains(privateNegativePrompt) == false)
@@ -1289,6 +1290,125 @@ struct OpenAIHandlerTests {
         #expect(body.contains(privateStorageURI) == false)
         #expect(body.contains(privateSourceArtifactID) == false)
         #expect(body.contains(privateErrorMessage) == false)
+        #expect(body.contains("storage_uri") == false)
+        #expect(body.contains("source_artifact_id") == false)
+    }
+
+    @Test("companion status endpoint returns redacted log tail")
+    func companionStatusEndpointReturnsRedactedLogTail() async throws {
+        final class Clock: @unchecked Sendable {
+            private var lockedDate: Date
+            private let lock = NSLock()
+
+            var date: Date {
+                get {
+                    lock.withLock { lockedDate }
+                }
+                set {
+                    lock.withLock {
+                        lockedDate = newValue
+                    }
+                }
+            }
+
+            init(date: Date) {
+                self.lockedDate = date
+            }
+        }
+
+        let clock = Clock(date: Date(timeIntervalSince1970: 2_100))
+        let imageJobReadModel = ImageJobReadModel(now: { clock.date })
+
+        let privatePrompt = "PRIVATE LOG TAIL PROMPT"
+        let privatePromptDelta = "PRIVATE LOG TAIL DELTA"
+        let privateNegativePrompt = "PRIVATE LOG TAIL NEGATIVE"
+        let privateSourceURI = "file:///Users/chenyu/private/log-source.png"
+        let privateStorageURI = "file:///Users/chenyu/private/log-output.png"
+        let privateErrorMessage = "PRIVATE LOG TAIL ERROR"
+
+        var recipe = Melix_Controlplane_V1_ImageJobRecipeSummary()
+        recipe.prompt = privatePrompt
+        recipe.negativePrompt = privateNegativePrompt
+        recipe.sourceImageUri = privateSourceURI
+
+        await imageJobReadModel.recordQueued(
+            requestID: "req-log-tail",
+            jobID: "job-log-tail",
+            modelID: "melix-dev-image",
+            operation: "image.generation",
+            lane: "multimodal.vision.background",
+            promptDigest: "sha256:log-tail",
+            recipe: recipe,
+            sourceArtifactID: "private-log-source-artifact",
+            promptDelta: privatePromptDelta
+        )
+        await imageJobReadModel.recordRunning(
+            jobID: "job-log-tail",
+            workerID: "vision-worker",
+            stage: "sampling",
+            pct: 0.5,
+            completedSteps: 1,
+            totalSteps: 2
+        )
+        var error = Melix_Controlplane_V1_ErrorStatus()
+        error.code = "worker_failed"
+        error.message = privateErrorMessage
+        clock.date = Date(timeIntervalSince1970: 2_101)
+        await imageJobReadModel.recordFailed(jobID: "job-log-tail", error: error)
+
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: []),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                abortRegistry: AbortRegistry()
+            ),
+            imageJobReadModel: imageJobReadModel
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .get,
+                path: "/v1/melix/companion/status",
+                headers: [:],
+                body: Data()
+            )
+        )
+        let body = try await collectBody(response.body)
+        let payload = try #require(JSONSerialization.jsonObject(with: Data(body.utf8)) as? [String: Any])
+        let logs = try #require(payload["logs"] as? [String: Any])
+        let entries = try #require(logs["entries"] as? [[String: Any]])
+        let first = try #require(entries.first)
+        let firstRedaction = try #require(first["redaction"] as? [String: Any])
+        let redaction = try #require(payload["redaction"] as? [String: Any])
+
+        #expect(response.statusCode == 200)
+        #expect(logs["source"] as? String == "image_jobs")
+        #expect(logs["total"] as? Int == 3)
+        #expect(logs["visible"] as? Int == 3)
+        #expect(entries.map { $0["state"] as? String } == ["failed", "running", "queued"])
+        #expect(first["event_type"] as? String == "image.job.state_changed")
+        #expect(first["job_id"] as? String == "job-log-tail")
+        #expect(first["request_id"] as? String == "req-log-tail")
+        #expect(first["model_id"] as? String == "melix-dev-image")
+        #expect(first["operation"] as? String == "image.generation")
+        #expect(first["lane"] as? String == "multimodal.vision.background")
+        #expect(first["worker_id"] as? String == "vision-worker")
+        #expect(first["progress_stage"] as? String == "failed")
+        #expect(first["failure_code"] as? String == "worker_failed")
+        #expect(firstRedaction["raw_log_line"] as? String == "omitted")
+        #expect(firstRedaction["raw_prompt"] as? String == "omitted")
+        #expect(firstRedaction["request_body"] as? String == "omitted")
+        #expect(firstRedaction["artifact_uris"] as? String == "omitted")
+        #expect(firstRedaction["local_paths"] as? String == "omitted")
+        #expect(firstRedaction["error_message"] as? String == "omitted")
+        #expect(redaction["logs"] as? String == "redacted_tail")
+        #expect(body.contains(privatePrompt) == false)
+        #expect(body.contains(privatePromptDelta) == false)
+        #expect(body.contains(privateNegativePrompt) == false)
+        #expect(body.contains(privateSourceURI) == false)
+        #expect(body.contains(privateStorageURI) == false)
+        #expect(body.contains(privateErrorMessage) == false)
+        #expect(body.contains("private-log-source-artifact") == false)
         #expect(body.contains("storage_uri") == false)
         #expect(body.contains("source_artifact_id") == false)
     }


### PR DESCRIPTION
## Summary
- Add a bounded, read-only image job state-event log tail to the companion status read model.
- Expose `logs` on `GET /v1/melix/companion/status` with safe job metadata and explicit redaction markers for raw log lines, prompts, request bodies, artifact URIs, local paths, and error messages.
- Distinguish `logs.visible` from `logs.total` so clients can tell when the retained tail has more entries than the payload returns.
- Cover ordering, retention, zero-limit behavior, cancel events, no-read-model empty logs, and endpoint redaction against private prompt/error/source strings.

## Plan or Spec
- Issue: #1759
- Plan: `docs/plans/2026-06-14-issue-1759-companion-log-tail.md`

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'ImageJobReadModelTests/imageJobLogTailPreservesRedactedStateEvents|OpenAIHandlerTests/companionStatusEndpointReturnsRedactedLogTail'
# Passed: 2 tests in 2 suites.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedLogTail|companionStatusEndpointReturnsEmptyLogsWithoutImageJobReadModel)'
# Passed after review fix: 2 tests in 1 suite.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'ImageJobReadModelTests/imageJobLogTailPreservesRedactedStateEvents|OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedLogTail|companionStatusEndpointReturnsEmptyLogsWithoutImageJobReadModel|companionStatusEndpointReturnsRedactedRecentReceiptSummaries|companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary|companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering|companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering)'
# Passed after review fix: 7 tests in 2 suites.
# Passed after merging origin/main 231ae9d4: 7 tests in 2 suites.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'ImageJobReadModelTests/imageJobLogTailPreservesRedactedStateEvents|OpenAIHandlerTests/(companionStatusEndpointReturnsRedactedLogTail|companionStatusEndpointReturnsEmptyLogsWithoutImageJobReadModel|companionStatusEndpointReturnsRedactedRecentReceiptSummaries|companionStatusEndpointReturnsRedactedRuntimeQueueJobAndSessionSummary|companionStatusEndpointSupportsLocalTrustedEmptyStoresAndDeterministicJobOrdering|companionStatusEndpointSupportsCredentialAuthAndNewestJobOrdering)'
# Passed after review fix: 7 tests in 2 suites.
# Passed after merging origin/main 231ae9d4: 7 tests in 2 suites.

UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/ImageJobs/ImageJobReadModel.swift services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/ControlPlaneTests/ImageJobReadModelTests.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
# Passed after review fix: TOTAL 99.37% changed-line coverage.
# Passed after merging origin/main 231ae9d4: TOTAL 99.37% changed-line coverage.

make swift-test
# Passed before PR update: swift-test completed rc=0.
# Passed after merging origin/main 231ae9d4: swift-test completed rc=0.

make py-test
# Passed before PR update: 4014 passed, 14 skipped, 2 warnings.
# Passed after merging origin/main 231ae9d4: 4014 passed, 14 skipped, 2 warnings.

make integration-test
# Passed before PR update: 120 passed, 1 skipped.
# Passed after merging origin/main 231ae9d4: 120 passed, 1 skipped.

git diff --check
# Passed: no whitespace errors.

.githooks/pre-commit
# Passed before initial commit: make swift-test rc=0; make py-test rc=0; make integration-test rc=0; performance report Status: ok, Regressions: 0.
# Passed after review fix: make swift-test rc=0; make py-test rc=0; make integration-test rc=0; performance report Status: ok, Regressions: 0.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts import pre_commit_gate

root = Path.cwd()
changed = [p for p in pre_commit_gate.run_git(root, ["diff", "--name-only", "origin/main...HEAD"]).splitlines() if p.strip()]
outcome = pre_commit_gate.run_performance_report(root, changed, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# Passed after merging origin/main 231ae9d4: performance report Status: ok, Regressions: 0.
```

## Coverage and Metrics
- Changed-line coverage after review fix and after merging `origin/main` 231ae9d4: 99.37% total, 315/317 changed lines covered.
- Per-file changed-line coverage after review fix and after merging `origin/main` 231ae9d4: `ImageJobReadModel.swift` 96.15% (50/52; uncovered defensive enum fallback lines 249 and 261), `OpenAIHandler.swift` 100.00% (39/39), `ImageJobReadModelTests.swift` 100.00% (66/66), `OpenAIHandlerTests.swift` 100.00% (160/160).
- Runtime metric path: existing `companion.status_latency_ms` continues to cover the status endpoint path.
- Pre-commit performance report before initial commit: `Status: ok`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`; no registered performance probes were selected for this change set.
- Initial performance report artifact: `.runtime/pre-commit-performance/20260614-153547-52c8bb0c/report/report.md`.
- Pre-commit performance report after review fix: `Status: ok`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`; no registered performance probes were selected for this change set.
- Review-fix performance report artifact: `.runtime/pre-commit-performance/20260614-160347-c5ec8c21/report/report.md`.
- Post-merge-main scoped performance report: `Status: ok`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`; no registered performance probes were selected for this change set.
- Post-merge-main performance report artifact: `.runtime/pre-commit-performance/20260614-163345-b09b9c4a/report/report.md`.
- Observability mode: minimal endpoint payload summary; no debug/evidence probe added.
- Probe overhead: N/A because the PR-scoped report selected no probes for this small in-memory status read-model change.

## Known Gaps
- Deferred issue #1759 work remains out of scope for this slice: QR/code pairing UX, desktop token controls, mobile/narrow viewport UI smoke, and companion UI rendering of the log tail.
- Generic filesystem log tailing, OSLog ingestion, worker stdout/stderr reads, raw runtime log lines, prompt text, request bodies, local paths, artifact URIs, and raw error messages remain intentionally out of scope.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
