### PR TITLE
perf: tighten native mtp key prefix checks

### DIFF
--- a/docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md
+++ b/docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md
@@ -12,6 +12,8 @@ The probe is extended to measure the model safetensor listing path directly agai
 
 2026-06-07 follow-up slice: the same registered probe now also seeds duplicate native-MTP metadata entries that do not end in `.safetensors`. The loader filters those names before the duplicate-set lookup, keeping missing-path warnings and `os.path.exists()` checks limited to candidate sidecar shard paths while reducing set churn on noisy index maps.
 
+2026-06-18 follow-up slice: the MTP weight-key predicate keeps the same string-prefix semantics but replaces the tuple-based `startswith()` hot path with fixed-length prefix comparisons. The registered probe's `key_*` metrics remain the validation signal for this micro-slice while the existing sidecar shard tests keep non-`str` and custom `str` subclass behavior covered.
+
 ## Verification plan
 
 ```bash

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -1617,6 +1617,7 @@ def test_native_mtp_extra_safetensor_files_filters_names_before_path_join(
             "language_model.mtp.layers.4.weight": "mtp-missing.safetensors",
             "language_model.mtp.layers.5.weight": "nested/mtp-00002.safetensors",
             "language_model.mtp.layers.5.duplicate_weight": "nested/mtp-00002.safetensors",
+            "language_model.mtp.layers.6.weight": "nested/model-00003.safetensors",
             "language_model.layers.0.weight": "ignored-mtp.safetensors",
         }
     }

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -11,6 +11,10 @@ logger = logging.getLogger(__name__)
 
 _PATCHED = False
 _MTP_WEIGHT_KEY_PREFIXES = ("language_model.mtp.", "mtp.")
+_MTP_WEIGHT_KEY_LONG_PREFIX = "language_model.mtp."
+_MTP_WEIGHT_KEY_SHORT_PREFIX = "mtp."
+_MTP_WEIGHT_KEY_LONG_PREFIX_LEN = len(_MTP_WEIGHT_KEY_LONG_PREFIX)
+_MTP_WEIGHT_KEY_SHORT_PREFIX_LEN = len(_MTP_WEIGHT_KEY_SHORT_PREFIX)
 
 
 def _load_json_payload(path: Path) -> dict[str, Any]:
@@ -23,10 +27,20 @@ def _load_json_payload(path: Path) -> dict[str, Any]:
 
 def _is_mtp_weight_key(key: Any) -> bool:
     if type(key) is str:
-        return key.startswith(_MTP_WEIGHT_KEY_PREFIXES)
+        return (
+            key[:_MTP_WEIGHT_KEY_LONG_PREFIX_LEN] == _MTP_WEIGHT_KEY_LONG_PREFIX
+            or key[:_MTP_WEIGHT_KEY_SHORT_PREFIX_LEN] == _MTP_WEIGHT_KEY_SHORT_PREFIX
+        )
     if isinstance(key, str):
-        return key.startswith(_MTP_WEIGHT_KEY_PREFIXES)
-    return str(key).startswith(_MTP_WEIGHT_KEY_PREFIXES)
+        return (
+            key[:_MTP_WEIGHT_KEY_LONG_PREFIX_LEN] == _MTP_WEIGHT_KEY_LONG_PREFIX
+            or key[:_MTP_WEIGHT_KEY_SHORT_PREFIX_LEN] == _MTP_WEIGHT_KEY_SHORT_PREFIX
+        )
+    value = str(key)
+    return (
+        value[:_MTP_WEIGHT_KEY_LONG_PREFIX_LEN] == _MTP_WEIGHT_KEY_LONG_PREFIX
+        or value[:_MTP_WEIGHT_KEY_SHORT_PREFIX_LEN] == _MTP_WEIGHT_KEY_SHORT_PREFIX
+    )
 
 
 def _model_safetensor_files(model_path: Path) -> list[str]:


### PR DESCRIPTION
## Summary
- Tighten the native-MTP weight-key predicate by replacing tuple `startswith()` checks with fixed-length prefix comparisons.
- Keep sidecar shard filtering behavior unchanged and add a nested `model*.safetensors` regression entry for the existing basename semantics.

## Plan or Spec
- `docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md`
- Registered PR-scoped probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics
# 10 passed in 0.30s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
# 8 passed in 0.34s; changed_line_coverage=100.00%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
# Run 1 exit 0; key_old_mean_ms=3614.3127 key_new_mean_ms=3336.6643 key_delta_ms=-277.6485 key_speedup=1.0832
# Run 2 exit 0; key_old_mean_ms=3677.9940 key_new_mean_ms=3340.9617 key_delta_ms=-337.0323 key_speedup=1.1009
# Run 3 exit 0; key_old_mean_ms=3687.9307 key_new_mean_ms=3316.4609 key_delta_ms=-371.4698 key_speedup=1.1120
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` = 100.00% (8/8 measurable changed lines covered).
- Registered local probe (`native-mtp-loader-safetensor-scandir`) key predicate metrics, three local Linux runs:
  - Run 1: `old_mean=3614.3127ms`, `new_mean=3336.6643ms`, `delta=-277.6485ms`, `speedup=1.0832x`.
  - Run 2: `old_mean=3677.9940ms`, `new_mean=3340.9617ms`, `delta=-337.0323ms`, `speedup=1.1009x`.
  - Run 3: `old_mean=3687.9307ms`, `new_mean=3316.4609ms`, `delta=-371.4698ms`, `speedup=1.1120x`.
- CI PR-scoped performance is still required as the merge-gate validation source.

## Known Gaps
- Full repository gates were not run locally; this Python micro-slice used the focused registered test, changed-scope coverage, and registered probe commands.
- CI must complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
