### PR TITLE
perf: fast-path missing probe policy values

### DIFF
--- a/docs/plans/2026-06-17-probe-policy-none-fastpath.md
+++ b/docs/plans/2026-06-17-probe-policy-none-fastpath.md
@@ -1,0 +1,24 @@
+# Probe policy `None` parse fast path
+
+## Scope
+
+This Python-only performance slice targets `ProbePolicy.from_value(None)` in
+`services/mlx-worker-python/worker/productization/probe_policy.py`. The affected
+path is covered by the registered PR-scoped probe `probe-policy-noop-overhead` in
+`infra/perf/pr_scoped_probes.json`, including focused `test_command`,
+`coverage_command`, and `probe_command` entries.
+
+## Change
+
+Move the `None` guard to the top of `ProbePolicy.from_value` so missing probe
+mode values return the cached default policy before string and enum type checks.
+This preserves the existing fallback/default semantics while reducing overhead
+on the no-op probe-policy path used when a caller passes an absent mode value.
+
+## Verification
+
+- Run the registered focused probe-policy tests.
+- Run the registered changed-scope coverage command for the probe-policy scope.
+- Run `scripts/probe_policy_noop_overhead_probe.py` locally on Linux and compare
+  the `mode_parse_none_call_ms_mean` metric before and after the change.
+- Rely on the registered PR-scoped performance workflow in CI for PR validation.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4414,6 +4414,12 @@
         "warn_abs": 2e-05
       },
       {
+        "key": "mode_parse_none_call_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_abs": 2e-05
+      },
+      {
         "key": "mode_parse_valid_call_ms_mean",
         "unit": "ms",
         "direction": "lower_is_better",

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -59,6 +59,8 @@ class ProbePolicy:
         *,
         default_mode: ProbeMode = ProbeMode.MINIMAL,
     ) -> ProbePolicy:
+        if value is None:
+            return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
         if type(value) is str:
             if not value:
                 return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
@@ -68,8 +70,6 @@ class ProbePolicy:
             return _probe_policy_from_uncached_string(value, default_mode)
         elif isinstance(value, ProbeMode):
             return _PROBE_POLICY_BY_MODE[value]
-        elif value is None:
-            return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
         elif isinstance(value, str):
             policy = _PROBE_POLICY_BY_VALUE_GET(value)
             if policy is not None:


### PR DESCRIPTION
## Summary
- Fast-path `ProbePolicy.from_value(None)` before string/enum type checks.
- Register `mode_parse_none_call_ms_mean` in the PR-scoped probe metrics so CI reports the targeted slice metric.
- Add the slice plan documenting the registered probe and Linux verification boundary.

## Plan or Spec
- `docs/plans/2026-06-17-probe-policy-none-fastpath.md`
- Registered probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PROBE_POLICY_OVERHEAD_ITERATIONS=1000000 MELIX_PROBE_POLICY_OVERHEAD_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 18 passed.
- Changed-scope coverage: 100.00% (2/2 changed measurable lines covered).
- Local Linux registered probe comparison (`mode_parse_none_call_ms_mean`, 1,000,000 iterations x 5 samples):
  - old_mean=0.000232261 ms
  - new_mean=0.000110434 ms
  - delta_ms=-0.000121827 ms
  - speedup=2.103x
  - improvement=52.45%
- Registered PR-scoped performance CI is required for final validation before merge.

## Known Gaps
- Local verification is Linux/Python-only; no Swift runtime effect is claimed.
- One exploratory coverage invocation included `infra/perf/pr_scoped_probes.json` and failed because coverage JSON has no entry for JSON files; the registered coverage command was rerun successfully without that non-Python file.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Probe has focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally and shows improvement.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
