### PR TITLE
perf: bind job registry restore loop helpers

### DIFF
--- a/docs/plans/2026-06-14-job-registry-restore-local-bindings.md
+++ b/docs/plans/2026-06-14-job-registry-restore-local-bindings.md
@@ -1,0 +1,36 @@
+# Job Registry Restore Local Bindings
+
+## Scope
+
+This Python-only performance slice is limited to the model-ops job registry restore hot loop:
+
+- `services/mlx-worker-python/worker/model_ops/job_registry.py`
+- `services/mlx-worker-python/tests/test_model_ops_job_registry.py`
+- `scripts/job_registry_restore_probe.py`
+
+The slice does not change restored job ordering, duplicate handling, manifest payload semantics, or generated protocol artifacts.
+
+## Registered PR-scoped probe
+
+Affected path coverage is provided by the registered probe `job-registry-restore-sort-elision` in `infra/perf/pr_scoped_probes.json`. The registry entry already has focused `test_command`, `coverage_command`, and `probe_command` entries and reports:
+
+- `restore_elapsed_ms_mean` (`lower_is_better`)
+- `per_manifest_ms_mean` (`lower_is_better`)
+
+## Implementation plan
+
+1. Keep the existing exact-operation fast path and fallback normalization behavior unchanged.
+2. Reduce repeated attribute/global lookups inside `_restore_manifest_jobs(...)` by binding stable helpers, the jobs dictionary, the job type, and the stage tuple once per restore call.
+3. Reuse the registered focused tests, changed-scope coverage, and local Linux probe to verify behavior and performance.
+
+## Validation commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_restore_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_restore_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_restore_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_restore_probe.py
+```
+
+CI remains the merge gate for the registered PR-scoped performance report.

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -314,8 +314,14 @@ class ModelOpsJobRegistry:
         manifest_paths,
         pct: float,
     ) -> None:
+        read_manifest_dict = self._read_manifest_dict
+        resolved_job_id = self._resolved_job_id
+        resolved_output_dir_for_restore = self._resolved_output_dir_for_restore
+        jobs = self._jobs
+        job_type = ModelOpsJob
+        write_manifest_stage = ("write_manifest", pct)
         for manifest_path in manifest_paths:
-            payload = self._read_manifest_dict(manifest_path)
+            payload = read_manifest_dict(manifest_path)
             if payload:
                 raw_operation = payload.get("operation", "")
                 if raw_operation != operation and str(raw_operation).strip() != operation:
@@ -323,17 +329,17 @@ class ModelOpsJobRegistry:
             else:
                 continue
 
-            job_id = self._resolved_job_id(manifest_path, payload)
-            if not job_id or job_id in self._jobs:
+            job_id = resolved_job_id(manifest_path, payload)
+            if not job_id or job_id in jobs:
                 continue
 
-            output_dir = self._resolved_output_dir_for_restore(operation, manifest_path)
-            self._jobs[job_id] = ModelOpsJob(
+            output_dir = resolved_output_dir_for_restore(operation, manifest_path)
+            jobs[job_id] = job_type(
                 job_id=job_id,
                 operation=operation,
                 source_model=str(payload.get("source_model", "")),
                 output_dir=str(output_dir),
-                stage_history=[("write_manifest", pct)],
+                stage_history=[write_manifest_stage],
                 manifest=payload,
                 manifest_cached=True,
                 output_path=str(manifest_path),


### PR DESCRIPTION
## Summary
- Bind stable helpers, the jobs dictionary, the job type, and the write-manifest stage tuple once per `_restore_manifest_jobs(...)` call.
- Keep restore ordering, duplicate handling, manifest payload handling, and operation fallback normalization unchanged.

## Plan or Spec
- `docs/plans/2026-06-14-job-registry-restore-local-bindings.md`
- Registered probe: `job-registry-restore-sort-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_restore_probe_script_emits_metrics
39 passed in 1.19s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_job_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_job_registry_restore_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/job_registry.py services/mlx-worker-python/tests/test_model_ops_job_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/job_registry_restore_probe.py
39 passed in 3.53s
TOTAL 11 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/job_registry_restore_probe.py
{"restore_elapsed_ms_mean": 114.514609, "per_manifest_ms_mean": 0.007634307, "job_count": 15000.0, "sample_count": 8.0, ...}

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id job-registry-restore-sort-elision --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-job-registry-restore-local-bindings-20260614 --head-repo "$PWD" --output /tmp/job_registry_restore_local_bindings_probe.json
base restore_elapsed_ms_mean=122.470787 ms; head restore_elapsed_ms_mean=115.542618 ms
base per_manifest_ms_mean=0.008164719 ms; head per_manifest_ms_mean=0.007702841 ms

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 11 0 100%`).
- Local registered probe comparison (`job-registry-restore-sort-elision`):
  - `restore_elapsed_ms_mean`: `122.470787 ms` → `115.542618 ms` (`-6.928169 ms`, `5.657%` faster).
  - `per_manifest_ms_mean`: `0.008164719 ms` → `0.007702841 ms` (`-0.000461878 ms`).
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Local validation is Linux/Python-only; CI remains required for the registered PR-scoped performance workflow.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
