### PR TITLE
perf: skip tool context scan when current fills capacity

### DIFF
--- a/docs/plans/2026-06-15-tool-registry-current-capacity-skip.md
+++ b/docs/plans/2026-06-15-tool-registry-current-capacity-skip.md
@@ -1,0 +1,33 @@
+# Tool registry current keyword capacity fast path
+
+This Python-only performance slice is limited to agentic tool keyword planning in
+`worker.runtime.tool_registry.select_agentic_tools_for_turn`.
+
+## Scope
+
+- Preserve keyword fallback behavior and selected-tool ordering.
+- Add current-turn keyword matches before scanning recent-turn context.
+- Skip recent-context keyword scanning when the always-available tool plus
+  current-turn keyword matches already fill `max_selected_tools`.
+- Keep vector-selected routing and always-only routing unchanged.
+
+## Registered probe
+
+The affected path is covered by `tool-registry-select-name-index-cache` in
+`infra/perf/pr_scoped_probes.json`. The registered probe includes focused
+`test_command`, `coverage_command`, and `probe_command` entries. This slice also
+extends `scripts/tool_registry_select_probe.py` with a current-capacity sample so
+the PR-scoped performance report records the optimized path directly.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and
+registered probe locally on Linux. GitHub Actions remains the merge gate for the
+PR-scoped performance report after push.
+
+## Expected metrics
+
+`current_capacity_planning_elapsed_ms_mean` should improve because the selector
+no longer allocates or scans recent-context text when the current turn already
+fills the requested tool capacity. Existing selector-planning metrics should stay
+neutral.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4681,6 +4681,17 @@
         "direction": "informational"
       },
       {
+        "key": "current_capacity_planning_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "current_capacity_selected_schema_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      },
+      {
         "key": "always_only_planning_elapsed_ms_mean",
         "unit": "ms",
         "direction": "lower_is_better",

--- a/scripts/tool_registry_select_probe.py
+++ b/scripts/tool_registry_select_probe.py
@@ -40,6 +40,8 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     missing_selection_error_samples: list[float] = []
     selector_planning_elapsed_samples: list[float] = []
     selector_selected_schema_bytes_samples: list[float] = []
+    current_capacity_planning_elapsed_samples: list[float] = []
+    current_capacity_selected_schema_bytes_samples: list[float] = []
     always_only_planning_elapsed_samples: list[float] = []
     always_only_selected_schema_bytes_samples: list[float] = []
     checksum = 0
@@ -130,6 +132,26 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         )
         checksum += selector_schema_bytes
 
+        current_capacity_schema_bytes = 0
+        current_capacity_started = time.perf_counter()
+        for _index in range(selector_iterations):
+            selection_result = select_agentic_tools_for_turn(
+                ToolSelectionInput(
+                    current_user_turn="Search the local text evidence.",
+                    recent_user_turns=("Visit fixture://docs/provider-contract.",),
+                    vector_available=False,
+                    max_selected_tools=2,
+                )
+            )
+            current_capacity_schema_bytes += int(selection_result.receipt["selected_schema_bytes"])
+        current_capacity_planning_elapsed_samples.append(
+            (time.perf_counter() - current_capacity_started) * 1000.0
+        )
+        current_capacity_selected_schema_bytes_samples.append(
+            float(current_capacity_schema_bytes / selector_iterations)
+        )
+        checksum += current_capacity_schema_bytes
+
         always_only_schema_bytes = 0
         always_only_started = time.perf_counter()
         for _index in range(selector_iterations):
@@ -169,6 +191,12 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         "selector_planning_elapsed_ms_mean": statistics.fmean(selector_planning_elapsed_samples),
         "selector_selected_schema_bytes_mean": statistics.fmean(
             selector_selected_schema_bytes_samples
+        ),
+        "current_capacity_planning_elapsed_ms_mean": statistics.fmean(
+            current_capacity_planning_elapsed_samples
+        ),
+        "current_capacity_selected_schema_bytes_mean": statistics.fmean(
+            current_capacity_selected_schema_bytes_samples
         ),
         "always_only_planning_elapsed_ms_mean": statistics.fmean(
             always_only_planning_elapsed_samples

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -769,6 +769,36 @@ def test_agentic_tool_selection_skips_empty_context_keyword_scan(
     assert scanned_texts == ["Open fixture://docs/provider-contract and summarize the page."]
 
 
+def test_agentic_tool_selection_skips_context_scan_when_current_fills_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanned_texts: list[str] = []
+    real_keyword_tool_matches = tool_registry_module._keyword_tool_matches
+
+    def record_keyword_tool_matches(text: str) -> tuple[str, ...]:
+        scanned_texts.append(text)
+        return real_keyword_tool_matches(text)
+
+    monkeypatch.setattr(
+        tool_registry_module,
+        "_keyword_tool_matches",
+        record_keyword_tool_matches,
+    )
+
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Search the local text evidence.",
+            vector_available=False,
+            recent_user_turns=("Visit fixture://docs/provider-contract.",),
+            max_selected_tools=2,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute", "text_search")
+    assert result.receipt["selection_mode"] == "keyword"
+    assert scanned_texts == ["Search the local text evidence."]
+
+
 def test_agentic_tool_selection_reuses_single_recent_context_text(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -513,16 +513,14 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
 
     if selection_mode != "vector":
         current_matches = _keyword_tool_matches(selection_input.current_user_turn)
-        if selection_input.recent_user_turns:
+        for tool_name in current_matches:
+            add_tool(tool_name, "keyword")
+        if selection_input.recent_user_turns and len(selected_names) < max_selected_tools:
             context_matches = _keyword_tool_matches(
                 _recent_user_turns_keyword_context(selection_input.recent_user_turns)
             )
-        else:
-            context_matches = ()
-        for tool_name in current_matches:
-            add_tool(tool_name, "keyword")
-        for tool_name in context_matches:
-            add_tool(tool_name, "keyword_context")
+            for tool_name in context_matches:
+                add_tool(tool_name, "keyword_context")
         if has_keyword_selection:
             selection_mode = "keyword"
             fallback_reason = "vector_unavailable" if not selection_input.vector_available else "vector_no_match"


### PR DESCRIPTION
## Summary
- Skip recent-context keyword scanning when current-turn keyword matches already fill the requested agentic tool capacity.
- Add a regression test proving the selector scans only the current turn in that capacity-filled path.
- Extend the registered tool registry select probe with a current-capacity metric sample.

## Plan or Spec
- Added `docs/plans/2026-06-15-tool-registry-current-capacity-skip.md`.
- Registered probe coverage: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json` already covers `tool_registry.py`, `test_tool_registry.py`, `test_pr_scoped_performance.py`, and `scripts/tool_registry_select_probe.py` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_skips_context_scan_when_current_fills_capacity services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_reuses_single_recent_context_text services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_joins_multiple_recent_context_turns services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_uses_recent_context_for_short_followup services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- Baseline comparison snippet over `origin/main` vs this branch for the current-capacity case.
- Registered focused test command for `tool-registry-select-name-index-cache`.
- Registered coverage command for `tool-registry-select-name-index-cache`.
- Registered probe command equivalent: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused regression tests: 5 passed.
- Registered focused tests: 85 passed.
- Changed-scope coverage: 100% (`TOTAL 26 0 100%`).
- Baseline current-capacity micro probe: old_mean=35.098952 ms, new_mean=33.060907 ms, delta_ms=-2.038045, speedup=1.062x over 8,000 iterations x 5 samples.
- Registered probe local output included `current_capacity_planning_elapsed_ms_mean=34.157312`, `current_capacity_selected_schema_bytes_mean=596.0`, `selector_planning_elapsed_ms_mean=44.037289`, `elapsed_ms_mean=22.718541`.

## Known Gaps
- Local validation is Linux/Python-only; GitHub Actions PR-scoped performance workflow is still required as the registered CI gate.
- The registered probe now includes an additional current-capacity sample, so total checksum values differ from older probe output by design.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Confirmed affected path has registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Added regression coverage before/with the implementation.
- [x] Ran focused local tests, changed-scope coverage, and registered probe locally.
- [ ] PR-scoped performance workflow completed successfully in CI.
- [ ] All required GitHub checks are green before merge.
