### PR TITLE
perf: stream report gate slowest phase top-k

### DIFF
--- a/docs/plans/2026-06-15-report-evidence-gate-slowest-phases-generator.md
+++ b/docs/plans/2026-06-15-report-evidence-gate-slowest-phases-generator.md
@@ -1,0 +1,17 @@
+# Report Evidence Gate Slowest Phase Top-K Streaming
+
+This Python performance slice is limited to `worker.productization.report_evidence_gate._slowest_probe_phases`.
+
+## Scope
+
+- Preserve the existing release evidence gate output shape and deterministic top-five ordering.
+- Replace materializing every candidate slowest phase before `heapq.nlargest` with a generator-backed top-k selection so the probe only streams rows into the heap selection.
+- Do not change release-matrix role matching, telemetry validation, or report rendering behavior.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped probe `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`. That entry includes focused `test_command`, `coverage_command`, and `probe_command` values and reports the `slowest_probe_phase_elapsed_ms_mean` metric for this slice.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, and registered probe locally on Linux before opening the PR. The PR-scoped performance workflow remains the merge gate for the registered probe report.

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -4,7 +4,7 @@ import heapq
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import AbstractSet, Any
+from typing import AbstractSet, Any, Iterator
 
 from worker.productization.benchmark_evaluation_report import validate_report_payload
 
@@ -469,33 +469,34 @@ def _slowest_probe_phases(report: dict[str, object]) -> list[dict[str, object]]:
     probe_summary = report.get("probe_summary")
     if not isinstance(probe_summary, dict):
         return []
-    rows: list[tuple[float, int, str, dict[str, object]]] = []
-    row_index = 0
-    rows_append = rows.append
-    for side in ("baseline", "candidate"):
-        side_summary = probe_summary.get(side)
-        if not isinstance(side_summary, dict):
-            continue
-        slowest_phases = side_summary.get("slowest_phases")
-        if not isinstance(slowest_phases, list):
-            continue
-        for row in slowest_phases:
-            if not isinstance(row, dict):
+
+    def iter_rows() -> Iterator[tuple[float, int, str, dict[str, object]]]:
+        row_index = 0
+        for side in ("baseline", "candidate"):
+            side_summary = probe_summary.get(side)
+            if not isinstance(side_summary, dict):
                 continue
-            duration = row.get("duration_ms")
-            if type(duration) is float:
-                duration_ms = duration
-            elif type(duration) is int:
-                duration_ms = float(duration)
-            elif type(duration) is str:
-                duration_ms = float(duration or 0.0)
-            else:
-                duration_ms = 0.0
-            rows_append((duration_ms, -row_index, side, row))
-            row_index += 1
+            slowest_phases = side_summary.get("slowest_phases")
+            if not isinstance(slowest_phases, list):
+                continue
+            for row in slowest_phases:
+                if not isinstance(row, dict):
+                    continue
+                duration = row.get("duration_ms")
+                if type(duration) is float:
+                    duration_ms = duration
+                elif type(duration) is int:
+                    duration_ms = float(duration)
+                elif type(duration) is str:
+                    duration_ms = float(duration or 0.0)
+                else:
+                    duration_ms = 0.0
+                yield (duration_ms, -row_index, side, row)
+                row_index += 1
+
     return [
         {"side": side, **row}
-        for _duration_ms, _row_order, side, row in heapq.nlargest(5, rows)
+        for _duration_ms, _row_order, side, row in heapq.nlargest(5, iter_rows())
     ]
 
 


### PR DESCRIPTION
## Summary
- Stream report evidence gate slowest phase rows into `heapq.nlargest` instead of materializing every candidate row first.
- Keep the deterministic top-five ordering and existing report output shape unchanged.

## Plan or Spec
- `docs/plans/2026-06-15-report-evidence-gate-slowest-phases-generator.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_keeps_top_five_order services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_accepts_typed_durations services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_fast_reject_preserves_empty_prefix services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_sparse_match_scans_row_items services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_preserves_stringified_presence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_matrix_roles_skip_probe_phase_scan_without_phase_rules services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_matrix_roles_scans_probe_phases_once_for_phase_rules services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_matrix_roles_select_multiple_run_kind_rules services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_dedupes_evidence_ids services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_single_role_keeps_stringified_evidence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_ignores_invalid_cached_roles services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# 22 passed in 0.92s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused test list>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
# TOTAL 22 1 95%; aggregate changed-line coverage 95.45%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# {"elapsed_ms_mean": 915.660925488919, ..., "slowest_probe_phase_elapsed_ms_mean": 36.96682946756482, ...}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 95.45% aggregate changed-line coverage (21/22 covered; one defensive branch for a malformed side summary remains uncovered).
- Registered probe: `report-evidence-gate-run-kind-set-membership`.
- Paired local probe comparison from this worktree:
  - baseline: `elapsed_ms_mean=934.3578026629984`, `slowest_probe_phase_elapsed_ms_mean=40.1606610044837`
  - candidate: `elapsed_ms_mean=926.8785750493407`, `slowest_probe_phase_elapsed_ms_mean=36.568183079361916`
  - delta: `elapsed_ms_mean=-7.479227613657713 ms`, `slowest_probe_phase_elapsed_ms_mean=-3.592477925121783 ms`

## Known Gaps
- Local validation is Linux/Python only. The registered PR-scoped performance workflow is required for CI-side probe validation before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via the registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
