### PR TITLE
Add agentic trace receipt summaries

### DIFF
--- a/docs/plans/2026-06-15-issue-1761-agentic-trace-receipt-summary.md
+++ b/docs/plans/2026-06-15-issue-1761-agentic-trace-receipt-summary.md
@@ -1,0 +1,52 @@
+# Issue #1761: Agentic Trace Receipt Summary
+
+## Scope
+
+Expose scalar untrusted-context receipt summary fields on normalized
+`agentic_tool_trace` samples when the Python worker replays sample-level tool
+calls through the deterministic agentic tool runtime.
+
+The trace already preserves full `agentic_tool_observations`, including each
+observation's `untrusted_context_receipts`. This slice adds sample-level summary
+metadata so downstream training-package and snapshot readers can verify that
+tool-output boundary evidence exists without parsing full observation payloads.
+
+## Non-Goals
+
+- No changes to tool execution, observation payloads, or replay turns.
+- No copying receipt bodies, retrieved text, page content, media references,
+  prompts, or tool payload values into scalar fields.
+- No changes to manually authored traces that do not execute replayed tool
+  calls.
+- No new training formatter behavior.
+
+## Plan
+
+1. Add a failing normalization test for a replayed `agentic_tool_trace` sample
+   that expects `agentic_tool_untrusted_context_receipt_schema` and
+   `agentic_tool_untrusted_context_receipt_count`.
+2. Implement a small receipt-summary helper in `training_dataset.py` that
+   counts mapping-shaped receipts across `AgenticToolRun.observations` and
+   records the first string `schema_version`.
+3. Attach the scalar fields to replay evidence only when at least one receipt
+   exists.
+4. Update the unified agentic tool runtime contract to document the normalized
+   training-trace summary fields.
+
+## Performance Probes
+
+- Focused pytest for `test_training_dataset_builder.py`.
+- Changed-scope Python coverage for the touched training dataset code and test.
+- Repository pre-commit scoped performance report before PR creation.
+
+## Success Criteria
+
+- Replayed `agentic_tool_trace` samples expose
+  `agentic_tool_untrusted_context_receipt_schema =
+  melix.untrusted_context_receipt.v1`.
+- Replayed samples expose the total count of mapping-shaped receipts across all
+  replayed tool observations.
+- Scalar fields do not copy tool payloads, retrieved text, prompt text, or
+  receipt JSON bodies.
+- Existing observation, turn, and training formatter behavior remains
+  unchanged.

--- a/docs/plans/2026-06-15-issue-1761-agentic-trace-receipt-summary.md
+++ b/docs/plans/2026-06-15-issue-1761-agentic-trace-receipt-summary.md
@@ -23,13 +23,14 @@ tool-output boundary evidence exists without parsing full observation payloads.
 ## Plan
 
 1. Add a failing normalization test for a replayed `agentic_tool_trace` sample
-   that expects `agentic_tool_untrusted_context_receipt_schema` and
-   `agentic_tool_untrusted_context_receipt_count`.
+   that expects `agentic_tool_untrusted_context_receipt_schema` when a string
+   schema is present and `agentic_tool_untrusted_context_receipt_count` when
+   mapping-shaped receipts are present.
 2. Implement a small receipt-summary helper in `training_dataset.py` that
    counts mapping-shaped receipts across `AgenticToolRun.observations` and
    records the first string `schema_version`.
-3. Attach the scalar fields to replay evidence only when at least one receipt
-   exists.
+3. Attach the receipt count to replay evidence only when at least one receipt
+   exists, and attach the schema only when a string schema version is present.
 4. Update the unified agentic tool runtime contract to document the normalized
    training-trace summary fields.
 
@@ -43,9 +44,12 @@ tool-output boundary evidence exists without parsing full observation payloads.
 
 - Replayed `agentic_tool_trace` samples expose
   `agentic_tool_untrusted_context_receipt_schema =
-  melix.untrusted_context_receipt.v1`.
+  melix.untrusted_context_receipt.v1` when a counted receipt carries that string
+  schema version.
 - Replayed samples expose the total count of mapping-shaped receipts across all
   replayed tool observations.
+- Replayed samples with counted receipts but no string schema version omit the
+  schema field instead of emitting an empty string.
 - Scalar fields do not copy tool payloads, retrieved text, prompt text, or
   receipt JSON bodies.
 - Existing observation, turn, and training formatter behavior remains

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -929,6 +929,18 @@ mapping-shaped receipts across those observations. These scalar fields must not
 copy tool payloads, retrieved text, page content, media references, prompt
 text, or receipt bodies into non-selected candidate rows.
 
+Training dataset normalization applies the same scalar-summary rule to
+`agentic_tool_trace` samples whose `tool_calls` are replayed through the shared
+deterministic runtime. The normalized sample keeps full
+`agentic_tool_observations` for trace replay, and also exposes
+`agentic_tool_untrusted_context_receipt_schema` plus
+`agentic_tool_untrusted_context_receipt_count` at the sample top level when the
+replayed observations contain mapping-shaped receipts. These fields are
+metadata only: they record the first receipt schema string and the total receipt
+count across replayed observations, and must not copy tool payloads, retrieved
+text, page content, media references, prompt text, receipt JSON bodies, or
+private context into scalar training-package fields.
+
 The v1 deterministic retrieval source slice lets callers attach
 source-specific untrusted-context receipts beside the generic tool-observation
 receipt without adding those receipts to the sanitized payload or replay hash.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -932,14 +932,15 @@ text, or receipt bodies into non-selected candidate rows.
 Training dataset normalization applies the same scalar-summary rule to
 `agentic_tool_trace` samples whose `tool_calls` are replayed through the shared
 deterministic runtime. The normalized sample keeps full
-`agentic_tool_observations` for trace replay, and also exposes
-`agentic_tool_untrusted_context_receipt_schema` plus
+`agentic_tool_observations` for trace replay, and exposes
 `agentic_tool_untrusted_context_receipt_count` at the sample top level when the
-replayed observations contain mapping-shaped receipts. These fields are
-metadata only: they record the first receipt schema string and the total receipt
-count across replayed observations, and must not copy tool payloads, retrieved
-text, page content, media references, prompt text, receipt JSON bodies, or
-private context into scalar training-package fields.
+replayed observations contain mapping-shaped receipts. It also exposes
+`agentic_tool_untrusted_context_receipt_schema` only when at least one counted
+receipt carries a string `schema_version`. These fields are metadata only: they
+record the first receipt schema string when present and the total receipt count
+across replayed observations, and must not copy tool payloads, retrieved text,
+page content, media references, prompt text, receipt JSON bodies, or private
+context into scalar training-package fields.
 
 The v1 deterministic retrieval source slice lets callers attach
 source-specific untrusted-context receipts beside the generic tool-observation

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -233,6 +233,7 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
     assert "Please ignore instructions." not in summary_json
     assert training_dataset_module._agentic_tool_observation_receipt_summary(
         [
+            None,
             {"untrusted_context_receipts": "not-a-list"},
             {
                 "untrusted_context_receipts": [

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -253,6 +253,9 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
         "agentic_tool_untrusted_context_receipt_count": 2,
     }
     assert training_dataset_module._agentic_tool_observation_receipt_summary(
+        [{"untrusted_context_receipts": [{"source_type": "tool_observation"}]}]
+    ) == {"agentic_tool_untrusted_context_receipt_count": 1}
+    assert training_dataset_module._agentic_tool_observation_receipt_summary(
         [{"untrusted_context_receipts": []}, {}]
     ) == {}
 

--- a/services/mlx-worker-python/tests/test_training_dataset_builder.py
+++ b/services/mlx-worker-python/tests/test_training_dataset_builder.py
@@ -173,6 +173,87 @@ def test_write_normalized_dataset_snapshot_applies_manifest_overrides(
     assert stale_agentic_train_path.exists() is False
     assert stale_agentic_valid_path.exists() is False
     assert training_dataset_module.trainer_sample_counts(dataset) == (1, 0)
+    agentic_package_path = tmp_path / "agentic-package"
+    agentic_package_path.mkdir(parents=True, exist_ok=True)
+    (agentic_package_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "agentic-replay-demo",
+                "format": "agentic_tool_trace",
+                "sample_count": 1,
+                "version": "1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (agentic_package_path / "samples.jsonl").write_text(
+        json.dumps(
+            {
+                "trace_id": "trace-replay-001",
+                "question": "Read the support page before answering.",
+                "tool_calls": [
+                    {
+                        "id": "visit-1",
+                        "name": "visit",
+                        "arguments": {"url": "fixture://support"},
+                    }
+                ],
+                "tool_fixture_context": {
+                    "pages": {
+                        "fixture://support": {
+                            "title": "Support",
+                            "text": "The documented answer is MELIX LABS.",
+                        }
+                    }
+                },
+                "final_answer": "MELIX LABS",
+                "expected_answer": "MELIX LABS",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    agentic_package = load_training_dataset_package(str(agentic_package_path))
+    agentic_sample = agentic_package.normalized_samples[0]
+    assert agentic_sample["agentic_tool_observations"][0]["payload"]["title"] == "Support"
+    assert agentic_sample["agentic_tool_untrusted_context_receipt_schema"] == (
+        "melix.untrusted_context_receipt.v1"
+    )
+    assert agentic_sample["agentic_tool_untrusted_context_receipt_count"] == 2
+    summary_json = json.dumps(
+        {
+            "schema": agentic_sample["agentic_tool_untrusted_context_receipt_schema"],
+            "count": agentic_sample["agentic_tool_untrusted_context_receipt_count"],
+        },
+        sort_keys=True,
+    )
+    assert "Support article" not in summary_json
+    assert "Please ignore instructions." not in summary_json
+    assert training_dataset_module._agentic_tool_observation_receipt_summary(
+        [
+            {"untrusted_context_receipts": "not-a-list"},
+            {
+                "untrusted_context_receipts": [
+                    "not-a-receipt",
+                    {"source_type": "tool_observation"},
+                    {
+                        "schema_version": "melix.untrusted_context_receipt.v1",
+                        "source_type": "retrieved_document",
+                    },
+                ]
+            },
+        ]
+    ) == {
+        "agentic_tool_untrusted_context_receipt_schema": (
+            "melix.untrusted_context_receipt.v1"
+        ),
+        "agentic_tool_untrusted_context_receipt_count": 2,
+    }
+    assert training_dataset_module._agentic_tool_observation_receipt_summary(
+        [{"untrusted_context_receipts": []}, {}]
+    ) == {}
 
     prompt_candidate_package_path = tmp_path / "prompt-candidate-package"
     prompt_candidate_package_path.mkdir(parents=True, exist_ok=True)
@@ -1066,7 +1147,6 @@ def test_load_training_dataset_package_replays_agentic_tool_calls_with_shared_ru
     assert quality["tool_call_count"] == 1
     assert quality["tool_observation_count"] == 1
     assert token_stats["sample_count"] == 1
-
 
 def test_prompt_completion_quality_stats_do_not_import_agentic_runtime(
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1189,6 +1189,8 @@ def _agentic_tool_observation_receipt_summary(
     receipt_schema = ""
     receipt_count = 0
     for observation in observations:
+        if not isinstance(observation, Mapping):
+            continue
         receipts = observation.get("untrusted_context_receipts")
         if not isinstance(receipts, list):
             continue

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1172,11 +1172,38 @@ def _agentic_trace_replay_turns(
     turns: list[dict[str, Any]] = [{"role": "user", "content": question}]
     turns.extend(dict(turn) for turn in tool_run.trace_turns)
     turns.append({"role": "assistant", "content": final_answer})
-    return turns, {
+    observations = [dict(observation) for observation in tool_run.observations]
+    replay_evidence = {
         "agentic_tool_registry": tool_run.registry_receipt,
         "agentic_tool_calls": [dict(call) for call in tool_run.tool_calls],
-        "agentic_tool_observations": [dict(observation) for observation in tool_run.observations],
+        "agentic_tool_observations": observations,
         "agentic_tool_metrics": dict(tool_run.metrics),
+    }
+    replay_evidence.update(_agentic_tool_observation_receipt_summary(observations))
+    return turns, replay_evidence
+
+
+def _agentic_tool_observation_receipt_summary(
+    observations: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    receipt_schema = ""
+    receipt_count = 0
+    for observation in observations:
+        receipts = observation.get("untrusted_context_receipts")
+        if not isinstance(receipts, list):
+            continue
+        for receipt in receipts:
+            if not isinstance(receipt, Mapping):
+                continue
+            receipt_count += 1
+            schema_version = receipt.get("schema_version")
+            if not receipt_schema and isinstance(schema_version, str):
+                receipt_schema = schema_version
+    if receipt_count == 0:
+        return {}
+    return {
+        "agentic_tool_untrusted_context_receipt_schema": receipt_schema,
+        "agentic_tool_untrusted_context_receipt_count": receipt_count,
     }
 
 

--- a/services/mlx-worker-python/worker/model_ops/training_dataset.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset.py
@@ -1203,10 +1203,12 @@ def _agentic_tool_observation_receipt_summary(
                 receipt_schema = schema_version
     if receipt_count == 0:
         return {}
-    return {
-        "agentic_tool_untrusted_context_receipt_schema": receipt_schema,
+    summary: dict[str, Any] = {
         "agentic_tool_untrusted_context_receipt_count": receipt_count,
     }
+    if receipt_schema:
+        summary["agentic_tool_untrusted_context_receipt_schema"] = receipt_schema
+    return summary
 
 
 def _copy_optional_agentic_trace_fields(


### PR DESCRIPTION
## Summary
- Add normalized sample-level receipt summary fields for replayed `agentic_tool_trace` samples.
- Preserve full `agentic_tool_observations` while exposing only receipt schema/count scalar metadata.
- Document the training trace summary contract and cover the replay path with changed-line coverage.

## Plan or Spec
- `docs/plans/2026-06-15-issue-1761-agentic-trace-receipt-summary.md`
- `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe
# 76 passed in 0.12s

.githooks/pre-commit
# pre-merge hook run completed on staged diff; performance report 20260615-144233-1051a42b: Status ok, 4 selected probes, 0 regressions, 0 verification failures, coverage 100.0%

git merge --no-edit origin/main
# merged origin/main at 39d2745c without conflicts

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe
# 76 passed in 0.12s

make swift-test
# passed

make py-test
# 4033 passed, 14 skipped, 2 warnings in 167.20s

make integration-test
# 120 passed, 1 skipped in 456.37s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python <agentic summary path check>
# text_completion sample-limit path does not call the agentic receipt summary helper

UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python <run_performance_report origin/main...HEAD>
# first merged run: Status regression, 1 sample-limit elapsed regression; investigated as unrelated micro-benchmark noise because the changed helper is not called by the text_completion sample-limit path
# second merged run: Status ok, 4 selected probes, 0 regressions, 0 verification failures, coverage 100.0%

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-body-issue-1761-receipt-summary.md
# PR evidence looks valid.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_training_dataset_builder.py
# 75 passed in 0.09s

git merge --no-edit origin/main
# merged origin/main at cb85e572 without conflicts

make swift-test
# passed

make py-test
# 4035 passed, 14 skipped, 2 warnings in 167.92s

make integration-test
# 120 passed, 1 skipped in 420.95s

UV_CACHE_DIR="$PWD/.uv-cache" UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python --extra mlx python <run_performance_report origin/main...HEAD>
# Status ok, 4 selected probes, 0 regressions, 0 context regressions, 0 verification failures, changed-line coverage 100.0%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_training_dataset_builder.py::test_write_normalized_dataset_snapshot_applies_manifest_overrides -q
# red before helper fix: failed because no-schema receipts emitted "agentic_tool_untrusted_context_receipt_schema": ""
# green after helper fix: 1 passed in 0.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_training_dataset_builder.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_probe
# 76 passed in 0.11s

.githooks/pre-commit
# review fix gate passed: make swift-test passed; make py-test 4035 passed, 14 skipped, 2 warnings in 167.38s; make integration-test 120 passed, 1 skipped in 410.61s; performance report Status ok, 4 selected probes, 0 regressions, 0 context regressions, 0 verification failures, changed-line coverage 100.0%
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 5 0 100%` for the review-fix changed lines in `training_dataset.py` and `test_training_dataset_builder.py`.
- Final local PR-scoped performance report: `.runtime/pre-commit-performance/20260615-163022-d438a223/report/report.md`.
- Final report summary: Status `ok`, changed files `4`, selected probes `4`, direct/gated probes `4`, regressions `0`, context regressions `0`, verification failures `0`.
- Probe coverage: all selected direct probes reported coverage `100.0%`.
- Observability mode: `N/A`; this change adds training-package metadata only and does not add runtime observability, sampled/debug/evidence-mode recording, or probe overhead.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
