### PR TITLE
perf: fast-path report evidence run-kind roles

### DIFF
--- a/docs/plans/2026-06-17-report-evidence-run-kind-role-membership.md
+++ b/docs/plans/2026-06-17-report-evidence-run-kind-role-membership.md
@@ -1,0 +1,38 @@
+# Report evidence run-kind role membership slice
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.productization.report_evidence_gate._report_matrix_roles` for release
+matrix rules that only match `run_kinds`. These rules are common in release
+evidence matrices, and the report's run-kind values are already normalized once
+per report.
+
+Affected files:
+
+- `services/mlx-worker-python/worker/productization/report_evidence_gate.py`
+- `services/mlx-worker-python/tests/test_report_evidence_gate.py`
+- `docs/plans/2026-06-17-report-evidence-run-kind-role-membership.md`
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`report-evidence-gate-run-kind-set-membership` in
+`infra/perf/pr_scoped_probes.json`. The registry entry already defines focused
+`test_command`, `coverage_command`, and `probe_command` entries. The primary
+metric for this slice is `matrix_roles_elapsed_ms_mean`, with
+`elapsed_ms_mean` as the aggregate registered-probe signal.
+
+## Intended change
+
+For run-kind-only tuple rules, avoid constructing or looking up a normalized
+frozenset per matrix role. Instead, compare the tuple entries directly against
+the once-per-report run-kind value set, preserving stringification behavior for
+non-string rule entries. Non-tuple run-kind iterables continue to use the
+existing normalization helper so mutable rule containers still reflect mutation.
+
+## Validation
+
+Run the registered focused tests, changed-scope coverage, and registered probe
+locally on Linux before opening the PR. CI remains the merge gate for the
+registered PR-scoped performance workflow.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -282,6 +282,7 @@ def test_report_evidence_gate_matrix_roles_keep_non_string_run_kind_match() -> N
 
 
 def test_report_evidence_gate_matrix_roles_select_multiple_run_kind_rules() -> None:
+    report_evidence_gate_module._string_frozenset_from_tuple.cache_clear()
     roles = report_evidence_gate_module._report_matrix_roles(
         {"runs": [{"run_kind": "serving_benchmark"}, {"run_kind": "evaluation"}]},
         {
@@ -292,6 +293,16 @@ def test_report_evidence_gate_matrix_roles_select_multiple_run_kind_rules() -> N
     )
 
     assert roles == ["serving", "evaluation"]
+    assert report_evidence_gate_module._string_frozenset_from_tuple.cache_info().misses == 0
+
+    mutable_roles = report_evidence_gate_module._report_matrix_roles(
+        {"runs": [{"run_kind": "dynamic"}, {"run_kind": "99"}]},
+        {
+            "dynamic": {"run_kinds": {"dynamic"}},
+            "numeric_rule": {"run_kinds": (99,)},
+        },
+    )
+    assert mutable_roles == ["dynamic", "numeric_rule"]
 
 
 def test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple() -> None:

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -302,7 +302,7 @@ def _report_matrix_roles(
         if _run_kind_only_rule(rule):
             if run_kind_values is None:
                 run_kind_values = _report_run_kind_values(runs)
-            if not _string_frozenset(rule.get("run_kinds", ())).isdisjoint(run_kind_values):
+            if _run_kind_rule_matches(rule.get("run_kinds", ()), run_kind_values):
                 roles.append(role)
             continue
         if rule.get("probe_phases") and probe_phases is None:
@@ -324,6 +324,18 @@ def _run_kind_only_rule(rule: dict[str, object]) -> bool:
         or rule.get("target_fields")
         or rule.get("probe_phases")
     )
+
+
+def _run_kind_rule_matches(run_kinds: object, run_kind_values: frozenset[str]) -> bool:
+    if isinstance(run_kinds, tuple):
+        for run_kind in run_kinds:
+            if type(run_kind) is str:
+                if run_kind in run_kind_values:
+                    return True
+            elif str(run_kind) in run_kind_values:
+                return True
+        return False
+    return not _string_frozenset(run_kinds).isdisjoint(run_kind_values)
 
 
 def _report_run_kind_values(runs: list[dict[str, object]]) -> frozenset[str]:


### PR DESCRIPTION
## Summary
- Fast-path report evidence release-matrix run-kind-only rules by comparing tuple rule values directly against the once-normalized report run-kind set.
- Preserve mutable non-tuple run-kind rule behavior through the existing normalization helper.
- Add a focused plan note for this Python performance slice.

## Plan or Spec
- `docs/plans/2026-06-17-report-evidence-run-kind-role-membership.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_fast_reject_preserves_empty_prefix services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation
# 3 passed in 0.12s (initial metric-prefix experiment; later rejected and reverted because the probe worsened)

bash /tmp/report_evidence_test_command.sh
# 22 passed in 0.20s

bash /tmp/report_evidence_coverage_command.sh
# 22 passed in 0.48s; changed-scope coverage TOTAL 15 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" MELIX_REPORT_EVIDENCE_RUN_KIND_ITERATIONS=20000 MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# elapsed_ms_mean=370.416572; matrix_roles_elapsed_ms_mean=1.501306

bash /tmp/report_evidence_probe_command.sh
# elapsed_ms_mean=938.542793; matrix_roles_elapsed_ms_mean=3.846578

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 15 0 100%`.
- Registered probe: `report-evidence-gate-run-kind-set-membership` (test, coverage, and probe commands are present in `infra/perf/pr_scoped_probes.json`).
- Local Linux probe comparison against `origin/main` with `MELIX_REPORT_EVIDENCE_RUN_KIND_ITERATIONS=50000` and `MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES=5`:
  - base `elapsed_ms_mean=933.899`, head `elapsed_ms_mean=908.847` (`-25.052 ms`, ~`2.68%` faster)
  - base `matrix_roles_elapsed_ms_mean=4.173`, head `matrix_roles_elapsed_ms_mean=3.768` (`-0.405 ms`, ~`9.71%` faster)
- Earlier 20k-sample baseline/head check: base `matrix_roles_elapsed_ms_mean=1.712881`, head `1.501306` (`-0.211575 ms`, ~`12.35%` faster).

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this PR is scoped to the registered focused Python probe and will rely on GitHub Actions for full CI.
- No protocol, dependency, or generated artifact changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
