### PR TITLE
perf: simplify dataset source path materialization

### DIFF
--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -588,7 +588,7 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
         except OSError:
             continue
     file_paths.sort()
-    return list(map(path_cls, file_paths))
+    return [path_cls(path) for path in file_paths]
 
 
 def _classify_source_kind_name(name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Simplifies dataset source scan path materialization from `list(map(Path, file_paths))` to a list comprehension after the existing sorted string scan.
- Keeps the registered `dataset-source-records-scandir` probe path and behavior unchanged while shaving a small amount of local Linux probe time.

## Plan or Spec
- No behavior/spec change. This follows the existing registered Python performance slice for `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin && git reset --hard origin/main` from `/root/.hermes/profiles/coder/workspace/melix` before creating this worktree.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics` → 3 passed.
- Registered focused test command equivalent from `dataset-source-records-scandir` → 13 passed.
- Registered coverage command equivalent plus `scripts/changed_scope_coverage.py ...` → changed-line coverage 100% (`TOTAL 1 0 100%`).
- Registered probe command equivalent: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py` repeated locally on Linux.
- `git diff --check` → passed.

## Coverage and Metrics
- Changed-line coverage: 100% for `services/mlx-worker-python/worker/productization/dataset_preparation.py` line 591.
- Local Linux registered probe comparison (`dataset_source_records_probe.py`, 6000 files / 250 dirs, repeated samples):
  - baseline `elapsed_ms_mean` runs: 11.1928, 11.7292, 12.6342 ms; mean 11.8521 ms.
  - optimized `elapsed_ms_mean` runs: 11.0226, 10.9349, 11.1921, 11.4754, 11.9147 ms; mean 11.3079 ms.
  - delta: -0.5442 ms; speedup: 1.048x.
  - optimized `source_kind_elapsed_ms_mean` runs: 14.9292, 14.8239, 14.7295, 16.4943, 15.3459 ms.
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- This is a small Python-only slice; no Swift runtime effect is claimed.
- Local Linux measurements are noisy, so CI registered probe completion remains the authoritative PR gate.

## Evidence Checklist
- [x] Worktree was synced from `origin/main` before the slice.
- [x] A registered PR-scoped probe covers the changed path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions and PR-scoped performance report are green.
