### PR TITLE
perf: fast-path empty coverage allowlists

### DIFF
--- a/docs/plans/2026-06-16-changed-scope-empty-allowlist-short-circuit.md
+++ b/docs/plans/2026-06-16-changed-scope-empty-allowlist-short-circuit.md
@@ -21,6 +21,10 @@ tests.
 This slice extends the existing probe to include the command-level empty
 allowlist path and to count whether the coverage JSON file is read.
 
+The 2026-06-17 follow-up slice keeps the same behavior but recognizes the
+literal empty JSON array (`[]`) before invoking the JSON decoder, which is the
+common no-paths-remaining value used by probe-scoped coverage checks.
+
 ## Verification plan
 
 1. Run the registered focused tests locally on Linux.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -143,6 +143,8 @@ def _changed_lines_by_path(repo_root: Path, rel_paths: list[str]) -> dict[str, s
 def _coverage_path_allowlist_from_raw(raw_value: str) -> frozenset[str] | None:
     if not raw_value:
         return None
+    if raw_value == "[]":
+        return frozenset()
     if (
         len(raw_value) >= 2
         and raw_value[0] == '"'

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -258,6 +258,19 @@ def test_coverage_path_allowlist_parses_simple_string_without_json_decoder(monke
     ) == {"pkg/direct.py"}
 
 
+def test_coverage_path_allowlist_parses_empty_array_without_json_decoder(monkeypatch) -> None:
+    changed_scope_coverage._coverage_path_allowlist_from_raw.cache_clear()
+
+    def fail_loads(*args: object, **kwargs: object) -> object:  # pragma: no cover
+        raise AssertionError("empty allowlists should avoid json.loads")
+
+    monkeypatch.setattr(changed_scope_coverage.json, "loads", fail_loads)
+
+    assert changed_scope_coverage._coverage_path_allowlist(
+        {"MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON": "[]"}
+    ) == frozenset()
+
+
 def test_coverage_path_allowlist_reuses_cached_raw_payload_parse(monkeypatch) -> None:
     changed_scope_coverage._coverage_path_allowlist_from_raw.cache_clear()
     calls = 0


### PR DESCRIPTION
## Summary
- Fast-path the literal empty changed-scope coverage allowlist (`[]`) before invoking `json.loads`.
- Add a regression test proving the empty array path avoids the JSON decoder.
- Update the existing changed-scope coverage plan with the follow-up slice note.

## Plan or Spec
- Updated `docs/plans/2026-06-16-changed-scope-empty-allowlist-short-circuit.md`.
- Affected path is already covered by registered PR-scoped probe `changed-scope-coverage-empty-path-short-circuit` with focused test, coverage, and probe commands in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-empty-path-short-circuit --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/changed_scope_empty_array_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 42 passed.
- Changed-scope coverage: 100.00% over changed measurable lines (`TOTAL 6 0 100%`).
- Registered local Linux probe `changed-scope-coverage-empty-path-short-circuit`:
  - `elapsed_ms_mean`: base 0.134138856 ms, head 0.128048539 ms (delta -0.006090317 ms, ~4.54% faster).
  - `main_empty_allowlist_elapsed_ms_mean`: base 0.446420229 ms, head 0.425134519 ms (delta -0.021285710 ms, ~4.77% faster).
  - `source_read_calls_mean`: base 0.0, head 0.0.
  - `main_empty_allowlist_coverage_read_calls_mean`: base 0.0, head 0.0.
- CI PR-scoped performance report is still required as the merge source of truth.

## Known Gaps
- Linux-local validation only; this slice is Python-only and does not require Swift runtime validation.

## Evidence Checklist
- [x] Registered PR-scoped probe exists for affected path.
- [x] Focused local tests passed.
- [x] Changed-scope coverage command passed at >=95% for touched scope.
- [x] Registered local probe showed directionally improved metrics.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
