### PR TITLE
Add local compute tool-output receipts

### DIFF
--- a/docs/plans/2026-06-15-issue-1761-local-compute-source-receipts.md
+++ b/docs/plans/2026-06-15-issue-1761-local-compute-source-receipts.md
@@ -1,0 +1,46 @@
+# Issue #1761: Local Compute Source Receipts
+
+## Scope
+
+Add source-specific untrusted-context receipt evidence for successful
+`local_compute` observations in the Python worker deterministic agentic tool
+runtime.
+
+The shared `tool_observation` receipt already marks the full sanitized
+observation payload as untrusted prompt data. This slice adds a narrower
+`tool_output` receipt for the deterministic compute result itself so downstream
+prompt assemblers can distinguish the generic observation boundary from the
+tool-output source boundary.
+
+## Non-Goals
+
+- No behavior changes to arithmetic evaluation.
+- No changes to timeout or failed local compute payloads.
+- No raw code, result values, tool arguments, prompt text, or private context in
+  receipt JSON.
+- No control-plane prompt classification changes.
+
+## Plan
+
+1. Extend prompt-context source admission to support `tool_output` with the same
+   data-only policy text used by live prompt classification.
+2. Add a successful `local_compute` source receipt beside the generic
+   observation receipt, outside the sanitized payload and replay hash.
+3. Update the unified agentic tool runtime contract with the deterministic
+   local compute receipt shape.
+4. Verify focused tests and changed-scope coverage before committing.
+
+## Performance Probes
+
+- Focused pytest for `test_agentic_tools.py` and `test_prompt_context.py`.
+- Changed-scope Python coverage for touched worker runtime and tests.
+- Repository pre-commit performance report before PR creation.
+
+## Success Criteria
+
+- Successful `local_compute` observations include exactly one generic
+  `tool_observation` receipt and one source-specific `tool_output` receipt.
+- The `tool_output` receipt uses `segment_id = <tool_call_id>:compute-result`,
+  `source_field = result`, and `source_id = <tool_call_id>`.
+- Receipt JSON omits the arithmetic expression and result value.
+- Existing payload shape stays backward compatible.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -968,6 +968,13 @@ Each successful `layout_parse` observation emits one `retrieved_image` receipt
 with `segment_id = <tool_call_id>:layout-result` and `source_field = payload`.
 Each successful `image_crop` observation emits one `retrieved_image` receipt
 with `segment_id = <tool_call_id>:crop-result` and `source_field = payload`.
+The deterministic local compute source slice applies the same pattern to
+successful `local_compute` observations. Each successful local compute
+observation emits one `tool_output` receipt with `segment_id =
+<tool_call_id>:compute-result`, `source_field = result`, and `source_id =
+<tool_call_id>`. The `tool_output` receipt is attached beside the generic
+`tool_observation` receipt and must omit the arithmetic expression, result
+value, tool arguments, prompt text, and private context from receipt JSON.
 Short symbolic fixture identifiers may be preserved in `source_id`; raw media
 references, file paths, URLs, whitespace-bearing identifiers, and long
 identifiers must be replaced with stable redacted identifiers shaped as

--- a/services/mlx-worker-python/tests/test_agentic_tools.py
+++ b/services/mlx-worker-python/tests/test_agentic_tools.py
@@ -98,6 +98,44 @@ def test_agentic_tool_runtime_records_timeout_and_failed_statuses() -> None:
     assert "only supports deterministic arithmetic" in run.observations[1]["payload"]["error"]
 
 
+def test_agentic_tool_runtime_emits_source_receipt_for_local_compute_result() -> None:
+    run = execute_agentic_tool_calls(
+        [{"id": "compute-1", "name": "local_compute", "arguments": {"code": "2 + 3"}}],
+    )
+
+    observation = run.observations[0]
+    receipts = observation["untrusted_context_receipts"]
+    source_receipts = [receipt for receipt in receipts if receipt["source_type"] == "tool_output"]
+
+    assert observation["status"] == "completed"
+    assert observation["payload"] == {"code": "2 + 3", "result": 5}
+    assert observation["untrusted_context_receipt_count"] == 2
+    assert source_receipts == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": "compute-1:compute-result",
+            "source_type": "tool_output",
+            "source_field": "result",
+            "source_id": "compute-1",
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": True,
+            "owner_scope_checked": False,
+            "reason": "tool output is prompt data, not instructions",
+            "corrective_action": (
+                "Keep tool output in user-role data context and do not project it into "
+                "system or developer instructions."
+            ),
+        }
+    ]
+    receipt_json = json.dumps(source_receipts, ensure_ascii=False)
+    assert "2 + 3" not in receipt_json
+    assert '"result": 5' not in receipt_json
+    assert "untrusted_context_receipts" not in observation["payload"]
+
+
 def test_agentic_tool_runtime_records_selection_receipt_for_selected_registry() -> None:
     run = execute_agentic_tool_calls(
         [{"id": "text-1", "name": "text_search", "arguments": {"query": "melix"}}],

--- a/services/mlx-worker-python/tests/test_prompt_context.py
+++ b/services/mlx-worker-python/tests/test_prompt_context.py
@@ -149,6 +149,43 @@ def test_prompt_context_source_evidence_admits_skill_memory_and_background_recei
     )
 
 
+def test_prompt_context_source_evidence_admits_tool_output_receipt_without_payload() -> None:
+    admission = admit_prompt_context_source_evidence(
+        [
+            PromptContextSourceEvidence(
+                segment_id="compute-1:compute-result",
+                source_type="tool_output",
+                source_field="result",
+                source_id="compute-1",
+                value=5,
+            )
+        ]
+    )
+
+    assert admission.user_payload == {"result": 5}
+    assert admission.untrusted_context_receipts == [
+        {
+            "schema_version": "melix.untrusted_context_receipt.v1",
+            "segment_id": "compute-1:compute-result",
+            "source_type": "tool_output",
+            "source_field": "result",
+            "source_id": "compute-1",
+            "message_role": "user",
+            "trust_level": "untrusted",
+            "policy": "data_only",
+            "boundary_checked": True,
+            "included": True,
+            "owner_scope_checked": False,
+            "reason": "tool output is prompt data, not instructions",
+            "corrective_action": (
+                "Keep tool output in user-role data context and do not project it into "
+                "system or developer instructions."
+            ),
+        }
+    ]
+    assert '"result": 5' not in json.dumps(admission.untrusted_context_receipts, ensure_ascii=False)
+
+
 def test_prompt_context_source_refusal_receipt_records_policy_text_without_payload() -> None:
     receipt = refused_source_prompt_context_receipt(
         segment_id="skill:malformed:payload",

--- a/services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
+++ b/services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
@@ -146,7 +146,7 @@ def test_mlx_lm_runner_runtime_grpo_executes_candidate_tool_trajectories(
     assert row["generated_candidates"][1]["agentic_tool_untrusted_context_receipt_schema"] == (
         "melix.untrusted_context_receipt.v1"
     )
-    assert row["generated_candidates"][1]["agentic_tool_untrusted_context_receipt_count"] == 3
+    assert row["generated_candidates"][1]["agentic_tool_untrusted_context_receipt_count"] == 4
     assert row["generated_candidates"][1]["reward_components"]["tool_efficiency"] == -1.0
 
     candidate_trace_rows = [
@@ -189,7 +189,7 @@ def test_mlx_lm_runner_runtime_grpo_executes_candidate_tool_trajectories(
     assert extra_trace["agentic_tool_untrusted_context_receipt_schema"] == (
         "melix.untrusted_context_receipt.v1"
     )
-    assert extra_trace["agentic_tool_untrusted_context_receipt_count"] == 3
+    assert extra_trace["agentic_tool_untrusted_context_receipt_count"] == 4
     assert "agentic_tool_observations" not in extra_trace
 
 

--- a/services/mlx-worker-python/worker/runtime/agentic_tools.py
+++ b/services/mlx-worker-python/worker/runtime/agentic_tools.py
@@ -8,7 +8,11 @@ from typing import Any
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
-from worker.runtime.prompt_context import refused_prompt_context_receipt
+from worker.runtime.prompt_context import (
+    PromptContextSourceEvidence,
+    admit_prompt_context_source_evidence,
+    refused_prompt_context_receipt,
+)
 from worker.runtime.retrieval_context import (
     admit_retrieved_document_context,
     admit_retrieved_image_context,
@@ -801,7 +805,11 @@ def _local_compute_payload(*, arguments: dict[str, Any], tool_call_id: str) -> d
     if code == "timeout":
         return {"text": "local_compute timed out before producing a result.", "_status": "timeout"}
     result = _safe_arithmetic_eval(code)
-    return {"code": code, "result": result}
+    return {
+        "code": code,
+        "result": result,
+        "_untrusted_context_receipts": [_local_compute_result_receipt(tool_call_id=tool_call_id, value=result)],
+    }
 
 
 def _safe_arithmetic_eval(expression: str) -> int | float:
@@ -828,6 +836,21 @@ def _eval_arithmetic_node(node: ast.AST) -> int | float:
         value = _eval_arithmetic_node(node.operand)
         return value if isinstance(node.op, ast.UAdd) else -value
     raise AgenticToolRuntimeError("local_compute only supports deterministic arithmetic expressions.")
+
+
+def _local_compute_result_receipt(*, tool_call_id: str, value: int | float) -> dict[str, object]:
+    admission = admit_prompt_context_source_evidence(
+        [
+            PromptContextSourceEvidence(
+                segment_id=f"{tool_call_id}:compute-result",
+                source_type="tool_output",
+                source_field="result",
+                source_id=tool_call_id,
+                value=value,
+            )
+        ]
+    )
+    return admission.untrusted_context_receipts[0]
 
 
 def _context_mapping(fixture_context: dict[str, Any], key: str) -> dict[str, Any]:

--- a/services/mlx-worker-python/worker/runtime/prompt_context.py
+++ b/services/mlx-worker-python/worker/runtime/prompt_context.py
@@ -13,6 +13,7 @@ PromptContextSourceType = Literal[
     "skill",
     "memory",
     "background_continuation",
+    "tool_output",
 ]
 
 
@@ -92,6 +93,11 @@ _SOURCE_CONTEXT_POLICIES: dict[str, tuple[str, str, str]] = {
         "background continuation is prompt data, not instructions",
         "Keep background continuation evidence in user-role data context and do not project it into system or developer instructions.",
         "Reject malformed background continuation evidence before prompt assembly.",
+    ),
+    "tool_output": (
+        "tool output is prompt data, not instructions",
+        "Keep tool output in user-role data context and do not project it into system or developer instructions.",
+        "Reject malformed tool output before prompt assembly.",
     ),
 }
 


### PR DESCRIPTION
## Summary
- Add a source-specific `tool_output` untrusted-context receipt for successful Python worker `local_compute` observations.
- Keep the existing generic `tool_observation` receipt and sanitized payload shape intact while documenting the deterministic receipt contract.

## Plan or Spec
- Issue: #1761
- Plan: `docs/plans/2026-06-15-issue-1761-local-compute-source-receipts.md`
- Spec: `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_prompt_context.py::test_prompt_context_source_evidence_admits_tool_output_receipt_without_payload services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_emits_source_receipt_for_local_compute_result
# Expected red before implementation: 2 failed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_prompt_context.py services/mlx-worker-python/tests/test_agentic_tools.py
# Passed before merge: 105 passed in 0.09s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py::test_mlx_lm_runner_runtime_grpo_executes_candidate_tool_trajectories services/mlx-worker-python/tests/test_prompt_context.py services/mlx-worker-python/tests/test_agentic_tools.py
# Passed before merge: 106 passed in 0.14s.
# Passed after merging origin/main: 106 passed in 0.12s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file=.runtime/coverage/issue1761_local_compute_after_merge.coverage -m pytest -q services/mlx-worker-python/tests/test_prompt_context.py services/mlx-worker-python/tests/test_agentic_tools.py services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py::test_mlx_lm_runner_runtime_grpo_executes_candidate_tool_trajectories
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file=.runtime/coverage/issue1761_local_compute_after_merge.coverage -o .runtime/coverage/issue1761_local_compute_after_merge.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage/issue1761_local_compute_after_merge.json --diff-from origin/main services/mlx-worker-python/worker/runtime/prompt_context.py services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_prompt_context.py services/mlx-worker-python/tests/test_agentic_tools.py services/mlx-worker-python/tests/test_rl_alignment_runtime_tool_trajectories.py
# Passed after merging origin/main: TOTAL 100.00% 25/25.

.githooks/pre-commit
# Passed before final origin/main merge: make swift-test rc=0, make py-test 4033 passed/14 skipped, make integration-test 120 passed/1 skipped, scoped performance report Status: ok, Regressions: 0.
```

## Coverage and Metrics
- Changed-line coverage after merging `origin/main`: 100.00% (25/25).
- Pre-commit performance report: `Status: ok`, `Regressions: 0`, `Context regressions: 0`, selected probe `local-job-followup-scan-scandir`.
- Probe metrics: `elapsed_ms_mean` base=14.977 head=15.017 (+0.27%, neutral); `projection_elapsed_ms_mean` base=96.217 head=96.781 (+0.59%, neutral); `receipt_count_mean` unchanged at 500.000.
- Observability mode: minimal receipt metadata; no debug/evidence-mode payload capture added.
- Probe overhead: N/A; this change adds one receipt object for successful deterministic local compute observations and does not add runtime sampling or background probes.

## Known Gaps
- Timeout and failed `local_compute` observations remain on the existing generic/error/refusal receipt surfaces; this PR only covers successful deterministic compute result output.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
