### PR TITLE
Add companion pairing descriptor

### DIFF
--- a/docs/plans/2026-06-15-issue-1759-companion-pairing-descriptor.md
+++ b/docs/plans/2026-06-15-issue-1759-companion-pairing-descriptor.md
@@ -104,6 +104,11 @@ Verification results on 2026-06-15:
 - After merging `origin/main` at `36a94fd5`, focused Swift tests passed again,
   changed-line coverage remained `TOTAL 99.29% 140/141`, and
   `git diff --check` passed again.
+- Review follow-up: static pairing route/capability lists were hoisted out of
+  the initializer, empty bind hosts now fall back to `127.0.0.1`, IPv4 hosts are
+  no longer bracketed, and IPv6 literal/bracketed hosts remain URL-safe.
+- After the review follow-up, focused Swift tests passed again and changed-line
+  coverage was `TOTAL 100.00% 155/155`.
 - Scoped performance report:
   `.runtime/pre-commit-performance/20260614-180426-36a94fd5/report/report.md`,
   `Status: ok`, 0 regressions, 0 selected probes.

--- a/docs/plans/2026-06-15-issue-1759-companion-pairing-descriptor.md
+++ b/docs/plans/2026-06-15-issue-1759-companion-pairing-descriptor.md
@@ -1,0 +1,123 @@
+# Issue 1759 Companion Pairing Descriptor
+
+## Goal
+
+Add a small, explicit pairing descriptor to companion read-only session creation
+responses so future QR/code and desktop token-control surfaces can consume a
+stable contract without inferring companion capability from a raw session token.
+
+## Best End-State Architecture
+
+Companion pairing should remain a gateway-scoped session flow. Trusted operator
+surfaces use an existing gateway credential to issue a `companion_read_only`
+session, then present a pairing descriptor that tells the companion client which
+header to use, which status URL to open, which read-only routes are allowed,
+and which control capabilities are forbidden. The descriptor must not duplicate
+the raw session token; the existing `resume.token` field remains the only raw
+token carrier in this endpoint response.
+
+This keeps the security boundary in the HTTP gateway and gives later desktop UI
+and QR-code work a deterministic payload to render.
+
+## Slice Boundary
+
+This slice only extends `POST /v1/melix/auth/session` responses for
+`scope = companion_read_only`.
+
+Included:
+
+- a `pairing` response object for companion sessions;
+- schema, scope, header name, status URL, allowed routes, forbidden capability
+  names, token transport, and expiry metadata;
+- focused Swift tests proving the pairing object is returned for companion
+  sessions, absent for operator sessions, and does not duplicate the raw token;
+- runbook documentation for companion session creation.
+
+Excluded:
+
+- QR image/code rendering;
+- desktop UI controls for issuing or revoking tokens;
+- mobile/narrow viewport smoke;
+- LAN discovery or public internet exposure;
+- changing the existing route authorization allowlist.
+
+## Performance Probes and Metrics
+
+- Runtime metric: existing persistent-session metrics continue to cover active,
+  remembered, expired, restore, and sign-out counts. This slice does not add a
+  new runtime metric because response assembly is a fixed-size DTO projection on
+  the existing auth-session route.
+- Observability mode: `minimal`, using existing route/session metrics only.
+- Probe overhead: N/A; no sampled or debug probe is introduced.
+- PR merge gate: scoped performance report must remain `Status: ok` with zero
+  regressions.
+
+## Implementation Plan
+
+1. Add a failing Swift gateway test that creates a remembered
+   `companion_read_only` auth session and expects `pairing.schema_version =
+   melix.companion.pairing.v1`, `pairing.status_url`, `pairing.resume_header`,
+   `pairing.token_transport = resume_header`, read-only route entries, and
+   forbidden mutating capability names. Assert `pairing` does not contain the
+   raw `resume.token`.
+2. Add an adjacent regression assertion proving ordinary operator-control
+   session creation still has no `pairing` object.
+3. Extend `OpenAIAuthSessionResponse` with optional `pairing` and populate it
+   only when the issued session scope is `companion_read_only`.
+4. Derive the status URL from the active gateway runtime binding as
+   `http://<host>:<port>/v1/melix/companion/status`.
+5. Update `docs/runbooks/persistent-sessions.md` with a companion pairing
+   creation example and safe-token note.
+6. Run focused tests, changed-line coverage, full local gate, pre-commit
+   performance report, then PR monitoring.
+
+## Verification
+
+Focused Swift tests:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companionAuthSessionCreationReturnsPairingDescriptor|gatewayAuthSessionsCanBeCreatedReusedAndRevoked|companionAuthSessionsCanReadStatusAndRevokeThemselvesButCannotMutateRuntime)'
+```
+
+Changed-line coverage:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIHandlerTests/(companionAuthSessionCreationReturnsPairingDescriptor|gatewayAuthSessionsCanBeCreatedReusedAndRevoked|companionAuthSessionsCanReadStatusAndRevokeThemselvesButCannotMutateRuntime)'
+UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+```
+
+Verification results on 2026-06-15:
+
+- Red check: `OpenAIHandlerTests/companionAuthSessionCreationReturnsPairingDescriptor`
+  failed before implementation because `payload["pairing"]` was absent.
+- Red check: after changing the test binding host to `0.0.0.0`, the same test
+  failed because `pairing.status_url` exposed `0.0.0.0` instead of the
+  client-usable `127.0.0.1` URL.
+- Green check: the companion pairing test passed after adding the pairing DTO
+  and display-host normalization.
+- Adjacent focused tests passed: 3 tests in 1 suite.
+- Changed-line coverage: `TOTAL 99.29% 140/141`.
+- `git diff --check`: passed.
+- `make swift-test`: passed.
+- `make py-test`: passed, `4014 passed, 14 skipped, 2 warnings`.
+- `make integration-test`: passed, `120 passed, 1 skipped`.
+- After merging `origin/main` at `36a94fd5`, focused Swift tests passed again,
+  changed-line coverage remained `TOTAL 99.29% 140/141`, and
+  `git diff --check` passed again.
+- Scoped performance report:
+  `.runtime/pre-commit-performance/20260614-180426-36a94fd5/report/report.md`,
+  `Status: ok`, 0 regressions, 0 selected probes.
+
+Full gate before PR:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```
+
+## Deferred Work
+
+- QR/code rendering and copyable pairing sheet.
+- Desktop companion-token issuance and revocation controls.
+- Mobile/narrow viewport smoke for the companion status flow.

--- a/docs/runbooks/persistent-sessions.md
+++ b/docs/runbooks/persistent-sessions.md
@@ -57,6 +57,35 @@ Expected response:
 - `resume.token` present
 - `session.remember_me = true`
 
+### Create A Companion Pairing Session
+
+```bash
+curl -sS \
+  -H 'content-type: application/json' \
+  -H 'x-api-key: sk-desktop' \
+  -d '{"remember_me":true,"scope":"companion_read_only"}' \
+  http://127.0.0.1:${MELIX_HTTP_PORT:-12436}/v1/melix/auth/session
+```
+
+Expected response:
+
+- `200`
+- `session.scope = "companion_read_only"`
+- `resume.header = "x-melix-session"`
+- `resume.token` present
+- `pairing.schema_version = "melix.companion.pairing.v1"`
+- `pairing.status_url` points at `/v1/melix/companion/status`
+- `pairing.allowed_routes` lists the read-only companion routes and
+  self-revocation route
+- `pairing.forbidden_capabilities` includes mutating and private-content
+  capabilities such as `run_inference`, `mutate_runtime`, and
+  `read_private_prompts`
+
+The pairing descriptor is safe to render in a QR/token-management sheet because
+it describes how the companion client should use the session. It does not
+duplicate the raw token. Keep treating `resume.token` as the only secret value
+in the response.
+
 ### Reuse The Session
 
 ```bash

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -6135,30 +6135,37 @@ private struct OpenAICompanionPairingPayload: Codable {
         statusURL = "http://\(Self.urlHost(displayHost)):\(gatewayRuntimeBinding.port)/v1/melix/companion/status"
         expiresAtUnixMs = metadata.expiresAtUnixMs
         allowedOrigins = gatewayRuntimeBinding.allowedOrigins
-        allowedRoutes = [
-            OpenAICompanionPairingRoutePayload(method: "GET", path: "/.well-known/melix.json"),
-            OpenAICompanionPairingRoutePayload(method: "GET", path: "/api/capabilities"),
-            OpenAICompanionPairingRoutePayload(method: "GET", path: "/api/instructions"),
-            OpenAICompanionPairingRoutePayload(method: "GET", path: "/api/config-metadata"),
-            OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/models"),
-            OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/melix/health"),
-            OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/cache/stats"),
-            OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/melix/companion/status"),
-            OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/melix/auth/session"),
-            OpenAICompanionPairingRoutePayload(method: "DELETE", path: "/v1/melix/auth/session"),
-        ]
-        forbiddenCapabilities = [
-            "mutate_runtime",
-            "run_inference",
-            "start_jobs",
-            "read_private_prompts",
-            "read_raw_logs",
-            "read_local_paths",
-        ]
+        allowedRoutes = Self.defaultAllowedRoutes
+        forbiddenCapabilities = Self.defaultForbiddenCapabilities
     }
+
+    private static let defaultAllowedRoutes = [
+        OpenAICompanionPairingRoutePayload(method: "GET", path: "/.well-known/melix.json"),
+        OpenAICompanionPairingRoutePayload(method: "GET", path: "/api/capabilities"),
+        OpenAICompanionPairingRoutePayload(method: "GET", path: "/api/instructions"),
+        OpenAICompanionPairingRoutePayload(method: "GET", path: "/api/config-metadata"),
+        OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/models"),
+        OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/melix/health"),
+        OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/cache/stats"),
+        OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/melix/companion/status"),
+        OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/melix/auth/session"),
+        OpenAICompanionPairingRoutePayload(method: "DELETE", path: "/v1/melix/auth/session"),
+    ]
+
+    private static let defaultForbiddenCapabilities = [
+        "mutate_runtime",
+        "run_inference",
+        "start_jobs",
+        "read_private_prompts",
+        "read_raw_logs",
+        "read_local_paths",
+    ]
 
     private static func displayHost(for bindHost: String) -> String {
         let candidate = bindHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !candidate.isEmpty else {
+            return "127.0.0.1"
+        }
         switch candidate.lowercased() {
         case "0.0.0.0", "::", "[::]":
             return "127.0.0.1"
@@ -6168,13 +6175,13 @@ private struct OpenAICompanionPairingPayload: Codable {
     }
 
     private static func urlHost(_ host: String) -> String {
-        guard !host.hasPrefix("["),
-              !host.hasSuffix("]"),
-              host.filter({ $0 == ":" }).count > 1
-        else {
+        if host.hasPrefix("[") && host.hasSuffix("]") {
             return host
         }
-        return "[\(host)]"
+        if host.contains(":") {
+            return "[\(host)]"
+        }
+        return host
     }
 
     enum CodingKeys: String, CodingKey {

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -1148,6 +1148,10 @@ public struct OpenAIHandler: Sendable {
             resume: OpenAIAuthSessionResumePayload(
                 header: PersistentAuthSessionStore.sessionHeaderName,
                 token: issued.token
+            ),
+            pairing: OpenAICompanionPairingPayload(
+                metadata: issued.metadata,
+                gatewayRuntimeBinding: gatewayRuntimeBinding
             )
         )
         return try encodedJSONResponse(response)
@@ -1161,7 +1165,8 @@ public struct OpenAIHandler: Sendable {
         }
         let response = OpenAIAuthSessionResponse(
             session: OpenAIAuthSessionPayload(metadata: metadata),
-            resume: nil
+            resume: nil,
+            pairing: nil
         )
         return try encodedJSONResponse(response)
     }
@@ -1179,7 +1184,8 @@ public struct OpenAIHandler: Sendable {
         case .success(let metadata):
             let response = OpenAIAuthSessionResponse(
                 session: OpenAIAuthSessionPayload(metadata: metadata),
-                resume: nil
+                resume: nil,
+                pairing: nil
             )
             return try encodedJSONResponse(response)
         case .failure(let failure):
@@ -6059,6 +6065,7 @@ private struct OpenAICreateAuthSessionRequest: Decodable {
 private struct OpenAIAuthSessionResponse: Codable {
     let session: OpenAIAuthSessionPayload
     let resume: OpenAIAuthSessionResumePayload?
+    let pairing: OpenAICompanionPairingPayload?
 }
 
 private struct OpenAIAuthSessionPayload: Codable {
@@ -6100,6 +6107,92 @@ private struct OpenAIAuthSessionPayload: Codable {
 private struct OpenAIAuthSessionResumePayload: Codable {
     let header: String
     let token: String
+}
+
+private struct OpenAICompanionPairingPayload: Codable {
+    let schemaVersion: String
+    let scope: PersistentAuthSessionScope
+    let tokenTransport: String
+    let resumeHeader: String
+    let statusURL: String
+    let expiresAtUnixMs: Int64
+    let allowedOrigins: [String]
+    let allowedRoutes: [OpenAICompanionPairingRoutePayload]
+    let forbiddenCapabilities: [String]
+
+    init?(
+        metadata: PersistentAuthSessionMetadata,
+        gatewayRuntimeBinding: GatewayRuntimeBinding
+    ) {
+        guard metadata.scope == .companionReadOnly else {
+            return nil
+        }
+        schemaVersion = "melix.companion.pairing.v1"
+        scope = metadata.scope
+        tokenTransport = "resume_header"
+        resumeHeader = PersistentAuthSessionStore.sessionHeaderName
+        let displayHost = Self.displayHost(for: gatewayRuntimeBinding.host)
+        statusURL = "http://\(Self.urlHost(displayHost)):\(gatewayRuntimeBinding.port)/v1/melix/companion/status"
+        expiresAtUnixMs = metadata.expiresAtUnixMs
+        allowedOrigins = gatewayRuntimeBinding.allowedOrigins
+        allowedRoutes = [
+            OpenAICompanionPairingRoutePayload(method: "GET", path: "/.well-known/melix.json"),
+            OpenAICompanionPairingRoutePayload(method: "GET", path: "/api/capabilities"),
+            OpenAICompanionPairingRoutePayload(method: "GET", path: "/api/instructions"),
+            OpenAICompanionPairingRoutePayload(method: "GET", path: "/api/config-metadata"),
+            OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/models"),
+            OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/melix/health"),
+            OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/cache/stats"),
+            OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/melix/companion/status"),
+            OpenAICompanionPairingRoutePayload(method: "GET", path: "/v1/melix/auth/session"),
+            OpenAICompanionPairingRoutePayload(method: "DELETE", path: "/v1/melix/auth/session"),
+        ]
+        forbiddenCapabilities = [
+            "mutate_runtime",
+            "run_inference",
+            "start_jobs",
+            "read_private_prompts",
+            "read_raw_logs",
+            "read_local_paths",
+        ]
+    }
+
+    private static func displayHost(for bindHost: String) -> String {
+        let candidate = bindHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch candidate.lowercased() {
+        case "0.0.0.0", "::", "[::]":
+            return "127.0.0.1"
+        default:
+            return candidate
+        }
+    }
+
+    private static func urlHost(_ host: String) -> String {
+        guard !host.hasPrefix("["),
+              !host.hasSuffix("]"),
+              host.filter({ $0 == ":" }).count > 1
+        else {
+            return host
+        }
+        return "[\(host)]"
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case scope
+        case tokenTransport = "token_transport"
+        case resumeHeader = "resume_header"
+        case statusURL = "status_url"
+        case expiresAtUnixMs = "expires_at_unix_ms"
+        case allowedOrigins = "allowed_origins"
+        case allowedRoutes = "allowed_routes"
+        case forbiddenCapabilities = "forbidden_capabilities"
+    }
+}
+
+private struct OpenAICompanionPairingRoutePayload: Codable {
+    let method: String
+    let path: String
 }
 
 private struct OpenAIEmbeddingsRequest: Codable {

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -890,65 +890,82 @@ struct OpenAIHandlerTests {
 
     @Test("companion auth session creation returns pairing descriptor")
     func companionAuthSessionCreationReturnsPairingDescriptor() async throws {
-        let metricsStore = MetricsStore()
-        let temporaryRoot = FileManager.default.temporaryDirectory
-            .appendingPathComponent("melix-companion-pairing-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+        func createPairingDescriptor(
+            host: String,
+            port: UInt32 = 12_499
+        ) async throws -> (
+            response: HTTPResponse,
+            session: [String: Any],
+            resume: [String: Any],
+            pairing: [String: Any],
+            body: String
+        ) {
+            let metricsStore = MetricsStore()
+            let temporaryRoot = FileManager.default.temporaryDirectory
+                .appendingPathComponent("melix-companion-pairing-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: temporaryRoot) }
 
-        let handler = OpenAIHandler(
-            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
-            requestCoordinator: RequestCoordinator(
-                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
-                abortRegistry: AbortRegistry()
-            ),
-            metricsStore: metricsStore,
-            gatewayAccessPolicy: GatewayAccessPolicy(
-                mode: .apiKeys,
-                sharedAccessEnabled: true,
-                keys: [
-                    .init(keyID: "codex", label: "Codex", tokenHint: "codex", token: "sk-codex"),
-                ]
-            ),
-            gatewayRuntimeBinding: GatewayRuntimeBinding(
-                host: "0.0.0.0",
-                port: 12_499,
-                allowedOrigins: ["http://127.0.0.1:52499"]
-            ),
-            persistentAuthSessionStore: PersistentAuthSessionStore(
-                storeURL: temporaryRoot.appendingPathComponent("persistent-auth-sessions.json"),
+            let handler = OpenAIHandler(
+                modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+                requestCoordinator: RequestCoordinator(
+                    workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                    abortRegistry: AbortRegistry()
+                ),
                 metricsStore: metricsStore,
-                retentionTTLSeconds: 3_600,
-                nowUnixMs: { 1_000 }
+                gatewayAccessPolicy: GatewayAccessPolicy(
+                    mode: .apiKeys,
+                    sharedAccessEnabled: true,
+                    keys: [
+                        .init(keyID: "codex", label: "Codex", tokenHint: "codex", token: "sk-codex"),
+                    ]
+                ),
+                gatewayRuntimeBinding: GatewayRuntimeBinding(
+                    host: host,
+                    port: port,
+                    allowedOrigins: ["http://127.0.0.1:52499"]
+                ),
+                persistentAuthSessionStore: PersistentAuthSessionStore(
+                    storeURL: temporaryRoot.appendingPathComponent("persistent-auth-sessions.json"),
+                    metricsStore: metricsStore,
+                    retentionTTLSeconds: 3_600,
+                    nowUnixMs: { 1_000 }
+                )
             )
-        )
 
-        let createResponse = try await handler.handle(
-            HTTPRequest(
-                method: .post,
-                path: "/v1/melix/auth/session",
-                headers: [
-                    "content-type": "application/json",
-                    "x-api-key": "sk-codex",
-                ],
-                body: try #require("""
-                {
-                  "remember_me": true,
-                  "scope": "companion_read_only"
-                }
-                """.data(using: .utf8))
+            let createResponse = try await handler.handle(
+                HTTPRequest(
+                    method: .post,
+                    path: "/v1/melix/auth/session",
+                    headers: [
+                        "content-type": "application/json",
+                        "x-api-key": "sk-codex",
+                    ],
+                    body: try #require("""
+                    {
+                      "remember_me": true,
+                      "scope": "companion_read_only"
+                    }
+                    """.data(using: .utf8))
+                )
             )
-        )
-        let payload = try await jsonPayload(from: createResponse.body)
-        let session = try #require(payload["session"] as? [String: Any])
-        let resume = try #require(payload["resume"] as? [String: Any])
-        let pairing = try #require(payload["pairing"] as? [String: Any])
+            let payload = try await jsonPayload(from: createResponse.body)
+            let session = try #require(payload["session"] as? [String: Any])
+            let resume = try #require(payload["resume"] as? [String: Any])
+            let pairing = try #require(payload["pairing"] as? [String: Any])
+            let body = try await collectBody(createResponse.body)
+            return (createResponse, session, resume, pairing, body)
+        }
+
+        let result = try await createPairingDescriptor(host: "0.0.0.0")
+        let session = result.session
+        let resume = result.resume
+        let pairing = result.pairing
         let allowedRoutes = try #require(pairing["allowed_routes"] as? [[String: Any]])
         let forbiddenCapabilities = try #require(pairing["forbidden_capabilities"] as? [String])
         let token = try #require(resume["token"] as? String)
-        let body = try await collectBody(createResponse.body)
 
-        #expect(createResponse.statusCode == 200)
+        #expect(result.response.statusCode == 200)
         #expect(session["scope"] as? String == "companion_read_only")
         #expect(pairing["schema_version"] as? String == "melix.companion.pairing.v1")
         #expect(pairing["scope"] as? String == "companion_read_only")
@@ -967,8 +984,20 @@ struct OpenAIHandlerTests {
         #expect(forbiddenCapabilities.contains("run_inference"))
         #expect(forbiddenCapabilities.contains("read_private_prompts"))
         #expect((pairing["token"] as? String) == nil)
-        #expect(body.contains("\"pairing\""))
-        #expect(body.components(separatedBy: token).count == 2)
+        #expect(result.body.contains("\"pairing\""))
+        #expect(result.body.components(separatedBy: token).count == 2)
+
+        let loopbackResult = try await createPairingDescriptor(host: "127.0.0.1", port: 12_500)
+        #expect(loopbackResult.pairing["status_url"] as? String == "http://127.0.0.1:12500/v1/melix/companion/status")
+
+        let emptyHostResult = try await createPairingDescriptor(host: "   \n", port: 12_501)
+        #expect(emptyHostResult.pairing["status_url"] as? String == "http://127.0.0.1:12501/v1/melix/companion/status")
+
+        let ipv6Result = try await createPairingDescriptor(host: "fd00::1", port: 12_502)
+        #expect(ipv6Result.pairing["status_url"] as? String == "http://[fd00::1]:12502/v1/melix/companion/status")
+
+        let bracketedIPv6Result = try await createPairingDescriptor(host: "[fd00::2]", port: 12_503)
+        #expect(bracketedIPv6Result.pairing["status_url"] as? String == "http://[fd00::2]:12503/v1/melix/companion/status")
     }
 
     @Test("companion status endpoint returns redacted runtime queue job and session summary")

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -740,6 +740,7 @@ struct OpenAIHandlerTests {
         let sessionState = try #require(error["session_state"] as? [String: Any])
 
         #expect(createResponse.statusCode == 200)
+        #expect(createPayload["pairing"] == nil)
         #expect(modelsResponse.statusCode == 200)
         #expect(inspectResponse.statusCode == 200)
         #expect(signOutResponse.statusCode == 200)
@@ -885,6 +886,89 @@ struct OpenAIHandlerTests {
         #expect(revokedModelsResponse.statusCode == 401)
         #expect(revokedError["code"] as? String == "revoked_session")
         #expect(await metricsStore.value(forKey: "companion_auth.rejected_request_count") == 1)
+    }
+
+    @Test("companion auth session creation returns pairing descriptor")
+    func companionAuthSessionCreationReturnsPairingDescriptor() async throws {
+        let metricsStore = MetricsStore()
+        let temporaryRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-companion-pairing-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: ScriptedWorkerClient(events: [])),
+                abortRegistry: AbortRegistry()
+            ),
+            metricsStore: metricsStore,
+            gatewayAccessPolicy: GatewayAccessPolicy(
+                mode: .apiKeys,
+                sharedAccessEnabled: true,
+                keys: [
+                    .init(keyID: "codex", label: "Codex", tokenHint: "codex", token: "sk-codex"),
+                ]
+            ),
+            gatewayRuntimeBinding: GatewayRuntimeBinding(
+                host: "0.0.0.0",
+                port: 12_499,
+                allowedOrigins: ["http://127.0.0.1:52499"]
+            ),
+            persistentAuthSessionStore: PersistentAuthSessionStore(
+                storeURL: temporaryRoot.appendingPathComponent("persistent-auth-sessions.json"),
+                metricsStore: metricsStore,
+                retentionTTLSeconds: 3_600,
+                nowUnixMs: { 1_000 }
+            )
+        )
+
+        let createResponse = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/melix/auth/session",
+                headers: [
+                    "content-type": "application/json",
+                    "x-api-key": "sk-codex",
+                ],
+                body: try #require("""
+                {
+                  "remember_me": true,
+                  "scope": "companion_read_only"
+                }
+                """.data(using: .utf8))
+            )
+        )
+        let payload = try await jsonPayload(from: createResponse.body)
+        let session = try #require(payload["session"] as? [String: Any])
+        let resume = try #require(payload["resume"] as? [String: Any])
+        let pairing = try #require(payload["pairing"] as? [String: Any])
+        let allowedRoutes = try #require(pairing["allowed_routes"] as? [[String: Any]])
+        let forbiddenCapabilities = try #require(pairing["forbidden_capabilities"] as? [String])
+        let token = try #require(resume["token"] as? String)
+        let body = try await collectBody(createResponse.body)
+
+        #expect(createResponse.statusCode == 200)
+        #expect(session["scope"] as? String == "companion_read_only")
+        #expect(pairing["schema_version"] as? String == "melix.companion.pairing.v1")
+        #expect(pairing["scope"] as? String == "companion_read_only")
+        #expect(pairing["resume_header"] as? String == "x-melix-session")
+        #expect(pairing["token_transport"] as? String == "resume_header")
+        #expect(pairing["status_url"] as? String == "http://127.0.0.1:12499/v1/melix/companion/status")
+        #expect(pairing["expires_at_unix_ms"] as? Int == 3_601_000)
+        #expect(pairing["allowed_origins"] as? [String] == ["http://127.0.0.1:52499"])
+        #expect(allowedRoutes.contains { route in
+            route["method"] as? String == "GET" && route["path"] as? String == "/v1/melix/companion/status"
+        })
+        #expect(allowedRoutes.contains { route in
+            route["method"] as? String == "DELETE" && route["path"] as? String == "/v1/melix/auth/session"
+        })
+        #expect(forbiddenCapabilities.contains("mutate_runtime"))
+        #expect(forbiddenCapabilities.contains("run_inference"))
+        #expect(forbiddenCapabilities.contains("read_private_prompts"))
+        #expect((pairing["token"] as? String) == nil)
+        #expect(body.contains("\"pairing\""))
+        #expect(body.components(separatedBy: token).count == 2)
     }
 
     @Test("companion status endpoint returns redacted runtime queue job and session summary")


### PR DESCRIPTION
## Summary
- Adds a `pairing` descriptor to `POST /v1/melix/auth/session` responses only for `companion_read_only` sessions.
- Documents the companion pairing creation flow and token-handling boundary.
- Covers the companion contract, operator-session non-regression, client-usable loopback status URLs, empty bind-host fallback, and IPv6 host formatting.

## Plan or Spec
- `docs/plans/2026-06-15-issue-1759-companion-pairing-descriptor.md`
- `docs/runbooks/persistent-sessions.md`
- Issue: #1759

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/companionAuthSessionCreationReturnsPairingDescriptor'
Result: failed before implementation because payload["pairing"] was absent; failed again after setting bind host to 0.0.0.0 because status_url exposed 0.0.0.0.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companionAuthSessionCreationReturnsPairingDescriptor|gatewayAuthSessionsCanBeCreatedReusedAndRevoked|companionAuthSessionsCanReadStatusAndRevokeThemselvesButCannotMutateRuntime)'
Result: passed, 3 tests in 1 suite.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIHandlerTests/(companionAuthSessionCreationReturnsPairingDescriptor|gatewayAuthSessionsCanBeCreatedReusedAndRevoked|companionAuthSessionsCanReadStatusAndRevokeThemselvesButCannotMutateRuntime)'
Result: passed, 3 tests in 1 suite.

UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
Result: TOTAL 99.29% 140/141.

# Review follow-up verification
git diff --check
Result: passed.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/(companionAuthSessionCreationReturnsPairingDescriptor|gatewayAuthSessionsCanBeCreatedReusedAndRevoked|companionAuthSessionsCanReadStatusAndRevokeThemselvesButCannotMutateRuntime)'
Result: passed, 3 tests in 1 suite.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIHandlerTests/(companionAuthSessionCreationReturnsPairingDescriptor|gatewayAuthSessionsCanBeCreatedReusedAndRevoked|companionAuthSessionsCanReadStatusAndRevokeThemselvesButCannotMutateRuntime)'
Result: passed, 3 tests in 1 suite.

UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
Result: TOTAL 100.00% 155/155.

UV_PYTHON=3.12 uv run python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/pr-scoped-performance-local/issue-1759-companion-pairing-20260614-191054/scope/changed-files.json --output .runtime/pr-scoped-performance-local/issue-1759-companion-pairing-20260614-191054/scope/scope.json
UV_PYTHON=3.12 uv run python scripts/pr_scoped_performance_report.py --scope .runtime/pr-scoped-performance-local/issue-1759-companion-pairing-20260614-191054/scope/scope.json --results-dir .runtime/pr-scoped-performance-local/issue-1759-companion-pairing-20260614-191054/probes --output-dir .runtime/pr-scoped-performance-local/issue-1759-companion-pairing-20260614-191054/report --format terminal --sticky-comment
Result: passed, status ok; changed files 4; selected probes 0; regressions 0; context regressions 0; verification failures 0.

git diff --check
Result: passed.

make swift-test
Result: passed.

make py-test
Result: passed, 4014 passed, 14 skipped, 2 warnings.

make integration-test
Result: passed, 120 passed, 1 skipped.

git commit -m "Add companion pairing descriptor"
Result: pre-commit hook passed full gate: make swift-test, make py-test, make integration-test, scoped performance report.
```

## Coverage and Metrics
- Changed-line coverage after merging current `origin/main`: `TOTAL 100.00% 155/155`.
- Local scoped performance report after merging current `origin/main`: `.runtime/pr-scoped-performance-local/issue-1759-companion-pairing-20260614-191054/report/report.md`.
- Pre-commit scoped performance report: `.runtime/pre-commit-performance/20260614-190452-d03d8899/report/report.md`.
- Performance status: `ok`; selected probes: 0; regressions: 0; context regressions: 0; verification failures: 0.
- Observability mode: `minimal`; existing persistent-session metrics remain the runtime observability surface.
- Probe overhead: N/A, no sampled/debug/evidence probe was introduced and no registered scoped probe matched this fixed-size DTO response assembly change.

## Known Gaps
- QR/code rendering is deferred.
- Desktop companion-token issuance and revocation controls are deferred.
- Mobile/narrow viewport smoke for the companion status flow is deferred.
- LAN discovery or public internet exposure is not included.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changed.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changed.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
