### PR TITLE
perf: fast-path single repeated embedding inputs

### DIFF
--- a/docs/plans/2026-06-17-deterministic-embedding-single-cycle-fastpath.md
+++ b/docs/plans/2026-06-17-deterministic-embedding-single-cycle-fastpath.md
@@ -1,0 +1,23 @@
+# Deterministic embedding single-cycle replay fast path
+
+## Scope
+
+This Python performance slice is limited to `DeterministicEmbeddingRuntime.embed_inputs()` in `services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py`.
+It preserves duplicate-input cache behavior and vector isolation while avoiding the repeated generator setup used when a large embedding request is the same input repeated many times.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `deterministic-embedding-duplicate-input-cache` in `infra/perf/pr_scoped_probes.json`.
+The registry entry has focused `test_command`, `coverage_command`, and `probe_command` entries. This slice extends the probe metrics with a `single_cycle_*` scenario so the registered probe validates the all-duplicate request shape that exercises the new fast path.
+
+## Implementation plan
+
+1. Keep the existing cycle detection contract unchanged.
+2. Add a narrow `cycle_length == 1` branch that embeds the repeated text once, appends the original vector once, and appends copies for the remaining positions.
+3. Add regression coverage proving all returned vectors remain isolated and the backend is called once.
+4. Run the registered focused tests, changed-scope coverage, and the registered probe locally on Linux.
+5. Use GitHub Actions PR-scoped performance as the final registered CI probe gate before merge.
+
+## Expected outcome
+
+The common single repeated input path should reduce `single_cycle_elapsed_ms_mean` and keep `single_cycle_embed_text_calls_mean == 1.0` without changing results for larger repeated cycles or non-cyclic duplicate inputs.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -558,6 +558,24 @@
         "unit": "calls",
         "direction": "lower_is_better",
         "warn_pct": 0.0
+      },
+      {
+        "key": "single_cycle_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "single_cycle_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "single_cycle_embed_text_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
       }
     ]
   },

--- a/scripts/deterministic_embedding_duplicate_probe.py
+++ b/scripts/deterministic_embedding_duplicate_probe.py
@@ -79,13 +79,12 @@ def assert_cycle_detection_contract() -> None:
     assert _repeated_input_cycle_length(valid_cycle) == 512
 
 
-def run_probe() -> dict[str, float]:
-    assert_cycle_detection_contract()
-    dimensions = 32
-    unique_inputs = [f"document-{index % 160}-payload-{index % 13}" for index in range(512)]
-    inputs = [unique_inputs[index % len(unique_inputs)] for index in range(8192)]
-    expected_unique_count = len(set(inputs))
-    sample_count = 5
+def _measure_inputs(
+    inputs: list[str],
+    *,
+    dimensions: int,
+    sample_count: int,
+) -> tuple[float, float, float, float]:
     elapsed_samples: list[float] = []
     call_samples: list[float] = []
     peak_samples: list[float] = []
@@ -112,14 +111,62 @@ def run_probe() -> dict[str, float]:
 
     if len(vectors) != len(inputs):
         raise AssertionError(f"unexpected vector count: {len(vectors)} != {len(inputs)}")
+    return (
+        statistics.fmean(elapsed_samples),
+        statistics.fmean(peak_samples),
+        statistics.fmean(call_samples),
+        checksum,
+    )
+
+
+def run_probe() -> dict[str, float]:
+    assert_cycle_detection_contract()
+    dimensions = 32
+    unique_inputs = [f"document-{index % 160}-payload-{index % 13}" for index in range(512)]
+    inputs = [unique_inputs[index % len(unique_inputs)] for index in range(8192)]
+    single_cycle_inputs = ["document-single-cycle-payload"] * len(inputs)
+    expected_unique_count = len(set(inputs))
+    sample_count = 5
+
+    elapsed_mean, peak_mean, call_mean, checksum = _measure_inputs(
+        inputs,
+        dimensions=dimensions,
+        sample_count=sample_count,
+    )
+    (
+        single_cycle_elapsed_mean,
+        single_cycle_peak_mean,
+        single_cycle_call_mean,
+        single_cycle_checksum,
+    ) = _measure_inputs(
+        single_cycle_inputs,
+        dimensions=dimensions,
+        sample_count=sample_count,
+    )
+
+    runtime = DeterministicEmbeddingRuntime(dimensions=dimensions)
+    backend = CountingEmbeddingBackend()
+    loaded_model = {
+        "model_id": "melix-dev-embed-counting",
+        "dimensions": dimensions,
+        "embedding_backend": backend,
+        "embedding_family_adapter": CountingEmbeddingFamilyAdapter(),
+    }
+    vectors = runtime.embed_inputs(loaded_model, inputs)
     assert vectors[0] is not vectors[len(unique_inputs)]
+    single_cycle_vectors = runtime.embed_inputs(loaded_model, single_cycle_inputs)
+    assert single_cycle_vectors[0] is not single_cycle_vectors[-1]
     return {
-        "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
-        "peak_bytes_mean": round(statistics.fmean(peak_samples), 6),
-        "embed_text_calls_mean": round(statistics.fmean(call_samples), 6),
+        "elapsed_ms_mean": round(elapsed_mean, 6),
+        "peak_bytes_mean": round(peak_mean, 6),
+        "embed_text_calls_mean": round(call_mean, 6),
+        "single_cycle_elapsed_ms_mean": round(single_cycle_elapsed_mean, 6),
+        "single_cycle_peak_bytes_mean": round(single_cycle_peak_mean, 6),
+        "single_cycle_embed_text_calls_mean": round(single_cycle_call_mean, 6),
         "input_count": float(len(inputs)),
         "unique_input_count": float(expected_unique_count),
         "checksum": round(checksum, 6),
+        "single_cycle_checksum": round(single_cycle_checksum, 6),
     }
 
 

--- a/services/mlx-worker-python/tests/test_embedding_runtime.py
+++ b/services/mlx-worker-python/tests/test_embedding_runtime.py
@@ -423,6 +423,29 @@ def test_embed_runtime_replays_repeated_cycles_without_shared_vectors() -> None:
     assert vectors[len(cycle) * 2] == [1.0, 1.0]
 
 
+def test_embed_runtime_replays_single_input_cycles_without_generator_reentry() -> None:
+    runtime = DeterministicEmbeddingRuntime()
+    backend = CountingEmbeddingBackend()
+    family = CountingEmbeddingFamilyAdapter()
+
+    vectors = runtime.embed_inputs(
+        {
+            "model_id": "melix-dev-embed-counting-single-cycle",
+            "dimensions": 2,
+            "embedding_backend": backend,
+            "embedding_family_adapter": family,
+        },
+        ["same-document"] * 2048,
+    )
+
+    assert backend.calls == [("same-document", 2)]
+    assert len(vectors) == 2048
+    assert vectors[0] == vectors[-1] == [1.0, 1.0]
+    assert vectors[0] is not vectors[-1]
+    vectors[0][0] = 99.0
+    assert vectors[-1] == [1.0, 1.0]
+
+
 def test_load_model_rejects_unsupported_embedding_backend() -> None:
     runtime = DeterministicEmbeddingRuntime()
     model = WorkerModelCatalog.dev_embedding_model(

--- a/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
@@ -63,8 +63,15 @@ class DeterministicEmbeddingRuntime:
         vectors: list[list[float]] = []
         append_vector = vectors.append
         embed_text = family.embed_text
+        input_count = len(inputs)
         cycle_length = _repeated_input_cycle_length(inputs)
         if cycle_length:
+            if cycle_length == 1:
+                vector = embed_text(backend, inputs[0], dimensions)
+                append_vector(vector)
+                for _ in range(input_count - 1):
+                    append_vector(vector.copy())
+                return vectors
             for text in inputs[:cycle_length]:
                 vector = embed_text(backend, text, dimensions)
                 append_vector(vector)


### PR DESCRIPTION
## Summary
- Add a narrow fast path for deterministic embedding batches where every input is the same text.
- Preserve vector isolation by copying the first embedded vector for replayed positions.
- Extend the registered `deterministic-embedding-duplicate-input-cache` PR-scoped probe with `single_cycle_*` metrics for this request shape.

## Plan or Spec
- `docs/plans/2026-06-17-deterministic-embedding-single-cycle-fastpath.md`

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_duplicate_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/deterministic_embedding_duplicate_probe.py ]; then python3 scripts/deterministic_embedding_duplicate_probe.py; else ...; fi'`
- Baseline comparison command run on `origin/main` against the single-cycle scenario using the same counting backend and sample count.

## Coverage and Metrics
- Focused tests: 19 passed.
- Changed-scope coverage: 36/36 measurable changed lines covered, 100%.
- Registered local probe output: `elapsed_ms_mean=19.805929`, `peak_bytes_mean=3016990.4`, `embed_text_calls_mean=512.0`, `single_cycle_elapsed_ms_mean=35.073553`, `single_cycle_peak_bytes_mean=2619813.6`, `single_cycle_embed_text_calls_mean=1.0`.
- `origin/main` single-cycle baseline: mean samples observed at `51.543037`, `51.443059`, and `50.058191` ms with `single_cycle_embed_text_calls_mean=1.0`.
- Local representative delta: old mean ~51.014762 ms vs new mean 35.073553 ms, about 15.941209 ms faster (~1.45x) for the all-duplicate 8192-input scenario.
- CI PR-scoped registered probe validation is required before merge.

## Known Gaps
- Linux local validation covers this Python slice. CI remains the authoritative registered PR-scoped performance gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally and emitted the new metrics.
- [ ] GitHub Actions and PR-scoped performance workflow completed successfully.
