### PR TITLE
perf: fast-path retrieval metadata refusals

### DIFF
--- a/docs/plans/2026-06-16-retrieval-lookup-metadata-refusal-fastpath.md
+++ b/docs/plans/2026-06-16-retrieval-lookup-metadata-refusal-fastpath.md
@@ -1,0 +1,48 @@
+# Retrieval lookup metadata refusal fast path
+
+## Scope
+
+This Python-only performance slice narrows `project_retrieval_lookup_result()` in
+`services/mlx-worker-python/worker/runtime/retrieval_context.py` to one invalid
+lookup-record path. When wrapper lookup metadata is present and the `records`
+field is missing or not an accepted records container, the function already
+returns a lookup-level refusal and ignores the intermediate store-record refusal.
+This slice returns that final refusal directly instead of first invoking
+`project_retrieval_store_records()` and copying its transient empty projection.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `retrieval-context-projection-fastpath` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` fields and watches:
+
+- `services/mlx-worker-python/worker/runtime/retrieval_context.py`
+- `services/mlx-worker-python/tests/test_retrieval_context.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/retrieval_context_projection_probe.py`
+
+No probe registry change is required for this slice.
+
+## Behavior parity
+
+- Preserve valid list and tuple `records` projections.
+- Preserve malformed wrapper metadata refusals before inspecting records.
+- Preserve the existing lookup-level refusal emitted for missing or malformed
+  records when lookup wrapper metadata is present.
+- Add a regression test proving the metadata-refusal path does not call the
+  store-record projector for invalid records.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and the
+registered probe locally on Linux:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_metadata_refusal_skips_store_projection services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_reads_records_once_for_metadata_refusal services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_uses_wrapper_metadata_for_malformed_records services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_preserves_valid_tuple_records_with_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_covers_lookup_wrapper_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_metadata_refusal_skips_store_projection services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_reads_records_once_for_metadata_refusal services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_uses_wrapper_metadata_for_malformed_records services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_preserves_valid_tuple_records_with_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_covers_lookup_wrapper_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
+```
+
+GitHub Actions remains the merge gate for the registered PR-scoped performance
+report.

--- a/services/mlx-worker-python/tests/test_retrieval_context.py
+++ b/services/mlx-worker-python/tests/test_retrieval_context.py
@@ -1435,6 +1435,62 @@ def test_project_retrieval_lookup_result_reads_records_once_for_metadata_refusal
     assert projection.refusal_receipts[0]["source_field"] == "live_rag_records"
 
 
+def test_project_retrieval_lookup_result_preserves_valid_tuple_records_with_metadata() -> None:
+    projection = project_retrieval_lookup_result(
+        {
+            "records": (
+                {
+                    "context_kind": "retrieved_document",
+                    "source_id": "doc:valid-tuple",
+                    "payload": {"title": "Tuple record"},
+                    "owner_scope_checked": True,
+                    "source_field": "retrieved_document_tuple",
+                },
+            )
+        },
+        lookup_source_id="live-rag:tuple",
+        lookup_segment_id="live-rag:tuple:lookup",
+        lookup_source_field="live_rag_tuple_records",
+    )
+
+    assert projection.prompt_user_payload == {
+        "retrieved_document_tuple": {"title": "Tuple record"}
+    }
+    assert projection.lookup_message == {
+        "role": "user",
+        "content": {"retrieved_document_tuple": {"title": "Tuple record"}},
+        "untrusted_context_receipts": projection.untrusted_context_receipts,
+    }
+    assert projection.refusal_receipts == []
+
+
+def test_project_retrieval_lookup_result_metadata_refusal_skips_store_projection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_store_projection(records: object) -> object:
+        raise AssertionError(  # pragma: no cover - failure guard
+            f"metadata refusal should not project invalid records: {records!r}"
+        )
+
+    monkeypatch.setattr(
+        retrieval_context_module,
+        "project_retrieval_store_records",
+        fail_store_projection,
+    )
+
+    projection = project_retrieval_lookup_result(
+        {"records": None},
+        lookup_source_id="live-rag:search-8",
+        lookup_segment_id="live-rag:search-8:lookup",
+        lookup_source_field="live_rag_records",
+    )
+
+    assert projection.prompt_user_payload == {}
+    assert projection.untrusted_context_receipts == []
+    assert projection.lookup_message is None
+    assert projection.refusal_receipts[0]["source_field"] == "live_rag_records"
+
+
 @pytest.mark.parametrize(
     ("kwargs", "expected_field"),
     (

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -352,6 +352,21 @@ def project_retrieval_lookup_result(
     copy_receipts = _copy_receipts
     lookup_records = lookup_result.get("records", _MISSING_LOOKUP_RECORDS)
     has_records = lookup_records is not _MISSING_LOOKUP_RECORDS
+    records_type = type(lookup_records)
+    records_container_is_valid = records_type is list or records_type is tuple
+    if has_lookup_metadata and (not has_records or not records_container_is_valid):
+        return RetrievalLookupResultProjection(
+            prompt_user_payload={},
+            untrusted_context_receipts=[],
+            refusal_receipts=[
+                _lookup_result_refusal(
+                    source_id=normalized_lookup_source_id,
+                    segment_id=normalized_lookup_segment_id,
+                    source_field=normalized_lookup_source_field,
+                )
+            ],
+            lookup_message=None,
+        )
     store_projection = project_store_records(lookup_records if has_records else None)
     prompt_user_payload = copy_payload(store_projection.user_payload)
     untrusted_context_receipts = copy_receipts(store_projection.untrusted_context_receipts)


### PR DESCRIPTION
## Summary
- Fast-path retrieval lookup results that already have wrapper metadata and invalid or missing `records` so they return the final lookup-level refusal without building a transient store-record projection.
- Add regression coverage for the skipped store projection and valid tuple records with metadata.
- Document the slice and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-06-16-retrieval-lookup-metadata-refusal-fastpath.md`
- Registered probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `git fetch origin main && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_metadata_refusal_skips_store_projection services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_reads_records_once_for_metadata_refusal services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_uses_wrapper_metadata_for_malformed_records services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_preserves_valid_tuple_records_with_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_covers_lookup_wrapper_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_metadata_refusal_skips_store_projection services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_reads_records_once_for_metadata_refusal services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_uses_wrapper_metadata_for_malformed_records services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_preserves_valid_tuple_records_with_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_covers_lookup_wrapper_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `9 passed in 0.95s`.
- Changed-scope coverage: `TOTAL 17 0 100%`.
- Local registered probe (Linux): `lookup_records_baseline_elapsed_ms_mean=0.0084690853`, `lookup_records_optimized_elapsed_ms_mean=0.0048587232`, `lookup_records_delta_ms=-0.0036103621`; `lookup_records_baseline_get_calls_mean=2.0`, `lookup_records_optimized_get_calls_mean=1.0`.
- Full probe context: `baseline_elapsed_ms_mean=0.0756637205`, `optimized_elapsed_ms_mean=0.0348490906`, `delta_ms=-0.0408146299`, `speedup=2.1711820669`; `lookup_copy_delta_ms=-0.6139138359`, `store_delta_ms=-0.0122456613`.
- GitHub Actions PR-scoped performance report is required before merge.

## Known Gaps
- Linux local verification covers the Python path only. No Swift runtime effects are changed.
- CI is the merge gate for the registered PR-scoped performance report.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux and showed improvement on the targeted lookup-record metadata-refusal metric.
- [ ] GitHub Actions checks completed successfully.
- [ ] PR-scoped performance report completed successfully with no in-scope regressions.
