### PR TITLE
perf: fast-path retrieval tuple pair copies

### DIFF
--- a/docs/plans/2026-06-15-retrieval-copy-tuple-pair-fastpath.md
+++ b/docs/plans/2026-06-15-retrieval-copy-tuple-pair-fastpath.md
@@ -1,0 +1,17 @@
+# Retrieval lookup payload tuple-pair copy fast path
+
+## Scope
+
+This Python performance slice is limited to `worker.runtime.retrieval_context._copy_payload_value`.
+The registered PR-scoped probe `retrieval-context-projection-fastpath` already covers this path with focused tests, coverage, and a local probe command.
+
+## Plan
+
+- Preserve retrieval lookup projection behavior and defensive copying semantics.
+- Add a small exact-tuple length-two copy branch for the common lookup metadata label shape used by retrieval context payloads.
+- Keep longer tuple behavior on the existing list-comprehension path.
+- Verify with the focused retrieval context tests, changed-scope coverage, and the registered retrieval context projection probe on Linux.
+
+## Metrics
+
+The local probe source is `scripts/retrieval_context_projection_probe.py` via the `retrieval-context-projection-fastpath` registry entry. The expected effect is lower `lookup_copy_optimized_elapsed_ms_mean` without changing projection/store metrics semantics.

--- a/services/mlx-worker-python/tests/test_retrieval_context.py
+++ b/services/mlx-worker-python/tests/test_retrieval_context.py
@@ -1432,6 +1432,7 @@ def _assert_retrieval_lookup_result_copies_store_projection_outputs(
                     "nested": {
                         "scores": [1, 2, {"label": "safe"}],
                         "tuple_values": ("a", {"b": "c"}),
+                        "tuple_values_three": ("a", {"b": "c"}, ["d"]),
                         "custom_mutable": mutable_default,
                     },
                 }
@@ -1458,6 +1459,7 @@ def _assert_retrieval_lookup_result_copies_store_projection_outputs(
             "nested": {
                 "scores": [1, 2, {"label": "safe"}],
                 "tuple_values": ("a", {"b": "c"}),
+                "tuple_values_three": ("a", {"b": "c"}, ["d"]),
                 "custom_mutable": ["fallback"],
             },
         }
@@ -1481,6 +1483,9 @@ def _assert_retrieval_lookup_result_copies_store_projection_outputs(
     assert copied_nested["scores"][2] is not source_nested["scores"][2]
     assert copied_nested["tuple_values"] is not source_nested["tuple_values"]
     assert copied_nested["tuple_values"][1] is not source_nested["tuple_values"][1]
+    assert copied_nested["tuple_values_three"] is not source_nested["tuple_values_three"]
+    assert copied_nested["tuple_values_three"][1] is not source_nested["tuple_values_three"][1]
+    assert copied_nested["tuple_values_three"][2] is not source_nested["tuple_values_three"][2]
     assert copied_nested["custom_mutable"] is not source_nested["custom_mutable"]
     assert projection.untrusted_context_receipts is not (
         store_projection.untrusted_context_receipts

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -350,6 +350,8 @@ def _copy_payload_value(value: Any) -> Any:
     if value_type is list:
         return [copy_value(item) for item in value]
     if value_type is tuple:
+        if len(value) == 2:
+            return (copy_value(value[0]), copy_value(value[1]))
         return tuple([copy_value(item) for item in value])
     return deepcopy(value)
 


### PR DESCRIPTION
## Summary
- Adds a two-item exact tuple fast path in `worker.runtime.retrieval_context._copy_payload_value`.
- Keeps longer tuple defensive-copy behavior on the existing generic path.
- Extends the retrieval lookup defensive-copy regression test to cover a length-three tuple fallback.

## Plan or Spec
- Added `docs/plans/2026-06-15-retrieval-copy-tuple-pair-fastpath.md` for this isolated Python performance slice.
- The affected path is already covered by the registered PR-scoped probe `retrieval-context-projection-fastpath`, including focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_isolates_refusals_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_malformed_entry_objects_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_preserves_multi_field_admission_duplicate_scan services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_copies_multi_receipt_admissions services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_projects_records_without_entry_reentry services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_copies_store_projection_outputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py` (3 runs)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 13 passed.
- Changed-scope coverage: 100% (`TOTAL 5 0 100%`).
- Local registered probe (Linux, 3 runs):
  - run 1: `lookup_copy_baseline_elapsed_ms_mean=0.791037`, `lookup_copy_optimized_elapsed_ms_mean=0.188969`, `lookup_copy_delta_ms=-0.602068`, `lookup_copy_speedup=4.186062`, `speedup=2.034171`
  - run 2: `lookup_copy_baseline_elapsed_ms_mean=0.800539`, `lookup_copy_optimized_elapsed_ms_mean=0.194456`, `lookup_copy_delta_ms=-0.606082`, `lookup_copy_speedup=4.116806`, `speedup=2.073276`
  - run 3: `lookup_copy_baseline_elapsed_ms_mean=0.808996`, `lookup_copy_optimized_elapsed_ms_mean=0.188908`, `lookup_copy_delta_ms=-0.620088`, `lookup_copy_speedup=4.282481`, `speedup=2.003994`

## Known Gaps
- CI must run the registered PR-scoped performance workflow for the final repository report.
- Local validation was performed on Linux for this Python slice.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe.
- [x] Probe entry includes focused test, coverage, and probe commands.
- [x] Focused regression tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe shows improved lookup-copy metrics.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
