### PR TITLE
perf: short-circuit empty changed-scope allowlists

### DIFF
--- a/docs/plans/2026-06-18-changed-scope-empty-allowlist-filter-performance.md
+++ b/docs/plans/2026-06-18-changed-scope-empty-allowlist-filter-performance.md
@@ -1,0 +1,25 @@
+# Changed-scope coverage empty allowlist filter performance
+
+## Scope
+
+Optimize one Python hot path in `scripts/changed_scope_coverage.py`: the path filter used when `MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON` resolves to an empty allowlist.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `changed-scope-coverage-empty-path-short-circuit` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes:
+
+- focused tests through `test_command`
+- changed-scope coverage through `coverage_command`
+- local/CI performance measurement through `probe_command` (`python3 scripts/changed_scope_coverage_probe.py`)
+
+## Implementation Plan
+
+1. Preserve current behavior for unset allowlists by returning the original path list.
+2. Add a direct empty-allowlist return before the list comprehension so empty allowlists avoid scanning every candidate path.
+3. Verify with the registered focused tests, coverage command, and probe on Linux.
+
+## Success Metric
+
+`main_empty_allowlist_elapsed_ms_mean` should decrease or remain within noise while `main_empty_allowlist_coverage_read_calls_mean` remains `0.0`. The probe also reports the helper path metric `elapsed_ms_mean`; no behavior change is expected there.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -172,6 +172,8 @@ def _coverage_path_allowlist(env: Mapping[str, str]) -> frozenset[str] | None:
 def _filter_coverage_paths(paths: list[str], allowlist: frozenset[str] | None) -> list[str]:
     if allowlist is None:
         return paths
+    if not allowlist:
+        return []
     return [path for path in paths if path in allowlist]
 
 


### PR DESCRIPTION
## Summary
- Short-circuit changed-scope coverage collection when an explicit allowlist is empty.
- Avoid parsing/read work for the empty allowlist path while preserving the default no-allowlist behavior.
- Document the performance slice decision and registered-probe evidence.

## Plan or Spec
- `docs/plans/2026-06-18-changed-scope-empty-allowlist-filter-performance.md`

## Commands Run
```text
# focused behavior tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 42 passed in 0.20s

# changed-scope coverage command from the registered probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 42 passed in 0.59s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 0 0 100%

# registered local probe, head only
python3 scripts/changed_scope_coverage_probe.py
# {"elapsed_ms_mean": 0.1312366553715297, "main_empty_allowlist_coverage_read_calls_mean": 0.0, "main_empty_allowlist_elapsed_ms_mean": 0.41447925780500683, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}

# baseline-vs-head local probe samples
# origin/main: {"elapsed_ms_mean": 0.1399823065314974, "main_empty_allowlist_coverage_read_calls_mean": 0.0, "main_empty_allowlist_elapsed_ms_mean": 0.530221765594823, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}
# HEAD:        {"elapsed_ms_mean": 0.13703121138470514, "main_empty_allowlist_coverage_read_calls_mean": 0.0, "main_empty_allowlist_elapsed_ms_mean": 0.44038199952670504, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}

git diff --check
```

## Coverage and Metrics
- Registered PR-scoped probe coverage exists for `scripts/changed_scope_coverage.py` via `Changed-scope coverage empty-path short circuit` in `infra/perf/pr_scoped_probes.json`.
- Local changed-scope coverage gate: `TOTAL 0 0 100%` for the registered changed-scope command.
- Local probe delta:
  - `elapsed_ms_mean`: baseline `0.139982 ms`, head `0.137031 ms`, delta `-0.002951 ms` (`2.11%` faster, `1.022x`).
  - `main_empty_allowlist_elapsed_ms_mean`: baseline `0.530222 ms`, head `0.440382 ms`, delta `-0.089840 ms` (`16.94%` faster, `1.204x`).
  - Read-call metrics remain `0.0` for the empty-allowlist path.
- CI PR-scoped performance validation is still required before merge.

## Known Gaps
- Local validation is Linux-only. This slice is Python-only; no Swift runtime effect is claimed locally.
- The focused changed-scope coverage command reports no measurable changed lines for the selected files because the command intentionally exercises the registered probe's current allowlist inputs.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
