### PR TITLE
perf: speed retrieval lookup scalar copies

### DIFF
--- a/docs/plans/2026-06-16-retrieval-copy-scalar-set.md
+++ b/docs/plans/2026-06-16-retrieval-copy-scalar-set.md
@@ -1,0 +1,42 @@
+# Retrieval lookup copy scalar-type membership slice
+
+## Scope
+
+This Python-only performance slice is limited to the JSON scalar fast path in
+`worker.runtime.retrieval_context._copy_payload_value()`.
+
+The helper recursively copies retrieval lookup payloads before exposing prompt
+projection output. The common payload path contains many JSON scalar leaves
+(`str`, `int`, `float`, and `bool`), and the previous implementation tested each
+scalar type through a chain of identity comparisons on every recursive leaf.
+
+## Registered probe coverage
+
+The affected path is covered by the registered PR-scoped probe
+`retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.
+That probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries, and reports the lookup-copy metrics
+`lookup_copy_optimized_elapsed_ms_mean`, `lookup_copy_delta_ms`, and
+`lookup_copy_speedup`.
+
+## Implementation plan
+
+1. Preserve behavior for copied payload isolation, including nested dict/list/
+   tuple containers and fallback `deepcopy` for non-JSON objects.
+2. Replace the repeated scalar identity comparison chain with a module-level
+   exact-type membership set for JSON scalar types.
+3. Run the focused retrieval-context tests and registered probe coverage command
+   locally on Linux.
+4. Run the registered retrieval-context projection probe locally on Linux and use
+   GitHub Actions PR-scoped performance as the final merge gate.
+
+## Verification
+
+Local Linux verification must include:
+
+- focused retrieval-context pytest coverage from the registered probe scope;
+- changed-scope coverage for `worker.runtime.retrieval_context` at or above 95%;
+- the registered `retrieval-context-projection-fastpath` probe command.
+
+The slice does not touch Swift runtime code; Swift/macOS runtime effects are not
+claimed locally.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -17,6 +17,7 @@ from worker.runtime.untrusted_context import untrusted_context_receipt
 RetrievalContextKind = Literal["retrieved_document", "retrieved_image"]
 
 _MISSING_LOOKUP_RECORDS = object()
+_JSON_SCALAR_TYPES = {str, int, float, bool}
 
 
 class RetrievalContextAdmissionError(ValueError):
@@ -460,7 +461,7 @@ def _copy_payload_value(value: Any) -> Any:
     if value is None:
         return value
     value_type = type(value)
-    if value_type is str or value_type is int or value_type is float or value_type is bool:
+    if value_type in _JSON_SCALAR_TYPES:
         return value
     copy_value = _copy_payload_value
     if value_type is dict:


### PR DESCRIPTION
## Summary
- Speed up retrieval lookup payload copying by replacing repeated exact scalar type comparisons with a module-level exact-type membership set.
- Keep recursive copy behavior unchanged for nested dict/list/tuple containers and fallback deepcopy handling.
- Add the governing plan for this Python performance slice.

## Plan or Spec
- `docs/plans/2026-06-16-retrieval-copy-scalar-set.md`
- Registered probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.retrieval_context -m pytest -q services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report --include='services/mlx-worker-python/worker/runtime/retrieval_context.py'`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" MELIX_RETRIEVAL_CONTEXT_PROJECTION_SAMPLES=7 MELIX_RETRIEVAL_CONTEXT_PROJECTION_ITERATIONS=400 uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 45 passed.
- Changed-scope coverage: `services/mlx-worker-python/worker/runtime/retrieval_context.py` 99% (309 statements, 2 missed).
- Local Linux registered probe on `origin/main`: `lookup_copy_optimized_elapsed_ms_mean=0.21391839570631938`, `lookup_copy_speedup=3.899162425888823`.
- Local Linux registered probe on this branch: `lookup_copy_optimized_elapsed_ms_mean=0.20796639113021748`, `lookup_copy_speedup=4.129649926345653`.
- Local head-vs-main lookup-copy delta: `-0.0059520045761019 ms` per iteration (~2.78% lower).
- Registered PR-scoped performance in GitHub Actions is required for final validation before merge.

## Known Gaps
- This is a Python-only Linux-verified slice; no Swift/macOS runtime effect is claimed locally.
- Local probe numbers are microbenchmark evidence; CI registered probe report remains the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux.
- [x] GitHub Actions PR-scoped performance completed successfully.
- [x] PR checks are green before merge.
