### PR TITLE
perf: strip retrieval store record fields once

### DIFF
--- a/docs/plans/2026-06-17-retrieval-context-strip-once.md
+++ b/docs/plans/2026-06-17-retrieval-context-strip-once.md
@@ -1,14 +1,16 @@
 # Retrieval context direct projection strip-once fast path
 
-This Python-only performance slice is limited to the direct `RetrievalContextEntry`
-projection path in `worker.runtime.retrieval_context.project_retrieval_contexts(...)`.
+This Python-only performance slice covers the direct `RetrievalContextEntry`
+projection path in `worker.runtime.retrieval_context.project_retrieval_contexts(...)`
+and the complete dict-record fast path in
+`worker.runtime.retrieval_context.project_retrieval_store_records(...)`.
 
 ## Scope
 
-The direct complete-entry path already bypasses the generic admission helper for
-validated `RetrievalContextEntry` objects. This slice keeps that behavior and
-normalizes hot receipt fields exactly once before both validation and receipt
-construction:
+The direct complete-entry paths already bypass the generic admission helper for
+validated `RetrievalContextEntry` objects and complete dict records. This slice
+keeps that behavior and normalizes hot receipt fields exactly once before both
+validation and receipt construction:
 
 - `source_id`
 - `segment_id`

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -303,41 +303,47 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
             corrective_action = record_get("corrective_action", "")
             if (
                 isinstance(source_id, str)
-                and source_id.strip()
                 and isinstance(payload, dict)
                 and isinstance(owner_scope_checked, bool)
                 and isinstance(segment_id, str)
-                and segment_id.strip()
                 and isinstance(source_field, str)
-                and source_field.strip()
                 and isinstance(reason, str)
-                and reason.strip()
                 and isinstance(corrective_action, str)
-                and corrective_action.strip()
             ):
+                normalized_source_id = source_id.strip()
+                normalized_segment_id = segment_id.strip()
                 normalized_source_field = source_field.strip()
-                receipt = build_untrusted_context_receipt(
-                    segment_id=segment_id.strip(),
-                    source_type=context_kind,
-                    source_field=normalized_source_field,
-                    source_id=source_id.strip(),
-                    message_role="user",
-                    owner_scope_checked=owner_scope_checked,
-                    included=True,
-                    reason=reason.strip(),
-                    corrective_action=corrective_action.strip(),
-                )
-                if normalized_source_field in user_payload:
-                    projection_refusal_receipts_append(
-                        duplicate_projection_receipt(
-                            receipt,
-                            duplicate_fields=[normalized_source_field],
-                        )
+                normalized_reason = reason.strip()
+                normalized_corrective_action = corrective_action.strip()
+                if (
+                    normalized_source_id
+                    and normalized_segment_id
+                    and normalized_source_field
+                    and normalized_reason
+                    and normalized_corrective_action
+                ):
+                    receipt = build_untrusted_context_receipt(
+                        segment_id=normalized_segment_id,
+                        source_type=context_kind,
+                        source_field=normalized_source_field,
+                        source_id=normalized_source_id,
+                        message_role="user",
+                        owner_scope_checked=owner_scope_checked,
+                        included=True,
+                        reason=normalized_reason,
+                        corrective_action=normalized_corrective_action,
                     )
+                    if normalized_source_field in user_payload:
+                        projection_refusal_receipts_append(
+                            duplicate_projection_receipt(
+                                receipt,
+                                duplicate_fields=[normalized_source_field],
+                            )
+                        )
+                        continue
+                    user_payload[normalized_source_field] = payload
+                    receipts_append(receipt)
                     continue
-                user_payload[normalized_source_field] = payload
-                receipts_append(receipt)
-                continue
 
         try:
             admission = admit_entry(


### PR DESCRIPTION
## Summary
- Normalize complete retrieval store record receipt fields once in the dict fast path before validation and receipt construction.
- Keep malformed/incomplete records on the existing generic admission/refusal path.
- Update the retrieval context strip-once plan to include the store-record projection path.

## Plan or Spec
- Updated `docs/plans/2026-06-17-retrieval-context-strip-once.md`.
- Registered probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json` already covers the touched Python path and includes focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `git status --short && git branch --show-current`
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" MELIX_RETRIEVAL_CONTEXT_PROJECTION_SAMPLES=5 MELIX_RETRIEVAL_CONTEXT_PROJECTION_ITERATIONS=300 uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py` (baseline snapshot before edit)
- Registered `retrieval-context-projection-fastpath` test command from `infra/perf/pr_scoped_probes.json`
- Registered `retrieval-context-projection-fastpath` coverage command from `infra/perf/pr_scoped_probes.json`
- Registered `retrieval-context-projection-fastpath` probe command from `infra/perf/pr_scoped_probes.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `24 passed in 1.08s`.
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Local Linux registered probe after edit:
  - `baseline_elapsed_ms_mean=1.0415068920701742`
  - `optimized_elapsed_ms_mean=0.18054292370964373`
  - `delta_ms=-0.8609639683605305`
  - `speedup=5.768749451211762x`
  - `store_baseline_elapsed_ms_mean=0.35767724671001944`
  - `store_optimized_elapsed_ms_mean=0.19447456546393888`
  - `store_delta_ms=-0.16320268124608056`
  - `store_speedup=1.8391980764000884x`
- Pre-edit local probe snapshot for the store path: `store_optimized_elapsed_ms_mean=0.19847607488433522`, `store_speedup=1.8422484353411885x` with 5 samples / 300 iterations.
- CI PR-scoped performance must run the registered probe before merge.

## Known Gaps
- Python-only slice; no Swift runtime behavior changed or claimed.
- Local metrics are Linux-only; the registered GitHub Actions PR-scoped performance report is the merge gate.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped probe with test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe was run on Linux.
- [ ] GitHub Actions PR-scoped performance completed successfully.
- [ ] All PR checks are green before merge.
