### PR TITLE
perf: bind retrieval payload copy helper

### DIFF
--- a/docs/plans/2026-06-14-retrieval-lookup-payload-copy-local-binding.md
+++ b/docs/plans/2026-06-14-retrieval-lookup-payload-copy-local-binding.md
@@ -1,0 +1,35 @@
+# Retrieval Lookup Payload Copy Local Binding
+
+## Summary
+
+This slice keeps retrieval lookup projection behavior unchanged and narrows one
+Python hot path: copying nested lookup payload values in
+`worker.runtime.retrieval_context._copy_payload` / `_copy_payload_value`.
+
+The affected path is already covered by the registered PR-scoped probe
+`retrieval-context-projection-fastpath`, which includes focused tests,
+changed-scope coverage, and a JSON performance probe command.
+
+## Probe Coverage
+
+Registered probe: `retrieval-context-projection-fastpath`
+
+Affected files covered by the probe registry:
+
+- `services/mlx-worker-python/worker/runtime/retrieval_context.py`
+- `services/mlx-worker-python/tests/test_retrieval_context.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/retrieval_context_projection_probe.py`
+
+## Implementation
+
+Bind `_copy_payload_value` to a local variable before dict/list/tuple
+comprehensions in the recursive copy helper. This removes repeated global name
+lookups while preserving the same exact-type copy semantics and the `deepcopy`
+fallback for unknown value types.
+
+## Validation Plan
+
+Run the registered focused tests, changed-scope coverage command, and registered
+probe locally on Linux. The PR-scoped performance workflow remains the source of
+truth for the CI probe report before merge.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -330,7 +330,8 @@ def project_retrieval_lookup_result(lookup_result: Any) -> RetrievalLookupResult
 
 
 def _copy_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
-    return {key: _copy_payload_value(value) for key, value in payload.items()}
+    copy_value = _copy_payload_value
+    return {key: copy_value(value) for key, value in payload.items()}
 
 
 def _copy_payload_value(value: Any) -> Any:
@@ -343,12 +344,13 @@ def _copy_payload_value(value: Any) -> Any:
         or value is None
     ):
         return value
+    copy_value = _copy_payload_value
     if value_type is dict:
-        return {key: _copy_payload_value(item) for key, item in value.items()}
+        return {key: copy_value(item) for key, item in value.items()}
     if value_type is list:
-        return [_copy_payload_value(item) for item in value]
+        return [copy_value(item) for item in value]
     if value_type is tuple:
-        return tuple([_copy_payload_value(item) for item in value])
+        return tuple([copy_value(item) for item in value])
     return deepcopy(value)
 
 


### PR DESCRIPTION
## Summary
- Bind the retrieval lookup payload copy helper to local variables before recursive dict/list/tuple comprehensions.
- Preserve exact-type copy semantics and the `deepcopy` fallback for unknown values.
- Document the slice and registered probe coverage in `docs/plans/2026-06-14-retrieval-lookup-payload-copy-local-binding.md`.

## Plan or Spec
- `docs/plans/2026-06-14-retrieval-lookup-payload-copy-local-binding.md`
- Registered PR-scoped probe: `retrieval-context-projection-fastpath`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_isolates_refusals_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_malformed_entry_objects_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_preserves_multi_field_admission_duplicate_scan services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_copies_multi_receipt_admissions services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_projects_records_without_entry_reentry services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_copies_store_projection_outputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 13 passed.
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Local Linux registered probe output:
  - `baseline_elapsed_ms_mean=0.07211934209668211`
  - `optimized_elapsed_ms_mean=0.03628010711898761`
  - `speedup=1.9878481025470187`
  - `lookup_copy_baseline_elapsed_ms_mean=0.8225160329935274`
  - `lookup_copy_optimized_elapsed_ms_mean=0.21235197350116713`
  - `lookup_copy_speedup=3.873361850291477`
  - `store_baseline_elapsed_ms_mean=0.23626220894844405`
  - `store_optimized_elapsed_ms_mean=0.22425375928703165`
  - `store_speedup=1.0535484876578693`

## Known Gaps
- This is a Python-only slice validated locally on Linux.
- CI PR-scoped performance report is still required before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe emitted JSON metrics.
- [ ] GitHub Actions and PR-scoped performance workflow completed successfully.
