### PR TITLE
feat(openai): strict SSE framing + opt-in prefill progress (#1392)

### DIFF
--- a/docs/control-plane-protocol.md
+++ b/docs/control-plane-protocol.md
@@ -542,6 +542,34 @@ to endpoint-specific SSE frames, and the control plane may use tool-result
 non-stream assistant text remains derived from public token deltas and completed
 assistant text only.
 
+### OpenAI SSE Framing And Prefill Progress
+
+The strict OpenAI-compatible stream shapes — Chat Completions and Completions —
+emit every OpenAI payload as an unnamed `data:` chunk. The gateway must not
+prefix these chunks with an `event:` name and must not inject non-OpenAI fields
+into the unnamed data channel, so SDK clients that parse only `data:` lines see
+a pure OpenAI stream. The Responses and Messages shapes keep their own
+protocol-specific named events because those protocols define them.
+
+Usage, on the strict shapes, is emitted as a trailing OpenAI chunk with an empty
+`choices` array and a `usage` object, after the finish chunk and before the
+terminal `data: [DONE]`. It is suppressed entirely unless the request opts in
+through `stream_options.include_usage`.
+
+Non-OpenAI telemetry never rides the unnamed `data:` channel. Reasoning,
+heartbeat, annotation, tool-result, and error frames use named SSE events, and
+worker events that have no OpenAI representation (queue, admission, cache, and
+prefill lifecycle payloads) are dropped from strict shapes by default.
+
+Prefill progress is opt-in. A client enables it with
+`stream_options.include_prefill_progress`, which the request layer records as the
+`melix.stream.include_prefill_progress` execution receipt. When enabled, the
+gateway emits prefill lifecycle as a named `event: prefill_progress` frame whose
+data carries `object: melix.prefill_progress`, a `phase` of `started` or
+`progress`, and the token counts. Because it is a named event, it stays invisible
+to strict OpenAI `data:`-only parsing; when the option is absent, prefill events
+produce no frame at all.
+
 Malformed or truncated tool fragments are recoverable parser observations. They should increment parser metrics and be skipped rather than fail the request. Display cleanup is not structural parsing; cleanup must not collapse meaningful leading or trailing content whitespace and must not re-emit generation-prefix control tokens.
 
 JSON-only structured-output requests without explicit tools suppress generic model-default tool parsing. The worker must not validate or output reasoning preambles as JSON content; any reasoning prefix is stripped before structured-output validation.

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -3595,7 +3595,8 @@ public struct OpenAIHandler: Sendable {
             shape: shape,
             toolParser: ToolParserSelection(executionExt: translated.workerRequest.execution.ext),
             options: SSEStreamWriter.StreamOptions(
-                includeUsage: translated.workerRequest.execution.ext["melix.stream.include_usage"] == "true"
+                includeUsage: translated.workerRequest.execution.ext["melix.stream.include_usage"] == "true",
+                includePrefillProgress: translated.workerRequest.execution.ext["melix.stream.include_prefill_progress"] == "true"
             ),
             onComplete: { [modelCatalog] in
                 await modelCatalog.finishRequest(modelID: translated.modelID)

--- a/services/control-plane-swift/Sources/HTTPGateway/SSE/SSEStreamWriter.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/SSE/SSEStreamWriter.swift
@@ -51,9 +51,14 @@ public struct SSEStreamWriter: Sendable {
 
     public struct StreamOptions: Sendable, Equatable {
         public let includeUsage: Bool
+        public let includePrefillProgress: Bool
 
-        public init(includeUsage: Bool = true) {
+        public init(
+            includeUsage: Bool = true,
+            includePrefillProgress: Bool = false
+        ) {
             self.includeUsage = includeUsage
+            self.includePrefillProgress = includePrefillProgress
         }
     }
 
@@ -102,9 +107,18 @@ public struct SSEStreamWriter: Sendable {
                 }
 
                 do {
+                    var deferredUsageEvent: Melix_Worker_V1_ExecuteEvent?
                     for try await event in stream {
-                        if !options.includeUsage, case .usageDelta = event.payload {
-                            continue
+                        if case .usageDelta = event.payload {
+                            guard options.includeUsage else {
+                                continue
+                            }
+                            // OpenAI strict shapes emit usage as the trailer chunk after the
+                            // finish chunk and before [DONE].
+                            if shape == .chatCompletions || shape == .completions {
+                                deferredUsageEvent = event
+                                continue
+                            }
                         }
                         let encodedEvent: Melix_Worker_V1_ExecuteEvent
                         if shape == .chatCompletions {
@@ -115,18 +129,30 @@ public struct SSEStreamWriter: Sendable {
                         } else {
                             encodedEvent = event
                         }
-                        if !Self.shouldSuppressEmptyChatTokenDelta(encodedEvent, shape: shape) {
+                        if !Self.shouldSuppressEmptyChatTokenDelta(encodedEvent, shape: shape),
+                           let encodedFrame = encode(
+                               event: encodedEvent,
+                               requestID: requestID,
+                               modelID: modelID,
+                               shape: shape,
+                               toolParser: toolParser,
+                               options: options
+                           ) {
                             emittedDataFrame = true
-                            yieldDataFrame(
-                                encode(
-                                    event: encodedEvent,
-                                    requestID: requestID,
-                                    modelID: modelID,
-                                    shape: shape,
-                                    toolParser: toolParser
-                                )
-                            )
+                            yieldDataFrame(encodedFrame)
                         }
+                    }
+                    if let deferredUsageEvent,
+                       let usageFrame = encode(
+                           event: deferredUsageEvent,
+                           requestID: requestID,
+                           modelID: modelID,
+                           shape: shape,
+                           toolParser: toolParser,
+                           options: options
+                       ) {
+                        emittedDataFrame = true
+                        yieldDataFrame(usageFrame)
                     }
                 } catch {
                     emittedDataFrame = true
@@ -237,13 +263,14 @@ public struct SSEStreamWriter: Sendable {
         requestID: String,
         modelID: String,
         shape: StreamShape,
-        toolParser: ToolParserSelection?
-    ) -> Data {
+        toolParser: ToolParserSelection?,
+        options: StreamOptions
+    ) -> Data? {
         switch shape {
         case .chatCompletions:
-            return encodeChatCompletions(event: event, requestID: requestID, modelID: modelID, toolParser: toolParser)
+            return encodeChatCompletions(event: event, requestID: requestID, modelID: modelID, toolParser: toolParser, options: options)
         case .completions:
-            return encodeCompletions(event: event, requestID: requestID, modelID: modelID, toolParser: toolParser)
+            return encodeCompletions(event: event, requestID: requestID, modelID: modelID, toolParser: toolParser, options: options)
         case .responses:
             return encodeResponses(event: event, requestID: requestID, modelID: modelID, toolParser: toolParser)
         case .messages:
@@ -251,16 +278,51 @@ public struct SSEStreamWriter: Sendable {
         }
     }
 
+    private func prefillProgressFrame(
+        event: Melix_Worker_V1_ExecuteEvent,
+        requestID: String,
+        options: StreamOptions
+    ) -> Data? {
+        guard options.includePrefillProgress else {
+            return nil
+        }
+        switch event.payload {
+        case .prefillStarted(let started):
+            return frame(
+                event: "prefill_progress",
+                json: [
+                    "object": "melix.prefill_progress",
+                    "request_id": requestID,
+                    "phase": "started",
+                    "input_tokens": Int(started.inputTokens),
+                ]
+            )
+        case .prefillProgress(let progress):
+            return frame(
+                event: "prefill_progress",
+                json: [
+                    "object": "melix.prefill_progress",
+                    "request_id": requestID,
+                    "phase": "progress",
+                    "processed_tokens": Int(progress.processedTokens),
+                    "total_tokens": Int(progress.totalTokens),
+                ]
+            )
+        default:
+            return nil
+        }
+    }
+
     private func encodeCompletions(
         event: Melix_Worker_V1_ExecuteEvent,
         requestID: String,
         modelID: String,
-        toolParser: ToolParserSelection?
-    ) -> Data {
+        toolParser: ToolParserSelection?,
+        options: StreamOptions
+    ) -> Data? {
         switch event.payload {
         case .tokenDelta(let delta):
-            return frame(
-                event: "message",
+            return dataFrame(
                 json: [
                     "id": requestID,
                     "object": "text_completion",
@@ -276,16 +338,22 @@ public struct SSEStreamWriter: Sendable {
                 ]
             )
         case .usageDelta(let usage):
-            return frame(
-                event: "usage",
+            return dataFrame(
                 json: [
-                    "request_id": requestID,
+                    "id": requestID,
+                    "object": "text_completion",
+                    "created": Int(now().timeIntervalSince1970),
+                    "model": modelID,
+                    "choices": [],
                     "usage": [
                         "prompt_tokens": Int(usage.promptTokens),
                         "completion_tokens": Int(usage.completionTokens),
+                        "total_tokens": Int(usage.promptTokens) + Int(usage.completionTokens),
                     ],
                 ]
             )
+        case .prefillStarted, .prefillProgress:
+            return prefillProgressFrame(event: event, requestID: requestID, options: options)
         case .reasoningDelta(let reasoning):
             return frame(
                 event: "reasoning",
@@ -347,8 +415,7 @@ public struct SSEStreamWriter: Sendable {
                 ]
             )
         case .completed(let completed):
-            return frame(
-                event: "message",
+            return dataFrame(
                 json: [
                     "id": requestID,
                     "object": "text_completion",
@@ -370,13 +437,7 @@ public struct SSEStreamWriter: Sendable {
                 message: error.error.message
             )
         default:
-            return frame(
-                event: "message",
-                json: [
-                    "request_id": requestID,
-                    "event_seq": Int(event.seq),
-                ]
-            )
+            return nil
         }
     }
 
@@ -384,12 +445,12 @@ public struct SSEStreamWriter: Sendable {
         event: Melix_Worker_V1_ExecuteEvent,
         requestID: String,
         modelID: String,
-        toolParser: ToolParserSelection?
-    ) -> Data {
+        toolParser: ToolParserSelection?,
+        options: StreamOptions
+    ) -> Data? {
         switch event.payload {
         case .tokenDelta(let delta):
-            return frame(
-                event: "message",
+            return dataFrame(
                 json: [
                     "id": requestID,
                     "object": "chat.completion.chunk",
@@ -407,8 +468,7 @@ public struct SSEStreamWriter: Sendable {
                 ]
             )
         case .usageDelta(let usage):
-            return frame(
-                event: "message",
+            return dataFrame(
                 json: [
                     "id": requestID,
                     "object": "chat.completion.chunk",
@@ -470,10 +530,7 @@ public struct SSEStreamWriter: Sendable {
                 ],
                 toolParser: toolParser
             )
-            return frame(
-                event: "message",
-                json: payload
-            )
+            return dataFrame(json: payload)
         case .annotationDelta(let annotation):
             var payload = annotationPayload(
                 annotation,
@@ -507,8 +564,7 @@ public struct SSEStreamWriter: Sendable {
                 ]
             )
         case .completed(let completed):
-            return frame(
-                event: "message",
+            return dataFrame(
                 json: [
                     "id": requestID,
                     "object": "chat.completion.chunk",
@@ -532,14 +588,10 @@ public struct SSEStreamWriter: Sendable {
                 code: error.error.code,
                 message: error.error.message
             )
+        case .prefillStarted, .prefillProgress:
+            return prefillProgressFrame(event: event, requestID: requestID, options: options)
         default:
-            return frame(
-                event: "message",
-                json: [
-                    "request_id": requestID,
-                    "event_seq": Int(event.seq),
-                ]
-            )
+            return nil
         }
     }
 
@@ -839,8 +891,9 @@ public struct SSEStreamWriter: Sendable {
             requestID: requestID,
             modelID: modelID,
             shape: shape,
-            toolParser: nil
-        )
+            toolParser: nil,
+            options: StreamOptions()
+        ) ?? doneFrame()
     }
 
     private func doneFrame() -> Data {
@@ -913,6 +966,14 @@ public struct SSEStreamWriter: Sendable {
         let payloadData = (try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])) ?? Data("{}".utf8)
         let payload = String(decoding: payloadData, as: UTF8.self)
         return Data("event: \(event)\ndata: \(payload)\n\n".utf8)
+    }
+
+    // Strict OpenAI stream shapes emit unnamed data-only chunks; named events are
+    // reserved for non-OpenAI telemetry.
+    private func dataFrame(json: [String: Any]) -> Data {
+        let payloadData = (try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])) ?? Data("{}".utf8)
+        let payload = String(decoding: payloadData, as: UTF8.self)
+        return Data("data: \(payload)\n\n".utf8)
     }
 }
 

--- a/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
+++ b/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
@@ -402,13 +402,19 @@ public struct TranslatedChatRequest: Sendable {
 
 public struct OpenAIStreamOptions: Codable, Sendable, Equatable {
     public let includeUsage: Bool?
+    public let includePrefillProgress: Bool?
 
     enum CodingKeys: String, CodingKey {
         case includeUsage = "include_usage"
+        case includePrefillProgress = "include_prefill_progress"
     }
 
-    public init(includeUsage: Bool? = nil) {
+    public init(
+        includeUsage: Bool? = nil,
+        includePrefillProgress: Bool? = nil
+    ) {
         self.includeUsage = includeUsage
+        self.includePrefillProgress = includePrefillProgress
     }
 }
 
@@ -958,6 +964,9 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         if let topLogprobs {
             receipts["melix.openai.top_logprobs.requested"] = String(topLogprobs)
             receipts["melix.openai.logprobs.effective"] = "unsupported"
+        }
+        if streamOptions?.includePrefillProgress == true {
+            receipts["melix.stream.include_prefill_progress"] = "true"
         }
         return receipts
     }

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/HTTPGatewayTestSupport.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/HTTPGatewayTestSupport.swift
@@ -187,3 +187,56 @@ func makeApplyGatewayAccessRequest(
     }
     return request
 }
+
+func makePrefillStartedEvent(
+    requestID: String,
+    seq: UInt64,
+    inputTokens: UInt32
+) -> Melix_Worker_V1_ExecuteEvent {
+    var event = Melix_Worker_V1_ExecuteEvent()
+    event.requestID = requestID
+    event.executionKind = "generate"
+    event.seq = seq
+    event.prefillStarted = Melix_Worker_V1_PrefillStarted()
+    event.prefillStarted.inputTokens = inputTokens
+    return event
+}
+
+func makePrefillProgressEvent(
+    requestID: String,
+    seq: UInt64,
+    processedTokens: UInt32,
+    totalTokens: UInt32
+) -> Melix_Worker_V1_ExecuteEvent {
+    var event = Melix_Worker_V1_ExecuteEvent()
+    event.requestID = requestID
+    event.executionKind = "generate"
+    event.seq = seq
+    event.prefillProgress = Melix_Worker_V1_PrefillProgress()
+    event.prefillProgress.processedTokens = processedTokens
+    event.prefillProgress.totalTokens = totalTokens
+    return event
+}
+
+struct SSERecord: Equatable {
+    let event: String?
+    let data: String
+}
+
+func parseSSERecords(_ payload: String) -> [SSERecord] {
+    payload.components(separatedBy: "\n\n").compactMap { block in
+        var eventName: String?
+        var dataLines: [String] = []
+        for line in block.split(separator: "\n", omittingEmptySubsequences: true) {
+            if line.hasPrefix("event: ") {
+                eventName = String(line.dropFirst("event: ".count))
+            } else if line.hasPrefix("data: ") {
+                dataLines.append(String(line.dropFirst("data: ".count)))
+            }
+        }
+        guard !dataLines.isEmpty else {
+            return nil
+        }
+        return SSERecord(event: eventName, data: dataLines.joined(separator: "\n"))
+    }
+}

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift
@@ -360,7 +360,7 @@ struct OpenAIConformanceMatrixTests {
 
         #expect(response.statusCode == 200)
         #expect(request.execution.toolConfig.toolChoice.contains("get_weather"))
-        #expect(payload.contains("event: message"))
+        #expect(payload.contains("event: message") == false)
         #expect(payload.contains("\"tool_calls\""))
         #expect(payload.contains("\"name\":\"get_weather\""))
         #expect(payload.contains("\"arguments\":\"{\\\"city\\\":\\\"Tokyo\\\"}\""))
@@ -406,10 +406,111 @@ struct OpenAIConformanceMatrixTests {
         #expect(payload.contains("\"total_tokens\":12"))
         #expect(orderedConformanceRanges(in: payload, needles: [
             "\"content\":\"done\"",
-            "\"usage\"",
             "\"finish_reason\":\"stop\"",
+            "\"usage\"",
             "data: [DONE]",
         ]))
+    }
+
+    @Test("streaming prefill progress stays invisible unless opted in")
+    func streamingPrefillProgressStaysInvisibleUnlessOptedIn() async throws {
+        func prefillEvents(requestID: String) -> [Melix_Worker_V1_ExecuteEvent] {
+            [
+                makePrefillStartedEvent(requestID: requestID, seq: 1, inputTokens: 6),
+                makePrefillProgressEvent(requestID: requestID, seq: 2, processedTokens: 3, totalTokens: 6),
+                makeTokenEvent(requestID: requestID, seq: 3, text: "hi"),
+                makeUsageEvent(requestID: requestID, seq: 4, promptTokens: 6, completionTokens: 1),
+                makeCompletedEvent(requestID: requestID, seq: 5, finishReason: "stop", assistantText: "hi"),
+            ]
+        }
+        func chunkOrder(_ payload: String) -> String {
+            parseSSERecords(payload).map { $0.event ?? "data" }.joined(separator: ",")
+        }
+        func expectStrictDataPurity(_ payload: String) throws {
+            for record in parseSSERecords(payload) where record.event == nil {
+                if record.data == "[DONE]" {
+                    continue
+                }
+                let object = try JSONSerialization.jsonObject(with: Data(record.data.utf8))
+                let json = try #require(object as? [String: Any])
+                #expect(json["object"] as? String == "chat.completion.chunk")
+            }
+        }
+
+        let defaultWorker = RecordingConformanceWorker(
+            requestID: "req-stream-pf-default",
+            events: prefillEvents(requestID: "req-stream-pf-default")
+        )
+        let defaultResponse = try await Self.handler(worker: defaultWorker).handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: Data(
+                    Self.body(extra: #""stream": true, "stream_options": { "include_usage": true }"#).utf8
+                )
+            )
+        )
+        let defaultPayload = try await collectConformanceBody(defaultResponse.body)
+
+        #expect(defaultResponse.statusCode == 200)
+        #expect(defaultPayload.contains("prefill_progress") == false)
+        #expect(defaultPayload.contains("\"processed_tokens\"") == false)
+        try expectStrictDataPurity(defaultPayload)
+        let defaultOrder = chunkOrder(defaultPayload)
+        #expect(defaultOrder == "data,data,data,data")
+
+        let optInWorker = RecordingConformanceWorker(
+            requestID: "req-stream-pf-opt-in",
+            events: prefillEvents(requestID: "req-stream-pf-opt-in")
+        )
+        let optInResponse = try await Self.handler(worker: optInWorker).handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: Data(
+                    Self.body(
+                        extra: #""stream": true, "stream_options": { "include_usage": true, "include_prefill_progress": true }"#
+                    ).utf8
+                )
+            )
+        )
+        let optInPayload = try await collectConformanceBody(optInResponse.body)
+        let optInRequest = try #require(await optInWorker.lastGenerateRequest)
+
+        #expect(optInResponse.statusCode == 200)
+        #expect(optInRequest.execution.ext["melix.stream.include_prefill_progress"] == "true")
+        #expect(optInPayload.contains("event: prefill_progress"))
+        #expect(optInPayload.contains("\"phase\":\"started\""))
+        #expect(optInPayload.contains("\"input_tokens\":6"))
+        #expect(optInPayload.contains("\"phase\":\"progress\""))
+        #expect(optInPayload.contains("\"processed_tokens\":3"))
+        try expectStrictDataPurity(optInPayload)
+        let optInOrder = chunkOrder(optInPayload)
+        #expect(optInOrder == "prefill_progress,prefill_progress,data,data,data,data")
+
+        let report = OpenAIConformanceReport(rows: [
+            OpenAIConformanceRow(
+                field: "stream_options.include_prefill_progress=absent",
+                route: "/v1/chat/completions -> SSE chunk order",
+                expectedBehavior: "prefill telemetry is dropped; only OpenAI data chunks reach the stream.",
+                observedStatus: defaultOrder == "data,data,data,data" ? .pass : .fail,
+                observedReason: "chunk_order=\(defaultOrder)"
+            ),
+            OpenAIConformanceRow(
+                field: "stream_options.include_prefill_progress=true",
+                route: "/v1/chat/completions -> SSE chunk order",
+                expectedBehavior: "prefill telemetry uses the named prefill_progress event and stays out of unnamed data chunks.",
+                observedStatus: optInOrder == "prefill_progress,prefill_progress,data,data,data,data" ? .pass : .fail,
+                observedReason: "chunk_order=\(optInOrder)"
+            ),
+        ])
+        #expect(report.summary.passed == 2)
+        #expect(report.summary.failed == 0)
+        let reportJSON = try report.jsonString()
+        #expect(reportJSON.contains("\"chunk_order=data,data,data,data\""))
+        #expect(reportJSON.contains("\"chunk_order=prefill_progress,prefill_progress,data,data,data,data\""))
     }
 
     @Test("orphan tool-call markup is suppressed across streaming and non-streaming chat")

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -1852,7 +1852,7 @@ struct OpenAIHandlerTests {
         #expect(request.execution.toolConfig.toolChoice == "auto")
         #expect(request.execution.ext["melix.tool_parser.mode"] == "xml")
         #expect(request.execution.ext["melix.tool_config.source"] == "openai_chat_tools")
-        #expect(payload.contains("event: message"))
+        #expect(payload.contains("event: message") == false)
         #expect(payload.contains("\"object\":\"chat.completion.chunk\""))
         #expect(payload.contains("\"tool_calls\""))
         #expect(payload.contains("\"index\":1"))

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/SSEStreamWriterTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/SSEStreamWriterTests.swift
@@ -23,7 +23,7 @@ struct SSEStreamWriterTests {
             writer.encode(stream: stream, requestID: "req-1", modelID: "melix-dev-text")
         )
 
-        #expect(payload.contains("event: message"))
+        #expect(payload.contains("event: message") == false)
         #expect(payload.contains("\"content\":\"A\""))
         #expect(payload.contains("event: heartbeat"))
         #expect(payload.contains("\"unix_ms\":99"))
@@ -33,10 +33,137 @@ struct SSEStreamWriterTests {
         #expect(orderedRanges(in: payload, needles: [
             "\"content\":\"A\"",
             "\"unix_ms\":99",
-            "\"prompt_tokens\":3",
             "\"finish_reason\":\"stop\"",
+            "\"prompt_tokens\":3",
             "data: [DONE]",
         ]))
+    }
+
+    @Test("chat completion data frames stay unnamed and pure under data-only parsing")
+    func chatCompletionDataFramesStayUnnamedAndPure() async throws {
+        let writer = SSEStreamWriter(now: { Date(timeIntervalSince1970: 456) }, keepaliveInterval: nil)
+
+        let stream = AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error> { continuation in
+            continuation.yield(makeTokenEvent(requestID: "req-pure", seq: 1, text: "A"))
+            continuation.yield(makeToolCallEvent(
+                requestID: "req-pure",
+                seq: 2,
+                callID: "tool-1",
+                toolName: "search",
+                argumentsJSONFragment: "{\"q\":\"melix\"}",
+                fragmentIndex: 1
+            ))
+            continuation.yield(makeUsageEvent(requestID: "req-pure", seq: 3, promptTokens: 3, completionTokens: 2))
+            continuation.yield(makeCompletedEvent(requestID: "req-pure", seq: 4, finishReason: "tool_calls", assistantText: ""))
+            continuation.finish()
+        }
+
+        let payload = try await collectChunks(
+            writer.encode(stream: stream, requestID: "req-pure", modelID: "melix-dev-text")
+        )
+
+        let unnamedRecords = parseSSERecords(payload).filter { $0.event == nil }
+        #expect(unnamedRecords.count >= 4)
+        for record in unnamedRecords {
+            if record.data == "[DONE]" {
+                continue
+            }
+            let object = try JSONSerialization.jsonObject(with: Data(record.data.utf8))
+            let json = try #require(object as? [String: Any])
+            #expect(json["object"] as? String == "chat.completion.chunk")
+        }
+        let usageIndex = try #require(unnamedRecords.firstIndex { $0.data.contains("\"prompt_tokens\":3") })
+        let finishIndex = try #require(unnamedRecords.firstIndex { $0.data.contains("\"finish_reason\":\"tool_calls\"") })
+        let doneIndex = try #require(unnamedRecords.firstIndex { $0.data == "[DONE]" })
+        #expect(finishIndex < usageIndex)
+        #expect(usageIndex < doneIndex)
+    }
+
+    @Test("chat completion streams drop prefill events by default")
+    func dropsPrefillEventsByDefault() async throws {
+        let writer = SSEStreamWriter(now: { Date(timeIntervalSince1970: 456) }, keepaliveInterval: nil)
+
+        let stream = AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error> { continuation in
+            continuation.yield(makePrefillStartedEvent(requestID: "req-warmup-off", seq: 1, inputTokens: 9))
+            continuation.yield(makePrefillProgressEvent(requestID: "req-warmup-off", seq: 2, processedTokens: 4, totalTokens: 9))
+            continuation.yield(makeTokenEvent(requestID: "req-warmup-off", seq: 3, text: "A"))
+            continuation.yield(makeCompletedEvent(requestID: "req-warmup-off", seq: 4, finishReason: "stop", assistantText: "A"))
+            continuation.finish()
+        }
+
+        let payload = try await collectChunks(
+            writer.encode(stream: stream, requestID: "req-warmup-off", modelID: "melix-dev-text")
+        )
+
+        #expect(payload.contains("prefill") == false)
+        #expect(payload.contains("\"event_seq\"") == false)
+        #expect(payload.contains("\"content\":\"A\""))
+        #expect(payload.contains("data: [DONE]"))
+    }
+
+    @Test("chat completion streams emit named prefill progress events when opted in")
+    func emitsNamedPrefillProgressWhenOptedIn() async throws {
+        let writer = SSEStreamWriter(now: { Date(timeIntervalSince1970: 456) }, keepaliveInterval: nil)
+
+        let stream = AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error> { continuation in
+            continuation.yield(makePrefillStartedEvent(requestID: "req-prefill-on", seq: 1, inputTokens: 9))
+            continuation.yield(makePrefillProgressEvent(requestID: "req-prefill-on", seq: 2, processedTokens: 4, totalTokens: 9))
+            continuation.yield(makeTokenEvent(requestID: "req-prefill-on", seq: 3, text: "A"))
+            continuation.yield(makeCompletedEvent(requestID: "req-prefill-on", seq: 4, finishReason: "stop", assistantText: "A"))
+            continuation.finish()
+        }
+
+        let payload = try await collectChunks(
+            writer.encode(
+                stream: stream,
+                requestID: "req-prefill-on",
+                modelID: "melix-dev-text",
+                options: .init(includeUsage: true, includePrefillProgress: true)
+            )
+        )
+
+        #expect(payload.contains("event: prefill_progress"))
+        #expect(payload.contains("\"phase\":\"started\""))
+        #expect(payload.contains("\"input_tokens\":9"))
+        #expect(payload.contains("\"phase\":\"progress\""))
+        #expect(payload.contains("\"processed_tokens\":4"))
+        #expect(payload.contains("\"total_tokens\":9"))
+
+        let unnamedRecords = parseSSERecords(payload).filter { $0.event == nil }
+        for record in unnamedRecords {
+            if record.data == "[DONE]" {
+                continue
+            }
+            let object = try JSONSerialization.jsonObject(with: Data(record.data.utf8))
+            let json = try #require(object as? [String: Any])
+            #expect(json["object"] as? String == "chat.completion.chunk")
+        }
+    }
+
+    @Test("completions streams drop prefill events by default")
+    func completionsShapeDropsPrefillEventsByDefault() async throws {
+        let writer = SSEStreamWriter(now: { Date(timeIntervalSince1970: 456) }, keepaliveInterval: nil)
+
+        let stream = AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error> { continuation in
+            continuation.yield(makePrefillStartedEvent(requestID: "cmp-warmup-off", seq: 1, inputTokens: 5))
+            continuation.yield(makeTokenEvent(requestID: "cmp-warmup-off", seq: 2, text: "A"))
+            continuation.yield(makeCompletedEvent(requestID: "cmp-warmup-off", seq: 3, finishReason: "stop", assistantText: "A"))
+            continuation.finish()
+        }
+
+        let payload = try await collectChunks(
+            writer.encode(
+                stream: stream,
+                requestID: "cmp-warmup-off",
+                modelID: "melix-dev-text",
+                shape: .completions
+            )
+        )
+
+        #expect(payload.contains("prefill") == false)
+        #expect(payload.contains("event: message") == false)
+        #expect(payload.contains("\"text\":\"A\""))
+        #expect(payload.contains("data: [DONE]"))
     }
 
     @Test("SSE suppresses usage frames when includeUsage is disabled")
@@ -275,8 +402,8 @@ struct SSEStreamWriterTests {
         #expect(payload.contains("data: [DONE]"))
     }
 
-    @Test("chat completion streams emit fallback frames for untyped events")
-    func emitsChatFallbackFrames() async throws {
+    @Test("chat completion streams drop untyped events instead of framing them")
+    func dropsChatFallbackFrames() async throws {
         let writer = SSEStreamWriter(now: { Date(timeIntervalSince1970: 456) })
 
         let stream = AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error> { continuation in
@@ -292,9 +419,10 @@ struct SSEStreamWriterTests {
             writer.encode(stream: stream, requestID: "req-fallback", modelID: "melix-dev-text")
         )
 
-        #expect(payload.contains("event: message"))
-        #expect(payload.contains("\"request_id\":\"req-fallback\""))
-        #expect(payload.contains("\"event_seq\":9"))
+        #expect(payload.contains("event: message") == false)
+        #expect(payload.contains("\"event_seq\"") == false)
+        #expect(payload.contains("\"id\":\"req-fallback\""))
+        #expect(payload.contains("\"finish_reason\":\"stop\""))
         #expect(payload.contains("data: [DONE]"))
     }
 
@@ -392,10 +520,16 @@ struct SSEStreamWriterTests {
 
         #expect(payload.contains("\"object\":\"text_completion\""))
         #expect(payload.contains("\"text\":\"A\""))
-        #expect(payload.contains("event: usage"))
+        #expect(payload.contains("event: usage") == false)
         #expect(payload.contains("\"prompt_tokens\":4"))
+        #expect(payload.contains("\"total_tokens\":5"))
         #expect(payload.contains("\"finish_reason\":\"stop\""))
         #expect(payload.contains("data: [DONE]"))
+        #expect(orderedRanges(in: payload, needles: [
+            "\"finish_reason\":\"stop\"",
+            "\"prompt_tokens\":4",
+            "data: [DONE]",
+        ]))
     }
 
     @Test("messages streams emit delta heartbeat completion fallback and done frames")
@@ -439,7 +573,7 @@ struct SSEStreamWriterTests {
         #expect(payload.contains("data: [DONE]"))
     }
 
-    @Test("completions streams emit heartbeat error fallback and done frames")
+    @Test("completions streams emit heartbeat and error frames while dropping fallback events")
     func emitsCompletionsHeartbeatErrorAndFallbackFrames() async throws {
         let writer = SSEStreamWriter(now: { Date(timeIntervalSince1970: 456) })
 
@@ -468,8 +602,8 @@ struct SSEStreamWriterTests {
         #expect(payload.contains("\"unix_ms\":654"))
         #expect(payload.contains("event: error"))
         #expect(payload.contains("\"code\":\"runtime_error\""))
-        #expect(payload.contains("event: message"))
-        #expect(payload.contains("\"event_seq\":3"))
+        #expect(payload.contains("event: message") == false)
+        #expect(payload.contains("\"event_seq\"") == false)
         #expect(payload.contains("data: [DONE]"))
     }
 
@@ -569,11 +703,11 @@ struct SSEStreamWriterTests {
         #expect(payload.contains("\"parser_mode\":\"qwen\""))
         #expect(payload.contains("\"parser_namespaces\":[\"tools.search\"]"))
         #expect(payload.contains("\"parser_fallback_mode\":\"xml\""))
+        #expect(payload.contains("event: message") == false)
         #expect(orderedRanges(in: payload, needles: [
             "event: reasoning",
-            "event: message",
             "\"tool_calls\"",
-            "event: message",
+            "\"finish_reason\":\"stop\"",
             "data: [DONE]",
         ]))
     }

--- a/tests/integration/test_phase6_operator_workflows.py
+++ b/tests/integration/test_phase6_operator_workflows.py
@@ -52,7 +52,7 @@ def _chat_completions_tool_call_stream_success(status: int, payload: object) -> 
         return False
     return (
         status == 200
-        and b"event: message" in payload
+        and b"event: message" not in payload
         and b"\"object\":\"chat.completion.chunk\"" in payload
         and b"\"tool_calls\"" in payload
         and b"\"name\":\"tools.vision\"" in payload
@@ -616,7 +616,7 @@ def test_multimodal_chat_suppresses_model_default_parser_selection_for_llava_fam
         )
 
         assert status == 200
-        assert b"event: message" in payload
+        assert b"event: message" not in payload
         assert b"\"object\":\"chat.completion.chunk\"" in payload
         assert b"\"tool_calls\"" not in payload
         assert b"\"parser_mode\":\"qwen\"" not in payload


### PR DESCRIPTION
Closes #1392. Child of #1384.

## Plan or Spec

#1392 asked for SwiftLM-style strict OpenAI SSE conformance and an opt-in prefill-progress channel. The acceptance gap surfaced when re-baselining #1384: the SSE writer framed OpenAI chunks as named `event: message` frames and had no `prefill_progress` event, with no test proving prefill telemetry stays invisible to strict OpenAI `data:`-only parsing.

This PR:
- Strict shapes (`chat.completions`, `completions`) emit every OpenAI payload as an unnamed `data:` chunk; `event:` names are reserved for non-OpenAI telemetry (reasoning/heartbeat/annotation/tool_result/error). Per-shape encoders return `Data?` (nil = drop).
- Usage on strict shapes is a trailing chunk after the finish chunk and before `data: [DONE]`, still gated by `stream_options.include_usage`.
- Worker events with no OpenAI representation (queue/admission/cache/prefill) are dropped from strict shapes by default.
- Prefill progress is opt-in via `stream_options.include_prefill_progress` → `melix.stream.include_prefill_progress` execution receipt → named `event: prefill_progress` frame (`object: melix.prefill_progress`, `phase` started/progress, token counts), invisible to strict data-only parsing.
- Documents the rule in `docs/control-plane-protocol.md` (§ OpenAI SSE Framing And Prefill Progress).

## Commands Run

- `swift test --package-path services/control-plane-swift --filter SSEStreamWriterTests --filter OpenAIConformanceMatrixTests --filter ProtocolCompatibilityMatrixTests --filter postChatCompletionsForwardsOpenAIToolsAndToolDeltas` → **40 tests, all pass**
- `git diff --check` → clean
- Stash/rebuild check of `RequestCoordinatorTests` on clean `origin/main` to attribute the pre-existing hang (see Known Gaps)

## Coverage and Metrics

Behavior coverage on the changed Swift scope: new `SSEStreamWriterTests` cases assert bare-`data:` purity (every unnamed chunk JSON-parses to `chat.completion.chunk`), default prefill drop, opt-in named `prefill_progress`, and the usage-trailer ordering; a new `OpenAIConformanceMatrixTests` row pair records exact chunk order for default (`data,data,data,data`) vs opt-in (`prefill_progress,prefill_progress,data,data,data,data`) into the machine-readable report. Updated three stale `event: message` assertions that encoded the old framing. The non-stream chat path is unaffected — it consumes the worker event stream via `aggregateChatCompletion`, not SSE bytes.

## Known Gaps

- The full `HTTPGatewayTests` target contains a pre-existing timing-fragile test — `RequestCoordinatorTests."python text compatibility sessions use generate instead of phase-aware prefill"` — that hangs/flakes in this contended local environment (it uses a `BlockingWorkerClient` trap plus an `AsyncStream` consumer with `Task.sleep` polling). It hangs identically on clean `origin/main` with my changes stashed, so it is unrelated to this diff. CI is the authoritative full-suite signal.
- Backend token logprobs, real proxy parity, and the runnable conformance harness remain separate #1384 children (#1990 / #1989 / #1986).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
