### PR TITLE
perf: bind retrieval lookup helper calls

### DIFF
--- a/docs/plans/2026-06-15-retrieval-lookup-helper-local-bindings.md
+++ b/docs/plans/2026-06-15-retrieval-lookup-helper-local-bindings.md
@@ -1,0 +1,44 @@
+# Retrieval Lookup Helper Local Bindings
+
+## Summary
+
+This Python-only performance slice keeps retrieval lookup projection behavior
+unchanged and narrows one hot path in
+`worker.runtime.retrieval_context.project_retrieval_lookup_result()`.
+
+The lookup projection path calls the store projection helper, then defensively
+copies the projected prompt payload and receipt lists. The slice binds those
+module-level helpers to local variables once per lookup projection call, avoiding
+repeated global helper lookup overhead while preserving the same copy semantics
+and output structure.
+
+## Probe Coverage
+
+Registered probe: `retrieval-context-projection-fastpath` in
+`infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` fields and watches:
+
+- `services/mlx-worker-python/worker/runtime/retrieval_context.py`
+- `services/mlx-worker-python/tests/test_retrieval_context.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/retrieval_context_projection_probe.py`
+
+The probe reports direct projection, store-record projection, and lookup-copy
+metrics, including `lookup_copy_optimized_elapsed_ms_mean` and
+`lookup_copy_speedup` for this slice.
+
+## Implementation
+
+1. Keep the invalid lookup-result refusal path unchanged.
+2. Bind `project_retrieval_store_records`, `_copy_payload`, and `_copy_receipts`
+   to locals before executing the valid lookup projection path.
+3. Leave payload/receipt defensive copying and lookup message construction
+   semantics unchanged.
+
+## Validation Plan
+
+Run the registered focused test command, changed-scope coverage command, and
+registered probe locally on Linux. Use the GitHub Actions PR-scoped performance
+workflow as the merge gate after opening the PR.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -306,12 +306,13 @@ def project_retrieval_lookup_result(lookup_result: Any) -> RetrievalLookupResult
             lookup_message=None,
         )
 
-    store_projection = project_retrieval_store_records(lookup_result.get("records"))
-    prompt_user_payload = _copy_payload(store_projection.user_payload)
-    untrusted_context_receipts = _copy_receipts(
-        store_projection.untrusted_context_receipts
-    )
-    refusal_receipts = _copy_receipts(store_projection.refusal_receipts)
+    project_store_records = project_retrieval_store_records
+    copy_payload = _copy_payload
+    copy_receipts = _copy_receipts
+    store_projection = project_store_records(lookup_result.get("records"))
+    prompt_user_payload = copy_payload(store_projection.user_payload)
+    untrusted_context_receipts = copy_receipts(store_projection.untrusted_context_receipts)
+    refusal_receipts = copy_receipts(store_projection.refusal_receipts)
     lookup_message: dict[str, Any] | None = None
     if prompt_user_payload:
         lookup_message = {


### PR DESCRIPTION
## Summary
- Bind retrieval lookup projection helper calls to local variables on the valid lookup-result path.
- Preserve payload/receipt defensive copying and lookup message output semantics.

## Plan or Spec
- `docs/plans/2026-06-15-retrieval-lookup-helper-local-bindings.md`
- Registered PR-scoped probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
exit 0; lookup_copy_optimized_elapsed_ms_mean=0.21364712455709065; lookup_copy_speedup=3.7665117037781313

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_isolates_refusals_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_malformed_entry_objects_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_preserves_multi_field_admission_duplicate_scan services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_copies_multi_receipt_admissions services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_projects_records_without_entry_reentry services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_copies_store_projection_outputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
exit 0; 13 passed in 0.93s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_isolates_refusals_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_malformed_entry_objects_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_preserves_multi_field_admission_duplicate_scan services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_copies_multi_receipt_admissions services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_projects_records_without_entry_reentry services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_copies_store_projection_outputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
exit 0; TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
exit 0; lookup_copy_optimized_elapsed_ms_mean=0.20668908221913235; lookup_copy_speedup=3.929580398447203

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (7/7 measurable changed lines).
- Local Linux registered probe before/after: `lookup_copy_optimized_elapsed_ms_mean` 0.21364712455709065 ms -> 0.20668908221913235 ms (delta -0.0069580423379583 ms, about 3.26% lower); `lookup_copy_speedup` 3.7665117037781313x -> 3.929580398447203x.
- Registered PR-scoped performance CI is required as the merge gate.

## Known Gaps
- Local validation is Linux/Python only. CI PR-scoped performance report is the authoritative registered probe validation before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
