### PR TITLE
perf: speed startup update result records

### DIFF
--- a/docs/plans/2026-06-16-startup-version-ord-local.md
+++ b/docs/plans/2026-06-16-startup-version-ord-local.md
@@ -1,0 +1,26 @@
+# Startup Update Result Tuple Record
+
+This Python performance slice is limited to the update-check result record in `worker.productization.startup_signals`.
+
+## Scope
+
+- Keep startup version comparison and update-check semantics unchanged.
+- Avoid broad startup signal behavior changes.
+- Represent `UpdateCheckResult` as a typed tuple record instead of a frozen dataclass so repeated update-check result construction avoids frozen dataclass initialization overhead while preserving attribute access and immutable fields.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `startup-signals-version-compare-single-pass` in `infra/perf/pr_scoped_probes.json`.
+
+The probe already declares focused `test_command`, `coverage_command`, and `probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/productization/startup_signals.py`
+- `services/mlx-worker-python/tests/test_startup_signals.py`
+- `scripts/startup_signals_version_probe.py`
+
+## Verification Plan
+
+1. Run the focused pytest command from the registered probe.
+2. Run changed-scope coverage from the registered probe and keep the generated coverage artifact out of the commit.
+3. Run `scripts/startup_signals_version_probe.py` locally on Linux before and after the change.
+4. Use GitHub Actions PR-scoped performance as the merge gate.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3503,6 +3503,17 @@
         "key": "comparison_total",
         "unit": "count",
         "direction": "informational"
+      },
+      {
+        "key": "update_result_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "update_result_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
       }
     ]
   },

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -40,7 +40,10 @@ def test_check_for_updates_reports_newer_available_version(tmp_path: Path) -> No
     assert result.update_available is True
     assert result.latest_version == "0.2.0"
     assert result.summary == "Update available: 0.2.0"
+    assert result[2] == "0.1.0"
     assert not hasattr(result, "__dict__")
+    with pytest.raises(AttributeError):
+        result.latest_version = "0.3.0"  # type: ignore[misc]
 
 
 def test_check_for_updates_reports_up_to_date_version(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -5,7 +5,7 @@ import re
 import socket
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterator, Mapping
+from typing import Any, Iterator, Mapping, NamedTuple
 
 
 PORT_CONFLICT_PATTERNS = (
@@ -26,8 +26,7 @@ _BYTE_WHITESPACE = bytes(value for value in range(256) if chr(value).isspace())
 _ORD = ord
 
 
-@dataclass(frozen=True, slots=True)
-class UpdateCheckResult:
+class UpdateCheckResult(NamedTuple):
     checked: bool
     update_available: bool
     installed_version: str


### PR DESCRIPTION
## Summary
- Replaces the startup `UpdateCheckResult` frozen dataclass with a typed tuple record to reduce hot-path construction overhead while preserving attribute access and immutable fields.
- Extends the registered `startup-signals-version-compare-single-pass` PR-scoped probe metrics to track `update_result_elapsed_ms_mean` as a lower-is-better metric.
- Adds a focused plan note for this Python performance slice.

## Plan or Spec
- `docs/plans/2026-06-16-startup-version-ord-local.md`
- Registered probe: `startup-signals-version-compare-single-pass` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `git status --short && git branch --show-current`
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_ignores_build_metadata_suffix services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_handles_suffixes_without_padding_lists services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_does_not_allocate_streaming_part_generators services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_raw_values_skip_normalization services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_identical_clean_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_v_prefix_equivalent_values_skip_part_parsing services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_raw_v_prefix_equivalent_values_skip_stripping services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_clean_differing_values_skip_stripping services/mlx-worker-python/tests/test_startup_signals.py::test_compare_versions_whitespace_differing_values_still_normalize services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics`
- Registered coverage command from `startup-signals-version-compare-single-pass`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_version_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: 13 passed.
- Changed-scope coverage: 100% (`TOTAL 5 0 100%`).
- Registered local probe sample on Linux after the change: `update_result_elapsed_ms_mean=79.93165383647595`, `elapsed_ms_mean=13.822307278003011`, `comparison_total=-32.0`.
- Repeated local baseline/head probe comparison for `update_result_elapsed_ms_mean`: old_mean=112.610249 ms, new_mean=76.022407 ms, delta=-36.587842 ms, speedup=1.4813x, improvement=32.49%.
- PR-scoped performance CI is required for registered probe validation before merge.

## Known Gaps
- Linux local validation covers this Python-only slice; GitHub Actions PR-scoped performance remains the merge gate.
- `update_result_peak_bytes_mean` increased from 560 to 592 bytes in the local probe and is tracked as informational.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance completed successfully.
