### PR TITLE
perf: elide retrieval store refusal list combine

### DIFF
--- a/docs/plans/2026-06-14-retrieval-store-refusal-list-elision.md
+++ b/docs/plans/2026-06-14-retrieval-store-refusal-list-elision.md
@@ -1,0 +1,29 @@
+# Retrieval store refusal list elision
+
+This Python-only performance slice is limited to `worker.runtime.retrieval_context.project_retrieval_store_records`.
+
+## Scope
+
+The hot path projects retrieval store records into prompt payloads. The common valid-record path usually has no store-level or projection-level refusal receipts, but the function still built a fresh combined list with starred unpacking at return time.
+
+This slice keeps the existing projection behavior while reusing the store-refusal accumulator as the return list and only extending it when projection refusals exist. No admission, duplicate detection, payload copy, or receipt-copy semantics change.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/retrieval_context.py`
+- `services/mlx-worker-python/tests/test_retrieval_context.py`
+- `scripts/retrieval_context_projection_probe.py`
+
+## Local verification plan
+
+Run on Linux before opening the PR:
+
+1. Focused retrieval-context tests from the registered probe.
+2. Changed-scope coverage from the registered probe.
+3. The registered probe command locally with repeated samples.
+
+GitHub Actions PR-scoped performance remains the final registered probe validation and merge gate.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -288,13 +288,12 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
             for receipt in admission_receipts:
                 receipts_append(receipt.copy())
 
+    if projection_refusal_receipts:
+        store_refusal_receipts.extend(projection_refusal_receipts)
     return RetrievalContextProjection(
         user_payload=user_payload,
         untrusted_context_receipts=receipts,
-        refusal_receipts=[
-            *store_refusal_receipts,
-            *projection_refusal_receipts,
-        ],
+        refusal_receipts=store_refusal_receipts,
     )
 
 


### PR DESCRIPTION
## Summary
- Elides the final starred-list combine in `project_retrieval_store_records`.
- Reuses the store-refusal accumulator and only extends it when projection refusals exist.
- Adds a focused plan note for the retrieval-store refusal-list slice.

## Plan or Spec
- `docs/plans/2026-06-14-retrieval-store-refusal-list-elision.md`
- Registered probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_isolates_refusals_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_malformed_entry_objects_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_preserves_multi_field_admission_duplicate_scan services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_copies_multi_receipt_admissions services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_projects_records_without_entry_reentry services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_copies_store_projection_outputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 13 passed.
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Local registered probe output:
  - `store_baseline_elapsed_ms_mean=0.23581089385386025`
  - `store_optimized_elapsed_ms_mean=0.21882195158728532`
  - `store_delta_ms=-0.016988942266574936`
  - `store_speedup=1.077638199199582`
  - `baseline_elapsed_ms_mean=0.07327183532262486`
  - `optimized_elapsed_ms_mean=0.035460578510537744`
  - `speedup=2.066289902767684`

## Known Gaps
- This is a Python-only slice validated locally on Linux.
- GitHub Actions PR-scoped performance is still required as the registered CI validation source before merge.

## Evidence Checklist
- [x] Registered PR-scoped probe exists and covers the changed production path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at 100% for changed lines.
- [x] Registered probe ran locally and reported numeric metrics.
- [ ] PR-scoped performance workflow passed on GitHub Actions.
