### PR TITLE
perf: map dataset source paths through bound constructor

### DIFF
--- a/docs/plans/2026-06-14-dataset-source-path-map-fastpath.md
+++ b/docs/plans/2026-06-14-dataset-source-path-map-fastpath.md
@@ -1,0 +1,34 @@
+# Dataset source path map fast path
+
+## Scope
+
+This Python-only performance slice targets
+`worker.productization.dataset_preparation._iter_source_file_paths` after the
+scandir traversal has collected and sorted source file path strings. The behavior
+remains unchanged: the helper returns a deterministically sorted `list[Path]`,
+skips scandir entry errors, and does not follow directory symlinks.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped probe
+`dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries and watches the dataset preparation implementation,
+focused ingest tests, PR-scoped performance tests, and
+`scripts/dataset_source_records_probe.py`.
+
+## Implementation plan
+
+1. Preserve the existing explicit `os.scandir` traversal and deterministic string
+   sort.
+2. Convert sorted path strings to `Path` instances through the locally bound
+   `Path` constructor with `list(map(...))` to avoid the Python-level list
+   comprehension loop in this final projection step.
+3. Re-run the registered focused tests, changed-scope coverage command, and the
+   registered probe locally on Linux before opening the PR.
+
+## Verification boundary
+
+This slice is Python-only and locally verifiable on Linux. The PR-scoped GitHub
+Actions performance workflow remains the merge gate for the registered probe
+report.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -588,7 +588,7 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
         except OSError:
             continue
     file_paths.sort()
-    return [path_cls(file_path) for file_path in file_paths]
+    return list(map(path_cls, file_paths))
 
 
 def _classify_source_kind_name(name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Optimizes `worker.productization.dataset_preparation._iter_source_file_paths` by projecting sorted path strings with the locally bound `Path` constructor via `list(map(...))`.
- Adds a small governing plan for this Python-only dataset source path projection slice.

## Plan or Spec
- `docs/plans/2026-06-14-dataset-source-path-map-fastpath.md`
- Registered probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=9 uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py` (baseline before edit)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=9 uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py` (after edit)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_reuses_cached_basename_classification services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_returns_cached_none_without_reclassifying services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_name_cache_clears_at_bound services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 13 passed.
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Baseline probe (9 samples): `elapsed_ms_mean=12.954184682004982`, `source_kind_elapsed_ms_mean=17.26870471611619`.
- Optimized probe (9 samples): `elapsed_ms_mean=11.103078360772795`, `source_kind_elapsed_ms_mean=14.92827825455202`.
- Local delta: `elapsed_ms_mean -1.851106321232187 ms` (~14.29% faster); source-kind pass improved by `-2.34042646156417 ms` (~13.55%), likely due to lower path projection overhead and run-to-run locality.
- Registered probe CI is required before merge.

## Known Gaps
- Linux local verification covers the Python slice; GitHub Actions PR-scoped performance is still the registered merge gate.
- This does not change traversal semantics or source-kind classification behavior.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before the slice.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage met the 95% requirement.
- [x] Local registered probe showed an improvement.
- [ ] PR-scoped performance CI completed successfully.
