### PR TITLE
perf: filter LoRA auxiliary module candidates

### DIFF
--- a/docs/plans/2026-06-15-lora-aux-module-prefix-filter.md
+++ b/docs/plans/2026-06-15-lora-aux-module-prefix-filter.md
@@ -1,0 +1,20 @@
+# LoRA auxiliary module prefix filter slice
+
+## Scope
+
+This Python performance slice is limited to `services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py` and the LoRA canary auxiliary-module scan used while building LoRA training receipts.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `lora-aux-modules-scandir` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for the LoRA runtime metadata module, receipt tests, PR-scoped performance tests, and `scripts/lora_aux_modules_scandir_probe.py`.
+
+## Change
+
+The auxiliary module detector already uses a single `os.scandir` pass and preserves `modeling_*.py`, `configuration_*.py`, `tokenization_*.py`, and `processing_*.py` semantics. This slice adds a precomputed first-character filter before the `.py` suffix and tuple-prefix checks so large base model directories with unrelated files can reject common non-candidate names with a cheaper membership check.
+
+## Verification Plan
+
+- Run the registered focused test command for `lora-aux-modules-scandir` locally on Linux.
+- Run the registered changed-scope coverage command locally on Linux and require at least 95% changed-scope coverage.
+- Run the registered probe locally on Linux and compare against `origin/main` with the PR-scoped performance runner.
+- Use GitHub Actions, including the registered PR-scoped performance report, as the merge gate before squash merging.

--- a/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
@@ -33,6 +33,9 @@ _AUXILIARY_MODULE_PATTERNS = (
 _AUXILIARY_MODULE_PREFIXES = tuple(
     pattern.removesuffix("*.py") for pattern in _AUXILIARY_MODULE_PATTERNS
 )
+_AUXILIARY_MODULE_PREFIX_CHARS = frozenset(
+    prefix[0] for prefix in _AUXILIARY_MODULE_PREFIXES
+)
 _PROCESSOR_RESUME_FILENAMES = (
     ("processor_config.json", "processor_config"),
     ("preprocessor_config.json", "preprocessor_config"),
@@ -337,12 +340,17 @@ def _processor_resume_mode(base_model_dir: Path) -> str:
 
 def _aux_modules_restored(base_model_dir: Path) -> bool:
     auxiliary_prefixes = _AUXILIARY_MODULE_PREFIXES
+    auxiliary_prefix_chars = _AUXILIARY_MODULE_PREFIX_CHARS
     scandir = os.scandir
     try:
         with scandir(base_model_dir) as entries:
             for entry in entries:
                 name = entry.name
-                if name.endswith(".py") and name.startswith(auxiliary_prefixes):
+                if (
+                    name[0] in auxiliary_prefix_chars
+                    and name.endswith(".py")
+                    and name.startswith(auxiliary_prefixes)
+                ):
                     return True
     except OSError:
         return False


### PR DESCRIPTION
## Summary
- Add a precomputed first-character filter before LoRA auxiliary-module suffix/prefix checks.
- Keep the existing single `os.scandir` traversal and canary receipt semantics unchanged.

## Plan or Spec
- `docs/plans/2026-06-15-lora-aux-module-prefix-filter.md`
- Registered probe: `lora-aux-modules-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_uses_os_path_isfile_with_precedence services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_fallback_precedence services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_returns_missing_without_resume_assets services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_uses_precompiled_patterns services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_skips_regex_without_substring services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_processor_resume_probe_baseline_modes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 14 passed in 1.04s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_aux_modules_scandir_probe.py
# 14 passed in 0.36s; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id lora-aux-modules-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-lora-aux-modules-filter-20260615 --output /tmp/lora-aux-prefix-perf.json
# passed; head verification ok; base/head probes ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Local registered probe comparison (`lora-aux-modules-scandir`):
  - `elapsed_ms_mean`: base `1.3400493854922908`, head `1.2907001988164015` (`delta_ms=-0.0493491866758893`, ~3.68% lower).
  - `elapsed_ms_min`: base `1.2511080130934715`, head `1.2198882177472115` (`delta_ms=-0.03121979534626007`).
  - `peak_bytes_mean`: base `815.0`, head `815.0`.
  - `scandir_calls_mean`: base `1.0`, head `1.0`.
- CI PR-scoped performance report is required as the merge gate before merge.

## Known Gaps
- Local Linux verifies Python behavior and the registered probe. No Swift runtime effect is involved in this slice.
- Probe timings are small and noisy; CI registered probe validation remains required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
