### PR TITLE
Add companion pairing QR preview

### DIFF
--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -10360,8 +10360,6 @@ enum DesktopAPICompanionPairingLayout {
 }
 
 enum CompanionPairingQRCode {
-    private static let context = CIContext()
-
     static func image(for code: String) -> NSImage? {
         let trimmedCode = code.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmedCode.isEmpty == false else { return nil }
@@ -10375,6 +10373,7 @@ enum CompanionPairingQRCode {
         let extent = outputImage.extent.integral
         guard extent.width > 0, extent.height > 0 else { return nil }
 
+        let context = CIContext()
         guard let cgImage = context.createCGImage(outputImage, from: extent) else {
             return nil
         }

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Charts
+import CoreImage.CIFilterBuiltins
 import MelixCLICore
 import MelixControlPlaneCore
 import SwiftUI
@@ -10298,6 +10299,26 @@ struct DesktopAPICompanionPairingPanel: View {
                         .help(allowedRoutesText)
                 }
 
+                if let pairingCode = viewModel.companionPairingCodeText(),
+                   let qrImage = CompanionPairingQRCode.image(for: pairingCode)
+                {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Pairing QR")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Image(nsImage: qrImage)
+                            .interpolation(.none)
+                            .resizable()
+                            .frame(
+                                width: DesktopAPICompanionPairingLayout.qrImageSize,
+                                height: DesktopAPICompanionPairingLayout.qrImageSize
+                            )
+                            .accessibilityLabel("Pairing QR")
+                            .help("Contains the read-only companion bearer token. Share only with a trusted local device.")
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
                 if let errorText = presentation.errorText {
                     Text(errorText)
                         .font(.caption)
@@ -10349,8 +10370,36 @@ struct DesktopAPICompanionPairingPanel: View {
     }
 }
 
-private enum DesktopAPICompanionPairingLayout {
+enum DesktopAPICompanionPairingLayout {
     static let compactContentWidth: CGFloat = 320
+    static let qrImageSize: CGFloat = 120
+}
+
+enum CompanionPairingQRCode {
+    private static let context = CIContext()
+
+    static func image(for code: String) -> NSImage? {
+        let trimmedCode = code.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedCode.isEmpty == false else { return nil }
+
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(trimmedCode.utf8)
+        filter.correctionLevel = "M"
+
+        guard let outputImage = filter.outputImage else { return nil }
+
+        let targetSize = DesktopAPICompanionPairingLayout.qrImageSize
+        let extent = outputImage.extent.integral
+        guard extent.width > 0, extent.height > 0 else { return nil }
+
+        let scale = targetSize / max(extent.width, extent.height)
+        let scaledImage = outputImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        guard let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent.integral) else {
+            return nil
+        }
+
+        return NSImage(cgImage: cgImage, size: NSSize(width: targetSize, height: targetSize))
+    }
 }
 
 struct DesktopAPICompanionPairingPresentation: Equatable {

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -10299,24 +10299,8 @@ struct DesktopAPICompanionPairingPanel: View {
                         .help(allowedRoutesText)
                 }
 
-                if let pairingCode = viewModel.companionPairingCodeText(),
-                   let qrImage = CompanionPairingQRCode.image(for: pairingCode)
-                {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text("Pairing QR")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                        Image(nsImage: qrImage)
-                            .interpolation(.none)
-                            .resizable()
-                            .frame(
-                                width: DesktopAPICompanionPairingLayout.qrImageSize,
-                                height: DesktopAPICompanionPairingLayout.qrImageSize
-                            )
-                            .accessibilityLabel("Pairing QR")
-                            .help("Contains the read-only companion bearer token. Share only with a trusted local device.")
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                if let pairingCode = viewModel.companionPairingCodeText() {
+                    CompanionPairingQRView(pairingCode: pairingCode)
                 }
 
                 if let errorText = presentation.errorText {
@@ -10388,17 +10372,63 @@ enum CompanionPairingQRCode {
 
         guard let outputImage = filter.outputImage else { return nil }
 
-        let targetSize = DesktopAPICompanionPairingLayout.qrImageSize
         let extent = outputImage.extent.integral
         guard extent.width > 0, extent.height > 0 else { return nil }
 
-        let scale = targetSize / max(extent.width, extent.height)
-        let scaledImage = outputImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
-        guard let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent.integral) else {
+        guard let cgImage = context.createCGImage(outputImage, from: extent) else {
             return nil
         }
 
-        return NSImage(cgImage: cgImage, size: NSSize(width: targetSize, height: targetSize))
+        let targetSize = DesktopAPICompanionPairingLayout.qrImageSize
+        return NSImage(size: NSSize(width: targetSize, height: targetSize), flipped: false) { rect in
+            guard let nsContext = NSGraphicsContext.current else { return false }
+            nsContext.imageInterpolation = .none
+            nsContext.cgContext.draw(cgImage, in: rect)
+            return true
+        }
+    }
+}
+
+struct CompanionPairingQRView: View {
+    let pairingCode: String
+    @State private var qrImage: NSImage?
+
+    init(pairingCode: String, initialImage: NSImage? = nil) {
+        self.pairingCode = pairingCode
+        _qrImage = State(initialValue: initialImage)
+    }
+
+    var body: some View {
+        Group {
+            if let qrImage {
+                CompanionPairingQRImageView(qrImage: qrImage)
+            }
+        }
+        .task(id: pairingCode) {
+            qrImage = CompanionPairingQRCode.image(for: pairingCode)
+        }
+    }
+}
+
+struct CompanionPairingQRImageView: View {
+    let qrImage: NSImage
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Pairing QR")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Image(nsImage: qrImage)
+                .interpolation(.none)
+                .resizable()
+                .frame(
+                    width: DesktopAPICompanionPairingLayout.qrImageSize,
+                    height: DesktopAPICompanionPairingLayout.qrImageSize
+                )
+                .accessibilityLabel("Pairing QR")
+                .help("Contains the read-only companion bearer token. Share only with a trusted local device.")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -4581,6 +4581,7 @@ struct DesktopFoundationViewTests {
         #expect(shellSource.contains("Copy Bundle"))
         #expect(shellSource.contains("Copy Code"))
         #expect(shellSource.contains("Pairing QR"))
+        #expect(shellSource.contains("CompanionPairingQRView"))
         #expect(shellSource.contains("CompanionPairingQRCode.image"))
         #expect(shellSource.contains("Issue a read-only companion token"))
         #expect(shellSource.contains("Revoke Token"))
@@ -4590,11 +4591,34 @@ struct DesktopFoundationViewTests {
     func companionPairingQRCodeGeneratesOnlyForActiveCodes() throws {
         let code = "melix-companion:eyJzY2hlbWFfdmVyc2lvbiI6Im1lbGl4LmNvbXBhbmlvbi5wYWlyaW5nLmJ1bmRsZS52MSJ9"
         let image = try #require(CompanionPairingQRCode.image(for: code))
+        let renderedData = try #require(image.tiffRepresentation)
+        let renderedBitmap = try #require(NSBitmapImageRep(data: renderedData))
 
         #expect(image.size.width == DesktopAPICompanionPairingLayout.qrImageSize)
         #expect(image.size.height == DesktopAPICompanionPairingLayout.qrImageSize)
+        #expect(renderedBitmap.pixelsWide == Int(DesktopAPICompanionPairingLayout.qrImageSize))
+        #expect(renderedBitmap.pixelsHigh == Int(DesktopAPICompanionPairingLayout.qrImageSize))
         #expect(CompanionPairingQRCode.image(for: "   ") == nil)
         #expect(CompanionPairingQRCode.image(for: "\n\t") == nil)
+    }
+
+    @Test("companion pairing QR view renders generated image")
+    @MainActor
+    func companionPairingQRViewRendersGeneratedImage() throws {
+        let code = "melix-companion:eyJzY2hlbWFfdmVyc2lvbiI6Im1lbGl4LmNvbXBhbmlvbi5wYWlyaW5nLmJ1bmRsZS52MSJ9"
+        let qrImage = try #require(CompanionPairingQRCode.image(for: code))
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-companion-qr-view-\(UUID().uuidString).png")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        try MelixSwiftUIScreenshotRenderer().render(
+            CompanionPairingQRView(pairingCode: code, initialImage: qrImage),
+            to: outputURL,
+            size: CGSize(width: 180, height: 180)
+        )
+        let pngData = try Data(contentsOf: outputURL)
+
+        #expect(Array(pngData.prefix(8)) == [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
     }
 
     @Test("api authentication surface includes companion status log tail panel")

--- a/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
@@ -4580,8 +4580,21 @@ struct DesktopFoundationViewTests {
         #expect(shellSource.contains("Issue Token"))
         #expect(shellSource.contains("Copy Bundle"))
         #expect(shellSource.contains("Copy Code"))
+        #expect(shellSource.contains("Pairing QR"))
+        #expect(shellSource.contains("CompanionPairingQRCode.image"))
         #expect(shellSource.contains("Issue a read-only companion token"))
         #expect(shellSource.contains("Revoke Token"))
+    }
+
+    @Test("companion pairing QR code generates only for active codes")
+    func companionPairingQRCodeGeneratesOnlyForActiveCodes() throws {
+        let code = "melix-companion:eyJzY2hlbWFfdmVyc2lvbiI6Im1lbGl4LmNvbXBhbmlvbi5wYWlyaW5nLmJ1bmRsZS52MSJ9"
+        let image = try #require(CompanionPairingQRCode.image(for: code))
+
+        #expect(image.size.width == DesktopAPICompanionPairingLayout.qrImageSize)
+        #expect(image.size.height == DesktopAPICompanionPairingLayout.qrImageSize)
+        #expect(CompanionPairingQRCode.image(for: "   ") == nil)
+        #expect(CompanionPairingQRCode.image(for: "\n\t") == nil)
     }
 
     @Test("api authentication surface includes companion status log tail panel")

--- a/docs/plans/2026-06-17-issue-1759-companion-pairing-qr.md
+++ b/docs/plans/2026-06-17-issue-1759-companion-pairing-qr.md
@@ -1,0 +1,91 @@
+# Issue 1759 Companion Pairing QR
+
+## Goal
+
+Render a local-only QR preview for the existing `melix-companion:` pairing code
+inside the desktop Authentication companion pairing panel.
+
+## Best End-State Architecture
+
+Companion QR rendering stays desktop-local and derives exclusively from the
+already transient `melix-companion:` code. The gateway authorization model does
+not change: companion tokens remain `companion_read_only`, revocable, and scoped
+to existing read-only routes. The QR image is a presentation of bearer material,
+not a new persisted credential.
+
+The desktop app should generate the QR image with macOS system frameworks
+(`CoreImage` plus `AppKit`) so the slice does not add dependencies or protocol
+surface. QR rendering belongs to the AppMain UI layer because it is a local
+operator transfer affordance, while `RuntimeViewModel` remains responsible only
+for producing the canonical pairing bundle and compact code.
+
+## Slice Boundary
+
+Included:
+
+- add a small QR generator for non-empty pairing-code strings;
+- render a bounded QR preview in the active companion pairing panel;
+- keep the existing narrow 360 px panel smoke guard;
+- document QR handling as secret bearer material;
+- focused Swift tests for QR generation, disabled empty input, source wiring,
+  and narrow panel hosting.
+
+Excluded:
+
+- mobile/PWA import of `melix-companion:` codes;
+- real browser companion status-page smoke;
+- changing gateway read-only routes, redaction, token scope, or token lifetime.
+
+## Performance Probes and Metrics
+
+- Runtime metrics: no new gateway call or polling path is introduced.
+- QR rendering is on-demand SwiftUI/AppKit presentation over the currently active
+  compact code. The code string is small relative to the companion bundle and is
+  only rendered in the Authentication panel.
+- Merge gate: scoped performance report must remain `Status: ok` with zero
+  regressions.
+
+## Implementation Plan
+
+1. Add failing menu-bar tests proving `CompanionPairingQRCode.image(for:)`
+   returns an image for a non-empty `melix-companion:` code and returns `nil`
+   for blank input.
+2. Add a source-level UI assertion that the Authentication companion pairing
+   surface contains a QR preview label and QR image generator wiring.
+3. Extend the active companion panel test to keep the 360 px host guard with the
+   QR preview present.
+4. Implement `CompanionPairingQRCode` with `CIFilter.qrCodeGenerator`, scaled
+   nearest-neighbor output, and an `NSImage`.
+5. Render the QR image only when `viewModel.companionPairingCodeText()` returns
+   a value, with bounded dimensions and help text warning that it contains the
+   read-only bearer token.
+6. Update `docs/runbooks/persistent-sessions.md` to describe QR transfer and the
+   same secret-handling boundary as the copied bundle/code.
+
+## Verification
+
+Focused Swift tests:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" xcrun swift test --package-path apps/macos-menubar --filter 'DesktopFoundationViewTests/(companionPairingQRCodeGeneratesOnlyForActiveCodes|apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
+```
+
+Changed-line coverage:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" xcrun swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'DesktopFoundationViewTests/(companionPairingQRCodeGeneratesOnlyForActiveCodes|apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
+uv run --python 3.12 python scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
+```
+
+Full gate before PR:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```
+
+## Deferred Work
+
+- Companion mobile/PWA import flow for `melix-companion:` QR/code payloads.
+- Real browser companion status-page smoke in a narrow viewport.

--- a/docs/runbooks/persistent-sessions.md
+++ b/docs/runbooks/persistent-sessions.md
@@ -102,6 +102,8 @@ Operator actions:
 - `Copy Code` copies a compact `melix-companion:` pairing code. The code is a
   URL-safe-base64 encoding of the same transient JSON bundle and is intended for
   future QR/code transfer surfaces.
+- `Pairing QR` renders the same compact `melix-companion:` pairing code as a
+  local QR preview for trusted companion-device import.
 - `Revoke Token` calls `DELETE /v1/melix/auth/session` with the active companion
   token through `X-Melix-Session`.
 
@@ -111,8 +113,9 @@ written into operator session state, server-session configuration, logs,
 metrics, or the safe descriptor displayed in the panel. Closing the desktop
 process drops the transient token reference; create a new companion token if the
 current token can no longer be copied or revoked from the panel. Treat copied
-pairing bundles and `melix-companion:` pairing codes as secret bearer material
-because both include the raw companion token inside the transferred payload.
+pairing bundles, `melix-companion:` pairing codes, and pairing QR screenshots as
+secret bearer material because each includes the raw companion token inside the
+transferred payload.
 
 ### Desktop Companion Status Refresh
 


### PR DESCRIPTION
## Summary
- Add a desktop-local QR preview for active companion pairing codes in the Authentication companion pairing panel.
- Generate the QR image from the existing transient `melix-companion:` code with CoreImage/AppKit, keeping gateway scope, token lifetime, and persistence behavior unchanged.
- Render the QR preview lazily through SwiftUI `.task(id:)` and draw the native QR bitmap into the target `NSImage` with interpolation disabled.
- Document that QR screenshots are secret bearer material because they contain the raw companion token payload.

Refs #1759.

## Plan or Spec
- `docs/plans/2026-06-17-issue-1759-companion-pairing-qr.md`
- `docs/runbooks/persistent-sessions.md`

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" xcrun swift test --package-path apps/macos-menubar --filter 'DesktopFoundationViewTests/(companionPairingQRCodeGeneratesOnlyForActiveCodes|companionPairingQRViewRendersGeneratedImage|apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
# passed: 4 tests in 1 suite

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" xcrun swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'DesktopFoundationViewTests/(companionPairingQRCodeGeneratesOnlyForActiveCodes|companionPairingQRViewRendersGeneratedImage|apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
# passed: 4 tests in 1 suite

uv run --python 3.12 python scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
# passed: TOTAL 98.91% (91/92 changed executable lines)

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" xcrun swift test --package-path apps/macos-menubar --filter 'DesktopFoundationViewTests/(companionPairingQRCodeGeneratesOnlyForActiveCodes|companionPairingQRViewRendersGeneratedImage|apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
# passed after CI menubar fix: 4 tests in 1 suite

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" xcrun swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'DesktopFoundationViewTests/(companionPairingQRCodeGeneratesOnlyForActiveCodes|companionPairingQRViewRendersGeneratedImage|apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
# passed after CI menubar fix: 4 tests in 1 suite

uv run --python 3.12 python scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
# passed after CI menubar fix: TOTAL 98.92% (92/93 changed executable lines)

git diff --check
# passed

make swift-test-menubar
# passed after CI menubar fix: 816 tests in 25 suites

set -o pipefail
make swift-test 2>&1 | tee .runtime/test-logs/issue-1759-qr-swift-test-after-review-testfix.log
# passed after review fix and latest origin/main; macOS menubar package: 816 tests in 25 suites

set -o pipefail
make py-test 2>&1 | tee .runtime/test-logs/issue-1759-qr-py-test-after-review-testfix.log
# passed after review fix and latest origin/main: 4062 passed, 14 skipped, 2 warnings

set -o pipefail
make integration-test 2>&1 | tee .runtime/test-logs/issue-1759-qr-integration-test-after-review-testfix.log
# passed after review fix and latest origin/main: 120 passed, 1 skipped

uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import sys
sys.path.insert(0, str(Path.cwd()))
import scripts.pre_commit_gate as gate
root = Path.cwd()
changed = [
    "apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift",
    "apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift",
    "docs/plans/2026-06-17-issue-1759-companion-pairing-qr.md",
    "docs/runbooks/persistent-sessions.md",
]
outcome = gate.run_performance_report(root, changed, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# passed after review fix and latest origin/main: Status ok, 0 regressions, 0 verification failures

git commit -m "Avoid shared CoreImage context for pairing QR"
# pre-commit passed: make swift-test, make py-test, make integration-test, scoped performance report

uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import sys
sys.path.insert(0, str(Path.cwd()))
import scripts.pre_commit_gate as gate
root = Path.cwd()
changed = [
    "apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift",
    "apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift",
    "docs/plans/2026-06-17-issue-1759-companion-pairing-qr.md",
    "docs/runbooks/persistent-sessions.md",
]
outcome = gate.run_performance_report(root, changed, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# passed on 68d69fc4: Status ok, 0 regressions, 0 verification failures

git merge --no-edit origin/main
# passed after origin/main moved to a80f6029: clean merge, no conflicts; branch head 5786bbeb

git diff --check
# passed after latest origin/main merge

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" xcrun swift test --package-path apps/macos-menubar --filter 'DesktopFoundationViewTests/(companionPairingQRCodeGeneratesOnlyForActiveCodes|companionPairingQRViewRendersGeneratedImage|apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
# passed after latest origin/main merge: 4 tests in 1 suite

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" xcrun swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'DesktopFoundationViewTests/(companionPairingQRCodeGeneratesOnlyForActiveCodes|companionPairingQRViewRendersGeneratedImage|apiAuthenticationSurfaceIncludesCompanionPairingTokenControls|companionPairingPanelRendersIdleActiveAndFailureStates)'
# passed after latest origin/main merge: 4 tests in 1 suite

uv run --python 3.12 python scripts/swift_changed_line_coverage.py --binary apps/macos-menubar/.build/arm64-apple-macosx/debug/MelixMacOSMenubarPackageTests.xctest/Contents/MacOS/MelixMacOSMenubarPackageTests --profdata apps/macos-menubar/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift
# passed after latest origin/main merge: TOTAL 98.92% (92/93 changed executable lines)

make swift-test-menubar
# passed after latest origin/main merge: 816 tests in 25 suites

uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import sys
sys.path.insert(0, str(Path.cwd()))
import scripts.pre_commit_gate as gate
root = Path.cwd()
changed = [
    "apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift",
    "apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift",
    "docs/plans/2026-06-17-issue-1759-companion-pairing-qr.md",
    "docs/runbooks/persistent-sessions.md",
]
outcome = gate.run_performance_report(root, changed, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# passed on 5786bbeb after latest origin/main merge: Status ok, 0 regressions, 0 verification failures
```

## Coverage and Metrics
- Changed-line coverage after the latest `origin/main` merge (`5786bbeb`): `98.92%` total (`92/93` changed executable lines).
  - `apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift`: `98.36%` (`60/61`)
  - `apps/macos-menubar/Tests/MenuBarTests/DesktopFoundationViewTests.swift`: `100.00%` (`32/32`)
- Full pre-commit gate on commit `68d69fc4`:
  - `make swift-test`: passed
  - `make py-test`: passed (`4062 passed, 14 skipped, 2 warnings`)
  - `make integration-test`: passed (`120 passed, 1 skipped`)
  - Pre-commit scoped performance report: passed (`0` regressions, `0` verification failures)
- Scoped performance report on merge commit `5786bbeb` for the full PR change set: `.runtime/pre-commit-performance/20260617-025151-5786bbeb/report/report.md`
  - Status: `ok`
  - Changed files: `4`
  - Selected probes: `0`
  - Regressions: `0`
  - Context regressions: `0`
  - Verification failures: `0`
- Observability mode: `off`; this slice adds local QR presentation only, with no new gateway calls, polling, metrics, or debug artifacts.
- Probe overhead: `N/A`; no observability or PR-scoped performance probe was added, and the existing registry selected no probes for this UI/docs change set.

## Known Gaps
- Deferred to later #1759 slices: companion/mobile import of `melix-companion:` QR/code payloads and real narrow-viewport companion status smoke.
- No protocol, dependency, or generated artifact changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
