### PR TITLE
perf: speed gemma profile gate evidence copies

### DIFF
--- a/docs/plans/2026-06-02-issue-1663-gemma-e4b-profile-gate.md
+++ b/docs/plans/2026-06-02-issue-1663-gemma-e4b-profile-gate.md
@@ -115,6 +115,9 @@ The persisted gate input is JSON with schema
 - The PR-scoped probe emits numeric gate metrics and fails on regressions in
   gate behavior. It also reports `elapsed_ms_mean` over repeated deterministic
   evaluations so evaluation-copy changes have a registered timing signal.
+- Returned evidence sections use a JSON-shaped copy fast path while preserving
+  caller/result isolation for selected profile, unsupported routes, and
+  benchmark payloads.
 
 ## Verification
 

--- a/services/mlx-worker-python/tests/test_gemma_e4b_profile_gate.py
+++ b/services/mlx-worker-python/tests/test_gemma_e4b_profile_gate.py
@@ -41,6 +41,20 @@ def test_gemma_e4b_profile_gate_preserves_input_and_returned_section_isolation()
     assert evidence["benchmark"]["threshold_status"]["status"] == "ok"
 
 
+def test_gemma_e4b_profile_gate_copy_fallback_preserves_non_json_values() -> None:
+    class CopyTracked:
+        pass
+
+    evidence = default_passing_evidence()
+    marker = CopyTracked()
+    evidence["selected_profile"]["copy_marker"] = marker
+
+    report = evaluate_gemma_e4b_profile_gate_evidence(evidence)
+
+    assert isinstance(report["selected_profile"]["copy_marker"], CopyTracked)
+    assert report["selected_profile"]["copy_marker"] is not marker
+
+
 def test_gemma_e4b_profile_gate_fails_when_profile_receipt_is_unverified() -> None:
     evidence = default_passing_evidence()
     evidence["selected_profile"]["profile_receipt"] = {

--- a/services/mlx-worker-python/worker/productization/gemma_e4b_profile_gate.py
+++ b/services/mlx-worker-python/worker/productization/gemma_e4b_profile_gate.py
@@ -137,9 +137,9 @@ def evaluate_gemma_e4b_profile_gate_evidence(evidence: dict[str, Any]) -> dict[s
         "status": "passed" if not failures else "failed",
         "artifact_status": str(evidence.get("artifact_status") or "present"),
         "model_id": str(evidence.get("model_id") or ""),
-        "selected_profile": copy.deepcopy(_as_dict(evidence.get("selected_profile"))),
-        "unsupported_routes": copy.deepcopy(_as_list(evidence.get("unsupported_routes"))),
-        "benchmark": copy.deepcopy(_as_dict(evidence.get("benchmark"))),
+        "selected_profile": _copy_json_like(_as_dict(evidence.get("selected_profile"))),
+        "unsupported_routes": _copy_json_like(_as_list(evidence.get("unsupported_routes"))),
+        "benchmark": _copy_json_like(_as_dict(evidence.get("benchmark"))),
         "metrics": metrics,
         "failures": failures,
     }
@@ -350,6 +350,16 @@ def _as_dict(value: Any) -> dict[str, Any]:
 
 def _as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
+
+
+def _copy_json_like(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _copy_json_like(child) for key, child in value.items()}
+    if isinstance(value, list):
+        return [_copy_json_like(child) for child in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return copy.deepcopy(value)
 
 
 def _text(value: Any) -> str:


### PR DESCRIPTION
## Summary
- Replace `copy.deepcopy` for Gemma E4B gate JSON-shaped returned evidence sections with a small recursive JSON-like copy fast path.
- Keep `copy.deepcopy` as a fallback for non-JSON values and add coverage for that fallback.
- Update the governing Gemma E4B profile gate plan to record the evidence-copy fast path.

## Plan or Spec
- Updated `docs/plans/2026-06-02-issue-1663-gemma-e4b-profile-gate.md` to document the JSON-shaped returned-section copy fast path and isolation requirement.
- Registered probe coverage already exists for `services/mlx-worker-python/worker/productization/gemma_e4b_profile_gate.py` via `gemma-e4b-profile-release-gate` in `infra/perf/pr_scoped_probes.json` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_gemma_e4b_profile_gate.py::test_gemma_e4b_profile_gate_normalizes_hyphenated_route_status services/mlx-worker-python/tests/test_gemma_e4b_profile_gate.py` (rejected earlier text-normalization trial; implementation reverted before this PR)
- `bash /tmp/gemma_test_cmd.sh` → `32 passed in 3.89s`
- `bash /tmp/gemma_cov_cmd.sh` → changed-scope coverage `TOTAL 17 0 100%`
- `bash /tmp/gemma_probe_cmd.sh` (baseline before accepted change) → `elapsed_ms_mean=63.103742618113756`
- `bash /tmp/gemma_probe_cmd.sh` x3 after accepted change → `elapsed_ms_mean=37.054321728646755`, `36.51972068473697`, `36.235249135643244`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 17 0 100%`.
- Registered local probe: `gemma-e4b-profile-release-gate`.
- Local Linux probe comparison: `old_mean=63.103743ms`, `new_mean=36.603097ms`, `delta_ms=-26.500645ms`, `speedup=1.7240x`, `improvement=42.00%`.
- Gate correctness metrics remained stable: `release_gate_passed=1.0`, `failure_count=0.0`, `benchmark_threshold_passed=1.0`, `unsupported_selected_route_count=0.0`.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime effect is claimed.
- Final merge should wait for GitHub Actions, including the PR-scoped performance workflow and registered probe report, to complete successfully.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered local probe shows an improvement.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
- [ ] All required PR checks are green.
