### PR TITLE
perf: elide retrieval store refusal list combine

### DIFF
--- a/docs/plans/2026-06-14-retrieval-store-refusal-list-elision.md
+++ b/docs/plans/2026-06-14-retrieval-store-refusal-list-elision.md
@@ -1,0 +1,29 @@
+# Retrieval store refusal list elision
+
+This Python-only performance slice is limited to `worker.runtime.retrieval_context.project_retrieval_store_records`.
+
+## Scope
+
+The hot path projects retrieval store records into prompt payloads. The common valid-record path usually has no store-level or projection-level refusal receipts, but the function still built a fresh combined list with starred unpacking at return time.
+
+This slice keeps the existing projection behavior while reusing the store-refusal accumulator as the return list and only extending it when projection refusals exist. No admission, duplicate detection, payload copy, or receipt-copy semantics change.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/retrieval_context.py`
+- `services/mlx-worker-python/tests/test_retrieval_context.py`
+- `scripts/retrieval_context_projection_probe.py`
+
+## Local verification plan
+
+Run on Linux before opening the PR:
+
+1. Focused retrieval-context tests from the registered probe.
+2. Changed-scope coverage from the registered probe.
+3. The registered probe command locally with repeated samples.
+
+GitHub Actions PR-scoped performance remains the final registered probe validation and merge gate.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -288,13 +288,12 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
             for receipt in admission_receipts:
                 receipts_append(receipt.copy())
 
+    if projection_refusal_receipts:
+        store_refusal_receipts.extend(projection_refusal_receipts)
     return RetrievalContextProjection(
         user_payload=user_payload,
         untrusted_context_receipts=receipts,
-        refusal_receipts=[
-            *store_refusal_receipts,
-            *projection_refusal_receipts,
-        ],
+        refusal_receipts=store_refusal_receipts,
     )
 
 


### PR DESCRIPTION
## Summary
- Reuse the store-refusal accumulator in `project_retrieval_store_records()` instead of always allocating a combined refusal list with starred unpacking.
- Keep retrieval admission, duplicate detection, payload copy, and receipt-copy behavior unchanged.
- Document the Python-only slice and registered probe coverage in `docs/plans/2026-06-14-retrieval-store-refusal-list-elision.md`.

## Plan or Spec
- Added `docs/plans/2026-06-14-retrieval-store-refusal-list-elision.md`.
- Affected path is covered by the registered PR-scoped probe `retrieval-context-projection-fastpath` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `git fetch origin && git rebase origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_isolates_refusals_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_malformed_entry_objects_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_preserves_multi_field_admission_duplicate_scan services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_copies_multi_receipt_admissions services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_projects_records_without_entry_reentry services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_copies_store_projection_outputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id retrieval-context-projection-fastpath --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-retrieval-store-refusal-elision-20260614 --head-repo "$PWD" --output /tmp/retrieval_refusal_elision_probe_1781476319.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 13 passed in 0.13s.
- Changed-scope coverage: `TOTAL 0 0 100%` from the registered coverage command.
- Local Linux registered probe completed successfully.
- Base probe store metrics: `store_optimized_elapsed_ms_mean=0.2161753224208951 ms`, `store_delta_ms=-0.0085745326110295 ms`, `store_speedup=1.0396647152644687x`.
- Head probe store metrics: `store_optimized_elapsed_ms_mean=0.2062719435031925 ms`, `store_delta_ms=-0.012557250780186463 ms`, `store_speedup=1.0608771632579888x`.
- Head vs base store optimized delta: `-0.0099033789177026 ms` (~4.58% lower).

## Known Gaps
- Local validation is Linux/Python-only. GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Worktree synced onto `origin/main` before PR creation.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe passed locally on Linux.
- [ ] GitHub Actions checks are green.
- [ ] PR-scoped performance workflow completed successfully.
