### PR TITLE
Add OpenAI proxy parity harness

### DIFF
--- a/docs/plans/2026-06-18-issue-1989-openai-proxy-parity.md
+++ b/docs/plans/2026-06-18-issue-1989-openai-proxy-parity.md
@@ -93,6 +93,11 @@ This PR does not persist Server Profiles, add UI, replace remote-provider health
 - Full Swift gate: `make swift-test` passed.
 - Python gate: `make py-test` passed with `4075 passed, 14 skipped, 2 warnings`.
 - Integration gate: `make integration-test` passed with `120 passed, 1 skipped`.
+- PR review fix: `makeNormalizedChatCompletionsURL` now accepts base URLs that already end in `/chat/completions`, and request receipt mismatch checks compare arrays directly instead of comparing `.description` strings.
+- Review-focused verification: `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceHarnessTests` passed with 17 tests in 1 suite after the review fix.
+- Review boundary verification: `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIConformanceHarnessTests|OpenAIConformanceMatrixTests'` passed with 34 tests in 2 suites after the review fix.
+- Review coverage verification: `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIConformanceHarnessTests|OpenAIConformanceMatrixTests'` passed with 34 tests in 2 suites after the review fix.
+- Review changed-line coverage: `UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift services/control-plane-swift/Sources/OpenAIConformanceHarnessCLI/main.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift` reported `97.55%` total changed-line coverage (`598/613`).
 
 ## Verification Commands
 

--- a/docs/plans/2026-06-18-issue-1989-openai-proxy-parity.md
+++ b/docs/plans/2026-06-18-issue-1989-openai-proxy-parity.md
@@ -1,0 +1,132 @@
+# Issue 1989 OpenAI Proxy Parity Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for implementation. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a runnable proxy parity row set that proves local and configured remote OpenAI-compatible targets preserve the same normalized request contract and response shapes for the same fixture requests.
+
+**Architecture:** Keep `OpenAIConformanceReport` as the single artifact schema from issue #1986. Add a parity harness beside `OpenAIConformanceHarness` that runs the existing chat/completions fixture rows against a local target and a remote Server Profile target, records sanitized normalized request receipts for each side, evaluates each response shape, and emits one report row per parity case. The row passes only when both sides have equivalent normalized request receipts and equivalent response-shape classifications; named receipt or response divergences become row failure reasons.
+
+**Tech Stack:** Swift Package executable target, Swift Testing, `RemoteProviderHTTPTransport`, `URLRequest`, `HTTPURLResponse`, `JSONSerialization`, `OpenAIConformanceReport`.
+
+---
+
+## Scope
+
+This PR implements issue #1989 as a child slice of #1384:
+
+- Add a reusable `OpenAIProxyParityHarness` under the Swift control-plane core.
+- Reuse `OpenAIConformanceReport` and `OpenAIConformanceRow` without changing the report schema.
+- Cover these parity rows:
+  - non-streaming `/v1/chat/completions` response shape,
+  - streaming tool-call SSE response shape,
+  - typed error-path shape that names field and phase.
+- Compare sanitized normalized request receipts:
+  - method,
+  - normalized route path,
+  - accept header,
+  - content type,
+  - request fixture kind,
+  - sorted body field names,
+  - stream flag,
+  - tool declaration names,
+  - tool-choice name,
+  - unsupported field name for the error fixture,
+  - model field presence, without leaking model IDs or API keys.
+- Compare normalized response-shape receipts instead of model text:
+  - non-streaming assistant message shape,
+  - streaming tool-call delta plus `[DONE]` shape,
+  - OpenAI-style error envelope with field and phase.
+- Extend `melix-openai-conformance` with a `proxy-parity` mode so operators can write the same JSON artifact from two live endpoints.
+
+This PR does not persist Server Profiles, add UI, replace remote-provider health/capability probes from #1757, require real model weights in CI, or compare generated semantic content.
+
+## Success Metrics
+
+- Mock parity mode produces `schema_version = melix.openai_conformance_report.v1`, `total = 3`, and all rows passing.
+- Receipt divergences identify the mismatched key, for example `request_receipt.body_fields local=[...] remote=[...]`.
+- Response divergences identify the side and shape reason, for example `remote_response=status=200 missing=tool_call_chunk`.
+- CLI argument validation names missing local and remote target fields.
+- Changed-line coverage for touched Swift scope is at least 95 percent.
+- PR-scoped performance report is `Status: ok` with no direct/gated regression.
+
+## Implementation Tasks
+
+- [x] Add failing Swift tests in `services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift`.
+  - Mock local/remote parity emits three passing rows using `OpenAIConformanceReport`.
+  - The parity transport captures two requests per fixture and compares sanitized request receipts.
+  - Request receipt mismatches fail with a named key.
+  - Response shape mismatches fail with a named side and shape reason.
+  - CLI parser accepts `--mode proxy-parity` and rejects missing local or remote fields with named usage errors.
+- [x] Add `OpenAIProxyParityHarness` in `services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift`.
+  - Introduce `OpenAIProxyParityTarget` for local and remote endpoint metadata.
+  - Execute each existing `HarnessRow` once for local and once for remote.
+  - Build sanitized `OpenAIProxyParityRequestReceipt` values from the actual `URLRequest`.
+  - Convert each response into a comparable response-shape receipt.
+  - Emit `OpenAIConformanceRow` values with explicit failure reasons when request or response receipts differ.
+- [x] Extend CLI parsing and execution.
+  - Support `--mode proxy-parity`.
+  - Add `--local-base-url`, `--local-model`, `--local-api-key`, `--remote-base-url`, `--remote-model`, and `--remote-api-key`.
+  - Preserve existing `mock-backend-ci` and `real-backend-smoke` behavior.
+- [x] Document usage and evidence.
+  - Update this plan with verification receipts.
+  - Keep ADR 0002 unchanged because it already defines Proxy Parity as additive evidence on top of the control-plane boundary.
+- [x] Verify focused scope.
+  - Run focused harness tests.
+  - Run focused conformance matrix tests to prove the authoritative boundary proof still passes.
+  - Run changed-line coverage for touched Swift files.
+  - Run full local gate and PR-scoped performance before PR creation.
+
+## Verification Receipts
+
+- Baseline: `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIConformanceHarnessTests|OpenAIConformanceMatrixTests'` passed with 26 tests in 2 suites before issue #1989 changes.
+- RED: `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceHarnessTests` failed because `OpenAIProxyParityHarness`, `OpenAIProxyParityTarget`, and `proxyParityTarget` did not exist.
+- RED follow-up: `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceHarnessTests/cliParserCoversProxyParityModeAndNamedMissingFields` failed because mode-specific CLI options were being silently ignored.
+- GREEN: `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceHarnessTests` passed with 13 tests in 1 suite after adding proxy parity mode.
+- Boundary proof: `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests` passed with 17 tests in 1 suite.
+- CLI mock smoke: `swift run --package-path services/control-plane-swift melix-openai-conformance --mode mock-backend-ci --output .runtime/issue1989/mock-report.json` wrote a report with `passed=3 failed=0 skipped=0`.
+- CLI proxy-parity unreachable smoke: `swift run --package-path services/control-plane-swift melix-openai-conformance --mode proxy-parity --local-base-url http://127.0.0.1:9/v1 --local-model local-model --remote-base-url http://127.0.0.1:10/v1 --remote-model remote-model --timeout-seconds 1 --output .runtime/issue1989/proxy-parity-unreachable-report.json` wrote schema `melix.openai_conformance_report.v1` with `passed=0 failed=3 skipped=0` and exited 1 because rows failed.
+- RED base-path normalization: `swift test --package-path services/control-plane-swift --filter 'OpenAIConformanceHarnessTests/proxyParityHarnessEmitsExistingReportSchemaForLocalAndRemoteTargets'` failed when the remote target used `/openai/v1/`, proving receipt comparison was treating provider base path as a parity mismatch.
+- GREEN base-path normalization: `swift test --package-path services/control-plane-swift --filter 'OpenAIConformanceHarnessTests/proxyParityHarnessEmitsExistingReportSchemaForLocalAndRemoteTargets'` passed after request receipts began comparing the normalized endpoint path while still dispatching to the configured remote base path.
+- Focused final: `swift test --package-path services/control-plane-swift --filter 'OpenAIConformanceHarnessTests|OpenAIConformanceMatrixTests'` passed with 33 tests in 2 suites.
+- Coverage GREEN: `HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIConformanceHarnessTests|OpenAIConformanceMatrixTests'` passed with 33 tests in 2 suites.
+- Changed-line coverage: `UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift services/control-plane-swift/Sources/OpenAIConformanceHarnessCLI/main.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift` reported `99.12%` total changed-line coverage (`561/566`).
+- Full Swift gate: `make swift-test` passed.
+- Python gate: `make py-test` passed with `4075 passed, 14 skipped, 2 warnings`.
+- Integration gate: `make integration-test` passed with `120 passed, 1 skipped`.
+
+## Verification Commands
+
+Focused:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceHarnessTests
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests
+git diff --check
+```
+
+Changed-line coverage:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIConformanceHarnessTests|OpenAIConformanceMatrixTests'
+UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py \
+  --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests \
+  --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata \
+  --diff-from origin/main \
+  services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift \
+  services/control-plane-swift/Sources/OpenAIConformanceHarnessCLI/main.swift \
+  services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift
+```
+
+Pre-PR local gate:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```
+
+Metrics:
+
+```bash
+UV_PYTHON="${MELIX_PRE_COMMIT_UV_PYTHON:-${UV_PYTHON:-3.12}}" uv run --frozen --project services/mlx-worker-python --extra mlx python scripts/pre_commit_gate.py
+```

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift
@@ -749,21 +749,38 @@ private struct OpenAIProxyParityRequestReceipt: Equatable, Sendable {
     }
 
     func firstMismatch(against other: OpenAIProxyParityRequestReceipt) -> String? {
-        let checks: [(String, String, String)] = [
-            ("method", method, other.method),
-            ("path", path, other.path),
-            ("accept", accept, other.accept),
-            ("content_type", contentType, other.contentType),
-            ("request_kind", requestKind, other.requestKind),
-            ("body_fields", bodyFields.description, other.bodyFields.description),
-            ("stream", String(stream), String(other.stream)),
-            ("tool_names", toolNames.description, other.toolNames.description),
-            ("tool_choice_name", toolChoiceName, other.toolChoiceName),
-            ("unsupported_field", unsupportedField, other.unsupportedField),
-            ("model_present", String(modelPresent), String(other.modelPresent)),
-        ]
-        for (key, local, remote) in checks where local != remote {
-            return "request_receipt.\(key) local=\(local) remote=\(remote)"
+        if method != other.method {
+            return "request_receipt.method local=\(method) remote=\(other.method)"
+        }
+        if path != other.path {
+            return "request_receipt.path local=\(path) remote=\(other.path)"
+        }
+        if accept != other.accept {
+            return "request_receipt.accept local=\(accept) remote=\(other.accept)"
+        }
+        if contentType != other.contentType {
+            return "request_receipt.content_type local=\(contentType) remote=\(other.contentType)"
+        }
+        if requestKind != other.requestKind {
+            return "request_receipt.request_kind local=\(requestKind) remote=\(other.requestKind)"
+        }
+        if bodyFields != other.bodyFields {
+            return "request_receipt.body_fields local=\(bodyFields) remote=\(other.bodyFields)"
+        }
+        if stream != other.stream {
+            return "request_receipt.stream local=\(stream) remote=\(other.stream)"
+        }
+        if toolNames != other.toolNames {
+            return "request_receipt.tool_names local=\(toolNames) remote=\(other.toolNames)"
+        }
+        if toolChoiceName != other.toolChoiceName {
+            return "request_receipt.tool_choice_name local=\(toolChoiceName) remote=\(other.toolChoiceName)"
+        }
+        if unsupportedField != other.unsupportedField {
+            return "request_receipt.unsupported_field local=\(unsupportedField) remote=\(other.unsupportedField)"
+        }
+        if modelPresent != other.modelPresent {
+            return "request_receipt.model_present local=\(modelPresent) remote=\(other.modelPresent)"
         }
         return nil
     }
@@ -820,8 +837,11 @@ private extension HarnessRequestKind {
 private func makeNormalizedChatCompletionsURL(baseURL: String) throws -> URL {
     let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
     let normalized = trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed
+    let urlString = normalized.hasSuffix("/chat/completions")
+        ? normalized
+        : "\(normalized)/chat/completions"
     guard normalized.isEmpty == false,
-          let url = URL(string: "\(normalized)/chat/completions")
+          let url = URL(string: urlString)
     else {
         throw OpenAIConformanceHarnessError.invalidBaseURL(baseURL)
     }

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift
@@ -106,18 +106,11 @@ public struct OpenAIConformanceHarness: Sendable {
         case .mockBackendCI:
             return URL(string: "https://mock.melix.local/v1/chat/completions")!
         case .realBackendSmoke(let baseURL, _, _, _):
-            let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-            let normalized = trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed
-            guard normalized.isEmpty == false,
-                  let url = URL(string: "\(normalized)/chat/completions")
-            else {
-                throw OpenAIConformanceHarnessError.invalidBaseURL(baseURL)
-            }
-            return url
+            return try makeNormalizedChatCompletionsURL(baseURL: baseURL)
         }
     }
 
-    private static func rows() -> [HarnessRow] {
+    fileprivate static func rows() -> [HarnessRow] {
         [
             HarnessRow(
                 field: "chat.completions.response_shape",
@@ -138,6 +131,158 @@ public struct OpenAIConformanceHarness: Sendable {
                 requestKind: .errorShape
             ),
         ]
+    }
+}
+
+public struct OpenAIProxyParityTarget: Equatable, Sendable {
+    public let localBaseURL: String
+    public let localModelID: String
+    public let localAPIKey: String
+    public let remoteBaseURL: String
+    public let remoteModelID: String
+    public let remoteAPIKey: String
+    public let timeoutSeconds: UInt32
+
+    public init(
+        localBaseURL: String,
+        localModelID: String,
+        localAPIKey: String,
+        remoteBaseURL: String,
+        remoteModelID: String,
+        remoteAPIKey: String,
+        timeoutSeconds: UInt32
+    ) {
+        self.localBaseURL = localBaseURL
+        self.localModelID = localModelID
+        self.localAPIKey = localAPIKey
+        self.remoteBaseURL = remoteBaseURL
+        self.remoteModelID = remoteModelID
+        self.remoteAPIKey = remoteAPIKey
+        self.timeoutSeconds = timeoutSeconds == 0 ? 30 : timeoutSeconds
+    }
+}
+
+public struct OpenAIProxyParityHarness: Sendable {
+    private let target: OpenAIProxyParityTarget
+    private let localTransport: any RemoteProviderHTTPTransport
+    private let remoteTransport: any RemoteProviderHTTPTransport
+
+    public init(
+        target: OpenAIProxyParityTarget,
+        localTransport: (any RemoteProviderHTTPTransport)? = nil,
+        remoteTransport: (any RemoteProviderHTTPTransport)? = nil
+    ) {
+        self.target = target
+        self.localTransport = localTransport ?? URLSessionRemoteProviderHTTPTransport()
+        self.remoteTransport = remoteTransport ?? URLSessionRemoteProviderHTTPTransport()
+    }
+
+    public func run() async throws -> OpenAIConformanceReport {
+        let rows = try await OpenAIConformanceHarness.rows().asyncMap { row in
+            try await execute(row)
+        }
+        return OpenAIConformanceReport(rows: rows)
+    }
+
+    private func execute(_ row: HarnessRow) async throws -> OpenAIConformanceRow {
+        let localRequest = try makeHTTPRequest(
+            for: row,
+            baseURL: target.localBaseURL,
+            modelID: target.localModelID,
+            apiKey: target.localAPIKey
+        )
+        let remoteRequest = try makeHTTPRequest(
+            for: row,
+            baseURL: target.remoteBaseURL,
+            modelID: target.remoteModelID,
+            apiKey: target.remoteAPIKey
+        )
+
+        async let localResult = execute(row, request: localRequest, transport: localTransport)
+        async let remoteResult = execute(row, request: remoteRequest, transport: remoteTransport)
+        let local = try await localResult
+        let remote = try await remoteResult
+
+        if let mismatch = local.requestReceipt.firstMismatch(against: remote.requestReceipt) {
+            return parityRow(row, status: .fail, reason: mismatch)
+        }
+        guard local.responseEvaluation.status == .pass else {
+            return parityRow(row, status: .fail, reason: "local_response=\(local.responseEvaluation.reason)")
+        }
+        guard remote.responseEvaluation.status == .pass else {
+            return parityRow(row, status: .fail, reason: "remote_response=\(remote.responseEvaluation.reason)")
+        }
+        guard local.responseEvaluation.reason == remote.responseEvaluation.reason else {
+            return parityRow(
+                row,
+                status: .fail,
+                reason: "response_shape local=\(local.responseEvaluation.reason) remote=\(remote.responseEvaluation.reason)"
+            )
+        }
+        return parityRow(
+            row,
+            status: .pass,
+            reason: "request_receipt=equivalent response_shape=equivalent"
+        )
+    }
+
+    private func execute(
+        _ row: HarnessRow,
+        request: URLRequest,
+        transport: any RemoteProviderHTTPTransport
+    ) async throws -> ProxyParityExecution {
+        let requestReceipt = try OpenAIProxyParityRequestReceipt(row: row, request: request)
+        do {
+            let (data, response) = try await transport.data(for: request)
+            return ProxyParityExecution(
+                requestReceipt: requestReceipt,
+                responseEvaluation: row.evaluate(data: data, response: response)
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            throw urlError
+        } catch {
+            return ProxyParityExecution(
+                requestReceipt: requestReceipt,
+                responseEvaluation: (.fail, "transport_failed=\(String(describing: error))")
+            )
+        }
+    }
+
+    private func makeHTTPRequest(
+        for row: HarnessRow,
+        baseURL: String,
+        modelID: String,
+        apiKey: String
+    ) throws -> URLRequest {
+        let url = try makeNormalizedChatCompletionsURL(baseURL: baseURL)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = TimeInterval(target.timeoutSeconds)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(row.acceptHeader, forHTTPHeaderField: "Accept")
+        request.setValue("OpenAI/Python 1.0.0 Melix/0.1", forHTTPHeaderField: "User-Agent")
+        let trimmedAPIKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedAPIKey.isEmpty == false {
+            request.setValue("Bearer \(trimmedAPIKey)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: row.body(modelID: modelID), options: [])
+        return request
+    }
+
+    private func parityRow(
+        _ row: HarnessRow,
+        status: OpenAIConformanceObservedStatus,
+        reason: String
+    ) -> OpenAIConformanceRow {
+        OpenAIConformanceRow(
+            field: "proxy_parity.\(row.field)",
+            route: "local and remote \(row.route)",
+            expectedBehavior: "Local backend and configured remote Server Profile produce equivalent request receipts and response shapes for \(row.expectedBehavior)",
+            observedStatus: status,
+            observedReason: reason
+        )
     }
 }
 
@@ -214,11 +359,19 @@ public enum OpenAIConformanceHarnessCLIError: Error, Equatable, CustomStringConv
 }
 
 public struct OpenAIConformanceHarnessCLI: Sendable {
-    public let target: OpenAIConformanceHarnessTarget
+    public let target: OpenAIConformanceHarnessTarget?
+    public let proxyParityTarget: OpenAIProxyParityTarget?
     public let outputURL: URL
 
     public init(target: OpenAIConformanceHarnessTarget, outputURL: URL) {
         self.target = target
+        self.proxyParityTarget = nil
+        self.outputURL = outputURL
+    }
+
+    public init(proxyParityTarget: OpenAIProxyParityTarget, outputURL: URL) {
+        self.target = nil
+        self.proxyParityTarget = proxyParityTarget
         self.outputURL = outputURL
     }
 
@@ -240,9 +393,15 @@ public struct OpenAIConformanceHarnessCLI: Sendable {
         let supportedOptions: Set<String> = [
             "--api-key",
             "--base-url",
+            "--local-api-key",
+            "--local-base-url",
+            "--local-model",
             "--mode",
             "--model",
             "--output",
+            "--remote-api-key",
+            "--remote-base-url",
+            "--remote-model",
             "--timeout-seconds",
         ]
         for option in values.keys where supportedOptions.contains(option) == false {
@@ -253,6 +412,7 @@ public struct OpenAIConformanceHarnessCLI: Sendable {
         guard let output = values["--output"], output.isEmpty == false else {
             throw OpenAIConformanceHarnessCLIError.missingValue("--output")
         }
+        try validateModeSpecificOptions(mode: mode, values: values)
         let outputURL = URL(fileURLWithPath: output)
         switch mode {
         case "mock-backend-ci":
@@ -286,17 +446,94 @@ public struct OpenAIConformanceHarnessCLI: Sendable {
                 ),
                 outputURL: outputURL
             )
+        case "proxy-parity":
+            guard let localBaseURL = values["--local-base-url"], localBaseURL.isEmpty == false else {
+                throw OpenAIConformanceHarnessCLIError.missingValue("--local-base-url")
+            }
+            guard let localModelID = values["--local-model"], localModelID.isEmpty == false else {
+                throw OpenAIConformanceHarnessCLIError.missingValue("--local-model")
+            }
+            guard let remoteBaseURL = values["--remote-base-url"], remoteBaseURL.isEmpty == false else {
+                throw OpenAIConformanceHarnessCLIError.missingValue("--remote-base-url")
+            }
+            guard let remoteModelID = values["--remote-model"], remoteModelID.isEmpty == false else {
+                throw OpenAIConformanceHarnessCLIError.missingValue("--remote-model")
+            }
+            let timeoutSeconds = try parseTimeoutSeconds(values["--timeout-seconds"])
+            return OpenAIConformanceHarnessCLI(
+                proxyParityTarget: OpenAIProxyParityTarget(
+                    localBaseURL: localBaseURL,
+                    localModelID: localModelID,
+                    localAPIKey: values["--local-api-key"] ?? "",
+                    remoteBaseURL: remoteBaseURL,
+                    remoteModelID: remoteModelID,
+                    remoteAPIKey: values["--remote-api-key"] ?? "",
+                    timeoutSeconds: timeoutSeconds
+                ),
+                outputURL: outputURL
+            )
         default:
             throw OpenAIConformanceHarnessCLIError.invalidMode(mode)
         }
     }
 
-    public func run(transport: (any RemoteProviderHTTPTransport)? = nil) async throws -> OpenAIConformanceReport {
-        let report = try await OpenAIConformanceHarness(target: target, transport: transport).run()
+    public func run(
+        transport: (any RemoteProviderHTTPTransport)? = nil
+    ) async throws -> OpenAIConformanceReport {
+        let report: OpenAIConformanceReport
+        if let proxyParityTarget {
+            report = try await OpenAIProxyParityHarness(
+                target: proxyParityTarget,
+                localTransport: transport,
+                remoteTransport: transport
+            ).run()
+        } else if let target {
+            report = try await OpenAIConformanceHarness(target: target, transport: transport).run()
+        } else {
+            throw OpenAIConformanceHarnessError.transportFailed("missing conformance target")
+        }
         let outputDirectory = outputURL.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
         try report.jsonData().write(to: outputURL, options: [.atomic])
         return report
+    }
+
+    private static func parseTimeoutSeconds(_ value: String?) throws -> UInt32 {
+        guard let value else {
+            return 30
+        }
+        guard let parsed = UInt32(value), parsed > 0 else {
+            throw OpenAIConformanceHarnessCLIError.invalidTimeout(value)
+        }
+        return parsed
+    }
+
+    private static func validateModeSpecificOptions(
+        mode: String,
+        values: [String: String]
+    ) throws {
+        let commonOptions: Set<String> = ["--mode", "--output", "--timeout-seconds"]
+        let allowedOptions: Set<String>
+        switch mode {
+        case "mock-backend-ci":
+            allowedOptions = commonOptions.union(["--model"])
+        case "real-backend-smoke":
+            allowedOptions = commonOptions.union(["--api-key", "--base-url", "--model"])
+        case "proxy-parity":
+            allowedOptions = commonOptions.union([
+                "--local-api-key",
+                "--local-base-url",
+                "--local-model",
+                "--remote-api-key",
+                "--remote-base-url",
+                "--remote-model",
+            ])
+        default:
+            return
+        }
+        for option in values.keys.sorted() where allowedOptions.contains(option) == false {
+            throw OpenAIConformanceHarnessCLIError.unknownOption(option)
+        }
     }
 }
 
@@ -476,6 +713,119 @@ private enum HarnessRequestKind: Sendable {
     case nonStreamingChat
     case streamingToolCall
     case errorShape
+}
+
+private struct ProxyParityExecution: Sendable {
+    let requestReceipt: OpenAIProxyParityRequestReceipt
+    let responseEvaluation: (status: OpenAIConformanceObservedStatus, reason: String)
+}
+
+private struct OpenAIProxyParityRequestReceipt: Equatable, Sendable {
+    let method: String
+    let path: String
+    let accept: String
+    let contentType: String
+    let requestKind: String
+    let bodyFields: [String]
+    let stream: Bool
+    let toolNames: [String]
+    let toolChoiceName: String
+    let unsupportedField: String
+    let modelPresent: Bool
+
+    init(row: HarnessRow, request: URLRequest) throws {
+        self.method = request.httpMethod ?? ""
+        self.path = row.requestKind.endpointPath
+        self.accept = request.value(forHTTPHeaderField: "Accept") ?? ""
+        self.contentType = request.value(forHTTPHeaderField: "Content-Type") ?? ""
+        self.requestKind = row.requestKind.receiptName
+        let body = try Self.bodyObject(from: request)
+        self.bodyFields = body.keys.sorted()
+        self.stream = body["stream"] as? Bool ?? false
+        self.toolNames = Self.toolNames(from: body)
+        self.toolChoiceName = Self.toolChoiceName(from: body)
+        self.unsupportedField = body["best_of"] == nil ? "" : "best_of"
+        self.modelPresent = (body["model"] as? String)?.isEmpty == false
+    }
+
+    func firstMismatch(against other: OpenAIProxyParityRequestReceipt) -> String? {
+        let checks: [(String, String, String)] = [
+            ("method", method, other.method),
+            ("path", path, other.path),
+            ("accept", accept, other.accept),
+            ("content_type", contentType, other.contentType),
+            ("request_kind", requestKind, other.requestKind),
+            ("body_fields", bodyFields.description, other.bodyFields.description),
+            ("stream", String(stream), String(other.stream)),
+            ("tool_names", toolNames.description, other.toolNames.description),
+            ("tool_choice_name", toolChoiceName, other.toolChoiceName),
+            ("unsupported_field", unsupportedField, other.unsupportedField),
+            ("model_present", String(modelPresent), String(other.modelPresent)),
+        ]
+        for (key, local, remote) in checks where local != remote {
+            return "request_receipt.\(key) local=\(local) remote=\(remote)"
+        }
+        return nil
+    }
+
+    private static func bodyObject(from request: URLRequest) throws -> [String: Any] {
+        guard let body = request.httpBody,
+              let object = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        else {
+            throw OpenAIConformanceHarnessError.transportFailed("proxy parity request body was not JSON")
+        }
+        return object
+    }
+
+    private static func toolNames(from body: [String: Any]) -> [String] {
+        guard let tools = body["tools"] as? [[String: Any]] else {
+            return []
+        }
+        return tools.compactMap { tool in
+            (tool["function"] as? [String: Any])?["name"] as? String
+        }.sorted()
+    }
+
+    private static func toolChoiceName(from body: [String: Any]) -> String {
+        guard let toolChoice = body["tool_choice"] as? [String: Any],
+              let function = toolChoice["function"] as? [String: Any],
+              let name = function["name"] as? String
+        else {
+            return ""
+        }
+        return name
+    }
+}
+
+private extension HarnessRequestKind {
+    var receiptName: String {
+        switch self {
+        case .nonStreamingChat:
+            return "non_streaming_chat"
+        case .streamingToolCall:
+            return "streaming_tool_call"
+        case .errorShape:
+            return "error_shape"
+        }
+    }
+
+    var endpointPath: String {
+        switch self {
+        case .nonStreamingChat, .streamingToolCall, .errorShape:
+            return "/chat/completions"
+        }
+    }
+}
+
+private func makeNormalizedChatCompletionsURL(baseURL: String) throws -> URL {
+    let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalized = trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed
+    guard normalized.isEmpty == false,
+          let url = URL(string: "\(normalized)/chat/completions")
+    else {
+        throw OpenAIConformanceHarnessError.invalidBaseURL(baseURL)
+    }
+    return url
 }
 
 private extension Array {

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift
@@ -52,6 +52,33 @@ struct OpenAIConformanceHarnessTests {
         #expect(try requests.allSatisfy { try requestBodyModel($0) == "remote-model" })
     }
 
+    @Test("real backend smoke mode accepts a base URL that already targets chat completions")
+    func realBackendSmokeModeAcceptsChatCompletionsBaseURL() async throws {
+        let transport = RecordingConformanceTransport(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: streamingToolCallBody()),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        let harness = OpenAIConformanceHarness(
+            target: .realBackendSmoke(
+                baseURL: " https://provider.example/openai/v1/chat/completions/ ",
+                modelID: "remote-model",
+                apiKey: "",
+                timeoutSeconds: 30
+            ),
+            transport: transport
+        )
+
+        let report = try await harness.run()
+        let requests = await transport.requests
+
+        #expect(report.summary.passed == 3)
+        #expect(requests.count == 3)
+        #expect(requests.allSatisfy {
+            $0.url?.absoluteString == "https://provider.example/openai/v1/chat/completions"
+        })
+    }
+
     @Test("error row observed reason names status field and phase")
     func errorRowObservedReasonNamesStatusFieldAndPhase() async throws {
         let transport = RecordingConformanceTransport(responses: [

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift
@@ -320,6 +320,306 @@ struct OpenAIConformanceHarnessTests {
         #expect(report.summary.failed > 0)
         #expect(report.summary.passed == 0)
     }
+
+    @Test("proxy parity harness emits existing report schema for local and remote targets")
+    func proxyParityHarnessEmitsExistingReportSchemaForLocalAndRemoteTargets() async throws {
+        let localTransport = RecordingConformanceTransport(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: streamingToolCallBody()),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        let remoteTransport = RecordingConformanceTransport(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: streamingToolCallBody()),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        let harness = OpenAIProxyParityHarness(
+            target: OpenAIProxyParityTarget(
+                localBaseURL: "https://local.example/v1",
+                localModelID: "local-model",
+                localAPIKey: "local-secret",
+                remoteBaseURL: "https://remote.example/openai/v1/",
+                remoteModelID: "remote-model",
+                remoteAPIKey: "remote-secret",
+                timeoutSeconds: 9
+            ),
+            localTransport: localTransport,
+            remoteTransport: remoteTransport
+        )
+
+        let report = try await harness.run()
+        let localRequests = await localTransport.requests
+        let remoteRequests = await remoteTransport.requests
+
+        #expect(report.schemaVersion == OpenAIConformanceReport.currentSchemaVersion)
+        #expect(report.summary.total == 3)
+        #expect(report.summary.passed == 3)
+        #expect(report.summary.failed == 0)
+        #expect(report.rows.map(\.field) == [
+            "proxy_parity.chat.completions.response_shape",
+            "proxy_parity.chat.completions.streaming_tool_call_shape",
+            "proxy_parity.chat.completions.error_shape",
+        ])
+        #expect(report.rows.allSatisfy {
+            $0.observedReason == "request_receipt=equivalent response_shape=equivalent"
+        })
+        #expect(localRequests.count == 3)
+        #expect(remoteRequests.count == 3)
+        #expect(localRequests.allSatisfy { $0.timeoutInterval == 9 })
+        #expect(remoteRequests.allSatisfy { $0.timeoutInterval == 9 })
+        #expect(localRequests.allSatisfy { $0.value(forHTTPHeaderField: "Authorization") == "Bearer local-secret" })
+        #expect(remoteRequests.allSatisfy { $0.value(forHTTPHeaderField: "Authorization") == "Bearer remote-secret" })
+        #expect(remoteRequests.allSatisfy { $0.url?.path == "/openai/v1/chat/completions" })
+        #expect(try localRequests.allSatisfy { try requestBodyModel($0) == "local-model" })
+        #expect(try remoteRequests.allSatisfy { try requestBodyModel($0) == "remote-model" })
+    }
+
+    @Test("proxy parity request receipt mismatches are named without leaking model IDs")
+    func proxyParityRequestReceiptMismatchesAreNamedWithoutLeakingModelIDs() async throws {
+        let localTransport = RecordingConformanceTransport(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: streamingToolCallBody()),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        let remoteTransport = RecordingConformanceTransport(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: streamingToolCallBody()),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        let harness = OpenAIProxyParityHarness(
+            target: OpenAIProxyParityTarget(
+                localBaseURL: "https://local.example/v1",
+                localModelID: "local-model",
+                localAPIKey: "",
+                remoteBaseURL: "https://remote.example/v1",
+                remoteModelID: "",
+                remoteAPIKey: "",
+                timeoutSeconds: 30
+            ),
+            localTransport: localTransport,
+            remoteTransport: remoteTransport
+        )
+
+        let report = try await harness.run()
+        let firstRow = try #require(report.rows.first)
+
+        #expect(report.summary.failed == 3)
+        #expect(firstRow.observedReason == "request_receipt.model_present local=true remote=false")
+        #expect(firstRow.observedReason.contains("local-model") == false)
+    }
+
+    @Test("proxy parity response shape mismatches are named by side")
+    func proxyParityResponseShapeMismatchesAreNamedBySide() async throws {
+        let localTransport = RecordingConformanceTransport(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: streamingToolCallBody()),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        let remoteTransport = RecordingConformanceTransport(responses: [
+            .json(statusCode: 200, body: chatCompletionBody()),
+            .sse(statusCode: 200, body: "data: [DONE]\n"),
+            .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+        ])
+        let harness = OpenAIProxyParityHarness(
+            target: OpenAIProxyParityTarget(
+                localBaseURL: "https://local.example/v1",
+                localModelID: "melix-dev-text",
+                localAPIKey: "",
+                remoteBaseURL: "https://remote.example/v1",
+                remoteModelID: "remote-model",
+                remoteAPIKey: "",
+                timeoutSeconds: 30
+            ),
+            localTransport: localTransport,
+            remoteTransport: remoteTransport
+        )
+
+        let report = try await harness.run()
+        let streamingRow = try #require(
+            report.rows.first { $0.field == "proxy_parity.chat.completions.streaming_tool_call_shape" }
+        )
+
+        #expect(report.summary.failed == 1)
+        #expect(streamingRow.observedReason == "remote_response=status=200 missing=tool_call_chunk")
+    }
+
+    @Test("proxy parity names local response and response-shape reason divergences")
+    func proxyParityNamesLocalResponseAndResponseShapeReasonDivergences() async throws {
+        let localFailure = try await OpenAIProxyParityHarness(
+            target: proxyParityTestTarget(),
+            localTransport: RecordingConformanceTransport(responses: [
+                .json(statusCode: 503, body: "{}"),
+                .sse(statusCode: 200, body: streamingToolCallBody()),
+                .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+            ]),
+            remoteTransport: RecordingConformanceTransport(responses: [
+                .json(statusCode: 200, body: chatCompletionBody()),
+                .sse(statusCode: 200, body: streamingToolCallBody()),
+                .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+            ])
+        ).run()
+        #expect(
+            row("proxy_parity.chat.completions.response_shape", in: localFailure)?.observedReason == "local_response=status=503"
+        )
+
+        let reasonDivergence = try await OpenAIProxyParityHarness(
+            target: proxyParityTestTarget(),
+            localTransport: RecordingConformanceTransport(responses: [
+                .json(statusCode: 200, body: chatCompletionBody()),
+                .sse(statusCode: 200, body: streamingToolCallBody()),
+                .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+            ]),
+            remoteTransport: RecordingConformanceTransport(responses: [
+                .json(statusCode: 200, body: chatCompletionBody()),
+                .sse(statusCode: 200, body: streamingToolCallBody()),
+                .json(statusCode: 422, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+            ])
+        ).run()
+        #expect(
+            row("proxy_parity.chat.completions.error_shape", in: reasonDivergence)?.observedReason ==
+                "response_shape local=status=400 field=best_of phase=openai_request_validation remote=status=422 field=best_of phase=openai_request_validation"
+        )
+    }
+
+    @Test("proxy parity records transport failures and rethrows cancellation")
+    func proxyParityRecordsTransportFailuresAndRethrowsCancellation() async throws {
+        let transportFailure = try await OpenAIProxyParityHarness(
+            target: proxyParityTestTarget(),
+            localTransport: ThrowingConformanceTransport(error: TestTransportError.networkLost),
+            remoteTransport: RecordingConformanceTransport(responses: [
+                .json(statusCode: 200, body: chatCompletionBody()),
+                .sse(statusCode: 200, body: streamingToolCallBody()),
+                .json(statusCode: 400, body: errorBody(field: "best_of", phase: "openai_request_validation")),
+            ])
+        ).run()
+        #expect(
+            row("proxy_parity.chat.completions.response_shape", in: transportFailure)?.observedReason ==
+                "local_response=transport_failed=networkLost"
+        )
+
+        let cancellingHarness = OpenAIProxyParityHarness(
+            target: proxyParityTestTarget(),
+            localTransport: ThrowingConformanceTransport(error: URLError(.cancelled)),
+            remoteTransport: RecordingConformanceTransport(responses: [
+                .json(statusCode: 200, body: chatCompletionBody()),
+            ])
+        )
+        await #expect(throws: URLError(.cancelled)) {
+            _ = try await cancellingHarness.run()
+        }
+
+        let cancellationErrorHarness = OpenAIProxyParityHarness(
+            target: proxyParityTestTarget(),
+            localTransport: ThrowingConformanceTransport(error: CancellationError()),
+            remoteTransport: RecordingConformanceTransport(responses: [
+                .json(statusCode: 200, body: chatCompletionBody()),
+            ])
+        )
+        do {
+            _ = try await cancellationErrorHarness.run()
+            Issue.record("expected cancellation to be rethrown")
+        } catch is CancellationError {
+        }
+    }
+
+    @Test("CLI parser covers proxy parity mode and named missing fields")
+    func cliParserCoversProxyParityModeAndNamedMissingFields() throws {
+        let cli = try OpenAIConformanceHarnessCLI.parse(arguments: [
+            "--mode", "proxy-parity",
+            "--local-base-url", "https://local.example/v1",
+            "--local-model", "local-model",
+            "--remote-base-url", "https://remote.example/v1",
+            "--remote-model", "remote-model",
+            "--remote-api-key", "remote-secret",
+            "--timeout-seconds", "11",
+            "--output", "parity-report.json",
+        ])
+
+        #expect(cli.proxyParityTarget == OpenAIProxyParityTarget(
+            localBaseURL: "https://local.example/v1",
+            localModelID: "local-model",
+            localAPIKey: "",
+            remoteBaseURL: "https://remote.example/v1",
+            remoteModelID: "remote-model",
+            remoteAPIKey: "remote-secret",
+            timeoutSeconds: 11
+        ))
+        #expect(throws: OpenAIConformanceHarnessCLIError.missingValue("--local-base-url")) {
+            try OpenAIConformanceHarnessCLI.parse(arguments: [
+                "--mode", "proxy-parity",
+                "--local-model", "local-model",
+                "--remote-base-url", "https://remote.example/v1",
+                "--remote-model", "remote-model",
+                "--output", "parity-report.json",
+            ])
+        }
+        #expect(throws: OpenAIConformanceHarnessCLIError.missingValue("--remote-model")) {
+            try OpenAIConformanceHarnessCLI.parse(arguments: [
+                "--mode", "proxy-parity",
+                "--local-base-url", "https://local.example/v1",
+                "--local-model", "local-model",
+                "--remote-base-url", "https://remote.example/v1",
+                "--output", "parity-report.json",
+            ])
+        }
+        #expect(throws: OpenAIConformanceHarnessCLIError.missingValue("--local-model")) {
+            try OpenAIConformanceHarnessCLI.parse(arguments: [
+                "--mode", "proxy-parity",
+                "--local-base-url", "https://local.example/v1",
+                "--remote-base-url", "https://remote.example/v1",
+                "--remote-model", "remote-model",
+                "--output", "parity-report.json",
+            ])
+        }
+        #expect(throws: OpenAIConformanceHarnessCLIError.missingValue("--remote-base-url")) {
+            try OpenAIConformanceHarnessCLI.parse(arguments: [
+                "--mode", "proxy-parity",
+                "--local-base-url", "https://local.example/v1",
+                "--local-model", "local-model",
+                "--remote-model", "remote-model",
+                "--output", "parity-report.json",
+            ])
+        }
+        #expect(throws: OpenAIConformanceHarnessCLIError.unknownOption("--remote-base-url")) {
+            try OpenAIConformanceHarnessCLI.parse(arguments: [
+                "--mode", "mock-backend-ci",
+                "--remote-base-url", "https://remote.example/v1",
+                "--output", "report.json",
+            ])
+        }
+        #expect(throws: OpenAIConformanceHarnessCLIError.unknownOption("--base-url")) {
+            try OpenAIConformanceHarnessCLI.parse(arguments: [
+                "--mode", "proxy-parity",
+                "--base-url", "https://local.example/v1",
+                "--model", "local-model",
+                "--local-base-url", "https://local.example/v1",
+                "--local-model", "local-model",
+                "--remote-base-url", "https://remote.example/v1",
+                "--remote-model", "remote-model",
+                "--output", "parity-report.json",
+            ])
+        }
+    }
+
+    @Test("proxy parity CLI run writes report using injected transport")
+    func proxyParityCLIRunWritesReportUsingInjectedTransport() async throws {
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-openai-proxy-parity-\(UUID().uuidString)")
+            .appendingPathComponent("parity-report.json")
+        let cli = OpenAIConformanceHarnessCLI(
+            proxyParityTarget: proxyParityTestTarget(),
+            outputURL: output
+        )
+
+        let report = try await cli.run(transport: MockOpenAIConformanceTransport())
+        let decoded = try JSONDecoder().decode(
+            OpenAIConformanceReport.self,
+            from: try Data(contentsOf: output)
+        )
+
+        #expect(report.summary.passed == 3)
+        #expect(decoded == report)
+    }
 }
 
 private actor RecordingConformanceTransport: RemoteProviderHTTPTransport {
@@ -402,6 +702,18 @@ private func row(
     in report: OpenAIConformanceReport
 ) -> OpenAIConformanceRow? {
     report.rows.first { $0.field == field }
+}
+
+private func proxyParityTestTarget() -> OpenAIProxyParityTarget {
+    OpenAIProxyParityTarget(
+        localBaseURL: "https://local.example/v1",
+        localModelID: "local-model",
+        localAPIKey: "",
+        remoteBaseURL: "https://remote.example/v1",
+        remoteModelID: "remote-model",
+        remoteAPIKey: "",
+        timeoutSeconds: 30
+    )
 }
 
 private func requestBodyModel(_ request: URLRequest) throws -> String? {


### PR DESCRIPTION
## Summary
- Adds `OpenAIProxyParityHarness` to compare local backend and configured remote Server Profile behavior for the existing OpenAI conformance row set.
- Emits the existing `melix.openai_conformance_report.v1` schema with named parity failures for request receipts, local/remote response shape failures, response-shape divergence, and transport failures.
- Extends `melix-openai-conformance` with `--mode proxy-parity` and side-specific local/remote endpoint options.
- Addresses review feedback by making chat-completions endpoint construction idempotent for copied endpoint URLs and by comparing request-receipt arrays directly.

Closes #1989.

## Plan or Spec
- Governing plan: `docs/plans/2026-06-18-issue-1989-openai-proxy-parity.md`
- Governing spec/decision: `docs/adr/0002-openai-conformance-at-control-plane-boundary.md`
- Parent issue: #1384

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIConformanceHarnessTests|OpenAIConformanceMatrixTests'
Result: passed, 34 tests in 2 suites after the review fix.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIConformanceHarnessTests|OpenAIConformanceMatrixTests'
Result: passed, 34 tests in 2 suites after the review fix.

UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceHarness.swift services/control-plane-swift/Sources/OpenAIConformanceHarnessCLI/main.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceHarnessTests.swift
Result: 97.55% changed-line coverage, 598/613 changed lines covered.

swift run --package-path services/control-plane-swift melix-openai-conformance --mode mock-backend-ci --output .runtime/issue1989/mock-report.json
Result: wrote report with passed=3 failed=0 skipped=0.

swift run --package-path services/control-plane-swift melix-openai-conformance --mode proxy-parity --local-base-url http://127.0.0.1:9/v1 --local-model local-model --remote-base-url http://127.0.0.1:10/v1 --remote-model remote-model --timeout-seconds 1 --output .runtime/issue1989/proxy-parity-unreachable-report.json
Result: wrote schema melix.openai_conformance_report.v1 with passed=0 failed=3 skipped=0 and exited 1 because rows failed as expected.

make swift-test
Result: passed.

make py-test
Result: passed, 4075 passed, 14 skipped, 2 warnings.

make integration-test
Result: passed, 120 passed, 1 skipped.

make swift-test
Result: passed after merging latest origin/main.

make py-test
Result: passed after merging latest origin/main, 4075 passed, 14 skipped, 2 warnings.

make integration-test
Result: passed after merging latest origin/main, 120 passed, 1 skipped.

.githooks/pre-commit
Result: passed make swift-test, make py-test, make integration-test, and PR-scoped performance gate.

UV_PYTHON=3.12 uv run python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/issue1989-after-main-merge/perf/changed-files.json --output .runtime/issue1989-after-main-merge/perf/scope/scope.json
UV_PYTHON=3.12 uv run python scripts/pr_scoped_performance_report.py --scope .runtime/issue1989-after-main-merge/perf/scope/scope.json --results-dir .runtime/issue1989-after-main-merge/perf/probes --output-dir .runtime/issue1989-after-main-merge/perf/report --format terminal --sticky-comment
Result: passed after merging latest origin/main, status ok, 3 changed files, 0 selected probes, 0 regressions.

git diff --cached --check
Result: passed.

UV_PYTHON=3.12 uv run python scripts/validate_pr_evidence.py --body-file .runtime/issue1989-pr-body.md
Result: passed.
```

## Coverage and Metrics
- Changed-line coverage: `97.55%` total (`598/613`) across the changed Swift harness and tests.
- PR-scoped performance report: `.runtime/pre-commit-performance/20260618-042501-21ceaeca/report/report.md`
- Post-main-merge local PR-scoped performance report: `.runtime/issue1989-after-main-merge/perf/report/report.md`
- Performance status: `ok`
- Changed files: `3`
- Selected probes: `0`
- Direct/gated probes: `0`
- Regressions: `0`
- Context regressions: `0`
- Verification failures: `0`
- Observability mode: `evidence` for the conformance/parity report artifact; no production telemetry or debug probe was added.
- Probe overhead: `N/A`, because the performance gate selected no registered probes for this change set and the harness runs only when invoked.

## Known Gaps
- No live remote Server Profile credentials are committed or exercised in CI; the new `proxy-parity` mode is configured at runtime by the operator.
- `make bootstrap` and `make proto` were not rerun because this change does not alter dependencies, protobuf schemas, or generated artifacts; `core.hooksPath` was already configured to `.githooks`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or `N/A` because no protobuf schema changed.
- [x] Dependency changes include updated lockfiles, or `N/A` because no dependencies changed.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
