### PR TITLE
perf: bind retrieval context receipt builder locally

### DIFF
--- a/docs/plans/2026-06-18-retrieval-context-receipt-local-binding-performance.md
+++ b/docs/plans/2026-06-18-retrieval-context-receipt-local-binding-performance.md
@@ -1,0 +1,20 @@
+# Retrieval Context Receipt Builder Local Binding Performance Slice
+
+## Scope
+
+This slice optimizes the registered `retrieval-context-projection-fastpath` hot path by binding the shared `untrusted_context_receipt()` helper once per projection call before tight direct-entry/store-record loops. The behavior is unchanged: valid retrieved document/image contexts still project the same user payloads, untrusted-context receipts, and refusal receipts.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`. The probe includes focused retrieval-context tests, changed-scope coverage, and `scripts/retrieval_context_projection_probe.py`, which reports direct projection, store-record projection, lookup payload copy, and lookup wrapper metrics.
+
+## Verification plan
+
+- Run the registered focused test command for retrieval-context behavior and PR-scoped probe coverage.
+- Run the registered changed-scope coverage command.
+- Run `scripts/retrieval_context_projection_probe.py` locally on Linux before and after the change and compare `optimized_elapsed_ms_mean` and `store_optimized_elapsed_ms_mean`.
+- Rely on GitHub Actions PR-scoped performance workflow for the final registered CI probe report before merge.
+
+## Expected outcome
+
+Local binding removes a global helper lookup from each valid direct projection/store-record iteration. The improvement should be visible primarily in `optimized_elapsed_ms_mean` and `store_optimized_elapsed_ms_mean`; lookup-copy and lookup-wrapper metrics are expected to remain within normal noise because this slice does not change those paths.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -123,6 +123,7 @@ def project_retrieval_contexts(
     refusal_receipts: list[dict[str, object]] = []
     admit_entry = _admit_entry
     duplicate_projection_receipt = _duplicate_projection_receipt
+    build_untrusted_context_receipt = untrusted_context_receipt
     refusal_receipts_extend = refusal_receipts.extend
     refusal_receipts_append = refusal_receipts.append
     receipts_append = receipts.append
@@ -161,7 +162,7 @@ def project_retrieval_contexts(
                     and normalized_reason
                     and normalized_corrective_action
                 ):
-                    receipt = untrusted_context_receipt(
+                    receipt = build_untrusted_context_receipt(
                         segment_id=normalized_segment_id,
                         source_type=context_kind,
                         source_field=normalized_source_field,
@@ -262,6 +263,7 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
     admit_entry = _admit_entry
     entry_type = RetrievalContextEntry
     duplicate_projection_receipt = _duplicate_projection_receipt
+    build_untrusted_context_receipt = untrusted_context_receipt
     projection_refusal_receipts_extend = projection_refusal_receipts.extend
     receipts_append = receipts.append
     user_payload_update = user_payload.update
@@ -314,7 +316,7 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
                 and corrective_action.strip()
             ):
                 normalized_source_field = source_field.strip()
-                receipt = untrusted_context_receipt(
+                receipt = build_untrusted_context_receipt(
                     segment_id=segment_id.strip(),
                     source_type=context_kind,
                     source_field=normalized_source_field,


### PR DESCRIPTION
## Summary
- Bind `untrusted_context_receipt()` to a local helper inside retrieval-context projection hot loops.
- Keep behavior unchanged while removing repeated global helper lookups for direct entry and store-record fast paths.

## Plan or Spec
- `docs/plans/2026-06-18-retrieval-context-receipt-local-binding-performance.md`
- Registered PR-scoped probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_isolates_refusals_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_malformed_entry_objects_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_preserves_multi_field_admission_duplicate_scan services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_fast_paths_complete_entries_without_admission_reentry services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_copies_multi_receipt_admissions services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_projects_records_without_entry_reentry services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_fast_paths_complete_dict_records services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_copies_store_projection_outputs services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_uses_wrapper_metadata_for_refusals services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_uses_wrapper_metadata_for_malformed_records services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_reads_records_once_for_metadata_refusal services/mlx-worker-python/tests/test_retrieval_context.py::test_lookup_result_metadata_refusal_skips_default_normalization_for_valid_metadata services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_copies_tuple_payloads_without_type_drift services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_refuses_malformed_wrapper_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_covers_lookup_wrapper_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 24 passed in 1.00s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused retrieval-context registered test selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
# 24 passed; TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
# before: optimized_elapsed_ms_mean=0.18560596575428331, store_optimized_elapsed_ms_mean=0.2047056531799691
# after:  optimized_elapsed_ms_mean=0.1745682688696044, store_optimized_elapsed_ms_mean=0.19500447869566934

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Local Linux registered probe metrics:
  - Direct projection optimized mean: `0.18560596575428331 ms` -> `0.1745682688696044 ms` (`-0.01103769688467891 ms`, about `5.95%` faster).
  - Store-record projection optimized mean: `0.2047056531799691 ms` -> `0.19500447869566934 ms` (`-0.00970117448429976 ms`, about `4.74%` faster).
  - Lookup-copy and lookup-wrapper metrics are not targeted by this slice and remained in the same probe report for guard coverage.
- CI must run the registered PR-scoped performance workflow and publish the `retrieval-context-projection-fastpath` report before merge.

## Known Gaps
- No Swift/runtime effect is claimed; this is a Python-only slice validated locally on Linux.
- Final registered probe validation is the GitHub Actions PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
