### PR TITLE
perf: fast-path retrieval receipt copies

### DIFF
--- a/docs/plans/2026-06-16-retrieval-lookup-receipt-copy.md
+++ b/docs/plans/2026-06-16-retrieval-lookup-receipt-copy.md
@@ -1,0 +1,33 @@
+# Retrieval lookup receipt-copy fast path
+
+## Goal
+
+Reduce receipt-copy overhead in `worker.runtime.retrieval_context.project_retrieval_lookup_result()` without changing payload or receipt isolation semantics.
+
+## Scope
+
+This Python-only performance slice is limited to:
+
+- `services/mlx-worker-python/worker/runtime/retrieval_context.py`
+- focused retrieval-context tests covered by the registered probe
+
+No retrieval admission, duplicate-field handling, payload deep-copy behavior, or refusal policy changes are included.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.
+
+The probe already includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/retrieval_context.py`
+- `services/mlx-worker-python/tests/test_retrieval_context.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/retrieval_context_projection_probe.py`
+
+## Optimization slice
+
+`_copy_receipts()` now copies flat receipt dictionaries with `receipt.copy()` instead of the generic `dict(receipt)` constructor. Receipt dictionaries remain shallow-copied, so callers still receive isolated receipt objects while avoiding extra constructor dispatch in the lookup-result copy path.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and registered probe command locally on Linux before opening the PR. GitHub Actions PR-scoped performance remains the final registered probe validation and merge gate.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -427,7 +427,7 @@ def _copy_payload_value(value: Any) -> Any:
 
 def _copy_receipts(receipts: list[dict[str, object]]) -> list[dict[str, object]]:
     # Receipt schemas are flat JSON metadata; payload-bearing values are never copied here.
-    return [dict(receipt) for receipt in receipts]
+    return [receipt.copy() for receipt in receipts]
 
 
 def _admit_entry(entry: RetrievalContextEntry) -> PromptContextAdmission:


### PR DESCRIPTION
## Summary
- Fast-path retrieval lookup receipt copies by using `dict.copy()` on flat receipt dictionaries instead of the generic `dict(receipt)` constructor.
- Add a small plan note documenting the Python-only slice and registered probe coverage.

## Plan or Spec
- `docs/plans/2026-06-16-retrieval-lookup-receipt-copy.md`
- Registered probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_isolates_refusals_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_malformed_entry_objects_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_preserves_multi_field_admission_duplicate_scan services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_copies_multi_receipt_admissions services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_projects_records_without_entry_reentry services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_copies_store_projection_outputs services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_uses_wrapper_metadata_for_refusals services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_uses_wrapper_metadata_for_malformed_records services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_reads_records_once_for_metadata_refusal services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_refuses_malformed_wrapper_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_covers_lookup_wrapper_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` → 20 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py` → TOTAL 1 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`retrieval_context.py` changed line 430 covered).
- Registered local probe output after change: `lookup_copy_optimized_elapsed_ms_mean=0.210713`, `lookup_copy_speedup=4.027872`, `optimized_elapsed_ms_mean=0.034163`, `speedup=2.280123`, `store_optimized_elapsed_ms_mean=0.204814`, `store_speedup=1.060671`.
- Same registered probe on synced `origin/main` sampled locally showed `lookup_copy_optimized_elapsed_ms_mean` in the `0.212254`–`0.223725` ms range; this branch sampled `0.209391`–`0.213026` ms in the same run window.

## Known Gaps
- Linux local validation covers the Python retrieval hot path only.
- GitHub Actions PR-scoped performance is still required as the final registered probe validation and merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused local tests passed on Linux.
- [x] Changed-scope coverage passed on Linux.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
