### PR TITLE
perf: cache code eval payload byte tokens

### DIFF
--- a/docs/plans/2026-06-15-code-eval-payload-byte-token-ord-cache.md
+++ b/docs/plans/2026-06-15-code-eval-payload-byte-token-ord-cache.md
@@ -1,0 +1,33 @@
+# Code Eval Payload Byte Token Ord Cache
+
+## Scope
+
+Optimize one Python hot path in `worker.engine.code_eval_runner`: the compact
+JSON payload fast path used by `_load_payload_file()` for code evaluation result
+payloads.
+
+## Registered probe
+
+The affected path is already covered by the PR-scoped registered probe
+`code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`. That probe
+provides focused `test_command`, `coverage_command`, and `probe_command` entries
+for:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `scripts/code_eval_payload_json_probe.py`
+
+## Change
+
+Cache the single-byte JSON structural ordinals used by the payload fast path at
+module import time and reuse those constants in object-bound checks, colon checks,
+and string-opening quote checks. This avoids repeated `ord()` calls in helpers
+that run for every payload parsed by the fast path while preserving the existing
+fallback behavior for malformed, escaped, or non-object JSON payloads.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage command, and the
+registered local probe on Linux. Compare the registered probe against an
+`origin/main` baseline worktree using repeated samples before accepting the
+slice.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -23,6 +23,10 @@ _ASCII_SPLITLINE_BOUNDARIES = frozenset("\n\r\v\f\x1c\x1d\x1e")
 _ASCII_NON_LINE_WHITESPACE = frozenset(" \t\x1f")
 _COUNT_TESTS_SPLITLINES_MAX_CHARS = 500_000
 _ORD_ZERO = ord("0")
+_ORD_QUOTE = ord('"')
+_ORD_COLON = ord(":")
+_ORD_OBJECT_START = ord("{")
+_ORD_OBJECT_END = ord("}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -423,19 +427,21 @@ _JSON_PAYLOAD_WHITESPACE = b" \t\r\n"
 
 def _json_object_payload_bounds(payload_bytes: bytes) -> tuple[int, int] | None:
     payload_length = len(payload_bytes)
-    if payload_length >= 2 and payload_bytes[0] == ord("{") and payload_bytes[-1] == ord("}"):
+    object_start = _ORD_OBJECT_START
+    object_end = _ORD_OBJECT_END
+    if payload_length >= 2 and payload_bytes[0] == object_start and payload_bytes[-1] == object_end:
         return 0, payload_length - 1
 
     start = 0
     while start < payload_length and payload_bytes[start] in _JSON_PAYLOAD_WHITESPACE:
         start += 1
-    if start >= payload_length or payload_bytes[start] != ord("{"):
+    if start >= payload_length or payload_bytes[start] != object_start:
         return None
 
     end = payload_length - 1
     while end > start and payload_bytes[end] in _JSON_PAYLOAD_WHITESPACE:
         end -= 1
-    if payload_bytes[end] != ord("}"):
+    if payload_bytes[end] != object_end:
         return None
     return start, end
 
@@ -508,7 +514,8 @@ def _json_field_value_start_for_token(
     whitespace = _JSON_PAYLOAD_WHITESPACE
     while cursor < payload_length and payload_bytes[cursor] in whitespace:
         cursor += 1
-    if cursor >= payload_length or payload_bytes[cursor] != ord(":"):
+    colon = _ORD_COLON
+    if cursor >= payload_length or payload_bytes[cursor] != colon:
         return None
     cursor += 1
     while cursor < payload_length and payload_bytes[cursor] in whitespace:
@@ -529,7 +536,8 @@ def _extract_json_string_field_with_token(payload_bytes: bytes, key_token: bytes
 
 
 def _extract_json_string_field_at(payload_bytes: bytes, start: int | None) -> str | None:
-    if start is None or payload_bytes[start] != ord('"'):
+    quote = _ORD_QUOTE
+    if start is None or payload_bytes[start] != quote:
         return None
     value_start = start + 1
     value_end = payload_bytes.find(b'"', value_start)


### PR DESCRIPTION
## Summary
- Cache JSON structural byte ordinals used by the code-eval payload fast path.
- Reuse those constants in object-bound, colon, and opening-quote checks while preserving malformed JSON fallback behavior.

## Plan or Spec
- `docs/plans/2026-06-15-code-eval-payload-byte-token-ord-cache.md`
- Registered PR-scoped probe: `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_required_field_check_preserves_fast_path_gate services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
9 passed in 1.81s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_required_field_check_preserves_fast_path_gate services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
9 passed in 6.01s

$ python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py
TOTAL 13 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
{"elapsed_ms_mean": 90.9456279394882, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 60425.0, "sample_count": 7.0}
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Local registered probe comparison against `origin/main` baseline worktree, 5 repeated probe runs each:
  - `old_mean=92.868961 ms`
  - `new_mean=91.981143 ms`
  - `delta_ms=-0.887817 ms`
  - `speedup=1.009652x` (`0.956%` improvement)
- Latest local head probe run: `elapsed_ms_mean=90.9456279394882`, `peak_bytes_mean=60425.0`, `payload_bytes=55474.0`.
- CI PR-scoped performance workflow is required for registered probe validation before merge.

## Known Gaps
- Linux local verification only; no Swift/macOS runtime effect is claimed for this Python-only slice.
- The measured local improvement is small and should be treated as accepted only if the registered CI probe stays green/non-regressing.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
