### PR TITLE
perf: dispatch retrieval admissions directly

### DIFF
--- a/docs/plans/2026-06-14-retrieval-admit-entry-direct.md
+++ b/docs/plans/2026-06-14-retrieval-admit-entry-direct.md
@@ -1,0 +1,39 @@
+# Retrieval Context Admission Direct Dispatch Slice
+
+This Python performance slice is limited to `worker.runtime.retrieval_context._admit_entry`.
+
+## Scope
+
+`project_retrieval_contexts` and `project_retrieval_store_records` call `_admit_entry` for every retrieval context item before prompt projection. The prior implementation dispatched valid document/image entries through the public wrapper helpers before returning to `_admit_context`. This slice preserves the wrapper APIs but lets `_admit_entry` call `_admit_context` directly for the two valid hot-path kinds.
+
+Out of scope:
+
+- changing public retrieval admission semantics
+- changing refusal receipt schemas
+- changing retrieval lookup payload copy behavior
+- changing probe registry definitions
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped performance probe `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.
+
+The registry includes focused commands for:
+
+- `test_command`
+- `coverage_command`
+- `probe_command`
+
+## Verification Plan
+
+Run the registered focused commands locally on Linux before opening the PR:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_accepts_valid_records services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_builds_prompt_message_with_copied_payloads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_accepts_valid_records services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_builds_prompt_message_with_copied_payloads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/retrieval_context_projection_probe.py"; if [ -f "$SCRIPT" ]; then python3 "$SCRIPT"; else python3 - <<"PYPROBE"
+raise SystemExit("probe script missing")
+PYPROBE
+fi'
+```
+
+CI remains the merge gate for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -366,20 +366,12 @@ def _admit_entry(entry: RetrievalContextEntry) -> PromptContextAdmission:
             source_field="entry",
             owner_scope_checked=False,
         )
-    if entry.context_kind == "retrieved_document":
-        return admit_retrieved_document_context(
-            document_id=entry.source_id,
-            document_payload=entry.payload,
-            owner_scope_checked=entry.owner_scope_checked,
-            segment_id=entry.segment_id,
-            source_field=entry.source_field,
-            reason=entry.reason,
-            corrective_action=entry.corrective_action,
-        )
-    if entry.context_kind == "retrieved_image":
-        return admit_retrieved_image_context(
-            image_id=entry.source_id,
-            image_payload=entry.payload,
+    context_kind = entry.context_kind
+    if context_kind == "retrieved_document" or context_kind == "retrieved_image":
+        return _admit_context(
+            context_kind=context_kind,
+            source_id=entry.source_id,
+            payload=entry.payload,
             owner_scope_checked=entry.owner_scope_checked,
             segment_id=entry.segment_id,
             source_field=entry.source_field,


### PR DESCRIPTION
## Summary
- Dispatch valid retrieval document/image entries directly from `_admit_entry` into `_admit_context`.
- Preserve public wrapper APIs and all refusal/receipt semantics.
- Document the slice and its registered probe gate in `docs/plans/2026-06-14-retrieval-admit-entry-direct.md`.

## Plan or Spec
- `docs/plans/2026-06-14-retrieval-admit-entry-direct.md`
- Registered probe: `retrieval-context-projection-fastpath`

## Commands Run
- `git fetch origin && git checkout main && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/retrieval_context_projection_probe.py"; if [ -f "$SCRIPT" ]; then python3 "$SCRIPT"; else python3 - <<"PYPROBE" ...'` (baseline before edit)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_accepts_valid_records services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_builds_prompt_message_with_copied_payloads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_accepts_valid_records services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_builds_prompt_message_with_copied_payloads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/retrieval_context_projection_probe.py"; if [ -f "$SCRIPT" ]; then python3 "$SCRIPT"; else python3 - <<"PYPROBE" ...'`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 13 passed.
- Changed-scope coverage: 100.00% (3/3 measurable changed lines covered).
- Baseline local probe before edit: `optimized_elapsed_ms_mean=0.035589759603941014`, `store_optimized_elapsed_ms_mean=0.2178016447994326`, `lookup_copy_optimized_elapsed_ms_mean=0.21493802329392306`.
- Local probe after edit: `optimized_elapsed_ms_mean=0.0351813089634691`, `store_optimized_elapsed_ms_mean=0.2176615667329835`, `lookup_copy_optimized_elapsed_ms_mean=0.21138463551843806`.
- Local deltas vs pre-edit local run: projection optimized mean `-0.0004084506404719147 ms` (~1.15% faster), store optimized mean `-0.00014007806644909542 ms`, lookup-copy optimized mean `-0.003553387775485 ms`.
- CI PR-scoped performance is required as the merge gate for registered probe validation.

## Known Gaps
- This is a Linux-verified Python slice; no Swift runtime behavior is changed.
- The local probe improvement is small, so the registered CI probe remains the authoritative merge gate.

## Evidence Checklist
- [x] Fresh worktree from `origin/main`.
- [x] Affected path has registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage captured locally.
- [x] Registered probe run locally.
- [ ] GitHub Actions / PR-scoped performance report completed successfully.
