### PR TITLE
perf: short-circuit empty changed-scope allowlists

### DIFF
--- a/docs/plans/2026-06-16-changed-scope-empty-allowlist-short-circuit.md
+++ b/docs/plans/2026-06-16-changed-scope-empty-allowlist-short-circuit.md
@@ -1,0 +1,31 @@
+# Changed-scope coverage empty allowlist short-circuit
+
+This Python performance slice is limited to `scripts/changed_scope_coverage.py`.
+
+## Scope
+
+When `MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON` filters every requested path out
+of a PR-scoped coverage check, the command can return the existing empty-success
+summary without loading `coverage.json` or invoking `git diff`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`changed-scope-coverage-empty-path-short-circuit` in
+`infra/perf/pr_scoped_probes.json`. The probe has focused `test_command`,
+`coverage_command`, and `probe_command` entries for
+`scripts/changed_scope_coverage.py`, `scripts/changed_scope_coverage_probe.py`,
+`tests/test_changed_scope_coverage.py`, and the PR-scoped performance registry
+tests.
+
+This slice extends the existing probe to include the command-level empty
+allowlist path and to count whether the coverage JSON file is read.
+
+## Verification plan
+
+1. Run the registered focused tests locally on Linux.
+2. Run the registered coverage command locally on Linux.
+3. Run the registered probe locally and compare the command-level empty allowlist
+   metrics against `origin/main`.
+4. Use GitHub Actions and the PR-scoped registered probe report as the merge
+   source of truth.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -2989,6 +2989,19 @@
         "unit": "reads",
         "direction": "lower_is_better",
         "warn_pct": 0.0
+      },
+      {
+        "key": "main_empty_allowlist_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0,
+        "warn_abs": 0.05
+      },
+      {
+        "key": "main_empty_allowlist_coverage_read_calls_mean",
+        "unit": "reads",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
       }
     ]
   },

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -256,8 +256,15 @@ def main() -> int:
     args = parser.parse_args()
 
     repo_root = Path.cwd()
-    coverage_payload = json.loads(Path(args.coverage_json).read_text(encoding="utf-8"))
     paths = _filter_coverage_paths(args.paths, _coverage_path_allowlist(os.environ))
+    if not paths:
+        print("aggregate_measurable_changed_lines=0")
+        print("aggregate_covered_changed_lines=0")
+        print("aggregate_missed_changed_lines=0")
+        print("TOTAL 0 0 100%")
+        return 0
+
+    coverage_payload = json.loads(Path(args.coverage_json).read_text(encoding="utf-8"))
     changed_lines_by_path = _changed_lines_by_path(repo_root, paths)
 
     total_measurable = 0

--- a/scripts/changed_scope_coverage_probe.py
+++ b/scripts/changed_scope_coverage_probe.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import json
+import os
 from pathlib import Path
 import statistics
+import sys
 import tempfile
 import time
 
@@ -23,6 +27,8 @@ def run_probe(repo_root: Path, *, path_count: int = 300, samples: int = 7) -> di
     module = _load_changed_scope_coverage(repo_root)
     elapsed_samples: list[float] = []
     read_samples: list[float] = []
+    main_elapsed_samples: list[float] = []
+    main_coverage_read_samples: list[float] = []
 
     with tempfile.TemporaryDirectory(prefix="melix-changed-scope-probe-") as tmp:
         root = Path(tmp)
@@ -65,8 +71,55 @@ def run_probe(repo_root: Path, *, path_count: int = 300, samples: int = 7) -> di
         finally:
             module.Path.read_text = original_read_text
 
+        if hasattr(module, "main"):
+            coverage_path = root / "coverage.json"
+            coverage_path.write_text(json.dumps(coverage_payload), encoding="utf-8")
+            original_argv = sys.argv
+            original_cwd = module.Path.cwd
+            original_environ = os.environ.copy()
+            original_read_text = module.Path.read_text
+            try:
+                module.Path.cwd = staticmethod(lambda: root)
+                os.environ["MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON"] = "[]"
+                for _ in range(samples):
+                    coverage_read_calls = 0
+
+                    def counted_main_read_text(self: Path, *args: object, **kwargs: object) -> str:
+                        nonlocal coverage_read_calls
+                        if self == coverage_path:  # pragma: no cover - regression signal on old target
+                            coverage_read_calls += 1
+                        return original_read_text(self, *args, **kwargs)  # pragma: no cover
+
+                    module.Path.read_text = counted_main_read_text
+                    sys.argv = [
+                        "changed_scope_coverage.py",
+                        "--coverage-json",
+                        str(coverage_path),
+                        *rel_paths,
+                    ]
+                    start = time.perf_counter()
+                    with contextlib.redirect_stdout(io.StringIO()):
+                        main_exit_code = module.main()
+                    if main_exit_code != 0:  # pragma: no cover - defensive probe failure path
+                        raise RuntimeError("empty filtered path run should pass")
+                    main_elapsed_samples.append((time.perf_counter() - start) * 1000.0)
+                    main_coverage_read_samples.append(float(coverage_read_calls))
+            finally:
+                module.Path.cwd = original_cwd
+                module.Path.read_text = original_read_text
+                sys.argv = original_argv
+                os.environ.clear()
+                os.environ.update(original_environ)
+        else:
+            main_elapsed_samples.append(0.0)
+            main_coverage_read_samples.append(0.0)
+
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "main_empty_allowlist_elapsed_ms_mean": statistics.fmean(main_elapsed_samples),
+        "main_empty_allowlist_coverage_read_calls_mean": statistics.fmean(
+            main_coverage_read_samples
+        ),
         "source_read_calls_mean": statistics.fmean(read_samples),
         "path_count": float(path_count),
         "sample_count": float(samples),

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -189,6 +189,42 @@ def test_main_filters_paths_to_probe_specific_allowlist(monkeypatch, tmp_path: P
     assert "TOTAL 1 0 100%" in output
 
 
+def test_main_short_circuits_empty_filtered_paths_without_reading_coverage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    coverage_json = tmp_path / "coverage.json"
+    coverage_json.write_text("not-json", encoding="utf-8")
+
+    def fail_changed_lines_by_path(*args: object, **kwargs: object) -> object:  # pragma: no cover
+        raise AssertionError("git diff should not run when no paths remain after filtering")
+
+    monkeypatch.setenv("MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON", "[]")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "changed_scope_coverage.py",
+            "--coverage-json",
+            str(coverage_json),
+            "direct.py",
+        ],
+    )
+    monkeypatch.setattr(changed_scope_coverage.Path, "cwd", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(
+        changed_scope_coverage,
+        "_changed_lines_by_path",
+        fail_changed_lines_by_path,
+    )
+
+    assert changed_scope_coverage.main() == 0
+
+    output = capsys.readouterr().out
+    assert "aggregate_measurable_changed_lines=0" in output
+    assert "TOTAL 0 0 100%" in output
+
+
 def test_coverage_path_allowlist_rejects_invalid_json() -> None:
     with pytest.raises(SystemExit, match="invalid MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON"):
         changed_scope_coverage._coverage_path_allowlist(


### PR DESCRIPTION
## Summary
- Short-circuit `scripts/changed_scope_coverage.py` when `MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON` filters all requested paths out.
- Avoid loading `coverage.json` or running `git diff` for the empty filtered path case.
- Extend the registered changed-scope coverage probe with command-level empty allowlist metrics.

## Plan or Spec
- `docs/plans/2026-06-16-changed-scope-empty-allowlist-short-circuit.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 41 passed in 0.22s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 41 passed in 0.59s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# Wrote JSON report to coverage.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 51 0 100%

python3 scripts/changed_scope_coverage_probe.py
# {"elapsed_ms_mean": 0.13336346351674624, "main_empty_allowlist_coverage_read_calls_mean": 0.0, "main_empty_allowlist_elapsed_ms_mean": 0.45720235045467106, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 51 0 100%`.
- Registered probe baseline vs branch, using the updated probe against `origin/main` and HEAD:
  - old `main_empty_allowlist_elapsed_ms_mean=0.6791360543242523`, new `0.4891957422452314`, delta `-0.1899403120790209 ms` (~27.97% faster).
  - old `main_empty_allowlist_coverage_read_calls_mean=1.0`, new `0.0`, delta `-1.0 read`.
  - old `elapsed_ms_mean=0.12926398111241205`, new `0.13125627966863768` for the existing helper-only metric; unchanged path, small noise-bound delta.
- Registered PR-scoped performance workflow is required as the CI source of truth before merge.

## Known Gaps
- Full `make py-test` / integration gates were not run locally; this is a focused Python tooling slice and CI is the broader validation source.
- No Swift runtime validation applies.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: PR-scoped synthetic performance probe only; no runtime observability mode changed.
- [x] Deferred work and known gaps are stated explicitly.
