### PR TITLE
Add companion token controls to desktop API workspace

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -10249,6 +10249,145 @@ struct DesktopAPIAuthenticationReferenceView: View {
     }
 }
 
+struct DesktopAPICompanionPairingPanel: View {
+    let viewModel: RuntimeViewModel
+
+    var body: some View {
+        let presentation = DesktopAPICompanionPairingPresentation(pairing: viewModel.companionPairing)
+
+        MelixSectionCard("Companion Pairing") {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .firstTextBaseline) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(presentation.statusTitle)
+                            .font(.headline)
+                        Text(presentation.statusDetail)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Text(presentation.scopeText)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+
+                if let statusURL = presentation.statusURL {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Status URL")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Text(statusURL)
+                            .font(.caption.monospaced())
+                            .textSelection(.enabled)
+                    }
+                }
+
+                if let allowedRoutesText = presentation.allowedRoutesText {
+                    Text(allowedRoutesText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(3)
+                }
+
+                if let errorText = presentation.errorText {
+                    Text(errorText)
+                        .font(.caption)
+                        .foregroundStyle(MelixDesignTokens.StatusColor.error)
+                }
+
+                ViewThatFits(in: .horizontal) {
+                    HStack(spacing: 8) {
+                        companionPairingButtons(presentation)
+                    }
+                    VStack(alignment: .leading, spacing: 8) {
+                        companionPairingButtons(presentation)
+                    }
+                }
+                .buttonStyle(.bordered)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private func companionPairingButtons(_ presentation: DesktopAPICompanionPairingPresentation) -> some View {
+        Button("Issue Read-Only Token") {
+            Task { await viewModel.issueCompanionPairing() }
+        }
+        .disabled(presentation.issueDisabled)
+
+        Button("Copy Pairing Bundle") {
+            if let bundleText = viewModel.companionPairingBundleText() {
+                copyToPasteboard(bundleText)
+            }
+        }
+        .disabled(presentation.copyDisabled)
+
+        Button("Revoke Token") {
+            Task { await viewModel.revokeCompanionPairing() }
+        }
+        .disabled(presentation.revokeDisabled)
+    }
+}
+
+struct DesktopAPICompanionPairingPresentation: Equatable {
+    let statusTitle: String
+    let statusDetail: String
+    let scopeText: String
+    let statusURL: String?
+    let allowedRoutesText: String?
+    let errorText: String?
+    let issueDisabled: Bool
+    let copyDisabled: Bool
+    let revokeDisabled: Bool
+
+    init(pairing: CompanionPairingState) {
+        statusTitle = Self.statusTitle(pairing.phase)
+        statusDetail = Self.statusDetail(pairing)
+        scopeText = pairing.scope.isEmpty ? "companion_read_only" : pairing.scope
+        statusURL = pairing.statusURL.isEmpty ? nil : pairing.statusURL
+        allowedRoutesText = pairing.allowedRoutes.isEmpty
+            ? nil
+            : "Allowed routes: \(pairing.allowedRoutes.joined(separator: ", "))"
+        errorText = (pairing.lastError?.isEmpty == false) ? pairing.lastError : nil
+        issueDisabled = pairing.phase == .issuing || pairing.phase == .revoking
+        copyDisabled = pairing.copyBundleAvailable == false
+        revokeDisabled = pairing.copyBundleAvailable == false || pairing.phase == .revoking
+    }
+
+    private static func statusTitle(_ phase: CompanionPairingPhase) -> String {
+        switch phase {
+        case .idle:
+            return "No active companion token"
+        case .issuing:
+            return "Issuing companion token"
+        case .active:
+            return "Read-only companion token active"
+        case .revoking:
+            return "Revoking companion token"
+        case .failed:
+            return "Companion pairing needs attention"
+        }
+    }
+
+    private static func statusDetail(_ pairing: CompanionPairingState) -> String {
+        switch pairing.phase {
+        case .idle:
+            return "Create a transient read-only session for the selected local server."
+        case .issuing:
+            return "Requesting a scoped companion session from the gateway."
+        case .active:
+            return pairing.expiresAtUnixMS > 0
+                ? "Session \(pairing.sessionID) expires at \(pairing.expiresAtUnixMS)."
+                : "Session \(pairing.sessionID) is active."
+        case .revoking:
+            return "Revocation uses the current companion session token once."
+        case .failed:
+            return pairing.lastError ?? "The companion token action failed."
+        }
+    }
+}
+
 struct DesktopAPIQuickStartSnippet: Identifiable {
     let id: String
     let language: String
@@ -10892,12 +11031,16 @@ struct DesktopAPIWorkspaceView: View {
                             selectedExport: viewModel.selectedAgentIntegrationExport
                         )
                     case .authentication:
-                        DesktopAPIAuthenticationReferenceView(
-                            referenceText: desktopAPIAuthenticationReferenceText(
-                                selectedSession: viewModel.selectedServerSession,
-                                selectedExport: viewModel.selectedAgentIntegrationExport
+                        VStack(alignment: .leading, spacing: 18) {
+                            DesktopAPIAuthenticationReferenceView(
+                                referenceText: desktopAPIAuthenticationReferenceText(
+                                    selectedSession: viewModel.selectedServerSession,
+                                    selectedExport: viewModel.selectedAgentIntegrationExport
+                                )
                             )
-                        )
+                            DesktopAPICompanionPairingPanel(viewModel: viewModel)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     case .quickStarts:
                         VStack(alignment: .leading, spacing: 18) {
                             DesktopAPIQuickStartPanel(

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -10377,9 +10377,11 @@ struct DesktopAPICompanionPairingPresentation: Equatable {
         case .issuing:
             return "Requesting a scoped companion session from the gateway."
         case .active:
-            return pairing.expiresAtUnixMS > 0
-                ? "Session \(pairing.sessionID) expires at \(pairing.expiresAtUnixMS)."
-                : "Session \(pairing.sessionID) is active."
+            if pairing.expiresAtUnixMS > 0 {
+                let expiresAt = Date(timeIntervalSince1970: Double(pairing.expiresAtUnixMS) / 1_000)
+                return "Session \(pairing.sessionID) expires at \(expiresAt.formatted(date: .abbreviated, time: .shortened))."
+            }
+            return "Session \(pairing.sessionID) is active."
         case .revoking:
             return "Revocation uses the current companion session token once."
         case .failed:

--- a/apps/macos-menubar/Sources/AppMain/Models/CompanionPairingClient.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/CompanionPairingClient.swift
@@ -1,0 +1,318 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public enum CompanionPairingPhase: String, Codable, Equatable, Sendable {
+    case idle
+    case issuing
+    case active
+    case revoking
+    case failed
+}
+
+public struct CompanionPairingDescriptor: Codable, Equatable, Sendable {
+    public let schemaVersion: String
+    public let statusURL: String
+    public let resumeHeader: String
+    public let tokenTransport: String
+    public let allowedRoutes: [String]
+    public let forbiddenCapabilities: [String]
+    public let expiresAtUnixMS: Int64
+
+    public init(
+        schemaVersion: String,
+        statusURL: String,
+        resumeHeader: String,
+        tokenTransport: String,
+        allowedRoutes: [String],
+        forbiddenCapabilities: [String],
+        expiresAtUnixMS: Int64
+    ) {
+        self.schemaVersion = schemaVersion
+        self.statusURL = statusURL
+        self.resumeHeader = resumeHeader
+        self.tokenTransport = tokenTransport
+        self.allowedRoutes = allowedRoutes
+        self.forbiddenCapabilities = forbiddenCapabilities
+        self.expiresAtUnixMS = expiresAtUnixMS
+    }
+}
+
+public struct CompanionPairingIssueResult: Equatable, Sendable {
+    public let sessionID: String
+    public let scope: String
+    public let rememberMe: Bool
+    public let expiresAtUnixMS: Int64
+    public let resumeHeader: String
+    public let resumeToken: String
+    public let pairing: CompanionPairingDescriptor
+
+    public init(
+        sessionID: String,
+        scope: String,
+        rememberMe: Bool,
+        expiresAtUnixMS: Int64,
+        resumeHeader: String,
+        resumeToken: String,
+        pairing: CompanionPairingDescriptor
+    ) {
+        self.sessionID = sessionID
+        self.scope = scope
+        self.rememberMe = rememberMe
+        self.expiresAtUnixMS = expiresAtUnixMS
+        self.resumeHeader = resumeHeader
+        self.resumeToken = resumeToken
+        self.pairing = pairing
+    }
+}
+
+public struct CompanionPairingState: Equatable, Sendable, CustomStringConvertible {
+    public var phase: CompanionPairingPhase
+    public var sessionID: String
+    public var scope: String
+    public var statusURL: String
+    public var resumeHeader: String
+    public var tokenTransport: String
+    public var allowedRoutes: [String]
+    public var forbiddenCapabilities: [String]
+    public var expiresAtUnixMS: Int64
+    public var lastError: String?
+
+    public init(
+        phase: CompanionPairingPhase = .idle,
+        sessionID: String = "",
+        scope: String = "",
+        statusURL: String = "",
+        resumeHeader: String = "",
+        tokenTransport: String = "",
+        allowedRoutes: [String] = [],
+        forbiddenCapabilities: [String] = [],
+        expiresAtUnixMS: Int64 = 0,
+        lastError: String? = nil
+    ) {
+        self.phase = phase
+        self.sessionID = sessionID
+        self.scope = scope
+        self.statusURL = statusURL
+        self.resumeHeader = resumeHeader
+        self.tokenTransport = tokenTransport
+        self.allowedRoutes = allowedRoutes
+        self.forbiddenCapabilities = forbiddenCapabilities
+        self.expiresAtUnixMS = expiresAtUnixMS
+        self.lastError = lastError
+    }
+
+    public var copyBundleAvailable: Bool {
+        phase == .active && sessionID.isEmpty == false && statusURL.isEmpty == false
+    }
+
+    public var description: String {
+        "CompanionPairingState(phase: \(phase.rawValue), sessionID: \(sessionID), scope: \(scope), statusURL: \(statusURL), resumeHeader: \(resumeHeader), tokenTransport: \(tokenTransport), allowedRoutes: \(allowedRoutes), forbiddenCapabilities: \(forbiddenCapabilities), expiresAtUnixMS: \(expiresAtUnixMS), lastError: \(String(describing: lastError)))"
+    }
+
+    static func active(from result: CompanionPairingIssueResult) -> CompanionPairingState {
+        CompanionPairingState(
+            phase: .active,
+            sessionID: result.sessionID,
+            scope: result.scope,
+            statusURL: result.pairing.statusURL,
+            resumeHeader: result.resumeHeader,
+            tokenTransport: result.pairing.tokenTransport,
+            allowedRoutes: result.pairing.allowedRoutes,
+            forbiddenCapabilities: result.pairing.forbiddenCapabilities,
+            expiresAtUnixMS: result.expiresAtUnixMS,
+            lastError: nil
+        )
+    }
+
+    static func failed(_ message: String) -> CompanionPairingState {
+        CompanionPairingState(phase: .failed, lastError: message)
+    }
+}
+
+public protocol CompanionPairingClient: Sendable {
+    func issuePairing(baseURL: URL, apiKey: String) async throws -> CompanionPairingIssueResult
+    func revokePairing(baseURL: URL, sessionToken: String) async throws
+}
+
+public protocol CompanionPairingHTTPTransport: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse)
+}
+
+public struct URLSessionCompanionPairingHTTPTransport: CompanionPairingHTTPTransport {
+    public init() {}
+
+    public func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CompanionPairingClientError.invalidResponse("Companion pairing response was not HTTP.")
+        }
+        return (data, httpResponse)
+    }
+}
+
+public struct LiveCompanionPairingClient: CompanionPairingClient {
+    private let transport: any CompanionPairingHTTPTransport
+
+    public init(
+        transport: any CompanionPairingHTTPTransport = URLSessionCompanionPairingHTTPTransport()
+    ) {
+        self.transport = transport
+    }
+
+    public func issuePairing(baseURL: URL, apiKey: String) async throws -> CompanionPairingIssueResult {
+        let url = baseURL
+            .appendingPathComponent("v1")
+            .appendingPathComponent("melix")
+            .appendingPathComponent("auth")
+            .appendingPathComponent("session")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.httpBody = try JSONEncoder().encode(CompanionPairingIssueRequest())
+
+        let (data, response) = try await transport.data(for: request)
+        try validateHTTPResponse(data: data, response: response)
+        let payload = try JSONDecoder().decode(CompanionPairingIssueResponse.self, from: data)
+        return try payload.result()
+    }
+
+    public func revokePairing(baseURL: URL, sessionToken: String) async throws {
+        let url = baseURL
+            .appendingPathComponent("v1")
+            .appendingPathComponent("melix")
+            .appendingPathComponent("auth")
+            .appendingPathComponent("session")
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue(sessionToken, forHTTPHeaderField: "x-melix-session")
+
+        let (data, response) = try await transport.data(for: request)
+        try validateHTTPResponse(data: data, response: response)
+    }
+
+    private func validateHTTPResponse(data: Data, response: HTTPURLResponse) throws {
+        guard (200..<300).contains(response.statusCode) else {
+            let message = String(decoding: data, as: UTF8.self)
+            throw CompanionPairingClientError.httpStatus(response.statusCode, message)
+        }
+    }
+}
+
+public enum CompanionPairingClientError: Error, CustomStringConvertible, Equatable {
+    case invalidResponse(String)
+    case invalidPayload(String)
+    case httpStatus(Int, String)
+
+    public var description: String {
+        switch self {
+        case .invalidResponse(let message):
+            return message
+        case .invalidPayload(let message):
+            return message
+        case .httpStatus(let statusCode, let message):
+            return "Companion pairing HTTP \(statusCode): \(message)"
+        }
+    }
+}
+
+private struct CompanionPairingIssueRequest: Encodable {
+    let rememberMe = true
+    let scope = "companion_read_only"
+
+    enum CodingKeys: String, CodingKey {
+        case rememberMe = "remember_me"
+        case scope
+    }
+}
+
+private struct CompanionPairingIssueResponse: Decodable {
+    let session: Session
+    let resume: Resume
+    let pairing: Pairing?
+
+    struct Session: Decodable {
+        let sessionID: String
+        let scope: String
+        let rememberMe: Bool
+        let expiresAtUnixMS: Int64
+
+        enum CodingKeys: String, CodingKey {
+            case sessionID = "session_id"
+            case scope
+            case rememberMe = "remember_me"
+            case expiresAtUnixMS = "expires_at_unix_ms"
+        }
+    }
+
+    struct Resume: Decodable {
+        let header: String
+        let token: String
+    }
+
+    struct Pairing: Decodable {
+        let schemaVersion: String
+        let statusURL: String
+        let resumeHeader: String
+        let tokenTransport: String
+        let allowedRoutes: [Route]
+        let forbiddenCapabilities: [String]
+        let expiresAtUnixMS: Int64
+
+        enum CodingKeys: String, CodingKey {
+            case schemaVersion = "schema_version"
+            case statusURL = "status_url"
+            case resumeHeader = "resume_header"
+            case tokenTransport = "token_transport"
+            case allowedRoutes = "allowed_routes"
+            case forbiddenCapabilities = "forbidden_capabilities"
+            case expiresAtUnixMS = "expires_at_unix_ms"
+        }
+
+        struct Route: Decodable {
+            let method: String
+            let path: String
+
+            var displayText: String {
+                let normalizedMethod = method.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+                let normalizedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard normalizedMethod.isEmpty == false else {
+                    return normalizedPath
+                }
+                guard normalizedPath.isEmpty == false else {
+                    return normalizedMethod
+                }
+                return "\(normalizedMethod) \(normalizedPath)"
+            }
+        }
+
+        func descriptor() -> CompanionPairingDescriptor {
+            CompanionPairingDescriptor(
+                schemaVersion: schemaVersion,
+                statusURL: statusURL,
+                resumeHeader: resumeHeader,
+                tokenTransport: tokenTransport,
+                allowedRoutes: allowedRoutes.map(\.displayText),
+                forbiddenCapabilities: forbiddenCapabilities,
+                expiresAtUnixMS: expiresAtUnixMS
+            )
+        }
+    }
+
+    func result() throws -> CompanionPairingIssueResult {
+        guard let pairing else {
+            throw CompanionPairingClientError.invalidPayload("Companion pairing response did not include a pairing descriptor.")
+        }
+        return CompanionPairingIssueResult(
+            sessionID: session.sessionID,
+            scope: session.scope,
+            rememberMe: session.rememberMe,
+            expiresAtUnixMS: session.expiresAtUnixMS,
+            resumeHeader: resume.header,
+            resumeToken: resume.token,
+            pairing: pairing.descriptor()
+        )
+    }
+}

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -6030,6 +6030,9 @@ public final class RuntimeViewModel {
     }
 
     public func issueCompanionPairing() async {
+        guard companionPairing.phase != .issuing && companionPairing.phase != .revoking else {
+            return
+        }
         guard let serverSession = selectedServerSession else {
             await failCompanionPairingIssue("Select a local server session before creating companion pairing.")
             return
@@ -6073,6 +6076,9 @@ public final class RuntimeViewModel {
     }
 
     public func revokeCompanionPairing() async {
+        guard companionPairing.phase != .revoking else {
+            return
+        }
         guard let baseURL = activeCompanionPairingBaseURL, activeCompanionSessionToken.isEmpty == false else {
             await failCompanionPairingRevoke("No active companion pairing token to revoke.")
             return

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -2478,6 +2478,7 @@ public final class RuntimeViewModel {
     public private(set) var serverSessions: [DesktopServerSessionState] = []
     public private(set) var remoteServers: [RemoteServer] = []
     public private(set) var chatSessions: [DesktopChatSessionState] = []
+    public private(set) var companionPairing = CompanionPairingState()
     public private(set) var lastError: String?
     public private(set) var lastCLIWorkflowFailure: RuntimeCLIWorkflowFailureState?
     public private(set) var productUpdateSummary: String?
@@ -3141,6 +3142,7 @@ public final class RuntimeViewModel {
     private let cliWorkflowRunner: (any MelixCLIWorkflowRunning)?
     private let operatorCommandRunner: MelixCLIRunner?
     private let serverSessionAPIKeyStore: any ServerSessionAPIKeyStoring
+    private let companionPairingClient: any CompanionPairingClient
     private let remoteServerStore: any RemoteServerStoring
     private let evaluationPromptStore: any EvaluationPromptStoring
     private let loraTrainingJobStore: any LoraTrainingJobStoring
@@ -3167,6 +3169,10 @@ public final class RuntimeViewModel {
     private var operatorStateRestored = false
     private var lastPersistedOperatorSessionState: OperatorSessionState?
     private var gatewayAPIKeyPersistFailures = 0.0
+    private var companionPairingIssueFailures = 0.0
+    private var companionPairingRevokeFailures = 0.0
+    private var activeCompanionSessionToken = ""
+    private var activeCompanionPairingBaseURL: URL?
     private var remoteServerPersistFailures = 0.0
     private var evaluationPromptPersistFailures = 0.0
     private var loraTrainingJobPersistFailures = 0.0
@@ -3402,6 +3408,7 @@ public final class RuntimeViewModel {
         cliWorkflowRunner: (any MelixCLIWorkflowRunning)? = nil,
         operatorCommandRunner: MelixCLIRunner? = nil,
         serverSessionAPIKeyStore: any ServerSessionAPIKeyStoring = NullServerSessionAPIKeyStore(),
+        companionPairingClient: any CompanionPairingClient = LiveCompanionPairingClient(),
         remoteServerStore: any RemoteServerStoring = NullRemoteServerStore(),
         evaluationPromptStore: any EvaluationPromptStoring = NullEvaluationPromptStore(),
         loraTrainingJobStore: any LoraTrainingJobStoring = NullLoraTrainingJobStore(),
@@ -3414,6 +3421,7 @@ public final class RuntimeViewModel {
         self.cliWorkflowRunner = cliWorkflowRunner
         self.operatorCommandRunner = operatorCommandRunner
         self.serverSessionAPIKeyStore = serverSessionAPIKeyStore
+        self.companionPairingClient = companionPairingClient
         self.remoteServerStore = remoteServerStore
         self.evaluationPromptStore = evaluationPromptStore
         self.loraTrainingJobStore = loraTrainingJobStore
@@ -6019,6 +6027,99 @@ public final class RuntimeViewModel {
             session.servingDefaults.numDraftTokens = max(0, value)
             session.updatedAt = Date()
         }
+    }
+
+    public func issueCompanionPairing() async {
+        guard let serverSession = selectedServerSession else {
+            await failCompanionPairingIssue("Select a local server session before creating companion pairing.")
+            return
+        }
+        guard let baseURL = Self.companionPairingBaseURL(for: serverSession) else {
+            await failCompanionPairingIssue("Selected server session does not have a valid companion pairing URL.")
+            return
+        }
+
+        let primaryKey: String
+        do {
+            guard let record = try serverSessionAPIKeyStore.loadPrimaryKey(serverSessionID: serverSession.id) else {
+                await failCompanionPairingIssue("Generate or restore a primary gateway API key before creating companion pairing.")
+                return
+            }
+            primaryKey = record.primaryKey
+        } catch {
+            await failCompanionPairingIssue("Primary gateway API key lookup failed: \(error)")
+            return
+        }
+
+        companionPairing = CompanionPairingState(phase: .issuing)
+        activeCompanionSessionToken = ""
+        activeCompanionPairingBaseURL = nil
+        notifyStateChanged()
+
+        let startedAt = Date()
+        do {
+            let result = try await companionPairingClient.issuePairing(baseURL: baseURL, apiKey: primaryKey)
+            activeCompanionSessionToken = result.resumeToken
+            activeCompanionPairingBaseURL = baseURL
+            companionPairing = CompanionPairingState.active(from: result)
+            await metrics.record(
+                name: "companion.pairing_issue_ms",
+                valueMs: Date().timeIntervalSince(startedAt) * 1_000
+            )
+            notifyStateChanged()
+        } catch {
+            await failCompanionPairingIssue("Companion pairing creation failed: \(error)")
+        }
+    }
+
+    public func revokeCompanionPairing() async {
+        guard let baseURL = activeCompanionPairingBaseURL, activeCompanionSessionToken.isEmpty == false else {
+            await failCompanionPairingRevoke("No active companion pairing token to revoke.")
+            return
+        }
+
+        let sessionToken = activeCompanionSessionToken
+        companionPairing.phase = .revoking
+        notifyStateChanged()
+
+        let startedAt = Date()
+        do {
+            try await companionPairingClient.revokePairing(baseURL: baseURL, sessionToken: sessionToken)
+            activeCompanionSessionToken = ""
+            activeCompanionPairingBaseURL = nil
+            companionPairing = CompanionPairingState()
+            await metrics.record(
+                name: "companion.pairing_revoke_ms",
+                valueMs: Date().timeIntervalSince(startedAt) * 1_000
+            )
+            notifyStateChanged()
+        } catch {
+            await failCompanionPairingRevoke("Companion pairing revocation failed: \(error)")
+        }
+    }
+
+    public func companionPairingBundleText() -> String? {
+        guard companionPairing.copyBundleAvailable, activeCompanionSessionToken.isEmpty == false else {
+            return nil
+        }
+        let payload = CompanionPairingClipboardBundle(
+            schemaVersion: "melix.companion.pairing.bundle.v1",
+            sessionID: companionPairing.sessionID,
+            scope: companionPairing.scope,
+            statusURL: companionPairing.statusURL,
+            resumeHeader: companionPairing.resumeHeader,
+            token: activeCompanionSessionToken,
+            tokenTransport: companionPairing.tokenTransport,
+            allowedRoutes: companionPairing.allowedRoutes,
+            forbiddenCapabilities: companionPairing.forbiddenCapabilities,
+            expiresAtUnixMS: companionPairing.expiresAtUnixMS
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        guard let data = try? encoder.encode(payload) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
     }
 
     public func updateSelectedServerSessionAutoSleepEnabled(_ value: Bool) {
@@ -13862,6 +13963,31 @@ public final class RuntimeViewModel {
         trimRecentEvents()
     }
 
+    private func failCompanionPairingIssue(_ message: String) async {
+        companionPairingIssueFailures += 1
+        activeCompanionSessionToken = ""
+        activeCompanionPairingBaseURL = nil
+        companionPairing = CompanionPairingState.failed(message)
+        recordLocalError(message)
+        await metrics.record(
+            name: "companion.pairing_issue_failures",
+            valueMs: companionPairingIssueFailures
+        )
+        notifyStateChanged()
+    }
+
+    private func failCompanionPairingRevoke(_ message: String) async {
+        companionPairingRevokeFailures += 1
+        companionPairing.phase = .failed
+        companionPairing.lastError = message
+        recordLocalError(message)
+        await metrics.record(
+            name: "companion.pairing_revoke_failures",
+            valueMs: companionPairingRevokeFailures
+        )
+        notifyStateChanged()
+    }
+
     private func beginRuntimeSettingsOperation() {
         runtimeSettingsOperationInProgress = true
         runtimeSettingsOperationMessage = ""
@@ -18160,4 +18286,61 @@ private func runtimeFormatBytes(_ bytes: UInt64) -> String {
     formatter.includesUnit = true
     formatter.includesCount = true
     return formatter.string(fromByteCount: Int64(bytes))
+}
+
+private struct CompanionPairingClipboardBundle: Encodable {
+    let schemaVersion: String
+    let sessionID: String
+    let scope: String
+    let statusURL: String
+    let resumeHeader: String
+    let token: String
+    let tokenTransport: String
+    let allowedRoutes: [String]
+    let forbiddenCapabilities: [String]
+    let expiresAtUnixMS: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case sessionID = "session_id"
+        case scope
+        case statusURL = "status_url"
+        case resumeHeader = "resume_header"
+        case token
+        case tokenTransport = "token_transport"
+        case allowedRoutes = "allowed_routes"
+        case forbiddenCapabilities = "forbidden_capabilities"
+        case expiresAtUnixMS = "expires_at_unix_ms"
+    }
+}
+
+private extension RuntimeViewModel {
+    static func companionPairingBaseURL(for session: DesktopServerSessionState) -> URL? {
+        let host = companionPairingDisplayHost(
+            session.gatewayConfigActiveBinding ? session.effectiveHost : session.host
+        )
+        let port = session.gatewayConfigActiveBinding ? session.effectivePort : session.port
+        guard port > 0 else {
+            return nil
+        }
+
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = host
+        components.port = port
+        return components.url
+    }
+
+    static func companionPairingDisplayHost(_ host: String) -> String {
+        let candidate = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard candidate.isEmpty == false else {
+            return "127.0.0.1"
+        }
+        switch candidate.lowercased() {
+        case "0.0.0.0", "::", "[::]":
+            return "127.0.0.1"
+        default:
+            return candidate.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        }
+    }
 }

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -4567,6 +4567,93 @@ struct DesktopFoundationViewTests {
         )
     }
 
+    @Test("api authentication surface includes companion pairing token controls")
+    func apiAuthenticationSurfaceIncludesCompanionPairingTokenControls() throws {
+        let root = try repositoryRootForDesktopFoundationTests()
+        let shellSourceURL = root.appendingPathComponent(
+            "apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift"
+        )
+        let shellSource = try String(contentsOf: shellSourceURL, encoding: .utf8)
+
+        #expect(shellSource.contains("DesktopAPICompanionPairingPanel"))
+        #expect(shellSource.contains("Companion Pairing"))
+        #expect(shellSource.contains("Issue Read-Only Token"))
+        #expect(shellSource.contains("Copy Pairing Bundle"))
+        #expect(shellSource.contains("Revoke Token"))
+    }
+
+    @Test("companion pairing panel renders idle active and failure states")
+    @MainActor
+    func companionPairingPanelRendersIdleActiveAndFailureStates() async throws {
+        let idleViewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        await idleViewModel.start()
+        let idlePresentation = DesktopAPICompanionPairingPresentation(pairing: idleViewModel.companionPairing)
+        _ = hostView(DesktopAPICompanionPairingPanel(viewModel: idleViewModel))
+
+        #expect(idlePresentation.statusTitle == "No active companion token")
+        #expect(idlePresentation.scopeText == "companion_read_only")
+        #expect(idlePresentation.issueDisabled == false)
+        #expect(idlePresentation.copyDisabled)
+        #expect(idlePresentation.revokeDisabled)
+
+        let activeClient = FakeCompanionPairingClient()
+        await activeClient.configureIssueResult(
+            CompanionPairingIssueResult(
+                sessionID: "companion-ui-session",
+                scope: "companion_read_only",
+                rememberMe: true,
+                expiresAtUnixMS: 1_718_000_000_000,
+                resumeHeader: "x-melix-session",
+                resumeToken: "melix_companion_ui_secret",
+                pairing: CompanionPairingDescriptor(
+                    schemaVersion: "melix.companion.pairing.v1",
+                    statusURL: "http://127.0.0.1:12436/v1/melix/companion/status",
+                    resumeHeader: "x-melix-session",
+                    tokenTransport: "resume_header",
+                    allowedRoutes: ["GET /v1/melix/companion/status"],
+                    forbiddenCapabilities: ["mutate_runtime"],
+                    expiresAtUnixMS: 1_718_000_000_000
+                )
+            )
+        )
+        let activeTemporaryRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-menubar-companion-panel-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: activeTemporaryRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: activeTemporaryRoot) }
+        let activeMelixHome = MelixHome(environment: ["MELIX_HOME": activeTemporaryRoot.path])
+        let activeAPIKeyStore = ServerSessionAPIKeyStore(melixHome: activeMelixHome)
+        let activeViewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            serverSessionAPIKeyStore: activeAPIKeyStore,
+            companionPairingClient: activeClient
+        )
+
+        await activeViewModel.start()
+        try activeAPIKeyStore.savePrimaryKey(
+            serverSessionID: try #require(activeViewModel.selectedServerSession?.id),
+            primaryKey: "melix_primary_desktop",
+            keyID: "primary"
+        )
+        await activeViewModel.issueCompanionPairing()
+        let activePresentation = DesktopAPICompanionPairingPresentation(pairing: activeViewModel.companionPairing)
+        _ = hostView(DesktopAPICompanionPairingPanel(viewModel: activeViewModel))
+
+        #expect(activePresentation.statusTitle == "Read-only companion token active")
+        #expect(activePresentation.statusURL == "http://127.0.0.1:12436/v1/melix/companion/status")
+        #expect(activePresentation.allowedRoutesText == "Allowed routes: GET /v1/melix/companion/status")
+        #expect(activePresentation.copyDisabled == false)
+        #expect(activePresentation.revokeDisabled == false)
+
+        let failureViewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        await failureViewModel.start()
+        await failureViewModel.revokeCompanionPairing()
+        let failurePresentation = DesktopAPICompanionPairingPresentation(pairing: failureViewModel.companionPairing)
+        _ = hostView(DesktopAPICompanionPairingPanel(viewModel: failureViewModel))
+
+        #expect(failurePresentation.statusTitle == "Companion pairing needs attention")
+        #expect(failurePresentation.errorText == "No active companion pairing token to revoke.")
+    }
+
     @Test("api reference tab projects typed onboarding surfaces and endpoints")
     @MainActor
     func apiReferenceTabProjectsTypedOnboardingSurfacesAndEndpoints() throws {

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -4639,6 +4639,8 @@ struct DesktopFoundationViewTests {
         _ = hostView(DesktopAPICompanionPairingPanel(viewModel: activeViewModel))
 
         #expect(activePresentation.statusTitle == "Read-only companion token active")
+        #expect(activePresentation.statusDetail.contains("1718000000000") == false)
+        #expect(activePresentation.statusDetail.contains("expires at"))
         #expect(activePresentation.statusURL == "http://127.0.0.1:12436/v1/melix/companion/status")
         #expect(activePresentation.allowedRoutesText == "Allowed routes: GET /v1/melix/companion/status")
         #expect(activePresentation.copyDisabled == false)

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -1699,6 +1699,57 @@ struct RuntimeViewModelTests {
         #expect(await metrics.snapshot()["companion.pairing_issue_failures"] == 1)
     }
 
+    @Test("companion pairing issue ignores duplicate in-flight requests")
+    @MainActor
+    func companionPairingIssueIgnoresDuplicateInFlightRequests() async throws {
+        let companionClient = FakeCompanionPairingClient()
+        await companionClient.configureIssueDelay(.milliseconds(50))
+        let viewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+                throwOnLoad: false,
+                throwOnSave: false,
+                loadPrimaryKeyValue: "melix_primary_desktop"
+            ),
+            companionPairingClient: companionClient
+        )
+
+        await viewModel.start()
+
+        async let firstIssue: Void = viewModel.issueCompanionPairing()
+        await viewModel.issueCompanionPairing()
+        await firstIssue
+
+        #expect(await companionClient.issueRequests.count == 1)
+        #expect(viewModel.companionPairing.phase == .active)
+    }
+
+    @Test("companion pairing revoke ignores duplicate in-flight requests")
+    @MainActor
+    func companionPairingRevokeIgnoresDuplicateInFlightRequests() async throws {
+        let companionClient = FakeCompanionPairingClient()
+        await companionClient.configureRevokeDelay(.milliseconds(50))
+        let viewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+                throwOnLoad: false,
+                throwOnSave: false,
+                loadPrimaryKeyValue: "melix_primary_desktop"
+            ),
+            companionPairingClient: companionClient
+        )
+
+        await viewModel.start()
+        await viewModel.issueCompanionPairing()
+
+        async let firstRevoke: Void = viewModel.revokeCompanionPairing()
+        await viewModel.revokeCompanionPairing()
+        await firstRevoke
+
+        #expect(await companionClient.revokeRequests.count == 1)
+        #expect(viewModel.companionPairing.phase == .idle)
+    }
+
     @Test("companion pairing surfaces key store and transport failures")
     @MainActor
     func companionPairingSurfacesKeyStoreAndTransportFailures() async throws {

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -1560,6 +1560,389 @@ struct RuntimeViewModelTests {
         #expect(metricValues["gateway.api_key_persist_failures"] == 0)
     }
 
+    @Test("issues companion pairing with stored primary key")
+    @MainActor
+    func issuesCompanionPairingWithStoredPrimaryKey() async throws {
+        let temporaryRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-menubar-companion-issue-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let melixHome = MelixHome(environment: ["MELIX_HOME": temporaryRoot.path])
+        let operatorSessionStore = OperatorSessionStore(melixHome: melixHome)
+        let apiKeyStore = ServerSessionAPIKeyStore(melixHome: melixHome)
+        let companionClient = FakeCompanionPairingClient()
+        await companionClient.configureIssueResult(
+            CompanionPairingIssueResult(
+                sessionID: "companion-session-1",
+                scope: "companion_read_only",
+                rememberMe: true,
+                expiresAtUnixMS: 1_718_000_000_000,
+                resumeHeader: "x-melix-session",
+                resumeToken: "melix_companion_secret",
+                pairing: CompanionPairingDescriptor(
+                    schemaVersion: "melix.companion.pairing.v1",
+                    statusURL: "http://127.0.0.1:18081/v1/melix/companion/status",
+                    resumeHeader: "x-melix-session",
+                    tokenTransport: "resume_header",
+                    allowedRoutes: ["/v1/melix/companion/status"],
+                    forbiddenCapabilities: ["run_inference", "mutate_runtime", "read_private_prompts"],
+                    expiresAtUnixMS: 1_718_000_000_000
+                )
+            )
+        )
+        let metrics = MenuBarMetricsStore()
+        let viewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            metrics: metrics,
+            operatorSessionStore: operatorSessionStore,
+            serverSessionAPIKeyStore: apiKeyStore,
+            companionPairingClient: companionClient
+        )
+
+        await viewModel.start()
+        viewModel.updateSelectedServerSessionHost("0.0.0.0")
+        viewModel.updateSelectedServerSessionPort(18_081)
+        let serverSessionID = try #require(viewModel.selectedServerSession?.id)
+        try apiKeyStore.savePrimaryKey(
+            serverSessionID: serverSessionID,
+            primaryKey: "melix_primary_desktop",
+            keyID: "primary"
+        )
+
+        await viewModel.issueCompanionPairing()
+
+        let request = try #require(await companionClient.issueRequests.last)
+        #expect(request.baseURL.absoluteString == "http://127.0.0.1:18081")
+        #expect(request.apiKey == "melix_primary_desktop")
+        #expect(viewModel.companionPairing.phase == .active)
+        #expect(viewModel.companionPairing.sessionID == "companion-session-1")
+        #expect(viewModel.companionPairing.statusURL == "http://127.0.0.1:18081/v1/melix/companion/status")
+        #expect(viewModel.companionPairing.resumeHeader == "x-melix-session")
+        #expect(viewModel.companionPairing.allowedRoutes == ["/v1/melix/companion/status"])
+        #expect(viewModel.companionPairing.copyBundleAvailable)
+        #expect(String(describing: viewModel.companionPairing).contains("melix_companion_secret") == false)
+        let copyBundle = try #require(viewModel.companionPairingBundleText())
+        #expect(copyBundle.contains("melix_companion_secret"))
+        #expect(copyBundle.contains("melix.companion.pairing.bundle.v1"))
+        #expect(copyBundle.contains("http://127.0.0.1:18081/v1/melix/companion/status"))
+        #expect(await metrics.snapshot()["companion.pairing_issue_ms"] != nil)
+    }
+
+    @Test("revokes active companion pairing token")
+    @MainActor
+    func revokesActiveCompanionPairingToken() async throws {
+        let companionClient = FakeCompanionPairingClient()
+        await companionClient.configureIssueResult(
+            CompanionPairingIssueResult(
+                sessionID: "companion-session-2",
+                scope: "companion_read_only",
+                rememberMe: true,
+                expiresAtUnixMS: 1_718_000_000_000,
+                resumeHeader: "x-melix-session",
+                resumeToken: "melix_companion_revoke_secret",
+                pairing: CompanionPairingDescriptor(
+                    schemaVersion: "melix.companion.pairing.v1",
+                    statusURL: "http://127.0.0.1:12436/v1/melix/companion/status",
+                    resumeHeader: "x-melix-session",
+                    tokenTransport: "resume_header",
+                    allowedRoutes: ["/v1/melix/companion/status"],
+                    forbiddenCapabilities: ["mutate_runtime"],
+                    expiresAtUnixMS: 1_718_000_000_000
+                )
+            )
+        )
+        let apiKeyStore = ThrowingServerSessionAPIKeyStore(
+            throwOnLoad: false,
+            throwOnSave: false,
+            loadPrimaryKeyValue: "melix_primary_desktop"
+        )
+        let metrics = MenuBarMetricsStore()
+        let viewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            metrics: metrics,
+            serverSessionAPIKeyStore: apiKeyStore,
+            companionPairingClient: companionClient
+        )
+
+        await viewModel.start()
+        await viewModel.issueCompanionPairing()
+        await viewModel.revokeCompanionPairing()
+
+        let revokeRequest = try #require(await companionClient.revokeRequests.last)
+        #expect(revokeRequest.sessionToken == "melix_companion_revoke_secret")
+        #expect(viewModel.companionPairing.phase == .idle)
+        #expect(viewModel.companionPairing.sessionID.isEmpty)
+        #expect(viewModel.companionPairing.copyBundleAvailable == false)
+        #expect(await metrics.snapshot()["companion.pairing_revoke_ms"] != nil)
+    }
+
+    @Test("companion pairing requires stored primary key")
+    @MainActor
+    func companionPairingRequiresStoredPrimaryKey() async throws {
+        let companionClient = FakeCompanionPairingClient()
+        let metrics = MenuBarMetricsStore()
+        let viewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            metrics: metrics,
+            serverSessionAPIKeyStore: NullServerSessionAPIKeyStore(),
+            companionPairingClient: companionClient
+        )
+
+        await viewModel.start()
+        await viewModel.issueCompanionPairing()
+
+        #expect(await companionClient.issueRequests.isEmpty)
+        #expect(viewModel.companionPairing.phase == .failed)
+        #expect(viewModel.companionPairing.lastError == "Generate or restore a primary gateway API key before creating companion pairing.")
+        #expect(viewModel.lastError == "Generate or restore a primary gateway API key before creating companion pairing.")
+        #expect(await metrics.snapshot()["companion.pairing_issue_failures"] == 1)
+    }
+
+    @Test("companion pairing surfaces key store and transport failures")
+    @MainActor
+    func companionPairingSurfacesKeyStoreAndTransportFailures() async throws {
+        let keyLookupMetrics = MenuBarMetricsStore()
+        let keyLookupViewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            metrics: keyLookupMetrics,
+            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+                throwOnLoad: true,
+                throwOnSave: false,
+                loadPrimaryKeyValue: nil
+            ),
+            companionPairingClient: FakeCompanionPairingClient()
+        )
+
+        await keyLookupViewModel.start()
+        await keyLookupViewModel.issueCompanionPairing()
+
+        #expect(keyLookupViewModel.companionPairing.phase == .failed)
+        #expect(keyLookupViewModel.lastError?.contains("Primary gateway API key lookup failed") == true)
+        #expect(await keyLookupMetrics.snapshot()["companion.pairing_issue_failures"] == 1)
+
+        let issueClient = FakeCompanionPairingClient()
+        await issueClient.configureIssueError(MenuBarTestError(description: "gateway offline"))
+        let issueMetrics = MenuBarMetricsStore()
+        let issueViewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            metrics: issueMetrics,
+            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+                throwOnLoad: false,
+                throwOnSave: false,
+                loadPrimaryKeyValue: "melix_primary_desktop"
+            ),
+            companionPairingClient: issueClient
+        )
+
+        await issueViewModel.start()
+        await issueViewModel.issueCompanionPairing()
+
+        #expect(await issueClient.issueRequests.count == 1)
+        #expect(issueViewModel.companionPairing.phase == .failed)
+        #expect(issueViewModel.lastError?.contains("Companion pairing creation failed") == true)
+        #expect(await issueMetrics.snapshot()["companion.pairing_issue_failures"] == 1)
+
+        let revokeClient = FakeCompanionPairingClient()
+        await revokeClient.configureRevokeError(MenuBarTestError(description: "revocation failed"))
+        let revokeMetrics = MenuBarMetricsStore()
+        let revokeViewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            metrics: revokeMetrics,
+            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+                throwOnLoad: false,
+                throwOnSave: false,
+                loadPrimaryKeyValue: "melix_primary_desktop"
+            ),
+            companionPairingClient: revokeClient
+        )
+
+        await revokeViewModel.start()
+        await revokeViewModel.issueCompanionPairing()
+        await revokeViewModel.revokeCompanionPairing()
+
+        #expect(await revokeClient.revokeRequests.count == 1)
+        #expect(revokeViewModel.companionPairing.phase == .failed)
+        #expect(revokeViewModel.lastError?.contains("Companion pairing revocation failed") == true)
+        #expect(await revokeMetrics.snapshot()["companion.pairing_revoke_failures"] == 1)
+
+        let emptyRevokeMetrics = MenuBarMetricsStore()
+        let emptyRevokeViewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            metrics: emptyRevokeMetrics
+        )
+
+        await emptyRevokeViewModel.start()
+        await emptyRevokeViewModel.revokeCompanionPairing()
+
+        #expect(emptyRevokeViewModel.companionPairing.phase == .failed)
+        #expect(emptyRevokeViewModel.lastError == "No active companion pairing token to revoke.")
+        #expect(await emptyRevokeMetrics.snapshot()["companion.pairing_revoke_failures"] == 1)
+        #expect(emptyRevokeViewModel.companionPairingBundleText() == nil)
+    }
+
+    @Test("live companion pairing client issues and revokes gateway sessions")
+    func liveCompanionPairingClientIssuesAndRevokesGatewaySessions() async throws {
+        let issuePayload = #"""
+        {
+          "session": {
+            "session_id": "companion-live-session",
+            "key_id": "primary",
+            "remember_me": true,
+            "scope": "companion_read_only",
+            "created_at_unix_ms": 1717000000000,
+            "expires_at_unix_ms": 1718000000000,
+            "revoked_at_unix_ms": 0,
+            "last_restored_at_unix_ms": 0,
+            "state": "active"
+          },
+          "resume": {
+            "header": "x-melix-session",
+            "token": "melix_live_secret"
+          },
+          "pairing": {
+            "schema_version": "melix.companion.pairing.v1",
+            "scope": "companion_read_only",
+            "token_transport": "resume_header",
+            "resume_header": "x-melix-session",
+            "status_url": "http://127.0.0.1:12436/v1/melix/companion/status",
+            "expires_at_unix_ms": 1718000000000,
+            "allowed_origins": [],
+            "allowed_routes": [
+              {"method": "GET", "path": "/v1/melix/companion/status"},
+              {"method": "delete", "path": "/v1/melix/auth/session"}
+            ],
+            "forbidden_capabilities": ["mutate_runtime", "read_private_prompts"]
+          }
+        }
+        """#.data(using: .utf8)!
+        let transport = FakeCompanionPairingHTTPTransport()
+        await transport.configureIssueResponse(body: issuePayload)
+        await transport.configureRevokeResponse(statusCode: 204)
+        let client = LiveCompanionPairingClient(transport: transport)
+        let baseURL = try #require(URL(string: "http://127.0.0.1:12436"))
+
+        let result = try await client.issuePairing(baseURL: baseURL, apiKey: "melix_primary_desktop")
+
+        #expect(result.sessionID == "companion-live-session")
+        #expect(result.scope == "companion_read_only")
+        #expect(result.rememberMe)
+        #expect(result.resumeHeader == "x-melix-session")
+        #expect(result.resumeToken == "melix_live_secret")
+        #expect(result.pairing.schemaVersion == "melix.companion.pairing.v1")
+        #expect(result.pairing.statusURL == "http://127.0.0.1:12436/v1/melix/companion/status")
+        #expect(result.pairing.allowedRoutes == [
+            "GET /v1/melix/companion/status",
+            "DELETE /v1/melix/auth/session",
+        ])
+        #expect(result.pairing.forbiddenCapabilities == ["mutate_runtime", "read_private_prompts"])
+
+        let issueRequest = try #require(await transport.requests.first)
+        #expect(issueRequest.url?.absoluteString == "http://127.0.0.1:12436/v1/melix/auth/session")
+        #expect(issueRequest.method == "POST")
+        let issueHeaders = Dictionary(
+            uniqueKeysWithValues: issueRequest.headers.map { ($0.key.lowercased(), $0.value) }
+        )
+        #expect(issueHeaders["content-type"] == "application/json")
+        #expect(issueHeaders["x-api-key"] == "melix_primary_desktop")
+        let issueBody = try #require(issueRequest.body)
+        let issueJSON = try #require(JSONSerialization.jsonObject(with: issueBody) as? [String: Any])
+        #expect(issueJSON["remember_me"] as? Bool == true)
+        #expect(issueJSON["scope"] as? String == "companion_read_only")
+
+        try await client.revokePairing(baseURL: baseURL, sessionToken: "melix_live_secret")
+
+        let requests = await transport.requests
+        #expect(requests.count == 2)
+        let revokeRequest = try #require(requests.last)
+        #expect(revokeRequest.url?.absoluteString == "http://127.0.0.1:12436/v1/melix/auth/session")
+        #expect(revokeRequest.method == "DELETE")
+        let revokeHeaders = Dictionary(
+            uniqueKeysWithValues: revokeRequest.headers.map { ($0.key.lowercased(), $0.value) }
+        )
+        #expect(revokeHeaders["x-melix-session"] == "melix_live_secret")
+    }
+
+    @Test("live companion pairing client reports gateway errors and normalizes route display text")
+    func liveCompanionPairingClientReportsGatewayErrorsAndNormalizesRouteDisplayText() async throws {
+        let baseURL = try #require(URL(string: "http://127.0.0.1:12436"))
+
+        let httpFailureTransport = FakeCompanionPairingHTTPTransport()
+        await httpFailureTransport.configureIssueResponse(
+            statusCode: 500,
+            body: Data("gateway offline".utf8)
+        )
+        let httpFailureClient = LiveCompanionPairingClient(transport: httpFailureTransport)
+        do {
+            _ = try await httpFailureClient.issuePairing(baseURL: baseURL, apiKey: "melix_primary_desktop")
+            Issue.record("Expected companion pairing HTTP failure.")
+        } catch let error as CompanionPairingClientError {
+            #expect(error.description == "Companion pairing HTTP 500: gateway offline")
+        }
+
+        let missingPairingPayload = #"""
+        {
+          "session": {
+            "session_id": "companion-missing-pairing",
+            "remember_me": true,
+            "scope": "companion_read_only",
+            "expires_at_unix_ms": 1718000000000
+          },
+          "resume": {
+            "header": "x-melix-session",
+            "token": "melix_missing_pairing_secret"
+          }
+        }
+        """#.data(using: .utf8)!
+        let missingPairingTransport = FakeCompanionPairingHTTPTransport()
+        await missingPairingTransport.configureIssueResponse(body: missingPairingPayload)
+        let missingPairingClient = LiveCompanionPairingClient(transport: missingPairingTransport)
+        do {
+            _ = try await missingPairingClient.issuePairing(baseURL: baseURL, apiKey: "melix_primary_desktop")
+            Issue.record("Expected missing pairing descriptor failure.")
+        } catch let error as CompanionPairingClientError {
+            #expect(error.description == "Companion pairing response did not include a pairing descriptor.")
+        }
+
+        let routeNormalizationPayload = #"""
+        {
+          "session": {
+            "session_id": "companion-route-normalization",
+            "remember_me": true,
+            "scope": "companion_read_only",
+            "expires_at_unix_ms": 1718000000000
+          },
+          "resume": {
+            "header": "x-melix-session",
+            "token": "melix_route_secret"
+          },
+          "pairing": {
+            "schema_version": "melix.companion.pairing.v1",
+            "token_transport": "resume_header",
+            "resume_header": "x-melix-session",
+            "status_url": "http://127.0.0.1:12436/v1/melix/companion/status",
+            "expires_at_unix_ms": 1718000000000,
+            "allowed_routes": [
+              {"method": "   ", "path": "/v1/path-only"},
+              {"method": "get", "path": "   "}
+            ],
+            "forbidden_capabilities": []
+          }
+        }
+        """#.data(using: .utf8)!
+        let routeNormalizationTransport = FakeCompanionPairingHTTPTransport()
+        await routeNormalizationTransport.configureIssueResponse(body: routeNormalizationPayload)
+        let routeNormalizationClient = LiveCompanionPairingClient(transport: routeNormalizationTransport)
+
+        let routeNormalizationResult = try await routeNormalizationClient.issuePairing(
+            baseURL: baseURL,
+            apiKey: "melix_primary_desktop"
+        )
+
+        #expect(routeNormalizationResult.pairing.allowedRoutes == ["/v1/path-only", "GET"])
+        #expect(CompanionPairingClientError.invalidResponse("not HTTP").description == "not HTTP")
+    }
+
     @Test("defers gateway apply when selected server session is not running")
     @MainActor
     func defersGatewayApplyWhenSelectedServerSessionIsNotRunning() async throws {

--- a/apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
@@ -148,6 +148,8 @@ actor FakeCompanionPairingClient: CompanionPairingClient {
     )
     private var issueError: Error?
     private var revokeError: Error?
+    private var issueDelay: Duration?
+    private var revokeDelay: Duration?
 
     func configureIssueResult(_ result: CompanionPairingIssueResult) {
         issueResult = result
@@ -162,8 +164,19 @@ actor FakeCompanionPairingClient: CompanionPairingClient {
         revokeError = error
     }
 
+    func configureIssueDelay(_ delay: Duration?) {
+        issueDelay = delay
+    }
+
+    func configureRevokeDelay(_ delay: Duration?) {
+        revokeDelay = delay
+    }
+
     func issuePairing(baseURL: URL, apiKey: String) async throws -> CompanionPairingIssueResult {
         issueRequests.append(CompanionPairingIssueRequestRecord(baseURL: baseURL, apiKey: apiKey))
+        if let issueDelay {
+            try? await Task.sleep(for: issueDelay)
+        }
         if let issueError {
             throw issueError
         }
@@ -172,6 +185,9 @@ actor FakeCompanionPairingClient: CompanionPairingClient {
 
     func revokePairing(baseURL: URL, sessionToken: String) async throws {
         revokeRequests.append(CompanionPairingRevokeRequestRecord(baseURL: baseURL, sessionToken: sessionToken))
+        if let revokeDelay {
+            try? await Task.sleep(for: revokeDelay)
+        }
         if let revokeError {
             throw revokeError
         }

--- a/apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
@@ -116,6 +116,115 @@ final class FakeRemoteServerStore: RemoteServerStoring, @unchecked Sendable {
     }
 }
 
+struct CompanionPairingIssueRequestRecord: Equatable, Sendable {
+    let baseURL: URL
+    let apiKey: String
+}
+
+struct CompanionPairingRevokeRequestRecord: Equatable, Sendable {
+    let baseURL: URL
+    let sessionToken: String
+}
+
+actor FakeCompanionPairingClient: CompanionPairingClient {
+    private(set) var issueRequests: [CompanionPairingIssueRequestRecord] = []
+    private(set) var revokeRequests: [CompanionPairingRevokeRequestRecord] = []
+    private var issueResult = CompanionPairingIssueResult(
+        sessionID: "companion-session-test",
+        scope: "companion_read_only",
+        rememberMe: true,
+        expiresAtUnixMS: 1_718_000_000_000,
+        resumeHeader: "x-melix-session",
+        resumeToken: "melix_companion_test_token",
+        pairing: CompanionPairingDescriptor(
+            schemaVersion: "melix.companion.pairing.v1",
+            statusURL: "http://127.0.0.1:12436/v1/melix/companion/status",
+            resumeHeader: "x-melix-session",
+            tokenTransport: "resume_header",
+            allowedRoutes: ["/v1/melix/companion/status"],
+            forbiddenCapabilities: ["mutate_runtime"],
+            expiresAtUnixMS: 1_718_000_000_000
+        )
+    )
+    private var issueError: Error?
+    private var revokeError: Error?
+
+    func configureIssueResult(_ result: CompanionPairingIssueResult) {
+        issueResult = result
+        issueError = nil
+    }
+
+    func configureIssueError(_ error: Error?) {
+        issueError = error
+    }
+
+    func configureRevokeError(_ error: Error?) {
+        revokeError = error
+    }
+
+    func issuePairing(baseURL: URL, apiKey: String) async throws -> CompanionPairingIssueResult {
+        issueRequests.append(CompanionPairingIssueRequestRecord(baseURL: baseURL, apiKey: apiKey))
+        if let issueError {
+            throw issueError
+        }
+        return issueResult
+    }
+
+    func revokePairing(baseURL: URL, sessionToken: String) async throws {
+        revokeRequests.append(CompanionPairingRevokeRequestRecord(baseURL: baseURL, sessionToken: sessionToken))
+        if let revokeError {
+            throw revokeError
+        }
+    }
+}
+
+struct CompanionPairingHTTPRequestRecord: Equatable, Sendable {
+    let url: URL?
+    let method: String
+    let headers: [String: String]
+    let body: Data?
+}
+
+actor FakeCompanionPairingHTTPTransport: CompanionPairingHTTPTransport {
+    private(set) var requests: [CompanionPairingHTTPRequestRecord] = []
+    private var issueStatusCode = 200
+    private var issueBody = Data()
+    private var revokeStatusCode = 204
+    private var revokeBody = Data()
+
+    func configureIssueResponse(statusCode: Int = 200, body: Data) {
+        issueStatusCode = statusCode
+        issueBody = body
+    }
+
+    func configureRevokeResponse(statusCode: Int = 204, body: Data = Data()) {
+        revokeStatusCode = statusCode
+        revokeBody = body
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let method = request.httpMethod ?? "GET"
+        requests.append(
+            CompanionPairingHTTPRequestRecord(
+                url: request.url,
+                method: method,
+                headers: request.allHTTPHeaderFields ?? [:],
+                body: request.httpBody
+            )
+        )
+
+        let body = method == "DELETE" ? revokeBody : issueBody
+        let statusCode = method == "DELETE" ? revokeStatusCode : issueStatusCode
+        let response = HTTPURLResponse(
+            url: request.url ?? URL(string: "http://127.0.0.1")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (body, response)
+    }
+}
+
 final class FakeEvaluationPromptStore: EvaluationPromptStoring, @unchecked Sendable {
     enum StoreError: Error, Equatable {
         case list

--- a/docs/plans/2026-06-15-issue-1759-companion-token-controls.md
+++ b/docs/plans/2026-06-15-issue-1759-companion-token-controls.md
@@ -87,19 +87,19 @@ Excluded:
 Focused AppMain tests:
 
 ```bash
-HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --filter 'RuntimeViewModelTests/(issuesCompanionPairingWithStoredPrimaryKey|revokesActiveCompanionPairingToken|companionPairingRequiresStoredPrimaryKey|companionPairingSurfacesKeyStoreAndTransportFailures|liveCompanionPairingClientIssuesAndRevokesGatewaySessions|liveCompanionPairingClientReportsGatewayErrorsAndNormalizesRouteDisplayText)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --filter 'RuntimeViewModelTests/(issuesCompanionPairingWithStoredPrimaryKey|revokesActiveCompanionPairingToken|companionPairingRequiresStoredPrimaryKey|companionPairingIssueIgnoresDuplicateInFlightRequests|companionPairingRevokeIgnoresDuplicateInFlightRequests|companionPairingSurfacesKeyStoreAndTransportFailures|liveCompanionPairingClientIssuesAndRevokesGatewaySessions|liveCompanionPairingClientReportsGatewayErrorsAndNormalizesRouteDisplayText)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
 ```
 
-Result: passed, 8 tests in 2 suites.
+Result: passed, 10 tests in 2 suites.
 
 Changed-line coverage:
 
 ```bash
-HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'RuntimeViewModelTests/(issuesCompanionPairingWithStoredPrimaryKey|revokesActiveCompanionPairingToken|companionPairingRequiresStoredPrimaryKey|companionPairingSurfacesKeyStoreAndTransportFailures|liveCompanionPairingClientIssuesAndRevokesGatewaySessions|liveCompanionPairingClientReportsGatewayErrorsAndNormalizesRouteDisplayText)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'RuntimeViewModelTests/(issuesCompanionPairingWithStoredPrimaryKey|revokesActiveCompanionPairingToken|companionPairingRequiresStoredPrimaryKey|companionPairingIssueIgnoresDuplicateInFlightRequests|companionPairingRevokeIgnoresDuplicateInFlightRequests|companionPairingSurfacesKeyStoreAndTransportFailures|liveCompanionPairingClientIssuesAndRevokesGatewaySessions|liveCompanionPairingClientReportsGatewayErrorsAndNormalizesRouteDisplayText)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
 UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Sources/AppMain/Models/CompanionPairingClient.swift apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
 ```
 
-Result: changed-line coverage `96.08%` (`907/944`).
+Result: changed-line coverage `96.24%` (`973/1011`).
 
 Full gate before commit:
 

--- a/docs/plans/2026-06-15-issue-1759-companion-token-controls.md
+++ b/docs/plans/2026-06-15-issue-1759-companion-token-controls.md
@@ -1,0 +1,117 @@
+# Issue 1759 Companion Token Controls
+
+## Goal
+
+Add desktop API-surface controls that let the operator issue, copy, and revoke a
+single read-only companion session token for the selected local server session.
+
+## Best End-State Architecture
+
+The desktop app should not become a second auth-session authority. It should use
+the selected server session's stored primary gateway API key to call
+`POST /v1/melix/auth/session` with `scope = companion_read_only`, render the
+safe pairing descriptor returned by the gateway, and keep the raw
+`resume.token` only in transient view-model memory so the same desktop session
+can copy or revoke it.
+
+Revocation should call the existing self-revocation route with
+`X-Melix-Session: <token>` and then clear the transient token state. Operator
+state persistence continues to store server-session settings and primary API
+keys only; it must not write companion session tokens or companion pairing
+bundles.
+
+## Slice Boundary
+
+This slice adds native desktop companion-token management in the API workspace.
+
+Included:
+
+- a desktop companion-pairing client for create and revoke calls;
+- view-model state for issue/revoke phases, safe descriptor fields, errors, and
+  a copyable one-time pairing bundle;
+- API workspace controls for issuing, copying, and revoking the active
+  companion token;
+- focused AppMain tests proving request shape, revocation, missing-key errors,
+  and token non-persistence.
+
+Excluded:
+
+- QR image rendering;
+- companion/mobile status page implementation;
+- mobile or narrow viewport smoke;
+- LAN discovery or public internet exposure;
+- changing the gateway companion route allowlist.
+
+## Performance Probes and Metrics
+
+- Runtime metrics: record `companion.pairing_issue_ms` and
+  `companion.pairing_revoke_ms` from the desktop view model around the HTTP
+  calls.
+- Failure metrics: record `companion.pairing_issue_failures` and
+  `companion.pairing_revoke_failures` as monotonically increasing desktop
+  counters when local validation or HTTP calls fail.
+- Probe overhead: bounded to two local HTTP calls and one metrics write per
+  operator action.
+- PR merge gate: scoped performance report must remain `Status: ok` with zero
+  regressions.
+
+## Implementation Plan
+
+1. Add failing `RuntimeViewModelTests` for issuing a companion pairing from the
+   selected server session. The test stores a primary key, injects a fake
+   companion client, calls `issueCompanionPairing()`, and asserts the client saw
+   `http://127.0.0.1:<port>` plus the primary key, the state exposes descriptor
+   fields, and the raw token does not appear in `String(describing: state)`.
+2. Add failing `RuntimeViewModelTests` for revoking the active companion token.
+   The test issues a fake token, calls `revokeCompanionPairing()`, asserts the
+   fake client saw the token, and asserts the visible state returns to idle.
+3. Add failing `RuntimeViewModelTests` for missing primary key validation. The
+   test calls `issueCompanionPairing()` without a stored key and expects a
+   visible error, zero client calls, and an issue-failure metric.
+4. Implement `CompanionPairingClient`, `LiveCompanionPairingClient`, and compact
+   DTO/state types under `apps/macos-menubar/Sources/AppMain/Models/`.
+5. Inject the companion client into `RuntimeViewModel`, add
+   `companionPairing`, `issueCompanionPairing()`,
+   `companionPairingBundleText()`, and `revokeCompanionPairing()` methods, and
+   keep the raw token in a private in-memory field only.
+6. Add a compact `Companion Pairing` panel to `DesktopAPIWorkspaceView` under
+   the Authentication section, using existing AppMain card/button patterns.
+7. Update `docs/runbooks/persistent-sessions.md` with the desktop control
+   boundary and token handling rule.
+8. Run focused tests, changed-line coverage, scoped performance, pre-commit
+   gate, PR creation, remote CI/performance monitoring, review-thread cleanup,
+   and squash merge.
+
+## Verification
+
+Focused AppMain tests:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --filter 'RuntimeViewModelTests/(issuesCompanionPairingWithStoredPrimaryKey|revokesActiveCompanionPairingToken|companionPairingRequiresStoredPrimaryKey|companionPairingSurfacesKeyStoreAndTransportFailures|liveCompanionPairingClientIssuesAndRevokesGatewaySessions|liveCompanionPairingClientReportsGatewayErrorsAndNormalizesRouteDisplayText)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
+```
+
+Result: passed, 8 tests in 2 suites.
+
+Changed-line coverage:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'RuntimeViewModelTests/(issuesCompanionPairingWithStoredPrimaryKey|revokesActiveCompanionPairingToken|companionPairingRequiresStoredPrimaryKey|companionPairingSurfacesKeyStoreAndTransportFailures|liveCompanionPairingClientIssuesAndRevokesGatewaySessions|liveCompanionPairingClientReportsGatewayErrorsAndNormalizesRouteDisplayText)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
+UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Sources/AppMain/Models/CompanionPairingClient.swift apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
+```
+
+Result: changed-line coverage `96.08%` (`907/944`).
+
+Full gate before commit:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```
+
+## Deferred Work
+
+- QR/code rendering.
+- Companion/mobile status UI.
+- Mobile/narrow viewport smoke for the companion status flow.
+- Multi-token session list management.

--- a/docs/runbooks/persistent-sessions.md
+++ b/docs/runbooks/persistent-sessions.md
@@ -86,6 +86,30 @@ it describes how the companion client should use the session. It does not
 duplicate the raw token. Keep treating `resume.token` as the only secret value
 in the response.
 
+### Desktop Companion Token Controls
+
+The macOS API workspace includes a `Companion Pairing` panel under the
+Authentication section. It uses the selected local server session's stored
+primary gateway API key to issue a remembered `companion_read_only` session,
+then renders the safe pairing descriptor returned by the gateway.
+
+Operator actions:
+
+- `Issue Read-Only Token` calls `POST /v1/melix/auth/session` with
+  `remember_me = true` and `scope = companion_read_only`.
+- `Copy Pairing Bundle` copies a one-time JSON bundle containing the descriptor
+  and the raw companion token for the operator to transfer to a companion
+  client.
+- `Revoke Token` calls `DELETE /v1/melix/auth/session` with the active
+  companion token through `X-Melix-Session`.
+
+The desktop view model keeps the raw companion token only in transient process
+memory so the current operator session can copy or revoke it. The token is not
+written into operator session state, server-session configuration, logs,
+metrics, or the safe descriptor displayed in the panel. Closing the desktop
+process drops the transient token reference; create a new companion token if the
+current token can no longer be copied or revoked from the panel.
+
 ### Reuse The Session
 
 ```bash


### PR DESCRIPTION
## Summary
- Add desktop companion pairing controls in the API workspace to issue, copy, and revoke a read-only companion session token for the selected local server.
- Route pairing through the gateway auth-session API while keeping the raw companion resume token in transient `RuntimeViewModel` memory only.
- Document the desktop token boundary and cover issue, revoke, missing-key, transport-error, and UI render states.

Refs #1759.

## Plan or Spec
- `docs/plans/2026-06-15-issue-1759-companion-token-controls.md`
- `docs/runbooks/persistent-sessions.md`

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --filter 'RuntimeViewModelTests/(issuesCompanionPairingWithStoredPrimaryKey|revokesActiveCompanionPairingToken|companionPairingRequiresStoredPrimaryKey|companionPairingIssueIgnoresDuplicateInFlightRequests|companionPairingRevokeIgnoresDuplicateInFlightRequests|companionPairingSurfacesKeyStoreAndTransportFailures|liveCompanionPairingClientIssuesAndRevokesGatewaySessions|liveCompanionPairingClientReportsGatewayErrorsAndNormalizesRouteDisplayText)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
Result: passed, 10 tests in 2 suites.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'RuntimeViewModelTests/(issuesCompanionPairingWithStoredPrimaryKey|revokesActiveCompanionPairingToken|companionPairingRequiresStoredPrimaryKey|companionPairingIssueIgnoresDuplicateInFlightRequests|companionPairingRevokeIgnoresDuplicateInFlightRequests|companionPairingSurfacesKeyStoreAndTransportFailures|liveCompanionPairingClientIssuesAndRevokesGatewaySessions|liveCompanionPairingClientReportsGatewayErrorsAndNormalizesRouteDisplayText)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
Result: passed, 10 tests in 2 suites.

UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Sources/AppMain/Models/CompanionPairingClient.swift apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
Result: changed-line coverage 96.24% (973/1011).

git diff --check
Result: passed.

make git-hooks-install
Result: passed; hooks path set to .githooks.

git commit -m "feat: add companion token controls"
Result: passed through the pre-commit hook:
- make swift-test: passed.
- make py-test: 4015 passed, 14 skipped, 2 warnings.
- make integration-test: 120 passed, 1 skipped.
- PR scoped performance report: Status ok, regressions 0, context regressions 0, verification failures 0.

After merging origin/main@5716f662:
- Focused AppMain tests: passed, 10 tests in 2 suites.
- Focused AppMain coverage tests: passed, 10 tests in 2 suites.
- Changed-line coverage: 96.24% (973/1011).
- git diff --check: passed.

git commit -m "fix: harden companion pairing controls"
Result: passed through the pre-commit hook:
- make swift-test: passed.
- make py-test: 4015 passed, 14 skipped, 2 warnings.
- make integration-test: 120 passed, 1 skipped.
- PR scoped performance report: Status ok, regressions 0, context regressions 0, verification failures 0.
```

## Coverage and Metrics
- Changed-line coverage: `96.24%` (`973/1011`) for the changed AppMain source/test scope.
- Runtime metrics added: `companion.pairing_issue_ms`, `companion.pairing_revoke_ms`, `companion.pairing_issue_failures`, and `companion.pairing_revoke_failures`.
- Scoped performance reports:
  - `.runtime/pre-commit-performance/20260614-210817-5596ad7b/report/report.md`; `Status: ok`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`.
  - `.runtime/pre-commit-performance/20260614-214340-131b4f5b/report/report.md`; `Status: ok`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`.
- Observability mode: minimal runtime metrics around operator-triggered local HTTP calls.
- Probe overhead: one metrics write per issue/revoke attempt plus the requested local gateway HTTP call; no PR-scoped probes were selected for this change set.

## Known Gaps
- QR/code rendering is deferred.
- Companion/mobile status UI and mobile/narrow viewport smoke are deferred.
- LAN discovery, public internet exposure, and multi-token session list management remain out of scope for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
