### PR TITLE
Cover OpenAI conformance error payloads and sampling

### DIFF
--- a/docs/plans/2026-06-18-issue-1991-openai-conformance-errors-sampling.md
+++ b/docs/plans/2026-06-18-issue-1991-openai-conformance-errors-sampling.md
@@ -49,9 +49,11 @@ This PR does not add real remote-provider proxy calls, backend token-logprob sup
   - Include `phase` in backend unavailable errors.
   - Include `field` and `phase` alongside prompt-budget metadata.
   - Reject explicitly unsupported OpenAI chat fields before worker dispatch.
+- [x] Incorporate PR review feedback for decode error field extraction.
+  - Cover `DecodingError.keyNotFound` so missing required keys name the missing key, not the parent container.
 - [x] Verify focused tests and changed-line coverage before full local gate.
   - `OpenAIConformanceMatrixTests`, `OpenAIHandlerTests`, and `TextEndpointContractTests` pass locally.
-  - Swift changed-line coverage for the touched scope is `97.32%` (`254/261`).
+  - Swift changed-line coverage for the touched scope is `97.67%` (`294/301`).
 - [x] Verify full local gate and PR-scoped performance before opening the PR.
   - `make swift-test` passes locally.
   - `make py-test` passes locally (`4066 passed, 14 skipped`).

--- a/docs/plans/2026-06-18-issue-1991-openai-conformance-errors-sampling.md
+++ b/docs/plans/2026-06-18-issue-1991-openai-conformance-errors-sampling.md
@@ -1,0 +1,84 @@
+# Issue 1991 OpenAI Conformance Error and Sampling Coverage Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for implementation. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the OpenAI conformance matrix so error-payload classes and sampling passthrough fields are proven at the Swift control-plane boundary.
+
+**Architecture:** Keep the slice inside `OpenAIHandler` and `ChatRequestTranslator` where deterministic tests can post OpenAI chat payloads, inspect typed HTTP errors, and inspect translated worker `SamplingConfig`. Reuse the existing table-driven `OpenAIConformanceMatrixTests` and the existing prompt-budget admission path instead of adding a parallel harness.
+
+**Tech Stack:** Swift Testing, `OpenAIHandler`, `ChatRequestTranslator`, `TextRequestShaper`, `ModelCatalog`, worker protobuf `SamplingConfig`, and the existing conformance report model.
+
+---
+
+## Scope
+
+This PR implements issue #1991 as a child slice of the OpenAI conformance plan in `docs/plans/2026-05-24-issue-1384-openai-conformance-suite.md`:
+
+- Add conformance rows for typed error payloads:
+  - unsupported request field at the OpenAI boundary,
+  - invalid schema at decode time,
+  - backend unavailable before dispatch,
+  - context overflow through prompt-budget admission.
+- Add conformance coverage for sampling passthrough:
+  - `seed` maps to worker sampling and compatibility receipts,
+  - `frequency_penalty` maps to worker sampling and compatibility receipts.
+- Preserve existing `max_tokens` and `max_completion_tokens` output-cap behavior.
+
+This PR does not add real remote-provider proxy calls, backend token-logprob support, or new protobuf schemas.
+
+## Success Metrics
+
+- Matrix rows assert `code`, `field`, and `phase` for the new error classes where applicable.
+- Error rows return before worker generation when the failure is pre-dispatch.
+- `frequency_penalty` reaches `Melix_Worker_V1_SamplingConfig.frequencyPenalty`.
+- `seed` and `frequency_penalty` are represented in `melix.generation.*` receipts.
+- Changed-line coverage for touched Swift files is at least 95 percent.
+- PR-scoped performance report is `ok` with no regression.
+
+## Implementation Tasks
+
+- [x] Add failing conformance rows in `services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift`.
+  - Assert typed payload fields for unsupported field, invalid schema, worker unavailable, and prompt-budget context overflow.
+  - Assert worker sampling and receipts for `seed` and `frequency_penalty`.
+- [x] Extend request normalization for `frequency_penalty`.
+  - Decode and encode `frequency_penalty` on OpenAI text-compatible request structs.
+  - Carry it through `NormalizedTextRequest` and `ShapedTextRequest`.
+  - Assign `GenerateRequest.sampling.frequencyPenalty` and receipt `melix.generation.frequency_penalty`.
+- [x] Add typed error metadata without changing existing status codes.
+  - Include `field` and `phase` in generation-bounds and decode errors.
+  - Include `phase` in backend unavailable errors.
+  - Include `field` and `phase` alongside prompt-budget metadata.
+  - Reject explicitly unsupported OpenAI chat fields before worker dispatch.
+- [x] Verify focused tests and changed-line coverage before full local gate.
+  - `OpenAIConformanceMatrixTests`, `OpenAIHandlerTests`, and `TextEndpointContractTests` pass locally.
+  - Swift changed-line coverage for the touched scope is `97.32%` (`254/261`).
+- [x] Verify full local gate and PR-scoped performance before opening the PR.
+  - `make swift-test` passes locally.
+  - `make py-test` passes locally (`4066 passed, 14 skipped`).
+  - `make integration-test` passes locally (`120 passed, 1 skipped`).
+  - PR-scoped pre-commit performance report is `Status: ok` with `0` regressions.
+
+## Verification Commands
+
+Focused:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests
+git diff --check
+```
+
+Pre-PR local gate:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```
+
+Metrics:
+
+```bash
+UV_PYTHON="${MELIX_PRE_COMMIT_UV_PYTHON:-${UV_PYTHON:-3.12}}" uv run --frozen --project services/mlx-worker-python --extra mlx python scripts/pre_commit_gate.py
+```
+
+The pre-commit gate writes the PR-scoped performance report under `.runtime/pre-commit-performance/`; the report must be `Status: ok` before PR creation.

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -4483,9 +4483,10 @@ button.primary:active {
         switch error {
         case .typeMismatch(_, let context),
              .valueNotFound(_, let context),
-             .keyNotFound(_, let context),
              .dataCorrupted(let context):
             codingPath = context.codingPath
+        case .keyNotFound(let key, let context):
+            codingPath = context.codingPath + [key]
         @unknown default:
             codingPath = []
         }

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -1664,6 +1664,9 @@ button.primary:active {
             if let boundsFailure = generationBoundsValidationFailure(in: request.body) {
                 return invalidGenerationBoundsResponse(boundsFailure)
             }
+            if let unsupportedField = unsupportedChatCompletionsField(in: request.body) {
+                return unsupportedRequestFieldResponse(field: unsupportedField)
+            }
             let chatRequest = try decoder.decode(OpenAIChatCompletionsRequest.self, from: request.body)
             if let resumeRequestID = chatRequest.resumeRequestID?.trimmingCharacters(in: .whitespacesAndNewlines),
                !resumeRequestID.isEmpty {
@@ -1699,8 +1702,11 @@ button.primary:active {
                 return invalidArgumentResponse(message: error.operatorMessage)
             }
             return mediaNormalizationErrorResponse(error)
-        } catch is DecodingError {
-            return invalidArgumentResponse(message: "Malformed multimodal chat payload.")
+        } catch let error as DecodingError {
+            return invalidRequestSchemaResponse(
+                field: decodingErrorField(error),
+                message: "Malformed multimodal chat payload."
+            )
         } catch let error as StructuredOutputFormatError {
             return invalidArgumentResponse(message: error.operatorMessage)
         } catch let error as ToolParserConfigurationError {
@@ -3760,6 +3766,8 @@ button.primary:active {
             payload: [
                 "error": [
                     "code": "prompt_budget_exceeded",
+                    "field": "messages",
+                    "phase": "prompt_budget",
                     "status": "invalid_request_error",
                     "message": "Prompt token estimate exceeds the local prompt budget for this request.",
                     "prompt_token_metadata": metadata,
@@ -4424,7 +4432,14 @@ button.primary:active {
     private func workerUnavailableResponse() -> HTTPResponse {
         jsonResponse(
             statusCode: 503,
-            payload: ["error": ["code": "worker_unavailable", "message": "The worker cannot accept requests."]]
+            payload: [
+                "error": [
+                    "code": "worker_unavailable",
+                    "field": "worker",
+                    "phase": "backend_dispatch",
+                    "message": "The worker cannot accept requests.",
+                ],
+            ]
         )
     }
 
@@ -4435,17 +4450,73 @@ button.primary:active {
         )
     }
 
+    private func unsupportedRequestFieldResponse(field: String) -> HTTPResponse {
+        jsonResponse(
+            statusCode: 400,
+            payload: [
+                "error": [
+                    "code": "unsupported_request_field",
+                    "field": field,
+                    "phase": "openai_request_validation",
+                    "message": "\(field) is not supported by this OpenAI-compatible endpoint.",
+                ],
+            ]
+        )
+    }
+
+    private func invalidRequestSchemaResponse(field: String, message: String) -> HTTPResponse {
+        jsonResponse(
+            statusCode: 400,
+            payload: [
+                "error": [
+                    "code": "invalid_request_schema",
+                    "field": field,
+                    "phase": "decode",
+                    "message": message,
+                ],
+            ]
+        )
+    }
+
+    private func decodingErrorField(_ error: DecodingError) -> String {
+        let codingPath: [CodingKey]
+        switch error {
+        case .typeMismatch(_, let context),
+             .valueNotFound(_, let context),
+             .keyNotFound(_, let context),
+             .dataCorrupted(let context):
+            codingPath = context.codingPath
+        @unknown default:
+            codingPath = []
+        }
+        return codingPath.last?.stringValue ?? "body"
+    }
+
     private func invalidGenerationBoundsResponse(_ failure: GenerationBoundsValidationFailure) -> HTTPResponse {
         jsonResponse(
             statusCode: 400,
             payload: [
                 "error": [
                     "code": "invalid_generation_bounds",
+                    "field": failure.field,
+                    "phase": "generation_bounds",
                     "message": failure.message,
                     "bounds_rejection_reason": failure.reason,
                 ],
             ]
         )
+    }
+
+    private func unsupportedChatCompletionsField(in body: Data) -> String? {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any]
+        else {
+            return nil
+        }
+        for field in ["best_of"] where object[field] != nil {
+            return field
+        }
+        return nil
     }
 
     private func generationBoundsValidationFailure(in body: Data) -> GenerationBoundsValidationFailure? {
@@ -4466,6 +4537,7 @@ button.primary:active {
            let maxCompletionTokens = maxCompletionTokens.value,
            maxTokens != maxCompletionTokens {
             return GenerationBoundsValidationFailure(
+                field: "max_tokens,max_completion_tokens",
                 reason: "output_cap_conflict",
                 message: "max_tokens and max_completion_tokens must match when both are provided."
             )
@@ -4489,6 +4561,7 @@ button.primary:active {
            let maxCompletionTokens = maxCompletionTokens.value,
            maxTokens != maxCompletionTokens {
             return GenerationBoundsValidationFailure(
+                field: "max_tokens,max_completion_tokens",
                 reason: "output_cap_conflict",
                 message: "max_tokens and max_completion_tokens must match when both are provided."
             )
@@ -4505,18 +4578,21 @@ button.primary:active {
         }
         guard let doubleValue = Double(token) else {
             return (nil, GenerationBoundsValidationFailure(
+                field: fieldName,
                 reason: "\(fieldName)_malformed",
                 message: "\(fieldName) must be a finite positive integer."
             ))
         }
         guard doubleValue.isFinite else {
             return (nil, GenerationBoundsValidationFailure(
+                field: fieldName,
                 reason: "\(fieldName)_non_finite",
                 message: "\(fieldName) must be finite."
             ))
         }
         guard doubleValue > 0 else {
             return (nil, GenerationBoundsValidationFailure(
+                field: fieldName,
                 reason: "\(fieldName)_non_positive",
                 message: "\(fieldName) must be greater than zero."
             ))
@@ -4525,6 +4601,7 @@ button.primary:active {
               doubleValue <= Double(UInt32.max)
         else {
             return (nil, GenerationBoundsValidationFailure(
+                field: fieldName,
                 reason: "\(fieldName)_malformed",
                 message: "\(fieldName) must be a positive integer no greater than \(UInt32.max)."
             ))
@@ -4631,6 +4708,7 @@ button.primary:active {
               CFGetTypeID(number) != CFBooleanGetTypeID()
         else {
             return (nil, GenerationBoundsValidationFailure(
+                field: fieldName,
                 reason: "\(reasonPrefix)_malformed",
                 message: "\(fieldName) must be a finite positive integer."
             ))
@@ -4638,12 +4716,14 @@ button.primary:active {
         let doubleValue = number.doubleValue
         guard doubleValue.isFinite else {
             return (nil, GenerationBoundsValidationFailure(
+                field: fieldName,
                 reason: "\(reasonPrefix)_non_finite",
                 message: "\(fieldName) must be finite."
             ))
         }
         guard doubleValue > 0 else {
             return (nil, GenerationBoundsValidationFailure(
+                field: fieldName,
                 reason: "\(reasonPrefix)_non_positive",
                 message: "\(fieldName) must be greater than zero."
             ))
@@ -4652,6 +4732,7 @@ button.primary:active {
               doubleValue <= Double(UInt32.max)
         else {
             return (nil, GenerationBoundsValidationFailure(
+                field: fieldName,
                 reason: "\(reasonPrefix)_malformed",
                 message: "\(fieldName) must be a positive integer no greater than \(UInt32.max)."
             ))
@@ -5901,6 +5982,7 @@ private enum HTTPRequestHandlingError: Error {
 }
 
 private struct GenerationBoundsValidationFailure {
+    let field: String
     let reason: String
     let message: String
 }
@@ -7338,6 +7420,10 @@ private extension RequestCoordinatorError {
             "code": errorCode,
             "message": errorMessage,
         ]
+        if case .workerUnavailable = self {
+            error["field"] = "worker"
+            error["phase"] = "backend_dispatch"
+        }
         if case .unsupportedAcceleration(let reason, _, let recoveryHint) = self {
             error["unsupported_reason"] = ModelCapabilityReceipts.unsupportedReasonIdentifier(reason)
             error["recovery_hint"] = recoveryHint

--- a/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
+++ b/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
@@ -127,6 +127,7 @@ public struct NormalizedTextRequest: Sendable, Equatable {
     public let minP: Double?
     public let repeatPenalty: Double?
     public let presencePenalty: Double?
+    public let frequencyPenalty: Double?
     public let seed: UInt32?
     public let sessionID: String?
     public let branchID: String?
@@ -166,6 +167,7 @@ public struct NormalizedTextRequest: Sendable, Equatable {
         minP: Double? = nil,
         repeatPenalty: Double? = nil,
         presencePenalty: Double? = nil,
+        frequencyPenalty: Double? = nil,
         seed: UInt32? = nil,
         sessionID: String?,
         branchID: String?,
@@ -204,6 +206,7 @@ public struct NormalizedTextRequest: Sendable, Equatable {
         self.minP = minP
         self.repeatPenalty = repeatPenalty
         self.presencePenalty = presencePenalty
+        self.frequencyPenalty = frequencyPenalty
         self.seed = seed
         self.sessionID = sessionID
         self.branchID = branchID
@@ -252,6 +255,7 @@ public extension NormalizedTextRequest {
             minP: minP,
             repeatPenalty: repeatPenalty,
             presencePenalty: presencePenalty,
+            frequencyPenalty: frequencyPenalty,
             seed: seed,
             sessionID: sessionID,
             branchID: branchID,
@@ -315,6 +319,7 @@ public struct ShapedTextRequest: Sendable, Equatable {
     public let minP: Double?
     public let repeatPenalty: Double?
     public let presencePenalty: Double?
+    public let frequencyPenalty: Double?
     public let seed: UInt32?
     public let streamIntervalTokens: UInt32
     public let maxConcurrentRequests: UInt32
@@ -665,6 +670,7 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
     public let minP: Double?
     public let repeatPenalty: Double?
     public let presencePenalty: Double?
+    public let frequencyPenalty: Double?
     public let seed: UInt32?
     public let resumeRequestID: String?
     public let stopSequences: [String]?
@@ -706,6 +712,7 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         case minP = "min_p"
         case repeatPenalty = "repeat_penalty"
         case presencePenalty = "presence_penalty"
+        case frequencyPenalty = "frequency_penalty"
         case seed
         case resumeRequestID = "resume_request_id"
         case stop
@@ -749,6 +756,7 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         minP: Double? = nil,
         repeatPenalty: Double? = nil,
         presencePenalty: Double? = nil,
+        frequencyPenalty: Double? = nil,
         seed: UInt32? = nil,
         resumeRequestID: String? = nil,
         stopSequences: [String]? = nil,
@@ -789,6 +797,7 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         self.minP = minP
         self.repeatPenalty = repeatPenalty
         self.presencePenalty = presencePenalty
+        self.frequencyPenalty = frequencyPenalty
         self.seed = seed
         self.resumeRequestID = resumeRequestID
         self.stopSequences = stopSequences
@@ -832,6 +841,7 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         self.minP = try container.decodeIfPresent(Double.self, forKey: .minP)
         self.repeatPenalty = try container.decodeIfPresent(Double.self, forKey: .repeatPenalty)
         self.presencePenalty = try container.decodeIfPresent(Double.self, forKey: .presencePenalty)
+        self.frequencyPenalty = try container.decodeIfPresent(Double.self, forKey: .frequencyPenalty)
         self.seed = try container.decodeIfPresent(UInt32.self, forKey: .seed)
         self.resumeRequestID = try container.decodeIfPresent(String.self, forKey: .resumeRequestID)
         self.stopSequences = try Self.decodeStopSequences(from: container)
@@ -881,6 +891,7 @@ public struct OpenAIChatCompletionsRequest: Codable, Sendable {
         try container.encodeIfPresent(minP, forKey: .minP)
         try container.encodeIfPresent(repeatPenalty, forKey: .repeatPenalty)
         try container.encodeIfPresent(presencePenalty, forKey: .presencePenalty)
+        try container.encodeIfPresent(frequencyPenalty, forKey: .frequencyPenalty)
         try container.encodeIfPresent(seed, forKey: .seed)
         try container.encodeIfPresent(resumeRequestID, forKey: .resumeRequestID)
         try encodeStopSequences(into: &container)
@@ -1037,6 +1048,7 @@ public struct OpenAICompletionsRequest: Codable, Sendable {
     public let minP: Double?
     public let repeatPenalty: Double?
     public let presencePenalty: Double?
+    public let frequencyPenalty: Double?
     public let seed: UInt32?
     public let stopSequences: [String]?
     public let sessionID: String?
@@ -1067,6 +1079,7 @@ public struct OpenAICompletionsRequest: Codable, Sendable {
         case minP = "min_p"
         case repeatPenalty = "repeat_penalty"
         case presencePenalty = "presence_penalty"
+        case frequencyPenalty = "frequency_penalty"
         case seed
         case stop
         case stopSequences = "stop_sequences"
@@ -1099,6 +1112,7 @@ public struct OpenAICompletionsRequest: Codable, Sendable {
         minP: Double? = nil,
         repeatPenalty: Double? = nil,
         presencePenalty: Double? = nil,
+        frequencyPenalty: Double? = nil,
         seed: UInt32? = nil,
         stopSequences: [String]? = nil,
         sessionID: String? = nil,
@@ -1128,6 +1142,7 @@ public struct OpenAICompletionsRequest: Codable, Sendable {
         self.minP = minP
         self.repeatPenalty = repeatPenalty
         self.presencePenalty = presencePenalty
+        self.frequencyPenalty = frequencyPenalty
         self.seed = seed
         self.stopSequences = stopSequences
         self.sessionID = sessionID
@@ -1160,6 +1175,7 @@ public struct OpenAICompletionsRequest: Codable, Sendable {
         self.minP = try container.decodeIfPresent(Double.self, forKey: .minP)
         self.repeatPenalty = try container.decodeIfPresent(Double.self, forKey: .repeatPenalty)
         self.presencePenalty = try container.decodeIfPresent(Double.self, forKey: .presencePenalty)
+        self.frequencyPenalty = try container.decodeIfPresent(Double.self, forKey: .frequencyPenalty)
         self.seed = try container.decodeIfPresent(UInt32.self, forKey: .seed)
         self.stopSequences = try Self.decodeStopSequences(from: container)
         self.sessionID = try container.decodeIfPresent(String.self, forKey: .sessionID)
@@ -1192,6 +1208,7 @@ public struct OpenAICompletionsRequest: Codable, Sendable {
         try container.encodeIfPresent(minP, forKey: .minP)
         try container.encodeIfPresent(repeatPenalty, forKey: .repeatPenalty)
         try container.encodeIfPresent(presencePenalty, forKey: .presencePenalty)
+        try container.encodeIfPresent(frequencyPenalty, forKey: .frequencyPenalty)
         try container.encodeIfPresent(seed, forKey: .seed)
         try Self.encodeStopSequences(stopSequences, into: &container)
         try container.encodeIfPresent(sessionID, forKey: .sessionID)
@@ -1412,6 +1429,7 @@ public struct OpenAIResponsesRequest: Codable, Sendable {
     public let minP: Double?
     public let repeatPenalty: Double?
     public let presencePenalty: Double?
+    public let frequencyPenalty: Double?
     public let seed: UInt32?
     public let stopSequences: [String]?
     public let sessionID: String?
@@ -1443,6 +1461,7 @@ public struct OpenAIResponsesRequest: Codable, Sendable {
         case minP = "min_p"
         case repeatPenalty = "repeat_penalty"
         case presencePenalty = "presence_penalty"
+        case frequencyPenalty = "frequency_penalty"
         case seed
         case stop
         case stopSequences = "stop_sequences"
@@ -1476,6 +1495,7 @@ public struct OpenAIResponsesRequest: Codable, Sendable {
         minP: Double? = nil,
         repeatPenalty: Double? = nil,
         presencePenalty: Double? = nil,
+        frequencyPenalty: Double? = nil,
         seed: UInt32? = nil,
         stopSequences: [String]? = nil,
         sessionID: String? = nil,
@@ -1506,6 +1526,7 @@ public struct OpenAIResponsesRequest: Codable, Sendable {
         self.minP = minP
         self.repeatPenalty = repeatPenalty
         self.presencePenalty = presencePenalty
+        self.frequencyPenalty = frequencyPenalty
         self.seed = seed
         self.stopSequences = stopSequences
         self.sessionID = sessionID
@@ -1539,6 +1560,7 @@ public struct OpenAIResponsesRequest: Codable, Sendable {
         self.minP = try container.decodeIfPresent(Double.self, forKey: .minP)
         self.repeatPenalty = try container.decodeIfPresent(Double.self, forKey: .repeatPenalty)
         self.presencePenalty = try container.decodeIfPresent(Double.self, forKey: .presencePenalty)
+        self.frequencyPenalty = try container.decodeIfPresent(Double.self, forKey: .frequencyPenalty)
         self.seed = try container.decodeIfPresent(UInt32.self, forKey: .seed)
         self.stopSequences = try Self.decodeStopSequences(from: container)
         self.sessionID = try container.decodeIfPresent(String.self, forKey: .sessionID)
@@ -1572,6 +1594,7 @@ public struct OpenAIResponsesRequest: Codable, Sendable {
         try container.encodeIfPresent(minP, forKey: .minP)
         try container.encodeIfPresent(repeatPenalty, forKey: .repeatPenalty)
         try container.encodeIfPresent(presencePenalty, forKey: .presencePenalty)
+        try container.encodeIfPresent(frequencyPenalty, forKey: .frequencyPenalty)
         try container.encodeIfPresent(seed, forKey: .seed)
         try Self.encodeStopSequences(stopSequences, into: &container)
         try container.encodeIfPresent(sessionID, forKey: .sessionID)
@@ -1822,6 +1845,7 @@ public struct MelixMessagesRequest: Codable, Sendable {
     public let minP: Double?
     public let repeatPenalty: Double?
     public let presencePenalty: Double?
+    public let frequencyPenalty: Double?
     public let seed: UInt32?
     public let stopSequences: [String]?
     public let metadata: MelixMessagesMetadata?
@@ -1855,6 +1879,7 @@ public struct MelixMessagesRequest: Codable, Sendable {
         case minP = "min_p"
         case repeatPenalty = "repeat_penalty"
         case presencePenalty = "presence_penalty"
+        case frequencyPenalty = "frequency_penalty"
         case seed
         case stopSequences = "stop_sequences"
         case metadata
@@ -1890,6 +1915,7 @@ public struct MelixMessagesRequest: Codable, Sendable {
         minP: Double? = nil,
         repeatPenalty: Double? = nil,
         presencePenalty: Double? = nil,
+        frequencyPenalty: Double? = nil,
         seed: UInt32? = nil,
         stopSequences: [String]? = nil,
         metadata: MelixMessagesMetadata? = nil,
@@ -1928,6 +1954,7 @@ public struct MelixMessagesRequest: Codable, Sendable {
         self.minP = minP
         self.repeatPenalty = repeatPenalty
         self.presencePenalty = presencePenalty
+        self.frequencyPenalty = frequencyPenalty
         self.seed = seed
         self.stopSequences = stopSequences
         self.metadata = metadata
@@ -1963,6 +1990,7 @@ public struct MelixMessagesRequest: Codable, Sendable {
         self.minP = try container.decodeIfPresent(Double.self, forKey: .minP)
         self.repeatPenalty = try container.decodeIfPresent(Double.self, forKey: .repeatPenalty)
         self.presencePenalty = try container.decodeIfPresent(Double.self, forKey: .presencePenalty)
+        self.frequencyPenalty = try container.decodeIfPresent(Double.self, forKey: .frequencyPenalty)
         self.seed = try container.decodeIfPresent(UInt32.self, forKey: .seed)
         self.stopSequences = try container.decodeIfPresent([String].self, forKey: .stopSequences)
         self.metadata = try container.decodeIfPresent(MelixMessagesMetadata.self, forKey: .metadata)
@@ -1998,6 +2026,7 @@ public struct MelixMessagesRequest: Codable, Sendable {
         try container.encodeIfPresent(minP, forKey: .minP)
         try container.encodeIfPresent(repeatPenalty, forKey: .repeatPenalty)
         try container.encodeIfPresent(presencePenalty, forKey: .presencePenalty)
+        try container.encodeIfPresent(frequencyPenalty, forKey: .frequencyPenalty)
         try container.encodeIfPresent(seed, forKey: .seed)
         try container.encodeIfPresent(stopSequences, forKey: .stopSequences)
         try container.encodeIfPresent(metadata, forKey: .metadata)
@@ -2126,6 +2155,7 @@ public struct ChatRequestTranslator: Sendable {
             minP: request.minP,
             repeatPenalty: request.repeatPenalty,
             presencePenalty: request.presencePenalty,
+            frequencyPenalty: request.frequencyPenalty,
             seed: request.seed,
             sessionID: request.sessionID,
             branchID: request.branchID,
@@ -2188,6 +2218,7 @@ public struct ChatRequestTranslator: Sendable {
             minP: request.minP,
             repeatPenalty: request.repeatPenalty,
             presencePenalty: request.presencePenalty,
+            frequencyPenalty: request.frequencyPenalty,
             seed: request.seed,
             sessionID: request.sessionID,
             branchID: request.branchID,
@@ -2233,6 +2264,7 @@ public struct ChatRequestTranslator: Sendable {
             minP: request.minP,
             repeatPenalty: request.repeatPenalty,
             presencePenalty: request.presencePenalty,
+            frequencyPenalty: request.frequencyPenalty,
             seed: request.seed,
             sessionID: request.sessionID,
             branchID: request.branchID,
@@ -2291,6 +2323,7 @@ public struct ChatRequestTranslator: Sendable {
             minP: request.minP,
             repeatPenalty: request.repeatPenalty,
             presencePenalty: request.presencePenalty,
+            frequencyPenalty: request.frequencyPenalty,
             seed: request.seed,
             sessionID: request.sessionID,
             branchID: request.branchID,
@@ -2345,6 +2378,7 @@ public struct ChatRequestTranslator: Sendable {
             minP: request.minP,
             repeatPenalty: request.repeatPenalty,
             presencePenalty: request.presencePenalty,
+            frequencyPenalty: request.frequencyPenalty,
             seed: request.seed,
             sessionID: request.sessionID,
             branchID: request.branchID,
@@ -2380,6 +2414,7 @@ public struct ChatRequestTranslator: Sendable {
         minP: Double? = nil,
         repeatPenalty: Double? = nil,
         presencePenalty: Double? = nil,
+        frequencyPenalty: Double? = nil,
         seed: UInt32? = nil,
         sessionID: String?,
         branchID: String?,
@@ -2423,6 +2458,7 @@ public struct ChatRequestTranslator: Sendable {
             minP: minP,
             repeatPenalty: repeatPenalty,
             presencePenalty: presencePenalty,
+            frequencyPenalty: frequencyPenalty,
             seed: seed,
             sessionID: sessionID,
             branchID: branchID,
@@ -2796,6 +2832,9 @@ public struct ChatRequestTranslator: Sendable {
         if let presencePenalty = shapedRequest.presencePenalty {
             generateRequest.sampling.presencePenalty = Float(presencePenalty)
         }
+        if let frequencyPenalty = shapedRequest.frequencyPenalty {
+            generateRequest.sampling.frequencyPenalty = Float(frequencyPenalty)
+        }
         if let seed = shapedRequest.seed {
             generateRequest.sampling.seed = seed
         }
@@ -2914,6 +2953,7 @@ public struct ChatRequestTranslator: Sendable {
         request.execution.ext["\(extPrefix)min_p"] = stringValue(shapedRequest.minP)
         request.execution.ext["\(extPrefix)repeat_penalty"] = stringValue(shapedRequest.repeatPenalty)
         request.execution.ext["\(extPrefix)presence_penalty"] = stringValue(shapedRequest.presencePenalty)
+        request.execution.ext["\(extPrefix)frequency_penalty"] = stringValue(shapedRequest.frequencyPenalty)
         request.execution.ext["\(extPrefix)seed"] = stringValue(shapedRequest.seed)
     }
 

--- a/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
+++ b/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
@@ -344,6 +344,7 @@ public struct TextRequestShaper: Sendable {
             minP: request.minP,
             repeatPenalty: request.repeatPenalty,
             presencePenalty: request.presencePenalty,
+            frequencyPenalty: request.frequencyPenalty,
             seed: request.seed,
             streamIntervalTokens: streamIntervalTokens,
             maxConcurrentRequests: maxConcurrentRequests,

--- a/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
@@ -1003,6 +1003,7 @@ struct TextEndpointContractTests {
             minP: 0.05,
             repeatPenalty: 1.1,
             presencePenalty: 0.2,
+            frequencyPenalty: 0.3,
             seed: 123,
             stopSequences: ["END", "DONE"],
             sessionID: "session-encode",
@@ -1042,6 +1043,7 @@ struct TextEndpointContractTests {
             minP: 0.02,
             repeatPenalty: 1.05,
             presencePenalty: 0.1,
+            frequencyPenalty: 0.25,
             seed: 456,
             stopSequences: ["STOP"],
             sessionID: "session-response",
@@ -1082,6 +1084,7 @@ struct TextEndpointContractTests {
             minP: 0.01,
             repeatPenalty: 1.0,
             presencePenalty: 0.0,
+            frequencyPenalty: 0.15,
             seed: 789,
             stopSequences: ["</final>"],
             metadata: .init(userID: "operator-encode"),
@@ -1115,18 +1118,21 @@ struct TextEndpointContractTests {
 
         #expect(completionsObject["stop"] as? [String] == ["END", "DONE"])
         #expect(completionsObject["max_tokens"] as? Int == 64)
+        #expect(completionsObject["frequency_penalty"] as? Double == 0.3)
         #expect(completionsObject["workflow"] as? String == "tool_followup")
         #expect(completionsObject["tool_parser"] != nil)
         #expect(completionsObject["chat_template_kwargs"] != nil)
 
         #expect(responsesObject["stop"] as? String == "STOP")
         #expect(responsesObject["max_completion_tokens"] as? Int == 48)
+        #expect(responsesObject["frequency_penalty"] as? Double == 0.25)
         #expect(responsesObject["instructions"] as? String == "Return JSON.")
         #expect(responsesObject["workflow"] as? String == "background_analysis")
         let encodedInput = try #require(responsesObject["input"] as? [[String: Any]])
         #expect(encodedInput.first?["recipient"] as? String == "tools.search")
 
         #expect(messagesObject["stop_sequences"] as? [String] == ["</final>"])
+        #expect(messagesObject["frequency_penalty"] as? Double == 0.15)
         #expect(messagesObject["metadata"] != nil)
         #expect(messagesObject["thinking"] != nil)
         #expect(messagesObject["system"] != nil)
@@ -1135,11 +1141,17 @@ struct TextEndpointContractTests {
         let decodedCompletions = try decoder.decode(OpenAICompletionsRequest.self, from: completionsData)
         let decodedResponses = try decoder.decode(OpenAIResponsesRequest.self, from: responsesData)
         let decodedMessages = try decoder.decode(MelixMessagesRequest.self, from: messagesData)
+        #expect(completions.frequencyPenalty == 0.3)
         #expect(decodedCompletions.stopSequences == ["END", "DONE"])
+        #expect(decodedCompletions.frequencyPenalty == 0.3)
         #expect(decodedCompletions.chatTemplateKwargs == chatTemplate)
         #expect(decodedResponses.stopSequences == ["STOP"])
+        #expect(responses.frequencyPenalty == 0.25)
+        #expect(decodedResponses.frequencyPenalty == 0.25)
         #expect(decodedResponses.toolParser == toolParser)
         #expect(decodedMessages.stopSequences == ["</final>"])
+        #expect(messages.frequencyPenalty == 0.15)
+        #expect(decodedMessages.frequencyPenalty == 0.15)
         #expect(decodedMessages.systemBlocks == [.init(type: .text, text: "Use compact JSON.")] as [MelixMessagesContentBlock]?)
         #expect(decodedMessages.metadata == .init(userID: "operator-encode"))
         #expect(decodedMessages.thinking == .init(type: "enabled", budgetTokens: 64))
@@ -2227,7 +2239,8 @@ struct TextEndpointContractTests {
                 stream: true,
                 temperature: 0.2,
                 topP: 0.9,
-                maxTokens: 128
+                maxTokens: 128,
+                frequencyPenalty: 0.35
             )
         )
         let completions = try translator.normalize(
@@ -2237,7 +2250,8 @@ struct TextEndpointContractTests {
                 stream: true,
                 temperature: 0.2,
                 topP: 0.9,
-                maxTokens: 128
+                maxTokens: 128,
+                frequencyPenalty: 0.35
             )
         )
         let responses = try translator.normalize(
@@ -2247,7 +2261,8 @@ struct TextEndpointContractTests {
                 stream: true,
                 temperature: 0.2,
                 topP: 0.9,
-                maxTokens: 128
+                maxTokens: 128,
+                frequencyPenalty: 0.35
             )
         )
         let messages = try translator.normalize(
@@ -2257,7 +2272,8 @@ struct TextEndpointContractTests {
                 stream: true,
                 temperature: 0.2,
                 topP: 0.9,
-                maxTokens: 128
+                maxTokens: 128,
+                frequencyPenalty: 0.35
             )
         )
 
@@ -2278,6 +2294,9 @@ struct TextEndpointContractTests {
         #expect(chat.maxTokens == completions.maxTokens)
         #expect(completions.maxTokens == responses.maxTokens)
         #expect(responses.maxTokens == messages.maxTokens)
+        #expect(chat.frequencyPenalty == completions.frequencyPenalty)
+        #expect(completions.frequencyPenalty == responses.frequencyPenalty)
+        #expect(responses.frequencyPenalty == messages.frequencyPenalty)
     }
 
     @Test("chat completions default to non-stream while other text endpoints default to stream")

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift
@@ -12,7 +12,27 @@ struct OpenAIConformanceMatrixTests {
         let route: String
         let expectedBehavior: String
         let requestBody: String
+        let workerCanDispatch: Bool
+        let model: Melix_Controlplane_V1_ModelSummary?
         let assertion: @Sendable (HTTPResponse, Melix_Worker_V1_GenerateRequest?) async throws -> OpenAIConformanceObservedStatus
+
+        init(
+            field: String,
+            route: String,
+            expectedBehavior: String,
+            requestBody: String,
+            workerCanDispatch: Bool = true,
+            model: Melix_Controlplane_V1_ModelSummary? = nil,
+            assertion: @escaping @Sendable (HTTPResponse, Melix_Worker_V1_GenerateRequest?) async throws -> OpenAIConformanceObservedStatus
+        ) {
+            self.field = field
+            self.route = route
+            self.expectedBehavior = expectedBehavior
+            self.requestBody = requestBody
+            self.workerCanDispatch = workerCanDispatch
+            self.model = model
+            self.assertion = assertion
+        }
     }
 
     @Test("chat compatibility rows normalize or reject at the OpenAI boundary")
@@ -36,11 +56,91 @@ struct OpenAIConformanceMatrixTests {
                 expectedBehavior: "conflicting max token fields return HTTP 400 and do not dispatch to the worker.",
                 requestBody: Self.body(extra: #""max_tokens": 16, "max_completion_tokens": 37"#)
             ) { response, request in
-                let payload = try await collectConformanceBody(response.body)
+                let error = try await conformanceErrorPayload(from: response.body)
                 #expect(response.statusCode == 400)
-                #expect(payload.contains("\"code\":\"invalid_generation_bounds\""))
-                #expect(payload.contains("max_tokens"))
-                #expect(payload.contains("max_completion_tokens"))
+                #expect(error["code"] as? String == "invalid_generation_bounds")
+                #expect(error["field"] as? String == "max_tokens,max_completion_tokens")
+                #expect(error["phase"] as? String == "generation_bounds")
+                #expect(error["bounds_rejection_reason"] as? String == "output_cap_conflict")
+                #expect(request == nil)
+                return .pass
+            },
+            MatrixRow(
+                field: "best_of",
+                route: "/v1/chat/completions -> typed unsupported-field rejection",
+                expectedBehavior: "unsupported OpenAI fields return a typed payload naming the field and boundary phase.",
+                requestBody: Self.body(extra: #""best_of": 2"#)
+            ) { response, request in
+                let error = try await conformanceErrorPayload(from: response.body)
+                #expect(response.statusCode == 400)
+                #expect(error["code"] as? String == "unsupported_request_field")
+                #expect(error["field"] as? String == "best_of")
+                #expect(error["phase"] as? String == "openai_request_validation")
+                #expect(request == nil)
+                return .pass
+            },
+            MatrixRow(
+                field: "messages",
+                route: "/v1/chat/completions -> typed schema rejection",
+                expectedBehavior: "invalid schema payloads return a typed error naming the incompatible field and decode phase.",
+                requestBody: """
+                {
+                  "model": "melix-dev-text",
+                  "messages": "not-an-array"
+                }
+                """
+            ) { response, request in
+                let error = try await conformanceErrorPayload(from: response.body)
+                #expect(response.statusCode == 400)
+                #expect(error["code"] as? String == "invalid_request_schema")
+                #expect(error["field"] as? String == "messages")
+                #expect(error["phase"] as? String == "decode")
+                #expect(request == nil)
+                return .pass
+            },
+            MatrixRow(
+                field: "backend_unavailable",
+                route: "/v1/chat/completions -> typed backend-unavailable rejection",
+                expectedBehavior: "worker unavailability returns a typed payload naming the dispatch phase before generation.",
+                requestBody: Self.body(extra: #""max_completion_tokens": 8"#),
+                workerCanDispatch: false
+            ) { response, request in
+                let error = try await conformanceErrorPayload(from: response.body)
+                #expect(response.statusCode == 503)
+                #expect(error["code"] as? String == "worker_unavailable")
+                #expect(error["field"] as? String == "worker")
+                #expect(error["phase"] as? String == "backend_dispatch")
+                #expect(request == nil)
+                return .pass
+            },
+            MatrixRow(
+                field: "context_overflow",
+                route: "/v1/chat/completions -> prompt-budget admission",
+                expectedBehavior: "context overflow returns a typed prompt-budget payload with context metadata and no worker dispatch.",
+                requestBody: """
+                {
+                  "model": "melix-dev-text",
+                  "max_tokens": 4,
+                  "messages": [
+                    { "role": "user", "content": "one two three four five six seven eight nine ten eleven twelve" }
+                  ]
+                }
+                """,
+                model: {
+                    var model = warmConformanceModel(id: "melix-dev-text")
+                    model.maxContext = 8
+                    return model
+                }()
+            ) { response, request in
+                let error = try await conformanceErrorPayload(from: response.body)
+                let metadata = try #require(error["prompt_token_metadata"] as? [String: Any])
+                #expect(response.statusCode == 400)
+                #expect(error["code"] as? String == "prompt_budget_exceeded")
+                #expect(error["field"] as? String == "messages")
+                #expect(error["phase"] as? String == "prompt_budget")
+                #expect(metadata["context_window_tokens"] as? Int == 8)
+                #expect(metadata["admission_phase"] as? String == "prompt_budget")
+                #expect(metadata["prefill_started"] as? Bool == false)
                 #expect(request == nil)
                 return .pass
             },
@@ -110,6 +210,20 @@ struct OpenAIConformanceMatrixTests {
                 return .pass
             },
             MatrixRow(
+                field: "seed,frequency_penalty",
+                route: "/v1/chat/completions -> sampling passthrough",
+                expectedBehavior: "seed and frequency_penalty forward into worker sampling and generation receipts.",
+                requestBody: Self.body(extra: #""seed": 123, "frequency_penalty": 0.35"#)
+            ) { response, request in
+                #expect(response.statusCode == 200)
+                let generated = try #require(request)
+                #expect(generated.sampling.seed == 123)
+                #expect(generated.sampling.frequencyPenalty == Float(0.35))
+                #expect(generated.execution.ext["melix.generation.seed"] == "123")
+                #expect(generated.execution.ext["melix.generation.frequency_penalty"] == "0.35")
+                return .pass
+            },
+            MatrixRow(
                 field: "logprobs,top_logprobs",
                 route: "/v1/chat/completions -> execution.ext effective receipt",
                 expectedBehavior: "logprobs requests are visible as unsupported-effective receipts until workers emit token distributions.",
@@ -126,8 +240,11 @@ struct OpenAIConformanceMatrixTests {
 
         var reportRows: [OpenAIConformanceRow] = []
         for row in rows {
-            let worker = RecordingConformanceWorker(requestID: "req-\(row.field)")
-            let handler = Self.handler(worker: worker)
+            let worker = RecordingConformanceWorker(
+                requestID: "req-\(row.field)",
+                canDispatchRequests: row.workerCanDispatch
+            )
+            let handler = Self.handler(worker: worker, model: row.model)
             let response = try await handler.handle(
                 HTTPRequest(
                     method: .post,
@@ -600,8 +717,11 @@ struct OpenAIConformanceMatrixTests {
         #expect(!stats.hasStats)
     }
 
-    private static func handler(worker: RecordingConformanceWorker) -> OpenAIHandler {
-        let catalog = ModelCatalog(seedModels: [warmConformanceModel(id: "melix-dev-text")])
+    private static func handler(
+        worker: RecordingConformanceWorker,
+        model: Melix_Controlplane_V1_ModelSummary? = nil
+    ) -> OpenAIHandler {
+        let catalog = ModelCatalog(seedModels: [model ?? warmConformanceModel(id: "melix-dev-text")])
         let registry = WorkerRegistry(defaultTextClient: worker, modelCatalog: catalog)
         return OpenAIHandler(
             modelCatalog: catalog,
@@ -670,6 +790,13 @@ private func collectConformanceBody(_ body: HTTPBody) async throws -> String {
     }
 }
 
+private func conformanceErrorPayload(from body: HTTPBody) async throws -> [String: Any] {
+    let payload = try await collectConformanceBody(body)
+    let data = try #require(payload.data(using: .utf8))
+    let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    return try #require(object["error"] as? [String: Any])
+}
+
 private func collectConformanceEvents(
     _ stream: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>
 ) async throws -> [Melix_Worker_V1_ExecuteEvent] {
@@ -699,22 +826,25 @@ private actor RecordingConformanceWorker:
     let requestID: String
     private let events: [Melix_Worker_V1_ExecuteEvent]
     private let loadModelHandle: String
+    private let dispatchAvailable: Bool
     private(set) var lastGenerateRequest: Melix_Worker_V1_GenerateRequest?
 
     init(
         requestID: String,
         events: [Melix_Worker_V1_ExecuteEvent]? = nil,
-        loadModelHandle: String = "melix-dev-text::swift"
+        loadModelHandle: String = "melix-dev-text::swift",
+        canDispatchRequests: Bool = true
     ) {
         self.requestID = requestID
         self.events = events ?? [
             makeCompletedEvent(requestID: requestID, seq: 1, finishReason: "stop", assistantText: "ok"),
         ]
         self.loadModelHandle = loadModelHandle
+        self.dispatchAvailable = canDispatchRequests
     }
 
     func canDispatchRequests() async -> Bool {
-        true
+        dispatchAvailable
     }
 
     func generate(

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -6036,6 +6036,47 @@ struct OpenAIHandlerTests {
         #expect(await workerClient.lastGenerateRequest == nil)
     }
 
+    @Test("POST /v1/chat/completions names missing required keys in schema error fields")
+    func postChatCompletionsReturnsMissingRequiredKeyInSchemaErrorField() async throws {
+        let workerClient = ScriptedWorkerClient(events: [])
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-missing-schema-key" })
+        )
+
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": true
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let error = try #require(payload["error"] as? [String: Any])
+
+        #expect(response.statusCode == 400)
+        #expect(error["code"] as? String == "invalid_request_schema")
+        #expect(error["field"] as? String == "messages")
+        #expect(error["phase"] as? String == "decode")
+        #expect(error["message"] as? String == "Malformed multimodal chat payload.")
+        #expect(await workerClient.lastLoadModelRequest == nil)
+        #expect(await workerClient.lastGenerateRequest == nil)
+    }
+
     @Test("POST /v1/chat/completions rejects media with tools before worker dispatch")
     func postChatCompletionsRejectsMediaWithToolsBeforeWorkerDispatch() async throws {
         let harness = makeGemma4VLMOpenAIHandler(

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -5987,8 +5987,8 @@ struct OpenAIHandlerTests {
         #expect(await workerClient.lastGenerateRequest == nil)
     }
 
-    @Test("POST /v1/chat/completions returns invalid argument for non-string multimodal part types")
-    func postChatCompletionsReturnsInvalidArgumentForNonStringMultimodalPartTypes() async throws {
+    @Test("POST /v1/chat/completions returns typed schema errors for non-string multimodal part types")
+    func postChatCompletionsReturnsTypedSchemaErrorsForNonStringMultimodalPartTypes() async throws {
         let workerClient = ScriptedWorkerClient(events: [])
         let handler = OpenAIHandler(
             modelCatalog: ModelCatalog(seedModels: [warmModel()]),
@@ -6024,11 +6024,14 @@ struct OpenAIHandlerTests {
                 body: body
             )
         )
-        let payload = try await collectBody(response.body)
+        let payload = try await jsonPayload(from: response.body)
+        let error = try #require(payload["error"] as? [String: Any])
 
         #expect(response.statusCode == 400)
-        #expect(payload.contains("\"code\":\"invalid_argument\""))
-        #expect(payload.contains("Malformed multimodal chat payload."))
+        #expect(error["code"] as? String == "invalid_request_schema")
+        #expect(error["field"] as? String == "type")
+        #expect(error["phase"] as? String == "decode")
+        #expect(error["message"] as? String == "Malformed multimodal chat payload.")
         #expect(await workerClient.lastLoadModelRequest == nil)
         #expect(await workerClient.lastGenerateRequest == nil)
     }


### PR DESCRIPTION
## Summary
- Add OpenAI conformance rows for unsupported fields, schema decode failures, backend unavailability, and prompt-budget context overflow with typed `code`, `field`, and `phase` payloads.
- Thread `frequency_penalty` through OpenAI-compatible request normalization, shaping, worker sampling, and generation receipts.
- Fix decode error field extraction for missing required keys after PR review and update the issue #1991 plan with coverage, local gate, and PR-scoped performance evidence.

## Plan or Spec
- `docs/plans/2026-06-18-issue-1991-openai-conformance-errors-sampling.md`
- Parent conformance plan: `docs/plans/2026-05-24-issue-1384-openai-conformance-suite.md`
- Closes #1991

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests
- Expected red before implementation: missing error field/phase assertions and unsupported `best_of` was not rejected as JSON error.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests
- Passed: 12 tests.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests
- Passed: 218 tests.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests/postChatCompletionsReturnsMissingRequiredKeyInSchemaErrorField
- Expected red during review fix: returned `field: body` instead of `field: messages`.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests/postChatCompletionsReturnsMissingRequiredKeyInSchemaErrorField
- Passed.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIConformanceMatrixTests|OpenAIHandlerTests'
- Passed: 231 tests in 2 suites.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" xcrun swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIConformanceMatrixTests|OpenAIHandlerTests|TextEndpointContractTests'
- Passed: 296 tests in 3 suites.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" xcrun swift test --package-path services/control-plane-swift --filter TextEndpointContractTests
- Passed: 65 tests.

UV_PYTHON=3.12 uv run --frozen --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --diff-from origin/main --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift services/control-plane-swift/Sources/Requests/TextRequestShaper.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
- Passed: changed-line coverage 97.67% (294/301).

git diff --check
- Passed.

make swift-test
- Passed.

make py-test
- Passed: 4066 passed, 14 skipped, 2 warnings.

make integration-test
- Passed: 120 passed, 1 skipped.

UV_CACHE_DIR="$PWD/.uv-cache" UV_PYTHON="${MELIX_PRE_COMMIT_UV_PYTHON:-${UV_PYTHON:-3.12}}" uv run --frozen --project services/mlx-worker-python --extra mlx python scripts/pre_commit_gate.py
- Passed: full gate and PR-scoped performance report Status ok.

git commit -m "test: cover OpenAI conformance errors and sampling"
- Passed: repository pre-commit hook reran full local gate and PR-scoped performance report.

git commit -m "fix: report missing OpenAI schema fields"
- Passed: repository pre-commit hook reran full local gate and PR-scoped performance report.
```

## Coverage and Metrics
- Changed-line coverage: 97.67% (294/301) for touched Swift source/tests.
- PR-scoped performance report after initial implementation: `Status: ok`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`.
- Initial performance report path: `.runtime/pre-commit-performance/20260617-171548-81972f5d/report/report.md`.
- PR-scoped performance report after review fix: `Status: ok`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`.
- Review-fix performance report path: `.runtime/pre-commit-performance/20260617-174519-085f65eb/report/report.md`.
- Selected probes: 0. No registered performance probes matched this OpenAI conformance/sampling diff.
- Observability mode: `minimal`; this change adds deterministic request/receipt assertions, not new runtime probes.
- Probe overhead: `N/A`; no new observability probes or performance probes were added.
- Protocol artifacts: `N/A`; no protocol schema changes were made.
- Dependency artifacts: `N/A`; no dependency changes were made.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
