### PR TITLE
perf: fast-path token byte pending checks

### DIFF
--- a/docs/plans/2026-06-16-stream-assembler-token-byte-pending-fastpath.md
+++ b/docs/plans/2026-06-16-stream-assembler-token-byte-pending-fastpath.md
@@ -1,0 +1,21 @@
+# Stream assembler token-byte pending fast path
+
+This Python performance slice is limited to `RequestStreamAssembler._token_byte_delta` in `services/mlx-worker-python/worker/runtime/stream_assembler.py`.
+
+## Scope
+
+- Preserve token-byte assembly semantics for complete ASCII, complete multibyte, split multibyte, and invalid UTF-8 fragments.
+- Keep the complete-token hot path on direct `bytes.decode()` without constructing the incremental decoder.
+- Avoid the extra `bool()` conversion on every complete token-byte fragment by branching directly on the pending-byte buffer and only materializing the `had_pending` flag on fallback paths.
+- Use the existing `stream-assembler-token-byte-fast-decode` registered PR-scoped probe as the local and CI performance gate.
+
+## Verification plan
+
+- Focused pytest for token-byte fast decode and fallback behavior.
+- Changed-scope coverage through the registered probe `coverage_command`.
+- Registered PR-scoped performance probe command for `stream-assembler-token-byte-fast-decode`.
+- Local before/after probe comparison on Linux; CI remains the repository merge gate for the registered probe report.
+
+## Metrics
+
+Expected local effect is lower CPU time for complete token-byte streams in the registered probe while preserving generated token counts and byte-fallback metrics.

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -616,12 +616,13 @@ class RequestStreamAssembler:
     def _token_byte_delta(self, token_bytes: bytes | None) -> str | None:
         if token_bytes is None:
             return None
-        had_pending = bool(self._pending_token_bytes)
-        if not had_pending:
+        if not self._pending_token_bytes:
             try:
                 return token_bytes.decode()
             except UnicodeDecodeError:
-                pass
+                had_pending = False
+        else:
+            had_pending = True
         self._pending_token_bytes += token_bytes
         decoder = _UTF8_INCREMENTAL_DECODER()
         try:


### PR DESCRIPTION
## Summary
- Fast-path `RequestStreamAssembler._token_byte_delta` by branching directly on the pending byte buffer for complete token-byte fragments.
- Preserve fallback behavior for split or invalid UTF-8 while avoiding the extra `bool()` conversion on the complete-token hot path.
- Add a focused plan for this token-byte pending-check performance slice.

## Plan or Spec
- `docs/plans/2026-06-16-stream-assembler-token-byte-pending-fastpath.md`
- Registered PR-scoped probe: `stream-assembler-token-byte-fast-decode` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline after syncing origin/main
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_token_bytes_probe.py
exit 0; elapsed_ms_mean=759.9772588349879

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_plain_token_metadata_keeps_fast_path_and_metrics services/mlx-worker-python/tests/test_stream_assembler.py::test_estimated_delta_token_count_matches_split_semantics_without_ascii_allocation services/mlx-worker-python/tests/test_stream_assembler.py::test_delta_token_annotation_uses_ascii_count_fast_path services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_ascii_without_incremental_decoder services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_multibyte_without_incremental_decoder services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_preserves_split_multibyte_sequence services/mlx-worker-python/tests/test_stream_assembler.py::test_standard_qwen_pipe_tool_parser_keeps_rescue_parser_off services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics
exit 0; 11 passed in 0.26s

# Changed-scope coverage through the registered probe command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics
exit 0; 90 passed in 0.90s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
exit 0
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_token_bytes_probe.py
exit 0; TOTAL 3 0 100%

# Registered probe on head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_token_bytes_probe.py
exit 0; elapsed_ms_mean=755.5790243670344, generated_token_count_mean=80000.0, peak_bytes_mean=6128411.2

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Registered local probe: `stream_assembler_token_bytes_probe.py`.
- Baseline single run: `elapsed_ms_mean=759.9772588349879` ms.
- Same-session old-code comparison after resetting the file to `origin/main`: `elapsed_ms_mean` samples `791.344123147428`, `760.5767139233649`, `797.4201413802803`; mean `783.1136594836911` ms.
- Head comparison samples before final verification: `758.4408266469836`, `751.0201540775597`, `766.1344678141177`; mean `758.5318161795537` ms.
- Mean delta vs same-session old-code comparison: `-24.5818433041374` ms (`~3.14%` faster).
- Final head registered probe run: `elapsed_ms_mean=755.5790243670344`, `generated_token_count_mean=80000.0`, `peak_bytes_mean=6128411.2`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this Python slice was verified with focused tests, changed-scope coverage, and the registered probe on Linux.
- Local Linux validation covers the Python runtime path only; GitHub Actions remains the merge gate for the registered PR-scoped performance workflow.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
