### PR TITLE
perf: trim PR scope command summaries once

### DIFF
--- a/docs/plans/2026-06-18-pr-scoped-command-summary-index-scan.md
+++ b/docs/plans/2026-06-18-pr-scoped-command-summary-index-scan.md
@@ -1,0 +1,21 @@
+# PR-scoped command summary trim pass
+
+## Slice
+
+Optimize `_summarize_command()` in the PR-scoped performance runner without changing its public output. The hot path is the CI heartbeat command summary and the registered scope matcher probe measures it with `command_summary_ms_mean`.
+
+## Registered probe
+
+The affected path is already covered by the registered `pr-scoped-performance-scope-matcher` probe in `infra/perf/pr_scoped_probes.json`. That probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for `services/mlx-worker-python/worker/productization/pr_scoped_performance.py` and `services/mlx-worker-python/tests/test_pr_scoped_performance.py`.
+
+## Implementation plan
+
+- Preserve the existing compact single-line summary semantics.
+- Use a single whole-command `strip()` before first-line selection so trailing blank heredoc lines are eliminated without allocating and scanning the remaining payload separately.
+- Keep the behavior tests under `test_command_summary_keeps_ci_heartbeats_compact` as the regression guard.
+
+## Verification plan
+
+- Run the focused scope matcher tests.
+- Run changed-scope coverage for `pr_scoped_performance.py` and `test_pr_scoped_performance.py` via the registered coverage command.
+- Run the registered scope matcher probe locally on Linux and compare `command_summary_ms_mean` against the pre-change baseline.

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -74,15 +74,13 @@ def _log_progress(message: str) -> None:
 
 
 def _summarize_command(command: str, *, max_length: int = 180) -> str:
-    command = command.lstrip()
+    command = command.strip()
     if not command:
         return "<empty command>"
 
-    first_line, separator, remaining_lines = command.partition("\n")
+    first_line, separator, _remaining_lines = command.partition("\n")
     summary = first_line.rstrip()
-    has_more_lines = bool(separator and remaining_lines.lstrip())
-
-    if has_more_lines:
+    if separator:
         summary = f"{summary} ..."
     if len(summary) > max_length:
         return f"{summary[: max_length - 4]} ..."


### PR DESCRIPTION
## Summary
- Optimize PR-scoped performance command summarization by trimming the command once before first-line selection.
- Preserve existing compact CI heartbeat output for multiline and whitespace-only commands.

## Plan or Spec
- Added `docs/plans/2026-06-18-pr-scoped-command-summary-index-scan.md` for this focused slice.
- Registered probe coverage: existing `pr-scoped-performance-scope-matcher` has focused `test_command`, `coverage_command`, and `probe_command` entries for the changed Python path.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (registered `pr-scoped-performance-scope-matcher` focused test command; 20 tests)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- Local comparison harness for old vs new `_summarize_command()` over 7 repeats x 20,000 iterations.
- Local registered scope matcher probe via `_probe_pr_scoped_scope_matcher(Path.cwd())`.
- `git diff --check`

## Coverage and Metrics
- Focused behavior tests: 2 passed in 0.20s.
- Registered focused tests: 20 passed in 14.97s.
- Registered coverage replay: 20 passed in 48.96s; changed-scope coverage `TOTAL 3 0 100%`.
- Local old/new comparison: `old_mean_ms=13.992574`, `new_mean_ms=11.345106`, `delta_ms=-2.647468`, `speedup=1.233358`.
- Local registered probe after change: `command_summary_ms_mean=11.450179`, `build_scope_report_ms_mean=2.893348`, `selected_probe_count_mean=7.0`, `force_all_selected_mean=0.0`.

## Known Gaps
- This is a Python slice verified locally on Linux. CI remains the source of truth for the registered PR-scoped performance report.
- No Swift runtime effects are claimed.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Local performance comparison shows improvement.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
