### PR TITLE
Add runnable OpenAI conformance harness

### DIFF
--- a/docs/plans/2026-06-18-issue-1986-openai-conformance-harness.md
+++ b/docs/plans/2026-06-18-issue-1986-openai-conformance-harness.md
@@ -1,0 +1,110 @@
+# Issue 1986 OpenAI Conformance Harness Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for implementation. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a runnable OpenAI conformance harness that emits the existing `OpenAIConformanceReport` schema for live local endpoints, configured remote server profiles, and deterministic CI mock mode.
+
+**Architecture:** Keep the in-process conformance matrix as the authoritative compatibility proof from ADR 0002, and add a client-side harness as an evidence layer. The harness shares Swift report types, runs a small row set through an injectable HTTP transport, and exposes a CLI executable that can use deterministic mock responses or a real OpenAI-compatible base URL.
+
+**Tech Stack:** Swift Package executable target, Swift Testing, `RemoteProviderHTTPTransport`, `URLRequest`, `HTTPURLResponse`, `JSONSerialization`, `OpenAIConformanceReport`.
+
+---
+
+## Scope
+
+This PR implements issue #1986 as a child slice of #1384:
+
+- Add a reusable `OpenAIConformanceHarness` under the Swift control-plane core.
+- Reuse `OpenAIConformanceReport` rows and summary without adding a parallel schema.
+- Cover these runnable rows:
+  - non-streaming `/v1/chat/completions` response shape,
+  - streaming tool-call SSE response shape,
+  - typed error-path shape that names an incompatible field and phase.
+- Add deterministic mock-backend CI mode with no model weights or live socket.
+- Add real-backend smoke mode for live local endpoints or configured remote server profile fields supplied as `base_url`, `model`, and optional API key.
+- Add a `melix-openai-conformance` executable that writes the report JSON artifact.
+
+This PR does not replace `OpenAIConformanceMatrixTests`, implement local-vs-remote proxy parity (#1989), add provider profile persistence, or require real model weights in CI.
+
+## Success Metrics
+
+- Mock-backend mode produces a report with `schema_version = melix.openai_conformance_report.v1` and all rows passing.
+- Real-backend mode uses the same row definitions and writes an artifact even when rows fail or skip.
+- Error row `observed_reason` includes HTTP status plus incompatible `field` and `phase` when the backend reports them.
+- CLI argument validation returns field-specific usage errors instead of generic crashes.
+- Changed-line coverage for touched Swift scope is at least 95 percent.
+- PR-scoped performance report is `Status: ok` with no direct/gated regression.
+
+## Implementation Tasks
+
+- [x] Add failing Swift tests in `services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift`.
+  - Mock mode report has three passing rows and uses the existing schema.
+  - Live transport requests normalize `base_url`, include auth only when supplied, and carry the requested model.
+  - Error-path row records `status`, `field`, and `phase` in `observed_reason`.
+  - CLI parser rejects missing real-backend `base_url`, `model`, and output path with named errors.
+- [x] Add `services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift`.
+  - Define `OpenAIConformanceHarnessTarget`, `OpenAIConformanceHarness`, and `MockOpenAIConformanceTransport`.
+  - Build rows once and execute them through `RemoteProviderHTTPTransport`.
+  - Convert request/response mismatches into `OpenAIConformanceRow` failures with specific reasons.
+- [x] Add the executable target.
+  - Add product `melix-openai-conformance` and target `OpenAIConformanceHarnessCLI` in `Package.swift`.
+  - Add `services/control-plane-swift/Sources/OpenAIConformanceHarnessCLI/main.swift`.
+  - Support `--mode mock-backend-ci|real-backend-smoke`, `--base-url`, `--model`, `--api-key`, and `--output`.
+- [x] Document usage.
+  - Update this plan with verification receipts.
+  - Keep ADR 0002 unchanged because the harness is already described there as additive evidence.
+- [x] Verify focused scope.
+  - Run focused harness tests.
+  - Run focused conformance matrix tests to prove the authoritative boundary proof still passes.
+  - Run changed-line coverage for touched Swift files.
+  - Full local gate and PR-scoped performance are still required before PR creation.
+
+## Verification Receipts
+
+- RED: `swift test --package-path services/control-plane-swift --filter OpenAIConformanceHarnessTests` failed because `OpenAIConformanceHarness` and `OpenAIConformanceHarnessCLI` did not exist.
+- GREEN: `swift test --package-path services/control-plane-swift --filter OpenAIConformanceHarnessTests` passed with 8 tests in 1 suite.
+- Boundary proof: `swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests` passed with 17 tests in 1 suite.
+- CLI smoke: `swift run --package-path services/control-plane-swift melix-openai-conformance --mode mock-backend-ci --output .runtime/issue1986/mock-report.json` wrote a report with `passed=3 failed=0 skipped=0`.
+- Focused coverage: `OpenAIConformanceHarnessTests|OpenAIConformanceMatrixTests` passed with 25 tests in 2 suites; changed-line coverage was `99.71%` (`699/701`) for touched Swift source/test files.
+- Review RED: `swift test --package-path services/control-plane-swift --filter OpenAIConformanceHarnessTests` failed on real-backend CLI fallback-to-mock, whitespace-sensitive SSE validation, `URLError.cancelled` handling, and silent `--model-id` option typos.
+- Review GREEN: `swift test --package-path services/control-plane-swift --filter OpenAIConformanceHarnessTests` passed with 9 tests in 1 suite after defaulting real-backend smoke to `URLSessionRemoteProviderHTTPTransport`, parsing SSE JSON events, propagating URLSession cancellations, and validating CLI option names.
+- Review boundary proof: `swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests` passed with 17 tests in 1 suite after the review fixes.
+- Review CLI smoke: `swift run --package-path services/control-plane-swift melix-openai-conformance --mode mock-backend-ci --output .runtime/issue1986/mock-report-after-review.json` wrote a report with `passed=3 failed=0 skipped=0`.
+- Review focused coverage: `OpenAIConformanceHarnessTests|OpenAIConformanceMatrixTests` passed with 26 tests in 2 suites; changed-line coverage was `99.62%` (`794/797`) for touched Swift source/test files.
+
+## Verification Commands
+
+Focused:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceHarnessTests
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests
+git diff --check
+```
+
+Changed-line coverage:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIConformanceHarnessTests|OpenAIConformanceMatrixTests'
+UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py \
+  --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests \
+  --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata \
+  --diff-from origin/main \
+  services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift \
+  services/control-plane-swift/Sources/OpenAIConformanceHarnessCLI/main.swift \
+  services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift
+```
+
+Pre-PR local gate:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```
+
+Metrics:
+
+```bash
+UV_PYTHON="${MELIX_PRE_COMMIT_UV_PYTHON:-${UV_PYTHON:-3.12}}" uv run --frozen --project services/mlx-worker-python --extra mlx python scripts/pre_commit_gate.py
+```

--- a/services/control-plane-swift/Package.swift
+++ b/services/control-plane-swift/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
     products: [
         .library(name: "MelixControlPlaneCore", targets: ["MelixControlPlaneCore"]),
         .executable(name: "melix-control-plane", targets: ["Bootstrap"]),
+        .executable(name: "melix-openai-conformance", targets: ["OpenAIConformanceHarnessCLI"]),
     ],
     dependencies: [
         .package(path: "../../packages/protocol/swift"),
@@ -26,7 +27,7 @@ let package = Package(
                 .product(name: "GRPCNIOTransportHTTP2Posix", package: "grpc-swift-nio-transport"),
             ],
             path: "Sources",
-            exclude: ["Bootstrap"],
+            exclude: ["Bootstrap", "OpenAIConformanceHarnessCLI"],
             sources: [
                 "EnginePool",
                 "HTTPGateway",
@@ -44,6 +45,11 @@ let package = Package(
             name: "Bootstrap",
             dependencies: ["MelixControlPlaneCore"],
             path: "Sources/Bootstrap"
+        ),
+        .executableTarget(
+            name: "OpenAIConformanceHarnessCLI",
+            dependencies: ["MelixControlPlaneCore"],
+            path: "Sources/OpenAIConformanceHarnessCLI"
         ),
         .testTarget(
             name: "ControlPlaneTests",

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift
@@ -1,0 +1,492 @@
+import Foundation
+
+public enum OpenAIConformanceHarnessError: Error, Equatable, CustomStringConvertible {
+    case invalidBaseURL(String)
+    case transportFailed(String)
+
+    public var description: String {
+        switch self {
+        case .invalidBaseURL(let value):
+            return "invalid OpenAI conformance base_url: \(value)"
+        case .transportFailed(let message):
+            return "OpenAI conformance transport failed: \(message)"
+        }
+    }
+}
+
+public enum OpenAIConformanceHarnessTarget: Equatable, Sendable {
+    case mockBackendCI(modelID: String)
+    case realBackendSmoke(baseURL: String, modelID: String, apiKey: String, timeoutSeconds: UInt32)
+
+    var modelID: String {
+        switch self {
+        case .mockBackendCI(let modelID), .realBackendSmoke(_, let modelID, _, _):
+            return modelID
+        }
+    }
+
+    var timeoutSeconds: UInt32 {
+        switch self {
+        case .mockBackendCI:
+            return 30
+        case .realBackendSmoke(_, _, _, let timeoutSeconds):
+            return timeoutSeconds == 0 ? 30 : timeoutSeconds
+        }
+    }
+}
+
+public struct OpenAIConformanceHarness: Sendable {
+    private let target: OpenAIConformanceHarnessTarget
+    private let transport: any RemoteProviderHTTPTransport
+
+    public init(
+        target: OpenAIConformanceHarnessTarget,
+        transport: (any RemoteProviderHTTPTransport)? = nil
+    ) {
+        self.target = target
+        if let transport {
+            self.transport = transport
+        } else {
+            switch target {
+            case .mockBackendCI:
+                self.transport = MockOpenAIConformanceTransport()
+            case .realBackendSmoke:
+                self.transport = URLSessionRemoteProviderHTTPTransport()
+            }
+        }
+    }
+
+    public func run() async throws -> OpenAIConformanceReport {
+        let rows = try await Self.rows().asyncMap { row in
+            try await execute(row)
+        }
+        return OpenAIConformanceReport(rows: rows)
+    }
+
+    private func execute(_ row: HarnessRow) async throws -> OpenAIConformanceRow {
+        let request = try makeHTTPRequest(for: row)
+        let data: Data
+        let response: HTTPURLResponse
+        do {
+            (data, response) = try await transport.data(for: request)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            throw urlError
+        } catch {
+            return row.reportRow(
+                status: .fail,
+                reason: "transport_failed=\(String(describing: error))"
+            )
+        }
+        let evaluation = row.evaluate(data: data, response: response)
+        return row.reportRow(status: evaluation.status, reason: evaluation.reason)
+    }
+
+    private func makeHTTPRequest(for row: HarnessRow) throws -> URLRequest {
+        let url = try normalizedChatCompletionsURL()
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = TimeInterval(target.timeoutSeconds)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(row.acceptHeader, forHTTPHeaderField: "Accept")
+        request.setValue("OpenAI/Python 1.0.0 Melix/0.1", forHTTPHeaderField: "User-Agent")
+        if case .realBackendSmoke(_, _, let apiKey, _) = target {
+            let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty == false {
+                request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
+            }
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: row.body(modelID: target.modelID), options: [])
+        return request
+    }
+
+    private func normalizedChatCompletionsURL() throws -> URL {
+        switch target {
+        case .mockBackendCI:
+            return URL(string: "https://mock.melix.local/v1/chat/completions")!
+        case .realBackendSmoke(let baseURL, _, _, _):
+            let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalized = trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed
+            guard normalized.isEmpty == false,
+                  let url = URL(string: "\(normalized)/chat/completions")
+            else {
+                throw OpenAIConformanceHarnessError.invalidBaseURL(baseURL)
+            }
+            return url
+        }
+    }
+
+    private static func rows() -> [HarnessRow] {
+        [
+            HarnessRow(
+                field: "chat.completions.response_shape",
+                route: "/v1/chat/completions -> non-streaming response",
+                expectedBehavior: "Non-streaming chat completions return one assistant message choice and usage-compatible JSON.",
+                requestKind: .nonStreamingChat
+            ),
+            HarnessRow(
+                field: "chat.completions.streaming_tool_call_shape",
+                route: "/v1/chat/completions -> streaming tool-call chunks",
+                expectedBehavior: "Streaming tool-call responses use OpenAI SSE chunk shape and terminate with [DONE].",
+                requestKind: .streamingToolCall
+            ),
+            HarnessRow(
+                field: "chat.completions.error_shape",
+                route: "/v1/chat/completions -> typed error payload",
+                expectedBehavior: "Unsupported request fields return a typed error naming field and phase.",
+                requestKind: .errorShape
+            ),
+        ]
+    }
+}
+
+public struct MockOpenAIConformanceTransport: RemoteProviderHTTPTransport {
+    public init() {}
+
+    public func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let body = try requestJSONObject(request)
+        let stream = body["stream"] as? Bool ?? false
+        let statusCode: Int
+        let payload: String
+        let contentType: String
+        if body["best_of"] != nil {
+            statusCode = 400
+            contentType = "application/json"
+            payload = """
+            {"error":{"message":"Unsupported request field","type":"invalid_request_error","code":"unsupported_request_field","field":"best_of","phase":"openai_request_validation"}}
+            """
+        } else if stream {
+            statusCode = 200
+            contentType = "text/event-stream"
+            payload = """
+            data: {"object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call-1","type":"function","function":{"name":"get_weather","arguments":"{\\"city\\":\\"Tokyo\\"}"}}]},"finish_reason":null}]}
+
+            data: {"object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+            data: [DONE]
+
+            """
+        } else {
+            statusCode = 200
+            contentType = "application/json"
+            payload = """
+            {"id":"chatcmpl-mock","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"pong"},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":1,"total_tokens":5}}
+            """
+        }
+        let response = HTTPURLResponse(
+            url: request.url ?? URL(string: "https://mock.melix.local/v1/chat/completions")!,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["content-type": contentType]
+        )!
+        return (Data(payload.utf8), response)
+    }
+
+    private func requestJSONObject(_ request: URLRequest) throws -> [String: Any] {
+        guard let body = request.httpBody,
+              let object = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        else {
+            throw OpenAIConformanceHarnessError.transportFailed("mock request body was not JSON")
+        }
+        return object
+    }
+}
+
+public enum OpenAIConformanceHarnessCLIError: Error, Equatable, CustomStringConvertible {
+    case unknownOption(String)
+    case missingValue(String)
+    case invalidMode(String)
+    case invalidTimeout(String)
+
+    public var description: String {
+        switch self {
+        case .unknownOption(let option):
+            return "unknown option: \(option)"
+        case .missingValue(let option):
+            return "missing value for \(option)"
+        case .invalidMode(let value):
+            return "invalid --mode: \(value)"
+        case .invalidTimeout(let value):
+            return "invalid --timeout-seconds: \(value)"
+        }
+    }
+}
+
+public struct OpenAIConformanceHarnessCLI: Sendable {
+    public let target: OpenAIConformanceHarnessTarget
+    public let outputURL: URL
+
+    public init(target: OpenAIConformanceHarnessTarget, outputURL: URL) {
+        self.target = target
+        self.outputURL = outputURL
+    }
+
+    public static func parse(arguments: [String]) throws -> OpenAIConformanceHarnessCLI {
+        var values: [String: String] = [:]
+        var index = 0
+        while index < arguments.count {
+            let option = arguments[index]
+            guard option.hasPrefix("--") else {
+                throw OpenAIConformanceHarnessCLIError.unknownOption(option)
+            }
+            guard index + 1 < arguments.count else {
+                throw OpenAIConformanceHarnessCLIError.missingValue(option)
+            }
+            values[option] = arguments[index + 1]
+            index += 2
+        }
+
+        let supportedOptions: Set<String> = [
+            "--api-key",
+            "--base-url",
+            "--mode",
+            "--model",
+            "--output",
+            "--timeout-seconds",
+        ]
+        for option in values.keys where supportedOptions.contains(option) == false {
+            throw OpenAIConformanceHarnessCLIError.unknownOption(option)
+        }
+
+        let mode = values["--mode"] ?? "mock-backend-ci"
+        guard let output = values["--output"], output.isEmpty == false else {
+            throw OpenAIConformanceHarnessCLIError.missingValue("--output")
+        }
+        let outputURL = URL(fileURLWithPath: output)
+        switch mode {
+        case "mock-backend-ci":
+            let modelID = values["--model"] ?? "melix-dev-text"
+            return OpenAIConformanceHarnessCLI(
+                target: .mockBackendCI(modelID: modelID),
+                outputURL: outputURL
+            )
+        case "real-backend-smoke":
+            guard let baseURL = values["--base-url"], baseURL.isEmpty == false else {
+                throw OpenAIConformanceHarnessCLIError.missingValue("--base-url")
+            }
+            guard let modelID = values["--model"], modelID.isEmpty == false else {
+                throw OpenAIConformanceHarnessCLIError.missingValue("--model")
+            }
+            let timeoutSeconds: UInt32
+            if let timeout = values["--timeout-seconds"] {
+                guard let parsed = UInt32(timeout), parsed > 0 else {
+                    throw OpenAIConformanceHarnessCLIError.invalidTimeout(timeout)
+                }
+                timeoutSeconds = parsed
+            } else {
+                timeoutSeconds = 30
+            }
+            return OpenAIConformanceHarnessCLI(
+                target: .realBackendSmoke(
+                    baseURL: baseURL,
+                    modelID: modelID,
+                    apiKey: values["--api-key"] ?? "",
+                    timeoutSeconds: timeoutSeconds
+                ),
+                outputURL: outputURL
+            )
+        default:
+            throw OpenAIConformanceHarnessCLIError.invalidMode(mode)
+        }
+    }
+
+    public func run(transport: (any RemoteProviderHTTPTransport)? = nil) async throws -> OpenAIConformanceReport {
+        let report = try await OpenAIConformanceHarness(target: target, transport: transport).run()
+        let outputDirectory = outputURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+        try report.jsonData().write(to: outputURL, options: [.atomic])
+        return report
+    }
+}
+
+private struct HarnessRow: Sendable {
+    let field: String
+    let route: String
+    let expectedBehavior: String
+    let requestKind: HarnessRequestKind
+
+    var acceptHeader: String {
+        switch requestKind {
+        case .streamingToolCall:
+            return "text/event-stream"
+        case .nonStreamingChat, .errorShape:
+            return "application/json"
+        }
+    }
+
+    func body(modelID: String) -> [String: Any] {
+        switch requestKind {
+        case .nonStreamingChat:
+            return [
+                "model": modelID,
+                "messages": [["role": "user", "content": "Reply with pong."]],
+                "stream": false,
+                "max_completion_tokens": 8,
+            ]
+        case .streamingToolCall:
+            return [
+                "model": modelID,
+                "messages": [["role": "user", "content": "Call get_weather for Tokyo."]],
+                "stream": true,
+                "tools": [[
+                    "type": "function",
+                    "function": [
+                        "name": "get_weather",
+                        "description": "Return weather for a city.",
+                        "parameters": [
+                            "type": "object",
+                            "properties": ["city": ["type": "string"]],
+                            "required": ["city"],
+                        ],
+                    ],
+                ]],
+                "tool_choice": [
+                    "type": "function",
+                    "function": ["name": "get_weather"],
+                ],
+            ]
+        case .errorShape:
+            return [
+                "model": modelID,
+                "messages": [["role": "user", "content": "Reject unsupported field."]],
+                "stream": false,
+                "best_of": 2,
+            ]
+        }
+    }
+
+    func evaluate(data: Data, response: HTTPURLResponse) -> (status: OpenAIConformanceObservedStatus, reason: String) {
+        switch requestKind {
+        case .nonStreamingChat:
+            return evaluateNonStreaming(data: data, response: response)
+        case .streamingToolCall:
+            return evaluateStreamingToolCall(data: data, response: response)
+        case .errorShape:
+            return evaluateErrorShape(data: data, response: response)
+        }
+    }
+
+    func reportRow(
+        status: OpenAIConformanceObservedStatus,
+        reason: String
+    ) -> OpenAIConformanceRow {
+        OpenAIConformanceRow(
+            field: field,
+            route: route,
+            expectedBehavior: expectedBehavior,
+            observedStatus: status,
+            observedReason: reason
+        )
+    }
+
+    private func evaluateNonStreaming(
+        data: Data,
+        response: HTTPURLResponse
+    ) -> (status: OpenAIConformanceObservedStatus, reason: String) {
+        guard response.statusCode == 200 else {
+            return (.fail, "status=\(response.statusCode)")
+        }
+        guard let object = try? jsonObject(data),
+              let choices = object["choices"] as? [[String: Any]],
+              let firstChoice = choices.first,
+              let message = firstChoice["message"] as? [String: Any],
+              message["role"] as? String == "assistant",
+              message["content"] is String
+        else {
+            return (.fail, "status=200 missing=choices[0].message")
+        }
+        return (.pass, "status=200")
+    }
+
+    private func evaluateStreamingToolCall(
+        data: Data,
+        response: HTTPURLResponse
+    ) -> (status: OpenAIConformanceObservedStatus, reason: String) {
+        guard response.statusCode == 200 else {
+            return (.fail, "status=\(response.statusCode)")
+        }
+        let text = String(decoding: data, as: UTF8.self)
+        let events = sseDataEvents(in: text)
+        guard events.contains("[DONE]") else {
+            return (.fail, "status=200 missing=done")
+        }
+        var hasToolCalls = false
+        var hasToolCallsFinishReason = false
+        for event in events where event != "[DONE]" {
+            guard let eventData = event.data(using: .utf8),
+                  let object = try? jsonObject(eventData),
+                  let choices = object["choices"] as? [[String: Any]]
+            else {
+                continue
+            }
+            for choice in choices {
+                if let delta = choice["delta"] as? [String: Any],
+                   delta["tool_calls"] != nil {
+                    hasToolCalls = true
+                }
+                if choice["finish_reason"] as? String == "tool_calls" {
+                    hasToolCallsFinishReason = true
+                }
+            }
+        }
+        guard hasToolCalls, hasToolCallsFinishReason else {
+            return (.fail, "status=200 missing=tool_call_chunk")
+        }
+        return (.pass, "status=200")
+    }
+
+    private func evaluateErrorShape(
+        data: Data,
+        response: HTTPURLResponse
+    ) -> (status: OpenAIConformanceObservedStatus, reason: String) {
+        guard response.statusCode >= 400 else {
+            return (.fail, "status=\(response.statusCode) expected_error=true")
+        }
+        let errorObject = (try? jsonObject(data))?["error"] as? [String: Any]
+        let field = errorObject?["field"] as? String
+        let phase = errorObject?["phase"] as? String
+        guard let field, field.isEmpty == false,
+              let phase, phase.isEmpty == false
+        else {
+            return (.fail, "status=\(response.statusCode) missing=field_or_phase")
+        }
+        return (.pass, "status=\(response.statusCode) field=\(field) phase=\(phase)")
+    }
+
+    private func jsonObject(_ data: Data) throws -> [String: Any] {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OpenAIConformanceHarnessError.transportFailed("response was not a JSON object")
+        }
+        return object
+    }
+
+    private func sseDataEvents(in text: String) -> [String] {
+        text.components(separatedBy: .newlines).compactMap { line in
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.hasPrefix("data:") else {
+                return nil
+            }
+            return String(trimmed.dropFirst("data:".count)).trimmingCharacters(in: .whitespaces)
+        }
+    }
+}
+
+private enum HarnessRequestKind: Sendable {
+    case nonStreamingChat
+    case streamingToolCall
+    case errorShape
+}
+
+private extension Array {
+    func asyncMap<T: Sendable>(
+        _ transform: @Sendable (Element) async throws -> T
+    ) async throws -> [T] {
+        var values: [T] = []
+        values.reserveCapacity(count)
+        for element in self {
+            try await values.append(transform(element))
+        }
+        return values
+    }
+}

--- a/services/control-plane-swift/Sources/OpenAIConformanceHarnessCLI/main.swift
+++ b/services/control-plane-swift/Sources/OpenAIConformanceHarnessCLI/main.swift
@@ -1,0 +1,22 @@
+import Foundation
+import MelixControlPlaneCore
+
+@main
+enum MelixOpenAIConformanceHarnessMain {
+    static func main() async {
+        do {
+            let cli = try OpenAIConformanceHarnessCLI.parse(
+                arguments: Array(CommandLine.arguments.dropFirst())
+            )
+            let report = try await cli.run()
+            print("OpenAI conformance report written to \(cli.outputURL.path)")
+            print("passed=\(report.summary.passed) failed=\(report.summary.failed) skipped=\(report.summary.skipped)")
+            if report.summary.failed > 0 {
+                Foundation.exit(1)
+            }
+        } catch {
+            fputs("\(error)\n", stderr)
+            Foundation.exit(2)
+        }
+    }
+}

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift
@@ -1,0 +1,464 @@
+import Foundation
+import Testing
+
+@testable import MelixControlPlaneCore
+
+@Suite("OpenAI Conformance Harness")
+struct OpenAIConformanceHarnessTests {
+    @Test("mock backend CI mode emits existing conformance report schema")
+    func mockBackendCIModeEmitsExistingConformanceReportSchema() async throws {
+        let harness = OpenAIConformanceHarness(
+            target: .mockBackendCI(modelID: "melix-dev-text")
+        )
+
+        let report = try await harness.run()
+
+        #expect(report.schemaVersion == OpenAIConformanceReport.currentSchemaVersion)
+        #expect(report.summary.total == 3)
+        #expect(report.summary.passed == 3)
+        #expect(report.summary.failed == 0)
+        #expect(report.rows.map(\.field) == [
+            "chat.completions.response_shape",
+            "chat.completions.streaming_tool_call_shape",
+            "chat.completions.error_shape",
+        ])
+    }
+
+    @Test("real backend smoke mode normalizes base URL and carries model and auth")
+    func realBackendSmokeModeNormalizesBaseURLAndCarriesModelAndAuth() async throws {
+        let transport = RecordingConformanceTransport(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: streamingToolCallBody()),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        let harness = OpenAIConformanceHarness(
+            target: .realBackendSmoke(
+                baseURL: " https://provider.example/v1/ ",
+                modelID: "remote-model",
+                apiKey: "sk-secret",
+                timeoutSeconds: 12
+            ),
+            transport: transport
+        )
+
+        let report = try await harness.run()
+        let requests = await transport.requests
+
+        #expect(report.summary.passed == 3)
+        #expect(requests.count == 3)
+        #expect(requests.allSatisfy { $0.url?.absoluteString == "https://provider.example/v1/chat/completions" })
+        #expect(requests.allSatisfy { $0.value(forHTTPHeaderField: "Authorization") == "Bearer sk-secret" })
+        #expect(requests.allSatisfy { $0.timeoutInterval == 12 })
+        #expect(try requests.allSatisfy { try requestBodyModel($0) == "remote-model" })
+    }
+
+    @Test("error row observed reason names status field and phase")
+    func errorRowObservedReasonNamesStatusFieldAndPhase() async throws {
+        let transport = RecordingConformanceTransport(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: streamingToolCallBody()),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        let harness = OpenAIConformanceHarness(
+            target: .realBackendSmoke(
+                baseURL: "https://provider.example/v1",
+                modelID: "remote-model",
+                apiKey: "",
+                timeoutSeconds: 0
+            ),
+            transport: transport
+        )
+
+        let report = try await harness.run()
+        let errorRow = try #require(report.rows.first { $0.field == "chat.completions.error_shape" })
+
+        #expect(errorRow.observedStatus == .pass)
+        #expect(errorRow.observedReason == "status=400 field=best_of phase=openai_request_validation")
+        #expect(await transport.requests.last?.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+
+    @Test("CLI parser returns named usage errors for missing real backend fields")
+    func cliParserReturnsNamedUsageErrorsForMissingRealBackendFields() throws {
+        #expect(throws: OpenAIConformanceHarnessCLIError.missingValue("--output")) {
+            try OpenAIConformanceHarnessCLI.parse(arguments: ["--mode", "mock-backend-ci"])
+        }
+        #expect(throws: OpenAIConformanceHarnessCLIError.missingValue("--base-url")) {
+            try OpenAIConformanceHarnessCLI.parse(
+                arguments: ["--mode", "real-backend-smoke", "--model", "remote-model", "--output", "report.json"]
+            )
+        }
+        #expect(throws: OpenAIConformanceHarnessCLIError.missingValue("--model")) {
+            try OpenAIConformanceHarnessCLI.parse(
+                arguments: ["--mode", "real-backend-smoke", "--base-url", "https://provider.example/v1", "--output", "report.json"]
+            )
+        }
+    }
+
+    @Test("CLI parser covers valid modes invalid options and artifact writing")
+    func cliParserCoversValidModesInvalidOptionsAndArtifactWriting() async throws {
+        let mockOutput = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-openai-conformance-\(UUID().uuidString)")
+            .appendingPathComponent("mock-report.json")
+        let mockCLI = try OpenAIConformanceHarnessCLI.parse(arguments: [
+            "--mode", "mock-backend-ci",
+            "--model", "mock-model",
+            "--output", mockOutput.path,
+        ])
+
+        #expect(mockCLI.target == .mockBackendCI(modelID: "mock-model"))
+        let mockReport = try await mockCLI.run()
+        #expect(mockReport.summary.passed == 3)
+        #expect(FileManager.default.fileExists(atPath: mockOutput.path))
+
+        let realCLI = try OpenAIConformanceHarnessCLI.parse(arguments: [
+            "--mode", "real-backend-smoke",
+            "--base-url", "https://provider.example/v1",
+            "--model", "remote-model",
+            "--api-key", "sk-secret",
+            "--timeout-seconds", "9",
+            "--output", "real-report.json",
+        ])
+        #expect(realCLI.target == .realBackendSmoke(
+            baseURL: "https://provider.example/v1",
+            modelID: "remote-model",
+            apiKey: "sk-secret",
+            timeoutSeconds: 9
+        ))
+
+        let defaultTimeoutCLI = try OpenAIConformanceHarnessCLI.parse(arguments: [
+            "--mode", "real-backend-smoke",
+            "--base-url", "https://provider.example/v1",
+            "--model", "remote-model",
+            "--output", "real-report.json",
+        ])
+        #expect(defaultTimeoutCLI.target == .realBackendSmoke(
+            baseURL: "https://provider.example/v1",
+            modelID: "remote-model",
+            apiKey: "",
+            timeoutSeconds: 30
+        ))
+
+        let unknown = OpenAIConformanceHarnessCLIError.unknownOption("model")
+        let invalidMode = OpenAIConformanceHarnessCLIError.invalidMode("other")
+        let invalidTimeout = OpenAIConformanceHarnessCLIError.invalidTimeout("zero")
+        #expect(unknown.description == "unknown option: model")
+        #expect(invalidMode.description == "invalid --mode: other")
+        #expect(invalidTimeout.description == "invalid --timeout-seconds: zero")
+        #expect(throws: unknown) {
+            try OpenAIConformanceHarnessCLI.parse(arguments: ["model", "x", "--output", "report.json"])
+        }
+        #expect(throws: OpenAIConformanceHarnessCLIError.unknownOption("--model-id")) {
+            try OpenAIConformanceHarnessCLI.parse(arguments: [
+                "--mode", "mock-backend-ci",
+                "--model-id", "mock-model",
+                "--output", "report.json",
+            ])
+        }
+        #expect(throws: OpenAIConformanceHarnessCLIError.missingValue("--mode")) {
+            try OpenAIConformanceHarnessCLI.parse(arguments: ["--mode"])
+        }
+        #expect(throws: invalidMode) {
+            try OpenAIConformanceHarnessCLI.parse(arguments: ["--mode", "other", "--output", "report.json"])
+        }
+        #expect(throws: invalidTimeout) {
+            try OpenAIConformanceHarnessCLI.parse(arguments: [
+                "--mode", "real-backend-smoke",
+                "--base-url", "https://provider.example/v1",
+                "--model", "remote-model",
+                "--timeout-seconds", "zero",
+                "--output", "report.json",
+            ])
+        }
+    }
+
+    @Test("harness records transport failures and rethrows cancellation")
+    func harnessRecordsTransportFailuresAndRethrowsCancellation() async throws {
+        let failingHarness = OpenAIConformanceHarness(
+            target: .realBackendSmoke(
+                baseURL: "https://provider.example/v1",
+                modelID: "remote-model",
+                apiKey: "",
+                timeoutSeconds: 30
+            ),
+            transport: ThrowingConformanceTransport(error: TestTransportError.networkLost)
+        )
+
+        let report = try await failingHarness.run()
+
+        #expect(report.summary.failed == 3)
+        #expect(report.rows.allSatisfy { $0.observedReason == "transport_failed=networkLost" })
+        #expect(OpenAIConformanceHarnessError.transportFailed("bad").description == "OpenAI conformance transport failed: bad")
+
+        let cancellingHarness = OpenAIConformanceHarness(
+            target: .realBackendSmoke(
+                baseURL: "https://provider.example/v1",
+                modelID: "remote-model",
+                apiKey: "",
+                timeoutSeconds: 30
+            ),
+            transport: ThrowingConformanceTransport(error: CancellationError())
+        )
+        do {
+            _ = try await cancellingHarness.run()
+            Issue.record("expected cancellation to be rethrown")
+        } catch is CancellationError {
+        }
+
+        let urlSessionCancellingHarness = OpenAIConformanceHarness(
+            target: .realBackendSmoke(
+                baseURL: "https://provider.example/v1",
+                modelID: "remote-model",
+                apiKey: "",
+                timeoutSeconds: 30
+            ),
+            transport: ThrowingConformanceTransport(error: URLError(.cancelled))
+        )
+        await #expect(throws: URLError(.cancelled)) {
+            _ = try await urlSessionCancellingHarness.run()
+        }
+    }
+
+    @Test("harness names invalid base URL and mock malformed requests")
+    func harnessNamesInvalidBaseURLAndMockMalformedRequests() async throws {
+        let invalidBaseHarness = OpenAIConformanceHarness(
+            target: .realBackendSmoke(
+                baseURL: " ",
+                modelID: "remote-model",
+                apiKey: "",
+                timeoutSeconds: 30
+            )
+        )
+
+        await #expect(throws: OpenAIConformanceHarnessError.invalidBaseURL(" ")) {
+            _ = try await invalidBaseHarness.run()
+        }
+        #expect(OpenAIConformanceHarnessError.invalidBaseURL(" ").description == "invalid OpenAI conformance base_url:  ")
+
+        var request = URLRequest(url: URL(string: "https://mock.melix.local/v1/chat/completions")!)
+        request.httpMethod = "POST"
+        await #expect(throws: OpenAIConformanceHarnessError.transportFailed("mock request body was not JSON")) {
+            _ = try await MockOpenAIConformanceTransport().data(for: request)
+        }
+    }
+
+    @Test("harness records shape failures with row-specific reasons")
+    func harnessRecordsShapeFailuresWithRowSpecificReasons() async throws {
+        let badNonStreamingStatus = try await runHarness(responses: [
+            .json(statusCode: 503, body: "{}"),
+            .sse(statusCode: 200, body: streamingToolCallBody()),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        #expect(row("chat.completions.response_shape", in: badNonStreamingStatus)?.observedReason == "status=503")
+
+        let malformedNonStreaming = try await runHarness(responses: [
+            .json(statusCode: 200, body: "not-json"),
+            .sse(statusCode: 200, body: streamingToolCallBody()),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        #expect(row("chat.completions.response_shape", in: malformedNonStreaming)?.observedReason == "status=200 missing=choices[0].message")
+
+        let badStreamingStatus = try await runHarness(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 502, body: ""),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        #expect(row("chat.completions.streaming_tool_call_shape", in: badStreamingStatus)?.observedReason == "status=502")
+
+        let missingDone = try await runHarness(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: #"data: {"choices":[{"delta":{"tool_calls":[]},"finish_reason":"tool_calls"}]}"#),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        #expect(row("chat.completions.streaming_tool_call_shape", in: missingDone)?.observedReason == "status=200 missing=done")
+
+        let missingToolCall = try await runHarness(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: "data: [DONE]\n"),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        #expect(row("chat.completions.streaming_tool_call_shape", in: missingToolCall)?.observedReason == "status=200 missing=tool_call_chunk")
+
+        let spacedSSE = try await runHarness(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: streamingToolCallBodyWithJSONWhitespace()),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        #expect(row("chat.completions.streaming_tool_call_shape", in: spacedSSE)?.observedStatus == .pass)
+
+        let errorReturnedSuccess = try await runHarness(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: streamingToolCallBody()),
+            .json(statusCode: 200, body: chatCompletionBody()),
+        ])
+        #expect(row("chat.completions.error_shape", in: errorReturnedSuccess)?.observedReason == "status=200 expected_error=true")
+
+        let errorMissingField = try await runHarness(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: streamingToolCallBody()),
+            .json(statusCode: 400, body: #"{"error":{"phase":"openai_request_validation"}}"#),
+        ])
+        #expect(row("chat.completions.error_shape", in: errorMissingField)?.observedReason == "status=400 missing=field_or_phase")
+    }
+
+    @Test("real backend CLI without injected transport does not fall back to mock")
+    func realBackendCLIWithoutInjectedTransportDoesNotFallBackToMock() async throws {
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-openai-conformance-\(UUID().uuidString)")
+            .appendingPathComponent("real-report.json")
+        let cli = OpenAIConformanceHarnessCLI(
+            target: .realBackendSmoke(
+                baseURL: "http://127.0.0.1:9/v1",
+                modelID: "remote-model",
+                apiKey: "",
+                timeoutSeconds: 1
+            ),
+            outputURL: output
+        )
+
+        let report = try await cli.run()
+
+        #expect(report.summary.failed > 0)
+        #expect(report.summary.passed == 0)
+    }
+}
+
+private actor RecordingConformanceTransport: RemoteProviderHTTPTransport {
+    enum Response {
+        case json(statusCode: Int, body: String)
+        case sse(statusCode: Int, body: String)
+    }
+
+    private let responses: [Response]
+    private(set) var requests: [URLRequest] = []
+
+    init(responses: [Response]) {
+        self.responses = responses
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        requests.append(request)
+        let response = responses[min(requests.count - 1, responses.count - 1)]
+        let statusCode: Int
+        let contentType: String
+        let body: String
+        switch response {
+        case .json(let code, let payload):
+            statusCode = code
+            contentType = "application/json"
+            body = payload
+        case .sse(let code, let payload):
+            statusCode = code
+            contentType = "text/event-stream"
+            body = payload
+        }
+        let httpResponse = try #require(HTTPURLResponse(
+            url: request.url ?? URL(string: "https://provider.example/v1/chat/completions")!,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["content-type": contentType]
+        ))
+        return (Data(body.utf8), httpResponse)
+    }
+}
+
+private enum TestTransportError: Error, CustomStringConvertible {
+    case networkLost
+
+    var description: String {
+        "networkLost"
+    }
+}
+
+private actor ThrowingConformanceTransport: RemoteProviderHTTPTransport {
+    private let error: any Error
+
+    init(error: any Error) {
+        self.error = error
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        throw error
+    }
+}
+
+private func runHarness(
+    responses: [RecordingConformanceTransport.Response]
+) async throws -> OpenAIConformanceReport {
+    let transport = RecordingConformanceTransport(responses: responses)
+    let harness = OpenAIConformanceHarness(
+        target: .realBackendSmoke(
+            baseURL: "https://provider.example/v1",
+            modelID: "remote-model",
+            apiKey: "",
+            timeoutSeconds: 30
+        ),
+        transport: transport
+    )
+    return try await harness.run()
+}
+
+private func row(
+    _ field: String,
+    in report: OpenAIConformanceReport
+) -> OpenAIConformanceRow? {
+    report.rows.first { $0.field == field }
+}
+
+private func requestBodyModel(_ request: URLRequest) throws -> String? {
+    let body = try #require(request.httpBody)
+    let object = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+    return object["model"] as? String
+}
+
+private func chatCompletionBody() -> String {
+    """
+    {
+      "id": "chatcmpl-test",
+      "object": "chat.completion",
+      "choices": [
+        {
+          "index": 0,
+          "message": { "role": "assistant", "content": "pong" },
+          "finish_reason": "stop"
+        }
+      ],
+      "usage": { "prompt_tokens": 4, "completion_tokens": 1, "total_tokens": 5 }
+    }
+    """
+}
+
+private func streamingToolCallBody() -> String {
+    """
+    data: {"object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call-1","type":"function","function":{"name":"get_weather","arguments":"{\\"city\\":\\"Tokyo\\"}"}}]},"finish_reason":null}]}
+
+    data: {"object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+    data: [DONE]
+
+    """
+}
+
+private func streamingToolCallBodyWithJSONWhitespace() -> String {
+    """
+    data: { "object": "chat.completion.chunk", "choices": [ { "index": 0, "delta": { "tool_calls": [ { "index": 0, "id": "call-1", "type": "function", "function": { "name": "get_weather", "arguments": "{\\"city\\":\\"Tokyo\\"}" } } ] }, "finish_reason": null } ] }
+
+    data: { "object": "chat.completion.chunk", "choices": [ { "index": 0, "delta": {}, "finish_reason": "tool_calls" } ] }
+
+    data: [DONE]
+
+    """
+}
+
+private func errorBody(field: String, phase: String) -> String {
+    """
+    {
+      "error": {
+        "message": "Unsupported request field",
+        "type": "invalid_request_error",
+        "code": "unsupported_request_field",
+        "field": "\(field)",
+        "phase": "\(phase)"
+      }
+    }
+    """
+}


### PR DESCRIPTION
## Summary
- Adds a runnable `melix-openai-conformance` Swift executable for mock-backend CI and real-backend smoke conformance evidence.
- Reuses the existing OpenAI conformance report schema and adds deterministic harness coverage for response shape, streaming tool-call shape, error shape, real-transport selection, cancellation propagation, SSE JSON parsing, and CLI option validation.
- Documents issue #1986 delivery and verification receipts in the governing plan.

Closes #1986.

## Plan or Spec
- `docs/plans/2026-06-18-issue-1986-openai-conformance-harness.md`
- `docs/adr/0002-openai-conformance-at-control-plane-boundary.md`
- `docs/plans/2026-05-24-issue-1384-openai-conformance-suite.md`

## Commands Run
```text
make git-hooks-install
# rc=0; configured .githooks

git diff --check
# rc=0

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceHarnessTests
# initial rc=0; 8 tests passed
# review-fix RED first showed expected failures for real-backend default transport, SSE whitespace parsing, cancellation propagation, and --model-id typo validation
# review-fix GREEN rc=0; 9 tests passed

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests
# rc=0; 17 tests passed

mkdir -p .runtime/issue1986 && HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift run --package-path services/control-plane-swift melix-openai-conformance --mode mock-backend-ci --output "$PWD/.runtime/issue1986/mock-report-after-review.json"
# rc=0; report schema melix.openai_conformance_report.v1; passed=3 failed=0 skipped=0

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIConformanceHarnessTests|OpenAIConformanceMatrixTests'
# rc=0; 26 tests passed

UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift services/control-plane-swift/Sources/OpenAIConformanceHarnessCLI/main.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift
# rc=0; TOTAL 99.62% changed-line coverage (794/797)

git commit --amend --no-edit
# rc=0; pre-commit enforced full gate on 256.0 GiB host:
# make swift-test rc=0 elapsed=231.3s
# make py-test rc=0 elapsed=167.2s; 4075 passed, 14 skipped, 2 warnings
# make integration-test rc=0 elapsed=451.1s; 120 passed, 1 skipped
# PR scoped performance report Status: ok; selected probes=0; direct/gated probes=0; regressions=0; context regressions=0; verification failures=0

git fetch origin main && git merge --no-edit origin/main
# rc=0; merged 7a8682e6 into this branch; no conflicts

git diff --check origin/main...HEAD
# rc=0 after merging latest origin/main

make swift-test
# rc=0 after merging latest origin/main; final stage macOS menubar reported 830 tests in 25 suites passed

make py-test
# rc=0 after merging latest origin/main; 4075 passed, 14 skipped, 2 warnings

make integration-test
# rc=0 after merging latest origin/main; 120 passed, 1 skipped

UV_PYTHON=3.12 uv run --frozen --project services/mlx-worker-python --extra mlx python .runtime/issue1986/local_pr_performance_report.py
# rc=0 after merging latest origin/main; Status: ok; changed files=5; selected probes=0; regressions=0; context regressions=0; verification failures=0
```

## Coverage and Metrics
- Changed-line coverage: 99.62% (794/797) for the harness, CLI entrypoint, and harness tests.
- Mock harness smoke artifact: `.runtime/issue1986/mock-report-after-review.json`, summary `passed=3 failed=0 skipped=0`.
- Pre-commit performance report after review fixes: `.runtime/pre-commit-performance/20260618-011137-da7d7c03/report/report.md`.
- Local performance report after merging latest `origin/main`: `.runtime/pre-commit-performance/20260618-014235-d3c682c5/report/report.md`.
- Performance status: `ok`; no selected/direct/gated probes for this change set; regressions=0; context regressions=0; verification failures=0.
- Observability mode: evidence. The harness emits a machine-readable conformance report artifact; probe overhead is N/A because no runtime/profiling probe or production observability path was added.

## Known Gaps
- Real-backend smoke mode is implemented as a runnable mode with `URLSessionRemoteProviderHTTPTransport` as its default transport, but it was not executed locally because this slice has no configured remote Server Profile credentials in the test environment.
- No protocol or dependency changes; no generated protobuf artifacts or lockfiles changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
