### PR TITLE
perf: fast-path dataset version sort keys

### DIFF
--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -496,8 +496,7 @@ def list_dataset_versions(
                 "dataset_version_path": manifest_path,
             }
         )
-    as_str = str
-    versions.sort(key=lambda item: (as_str(item["created_at"]), as_str(item["version_id"])))
+    versions.sort(key=_dataset_version_list_sort_key)
     return {
         "schema_version": DATASET_VERSION_LIST_SCHEMA_VERSION,
         "workspace_manifest_path": manifest_path_string,
@@ -508,6 +507,15 @@ def list_dataset_versions(
             "dataset_version_count": len(versions),
         },
     }
+
+
+def _dataset_version_list_sort_key(item: dict[str, Any]) -> tuple[str, str]:
+    created_at = item["created_at"]
+    version_id = item["version_id"]
+    return (
+        created_at if type(created_at) is str else str(created_at),
+        version_id if type(version_id) is str else str(version_id),
+    )
 
 
 def _iter_dataset_version_manifest_paths(versions_root: Path) -> Iterable[str]:


### PR DESCRIPTION
## Summary
- Fast-path dataset version listing sort keys when `created_at` and `version_id` are already strings.
- Preserves fallback string coercion for non-string metadata values while avoiding two `str()` calls per listed version in the common manifest path.

## Plan or Spec
- Registered probe: `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json` already covers `services/mlx-worker-python/worker/productization/dataset_preparation.py` with focused test, coverage, and probe commands.
- No docs/spec behavior change: ordering semantics remain `(str(created_at), str(version_id))` compatible.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` → 7 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py` → changed-line coverage 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py` → candidate probe JSON emitted
- Paired baseline/candidate probe with detached `origin/main` worktree and this branch.
- `uv run --project services/mlx-worker-python ruff check services/mlx-worker-python/worker/productization/dataset_preparation.py` → All checks passed
- `git diff --check` → passed

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Local registered probe baseline (`origin/main`): `elapsed_ms_mean=44.810098`, `elapsed_ms_min=41.795524`, `elapsed_ms_p95=45.822428`, `version_count=2500`.
- Local registered probe candidate: `elapsed_ms_mean=41.881464`, `elapsed_ms_min=39.735138`, `elapsed_ms_p95=42.230801`, `version_count=2500`.
- Delta: `mean -2.928634 ms` (~6.54% faster), `p95 -3.591627 ms`.
- CI PR-scoped performance workflow is required for merge validation.

## Known Gaps
- Linux local validation only; this slice touches Python code and has no Swift/macOS runtime component.
- Improvement is intentionally small and scoped to the common string metadata path for version-list sorting.

## Evidence Checklist
- [x] Registered PR-scoped probe exists for the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally with baseline/candidate comparison.
- [ ] GitHub Actions and registered PR-scoped performance report passed.
