### PR TITLE
perf: fast path always-only tool selection

### DIFF
--- a/docs/plans/2026-06-16-tool-registry-always-only-fastpath-performance.md
+++ b/docs/plans/2026-06-16-tool-registry-always-only-fastpath-performance.md
@@ -1,0 +1,36 @@
+# Tool Registry Always-Only Selection Fast Path Performance Slice
+
+## Scope
+
+This slice optimizes `select_agentic_tools_for_turn()` when `max_selected_tools`
+normalizes to one. In that case the always-available `local_compute` tool fills
+all available selection capacity, so vector and keyword routing cannot add any
+other tool. Behavior remains unchanged: the returned receipt still reports
+fallback selection with `local_compute` sourced from `always`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+That probe includes focused tool-registry behavior tests, changed-scope coverage,
+and `scripts/tool_registry_select_probe.py`, which reports the always-only
+planning path as `always_only_planning_elapsed_ms_mean` alongside the broader
+selection/config metrics.
+
+## Verification plan
+
+- Run the registered focused test command for tool registry selection behavior
+  and PR-scoped probe coverage.
+- Run the registered changed-scope coverage command.
+- Run `scripts/tool_registry_select_probe.py` locally on Linux before and after
+  the change, with repeated samples, and compare the always-only planning metric.
+- Rely on GitHub Actions PR-scoped performance workflow for the final registered
+  CI probe report before merge.
+
+## Expected outcome
+
+Short-circuiting before the per-call closure/list setup avoids work on prompts
+where tool-selection capacity is already exhausted by the always-available tool.
+The improvement should be most visible in
+`always_only_planning_elapsed_ms_mean`; other selector paths should remain within
+normal noise.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -468,6 +468,15 @@ def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> co
 def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSelectionResult:
     registry = agentic_tool_catalog_registry()
     max_selected_tools = max(1, selection_input.max_selected_tools)
+    if max_selected_tools == 1:
+        return _build_tool_selection_result(
+            registry,
+            ["local_compute"],
+            {"local_compute": "always"},
+            selection_input,
+            "fallback",
+            "no_keyword_match",
+        )
     selected_sources: dict[str, str] = {}
     selected_names: list[str] = []
     has_vector_selection = False


### PR DESCRIPTION
## Summary
- Add an always-only fast path for agentic tool selection when `max_selected_tools` normalizes to one.
- Skip per-call selection closure/list setup when the always-available `local_compute` tool already fills the selection capacity.
- Document the slice and registered probe coverage in `docs/plans/2026-06-16-tool-registry-always-only-fastpath-performance.md`.

## Plan or Spec
- `docs/plans/2026-06-16-tool-registry-always-only-fastpath-performance.md`
- Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` on `origin/main` baseline
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` on this branch
- `git diff --check`

## Coverage and Metrics
- Focused tests: 85 passed.
- Changed-scope coverage: 100% (`TOTAL 2 0 100%`).
- Local Linux probe baseline (`origin/main`): `always_only_planning_elapsed_ms_mean=27.570749`, `elapsed_ms_mean=21.895007`.
- Local Linux probe branch: `always_only_planning_elapsed_ms_mean=25.143261`, `elapsed_ms_mean=21.674310`.
- Local delta: always-only planning `-2.427488 ms` (~8.80% faster), overall select loop `-0.220697 ms` (~1.01% faster).

## Known Gaps
- Local verification covers Python behavior and the registered Python probe on Linux.
- Final merge should wait for GitHub Actions, including the PR-scoped performance workflow, to validate the registered CI probe.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met the 95% requirement.
- [x] Registered probe ran locally with before/after metrics.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
