### PR TITLE
Render companion log tail in desktop API workspace

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -10390,6 +10390,151 @@ struct DesktopAPICompanionPairingPresentation: Equatable {
     }
 }
 
+struct DesktopAPICompanionStatusPanel: View {
+    let viewModel: RuntimeViewModel
+
+    var body: some View {
+        let presentation = DesktopAPICompanionStatusPresentation(status: viewModel.companionStatus)
+
+        MelixSectionCard("Companion Status") {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .firstTextBaseline) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(presentation.statusTitle)
+                            .font(.headline)
+                        Text(presentation.statusDetail)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Button("Refresh Status") {
+                        Task { await viewModel.refreshCompanionStatus() }
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(presentation.refreshDisabled)
+                }
+
+                if let errorText = presentation.errorText {
+                    Text(errorText)
+                        .font(.caption)
+                        .foregroundStyle(MelixDesignTokens.StatusColor.error)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Redacted Log Tail")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    if presentation.logRows.isEmpty {
+                        Text("No companion log entries loaded.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(presentation.logRows) { row in
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack(alignment: .firstTextBaseline) {
+                                    Text(row.title)
+                                        .font(.caption.weight(.semibold))
+                                    Spacer()
+                                    Text(row.timeText)
+                                        .font(.caption.monospacedDigit())
+                                        .foregroundStyle(.secondary)
+                                }
+                                Text(row.detail)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(row.redactionText)
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
+                            }
+                            .padding(10)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color.secondary.opacity(0.06), in: RoundedRectangle(cornerRadius: 8))
+                        }
+                    }
+                }
+
+                if let redactionText = presentation.redactionText {
+                    Text("Logs: \(redactionText)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+struct DesktopAPICompanionStatusPresentation: Equatable {
+    struct LogRow: Identifiable, Equatable {
+        let id: String
+        let title: String
+        let detail: String
+        let timeText: String
+        let redactionText: String
+    }
+
+    let statusTitle: String
+    let statusDetail: String
+    let errorText: String?
+    let redactionText: String?
+    let refreshDisabled: Bool
+    let logRows: [LogRow]
+
+    init(status: CompanionStatusState) {
+        statusTitle = Self.statusTitle(status)
+        statusDetail = Self.statusDetail(status)
+        errorText = (status.lastError?.isEmpty == false) ? status.lastError : nil
+        redactionText = status.redactionLogs.isEmpty ? nil : status.redactionLogs
+        refreshDisabled = status.phase == .loading
+        logRows = status.logTail.entries.map(Self.logRow(entry:))
+    }
+
+    private static func statusTitle(_ status: CompanionStatusState) -> String {
+        switch status.phase {
+        case .idle:
+            return "Companion status not loaded"
+        case .loading:
+            return "Refreshing companion status"
+        case .loaded:
+            return "Companion status \(status.status.isEmpty ? "loaded" : status.status)"
+        case .failed:
+            return "Companion status needs attention"
+        }
+    }
+
+    private static func statusDetail(_ status: CompanionStatusState) -> String {
+        switch status.phase {
+        case .idle:
+            return "Refresh after issuing a read-only companion token."
+        case .loading:
+            return "Reading the companion status endpoint with the transient read-only token."
+        case .loaded:
+            return "Read-only companion status, \(status.logTail.visible) of \(status.logTail.total) redacted log entries visible."
+        case .failed:
+            return status.lastError ?? "The companion status refresh failed."
+        }
+    }
+
+    private static func logRow(entry: CompanionStatusLogEntryState) -> LogRow {
+        let failureSuffix = entry.failureCode.isEmpty ? "" : " • \(entry.failureCode)"
+        return LogRow(
+            id: "\(entry.jobID)-\(entry.updatedAtUnixMS)-\(entry.eventType)",
+            title: "\(entry.jobID) • \(entry.state)",
+            detail: "\(entry.operation) • \(entry.progressStage) • \(entry.lane)\(failureSuffix)",
+            timeText: companionStatusTimestampText(entry.updatedAtUnixMS),
+            redactionText: entry.redactionSummary
+        )
+    }
+}
+
+private func companionStatusTimestampText(_ unixMS: Int64) -> String {
+    guard unixMS > 0 else {
+        return "unknown"
+    }
+    let date = Date(timeIntervalSince1970: Double(unixMS) / 1_000)
+    return date.formatted(date: .omitted, time: .shortened)
+}
+
 struct DesktopAPIQuickStartSnippet: Identifiable {
     let id: String
     let language: String
@@ -11041,6 +11186,7 @@ struct DesktopAPIWorkspaceView: View {
                                 )
                             )
                             DesktopAPICompanionPairingPanel(viewModel: viewModel)
+                            DesktopAPICompanionStatusPanel(viewModel: viewModel)
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                     case .quickStarts:

--- a/apps/macos-menubar/Sources/AppMain/Models/CompanionStatusClient.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/CompanionStatusClient.swift
@@ -1,0 +1,340 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public enum CompanionStatusPhase: String, Codable, Equatable, Sendable {
+    case idle
+    case loading
+    case loaded
+    case failed
+}
+
+public struct CompanionStatusLogEntryState: Codable, Equatable, Sendable {
+    public let eventType: String
+    public let source: String
+    public let jobID: String
+    public let requestID: String
+    public let modelID: String
+    public let operation: String
+    public let state: String
+    public let lane: String
+    public let workerID: String
+    public let progressStage: String
+    public let updatedAtUnixMS: Int64
+    public let failureCode: String
+    public let redactionSummary: String
+
+    public init(
+        eventType: String,
+        source: String,
+        jobID: String,
+        requestID: String,
+        modelID: String,
+        operation: String,
+        state: String,
+        lane: String,
+        workerID: String,
+        progressStage: String,
+        updatedAtUnixMS: Int64,
+        failureCode: String,
+        redactionSummary: String
+    ) {
+        self.eventType = eventType
+        self.source = source
+        self.jobID = jobID
+        self.requestID = requestID
+        self.modelID = modelID
+        self.operation = operation
+        self.state = state
+        self.lane = lane
+        self.workerID = workerID
+        self.progressStage = progressStage
+        self.updatedAtUnixMS = updatedAtUnixMS
+        self.failureCode = failureCode
+        self.redactionSummary = redactionSummary
+    }
+}
+
+public struct CompanionStatusLogTailState: Codable, Equatable, Sendable {
+    public let source: String
+    public let visible: Int
+    public let total: Int
+    public let entries: [CompanionStatusLogEntryState]
+
+    public init(
+        source: String = "image_jobs",
+        visible: Int = 0,
+        total: Int = 0,
+        entries: [CompanionStatusLogEntryState] = []
+    ) {
+        self.source = source
+        self.visible = visible
+        self.total = total
+        self.entries = entries
+    }
+}
+
+public struct CompanionStatusSnapshot: Codable, Equatable, Sendable {
+    public let status: String
+    public let readOnly: Bool
+    public let authorizationScope: String
+    public let logTail: CompanionStatusLogTailState
+    public let redactionLogs: String
+
+    public init(
+        status: String,
+        readOnly: Bool,
+        authorizationScope: String,
+        logTail: CompanionStatusLogTailState,
+        redactionLogs: String
+    ) {
+        self.status = status
+        self.readOnly = readOnly
+        self.authorizationScope = authorizationScope
+        self.logTail = logTail
+        self.redactionLogs = redactionLogs
+    }
+}
+
+public struct CompanionStatusState: Equatable, Sendable, CustomStringConvertible {
+    public var phase: CompanionStatusPhase
+    public var status: String
+    public var readOnly: Bool
+    public var authorizationScope: String
+    public var logTail: CompanionStatusLogTailState
+    public var redactionLogs: String
+    public var lastError: String?
+
+    public init(
+        phase: CompanionStatusPhase = .idle,
+        status: String = "",
+        readOnly: Bool = false,
+        authorizationScope: String = "",
+        logTail: CompanionStatusLogTailState = CompanionStatusLogTailState(),
+        redactionLogs: String = "",
+        lastError: String? = nil
+    ) {
+        self.phase = phase
+        self.status = status
+        self.readOnly = readOnly
+        self.authorizationScope = authorizationScope
+        self.logTail = logTail
+        self.redactionLogs = redactionLogs
+        self.lastError = lastError
+    }
+
+    public var description: String {
+        "CompanionStatusState(phase: \(phase.rawValue), status: \(status), readOnly: \(readOnly), authorizationScope: \(authorizationScope), logTail: \(logTail), redactionLogs: \(redactionLogs), lastError: \(String(describing: lastError)))"
+    }
+
+    public static func loaded(from snapshot: CompanionStatusSnapshot) -> CompanionStatusState {
+        CompanionStatusState(
+            phase: .loaded,
+            status: snapshot.status,
+            readOnly: snapshot.readOnly,
+            authorizationScope: snapshot.authorizationScope,
+            logTail: snapshot.logTail,
+            redactionLogs: snapshot.redactionLogs
+        )
+    }
+
+    public static func failed(_ message: String) -> CompanionStatusState {
+        CompanionStatusState(phase: .failed, lastError: message)
+    }
+}
+
+public protocol CompanionStatusClient: Sendable {
+    func refreshStatus(
+        statusURL: URL,
+        resumeHeader: String,
+        sessionToken: String
+    ) async throws -> CompanionStatusSnapshot
+}
+
+public protocol CompanionStatusHTTPTransport: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse)
+}
+
+public struct URLSessionCompanionStatusHTTPTransport: CompanionStatusHTTPTransport {
+    public init() {}
+
+    public func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CompanionStatusClientError.invalidResponse("Companion status response was not HTTP.")
+        }
+        return (data, httpResponse)
+    }
+}
+
+public struct LiveCompanionStatusClient: CompanionStatusClient {
+    private let transport: any CompanionStatusHTTPTransport
+
+    public init(
+        transport: any CompanionStatusHTTPTransport = URLSessionCompanionStatusHTTPTransport()
+    ) {
+        self.transport = transport
+    }
+
+    public func refreshStatus(
+        statusURL: URL,
+        resumeHeader: String,
+        sessionToken: String
+    ) async throws -> CompanionStatusSnapshot {
+        var request = URLRequest(url: statusURL)
+        request.httpMethod = "GET"
+        request.setValue(sessionToken, forHTTPHeaderField: resumeHeader)
+
+        let (data, response) = try await transport.data(for: request)
+        try validateHTTPResponse(data: data, response: response)
+        let payload = try JSONDecoder().decode(CompanionStatusResponsePayload.self, from: data)
+        return payload.snapshot()
+    }
+
+    private func validateHTTPResponse(data: Data, response: HTTPURLResponse) throws {
+        guard (200..<300).contains(response.statusCode) else {
+            let message = String(decoding: data, as: UTF8.self)
+            throw CompanionStatusClientError.httpStatus(response.statusCode, message)
+        }
+    }
+}
+
+public enum CompanionStatusClientError: Error, CustomStringConvertible, Equatable {
+    case invalidResponse(String)
+    case httpStatus(Int, String)
+
+    public var description: String {
+        switch self {
+        case .invalidResponse(let message):
+            return message
+        case .httpStatus(let statusCode, let message):
+            return "Companion status HTTP \(statusCode): \(message)"
+        }
+    }
+}
+
+private struct CompanionStatusResponsePayload: Decodable {
+    let readOnly: Bool
+    let status: String
+    let authorization: Authorization
+    let logs: Logs
+    let redaction: Redaction
+
+    struct Authorization: Decodable {
+        let scope: String
+    }
+
+    struct Logs: Decodable {
+        let source: String
+        let visible: Int
+        let total: Int
+        let entries: [Entry]
+    }
+
+    struct Entry: Decodable {
+        let eventType: String
+        let source: String
+        let jobID: String
+        let requestID: String
+        let modelID: String
+        let operation: String
+        let state: String
+        let lane: String
+        let workerID: String
+        let progressStage: String
+        let updatedAtUnixMS: Int64
+        let failureCode: String
+        let redaction: EntryRedaction
+
+        enum CodingKeys: String, CodingKey {
+            case eventType = "event_type"
+            case source
+            case jobID = "job_id"
+            case requestID = "request_id"
+            case modelID = "model_id"
+            case operation
+            case state
+            case lane
+            case workerID = "worker_id"
+            case progressStage = "progress_stage"
+            case updatedAtUnixMS = "updated_at_unix_ms"
+            case failureCode = "failure_code"
+            case redaction
+        }
+
+        func asState() -> CompanionStatusLogEntryState {
+            CompanionStatusLogEntryState(
+                eventType: eventType,
+                source: source,
+                jobID: jobID,
+                requestID: requestID,
+                modelID: modelID,
+                operation: operation,
+                state: state,
+                lane: lane,
+                workerID: workerID,
+                progressStage: progressStage,
+                updatedAtUnixMS: updatedAtUnixMS,
+                failureCode: failureCode,
+                redactionSummary: redaction.summary
+            )
+        }
+    }
+
+    struct EntryRedaction: Decodable {
+        let rawLogLine: String
+        let rawPrompt: String
+        let requestBody: String
+        let artifactURIs: String
+        let localPaths: String
+        let errorMessage: String
+
+        enum CodingKeys: String, CodingKey {
+            case rawLogLine = "raw_log_line"
+            case rawPrompt = "raw_prompt"
+            case requestBody = "request_body"
+            case artifactURIs = "artifact_uris"
+            case localPaths = "local_paths"
+            case errorMessage = "error_message"
+        }
+
+        var summary: String {
+            [
+                "raw log line \(rawLogLine)",
+                "raw prompt \(rawPrompt)",
+                "request body \(requestBody)",
+                "artifact URIs \(artifactURIs)",
+                "local paths \(localPaths)",
+                "error message \(errorMessage)",
+            ].joined(separator: "; ")
+        }
+    }
+
+    struct Redaction: Decodable {
+        let logs: String
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case readOnly = "read_only"
+        case status
+        case authorization
+        case logs
+        case redaction
+    }
+
+    func snapshot() -> CompanionStatusSnapshot {
+        CompanionStatusSnapshot(
+            status: status,
+            readOnly: readOnly,
+            authorizationScope: authorization.scope,
+            logTail: CompanionStatusLogTailState(
+                source: logs.source,
+                visible: logs.visible,
+                total: logs.total,
+                entries: logs.entries.map { $0.asState() }
+            ),
+            redactionLogs: redaction.logs
+        )
+    }
+}

--- a/apps/macos-menubar/Sources/AppMain/Models/CompanionStatusClient.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/CompanionStatusClient.swift
@@ -244,7 +244,7 @@ private struct CompanionStatusResponsePayload: Decodable {
         let workerID: String
         let progressStage: String
         let updatedAtUnixMS: Int64
-        let failureCode: String
+        let failureCode: String?
         let redaction: EntryRedaction
 
         enum CodingKeys: String, CodingKey {
@@ -276,19 +276,19 @@ private struct CompanionStatusResponsePayload: Decodable {
                 workerID: workerID,
                 progressStage: progressStage,
                 updatedAtUnixMS: updatedAtUnixMS,
-                failureCode: failureCode,
+                failureCode: failureCode ?? "",
                 redactionSummary: redaction.summary
             )
         }
     }
 
     struct EntryRedaction: Decodable {
-        let rawLogLine: String
-        let rawPrompt: String
-        let requestBody: String
-        let artifactURIs: String
-        let localPaths: String
-        let errorMessage: String
+        let rawLogLine: String?
+        let rawPrompt: String?
+        let requestBody: String?
+        let artifactURIs: String?
+        let localPaths: String?
+        let errorMessage: String?
 
         enum CodingKeys: String, CodingKey {
             case rawLogLine = "raw_log_line"
@@ -301,13 +301,13 @@ private struct CompanionStatusResponsePayload: Decodable {
 
         var summary: String {
             [
-                "raw log line \(rawLogLine)",
-                "raw prompt \(rawPrompt)",
-                "request body \(requestBody)",
-                "artifact URIs \(artifactURIs)",
-                "local paths \(localPaths)",
-                "error message \(errorMessage)",
-            ].joined(separator: "; ")
+                rawLogLine.map { "raw log line \($0)" },
+                rawPrompt.map { "raw prompt \($0)" },
+                requestBody.map { "request body \($0)" },
+                artifactURIs.map { "artifact URIs \($0)" },
+                localPaths.map { "local paths \($0)" },
+                errorMessage.map { "error message \($0)" },
+            ].compactMap { $0 }.joined(separator: "; ")
         }
     }
 

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -2479,6 +2479,7 @@ public final class RuntimeViewModel {
     public private(set) var remoteServers: [RemoteServer] = []
     public private(set) var chatSessions: [DesktopChatSessionState] = []
     public private(set) var companionPairing = CompanionPairingState()
+    public private(set) var companionStatus = CompanionStatusState()
     public private(set) var lastError: String?
     public private(set) var lastCLIWorkflowFailure: RuntimeCLIWorkflowFailureState?
     public private(set) var productUpdateSummary: String?
@@ -3143,6 +3144,7 @@ public final class RuntimeViewModel {
     private let operatorCommandRunner: MelixCLIRunner?
     private let serverSessionAPIKeyStore: any ServerSessionAPIKeyStoring
     private let companionPairingClient: any CompanionPairingClient
+    private let companionStatusClient: any CompanionStatusClient
     private let remoteServerStore: any RemoteServerStoring
     private let evaluationPromptStore: any EvaluationPromptStoring
     private let loraTrainingJobStore: any LoraTrainingJobStoring
@@ -3171,6 +3173,7 @@ public final class RuntimeViewModel {
     private var gatewayAPIKeyPersistFailures = 0.0
     private var companionPairingIssueFailures = 0.0
     private var companionPairingRevokeFailures = 0.0
+    private var companionStatusRefreshFailures = 0.0
     private var activeCompanionSessionToken = ""
     private var activeCompanionPairingBaseURL: URL?
     private var remoteServerPersistFailures = 0.0
@@ -3409,6 +3412,7 @@ public final class RuntimeViewModel {
         operatorCommandRunner: MelixCLIRunner? = nil,
         serverSessionAPIKeyStore: any ServerSessionAPIKeyStoring = NullServerSessionAPIKeyStore(),
         companionPairingClient: any CompanionPairingClient = LiveCompanionPairingClient(),
+        companionStatusClient: any CompanionStatusClient = LiveCompanionStatusClient(),
         remoteServerStore: any RemoteServerStoring = NullRemoteServerStore(),
         evaluationPromptStore: any EvaluationPromptStoring = NullEvaluationPromptStore(),
         loraTrainingJobStore: any LoraTrainingJobStoring = NullLoraTrainingJobStore(),
@@ -3422,6 +3426,7 @@ public final class RuntimeViewModel {
         self.operatorCommandRunner = operatorCommandRunner
         self.serverSessionAPIKeyStore = serverSessionAPIKeyStore
         self.companionPairingClient = companionPairingClient
+        self.companionStatusClient = companionStatusClient
         self.remoteServerStore = remoteServerStore
         self.evaluationPromptStore = evaluationPromptStore
         self.loraTrainingJobStore = loraTrainingJobStore
@@ -6057,6 +6062,7 @@ public final class RuntimeViewModel {
         companionPairing = CompanionPairingState(phase: .issuing)
         activeCompanionSessionToken = ""
         activeCompanionPairingBaseURL = nil
+        companionStatus = CompanionStatusState()
         notifyStateChanged()
 
         let startedAt = Date()
@@ -6065,6 +6071,7 @@ public final class RuntimeViewModel {
             activeCompanionSessionToken = result.resumeToken
             activeCompanionPairingBaseURL = baseURL
             companionPairing = CompanionPairingState.active(from: result)
+            companionStatus = CompanionStatusState()
             await metrics.record(
                 name: "companion.pairing_issue_ms",
                 valueMs: Date().timeIntervalSince(startedAt) * 1_000
@@ -6094,6 +6101,7 @@ public final class RuntimeViewModel {
             activeCompanionSessionToken = ""
             activeCompanionPairingBaseURL = nil
             companionPairing = CompanionPairingState()
+            companionStatus = CompanionStatusState()
             await metrics.record(
                 name: "companion.pairing_revoke_ms",
                 valueMs: Date().timeIntervalSince(startedAt) * 1_000
@@ -6126,6 +6134,43 @@ public final class RuntimeViewModel {
             return nil
         }
         return String(data: data, encoding: .utf8)
+    }
+
+    public func refreshCompanionStatus() async {
+        guard companionStatus.phase != .loading else {
+            return
+        }
+        guard companionPairing.phase == .active,
+              activeCompanionSessionToken.isEmpty == false,
+              let statusURL = URL(string: companionPairing.statusURL),
+              companionPairing.resumeHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        else {
+            await failCompanionStatusRefresh("Issue a read-only companion token before refreshing companion status.")
+            return
+        }
+
+        let resumeHeader = companionPairing.resumeHeader
+        let sessionToken = activeCompanionSessionToken
+        companionStatus.phase = .loading
+        companionStatus.lastError = nil
+        notifyStateChanged()
+
+        let startedAt = Date()
+        do {
+            let snapshot = try await companionStatusClient.refreshStatus(
+                statusURL: statusURL,
+                resumeHeader: resumeHeader,
+                sessionToken: sessionToken
+            )
+            companionStatus = CompanionStatusState.loaded(from: snapshot)
+            await metrics.record(
+                name: "companion.status_refresh_ms",
+                valueMs: Date().timeIntervalSince(startedAt) * 1_000
+            )
+            notifyStateChanged()
+        } catch {
+            await failCompanionStatusRefresh("Companion status refresh failed: \(error)")
+        }
     }
 
     public func updateSelectedServerSessionAutoSleepEnabled(_ value: Bool) {
@@ -13990,6 +14035,17 @@ public final class RuntimeViewModel {
         await metrics.record(
             name: "companion.pairing_revoke_failures",
             valueMs: companionPairingRevokeFailures
+        )
+        notifyStateChanged()
+    }
+
+    private func failCompanionStatusRefresh(_ message: String) async {
+        companionStatusRefreshFailures += 1
+        companionStatus = CompanionStatusState.failed(message)
+        recordLocalError(message)
+        await metrics.record(
+            name: "companion.status_refresh_failures",
+            valueMs: companionStatusRefreshFailures
         )
         notifyStateChanged()
     }

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift
@@ -6136,6 +6136,7 @@ public final class RuntimeViewModel {
         return String(data: data, encoding: .utf8)
     }
 
+    @MainActor
     public func refreshCompanionStatus() async {
         guard companionStatus.phase != .loading else {
             return
@@ -14039,13 +14040,14 @@ public final class RuntimeViewModel {
         notifyStateChanged()
     }
 
+    @MainActor
     private func failCompanionStatusRefresh(_ message: String) async {
         companionStatusRefreshFailures += 1
         companionStatus = CompanionStatusState.failed(message)
         recordLocalError(message)
         await metrics.record(
             name: "companion.status_refresh_failures",
-            valueMs: companionStatusRefreshFailures
+            valueMs: 1.0
         )
         notifyStateChanged()
     }

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -4582,6 +4582,20 @@ struct DesktopFoundationViewTests {
         #expect(shellSource.contains("Revoke Token"))
     }
 
+    @Test("api authentication surface includes companion status log tail panel")
+    func apiAuthenticationSurfaceIncludesCompanionStatusLogTailPanel() throws {
+        let root = try repositoryRootForDesktopFoundationTests()
+        let shellSourceURL = root.appendingPathComponent(
+            "apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift"
+        )
+        let shellSource = try String(contentsOf: shellSourceURL, encoding: .utf8)
+
+        #expect(shellSource.contains("DesktopAPICompanionStatusPanel"))
+        #expect(shellSource.contains("Companion Status"))
+        #expect(shellSource.contains("Refresh Status"))
+        #expect(shellSource.contains("Redacted Log Tail"))
+    }
+
     @Test("companion pairing panel renders idle active and failure states")
     @MainActor
     func companionPairingPanelRendersIdleActiveAndFailureStates() async throws {
@@ -4654,6 +4668,130 @@ struct DesktopFoundationViewTests {
 
         #expect(failurePresentation.statusTitle == "Companion pairing needs attention")
         #expect(failurePresentation.errorText == "No active companion pairing token to revoke.")
+    }
+
+    @Test("companion status panel renders idle loaded and failure states")
+    @MainActor
+    func companionStatusPanelRendersIdleLoadedAndFailureStates() async throws {
+        let idleViewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        await idleViewModel.start()
+        let idlePresentation = DesktopAPICompanionStatusPresentation(status: idleViewModel.companionStatus)
+        _ = hostView(DesktopAPICompanionStatusPanel(viewModel: idleViewModel))
+
+        #expect(idlePresentation.statusTitle == "Companion status not loaded")
+        #expect(idlePresentation.statusDetail == "Refresh after issuing a read-only companion token.")
+        #expect(idlePresentation.refreshDisabled == false)
+        #expect(idlePresentation.logRows.isEmpty)
+
+        let loadingPresentation = DesktopAPICompanionStatusPresentation(
+            status: CompanionStatusState(phase: .loading)
+        )
+        #expect(loadingPresentation.statusTitle == "Refreshing companion status")
+        #expect(loadingPresentation.statusDetail == "Reading the companion status endpoint with the transient read-only token.")
+        #expect(loadingPresentation.refreshDisabled)
+
+        let activePairingClient = FakeCompanionPairingClient()
+        let statusClient = FakeCompanionStatusClient()
+        let activeTemporaryRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "melix-menubar-companion-status-panel-\(UUID().uuidString)"
+        )
+        try FileManager.default.createDirectory(at: activeTemporaryRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: activeTemporaryRoot) }
+        let activeMelixHome = MelixHome(environment: ["MELIX_HOME": activeTemporaryRoot.path])
+        let activeAPIKeyStore = ServerSessionAPIKeyStore(melixHome: activeMelixHome)
+        await statusClient.configureRefreshResult(
+            CompanionStatusSnapshot(
+                status: "ok",
+                readOnly: true,
+                authorizationScope: "companion_read_only",
+                logTail: CompanionStatusLogTailState(
+                    source: "image_jobs",
+                    visible: 1,
+                    total: 2,
+                    entries: [
+                        CompanionStatusLogEntryState(
+                            eventType: "state_update",
+                            source: "image_jobs",
+                            jobID: "image-job-ui",
+                            requestID: "request-ui",
+                            modelID: "melix-dev-image",
+                            operation: "image_generate",
+                            state: "failed",
+                            lane: "interactive",
+                            workerID: "image-worker-ui",
+                            progressStage: "failed",
+                            updatedAtUnixMS: 1_718_000_020_000,
+                            failureCode: "image_worker_failed",
+                            redactionSummary: "raw log line omitted; raw prompt omitted; request body omitted; artifact URIs omitted; local paths omitted; error message omitted"
+                        ),
+                    ]
+                ),
+                redactionLogs: "redacted_tail"
+            )
+        )
+        let activeViewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            serverSessionAPIKeyStore: activeAPIKeyStore,
+            companionPairingClient: activePairingClient,
+            companionStatusClient: statusClient
+        )
+
+        await activeViewModel.start()
+        try activeAPIKeyStore.savePrimaryKey(
+            serverSessionID: try #require(activeViewModel.selectedServerSession?.id),
+            primaryKey: "melix_primary_desktop",
+            keyID: "primary"
+        )
+        await activeViewModel.issueCompanionPairing()
+        await activeViewModel.refreshCompanionStatus()
+        let loadedPresentation = DesktopAPICompanionStatusPresentation(status: activeViewModel.companionStatus)
+        _ = hostView(DesktopAPICompanionStatusPanel(viewModel: activeViewModel))
+
+        #expect(loadedPresentation.statusTitle == "Companion status ok")
+        #expect(loadedPresentation.statusDetail == "Read-only companion status, 1 of 2 redacted log entries visible.")
+        #expect(loadedPresentation.logRows.map(\.title) == ["image-job-ui • failed"])
+        #expect(loadedPresentation.logRows.first?.detail.contains("image_worker_failed") == true)
+        #expect(loadedPresentation.logRows.first?.redactionText.contains("raw prompt omitted") == true)
+        #expect(loadedPresentation.redactionText == "redacted_tail")
+
+        let unknownTimePresentation = DesktopAPICompanionStatusPresentation(
+            status: CompanionStatusState.loaded(
+                from: CompanionStatusSnapshot(
+                    status: "",
+                    readOnly: true,
+                    authorizationScope: "companion_read_only",
+                    logTail: CompanionStatusLogTailState(
+                        visible: 1,
+                        total: 1,
+                        entries: [
+                            CompanionStatusLogEntryState(
+                                eventType: "state_update",
+                                source: "image_jobs",
+                                jobID: "image-job-unknown-time",
+                                requestID: "request-ui",
+                                modelID: "melix-dev-image",
+                                operation: "image_generate",
+                                state: "queued",
+                                lane: "background",
+                                workerID: "",
+                                progressStage: "queued",
+                                updatedAtUnixMS: 0,
+                                failureCode: "",
+                                redactionSummary: "raw log line omitted"
+                            )
+                        ]
+                    ),
+                    redactionLogs: ""
+                )
+            )
+        )
+        #expect(unknownTimePresentation.statusTitle == "Companion status loaded")
+        #expect(unknownTimePresentation.logRows.first?.timeText == "unknown")
+
+        let failureStatus = CompanionStatusState.failed("Companion status refresh failed: gateway offline")
+        let failurePresentation = DesktopAPICompanionStatusPresentation(status: failureStatus)
+        #expect(failurePresentation.statusTitle == "Companion status needs attention")
+        #expect(failurePresentation.errorText == "Companion status refresh failed: gateway offline")
     }
 
     @Test("api reference tab projects typed onboarding surfaces and endpoints")

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -2164,6 +2164,53 @@ struct RuntimeViewModelTests {
         #expect(await metrics.snapshot()["companion.status_refresh_failures"] == 1)
     }
 
+    @Test("companion status refresh failure metric records one event per failure")
+    @MainActor
+    func companionStatusRefreshFailureMetricRecordsOneEventPerFailure() async throws {
+        let pairingClient = FakeCompanionPairingClient()
+        await pairingClient.configureIssueResult(
+            CompanionPairingIssueResult(
+                sessionID: "companion-status-repeated-failure-session",
+                scope: "companion_read_only",
+                rememberMe: true,
+                expiresAtUnixMS: 1_718_000_000_000,
+                resumeHeader: "x-melix-session",
+                resumeToken: "melix_companion_status_failure_secret",
+                pairing: CompanionPairingDescriptor(
+                    schemaVersion: "melix.companion.pairing.v1",
+                    statusURL: "http://127.0.0.1:12436/v1/melix/companion/status",
+                    resumeHeader: "x-melix-session",
+                    tokenTransport: "resume_header",
+                    allowedRoutes: ["GET /v1/melix/companion/status"],
+                    forbiddenCapabilities: ["mutate_runtime", "read_private_prompts"],
+                    expiresAtUnixMS: 1_718_000_000_000
+                )
+            )
+        )
+        let statusClient = FakeCompanionStatusClient()
+        await statusClient.configureRefreshError(MenuBarTestError(description: "gateway offline"))
+        let metrics = MenuBarMetricsStore()
+        let viewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            metrics: metrics,
+            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+                throwOnLoad: false,
+                throwOnSave: false,
+                loadPrimaryKeyValue: "melix_primary_desktop"
+            ),
+            companionPairingClient: pairingClient,
+            companionStatusClient: statusClient
+        )
+
+        await viewModel.start()
+        await viewModel.issueCompanionPairing()
+        await viewModel.refreshCompanionStatus()
+        await viewModel.refreshCompanionStatus()
+
+        #expect(await statusClient.refreshRequests.count == 2)
+        #expect(await metrics.snapshot()["companion.status_refresh_failures"] == 1)
+    }
+
     @Test("live companion status client fetches redacted log tail and reports errors")
     func liveCompanionStatusClientFetchesRedactedLogTailAndReportsErrors() async throws {
         let payload = #"""
@@ -2248,6 +2295,65 @@ struct RuntimeViewModelTests {
         } catch let error as CompanionStatusClientError {
             #expect(error.description == "Companion status HTTP 403: forbidden")
         }
+    }
+
+    @Test("live companion status client tolerates omitted optional redaction fields")
+    func liveCompanionStatusClientToleratesOmittedOptionalRedactionFields() async throws {
+        let payload = #"""
+        {
+          "schema_version": "melix.companion.status.v1",
+          "read_only": true,
+          "status": "ok",
+          "authorization": {
+            "mode": "session",
+            "scope": "companion_read_only",
+            "state": "active",
+            "session_id": "companion-live-status"
+          },
+          "logs": {
+            "source": "image_jobs",
+            "visible": 1,
+            "total": 1,
+            "entries": [
+              {
+                "event_type": "state_update",
+                "source": "image_jobs",
+                "job_id": "image-job-live",
+                "request_id": "request-live",
+                "model_id": "melix-dev-image",
+                "operation": "image_generate",
+                "state": "succeeded",
+                "lane": "interactive",
+                "worker_id": "image-worker-live",
+                "progress_stage": "complete",
+                "created_at_unix_ms": 1718000000000,
+                "updated_at_unix_ms": 1718000001000,
+                "failure_code": null,
+                "redaction": {
+                  "raw_log_line": "omitted"
+                }
+              }
+            ]
+          },
+          "redaction": {
+            "logs": "redacted_tail"
+          }
+        }
+        """#.data(using: .utf8)!
+        let transport = FakeCompanionStatusHTTPTransport()
+        await transport.configureResponse(body: payload)
+        let client = LiveCompanionStatusClient(transport: transport)
+        let statusURL = try #require(URL(string: "http://127.0.0.1:12436/v1/melix/companion/status"))
+
+        let snapshot = try await client.refreshStatus(
+            statusURL: statusURL,
+            resumeHeader: "x-melix-session",
+            sessionToken: "melix_live_companion_status_secret"
+        )
+
+        let entry = try #require(snapshot.logTail.entries.first)
+        #expect(entry.failureCode == "")
+        #expect(entry.redactionSummary == "raw log line omitted")
     }
 
     @Test("defers gateway apply when selected server session is not running")

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift
@@ -1994,6 +1994,262 @@ struct RuntimeViewModelTests {
         #expect(CompanionPairingClientError.invalidResponse("not HTTP").description == "not HTTP")
     }
 
+    @Test("refreshes companion status log tail with active read-only token")
+    @MainActor
+    func refreshesCompanionStatusLogTailWithActiveReadOnlyToken() async throws {
+        let pairingClient = FakeCompanionPairingClient()
+        await pairingClient.configureIssueResult(
+            CompanionPairingIssueResult(
+                sessionID: "companion-status-session",
+                scope: "companion_read_only",
+                rememberMe: true,
+                expiresAtUnixMS: 1_718_000_000_000,
+                resumeHeader: "x-melix-session",
+                resumeToken: "melix_companion_status_secret",
+                pairing: CompanionPairingDescriptor(
+                    schemaVersion: "melix.companion.pairing.v1",
+                    statusURL: "http://127.0.0.1:12436/v1/melix/companion/status",
+                    resumeHeader: "x-melix-session",
+                    tokenTransport: "resume_header",
+                    allowedRoutes: ["GET /v1/melix/companion/status"],
+                    forbiddenCapabilities: ["mutate_runtime", "read_private_prompts"],
+                    expiresAtUnixMS: 1_718_000_000_000
+                )
+            )
+        )
+        let statusClient = FakeCompanionStatusClient()
+        await statusClient.configureRefreshResult(
+            CompanionStatusSnapshot(
+                status: "ok",
+                readOnly: true,
+                authorizationScope: "companion_read_only",
+                logTail: CompanionStatusLogTailState(
+                    source: "image_jobs",
+                    visible: 2,
+                    total: 4,
+                    entries: [
+                        CompanionStatusLogEntryState(
+                            eventType: "state_update",
+                            source: "image_jobs",
+                            jobID: "image-job-2",
+                            requestID: "request-2",
+                            modelID: "melix-dev-image",
+                            operation: "image_generate",
+                            state: "failed",
+                            lane: "interactive",
+                            workerID: "image-worker-1",
+                            progressStage: "failed",
+                            updatedAtUnixMS: 1_718_000_020_000,
+                            failureCode: "image_worker_failed",
+                            redactionSummary: "raw log line omitted; raw prompt omitted; request body omitted; artifact URIs omitted; local paths omitted; error message omitted"
+                        ),
+                        CompanionStatusLogEntryState(
+                            eventType: "state_update",
+                            source: "image_jobs",
+                            jobID: "image-job-1",
+                            requestID: "request-1",
+                            modelID: "melix-dev-image",
+                            operation: "image_generate",
+                            state: "running",
+                            lane: "background",
+                            workerID: "image-worker-2",
+                            progressStage: "sampling",
+                            updatedAtUnixMS: 1_718_000_010_000,
+                            failureCode: "",
+                            redactionSummary: "raw log line omitted; raw prompt omitted"
+                        ),
+                    ]
+                ),
+                redactionLogs: "redacted_tail"
+            )
+        )
+        let metrics = MenuBarMetricsStore()
+        let viewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            metrics: metrics,
+            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+                throwOnLoad: false,
+                throwOnSave: false,
+                loadPrimaryKeyValue: "melix_primary_desktop"
+            ),
+            companionPairingClient: pairingClient,
+            companionStatusClient: statusClient
+        )
+
+        await viewModel.start()
+        await viewModel.issueCompanionPairing()
+        await viewModel.refreshCompanionStatus()
+
+        let refreshRequest = try #require(await statusClient.refreshRequests.last)
+        #expect(refreshRequest.statusURL.absoluteString == "http://127.0.0.1:12436/v1/melix/companion/status")
+        #expect(refreshRequest.resumeHeader == "x-melix-session")
+        #expect(refreshRequest.sessionToken == "melix_companion_status_secret")
+        #expect(viewModel.companionStatus.phase == .loaded)
+        #expect(viewModel.companionStatus.status == "ok")
+        #expect(viewModel.companionStatus.logTail.visible == 2)
+        #expect(viewModel.companionStatus.logTail.total == 4)
+        #expect(viewModel.companionStatus.logTail.entries.map(\.jobID) == ["image-job-2", "image-job-1"])
+        #expect(viewModel.companionStatus.logTail.entries.first?.failureCode == "image_worker_failed")
+        #expect(viewModel.companionStatus.redactionLogs == "redacted_tail")
+        #expect(String(describing: viewModel.companionStatus).contains("melix_companion_status_secret") == false)
+        #expect(String(describing: viewModel.companionStatus).contains("private prompt") == false)
+        #expect(await metrics.snapshot()["companion.status_refresh_ms"] != nil)
+    }
+
+    @Test("companion status refresh requires active pairing")
+    @MainActor
+    func companionStatusRefreshRequiresActivePairing() async throws {
+        let statusClient = FakeCompanionStatusClient()
+        let metrics = MenuBarMetricsStore()
+        let viewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            metrics: metrics,
+            companionStatusClient: statusClient
+        )
+
+        await viewModel.start()
+        await viewModel.refreshCompanionStatus()
+
+        #expect(await statusClient.refreshRequests.isEmpty)
+        #expect(viewModel.companionStatus.phase == .failed)
+        #expect(viewModel.companionStatus.lastError == "Issue a read-only companion token before refreshing companion status.")
+        #expect(await metrics.snapshot()["companion.status_refresh_failures"] == 1)
+    }
+
+    @Test("companion status refresh surfaces transport failures")
+    @MainActor
+    func companionStatusRefreshSurfacesTransportFailures() async throws {
+        let pairingClient = FakeCompanionPairingClient()
+        await pairingClient.configureIssueResult(
+            CompanionPairingIssueResult(
+                sessionID: "companion-status-failure-session",
+                scope: "companion_read_only",
+                rememberMe: true,
+                expiresAtUnixMS: 1_718_000_000_000,
+                resumeHeader: "x-melix-session",
+                resumeToken: "melix_companion_status_failure_secret",
+                pairing: CompanionPairingDescriptor(
+                    schemaVersion: "melix.companion.pairing.v1",
+                    statusURL: "http://127.0.0.1:12436/v1/melix/companion/status",
+                    resumeHeader: "x-melix-session",
+                    tokenTransport: "resume_header",
+                    allowedRoutes: ["GET /v1/melix/companion/status"],
+                    forbiddenCapabilities: ["mutate_runtime", "read_private_prompts"],
+                    expiresAtUnixMS: 1_718_000_000_000
+                )
+            )
+        )
+        let statusClient = FakeCompanionStatusClient()
+        await statusClient.configureRefreshError(MenuBarTestError(description: "gateway offline"))
+        let metrics = MenuBarMetricsStore()
+        let viewModel = RuntimeViewModel(
+            client: FakeControlPlaneXPCClient(),
+            metrics: metrics,
+            serverSessionAPIKeyStore: ThrowingServerSessionAPIKeyStore(
+                throwOnLoad: false,
+                throwOnSave: false,
+                loadPrimaryKeyValue: "melix_primary_desktop"
+            ),
+            companionPairingClient: pairingClient,
+            companionStatusClient: statusClient
+        )
+
+        await viewModel.start()
+        await viewModel.issueCompanionPairing()
+        await viewModel.refreshCompanionStatus()
+
+        #expect(await statusClient.refreshRequests.count == 1)
+        #expect(viewModel.companionStatus.phase == .failed)
+        #expect(viewModel.companionStatus.lastError == "Companion status refresh failed: gateway offline")
+        #expect(await metrics.snapshot()["companion.status_refresh_failures"] == 1)
+    }
+
+    @Test("live companion status client fetches redacted log tail and reports errors")
+    func liveCompanionStatusClientFetchesRedactedLogTailAndReportsErrors() async throws {
+        let payload = #"""
+        {
+          "schema_version": "melix.companion.status.v1",
+          "read_only": true,
+          "status": "ok",
+          "authorization": {
+            "mode": "session",
+            "scope": "companion_read_only",
+            "state": "active",
+            "session_id": "companion-live-status"
+          },
+          "logs": {
+            "source": "image_jobs",
+            "visible": 1,
+            "total": 3,
+            "entries": [
+              {
+                "event_type": "state_update",
+                "source": "image_jobs",
+                "job_id": "image-job-live",
+                "request_id": "request-live",
+                "model_id": "melix-dev-image",
+                "operation": "image_generate",
+                "state": "failed",
+                "lane": "interactive",
+                "worker_id": "image-worker-live",
+                "progress_stage": "failed",
+                "created_at_unix_ms": 1718000000000,
+                "updated_at_unix_ms": 1718000001000,
+                "failure_code": "image_worker_failed",
+                "redaction": {
+                  "raw_log_line": "omitted",
+                  "raw_prompt": "omitted",
+                  "request_body": "omitted",
+                  "artifact_uris": "omitted",
+                  "local_paths": "omitted",
+                  "error_message": "omitted"
+                }
+              }
+            ]
+          },
+          "redaction": {
+            "logs": "redacted_tail"
+          }
+        }
+        """#.data(using: .utf8)!
+        let transport = FakeCompanionStatusHTTPTransport()
+        await transport.configureResponse(body: payload)
+        let client = LiveCompanionStatusClient(transport: transport)
+        let statusURL = try #require(URL(string: "http://127.0.0.1:12436/v1/melix/companion/status"))
+
+        let snapshot = try await client.refreshStatus(
+            statusURL: statusURL,
+            resumeHeader: "x-melix-session",
+            sessionToken: "melix_live_companion_status_secret"
+        )
+
+        let request = try #require(await transport.requests.first)
+        #expect(request.url?.absoluteString == "http://127.0.0.1:12436/v1/melix/companion/status")
+        #expect(request.method == "GET")
+        let headers = Dictionary(uniqueKeysWithValues: request.headers.map { ($0.key.lowercased(), $0.value) })
+        #expect(headers["x-melix-session"] == "melix_live_companion_status_secret")
+        #expect(snapshot.status == "ok")
+        #expect(snapshot.authorizationScope == "companion_read_only")
+        #expect(snapshot.logTail.visible == 1)
+        #expect(snapshot.logTail.total == 3)
+        #expect(snapshot.logTail.entries.first?.jobID == "image-job-live")
+        #expect(snapshot.logTail.entries.first?.redactionSummary.contains("raw log line omitted") == true)
+
+        let failureTransport = FakeCompanionStatusHTTPTransport()
+        await failureTransport.configureResponse(statusCode: 403, body: Data("forbidden".utf8))
+        let failureClient = LiveCompanionStatusClient(transport: failureTransport)
+        do {
+            _ = try await failureClient.refreshStatus(
+                statusURL: statusURL,
+                resumeHeader: "x-melix-session",
+                sessionToken: "revoked"
+            )
+            Issue.record("Expected companion status HTTP failure.")
+        } catch let error as CompanionStatusClientError {
+            #expect(error.description == "Companion status HTTP 403: forbidden")
+        }
+    }
+
     @Test("defers gateway apply when selected server session is not running")
     @MainActor
     func defersGatewayApplyWhenSelectedServerSessionIsNotRunning() async throws {

--- a/apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
@@ -126,6 +126,12 @@ struct CompanionPairingRevokeRequestRecord: Equatable, Sendable {
     let sessionToken: String
 }
 
+struct CompanionStatusRequestRecord: Equatable, Sendable {
+    let statusURL: URL
+    let resumeHeader: String
+    let sessionToken: String
+}
+
 actor FakeCompanionPairingClient: CompanionPairingClient {
     private(set) var issueRequests: [CompanionPairingIssueRequestRecord] = []
     private(set) var revokeRequests: [CompanionPairingRevokeRequestRecord] = []
@@ -194,6 +200,62 @@ actor FakeCompanionPairingClient: CompanionPairingClient {
     }
 }
 
+actor FakeCompanionStatusClient: CompanionStatusClient {
+    private(set) var refreshRequests: [CompanionStatusRequestRecord] = []
+    private var refreshResult = CompanionStatusSnapshot(
+        status: "ok",
+        readOnly: true,
+        authorizationScope: "companion_read_only",
+        logTail: CompanionStatusLogTailState(
+            source: "image_jobs",
+            visible: 1,
+            total: 1,
+            entries: [
+                CompanionStatusLogEntryState(
+                    eventType: "state_update",
+                    source: "image_jobs",
+                    jobID: "image-job-1",
+                    requestID: "request-1",
+                    modelID: "melix-dev-image",
+                    operation: "image_generate",
+                    state: "running",
+                    lane: "interactive",
+                    workerID: "image-worker-1",
+                    progressStage: "sampling",
+                    updatedAtUnixMS: 1_718_000_010_000,
+                    failureCode: "",
+                    redactionSummary: "raw log line omitted; raw prompt omitted; request body omitted; artifact URIs omitted; local paths omitted; error message omitted"
+                ),
+            ]
+        ),
+        redactionLogs: "redacted_tail"
+    )
+    private var refreshError: Error?
+
+    func configureRefreshResult(_ result: CompanionStatusSnapshot) {
+        refreshResult = result
+        refreshError = nil
+    }
+
+    func configureRefreshError(_ error: Error?) {
+        refreshError = error
+    }
+
+    func refreshStatus(statusURL: URL, resumeHeader: String, sessionToken: String) async throws -> CompanionStatusSnapshot {
+        refreshRequests.append(
+            CompanionStatusRequestRecord(
+                statusURL: statusURL,
+                resumeHeader: resumeHeader,
+                sessionToken: sessionToken
+            )
+        )
+        if let refreshError {
+            throw refreshError
+        }
+        return refreshResult
+    }
+}
+
 struct CompanionPairingHTTPRequestRecord: Equatable, Sendable {
     let url: URL?
     let method: String
@@ -231,6 +293,35 @@ actor FakeCompanionPairingHTTPTransport: CompanionPairingHTTPTransport {
 
         let body = method == "DELETE" ? revokeBody : issueBody
         let statusCode = method == "DELETE" ? revokeStatusCode : issueStatusCode
+        let response = HTTPURLResponse(
+            url: request.url ?? URL(string: "http://127.0.0.1")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (body, response)
+    }
+}
+
+actor FakeCompanionStatusHTTPTransport: CompanionStatusHTTPTransport {
+    private(set) var requests: [CompanionPairingHTTPRequestRecord] = []
+    private var statusCode = 200
+    private var body = Data()
+
+    func configureResponse(statusCode: Int = 200, body: Data) {
+        self.statusCode = statusCode
+        self.body = body
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        requests.append(
+            CompanionPairingHTTPRequestRecord(
+                url: request.url,
+                method: request.httpMethod ?? "GET",
+                headers: request.allHTTPHeaderFields ?? [:],
+                body: request.httpBody
+            )
+        )
         let response = HTTPURLResponse(
             url: request.url ?? URL(string: "http://127.0.0.1")!,
             statusCode: statusCode,

--- a/docs/plans/2026-06-15-issue-1759-companion-log-tail-ui.md
+++ b/docs/plans/2026-06-15-issue-1759-companion-log-tail-ui.md
@@ -1,0 +1,98 @@
+# Issue 1759 Companion Log Tail UI
+
+## Goal
+
+Render the existing redacted companion status log tail in the desktop API
+workspace so the operator can verify what a read-only companion session would
+show before the mobile surface lands.
+
+## Best End-State Architecture
+
+The desktop app should treat companion status as read-only remote data fetched
+through the already-issued companion session token. AppMain must not read raw
+log files, persist companion tokens, or gain new mutation rights. It should call
+the gateway `GET /v1/melix/companion/status` route with the transient companion
+session token, decode only the safe status/log-tail fields, and render those
+fields next to the existing companion pairing controls.
+
+The gateway remains the source of truth for companion authorization, redaction,
+and status payload shape. The desktop view model owns only transient fetch
+state, latency/failure metrics, and a small presentation state.
+
+## Slice Boundary
+
+Included:
+
+- AppMain companion status client for `GET /v1/melix/companion/status`;
+- transient view-model state for status fetch phase, safe log-tail entries,
+  redaction labels, errors, and refresh metrics;
+- API Authentication workspace panel that renders the redacted log-tail summary
+  and refresh control;
+- focused AppMain tests for request shape, token handling, payload decoding,
+  error handling, and UI presentation.
+
+Excluded:
+
+- changing the gateway companion status endpoint or route allowlist;
+- QR image rendering;
+- mobile/PWA companion status page implementation;
+- narrow viewport smoke automation;
+- raw OSLog/stdout/stderr/file log tailing;
+- persisting companion tokens or fetched companion status payloads.
+
+## Performance Probes and Metrics
+
+- Runtime metric: record `companion.status_refresh_ms` around the desktop HTTP
+  fetch.
+- Failure metric: record `companion.status_refresh_failures` when local
+  validation or HTTP/decoding fails.
+- Probe overhead: one local read-only HTTP call per operator refresh action; no
+  polling loop in this slice.
+- PR merge gate: scoped performance report must remain `Status: ok` with zero
+  regressions.
+
+## Implementation Plan
+
+1. Add failing `RuntimeViewModelTests` proving `refreshCompanionStatus()` uses
+   the active companion pairing `status_url`, resume header, and transient token
+   to fetch a redacted log-tail payload.
+2. Add failing `RuntimeViewModelTests` for missing active companion token and
+   live client decoding/HTTP errors.
+3. Add failing `DesktopFoundationViewTests` proving the API authentication
+   surface contains the companion status/log-tail panel and that its presentation
+   renders idle, loaded, and failure states without exposing raw log content.
+4. Implement `CompanionStatusClient`, `LiveCompanionStatusClient`, DTOs, and
+   safe state structs under `apps/macos-menubar/Sources/AppMain/Models/`.
+5. Inject the companion status client into `RuntimeViewModel`, add
+   `companionStatus`, `refreshCompanionStatus()`, metrics, and clear status on
+   token issue/revoke boundaries.
+6. Add `DesktopAPICompanionStatusPanel` to the API Authentication section using
+   existing AppMain card/button patterns.
+7. Update `docs/runbooks/persistent-sessions.md` with the desktop companion
+   status refresh boundary.
+8. Run focused tests, changed-line coverage, full local gate, scoped
+   performance, PR evidence, remote CI/performance monitoring, review cleanup,
+   and squash merge.
+
+## Verification
+
+Focused AppMain tests:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --filter 'RuntimeViewModelTests/(refreshesCompanionStatusLogTailWithActiveReadOnlyToken|companionStatusRefreshRequiresActivePairing|companionStatusRefreshSurfacesTransportFailures|liveCompanionStatusClientFetchesRedactedLogTailAndReportsErrors)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionStatusLogTailPanel|companionStatusPanelRendersIdleLoadedAndFailureStates)'
+```
+
+Changed-line coverage:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'RuntimeViewModelTests/(refreshesCompanionStatusLogTailWithActiveReadOnlyToken|companionStatusRefreshRequiresActivePairing|companionStatusRefreshSurfacesTransportFailures|liveCompanionStatusClientFetchesRedactedLogTailAndReportsErrors)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionStatusLogTailPanel|companionStatusPanelRendersIdleLoadedAndFailureStates)'
+UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Sources/AppMain/Models/CompanionStatusClient.swift apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
+```
+
+Full gate before commit:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```

--- a/docs/runbooks/persistent-sessions.md
+++ b/docs/runbooks/persistent-sessions.md
@@ -110,6 +110,26 @@ metrics, or the safe descriptor displayed in the panel. Closing the desktop
 process drops the transient token reference; create a new companion token if the
 current token can no longer be copied or revoked from the panel.
 
+### Desktop Companion Status Refresh
+
+The macOS API workspace also includes a `Companion Status` panel under the
+Authentication section. It is a read-only status probe for the active companion
+pairing token. The panel calls the gateway `GET /v1/melix/companion/status`
+route with the transient companion token and renders only the safe response
+fields returned by the gateway.
+
+Operator action:
+
+- `Refresh Status` calls the descriptor `pairing.status_url` with the descriptor
+  `pairing.resume_header` and active companion token.
+
+The desktop app does not tail local log files, persist fetched companion status,
+or expand the companion session allowlist. Gateway authorization and redaction
+remain the source of truth. The displayed log-tail rows must come from the
+response `logs.entries` collection and must keep raw log lines, private prompts,
+request bodies, artifact URIs, local paths, and raw error text omitted according
+to the response `redaction` labels.
+
 ### Reuse The Session
 
 ```bash
@@ -211,7 +231,8 @@ The smoke covers:
 
 ## Metrics
 
-M9.4 records these metrics in the touched scope:
+Persistent sessions and companion desktop controls record these metrics in the
+touched scope:
 
 - `persistent_session.active_session_count`
 - `persistent_session.remembered_session_count`
@@ -219,3 +240,5 @@ M9.4 records these metrics in the touched scope:
 - `persistent_session.restore_success_rate`
 - `persistent_session.sign_out_latency_ms`
 - `persistent_session.retention_ttl_seconds`
+- `companion.status_refresh_ms`
+- `companion.status_refresh_failures`


### PR DESCRIPTION
## Summary
- Adds an AppMain companion status client for the existing read-only `GET /v1/melix/companion/status` endpoint, using only the active transient companion session token.
- Adds desktop API Authentication state and UI for refreshing and rendering the redacted image job log tail without reading raw logs or persisting companion tokens.
- Updates the companion session runbook with the desktop refresh boundary and keeps this as a scoped desktop slice of #1759.

Refs #1759.

## Plan or Spec
- Governing plan: `docs/plans/2026-06-15-issue-1759-companion-log-tail-ui.md`
- Runbook update: `docs/runbooks/persistent-sessions.md`

## Commands Run
```text
make bootstrap
Outcome: passed. Git hooks configured and Python environment checked.

make proto
Outcome: passed. No generated protocol diff remained afterward.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --filter 'RuntimeViewModelTests/(refreshesCompanionStatusLogTailWithActiveReadOnlyToken|companionStatusRefreshRequiresActivePairing|companionStatusRefreshSurfacesTransportFailures|liveCompanionStatusClientFetchesRedactedLogTailAndReportsErrors)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionStatusLogTailPanel|companionStatusPanelRendersIdleLoadedAndFailureStates)'
Outcome: passed. 6 tests in 2 suites passed.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'RuntimeViewModelTests/(refreshesCompanionStatusLogTailWithActiveReadOnlyToken|companionStatusRefreshRequiresActivePairing|companionStatusRefreshSurfacesTransportFailures|liveCompanionStatusClientFetchesRedactedLogTailAndReportsErrors)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionStatusLogTailPanel|companionStatusPanelRendersIdleLoadedAndFailureStates)'
Outcome: passed and wrote coverage data.

UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Sources/AppMain/Models/CompanionStatusClient.swift apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
Outcome: passed. TOTAL 97.34% changed-line coverage, 731/751 covered.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --filter 'RuntimeViewModelTests/(issuesCompanionPairingWithStoredPrimaryKey|revokesActiveCompanionPairingToken|companionPairingRequiresStoredPrimaryKey|companionPairingIssueIgnoresDuplicateInFlightRequests|companionPairingRevokeIgnoresDuplicateInFlightRequests|companionPairingSurfacesKeyStoreAndTransportFailures|liveCompanionPairingClientIssuesAndRevokesGatewaySessions|liveCompanionPairingClientReportsGatewayErrorsAndNormalizesRouteDisplayText|refreshesCompanionStatusLogTailWithActiveReadOnlyToken|companionStatusRefreshRequiresActivePairing|companionStatusRefreshSurfacesTransportFailures|liveCompanionStatusClientFetchesRedactedLogTailAndReportsErrors)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates|apiAuthenticationSurfaceIncludesCompanionStatusLogTailPanel|companionStatusPanelRendersIdleLoadedAndFailureStates)'
Outcome: passed. 16 tests in 2 suites passed.

git diff --check
Outcome: passed with no whitespace errors.

make git-hooks-install
Outcome: passed. Configured git hooks path: .githooks.

git commit -m "feat: render companion log tail in desktop api"
Outcome: passed. The pre-commit hook ran make swift-test, make py-test, make integration-test, and scoped performance.

Pre-commit make swift-test
Outcome: passed. Final AppMain package summary included 812 tests in 25 suites passed; the hook completed make swift-test with rc=0.

Pre-commit make py-test
Outcome: passed. 4030 passed, 14 skipped, 2 warnings.

Pre-commit make integration-test
Outcome: passed. 120 passed, 1 skipped.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --filter 'RuntimeViewModelTests/(companionStatusRefreshFailureMetricRecordsOneEventPerFailure|liveCompanionStatusClientToleratesOmittedOptionalRedactionFields)'
Outcome: red before the review fix, then passed after the fix. The red run failed because repeated failures recorded the cumulative metric value and because `failure_code: null` failed decoding. The green run passed 2 tests in 1 suite.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --filter 'RuntimeViewModelTests/(issuesCompanionPairingWithStoredPrimaryKey|revokesActiveCompanionPairingToken|companionPairingRequiresStoredPrimaryKey|companionPairingIssueIgnoresDuplicateInFlightRequests|companionPairingRevokeIgnoresDuplicateInFlightRequests|companionPairingSurfacesKeyStoreAndTransportFailures|liveCompanionPairingClientIssuesAndRevokesGatewaySessions|liveCompanionPairingClientReportsGatewayErrorsAndNormalizesRouteDisplayText|refreshesCompanionStatusLogTailWithActiveReadOnlyToken|companionStatusRefreshRequiresActivePairing|companionStatusRefreshSurfacesTransportFailures|companionStatusRefreshFailureMetricRecordsOneEventPerFailure|liveCompanionStatusClientFetchesRedactedLogTailAndReportsErrors|liveCompanionStatusClientToleratesOmittedOptionalRedactionFields)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates|apiAuthenticationSurfaceIncludesCompanionStatusLogTailPanel|companionStatusPanelRendersIdleLoadedAndFailureStates)'
Outcome: passed. 18 tests in 2 suites passed.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'RuntimeViewModelTests/(refreshesCompanionStatusLogTailWithActiveReadOnlyToken|companionStatusRefreshRequiresActivePairing|companionStatusRefreshSurfacesTransportFailures|companionStatusRefreshFailureMetricRecordsOneEventPerFailure|liveCompanionStatusClientFetchesRedactedLogTailAndReportsErrors|liveCompanionStatusClientToleratesOmittedOptionalRedactionFields)|DesktopFoundationViewTests/(apiAuthenticationSurfaceIncludesCompanionStatusLogTailPanel|companionStatusPanelRendersIdleLoadedAndFailureStates)'
Outcome: passed. 8 tests in 2 suites passed and wrote coverage data.

UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Sources/AppMain/Models/CompanionStatusClient.swift apps/macos-menubar/Sources/AppMain/Models/RuntimeViewModel.swift apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Tests/MenuBarTests/RuntimeViewModelTests.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift apps/macos-menubar/Tests/MenuBarTests/TestSupport.swift
Outcome: passed. TOTAL 97.65% changed-line coverage, 832/852 covered.

git commit -m "fix: harden companion status refresh"
Outcome: passed. The pre-commit hook ran make swift-test, make py-test, make integration-test, and scoped performance.

Second pre-commit make swift-test
Outcome: passed. Final AppMain package summary included 814 tests in 25 suites passed; the hook completed make swift-test with rc=0.

Second pre-commit make py-test
Outcome: passed. 4030 passed, 14 skipped, 2 warnings.

Second pre-commit make integration-test
Outcome: passed. 120 passed, 1 skipped.
```

## Coverage and Metrics
- Changed-line coverage: 97.65% for the touched AppMain source/test files, 832/852 covered.
- Runtime metric added: `companion.status_refresh_ms` around the manual status refresh HTTP fetch.
- Failure metric added: `companion.status_refresh_failures` for local validation, transport, HTTP, and decode failures. Review fix changed this to record `1.0` per failure event rather than a cumulative counter value.
- Observability mode: `minimal`, using existing local metric recording only.
- Probe overhead: one local read-only HTTP call per operator-triggered refresh; no polling loop, no raw log reads, and no token persistence.
- Scoped performance report: `.runtime/pre-commit-performance/20260615-102233-71d15617/report/report.md`
- Scoped performance status: `ok`; changed files 8; selected probes 0; regressions 0; context regressions 0; verification failures 0.
- Review-fix scoped performance report: `.runtime/pre-commit-performance/20260615-105415-eb1333cf/report/report.md`
- Review-fix scoped performance status: `ok`; changed files 3; selected probes 0; regressions 0; context regressions 0; verification failures 0.

## Known Gaps
- This is the desktop AppMain log-tail preview slice for #1759. Mobile/PWA companion pages, QR rendering, narrow viewport smoke automation, and broader companion status surfaces remain outside this PR.
- No protocol or dependency changes were made.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes were made; `make proto` produced no remaining diff.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes were made.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
