### PR TITLE
perf: fast-path empty Swift CLI metrics

### DIFF
--- a/Sources/MelixCLICore/MelixCLIJSON.swift
+++ b/Sources/MelixCLICore/MelixCLIJSON.swift
@@ -129,6 +129,9 @@ enum MelixCLIJSON {
         adding metricName: String,
         placeholder: MelixCLIJSONMetricPatch.Placeholder
     ) -> [String: Any] {
+        if metrics.isEmpty {
+            return [metricName: placeholder.token]
+        }
         var finalMetrics = [String: Any](minimumCapacity: metrics.count + 1)
         for (key, value) in metrics {
             finalMetrics[key] = value

--- a/docs/plans/2026-06-15-swift-cli-empty-metrics-fastpath.md
+++ b/docs/plans/2026-06-15-swift-cli-empty-metrics-fastpath.md
@@ -1,0 +1,27 @@
+# Swift CLI empty metrics fast path
+
+## Scope
+
+Optimize one Swift CLI JSON envelope path: when an envelope caller supplies no
+pre-existing metrics, construct the injected metrics dictionary directly instead
+of allocating an empty dictionary with reserved capacity and running an empty
+copy loop.
+
+## Registered probe
+
+The affected path is already covered by the PR-scoped registered probe
+`swift-cli-json-envelope-encoding` in `infra/perf/pr_scoped_probes.json`.
+The probe watches `Sources/MelixCLICore/MelixCLIJSON.swift` and has focused
+`test_command`, `coverage_command`, and `probe_command` entries that run on the
+`macos-15` runner.
+
+## Verification boundary
+
+This scheduled slice runs from Linux, where `swift` is not installed, so local
+Swift runtime effects are not validated here. The macOS PR-scoped performance
+workflow is the source of truth for the Swift performance metric.
+
+## Expected behavior
+
+JSON envelope content stays identical. Only the internal construction path for
+empty input metrics changes.


### PR DESCRIPTION
## Summary
- Add a fast path for Swift CLI JSON envelopes when callers provide no pre-existing metrics.
- Keep the JSON envelope shape unchanged while avoiding the empty metrics copy loop.
- Document the Linux/Swift verification boundary for this slice.

## Plan or Spec
- `docs/plans/2026-06-15-swift-cli-empty-metrics-fastpath.md`
- Registered probe: `swift-cli-json-envelope-encoding` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `command -v swift` → `swift not installed on Linux runner`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json /tmp/melix-swift-changed.json --output /tmp/melix-swift-scope.json`
- `git diff --check`

## Coverage and Metrics
- Local Linux: focused PR-scoped registry test passed (`1 passed in 0.85s`).
- Local changed-file probe selection selected `swift-cli-json-envelope-encoding`.
- Swift runtime/test/probe execution requires macOS; CI registered PR-scoped performance is the validation source.
- Expected direction: lower Swift CLI JSON envelope encoding elapsed time for empty metrics inputs.

## Known Gaps
- Linux host does not have `swift`; no local Swift runtime effect is claimed.
- Awaiting macOS CI for the registered `swift-cli-json-envelope-encoding` probe metrics.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe.
- [x] Registered probe has focused test, coverage, and probe commands.
- [x] Local Linux registry/scope verification completed.
- [ ] macOS registered PR-scoped performance probe completed in CI.
- [ ] PR checks green before merge.
