### PR TITLE
perf: fast-path retrieval list payload copies

### DIFF
--- a/docs/plans/2026-06-16-retrieval-lookup-list-copy-fastpath.md
+++ b/docs/plans/2026-06-16-retrieval-lookup-list-copy-fastpath.md
@@ -1,0 +1,36 @@
+# Retrieval Lookup List Copy Fast Path
+
+## Summary
+
+This Python-only performance slice keeps retrieval lookup projection behavior
+unchanged and narrows one hot path in
+`worker.runtime.retrieval_context._copy_payload_value`: small list payload copies.
+Lookup payload metadata commonly contains empty, one-item, two-item, and
+three-item lists, and the registered probe includes a three-item `scores` list in
+each synthetic retrieved context.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `retrieval-context-projection-fastpath` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/retrieval_context.py`
+- `services/mlx-worker-python/tests/test_retrieval_context.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/retrieval_context_projection_probe.py`
+
+No new probe registration is required for this slice.
+
+## Optimization slice
+
+Fast-path exact `list` payload copies for lengths 0, 1, 2, and 3 in the same
+recursive helper that already fast-paths small tuples. Longer lists and unknown
+value types keep the existing comprehension / `deepcopy` behavior.
+
+## Validation plan
+
+Run the registered focused tests, changed-scope coverage command, and registered
+probe locally on Linux before pushing. GitHub Actions and the PR-scoped
+performance workflow remain the merge gate before the PR is squash-merged.

--- a/services/mlx-worker-python/tests/test_retrieval_context.py
+++ b/services/mlx-worker-python/tests/test_retrieval_context.py
@@ -1630,6 +1630,8 @@ def test_project_retrieval_lookup_result_preserves_valid_tuple_records_with_meta
 def test_project_retrieval_lookup_result_copies_tuple_payloads_without_type_drift() -> None:
     nested_value = {"rank": 1}
     three_item_nested_value = {"rank": 3}
+    two_item_list_value = {"rank": 20}
+    three_item_list_value = {"rank": 30}
     lookup_result = {
         "records": [
             {
@@ -1681,6 +1683,34 @@ def test_project_retrieval_lookup_result_copies_tuple_payloads_without_type_drif
                     "owner_scope_checked": True,
                     "source_field": "long_tuple",
                 },
+                {
+                    "context_kind": "retrieved_document",
+                    "source_id": "doc:empty-list",
+                    "payload": {"metadata": []},
+                    "owner_scope_checked": True,
+                    "source_field": "empty_list",
+                },
+                {
+                    "context_kind": "retrieved_document",
+                    "source_id": "doc:single-list",
+                    "payload": {"metadata": [{"rank": 10}]},
+                    "owner_scope_checked": True,
+                    "source_field": "single_list",
+                },
+                {
+                    "context_kind": "retrieved_document",
+                    "source_id": "doc:two-list",
+                    "payload": {"metadata": ["a", two_item_list_value]},
+                    "owner_scope_checked": True,
+                    "source_field": "two_list",
+                },
+                {
+                    "context_kind": "retrieved_document",
+                    "source_id": "doc:three-list",
+                    "payload": {"metadata": ["a", three_item_list_value, "c"]},
+                    "owner_scope_checked": True,
+                    "source_field": "three_list",
+                },
             ]
         }
     )
@@ -1691,6 +1721,17 @@ def test_project_retrieval_lookup_result_copies_tuple_payloads_without_type_drif
     long_metadata = varied_projection.prompt_user_payload["long_tuple"]["metadata"]
     assert long_metadata == ("a", {"rank": 3}, "c")
     assert long_metadata[1] is not three_item_nested_value
+    empty_list_metadata = varied_projection.prompt_user_payload["empty_list"]["metadata"]
+    assert type(empty_list_metadata) is list
+    assert empty_list_metadata == []
+    single_list_metadata = varied_projection.prompt_user_payload["single_list"]["metadata"]
+    assert single_list_metadata == [{"rank": 10}]
+    two_list_metadata = varied_projection.prompt_user_payload["two_list"]["metadata"]
+    assert two_list_metadata == ["a", {"rank": 20}]
+    assert two_list_metadata[1] is not two_item_list_value
+    three_list_metadata = varied_projection.prompt_user_payload["three_list"]["metadata"]
+    assert three_list_metadata == ["a", {"rank": 30}, "c"]
+    assert three_list_metadata[1] is not three_item_list_value
 
 
 def test_project_retrieval_lookup_result_metadata_refusal_skips_store_projection(

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -515,6 +515,15 @@ def _copy_payload_value(value: Any) -> Any:
     if value_type is dict:
         return {key: copy_value(item) for key, item in value.items()}
     if value_type is list:
+        value_len = len(value)
+        if value_len == 3:
+            return [copy_value(value[0]), copy_value(value[1]), copy_value(value[2])]
+        if value_len == 2:
+            return [copy_value(value[0]), copy_value(value[1])]
+        if value_len == 1:
+            return [copy_value(value[0])]
+        if value_len == 0:
+            return []
         return [copy_value(item) for item in value]
     if value_type is tuple:
         value_len = len(value)


### PR DESCRIPTION
## Summary
- Fast-path exact list payload copies in `worker.runtime.retrieval_context._copy_payload_value` for lengths 0, 1, 2, and 3.
- Extend retrieval lookup payload copy regression coverage to prove small lists keep list type and nested mutable values are still copied.

## Plan or Spec
- `docs/plans/2026-06-16-retrieval-lookup-list-copy-fastpath.md`
- Registered probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json` already covers the affected path and includes focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# Baseline before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
exit 0; lookup_copy_optimized_elapsed_ms_mean=0.25051521020941436; lookup_copy_speedup=3.7522996284530685

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...retrieval-context-projection-fastpath focused tests...
exit 0; 24 passed in 0.95s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...retrieval-context-projection-fastpath focused tests... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
exit 0; TOTAL 22 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
exit 0; lookup_copy_optimized_elapsed_ms_mean=0.23660793268520916; lookup_copy_speedup=4.092961775178292

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 22 0 100%`.
- Registered local probe (`retrieval-context-projection-fastpath`) after the slice:
  - `baseline_elapsed_ms_mean=1.0188961233611085`
  - `optimized_elapsed_ms_mean=0.18489673850126565`
  - `delta_ms=-0.8339993848598428`
  - `speedup=5.510622478363154`
  - `lookup_copy_baseline_elapsed_ms_mean=0.9684272241845194`
  - `lookup_copy_optimized_elapsed_ms_mean=0.23660793268520916`
  - `lookup_copy_delta_ms=-0.7318192914993102`
  - `lookup_copy_speedup=4.092961775178292`
- Baseline run before implementation for the same local probe reported `lookup_copy_optimized_elapsed_ms_mean=0.25051521020941436`, so this slice improved the local lookup-copy optimized mean by about `0.0139 ms` per iteration.
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime effect is claimed.
- The registered CI PR-scoped performance report is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
