### PR TITLE
perf: speed hub cursor link boundary parsing

### DIFF
--- a/docs/plans/2026-06-16-hub-cursor-link-boundary-fastpath.md
+++ b/docs/plans/2026-06-16-hub-cursor-link-boundary-fastpath.md
@@ -1,0 +1,35 @@
+# Hub catalog next-cursor link boundary fast path
+
+## Scope
+
+This performance slice keeps the registered Hub catalog next-cursor parser behavior unchanged while shaving one reverse search from the RFC 5988 Link header fast path.
+
+Affected path:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+
+Registered PR-scoped probe:
+
+- `hub-catalog-next-cursor-fast-parse`
+
+## Rationale
+
+`_next_cursor_from_link()` already locates the `rel="next"` marker before extracting the associated URL. The previous implementation searched backward for the URL closing `>` first, then searched backward again for `<` before that close marker. For the valid next-link shape used by Hub responses, the opening `<` before the relation marker is enough to bound a forward search for the closing `>` between the URL start and relation marker.
+
+The slice therefore changes only the link-boundary lookup order:
+
+1. Find `rel="next"`.
+2. Find the nearest preceding `<`.
+3. Find the matching `>` between that `<` and `rel="next"`.
+
+Malformed headers still skip to the next relation marker or return an empty cursor, matching the existing parser contract.
+
+## Verification Plan
+
+Run the registered probe commands for `hub-catalog-next-cursor-fast-parse` on Linux:
+
+- focused tests from `test_command`
+- changed-scope coverage from `coverage_command`
+- registered probe from `probe_command`
+
+The PR-scoped performance workflow is the authoritative CI evidence for the registered probe report.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -334,12 +334,12 @@ def _next_cursor_from_link(link_header: str) -> str:
         relation_start = link_header.find(marker, search_start)
         if relation_start < 0:
             return ""
-        url_end = link_header.rfind(">", 0, relation_start)
-        if url_end < 0:
+        url_start = link_header.rfind("<", 0, relation_start)
+        if url_start < 0:
             search_start = relation_start + marker_len
             continue
-        url_start = link_header.rfind("<", 0, url_end)
-        if url_start < 0:
+        url_end = link_header.find(">", url_start + 1, relation_start)
+        if url_end < 0:
             search_start = relation_start + marker_len
             continue
         query_start = link_header.rfind("?", url_start + 1, url_end)


### PR DESCRIPTION
## Summary
- Speeds up Hub catalog Link header next-cursor parsing by finding the URL opening `<` first, then bounding the closing `>` before `rel="next"`.
- Keeps the existing malformed-header fallback behavior and cursor decoding contract unchanged.

## Plan or Spec
- `docs/plans/2026-06-16-hub-cursor-link-boundary-fastpath.md`
- Registered PR-scoped probe: `hub-catalog-next-cursor-fast-parse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_next_cursor_probe.py
# exit 0; baseline before change: {"checksum": 6509477.0, "cursor_parse_calls_mean": 50000.0, "elapsed_ms_mean": 698.7191350199282, "peak_bytes_mean": 832.0, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics
# exit 0; 84 passed in 1.20s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_next_cursor_probe.py
# exit 0; changed_line_coverage=100.00%; TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_next_cursor_probe.py
# exit 0; after change: {"checksum": 6509477.0, "cursor_parse_calls_mean": 50000.0, "elapsed_ms_mean": 685.9265430830419, "peak_bytes_mean": 832.0, "sample_count": 5.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 4 0 100%`).
- Local registered probe (`hub-catalog-next-cursor-fast-parse`): `elapsed_ms_mean` improved from `698.7191350199282` ms to `685.9265430830419` ms (`-12.79259193688631` ms, about `1.83%` faster); `peak_bytes_mean` unchanged at `832.0`; `cursor_parse_calls_mean=50000.0`.
- CI PR-scoped performance workflow is required for authoritative registered probe validation.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime behavior is touched.
- CI registered probe report is pending after PR creation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
