### PR TITLE
perf: slot deterministic VLM cache entries

### DIFF
--- a/docs/plans/2026-06-17-deterministic-vlm-cache-entry-slots.md
+++ b/docs/plans/2026-06-17-deterministic-vlm-cache-entry-slots.md
@@ -1,0 +1,39 @@
+# Deterministic VLM Cache Entry Slots
+
+## Scope
+
+This Python performance slice is limited to `VisionCacheEntry` in
+`services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py`.
+
+The optimization preserves deterministic VLM cache identity fields and cache-hit
+behavior while making the frozen cache-entry record slotted. This removes the
+per-entry instance dictionary for the hot deterministic VLM cache-entry creation
+path.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`deterministic-vlm-completion-token-scan` in `infra/perf/pr_scoped_probes.json`.
+The registered probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for `deterministic_vlm_runtime.py`,
+`test_vision_runtime.py`, `test_pr_scoped_performance.py`, and
+`scripts/deterministic_vlm_completion_token_probe.py`.
+
+No registry change is needed for this slice because the probe watches the changed
+runtime file and repeatedly creates deterministic VLM cache entries while
+measuring elapsed time and peak bytes.
+
+## Plan
+
+1. Keep the slice limited to the cache-entry record shape.
+2. Add `slots=True` to `VisionCacheEntry` without changing fields or behavior.
+3. Run focused tests, changed-scope coverage, and the registered probe locally on
+   Linux; compare against the pre-change baseline.
+4. Use GitHub Actions and the registered PR-scoped performance workflow as the
+   merge gate.
+
+## Expected Performance Signal
+
+The primary signal is lower `peak_bytes_mean` in the registered deterministic VLM
+completion-token probe. `elapsed_ms_mean` may also improve from reduced instance
+allocation overhead, but memory reduction is the key metric for this slice.

--- a/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
@@ -88,7 +88,7 @@ class VisionProbeSnapshot:
     text_batch_generator_speculative_cache_ops_ms_total: float = 0.0
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class VisionCacheEntry:
     cache_identity: str
     scope_id: str


### PR DESCRIPTION
## Summary
- Make the deterministic VLM `VisionCacheEntry` frozen dataclass slotted to avoid per-entry instance dictionaries on the cache-entry creation path.
- Keep cache identity fields and deterministic VLM cache-hit behavior unchanged.

## Plan or Spec
- `docs/plans/2026-06-17-deterministic-vlm-cache-entry-slots.md`
- Registered probe: `deterministic-vlm-completion-token-scan` in `infra/perf/pr_scoped_probes.json` already covers the changed runtime path and includes focused test, coverage, and probe commands.

## Commands Run
```text
# Baseline from origin/main before the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DETERMINISTIC_VLM_COMPLETION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/deterministic_vlm_completion_token_probe.py
# exit 0; {"completion_tokens": 6000, "elapsed_ms_mean": 82.158880867064, "iterations": 400, "peak_bytes_mean": 443516.8, "prompt_token_count_calls_mean": 400.0, "samples": 5, "split_calls_mean": 0.0, "token_count_calls_mean": 1.0}

# Registered deterministic-vlm-completion-token-scan test commands
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py -q
# exit 0; 10 passed in 2.18s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py -q
# exit 0; 10 passed in 0.88s

# Registered deterministic-vlm-completion-token-scan coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=services/mlx-worker-python/worker/runtime -m pytest services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py -q && uv run --project services/mlx-worker-python coverage json -o coverage.json && uv run python3 scripts/changed_line_coverage.py --coverage-json coverage.json --base-ref origin/main --paths services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_vlm_completion_token_probe.py --fail-under 95
# exit 0; changed-line coverage TOTAL 1 0 100%

# Registered deterministic-vlm-completion-token-scan probe command after the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DETERMINISTIC_VLM_COMPLETION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/deterministic_vlm_completion_token_probe.py
# exit 0; {"completion_tokens": 6000, "elapsed_ms_mean": 78.49010396748781, "iterations": 400, "peak_bytes_mean": 427289.6, "prompt_token_count_calls_mean": 400.0, "samples": 5, "split_calls_mean": 0.0, "token_count_calls_mean": 1.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-line coverage: 100.00% (`aggregate_measurable_changed_lines=1`, `aggregate_covered_changed_lines=1`, `aggregate_missed_changed_lines=0`).
- Probe baseline: `elapsed_ms_mean=82.158880867064`, `peak_bytes_mean=443516.8`.
- Probe after change: `elapsed_ms_mean=78.49010396748781`, `peak_bytes_mean=427289.6`.
- Delta: elapsed `-3.668776899576 ms` (`4.465466%` lower); peak bytes `-16227.2` (`3.658757%` lower).
- Registered PR-scoped performance CI is required as the final merge gate.

## Known Gaps
- Local validation was Linux-only. The changed path is Python runtime code and was verified locally; GitHub Actions remains the authoritative registered PR-scoped performance gate before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
