### PR TITLE
perf: use dict cache for package version lookups

### DIFF
--- a/docs/plans/2026-06-15-runtime-utils-package-version-dict-cache.md
+++ b/docs/plans/2026-06-15-runtime-utils-package-version-dict-cache.md
@@ -1,0 +1,62 @@
+# Runtime utils package-version dict cache performance slice
+
+## Scope
+
+Optimize the Python worker runtime utility hot path for repeated installed package
+version checks. The current implementation already caches successful and missing
+`importlib.metadata.version()` lookups; this slice keeps that behavior but replaces
+the bounded `functools.lru_cache` wrapper with a module-local dictionary lookup to
+reduce per-call overhead in tight runtime metadata loops.
+
+Behavior must remain unchanged:
+
+- successful version lookups are cached by package name;
+- missing packages cache as the empty string;
+- `clear_installed_package_version_cache()` invalidates all cached package names;
+- callers still receive only a string version or `""`.
+
+## Registered probe
+
+The affected path is already covered by the PR-scoped registered probe
+`runtime-utils-package-version-cache` in `infra/perf/pr_scoped_probes.json`.
+The probe watches `services/mlx-worker-python/worker/runtime/runtime_utils.py`,
+includes focused `test_command`, `coverage_command`, and `probe_command` entries,
+and measures `elapsed_ms_mean` plus `metadata_version_calls_mean`.
+
+## Implementation plan
+
+1. Reuse the existing focused cache behavior tests for success, missing-package,
+   and explicit cache-clear semantics.
+2. Replace `@lru_cache(maxsize=128)` on `installed_package_version()` with a
+   module-local dictionary keyed by package name.
+3. Keep the public cache-clear helper name stable and implement it by clearing
+   the dictionary.
+4. Run the registered focused tests, changed-scope coverage, and registered probe
+   locally on Linux. Use the PR-scoped performance workflow as the CI validation
+   source after push.
+
+## Baseline and local probe evidence
+
+Local Linux registered probe before the change:
+
+```json
+{"elapsed_ms_mean": 8.063814137130976, "iterations_per_sample": 60000.0, "metadata_version_calls_mean": 3.0, "package_count": 3.0, "sample_count": 5.0}
+```
+
+A five-run local comparison on the same Linux host after the virtual environment
+was warm showed:
+
+- baseline mean: `7.9760694690048695 ms`
+- dict-cache mean: `7.93121799826622 ms`
+- mean delta: `-0.0448514707386495 ms` (`0.5623254776421254%` faster)
+- baseline median: `7.983871269971132 ms`
+- dict-cache median: `7.7527957037091255 ms` (`2.8942797102844855%` faster)
+- `metadata_version_calls_mean`: unchanged at `3.0`
+
+## Success criteria
+
+- Focused runtime-utils package-version tests pass.
+- Changed-scope coverage for the touched runtime utility, tests, and probe paths
+  is at least 95%.
+- The registered probe keeps `metadata_version_calls_mean` at 3.0 and reduces or
+  does not regress `elapsed_ms_mean`.

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -115,16 +115,24 @@ def clear_callable_kwarg_signature_cache() -> None:
     _callable_kwarg_signature_cached.cache_clear()
 
 
-@lru_cache(maxsize=128)
+_INSTALLED_PACKAGE_VERSION_CACHE: dict[str, str] = {}
+
+
 def installed_package_version(package_name: str) -> str:
     try:
-        return importlib.metadata.version(package_name)
+        return _INSTALLED_PACKAGE_VERSION_CACHE[package_name]
+    except KeyError:
+        pass
+    try:
+        version = importlib.metadata.version(package_name)
     except importlib.metadata.PackageNotFoundError:
-        return ""
+        version = ""
+    _INSTALLED_PACKAGE_VERSION_CACHE[package_name] = version
+    return version
 
 
 def clear_installed_package_version_cache() -> None:
-    installed_package_version.cache_clear()
+    _INSTALLED_PACKAGE_VERSION_CACHE.clear()
 
 
 def estimate_model_weight_resident_bytes(model_path: str) -> int:


### PR DESCRIPTION
## Summary
- Replaces the `installed_package_version()` `lru_cache` wrapper with a module-local dictionary cache to reduce repeated hot-path cache lookup overhead.
- Keeps successful lookup caching, missing-package empty-string caching, and explicit cache invalidation behavior unchanged.
- Adds the governing performance-slice plan for the registered runtime-utils package-version probe.

## Plan or Spec
- `docs/plans/2026-06-15-runtime-utils-package-version-dict-cache.md`
- Registered probe: `runtime-utils-package-version-cache` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_installed_package_version_returns_empty_for_missing_package services/mlx-worker-python/tests/test_runtime_utils.py::test_installed_package_version_caches_successful_lookups services/mlx-worker-python/tests/test_runtime_utils.py::test_installed_package_version_caches_missing_lookups services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_package_version_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_installed_package_version_returns_empty_for_missing_package services/mlx-worker-python/tests/test_runtime_utils.py::test_installed_package_version_caches_successful_lookups services/mlx-worker-python/tests/test_runtime_utils.py::test_installed_package_version_caches_missing_lookups services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_package_version_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_package_version_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_package_version_probe.py` (baseline and post-change repeated samples)
- `git diff --check`

## Coverage and Metrics
- Focused tests: `6 passed`.
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Baseline local registered probe sample: `elapsed_ms_mean=8.063814137130976`, `metadata_version_calls_mean=3.0`.
- Warm five-run local comparison:
  - baseline mean: `7.9760694690048695 ms`
  - dict-cache mean: `7.93121799826622 ms`
  - mean delta: `-0.0448514707386495 ms` (`0.5623254776421254%` faster)
  - median delta: `2.8942797102844855%` faster
  - metadata calls unchanged at `3.0`
- Registered PR-scoped performance CI is required for merge validation.

## Known Gaps
- Linux local probe results are small and noisy; the registered PR-scoped performance workflow is the authoritative merge gate.
- No Swift runtime behavior is changed in this slice.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe was run before and after the change.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
