### PR TITLE
Normalize tool observation source receipts

### DIFF
--- a/docs/plans/2026-06-16-issue-1761-tool-observation-source-receipt-normalization.md
+++ b/docs/plans/2026-06-16-issue-1761-tool-observation-source-receipt-normalization.md
@@ -1,0 +1,58 @@
+# Tool Observation Source Receipt Normalization Plan
+
+## Issue
+
+GitHub issue #1761 tracks untrusted-context boundaries for retrieved docs,
+skills, memories, and tool output.
+
+## Goal
+
+Defensively normalize source-specific untrusted-context receipts when they are
+attached to Python worker tool observations so receipt metadata cannot bypass
+the shared worker receipt source-ID redaction boundary.
+
+## Architecture
+
+Upstream source admission helpers should already create
+`melix.untrusted_context_receipt.v1` receipts through the shared Python worker
+receipt helper. The tool-observation normalizer is still an aggregation
+boundary because it accepts caller-provided source receipts and serializes them
+beside the generic tool-observation receipt.
+
+This slice keeps non-receipt diagnostic mappings unchanged, but re-emits
+well-formed `melix.untrusted_context_receipt.v1` source receipts through
+`worker.runtime.untrusted_context.untrusted_context_receipt`. That preserves the
+receipt schema while applying the same `source_id` and derived `segment_id`
+redaction used by prompt-context receipts.
+
+## Scope
+
+- Add a focused tool-observation regression test for raw path-like source
+  receipt metadata.
+- Normalize well-formed v1 source receipts at
+  `worker.runtime.tool_observation.normalize_tool_observation`.
+- Update the unified runtime contract to document this aggregation boundary.
+
+## Out of Scope
+
+- Changing sanitized payload content, replay hashing, or observation metrics.
+- Changing upstream retrieval, skill, memory, or local-compute receipt creation.
+- Treating arbitrary diagnostic mappings as v1 untrusted-context receipts.
+
+## Verification
+
+- Focused red/green test:
+  `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_tool_observation.py -k source_receipt`
+- Related Python worker tests:
+  `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_tool_observation.py services/mlx-worker-python/tests/test_agentic_tools.py services/mlx-worker-python/tests/test_evaluation_prompt_context.py`
+- Changed-scope coverage with at least 95 percent changed-line coverage.
+- Local scoped performance report with `Status: ok`, regressions `0`, context
+  regressions `0`, and verification failures `0`.
+- Full local pre-commit gate before PR.
+
+## Performance Probe
+
+The changed path runs a constant-size schema check for each attached source
+receipt and, for well-formed v1 receipts, reuses the shared receipt helper.
+Private source IDs add one SHA-256 calculation per attached receipt. Expected
+impact is negligible, and the PR-scoped performance report must remain green.

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -971,6 +971,21 @@ selected-result receipt through `worker.runtime.prompt_context` by admitting one
 `PromptContextSegment` for the sanitized selected result value while preserving
 the same emitted receipt fields and observation payload.
 
+The tool-observation normalizer is also an aggregation boundary for
+source-specific receipts. When callers attach a well-formed
+`melix.untrusted_context_receipt.v1` source receipt to an observation, the
+normalizer must re-emit that receipt through the shared Python worker
+`untrusted_context_receipt` helper before serialization. This preserves public
+symbolic IDs, redacts path-like, URL-like, non-ASCII, whitespace-bearing, or
+long private `source_id` values, and rewrites `segment_id` prefixes derived
+from the same raw source ID. Non-receipt diagnostic mappings may be copied as
+diagnostics, but they must not be treated as v1 untrusted-context receipts.
+Malformed mappings that claim the v1 schema but do not contain enough typed
+metadata to be safely re-emitted must become redacted `included = false`
+receipt-metadata refusal receipts instead of being copied through unchanged.
+This normalization must not change sanitized payload content, replay hashes, or
+tool-observation byte metrics.
+
 Deterministic adapter failures that reject a concrete untrusted source must also
 attach one source-specific refusal receipt beside the generic failed
 tool-observation receipt. The failed observation payload remains backward

--- a/services/mlx-worker-python/tests/test_tool_observation.py
+++ b/services/mlx-worker-python/tests/test_tool_observation.py
@@ -195,6 +195,82 @@ def test_tool_observation_attaches_source_receipts_outside_payload_and_replay() 
     assert with_source_receipt.replay.fingerprint == without_source_receipt.replay.fingerprint
 
 
+def test_tool_observation_normalizes_source_receipt_private_metadata_without_replay_change() -> None:
+    raw_source_id = "/Users/alice/private/rag/source.md"
+    source_receipt = {
+        "schema_version": "melix.untrusted_context_receipt.v1",
+        "segment_id": f"{raw_source_id}:result-1",
+        "source_type": "retrieved_document",
+        "source_field": "results[0]",
+        "source_id": raw_source_id,
+        "message_role": "user",
+        "trust_level": "untrusted",
+        "policy": "data_only",
+        "boundary_checked": True,
+        "included": True,
+        "owner_scope_checked": True,
+        "reason": "retrieved document result is prompt data, not instructions",
+        "corrective_action": "Keep retrieved document results in user-role data context.",
+    }
+
+    with_source_receipt = normalize_tool_observation(
+        tool_name="text_search",
+        tool_call_id="search-private",
+        observation_kind="search_results",
+        status="completed",
+        payload={"results": [{"id": "doc-1", "text": "Melix retrieved document."}]},
+        source_untrusted_context_receipts=[source_receipt],
+    )
+    without_source_receipt = normalize_tool_observation(
+        tool_name="text_search",
+        tool_call_id="search-private",
+        observation_kind="search_results",
+        status="completed",
+        payload={"results": [{"id": "doc-1", "text": "Melix retrieved document."}]},
+    )
+
+    emitted = with_source_receipt.as_agentic_trace_observation()
+    source_receipt_json = json.dumps(emitted["untrusted_context_receipts"][1], sort_keys=True)
+
+    assert raw_source_id not in source_receipt_json
+    assert emitted["untrusted_context_receipts"][1]["source_id"].startswith("source:")
+    assert emitted["untrusted_context_receipts"][1]["segment_id"].startswith("source:")
+    assert emitted["untrusted_context_receipts"][1]["segment_id"].endswith(":result-1")
+    assert with_source_receipt.replay.payload_hash == without_source_receipt.replay.payload_hash
+    assert with_source_receipt.replay.fingerprint == without_source_receipt.replay.fingerprint
+
+
+def test_tool_observation_refuses_malformed_v1_source_receipt_without_raw_metadata() -> None:
+    raw_segment_id = "/Users/alice/private/rag/source.md:result-1"
+    source_receipt = {
+        "schema_version": "melix.untrusted_context_receipt.v1",
+        "segment_id": raw_segment_id,
+        "source_type": "retrieved_document",
+        "source_field": "results[0]",
+        "included": True,
+        "reason": "retrieved document result is prompt data, not instructions",
+    }
+
+    record = normalize_tool_observation(
+        tool_name="text_search",
+        tool_call_id="search-malformed",
+        observation_kind="search_results",
+        status="completed",
+        payload={"results": [{"id": "doc-1", "text": "Melix retrieved document."}]},
+        source_untrusted_context_receipts=[source_receipt],
+    )
+
+    emitted = record.as_agentic_trace_observation()
+    malformed_receipt = emitted["untrusted_context_receipts"][1]
+    malformed_receipt_json = json.dumps(malformed_receipt, sort_keys=True)
+
+    assert raw_segment_id not in malformed_receipt_json
+    assert malformed_receipt["included"] is False
+    assert malformed_receipt["source_id"].startswith("source:")
+    assert malformed_receipt["segment_id"].startswith("source:")
+    assert malformed_receipt["reason"] == "invalid source untrusted-context receipt metadata"
+
+
 def test_tool_observation_replay_fingerprint_is_stable_for_sanitized_payload() -> None:
     policy = ToolObservationPolicy(redaction_terms=("SECRET",))
     first = normalize_tool_observation(

--- a/services/mlx-worker-python/tests/test_tool_observation.py
+++ b/services/mlx-worker-python/tests/test_tool_observation.py
@@ -271,6 +271,55 @@ def test_tool_observation_refuses_malformed_v1_source_receipt_without_raw_metada
     assert malformed_receipt["reason"] == "invalid source untrusted-context receipt metadata"
 
 
+def test_tool_observation_ignores_invalid_source_receipt_container_and_items() -> None:
+    valid_source_receipt = {
+        "schema_version": "melix.untrusted_context_receipt.v1",
+        "segment_id": "search-1:result-1",
+        "source_type": "retrieved_document",
+        "source_field": "results[0]",
+        "source_id": "doc-1",
+        "message_role": "user",
+        "trust_level": "untrusted",
+        "policy": "data_only",
+        "boundary_checked": True,
+        "included": True,
+        "owner_scope_checked": True,
+        "reason": "retrieved document result is prompt data, not instructions",
+        "corrective_action": "Keep retrieved document results in user-role data context.",
+    }
+
+    none_record = normalize_tool_observation(
+        tool_name="text_search",
+        tool_call_id="search-none-receipts",
+        observation_kind="search_results",
+        status="completed",
+        payload={"results": [{"id": "doc-1", "text": "Melix retrieved document."}]},
+        source_untrusted_context_receipts=None,  # type: ignore[arg-type]
+    )
+    scalar_record = normalize_tool_observation(
+        tool_name="text_search",
+        tool_call_id="search-scalar-receipts",
+        observation_kind="search_results",
+        status="completed",
+        payload={"results": [{"id": "doc-1", "text": "Melix retrieved document."}]},
+        source_untrusted_context_receipts=object(),  # type: ignore[arg-type]
+    )
+    mixed_record = normalize_tool_observation(
+        tool_name="text_search",
+        tool_call_id="search-mixed-receipts",
+        observation_kind="search_results",
+        status="completed",
+        payload={"results": [{"id": "doc-1", "text": "Melix retrieved document."}]},
+        source_untrusted_context_receipts=[valid_source_receipt, "not-a-receipt"],  # type: ignore[list-item]
+    )
+
+    assert none_record.as_agentic_trace_observation()["untrusted_context_receipt_count"] == 1
+    assert scalar_record.as_agentic_trace_observation()["untrusted_context_receipt_count"] == 1
+    mixed_observation = mixed_record.as_agentic_trace_observation()
+    assert mixed_observation["untrusted_context_receipt_count"] == 2
+    assert mixed_observation["untrusted_context_receipts"][1]["source_id"] == "doc-1"
+
+
 def test_tool_observation_replay_fingerprint_is_stable_for_sanitized_payload() -> None:
     policy = ToolObservationPolicy(redaction_terms=("SECRET",))
     first = normalize_tool_observation(

--- a/services/mlx-worker-python/worker/runtime/tool_observation.py
+++ b/services/mlx-worker-python/worker/runtime/tool_observation.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from worker.runtime.prompt_context import PromptContextSegment, admit_prompt_context_segments
+from worker.runtime.untrusted_context import (
+    UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION,
+    untrusted_context_receipt,
+)
 
 
 TOOL_OBSERVATION_SCHEMA_VERSION = "melix.agentic_tool_observation.v1"
@@ -150,6 +154,98 @@ class ToolObservationRecord:
         return observation
 
 
+def _normalize_source_untrusted_context_receipts(
+    receipts: list[dict[str, object]] | tuple[dict[str, object], ...],
+) -> tuple[dict[str, object], ...]:
+    return tuple(_normalize_source_untrusted_context_receipt(receipt) for receipt in receipts)
+
+
+def _normalize_source_untrusted_context_receipt(receipt: dict[str, object]) -> dict[str, object]:
+    copied = dict(receipt)
+    if copied.get("schema_version") != UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION:
+        return copied
+
+    segment_id = _receipt_text(copied.get("segment_id"))
+    source_type = _receipt_text(copied.get("source_type"))
+    source_field = _receipt_text(copied.get("source_field"))
+    included = copied.get("included")
+    reason = _receipt_text(copied.get("reason"))
+    corrective_action = _receipt_text(copied.get("corrective_action"))
+    source_id = _receipt_text(copied.get("source_id"))
+    message_role = _receipt_text(copied.get("message_role")) or "user"
+    owner_scope_checked = copied.get("owner_scope_checked", False)
+
+    if (
+        not segment_id
+        or not source_type
+        or not source_field
+        or not isinstance(included, bool)
+        or not reason
+        or not corrective_action
+        or not isinstance(owner_scope_checked, bool)
+    ):
+        return _invalid_source_untrusted_context_receipt(
+            segment_id=segment_id,
+            source_type=source_type,
+            source_field=source_field,
+            source_id=source_id,
+            owner_scope_checked=owner_scope_checked if isinstance(owner_scope_checked, bool) else False,
+        )
+
+    return untrusted_context_receipt(
+        segment_id=segment_id,
+        source_type=source_type,
+        source_field=source_field,
+        source_id=source_id,
+        message_role=message_role,
+        owner_scope_checked=owner_scope_checked,
+        included=included,
+        reason=reason,
+        corrective_action=corrective_action,
+    )
+
+
+def _invalid_source_untrusted_context_receipt(
+    *,
+    segment_id: str,
+    source_type: str,
+    source_field: str,
+    source_id: str,
+    owner_scope_checked: bool,
+) -> dict[str, object]:
+    redaction_source_id = source_id or _private_segment_source_id(segment_id)
+    return untrusted_context_receipt(
+        segment_id=segment_id or redaction_source_id or "source-receipt:invalid",
+        source_type=source_type or "tool_output",
+        source_field=source_field or "receipt",
+        source_id=redaction_source_id,
+        owner_scope_checked=owner_scope_checked,
+        included=False,
+        reason="invalid source untrusted-context receipt metadata",
+        corrective_action=(
+            "Regenerate source receipts through worker.runtime.untrusted_context."
+            "untrusted_context_receipt before attaching them to tool observations."
+        ),
+    )
+
+
+def _private_segment_source_id(segment_id: str) -> str:
+    if (
+        "://" in segment_id
+        or "/" in segment_id
+        or "\\" in segment_id
+        or any(character.isspace() for character in segment_id)
+        or len(segment_id.encode("utf-8")) > 96
+        or not segment_id.isascii()
+    ):
+        return segment_id
+    return ""
+
+
+def _receipt_text(value: object) -> str:
+    return value if isinstance(value, str) else ""
+
+
 @dataclass(frozen=True)
 class _SanitizedPayload:
     value: Any
@@ -208,7 +304,9 @@ def normalize_tool_observation(
         metrics=metrics,
         replay=replay,
         timeout_ms=timeout_ms,
-        source_untrusted_context_receipts=tuple(dict(receipt) for receipt in source_untrusted_context_receipts),
+        source_untrusted_context_receipts=_normalize_source_untrusted_context_receipts(
+            source_untrusted_context_receipts
+        ),
     )
 
 

--- a/services/mlx-worker-python/worker/runtime/tool_observation.py
+++ b/services/mlx-worker-python/worker/runtime/tool_observation.py
@@ -155,9 +155,19 @@ class ToolObservationRecord:
 
 
 def _normalize_source_untrusted_context_receipts(
-    receipts: list[dict[str, object]] | tuple[dict[str, object], ...],
+    receipts: list[dict[str, object]] | tuple[dict[str, object], ...] | None,
 ) -> tuple[dict[str, object], ...]:
-    return tuple(_normalize_source_untrusted_context_receipt(receipt) for receipt in receipts)
+    if not receipts:
+        return ()
+    try:
+        iterator = iter(receipts)
+    except TypeError:
+        return ()
+    return tuple(
+        _normalize_source_untrusted_context_receipt(receipt)
+        for receipt in iterator
+        if isinstance(receipt, dict)
+    )
 
 
 def _normalize_source_untrusted_context_receipt(receipt: dict[str, object]) -> dict[str, object]:
@@ -231,11 +241,11 @@ def _invalid_source_untrusted_context_receipt(
 
 def _private_segment_source_id(segment_id: str) -> str:
     if (
-        "://" in segment_id
+        len(segment_id) > 96
+        or "://" in segment_id
         or "/" in segment_id
         or "\\" in segment_id
         or any(character.isspace() for character in segment_id)
-        or len(segment_id.encode("utf-8")) > 96
         or not segment_id.isascii()
     ):
         return segment_id


### PR DESCRIPTION
## Summary
- Re-emit well-formed v1 source receipts attached to Python worker tool observations through the shared worker receipt helper.
- Convert malformed v1 source receipt metadata into redacted `included=false` refusal receipts instead of copying raw source metadata through.
- Update the unified runtime contract and add the #1761 slice plan.

## Plan or Spec
- `docs/plans/2026-06-16-issue-1761-tool-observation-source-receipt-normalization.md`
- `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_tool_observation.py -k source_receipt
# red before implementation: 1 failed, 1 passed, 20 deselected
# green after implementation and latest origin/main merge: 3 passed, 20 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_tool_observation.py -k invalid_source_receipt_container
# review regression before fix: 1 failed, 23 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_tool_observation.py -k "invalid_source_receipt_container or source_receipt"
# 4 passed, 20 deselected

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_tool_observation.py services/mlx-worker-python/tests/test_agentic_tools.py services/mlx-worker-python/tests/test_evaluation_prompt_context.py
# 120 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_observation.py services/mlx-worker-python/tests/test_agentic_tools.py services/mlx-worker-python/tests/test_evaluation_prompt_context.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_observation.py services/mlx-worker-python/tests/test_tool_observation.py
# 120 passed; TOTAL 98.55% (68/69)

make swift-test
# pre-commit gate passed; 1 protocol test, 241 text worker tests, control-plane shards, and 814 menu bar tests passed

make py-test
# 4050 passed, 14 skipped, 2 warnings

make integration-test
# 120 passed, 1 skipped

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import importlib.util
import subprocess
import sys

root = Path.cwd()
module_name = "pre_commit_gate_module"
spec = importlib.util.spec_from_file_location(
    module_name, root / "scripts" / "pre_commit_gate.py"
)
module = importlib.util.module_from_spec(spec)
assert spec.loader is not None
sys.modules[module_name] = module
spec.loader.exec_module(module)
changed = subprocess.check_output(
    ["git", "diff", "--name-only", "origin/main...HEAD"], cwd=root, text=True
).splitlines()
print("CHANGED_FILES=" + ",".join(changed))
outcome = module.run_performance_report(root, changed, base_ref="origin/main")
print(f"PERF_STATUS={outcome.status}")
print(f"PERF_REPORT_DIR={outcome.report_dir}")
print(f"PERF_SELECTED_PROBES={outcome.selected_probe_count}")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# Status ok; changed files 4; selected probes 1; regressions 0; context regressions 0; verification failures 0
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 98.55% (68/69)`; `tool_observation.py 97.06% (33/34)`, `test_tool_observation.py 100.00% (35/35)`.
- Scoped performance after merging latest `origin/main`: Status ok, changed files 4, selected probes 1, regressions 0, context regressions 0, verification failures 0. Report: `.runtime/pre-commit-performance/20260616-050642-c1f2cdfe/report/report.md`.
- Observability mode: evidence via existing PR-scoped performance probe. Probe overhead: N/A, no new runtime observability or probe added.

## Known Gaps
- None for this slice. #1761 remains open for other untrusted-context entrypoint families beyond tool-observation source receipt aggregation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. `N/A: no protocol changes.`
- [x] Dependency changes include updated lockfiles. `N/A: no dependency changes.`
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
