### PR TITLE
perf: sort lora reward summary accumulators in place

### DIFF
--- a/docs/plans/2026-06-17-lora-reward-summary-sort-in-place.md
+++ b/docs/plans/2026-06-17-lora-reward-summary-sort-in-place.md
@@ -1,0 +1,44 @@
+# LoRA reward summary in-place sort performance slice
+
+## Scope
+
+This Python-only performance slice is limited to the LoRA reward summary helper in
+`services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py`.
+
+The helper already computes reward totals, candidate group margins, and variance
+in one pass. The remaining allocation point is percentile preparation: the helper
+uses `sorted(...)` to build copied ordered lists for reward scores and candidate
+margins even though those local accumulators are not reused afterward.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`lora-reward-summary-candidate-minmax` in `infra/perf/pr_scoped_probes.json`.
+The probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries and measures:
+
+- `elapsed_ms_mean` (lower is better)
+- `sorted_calls_mean` (lower is better)
+
+## Implementation Plan
+
+1. Keep the existing single-pass score and candidate margin accumulation.
+2. Replace copied `sorted(...)` calls with in-place `.sort()` on local accumulator
+   lists immediately before percentile calculation.
+3. Preserve percentile outputs and existing invalid-candidate handling.
+4. Keep tests focused on the registered probe path and verify the registered
+   probe locally on Linux.
+
+## Verification Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_reward_summary_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/lora_reward_summary_probe.py
+```
+
+## Acceptance Criteria
+
+- Focused tests pass.
+- Changed-scope coverage is at least 95%.
+- Registered probe shows fewer `sorted_calls_mean` and no elapsed regression.

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -124,7 +124,7 @@ def test_reward_summary_reuses_candidate_group_minmax(
     assert summary["candidate_group_reward_variance_mean"] == pytest.approx(
         0.19777777777777786
     )
-    assert sorted_calls == [8, 2]
+    assert sorted_calls == []
 
 
 def test_latest_checkpoint_from_directory_prefers_last_numeric_token(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -5338,7 +5338,7 @@ def test_lora_reward_summary_probe_script_emits_metrics() -> None:
     metrics = _probe_command_json(probe=probe, repo_root=REPO_ROOT)
 
     assert metrics["elapsed_ms_mean"] > 0
-    assert metrics["sorted_calls_mean"] == 2.0
+    assert metrics["sorted_calls_mean"] == 0.0
     assert metrics["sample_count"] == 5000.0
     assert metrics["candidate_count"] == 32.0
     assert metrics["checksum"] > 0
@@ -5356,7 +5356,7 @@ def test_lora_reward_summary_probe_script_main_covers_checked_in_file(
     assert module.main() == 0
     payload = json.loads(capsys.readouterr().out.strip())
 
-    assert payload["sorted_calls_mean"] == 2.0
+    assert payload["sorted_calls_mean"] == 0.0
     assert payload["sample_count"] == 5000.0
     assert payload["candidate_count"] == 32.0
 

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -826,14 +826,14 @@ def _reward_summary(samples: list[dict[str, Any]]) -> dict[str, float | int]:
             candidate_group_variance_total += candidate_group_variance
     if not scores:
         return {}
-    ordered = sorted(scores)
+    scores.sort()
     summary: dict[str, float | int] = {
         "reward_mean": score_total / len(scores),
-        "reward_p50": _percentile_value(ordered, 0.5),
-        "reward_p95": _percentile_value(ordered, 0.95),
+        "reward_p50": _percentile_value(scores, 0.5),
+        "reward_p95": _percentile_value(scores, 0.95),
     }
     if candidate_group_margins:
-        ordered_margins = sorted(candidate_group_margins)
+        candidate_group_margins.sort()
         candidate_group_count = len(candidate_group_margins)
         summary.update(
             {
@@ -841,11 +841,11 @@ def _reward_summary(samples: list[dict[str, Any]]) -> dict[str, float | int]:
                 "candidate_group_reward_margin_mean": candidate_group_margin_total
                 / candidate_group_count,
                 "candidate_group_reward_margin_p50": _percentile_value(
-                    ordered_margins,
+                    candidate_group_margins,
                     0.5,
                 ),
                 "candidate_group_reward_margin_p95": _percentile_value(
-                    ordered_margins,
+                    candidate_group_margins,
                     0.95,
                 ),
                 "candidate_group_reward_variance_mean": candidate_group_variance_total


### PR DESCRIPTION
## Summary
- Sort LoRA reward summary accumulator lists in place before percentile calculation instead of allocating copied `sorted(...)` lists.
- Update focused regression/probe expectations so the registered probe records `sorted_calls_mean=0`.

## Plan or Spec
- `docs/plans/2026-06-17-lora-reward-summary-sort-in-place.md`
- Registered PR-scoped probe: `lora-reward-summary-candidate-minmax` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline from origin/main
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/lora_reward_summary_probe.py
# exit 0; elapsed_ms_mean=45.09584681363776, sorted_calls_mean=2

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file
# exit 0; 9 passed in 2.83s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_reward_summary_probe.py
# exit 0; 9 passed; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/lora_reward_summary_probe.py
# exit 0; elapsed_ms_mean=36.297308455687016, sorted_calls_mean=0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 5 0 100%`).
- Local registered probe (Linux): `old_mean=45.09584681363776ms`, `new_mean=36.297308455687016ms`, `delta_ms=-8.798538`, `speedup=1.2424x`, `improvement=19.51%`.
- Probe counter: `sorted_calls_mean` changed from `2` to `0`.
- CI PR-scoped performance workflow is required for the repository registered probe validation before merge.

## Known Gaps
- None for the Python slice. Swift/runtime effects are not involved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no new debug mode.
- [x] Deferred work and known gaps are stated explicitly.
