### PR TITLE
perf: fast-path trajectory scalar list copies

### DIFF
--- a/docs/plans/2026-06-17-trajectory-list-immutable-fastpath.md
+++ b/docs/plans/2026-06-17-trajectory-list-immutable-fastpath.md
@@ -1,0 +1,31 @@
+# Trajectory provenance scalar list copy fast path
+
+## Scope
+
+This slice keeps trajectory provenance normalization behavior unchanged while
+extending the existing JSON scalar-list copy fast path beyond lists of four
+items. The target path is `services/mlx-worker-python/worker/trajectory_provenance.py`.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped probe
+`trajectory-provenance-copy-elision` in `infra/perf/pr_scoped_probes.json`. The
+probe has focused `test_command`, `coverage_command`, and `probe_command`
+entries and exercises trajectory quality component labels.
+
+## Implementation plan
+
+- Preserve deep-copy isolation for nested mutable containers.
+- Detect all-immutable JSON lists with one linear scan and copy them directly
+  with `list.copy()` instead of recursive per-item dispatch.
+- Extend focused tests so scalar lists longer than four items avoid recursive
+  copy dispatch.
+- Use the existing registered probe fixture to verify the scalar list copy path
+  still improves the trajectory normalization workload without widening the PR
+  scope.
+
+## Verification
+
+Run the registered test command, changed-scope coverage command, and probe
+command locally on Linux before opening the PR. GitHub Actions remains the
+registered PR-scoped performance gate before merge.

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -499,6 +499,7 @@ def test_normalize_trajectory_provenance_keeps_scalars_and_skips_empty_values() 
         ["agentic", "trajectory"],
         ["agentic", "trajectory", 3],
         ["agentic", "trajectory", 3, True],
+        ["agentic", "trajectory", "quality", 3, True, None, 0.75],
     ],
 )
 def test_copy_json_list_copies_short_scalar_lists_without_recursive_calls(

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -43,33 +43,10 @@ _JSON_IMMUTABLE_TYPE_SET = frozenset(_JSON_IMMUTABLE_TYPES)
 
 def _copy_json_list(value: list[Any]) -> list[Any]:
     immutable_types = _JSON_IMMUTABLE_TYPE_SET
-    value_len = len(value)
-    if value_len == 0:
-        return []
-    if value_len == 1 and type(value[0]) in immutable_types:
-        return value.copy()
-    if (
-        value_len == 2
-        and type(value[0]) in immutable_types
-        and type(value[1]) in immutable_types
-    ):
-        return value.copy()
-    if (
-        value_len == 3
-        and type(value[0]) in immutable_types
-        and type(value[1]) in immutable_types
-        and type(value[2]) in immutable_types
-    ):
-        return value.copy()
-    if (
-        value_len == 4
-        and type(value[0]) in immutable_types
-        and type(value[1]) in immutable_types
-        and type(value[2]) in immutable_types
-        and type(value[3]) in immutable_types
-    ):
-        return value.copy()
-    return [_copy_trajectory_provenance_value(item) for item in value]
+    for item in value:
+        if type(item) not in immutable_types:
+            return [_copy_trajectory_provenance_value(item) for item in value]
+    return value.copy()
 
 
 def _copy_trajectory_provenance_value(value: Any) -> Any:


### PR DESCRIPTION
## Summary
- Fast-path trajectory provenance JSON lists whose items are all immutable scalars with a single scan plus `list.copy()`.
- Extend the focused regression test to cover scalar lists longer than the prior four-item special case.
- Extend the registered trajectory provenance copy-elision probe fixture so component labels exercise the longer scalar-list path.

## Plan or Spec
- `docs/plans/2026-06-17-trajectory-list-immutable-fastpath.md`
- Registered PR-scoped probe: `trajectory-provenance-copy-elision` in `infra/perf/pr_scoped_probes.json` (has focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_provenance_copy_elision_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 13 passed in 0.63s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names
# 10 passed in 0.69s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
# TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 scripts/trajectory_provenance_copy_elision_probe.py
# {"baseline_elapsed_ms_mean": 1776.7942254431546, "baseline_peak_bytes_mean": 36632.0, "component_count": 64.0, "delta_ms": -1366.7192130349576, "elapsed_ms_mean": 410.0750124081969, "iteration_count": 2000.0, "optimized_elapsed_ms_mean": 410.0750124081969, "optimized_peak_bytes_mean": 21008.0, "peak_bytes_mean": 21008.0, "sample_count": 5.0, "speedup": 4.332851726343418}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/trajectory_provenance.py` = 100% (`TOTAL 4 0 100%`).
- Registered local probe (`trajectory_provenance_copy_elision_probe.py`): `baseline_elapsed_ms_mean=1776.7942254431546`, `optimized_elapsed_ms_mean=410.0750124081969`, `delta_ms=-1366.7192130349576`, `speedup=4.332851726343418`, `baseline_peak_bytes_mean=36632.0`, `optimized_peak_bytes_mean=21008.0`.
- CI PR-scoped performance workflow is required before merge for the registered probe report.

## Known Gaps
- Linux local validation covers the Python path only. No Swift runtime effect is claimed.
- Full repository gates were not run locally; this PR uses the focused registered test, coverage, and probe commands for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
