### PR TITLE
perf: trim tool selection hot-path allocations

### DIFF
--- a/docs/plans/2026-06-15-tool-selection-metrics-binding.md
+++ b/docs/plans/2026-06-15-tool-selection-metrics-binding.md
@@ -1,0 +1,35 @@
+# Tool selection hot-path allocation performance slice
+
+## Scope
+
+Optimize the Python agentic tool-selection hot path by avoiding repeated metrics
+snapshot lookups in the receipt builder and replacing the whitespace-only keyword
+check's `strip()` allocation with `isspace()`. The behavior remains unchanged:
+selected tool ordering, selection sources, schema byte counts, keyword matching,
+and fallback metadata must match the existing contract.
+
+## Registered probe
+
+The affected path is already covered by the PR-scoped registered probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+That probe watches `services/mlx-worker-python/worker/runtime/tool_registry.py`,
+includes focused `test_command`, `coverage_command`, and `probe_command` entries,
+and measures selector planning latency plus selected schema byte metrics.
+
+## Implementation plan
+
+1. Add a focused regression test proving `_build_tool_selection_result()` reads
+   the full and selected registry metrics snapshots once each.
+2. Bind `registry.metrics()` and `selected_registry.metrics()` to local variables
+   inside `_build_tool_selection_result()` and reuse them for receipt fields.
+3. Replace the keyword matcher's whitespace-only guard with `str.isspace()` to
+   avoid building a stripped copy on the cached hot path.
+4. Run the registered focused tests, changed-scope coverage, and the registered
+   probe locally on Linux. Use the PR-scoped performance workflow as the CI
+   validation source after push.
+
+## Success criteria
+
+- Focused tool-registry tests pass.
+- Changed-scope coverage for the touched files is at least 95%.
+- The registered probe shows a non-regressing selector-planning metric.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -971,6 +971,37 @@ def test_agentic_tool_selection_records_fallback_when_no_keyword_matches() -> No
     ]
 
 
+def test_tool_selection_receipt_reuses_bound_metric_snapshots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = tool_registry_module.agentic_tool_catalog_registry()
+    original_metrics = ToolRegistry.metrics
+    metrics_call_count = 0
+
+    def counted_metrics(self: ToolRegistry) -> object:
+        nonlocal metrics_call_count
+        metrics_call_count += 1
+        return original_metrics(self)
+
+    monkeypatch.setattr(ToolRegistry, "metrics", counted_metrics)
+
+    result = tool_registry_module._build_tool_selection_result(
+        registry,
+        ["local_compute", "text_search"],
+        {"local_compute": "always", "text_search": "keyword"},
+        ToolSelectionInput(
+            current_user_turn="Search local evidence.",
+            vector_available=False,
+            max_selected_tools=4,
+        ),
+        "keyword",
+        "vector_unavailable",
+    )
+
+    assert result.receipt["full_schema_bytes"] >= result.receipt["selected_schema_bytes"]
+    assert metrics_call_count == 2
+
+
 def test_agentic_tool_selection_records_fallback_for_whitespace_only_turn() -> None:
     result = select_agentic_tools_for_turn(
         ToolSelectionInput(

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -546,7 +546,9 @@ def _build_tool_selection_result(
     fallback_reason: str,
 ) -> ToolSelectionResult:
     selected_registry = registry.select(tuple(selected_names))
-    selected_tool_count = selected_registry.metrics().tool_count
+    registry_metrics = registry.metrics()
+    selected_metrics = selected_registry.metrics()
+    selected_tool_count = selected_metrics.tool_count
     receipt = {
         "schema_version": "melix.agentic_tool_selection.v1",
         "toolset_version": BUILTIN_TOOLSET_VERSION,
@@ -557,9 +559,9 @@ def _build_tool_selection_result(
             {"tool_id": tool_name, "source": selected_sources[tool_name]}
             for tool_name in selected_registry.names()
         ],
-        "dropped_tool_count": max(0, registry.metrics().tool_count - selected_tool_count),
-        "full_schema_bytes": registry.metrics().schema_bytes,
-        "selected_schema_bytes": selected_registry.metrics().schema_bytes,
+        "dropped_tool_count": max(0, registry_metrics.tool_count - selected_tool_count),
+        "full_schema_bytes": registry_metrics.schema_bytes,
+        "selected_schema_bytes": selected_metrics.schema_bytes,
     }
     return ToolSelectionResult(registry=selected_registry, receipt=receipt)
 
@@ -575,7 +577,7 @@ def _keyword_tool_matches(text: str) -> tuple[str, ...]:
     if not text:
         return ()
     normalized_text = text.casefold()
-    if not normalized_text.strip():
+    if normalized_text.isspace():
         return ()
     boundary_text = ""
     matches: list[str] = []


### PR DESCRIPTION
## Summary
- Trim agentic tool-selection hot-path allocations by reusing bound registry metric snapshots inside the receipt builder.
- Replace the keyword matcher's whitespace-only `strip()` guard with `isspace()` to avoid building an unused stripped string.
- Add a focused regression test that proves the receipt builder reads the full and selected metrics snapshots once each.

## Plan or Spec
- `docs/plans/2026-06-15-tool-selection-metrics-binding.md`
- Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 84 passed in 1.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# 84 passed in 0.44s; changed-scope TOTAL 15 0 100%

python3 - <<'PY'
# ran scripts/tool_registry_select_probe.py three times on origin/main and this branch
PY
# selector_planning_elapsed_ms_mean: base_mean=34.7481343584756, head_mean=33.69029636184374, delta_ms=-1.0578379966318607, speedup=3.044301560822755%

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 15 0 100%`).
- Local registered probe (`tool-registry-select-name-index-cache`, Linux): `selector_planning_elapsed_ms_mean` improved from `34.7481` ms to `33.6903` ms across three local probe runs (`delta_ms=-1.0578`, `speedup=3.04%`).
- PR-scoped performance CI is required to validate the registered probe report for the PR head.

## Known Gaps
- Local validation is Linux-only. This is a Python slice, so no Swift runtime effect is claimed.
- CI must still complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
