### PR TITLE
Add agentic tool error refusal receipts

### DIFF
--- a/docs/plans/2026-06-15-issue-1761-agentic-tool-error-refusal-receipts.md
+++ b/docs/plans/2026-06-15-issue-1761-agentic-tool-error-refusal-receipts.md
@@ -1,0 +1,51 @@
+# Issue 1761 Agentic Tool Error Refusal Receipts Plan
+
+## Goal
+
+Add source-specific refusal receipts to deterministic agentic tool adapter failures so malformed untrusted inputs, owner-scope mismatches, and workspace path refusals are visible in the same `melix.untrusted_context_receipt.v1` stream as admitted source evidence.
+
+## Scope
+
+- Keep the existing failed observation payload fields for backward compatibility.
+- Add an `included = false` source receipt when a deterministic adapter raises `AgenticToolRuntimeError` with source metadata.
+- Cover invalid untrusted value types, owner-scope mismatches, and workspace path resolver refusals.
+- Do not change successful adapter payloads, prompt payload projection, or the generic observation-level receipt.
+
+## Architecture
+
+`DeterministicAgenticToolRuntime.execute` already catches `AgenticToolRuntimeError`, copies its `details` into the failed payload, and normalizes the payload through `normalize_tool_observation`. This slice will derive a source-specific refusal receipt from those details before normalization and pass it through `source_untrusted_context_receipts`.
+
+The mapper will only emit receipts for known refusal reasons that include enough source metadata. Unknown tool runtime failures continue to rely on the existing generic tool-observation receipt.
+
+## Performance Probes
+
+- Measurement point: deterministic agentic tool adapter failure normalization in `services/mlx-worker-python/worker/runtime/agentic_tools.py`.
+- Success metric: existing `pr-scoped-performance` selected probe reports `Status: ok`, `Regressions: 0`, `Context regressions: 0`, and `Verification failures: 0`.
+- Expected overhead: one small dictionary construction only on failed adapter paths; successful hot paths are unchanged.
+- Observability mode: `evidence`.
+
+## Implementation Steps
+
+1. Add failing tests in `services/mlx-worker-python/tests/test_agentic_tools.py`:
+   - invalid skill/memory lookup input emits an `included = false` receipt with `reason = invalid_untrusted_input_type`.
+   - skill/memory owner mismatch emits an `included = false` receipt with `reason = owner_scope_mismatch`.
+   - workspace path refusal emits an `included = false` receipt with `reason = workspace_path_refused`.
+2. Implement a small helper in `services/mlx-worker-python/worker/runtime/agentic_tools.py` that maps `AgenticToolRuntimeError.details` into `refused_prompt_context_receipt`.
+3. Pass the derived refusal receipt into `normalize_tool_observation` through `source_untrusted_context_receipts`.
+4. Update `docs/unified-agentic-tool-runtime-contract.md` to describe failed deterministic adapter source receipts.
+5. Run focused pytest, changed-scope coverage, `git diff --check`, and the full local pre-commit gate before commit.
+
+## Verification
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_agentic_tools.py -q
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_agentic_tools.py --cov=worker.runtime.agentic_tools --cov-report=term-missing
+git diff --check
+make bootstrap
+make proto
+make swift-test
+make py-test
+make integration-test
+```

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -924,6 +924,23 @@ selected-result receipt through `worker.runtime.prompt_context` by admitting one
 `PromptContextSegment` for the sanitized selected result value while preserving
 the same emitted receipt fields and observation payload.
 
+Deterministic adapter failures that reject a concrete untrusted source must also
+attach one source-specific refusal receipt beside the generic failed
+tool-observation receipt. The failed observation payload remains backward
+compatible and keeps the existing `reason`, `source_type`, `source_id`,
+`corrective_action`, and any diagnostic fields. The source refusal receipt uses
+the same `melix.untrusted_context_receipt.v1` schema with `included = false` and
+does not copy malformed values, cross-owner content, workspace paths beyond the
+public source ID, or private prompt text into receipt fields. The deterministic
+runtime currently emits these refusal receipts for:
+
+- `invalid_untrusted_input_type`: `segment_id = <source_id>:invalid-untrusted-input`
+  and `source_field` set to the rejected field.
+- `owner_scope_mismatch`: `segment_id = <source_id>:owner-scope-refusal`,
+  `source_field = owner_scope`, and `owner_scope_checked = true`.
+- `workspace_path_refused`: `segment_id = <source_id>:workspace-path-refusal`
+  and `source_field = workspace_path`.
+
 The deterministic visual tool source slice applies the same source-specific
 receipt pattern to successful `layout_parse` and `image_crop` observations.
 Each successful `layout_parse` observation emits one `retrieved_image` receipt
@@ -999,7 +1016,9 @@ the configured owner-scope check ran and passed. Workspace-local reads preserve
 their `workspace_path_receipt`, but set `owner_scope_checked = false` unless a
 separate owner-scope check is added later. Missing pages, workspace path
 refusals, and unavailable workspace files must not emit an admitted
-`retrieved_document` source receipt.
+`retrieved_document` source receipt. Workspace path refusals instead emit the
+failed adapter source refusal receipt described above with
+`source_type = workspace_file`.
 
 Live MCP, agent, workflow, and local-job mutation surfaces must reuse this
 operator layer or preserve the same resolver-before-filesystem-access invariant

--- a/services/mlx-worker-python/tests/test_agentic_tools.py
+++ b/services/mlx-worker-python/tests/test_agentic_tools.py
@@ -29,6 +29,28 @@ _BUILT_IN_TOOL_CALLS = (
 )
 
 
+def _source_refusal_receipts(observation: dict[str, object]) -> list[dict[str, object]]:
+    return [
+        receipt
+        for receipt in observation["untrusted_context_receipts"]
+        if isinstance(receipt, dict) and receipt.get("included") is False
+    ]
+
+
+@pytest.mark.parametrize(
+    "details",
+    [
+        {"reason": "invalid_untrusted_input_type", "source_type": "skill", "source_id": "skill:bad"},
+        {"reason": "owner_scope_mismatch", "source_type": "memory", "corrective_action": "reject"},
+        {"reason": "workspace_path_refused", "source_id": "config/.env", "corrective_action": "reject"},
+    ],
+)
+def test_agentic_tool_runtime_refusal_receipt_mapper_skips_incomplete_metadata(
+    details: dict[str, object],
+) -> None:
+    assert agentic_tools_module._runtime_error_refusal_receipts(details) == ()
+
+
 def test_agentic_tool_runtime_executes_all_builtin_tools_with_shared_observation_shape() -> None:
     run = execute_agentic_tool_calls(
         [
@@ -1169,6 +1191,23 @@ def test_agentic_tool_runtime_fails_closed_for_invalid_skill_memory_lookup_input
     assert observation["payload"]["source_id"] == expected_source_id
     assert observation["payload"]["expected_type"] == expected_type
     assert observation["payload"]["actual_type"] == actual_type
+    assert _source_refusal_receipts(observation) == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": f"{expected_source_id}:invalid-untrusted-input",
+            "source_type": expected_source_type,
+            "source_field": expected_field,
+            "source_id": expected_source_id,
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": False,
+            "owner_scope_checked": False,
+            "reason": "invalid_untrusted_input_type",
+            "corrective_action": "Provide this untrusted value as a JSON string.",
+        }
+    ]
 
 
 @pytest.mark.parametrize(
@@ -1223,6 +1262,23 @@ def test_agentic_tool_runtime_fails_closed_for_skill_memory_owner_scope_mismatch
     assert observation["payload"]["owner_scope_checked"] is True
     assert observation["payload"]["expected_owner_id"] == "operator-a"
     assert observation["payload"]["actual_owner_id"] == "operator-b"
+    assert _source_refusal_receipts(observation) == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": f"{expected_source_id}:owner-scope-refusal",
+            "source_type": expected_source_type,
+            "source_field": "owner_scope",
+            "source_id": expected_source_id,
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": False,
+            "owner_scope_checked": True,
+            "reason": "owner_scope_mismatch",
+            "corrective_action": "Do not project cross-owner untrusted content into tool observations.",
+        }
+    ]
 
 
 def test_agentic_tool_runtime_emits_source_receipt_for_fixture_visit_page() -> None:
@@ -1460,6 +1516,23 @@ def test_agentic_tool_runtime_fails_closed_for_invalid_untrusted_value_types(
     assert observation["payload"]["expected_type"] == "str"
     assert observation["payload"]["corrective_action"] == "Provide this untrusted value as a JSON string."
     assert run.metrics["agentic_tool.failed_count"] == 1.0
+    assert _source_refusal_receipts(observation) == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": f"{expected_source_id}:invalid-untrusted-input",
+            "source_type": expected_source_type,
+            "source_field": expected_field,
+            "source_id": expected_source_id,
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": False,
+            "owner_scope_checked": False,
+            "reason": "invalid_untrusted_input_type",
+            "corrective_action": "Provide this untrusted value as a JSON string.",
+        }
+    ]
 
 
 @pytest.mark.parametrize(
@@ -1512,6 +1585,23 @@ def test_agentic_tool_runtime_fails_closed_for_invalid_layout_and_crop_payloads(
     assert observation["payload"]["source_id"] == expected_source_id
     assert observation["payload"]["expected_type"] == expected_type
     assert observation["payload"]["actual_type"] == actual_type
+    assert _source_refusal_receipts(observation) == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": f"{expected_source_id}:invalid-untrusted-input",
+            "source_type": expected_source_type,
+            "source_field": expected_field,
+            "source_id": expected_source_id,
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": False,
+            "owner_scope_checked": False,
+            "reason": "invalid_untrusted_input_type",
+            "corrective_action": "Provide this untrusted value as a JSON string.",
+        }
+    ]
 
 
 @pytest.mark.parametrize(
@@ -1689,6 +1779,23 @@ def test_agentic_tool_runtime_fails_closed_for_owner_scope_mismatch(
     assert observation["payload"]["privilege"] == expected_privilege
     assert "cross-owner" in observation["payload"]["corrective_action"]
     assert run.metrics["agentic_tool.failed_count"] == 1.0
+    assert _source_refusal_receipts(observation) == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": f"{expected_source_id}:owner-scope-refusal",
+            "source_type": expected_source_type,
+            "source_field": "owner_scope",
+            "source_id": expected_source_id,
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": False,
+            "owner_scope_checked": True,
+            "reason": "owner_scope_mismatch",
+            "corrective_action": "Do not project cross-owner untrusted content into tool observations.",
+        }
+    ]
 
 
 def test_agentic_tool_runtime_allows_matching_owner_scope_payloads() -> None:
@@ -1898,6 +2005,23 @@ def test_agentic_tool_runtime_visit_refuses_workspace_path_before_reading(
         receipt["source_type"] != "retrieved_document"
         for receipt in observation["untrusted_context_receipts"]
     )
+    assert _source_refusal_receipts(observation) == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": f"{requested_path}:workspace-path-refusal",
+            "source_type": "workspace_file",
+            "source_field": "workspace_path",
+            "source_id": requested_path,
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": False,
+            "owner_scope_checked": False,
+            "reason": "workspace_path_refused",
+            "corrective_action": "Use a path accepted by the Workspace path resolver before reading local files.",
+        }
+    ]
 
 
 def test_agentic_tool_runtime_visit_reports_missing_workspace_file_with_receipt(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/runtime/agentic_tools.py
+++ b/services/mlx-worker-python/worker/runtime/agentic_tools.py
@@ -8,6 +8,7 @@ from typing import Any
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
+from worker.runtime.prompt_context import refused_prompt_context_receipt
 from worker.runtime.retrieval_context import (
     admit_retrieved_document_context,
     admit_retrieved_image_context,
@@ -147,6 +148,7 @@ class DeterministicAgenticToolRuntime:
             raise AgenticToolRuntimeError(f"Unknown agentic tool requested: {tool_name}")
         _validate_required_arguments(descriptor, arguments)
         started_at = perf_counter()
+        source_untrusted_context_receipts: tuple[dict[str, object], ...] = ()
         try:
             payload = self._execute_payload(
                 tool_name=tool_name,
@@ -156,12 +158,15 @@ class DeterministicAgenticToolRuntime:
         except AgenticToolRuntimeError as exc:
             payload = {"error": str(exc), "_status": "failed"}
             payload.update(exc.details)
+            source_untrusted_context_receipts = _runtime_error_refusal_receipts(exc.details)
         except (SyntaxError, TypeError, ValueError) as exc:
             payload = {"error": str(exc), "_status": "failed"}
         status = str(payload.pop("_status", "completed"))
-        source_untrusted_context_receipts = tuple(
+        payload_untrusted_context_receipts = tuple(
             payload.pop("_untrusted_context_receipts", ())
         )
+        if not source_untrusted_context_receipts:
+            source_untrusted_context_receipts = payload_untrusted_context_receipts
         observation = normalize_tool_observation(
             tool_name=tool_name,
             tool_call_id=tool_call_id,
@@ -1081,6 +1086,73 @@ def _skill_memory_lookup_result_receipts(
         *projection.untrusted_context_receipts,
         *projection.refusal_receipts,
     ]
+
+
+def _runtime_error_refusal_receipts(details: dict[str, Any]) -> tuple[dict[str, object], ...]:
+    reason = details.get("reason")
+    if reason == "invalid_untrusted_input_type":
+        receipt = _invalid_untrusted_type_refusal_receipt(details)
+    elif reason == "owner_scope_mismatch":
+        receipt = _owner_scope_refusal_receipt(details)
+    elif reason == "workspace_path_refused":
+        receipt = _workspace_path_refusal_receipt(details)
+    else:
+        return ()
+    return (receipt,) if receipt is not None else ()
+
+
+def _invalid_untrusted_type_refusal_receipt(details: dict[str, Any]) -> dict[str, object] | None:
+    source_id = _receipt_text(details.get("source_id"))
+    source_type = _receipt_text(details.get("source_type"))
+    source_field = _receipt_text(details.get("field"))
+    corrective_action = _receipt_text(details.get("corrective_action"))
+    if not source_id or not source_type or not source_field or not corrective_action:
+        return None
+    return refused_prompt_context_receipt(
+        segment_id=f"{source_id}:invalid-untrusted-input",
+        source_type=source_type,
+        source_field=source_field,
+        source_id=source_id,
+        reason="invalid_untrusted_input_type",
+        corrective_action=corrective_action,
+    )
+
+
+def _owner_scope_refusal_receipt(details: dict[str, Any]) -> dict[str, object] | None:
+    source_id = _receipt_text(details.get("source_id"))
+    source_type = _receipt_text(details.get("source_type"))
+    corrective_action = _receipt_text(details.get("corrective_action"))
+    if not source_id or not source_type or not corrective_action:
+        return None
+    return refused_prompt_context_receipt(
+        segment_id=f"{source_id}:owner-scope-refusal",
+        source_type=source_type,
+        source_field="owner_scope",
+        source_id=source_id,
+        owner_scope_checked=True,
+        reason="owner_scope_mismatch",
+        corrective_action=corrective_action,
+    )
+
+
+def _workspace_path_refusal_receipt(details: dict[str, Any]) -> dict[str, object] | None:
+    source_id = _receipt_text(details.get("source_id"))
+    source_type = _receipt_text(details.get("source_type"))
+    corrective_action = _receipt_text(details.get("corrective_action"))
+    if not source_id or not source_type or not corrective_action:
+        return None
+    return refused_prompt_context_receipt(
+        segment_id=f"{source_id}:workspace-path-refusal",
+        source_type=source_type,
+        source_field="workspace_path",
+        source_id=source_id,
+        reason="workspace_path_refused",
+        corrective_action=corrective_action,
+    )
+
+
+def _receipt_text(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
 
 
 def _visit_document_receipt(


### PR DESCRIPTION
## Summary
- Add source-specific `included = false` untrusted-context refusal receipts for deterministic agentic tool adapter failures.
- Cover invalid untrusted input types, owner-scope mismatches, and workspace-path refusals while preserving the existing failed observation payload contract.
- Document the refusal receipt contract and the implementation/performance probes for this #1761 slice.

Refs #1761.

## Plan or Spec
- `docs/plans/2026-06-15-issue-1761-agentic-tool-error-refusal-receipts.md`
- `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
make bootstrap && make proto
Result: pass; generated protobuf/lockfile state unchanged.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_agentic_tools.py -q -k 'invalid_skill_memory_lookup_inputs or invalid_untrusted_value_types or invalid_layout_and_crop_payloads or skill_memory_owner_scope_mismatch or owner_scope_mismatch or visit_refuses_workspace_path_before_reading'
Result before implementation: expected red, 21 failed because source-specific refusal receipts were absent.
Result after implementation: 21 passed, 67 deselected.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
Result: 91 passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file=.runtime/coverage/agentic_tool_error_refusal.coverage --source=worker.runtime.agentic_tools -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file=.runtime/coverage/agentic_tool_error_refusal.coverage -o .runtime/coverage/agentic_tool_error_refusal.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json .runtime/coverage/agentic_tool_error_refusal.json services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
Result: 91 passed; changed-line coverage 100.00% (40/40).

git diff --check
Result: pass.

make swift-test && make py-test && make integration-test
Result: pass; py-test 4018 passed, 14 skipped, 2 warnings; integration-test 120 passed, 1 skipped.

git commit -m "feat: add agentic tool error refusal receipts"
Result: pass; pre-commit hook ran make swift-test, make py-test, make integration-test, and scoped performance report.
```

## Coverage and Metrics
- Changed-line coverage: `100.00%` (`40/40`) for `services/mlx-worker-python/worker/runtime/agentic_tools.py` and `services/mlx-worker-python/tests/test_agentic_tools.py`.
- Pre-commit performance report: `.runtime/pre-commit-performance/20260615-042238-c2b42d7e/report/report.md`
- Performance status: `ok`; selected probes `1`; regressions `0`; context regressions `0`; verification failures `0`.
- Direct probe: `local-job-followup-scan-scandir`; targeted tests `pass`; coverage `pass (100.0%)`.
- Key metrics: `elapsed_ms_mean` base `15.147`, head `15.106`, delta `-0.27%`; `projection_elapsed_ms_mean` base `96.811`, head `97.298`, delta `+0.50%`; all reported statuses `neutral`.
- Observability mode: `minimal`, using existing untrusted-context receipts and existing `agentic_tool.failed_count`; no new runtime counters or debug artifacts.
- Probe overhead: `N/A`; this change only adds deterministic receipt construction on existing failed adapter paths and relies on the existing PR-scoped performance probe.

## Known Gaps
- This PR is a focused #1761 slice for deterministic adapter failure receipts; broader untrusted-context coverage continues in follow-up slices.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
