### PR TITLE
perf: skip empty startup failure pattern scans

### DIFF
--- a/docs/plans/2026-06-15-startup-empty-pattern-skip.md
+++ b/docs/plans/2026-06-15-startup-empty-pattern-skip.md
@@ -1,0 +1,28 @@
+# Startup Failure Empty Pattern Scan Skip
+
+## Scope
+
+This performance slice keeps startup failure classification behavior unchanged while
+skipping direct substring pattern scans when the direct error text or gathered log
+excerpt is empty. The affected code path is
+`services/mlx-worker-python/worker/productization/startup_signals.py`.
+
+## Registered Probe
+
+The path is covered by the registered PR-scoped performance probe
+`startup-signals-lazy-worker-log-excerpts` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries, and watches the
+startup signals implementation, focused tests, probe script, and PR scoped
+performance tests.
+
+## Verification Plan
+
+- Add a regression test proving empty direct error/log values do not call the
+  pattern matcher.
+- Keep existing direct error text, control-plane log, worker log, and hang
+  classification tests passing.
+- Run the registered focused test command, changed-scope coverage command, and
+  registered probe locally on Linux before opening the PR.
+- Use the PR-scoped performance workflow as the merge gate for registered probe
+  validation.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3383,6 +3383,24 @@
         "warn_pct": 0.0
       },
       {
+        "key": "empty_hang_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 15.0
+      },
+      {
+        "key": "empty_hang_log_path_exists_checks_mean",
+        "unit": "checks",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "empty_hang_log_reads_mean",
+        "unit": "reads",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
         "key": "worker_crash_elapsed_ms_mean",
         "unit": "ms",
         "direction": "lower_is_better",

--- a/scripts/startup_signals_log_probe.py
+++ b/scripts/startup_signals_log_probe.py
@@ -157,6 +157,9 @@ def main() -> int:
     direct_control_elapsed: list[float] = []
     direct_control_reads: list[float] = []
     direct_control_exists: list[float] = []
+    empty_hang_elapsed: list[float] = []
+    empty_hang_reads: list[float] = []
+    empty_hang_exists: list[float] = []
     worker_elapsed: list[float] = []
     worker_reads: list[float] = []
     worker_exists: list[float] = []
@@ -197,6 +200,19 @@ def main() -> int:
             direct_control_reads.append(reads / iterations)
             direct_control_exists.append(exists / iterations)
 
+            elapsed, reads, exists = _measure_case(
+                {
+                    "http_port": 12436,
+                    "ready_probe_url": "http://127.0.0.1:12436/v1/models",
+                },
+                error_text="",
+                expected_classification="startup_hang",
+                iterations=iterations,
+            )
+            empty_hang_elapsed.append(elapsed)
+            empty_hang_reads.append(reads / iterations)
+            empty_hang_exists.append(exists / iterations)
+
             worker_manifest = dict(manifest)
             worker_manifest.pop("control_plane_stderr_path")
             elapsed, reads, exists = _measure_case(
@@ -236,6 +252,18 @@ def main() -> int:
                 ),
                 "direct_control_crash_log_reads_mean": round(
                     statistics.fmean(direct_control_reads),
+                    6,
+                ),
+                "empty_hang_elapsed_ms_mean": round(
+                    statistics.fmean(empty_hang_elapsed),
+                    6,
+                ),
+                "empty_hang_log_path_exists_checks_mean": round(
+                    statistics.fmean(empty_hang_exists),
+                    6,
+                ),
+                "empty_hang_log_reads_mean": round(
+                    statistics.fmean(empty_hang_reads),
                     6,
                 ),
                 "iterations": float(iterations),

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -4582,6 +4582,9 @@ def test_startup_signals_probe_script_emits_metrics(capsys: pytest.CaptureFixtur
     assert payload["direct_control_crash_elapsed_ms_mean"] > 0
     assert payload["direct_control_crash_log_path_exists_checks_mean"] == 0.0
     assert payload["direct_control_crash_log_reads_mean"] == 0.0
+    assert payload["empty_hang_elapsed_ms_mean"] > 0
+    assert payload["empty_hang_log_path_exists_checks_mean"] == 0.0
+    assert payload["empty_hang_log_reads_mean"] == 0.0
     assert payload["worker_crash_elapsed_ms_mean"] > 0
     assert payload["worker_crash_log_path_exists_checks_mean"] == 0.0
     assert payload["worker_crash_log_reads_mean"] == 1.0

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -606,3 +606,28 @@ def test_classify_startup_failure_falls_back_to_hang_when_logs_are_empty() -> No
 
     assert report.classification == "startup_hang"
     assert "11434" in report.summary
+
+
+def test_classify_startup_failure_skips_empty_pattern_scans(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    empty_pattern_scan_calls = 0
+    original_contains_any = startup_signals_module._contains_any
+
+    def tracked_contains_any(value: str, patterns: tuple[str, ...]) -> bool:
+        nonlocal empty_pattern_scan_calls
+        if value == "":  # pragma: no cover - regression path only
+            empty_pattern_scan_calls += 1  # pragma: no cover
+        return original_contains_any(value, patterns)
+
+    monkeypatch.setattr(startup_signals_module, "_contains_any", tracked_contains_any)
+
+    report = classify_startup_failure(
+        {
+            "http_port": 11434,
+            "ready_probe_url": "http://127.0.0.1:11434/v1/models",
+        }
+    )
+
+    assert report.classification == "startup_hang"
+    assert empty_pattern_scan_calls == 0

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -260,30 +260,50 @@ def classify_startup_failure(
 ) -> StartupFailureReport:
     ready_probe_url = str(manifest.get("ready_probe_url", ""))
     http_port = int(manifest.get("http_port", 0) or 0)
-    error_lower = error_text.lower()
     primary_log_path = str(manifest.get("control_plane_stderr_path", ""))
+    summary = ""
+    detail = ""
+    excerpt = ""
 
-    if _contains_any(error_lower, PORT_CONFLICT_PATTERNS):
-        summary = f"Configured HTTP port {http_port} is already in use."
-        detail = (
-            f"The control plane could not bind to {ready_probe_url}. "
-            f"Choose a different host port or stop the conflicting process."
-        )
-        excerpt = error_text
-        classification = "host_port_conflict"
-    elif _contains_any(error_lower, CRASH_PATTERNS):
-        summary = "Control plane crashed before startup completed."
-        detail = f"Melix never reached {ready_probe_url}. Inspect the control-plane logs for the crash cause."
-        excerpt = error_text
-        classification = "control_plane_crash"
+    if error_text:
+        error_lower = error_text.lower()
+        if _contains_any(error_lower, PORT_CONFLICT_PATTERNS):
+            summary = f"Configured HTTP port {http_port} is already in use."
+            detail = (
+                f"The control plane could not bind to {ready_probe_url}. "
+                f"Choose a different host port or stop the conflicting process."
+            )
+            excerpt = error_text
+            classification = "host_port_conflict"
+        elif _contains_any(error_lower, CRASH_PATTERNS):
+            summary = "Control plane crashed before startup completed."
+            detail = f"Melix never reached {ready_probe_url}. Inspect the control-plane logs for the crash cause."
+            excerpt = error_text
+            classification = "control_plane_crash"
+        else:
+            classification = ""
     else:
+        classification = ""
+
+    if not classification:
         control_plane_excerpt = _log_excerpt(
             manifest.get("control_plane_stderr_path"),
             manifest.get("control_plane_stdout_path"),
         )
-        control_plane_lower = control_plane_excerpt.lower()
 
-        if _contains_any(control_plane_lower, PORT_CONFLICT_PATTERNS):
+        if control_plane_excerpt:
+            control_plane_lower = control_plane_excerpt.lower()
+            control_plane_port_conflict = _contains_any(
+                control_plane_lower, PORT_CONFLICT_PATTERNS
+            )
+            control_plane_crash = not control_plane_port_conflict and _contains_any(
+                control_plane_lower, CRASH_PATTERNS
+            )
+        else:
+            control_plane_port_conflict = False
+            control_plane_crash = False
+
+        if control_plane_port_conflict:
             summary = f"Configured HTTP port {http_port} is already in use."
             detail = (
                 f"The control plane could not bind to {ready_probe_url}. "
@@ -291,7 +311,7 @@ def classify_startup_failure(
             )
             excerpt = control_plane_excerpt
             classification = "host_port_conflict"
-        elif control_plane_excerpt and _contains_any(control_plane_lower, CRASH_PATTERNS):
+        elif control_plane_crash:
             summary = "Control plane crashed before startup completed."
             detail = f"Melix never reached {ready_probe_url}. Inspect the control-plane logs for the crash cause."
             excerpt = control_plane_excerpt
@@ -303,8 +323,10 @@ def classify_startup_failure(
                 manifest.get("python_worker_stdout_path"),
                 manifest.get("swift_text_worker_stdout_path"),
             )
-            combined_worker = worker_excerpt_value.lower()
-            if worker_excerpt_value and _contains_any(combined_worker, CRASH_PATTERNS):
+            worker_crash = bool(worker_excerpt_value) and _contains_any(
+                worker_excerpt_value.lower(), CRASH_PATTERNS
+            )
+            if worker_crash:
                 primary_log_path = str(
                     manifest.get("python_worker_stderr_path")
                     or manifest.get("swift_text_worker_stderr_path")


### PR DESCRIPTION
## Summary
- Skip startup failure substring pattern scans when direct error text or gathered log excerpts are empty.
- Extend the registered startup-signals PR-scoped probe with an `empty_hang_*` measurement for the optimized path.
- Add a regression test proving empty startup failure inputs do not call the pattern matcher.

## Plan or Spec
- `docs/plans/2026-06-15-startup-empty-pattern-skip.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_classify_startup_failure_skips_empty_pattern_scans
# First run before implementation failed as expected: 1 failed, empty_pattern_scan_calls == 3.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_classify_startup_failure_skips_empty_pattern_scans services/mlx-worker-python/tests/test_startup_signals.py::test_classify_startup_failure_falls_back_to_hang_when_logs_are_empty services/mlx-worker-python/tests/test_startup_signals.py::test_classify_startup_failure_reports_host_port_conflict services/mlx-worker-python/tests/test_startup_signals.py::test_classify_startup_failure_reports_worker_crash
# 4 passed in 0.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# 43 passed in 2.69s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
# 43 passed in 2.95s; TOTAL 47 1 98%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py
# emitted registered probe metrics including empty_hang_elapsed_ms_mean=0.877941

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 47 1 98%`.
- Registered local probe (`scripts/startup_signals_log_probe.py`) candidate output: `empty_hang_elapsed_ms_mean=0.877941`, `empty_hang_log_reads_mean=0.0`, `empty_hang_log_path_exists_checks_mean=0.0`.
- Direct local baseline microprobe on `origin/main`: `empty_hang_elapsed_ms_mean=54.568658` ms for 20,000 iterations.
- Direct local candidate microprobe: `empty_hang_elapsed_ms_mean=48.464792` ms for 20,000 iterations (`delta=-6.103866` ms, ~11.19% faster).
- Registered PR-scoped performance workflow is required for CI validation before merge.

## Known Gaps
- Linux local validation covers Python behavior and probe output only; GitHub Actions PR-scoped performance is the registered merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
