### PR TITLE
perf: fast-path null retrieval payload copies

### DIFF
--- a/docs/plans/2026-06-15-retrieval-copy-none-fastpath.md
+++ b/docs/plans/2026-06-15-retrieval-copy-none-fastpath.md
@@ -1,0 +1,45 @@
+# Retrieval Copy None Fast Path
+
+## Summary
+
+This Python-only performance slice keeps retrieval lookup projection behavior
+unchanged and narrows one hot path in
+`worker.runtime.retrieval_context._copy_payload_value()`.
+
+The lookup payload copier is called recursively for JSON-like prompt payloads
+emitted by retrieval store projection. It already returns immutable scalar
+values directly and recursively copies mutable containers. This slice moves the
+`None` fast path ahead of the exact-type checks so null payload fields return
+immediately instead of paying the full scalar comparison chain.
+
+## Probe Coverage
+
+Registered probe: `retrieval-context-projection-fastpath` in
+`infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` fields and watches:
+
+- `services/mlx-worker-python/worker/runtime/retrieval_context.py`
+- `services/mlx-worker-python/tests/test_retrieval_context.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/retrieval_context_projection_probe.py`
+
+The checked-in probe reports direct projection, store-record projection, and
+lookup-copy metrics, including `lookup_copy_optimized_elapsed_ms_mean` and
+`lookup_copy_speedup` for the payload copy path.
+
+## Implementation
+
+1. Preserve recursive copy semantics for dict, list, tuple, and custom mutable
+   fallback values.
+2. Return `None` before computing `type(value)` and checking the other immutable
+   scalar types.
+3. Extend the lookup copy regression fixture with a nested null field so the
+   behavior remains covered.
+
+## Validation Plan
+
+Run the registered focused test command, changed-scope coverage command, and
+registered probe locally on Linux. Use the GitHub Actions PR-scoped performance
+workflow as the merge gate after opening the PR.

--- a/scripts/retrieval_context_projection_probe.py
+++ b/scripts/retrieval_context_projection_probe.py
@@ -84,6 +84,7 @@ def _build_lookup_payload(count: int) -> dict[str, Any]:
             "index": index,
             "title": f"retrieved payload {index}",
             "metadata": {
+                "optional_note": None,
                 "scores": [index, index + 1, {"rank": index % 7}],
                 "labels": (
                     "retrieved",

--- a/services/mlx-worker-python/tests/test_retrieval_context.py
+++ b/services/mlx-worker-python/tests/test_retrieval_context.py
@@ -1540,6 +1540,7 @@ def _assert_retrieval_lookup_result_copies_store_projection_outputs(
                         "scores": [1, 2, {"label": "safe"}],
                         "tuple_values": ("a", {"b": "c"}),
                         "custom_mutable": mutable_default,
+                        "optional_note": None,
                     },
                 }
             },
@@ -1566,6 +1567,7 @@ def _assert_retrieval_lookup_result_copies_store_projection_outputs(
                 "scores": [1, 2, {"label": "safe"}],
                 "tuple_values": ("a", {"b": "c"}),
                 "custom_mutable": ["fallback"],
+                "optional_note": None,
             },
         }
     }

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -391,14 +391,10 @@ def _copy_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _copy_payload_value(value: Any) -> Any:
+    if value is None:
+        return value
     value_type = type(value)
-    if (
-        value_type is str
-        or value_type is int
-        or value_type is float
-        or value_type is bool
-        or value is None
-    ):
+    if value_type is str or value_type is int or value_type is float or value_type is bool:
         return value
     copy_value = _copy_payload_value
     if value_type is dict:


### PR DESCRIPTION
## Summary
- Fast-path `None` values before exact scalar type checks in the retrieval lookup payload copier.
- Add null payload coverage to the focused retrieval lookup copy regression fixture.
- Extend the registered retrieval-context probe payload with a null metadata field so the PR-scoped performance gate covers this branch.

## Plan or Spec
- `docs/plans/2026-06-15-retrieval-copy-none-fastpath.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (registered `retrieval-context-projection-fastpath` focused test command) → 19 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json ...` → TOTAL 3 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py`
- Base/head repeated local comparison using the updated probe script against `origin/main` and this branch.

## Coverage and Metrics
- Changed-scope coverage: 100.00% (3/3 measurable changed lines).
- Local registered probe on this branch: `lookup_copy_optimized_elapsed_ms_mean=0.21535411094581441`, `lookup_copy_baseline_elapsed_ms_mean=0.8610775173708264`, `lookup_copy_speedup=3.9984261901899956`.
- Local base/head comparison with the updated probe script (3 runs): base `lookup_copy_optimized_elapsed_ms_mean` mean `0.22509391391871583`; head mean `0.21603417893250784` (~4.0% lower).

## Known Gaps
- Linux local validation covers the Python retrieval-context path only.
- The registered PR-scoped performance workflow in CI remains the merge gate for base/head reporting.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance report completed.
