### PR TITLE
perf: fast-path startup pattern membership

### DIFF
--- a/docs/plans/2026-06-15-startup-pattern-membership-fastpath.md
+++ b/docs/plans/2026-06-15-startup-pattern-membership-fastpath.md
@@ -1,0 +1,15 @@
+# Startup Pattern Membership Fast Path
+
+This Python performance slice keeps startup failure classification behavior unchanged while reducing fixed-pattern membership overhead in `services/mlx-worker-python/worker/productization/startup_signals.py`.
+
+The affected path is covered by the registered PR-scoped probe `startup-signals-lazy-worker-log-excerpts` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for the startup signals implementation, tests, probe script, and PR-scoped registry coverage.
+
+## Scope
+
+- Add direct fixed-pattern checks for the startup port-conflict and crash pattern tuples.
+- Preserve the generic tuple scan fallback for any future non-standard pattern tuple.
+- Keep the slice Python-only and locally verifiable on Linux.
+
+## Validation
+
+Run the focused startup-signals tests, changed-scope coverage, and the registered `startup-signals-lazy-worker-log-excerpts` probe locally on Linux before pushing. GitHub Actions PR-scoped performance remains the merge gate.

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -608,6 +608,19 @@ def test_classify_startup_failure_falls_back_to_hang_when_logs_are_empty() -> No
     assert "11434" in report.summary
 
 
+def test_contains_any_fast_paths_preserve_empty_value_and_fallback_behavior() -> None:
+    assert startup_signals_module._contains_any("", startup_signals_module.CRASH_PATTERNS) is False
+    assert (
+        startup_signals_module._contains_any(
+            "EADDRINUSE".lower(),
+            startup_signals_module.PORT_CONFLICT_PATTERNS,
+        )
+        is True
+    )
+    assert startup_signals_module._contains_any("custom sentinel", ("sentinel",)) is True
+    assert startup_signals_module._contains_any("custom sentinel", ("missing",)) is False
+
+
 def test_classify_startup_failure_skips_empty_pattern_scans(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -354,6 +354,24 @@ def classify_startup_failure(
 
 
 def _contains_any(value: str, patterns: tuple[str, ...]) -> bool:
+    if not value:
+        return False
+    if patterns is PORT_CONFLICT_PATTERNS:
+        return (
+            "address already in use" in value
+            or "eaddrinuse" in value
+            or "bind() failed" in value
+            or "port is already in use" in value
+        )
+    if patterns is CRASH_PATTERNS:
+        return (
+            "fatal error" in value
+            or "traceback" in value
+            or "uncaught" in value
+            or "assertion failed" in value
+            or "terminated" in value
+            or "abort trap" in value
+        )
     for pattern in patterns:
         if pattern in value:
             return True


### PR DESCRIPTION
## Summary
- Fast-path startup failure pattern membership for the fixed port-conflict and crash pattern tuples.
- Preserve the generic tuple fallback for future non-standard pattern groups.
- Add regression coverage for empty input, fixed-tuple matching, and fallback behavior.

## Plan or Spec
- Added `docs/plans/2026-06-15-startup-pattern-membership-fastpath.md`.
- Registered probe already covers this path: `startup-signals-lazy-worker-log-excerpts` in `infra/perf/pr_scoped_probes.json`, including focused `test_command`, `coverage_command`, and `probe_command`.

## Commands Run
- `git status --short && git branch --show-current`
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_startup_signals.py::test_contains_any_fast_paths_preserve_empty_value_and_fallback_behavior services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `44 passed`.
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Local registered probe (baseline from pre-change run vs post-change repeated mean from three direct post-change probe runs):
  - `conflict_elapsed_ms_mean`: 0.865100 -> 0.746821 ms (`-0.118279 ms`, `-13.67%`)
  - `control_crash_elapsed_ms_mean`: 9.771592 -> 8.185129 ms (`-1.586463 ms`, `-16.24%`)
  - `direct_control_crash_elapsed_ms_mean`: 0.781208 -> 0.693682 ms (`-0.087526 ms`, `-11.20%`)
  - `empty_hang_elapsed_ms_mean`: 0.835168 -> 0.733803 ms (`-0.101365 ms`, `-12.14%`)
  - `worker_crash_elapsed_ms_mean`: 9.461686 -> 8.327405 ms (`-1.134281 ms`, `-11.99%`)
  - `tail_scan_elapsed_ms_mean`: 161.702940 -> 151.511396 ms (`-10.191544 ms`, `-6.30%`)
- Final uv-run probe sample: `conflict_elapsed_ms_mean=0.816849`, `control_crash_elapsed_ms_mean=9.393218`, `direct_control_crash_elapsed_ms_mean=0.815144`, `empty_hang_elapsed_ms_mean=0.870217`, `worker_crash_elapsed_ms_mean=8.866175`, `tail_scan_elapsed_ms_mean=150.385817`.

## Known Gaps
- Linux-local validation only; no Swift runtime behavior is changed.
- GitHub Actions PR-scoped performance report is still the merge gate.

## Evidence Checklist
- [x] Started from synced `origin/main` in an isolated worktree under `/root/.hermes/profiles/coder/workspace/worktrees/`.
- [x] Verified the affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Added/updated focused tests before relying on the optimization.
- [x] Ran focused tests, changed-scope coverage, and local registered probe.
- [ ] GitHub Actions `ci-pr` is green.
- [ ] GitHub Actions `pr-scoped-performance` registered probe/report is green.
