### PR TITLE
Fix VLM streaming budget parity

### DIFF
--- a/docs/plans/2026-06-18-issue-1452-streaming-budget-parity.md
+++ b/docs/plans/2026-06-18-issue-1452-streaming-budget-parity.md
@@ -1,0 +1,97 @@
+# Issue 42 U2.2.3 Streaming Budget Parity Fixtures
+
+## Source
+
+- GitHub issue: <https://github.com/Keith-CY/melix/issues/1452>
+- Parent plan: <https://github.com/Keith-CY/melix/issues/1430>
+- Governing roadmap: `docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md`
+- Prior slices:
+  - `docs/plans/2026-05-24-issue-42-u2-2-1-attention-cost-auto-chunk-policy.md`
+  - `docs/plans/2026-05-25-issue-42-u2-2-2-chunked-auxiliary-tensor-slicing.md`
+
+## Goal
+
+Add regression fixtures that prove over-budget VLM attention admission behaves
+the same for streaming and non-streaming OpenAI chat requests, including the
+public HTTP boundary before any SSE bytes are emitted.
+
+## Architecture
+
+The Python worker owns VLM execution truth and already emits a typed
+`multimodal_prefill_attention_budget_exceeded` error event before decode when a
+media-expanded attention estimate exceeds the active budget. The Swift HTTP
+gateway owns the OpenAI API contract and must not start a server-sent-events
+response when the first worker event is that admission refusal.
+
+This slice keeps the attention-cost calculation in the worker. The gateway adds
+a narrow first-event inspection path for streaming chat: if the first worker
+event is a typed admission refusal, return the existing OpenAI JSON error
+envelope instead of `text/event-stream`; otherwise replay the first event and
+continue streaming normally.
+
+## Behavior Contract
+
+- Streaming and non-streaming VLM requests with the same prompt, media, model,
+  and token cap surface the same worker error code.
+- Streaming over-budget VLM requests return an HTTP JSON error response before
+  the first SSE data frame. The response body must not be `.stream`.
+- The OpenAI JSON error envelope preserves typed worker details:
+  `predicted_attention_bytes`, `attention_budget_bytes`,
+  `auto_chunk_reason`, `prefill_chunk_mode`, and
+  `selected_prefill_step_size`.
+- Normal streaming requests keep the current SSE behavior by replaying any
+  first event consumed during admission inspection.
+
+## Implementation Steps
+
+1. Add a failing HTTP gateway test in
+   `services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift`
+   that scripts a first worker error event for a media-bearing VLM chat request
+   with `stream=true` and asserts JSON 400, no SSE body, and typed attention
+   details.
+2. Add a paired non-streaming fixture for the same media prompt and worker
+   error event, asserting the same error code and detail fields.
+3. Add a small helper in
+   `services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift`
+   that reads the first worker event before creating an SSE response, maps
+   first-event admission errors to `workerErrorResponse`, and otherwise returns
+   a stream that replays the first event.
+4. Run the new tests first to confirm the red state, then implement the helper
+   and verify the focused Swift tests turn green.
+5. Run full local gates and build the scoped performance report before opening
+   the pull request.
+
+## Performance Probes And Success Metrics
+
+- Measurement point: OpenAI chat streaming response setup in
+  `OpenAIHandler.streamResponse`.
+- Success metric: PR-scoped performance report has status `ok` with no
+  regression. This slice adds one first-event await on streaming text requests;
+  the PR report must confirm no selected probe regression for the changed
+  scope.
+- Observability mode: minimal. No new runtime counters or evidence-mode probes
+  are added because the behavior is a public error-boundary fixture.
+- Probe overhead: N/A for new probes; this slice does not add a production
+  probe. Existing PR-scoped performance infrastructure is used.
+
+## Verification
+
+Required focused checks before PR handoff:
+
+- `swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests`
+- `make swift-test`
+- `make py-test`
+- `make integration-test`
+- Scoped PR performance report with status `ok` and zero regressions.
+
+Changed-scope coverage must be reported before commit. If the Swift package
+coverage tooling cannot measure the touched scope directly, record the focused
+test coverage limitation and include the focused test pass plus full Swift gate.
+
+## Non-Goals
+
+- No protobuf schema change.
+- No change to the worker attention-cost estimator.
+- No throughput claim for VLM chunking.
+- No change to unrelated SSE error frames that occur after a normal streaming
+  response has already started.

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -4188,8 +4188,27 @@ button.primary:active {
 
         await modelCatalog.beginRequest(modelID: translated.modelID)
         await scheduleIdleSweepIfNeeded(idleSweepRequest)
+        let workerStream: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>
+        if shouldInspectFirstStreamEventForPreSSEAdmission(translated) {
+            let inspection = await firstEvent(from: execution.stream)
+            switch inspection.firstEvent {
+            case .event(let firstEvent):
+                if let firstEvent, case .error(let error) = firstEvent.payload,
+                   isPreSSEAdmissionError(error.error) {
+                    await modelCatalog.finishRequest(modelID: translated.modelID)
+                    return workerErrorResponse(error.error)
+                }
+                workerStream = inspection.replayingStream
+            case .failure:
+                await modelCatalog.finishRequest(modelID: translated.modelID)
+                return workerUnavailableResponse()
+            }
+        } else {
+            workerStream = execution.stream
+        }
+
         let stream = sseWriter.encode(
-            stream: execution.stream,
+            stream: workerStream,
             requestID: execution.requestID,
             modelID: translated.responseModelID ?? execution.modelID,
             shape: shape,
@@ -4211,6 +4230,85 @@ button.primary:active {
             ],
             body: .stream(stream)
         )
+    }
+
+    private func shouldInspectFirstStreamEventForPreSSEAdmission(_ translated: TranslatedChatRequest) -> Bool {
+        normalizedMediaPartCount(from: translated.workerRequest.execution.ext) > 0
+    }
+
+    private func firstEvent(
+        from stream: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>
+    ) async -> FirstStreamEventInspection {
+        let probe = FirstStreamEventProbe()
+        let replayingStream = AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error> { continuation in
+            let task = Task {
+                var didPublishFirstEvent = false
+                do {
+                    for try await event in stream {
+                        if !didPublishFirstEvent {
+                            didPublishFirstEvent = true
+                            await probe.publish(.event(event))
+                        }
+                        continuation.yield(event)
+                    }
+                    if !didPublishFirstEvent {
+                        await probe.publish(.event(nil))
+                    }
+                    continuation.finish()
+                } catch {
+                    if !didPublishFirstEvent {
+                        await probe.publish(.failure)
+                    }
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+        let firstEvent = await probe.wait()
+        return FirstStreamEventInspection(firstEvent: firstEvent, replayingStream: replayingStream)
+    }
+
+    private struct FirstStreamEventInspection: Sendable {
+        let firstEvent: FirstStreamEventProbe.Result
+        let replayingStream: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>
+    }
+
+    private actor FirstStreamEventProbe {
+        enum Result: Sendable {
+            case event(Melix_Worker_V1_ExecuteEvent?)
+            case failure
+        }
+
+        private var result: Result?
+        private var waiters: [CheckedContinuation<Result, Never>] = []
+
+        func publish(_ result: Result) {
+            guard self.result == nil else {
+                return
+            }
+            self.result = result
+            let waiters = self.waiters
+            self.waiters.removeAll()
+            for waiter in waiters {
+                waiter.resume(returning: result)
+            }
+        }
+
+        func wait() async -> Result {
+            await withCheckedContinuation { continuation in
+                if let result {
+                    continuation.resume(returning: result)
+                } else {
+                    waiters.append(continuation)
+                }
+            }
+        }
+    }
+
+    private func isPreSSEAdmissionError(_ error: Melix_Worker_V1_ErrorStatus) -> Bool {
+        error.code == "multimodal_prefill_attention_budget_exceeded"
     }
 
     private func encodedJSONResponse<T: Encodable>(_ payload: T, statusCode: Int = 200) throws -> HTTPResponse {
@@ -4835,7 +4933,7 @@ button.primary:active {
     private func workerErrorResponse(_ error: Melix_Worker_V1_ErrorStatus) -> HTTPResponse {
         let statusCode: Int
         switch error.code {
-        case "invalid_argument":
+        case "invalid_argument", "multimodal_prefill_attention_budget_exceeded":
             statusCode = 400
         case "not_found":
             statusCode = 404

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -4206,6 +4206,9 @@ button.primary:active {
                     workerStream = AsyncThrowingStream(unfolding: { nil })
                 }
             } catch {
+                // This is still before SSE response construction, so first-pull
+                // worker/RPC failures remain JSON errors; later stream failures
+                // continue through SSEStreamWriter as event-stream frames.
                 await modelCatalog.finishRequest(modelID: translated.modelID)
                 return workerUnavailableResponse()
             }
@@ -4242,6 +4245,8 @@ button.primary:active {
         normalizedMediaPartCount(from: translated.workerRequest.execution.ext) > 0
     }
 
+    // AsyncThrowingStream(unfolding:) serializes calls to the captured state, so
+    // this unchecked Sendable wrapper keeps the replay state single-consumer.
     private final class FirstStreamEventReplayState: @unchecked Sendable {
         private var firstEvent: Melix_Worker_V1_ExecuteEvent?
         private var iterator: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>.Iterator

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -4190,16 +4190,22 @@ button.primary:active {
         await scheduleIdleSweepIfNeeded(idleSweepRequest)
         let workerStream: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>
         if shouldInspectFirstStreamEventForPreSSEAdmission(translated) {
-            let inspection = await firstEvent(from: execution.stream)
-            switch inspection.firstEvent {
-            case .event(let firstEvent):
-                if let firstEvent, case .error(let error) = firstEvent.payload,
-                   isPreSSEAdmissionError(error.error) {
-                    await modelCatalog.finishRequest(modelID: translated.modelID)
-                    return workerErrorResponse(error.error)
+            var iterator = execution.stream.makeAsyncIterator()
+            do {
+                if let firstEvent = try await iterator.next() {
+                    if case .error(let error) = firstEvent.payload,
+                       isPreSSEAdmissionError(error.error) {
+                        await modelCatalog.finishRequest(modelID: translated.modelID)
+                        return workerErrorResponse(error.error)
+                    }
+                    let state = FirstStreamEventReplayState(firstEvent: firstEvent, iterator: iterator)
+                    workerStream = AsyncThrowingStream(unfolding: {
+                        try await state.next()
+                    })
+                } else {
+                    workerStream = AsyncThrowingStream(unfolding: { nil })
                 }
-                workerStream = inspection.replayingStream
-            case .failure:
+            } catch {
                 await modelCatalog.finishRequest(modelID: translated.modelID)
                 return workerUnavailableResponse()
             }
@@ -4236,74 +4242,24 @@ button.primary:active {
         normalizedMediaPartCount(from: translated.workerRequest.execution.ext) > 0
     }
 
-    private func firstEvent(
-        from stream: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>
-    ) async -> FirstStreamEventInspection {
-        let probe = FirstStreamEventProbe()
-        let replayingStream = AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error> { continuation in
-            let task = Task {
-                var didPublishFirstEvent = false
-                do {
-                    for try await event in stream {
-                        if !didPublishFirstEvent {
-                            didPublishFirstEvent = true
-                            await probe.publish(.event(event))
-                        }
-                        continuation.yield(event)
-                    }
-                    if !didPublishFirstEvent {
-                        await probe.publish(.event(nil))
-                    }
-                    continuation.finish()
-                } catch {
-                    if !didPublishFirstEvent {
-                        await probe.publish(.failure)
-                    }
-                    continuation.finish(throwing: error)
-                }
-            }
-            continuation.onTermination = { _ in
-                task.cancel()
-            }
-        }
-        let firstEvent = await probe.wait()
-        return FirstStreamEventInspection(firstEvent: firstEvent, replayingStream: replayingStream)
-    }
+    private final class FirstStreamEventReplayState: @unchecked Sendable {
+        private var firstEvent: Melix_Worker_V1_ExecuteEvent?
+        private var iterator: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>.Iterator
 
-    private struct FirstStreamEventInspection: Sendable {
-        let firstEvent: FirstStreamEventProbe.Result
-        let replayingStream: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>
-    }
-
-    private actor FirstStreamEventProbe {
-        enum Result: Sendable {
-            case event(Melix_Worker_V1_ExecuteEvent?)
-            case failure
+        init(
+            firstEvent: Melix_Worker_V1_ExecuteEvent,
+            iterator: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>.Iterator
+        ) {
+            self.firstEvent = firstEvent
+            self.iterator = iterator
         }
 
-        private var result: Result?
-        private var waiters: [CheckedContinuation<Result, Never>] = []
-
-        func publish(_ result: Result) {
-            guard self.result == nil else {
-                return
+        func next() async throws -> Melix_Worker_V1_ExecuteEvent? {
+            if let firstEvent {
+                self.firstEvent = nil
+                return firstEvent
             }
-            self.result = result
-            let waiters = self.waiters
-            self.waiters.removeAll()
-            for waiter in waiters {
-                waiter.resume(returning: result)
-            }
-        }
-
-        func wait() async -> Result {
-            await withCheckedContinuation { continuation in
-                if let result {
-                    continuation.resume(returning: result)
-                } else {
-                    waiters.append(continuation)
-                }
-            }
+            return try await iterator.next()
         }
     }
 

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/HTTPGatewayTestSupport.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/HTTPGatewayTestSupport.swift
@@ -158,7 +158,8 @@ func makeErrorEvent(
     requestID: String,
     seq: UInt64,
     code: String,
-    message: String
+    message: String,
+    details: [String: String] = [:]
 ) -> Melix_Worker_V1_ExecuteEvent {
     var event = Melix_Worker_V1_ExecuteEvent()
     event.requestID = requestID
@@ -167,6 +168,7 @@ func makeErrorEvent(
     event.error = Melix_Worker_V1_ErrorEvent()
     event.error.error.code = code
     event.error.error.message = message
+    event.error.error.details = details
     return event
 }
 

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -4457,6 +4457,37 @@ struct OpenAIHandlerTests {
         #expect(await vlmClient.lastGenerateRequest == nil)
     }
 
+    @Test("POST /v1/chat/completions preserves first VLM token after streaming admission inspection")
+    func postChatCompletionsPreservesFirstVLMTokenAfterStreamingAdmissionInspection() async throws {
+        let requestID = "req-http-vlm-first-token-replay"
+        let harness = makeGemma4VLMOpenAIHandler(
+            requestID: requestID,
+            vlmEvents: [
+                makeTokenEvent(requestID: requestID, seq: 1, text: "first"),
+                makeCompletedEvent(requestID: requestID, seq: 2, finishReason: "stop", assistantText: "first"),
+            ],
+            configureModel: { model in
+                model.settings.ext["melix.vlm.execution_mode"] = "multimodal"
+            }
+        )
+        let body = try #require(vlmAttentionBudgetChatBody(stream: true))
+
+        let response = try await harness.handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        let payload = try await collectBody(response.body)
+
+        #expect(response.statusCode == 200)
+        #expect(response.headers["content-type"] == "text/event-stream; charset=utf-8")
+        #expect(payload.contains("\"content\":\"first\""), Comment(rawValue: payload))
+        #expect(payload.contains("data: [DONE]"), Comment(rawValue: payload))
+    }
+
     @Test("POST /v1/chat/completions dispatches valid non-stream media to VLM workers")
     func postChatCompletionsDispatchesValidNonStreamMediaToVLMWorkers() async throws {
         let temporaryRoot = FileManager.default.temporaryDirectory
@@ -4541,6 +4572,158 @@ struct OpenAIHandlerTests {
         #expect(prefillRequest.messages[0].parts[1].imageBytes == Data("image".utf8))
         #expect(await textClient.lastGenerateRequest == nil)
         #expect(await vlmClient.lastGenerateRequest == nil)
+    }
+
+    @Test("POST /v1/chat/completions rejects streaming VLM attention budget before first SSE byte")
+    func postChatCompletionsRejectsStreamingVLMAttentionBudgetBeforeFirstSSEByte() async throws {
+        let requestID = "req-http-vlm-attention-budget-stream"
+        let details = vlmAttentionBudgetDetails()
+        let harness = makeGemma4VLMOpenAIHandler(
+            requestID: requestID,
+            vlmPrefillResponse: vlmAttentionBudgetPrefillRefusal(details: details),
+            configureModel: { model in
+                model.settings.ext["melix.vlm.execution_mode"] = "multimodal"
+            }
+        )
+        let body = try #require(vlmAttentionBudgetChatBody(stream: true))
+
+        let response = try await harness.handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        let payload = try await jsonPayload(from: response.body)
+        let error = try #require(payload["error"] as? [String: Any])
+        let responseDetails = try #require(error["details"] as? [String: Any])
+
+        #expect(response.statusCode == 400)
+        #expect(response.headers["content-type"] == "application/json")
+        #expect(error["code"] as? String == "multimodal_prefill_attention_budget_exceeded")
+        #expect(error["message"] as? String == "Predicted multimodal prefill attention memory exceeds the active budget.")
+        #expect(responseDetails["predicted_attention_bytes"] as? String == details["predicted_attention_bytes"])
+        #expect(responseDetails["attention_budget_bytes"] as? String == details["attention_budget_bytes"])
+        #expect(responseDetails["auto_chunk_reason"] as? String == "attention_budget_exceeded")
+        #expect(responseDetails["prefill_chunk_mode"] as? String == "refused")
+        #expect(responseDetails["selected_prefill_step_size"] as? String == "0")
+        if case .stream = response.body {
+            Issue.record("Streaming VLM attention-budget admission must not return an SSE body.")
+        }
+        #expect(await harness.vlmClient.lastPrefillRequest != nil)
+        #expect(await harness.vlmClient.lastDecodeRequest == nil)
+        #expect(await harness.vlmClient.lastGenerateRequest == nil)
+    }
+
+    @Test("POST /v1/chat/completions preserves non-admission VLM stream errors as SSE frames")
+    func postChatCompletionsPreservesNonAdmissionVLMStreamErrorsAsSSEFrames() async throws {
+        let requestID = "req-http-vlm-pre-first-event-failure"
+        let harness = makeGemma4VLMOpenAIHandler(
+            requestID: requestID,
+            vlmEvents: [],
+            vlmStreamFailure: OpenAIHandlerTestError(description: "vlm stream failed before first event"),
+            configureModel: { model in
+                model.settings.ext["melix.vlm.execution_mode"] = "multimodal"
+            }
+        )
+        let body = try #require(vlmAttentionBudgetChatBody(stream: true))
+
+        let response = try await harness.handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        let payload = try await collectBody(response.body)
+
+        #expect(response.statusCode == 200)
+        #expect(response.headers["content-type"] == "text/event-stream; charset=utf-8")
+        #expect(payload.contains("event: error"), Comment(rawValue: payload))
+        #expect(payload.contains("\"code\":\"transport_error\""), Comment(rawValue: payload))
+        #expect(payload.contains("data: [DONE]"), Comment(rawValue: payload))
+        #expect(await harness.vlmClient.lastPrefillRequest != nil)
+    }
+
+    @Test("POST /v1/chat/completions preserves empty VLM stream completion after admission inspection")
+    func postChatCompletionsPreservesEmptyVLMStreamCompletionAfterAdmissionInspection() async throws {
+        let requestID = "req-http-vlm-empty-stream-replay"
+        let harness = makeGemma4VLMOpenAIHandler(
+            requestID: requestID,
+            vlmEvents: [],
+            configureModel: { model in
+                model.settings.ext["melix.vlm.execution_mode"] = "multimodal"
+            }
+        )
+        let body = try #require(vlmAttentionBudgetChatBody(stream: true))
+
+        let response = try await harness.handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        let payload = try await collectBody(response.body)
+
+        #expect(response.statusCode == 200)
+        #expect(response.headers["content-type"] == "text/event-stream; charset=utf-8")
+        #expect(payload.contains("\"request_id\":\"\(requestID)\""), Comment(rawValue: payload))
+        #expect(payload.contains("data: [DONE]"), Comment(rawValue: payload))
+    }
+
+    @Test("POST /v1/chat/completions preserves VLM attention budget details across stream modes")
+    func postChatCompletionsPreservesVLMAttentionBudgetDetailsAcrossStreamModes() async throws {
+        let details = vlmAttentionBudgetDetails()
+        let streamRequestID = "req-http-vlm-attention-budget-stream-parity"
+        let nonStreamRequestID = "req-http-vlm-attention-budget-json-parity"
+        let streamHarness = makeGemma4VLMOpenAIHandler(
+            requestID: streamRequestID,
+            vlmPrefillResponse: vlmAttentionBudgetPrefillRefusal(details: details),
+            configureModel: { model in
+                model.settings.ext["melix.vlm.execution_mode"] = "multimodal"
+            }
+        )
+        let nonStreamHarness = makeGemma4VLMOpenAIHandler(
+            requestID: nonStreamRequestID,
+            vlmPrefillResponse: vlmAttentionBudgetPrefillRefusal(details: details),
+            configureModel: { model in
+                model.settings.ext["melix.vlm.execution_mode"] = "multimodal"
+            }
+        )
+
+        let streamResponse = try await streamHarness.handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: try #require(vlmAttentionBudgetChatBody(stream: true))
+            )
+        )
+        let nonStreamResponse = try await nonStreamHarness.handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: try #require(vlmAttentionBudgetChatBody(stream: false))
+            )
+        )
+        let streamError = try #require((try await jsonPayload(from: streamResponse.body))["error"] as? [String: Any])
+        let nonStreamError = try #require((try await jsonPayload(from: nonStreamResponse.body))["error"] as? [String: Any])
+        let streamDetails = try #require(streamError["details"] as? [String: Any])
+        let nonStreamDetails = try #require(nonStreamError["details"] as? [String: Any])
+
+        #expect(streamResponse.statusCode == 400)
+        #expect(nonStreamResponse.statusCode == 400)
+        #expect(streamError["code"] as? String == nonStreamError["code"] as? String)
+        #expect(streamDetails["predicted_attention_bytes"] as? String == nonStreamDetails["predicted_attention_bytes"] as? String)
+        #expect(streamDetails["attention_budget_bytes"] as? String == nonStreamDetails["attention_budget_bytes"] as? String)
+        #expect(streamDetails["auto_chunk_reason"] as? String == nonStreamDetails["auto_chunk_reason"] as? String)
+        #expect(streamDetails["prefill_chunk_mode"] as? String == nonStreamDetails["prefill_chunk_mode"] as? String)
+        #expect(streamDetails["selected_prefill_step_size"] as? String == nonStreamDetails["selected_prefill_step_size"] as? String)
     }
 
     @Test("model sparse-prefill policy is applied to generated worker requests")
@@ -13200,6 +13383,9 @@ struct OpenAIHandlerTests {
         finishReason: String = "stop",
         assistantText: String = "ready",
         textEvents: [Melix_Worker_V1_ExecuteEvent]? = nil,
+        vlmEvents: [Melix_Worker_V1_ExecuteEvent]? = nil,
+        vlmStreamFailure: Error? = nil,
+        vlmPrefillResponse: Melix_Worker_V1_PrefillResponse? = nil,
         textLoadModelHandle: String = "melix-dev-text::swift",
         gatewayServingDefaultsStore: GatewayServingDefaultsStore? = nil,
         mcpToolCatalog: MCPToolCatalog = .empty,
@@ -13230,16 +13416,19 @@ struct OpenAIHandlerTests {
             events: resolvedTextEvents,
             loadModelHandle: textLoadModelHandle
         )
+        let resolvedVLMEvents = vlmEvents ?? [
+            makeCompletedEvent(
+                requestID: requestID,
+                seq: 1,
+                finishReason: finishReason,
+                assistantText: assistantText
+            ),
+        ]
         let vlmClient = ScriptedWorkerClient(
-            events: [
-                makeCompletedEvent(
-                    requestID: requestID,
-                    seq: 1,
-                    finishReason: finishReason,
-                    assistantText: assistantText
-                ),
-            ],
-            loadModelHandle: "melix-dev-vlm::swift-vision"
+            events: resolvedVLMEvents,
+            streamFailure: vlmStreamFailure,
+            loadModelHandle: "melix-dev-vlm::swift-vision",
+            prefillResponseOverride: vlmPrefillResponse
         )
         let workerRegistry = WorkerRegistry(
             defaultTextClient: textClient,
@@ -13382,6 +13571,7 @@ private actor ScriptedWorkerClient:
     private let runtimeKVCacheBytes: UInt64
     private let runtimeStatsFailure: Error?
     private let runtimeStatsResponseOverride: Melix_Worker_V1_GetRuntimeStatsResponse?
+    private let prefillResponseOverride: Melix_Worker_V1_PrefillResponse?
     private let unloadDelayNanoseconds: UInt64
     private let unloadGate: ScriptedWorkerUnloadGate?
     private(set) var lastGenerateRequest: Melix_Worker_V1_GenerateRequest?
@@ -13402,6 +13592,7 @@ private actor ScriptedWorkerClient:
         runtimeKVCacheBytes: UInt64 = 0,
         runtimeStatsFailure: Error? = nil,
         runtimeStatsResponseOverride: Melix_Worker_V1_GetRuntimeStatsResponse? = nil,
+        prefillResponseOverride: Melix_Worker_V1_PrefillResponse? = nil,
         unloadDelayNanoseconds: UInt64 = 0,
         unloadGate: ScriptedWorkerUnloadGate? = nil
     ) {
@@ -13415,6 +13606,7 @@ private actor ScriptedWorkerClient:
         self.runtimeKVCacheBytes = runtimeKVCacheBytes
         self.runtimeStatsFailure = runtimeStatsFailure
         self.runtimeStatsResponseOverride = runtimeStatsResponseOverride
+        self.prefillResponseOverride = prefillResponseOverride
         self.unloadDelayNanoseconds = unloadDelayNanoseconds
         self.unloadGate = unloadGate
     }
@@ -13456,6 +13648,9 @@ private actor ScriptedWorkerClient:
         request: Melix_Worker_V1_PrefillRequest
     ) async throws -> Melix_Worker_V1_PrefillResponse {
         lastPrefillRequest = request
+        if let prefillResponseOverride {
+            return prefillResponseOverride
+        }
         var response = Melix_Worker_V1_PrefillResponse()
         response.ok = true
         response.decodeHandle = "decode-\(request.execution.id.requestID)"
@@ -14200,6 +14395,48 @@ private func compatPolicyChatBody(stream: Bool) -> Data? {
       ]
     }
     """.data(using: .utf8)
+}
+
+private func vlmAttentionBudgetChatBody(stream: Bool) -> Data? {
+    """
+    {
+      "model": "melix-dev-vlm",
+      "stream": \(stream ? "true" : "false"),
+      "max_tokens": 8,
+      "messages": [
+        {
+          "role": "user",
+          "content": [
+            { "type": "text", "text": "Describe this image." },
+            { "type": "image_url", "image_url": { "data": "aW1hZ2U=" } }
+          ]
+        }
+      ]
+    }
+    """.data(using: .utf8)
+}
+
+private func vlmAttentionBudgetDetails() -> [String: String] {
+    [
+        "family_id": "gemma4-v1",
+        "prompt_tokens": "512",
+        "predicted_attention_bytes": "17179869184",
+        "attention_budget_bytes": "1",
+        "auto_chunk_reason": "attention_budget_exceeded",
+        "prefill_chunk_mode": "refused",
+        "selected_prefill_step_size": "0",
+    ]
+}
+
+private func vlmAttentionBudgetPrefillRefusal(
+    details: [String: String]
+) -> Melix_Worker_V1_PrefillResponse {
+    var response = Melix_Worker_V1_PrefillResponse()
+    response.ok = false
+    response.error.code = "multimodal_prefill_attention_budget_exceeded"
+    response.error.message = "Predicted multimodal prefill attention memory exceeds the active budget."
+    response.error.details = details
+    return response
 }
 
 private func compatReceiptFieldNames(_ receipt: String) -> Set<String> {

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -4674,7 +4674,8 @@ struct OpenAIHandlerTests {
 
         #expect(response.statusCode == 200)
         #expect(response.headers["content-type"] == "text/event-stream; charset=utf-8")
-        #expect(payload.contains("\"request_id\":\"\(requestID)\""), Comment(rawValue: payload))
+        #expect(payload.contains("\"id\":\"\(requestID)\""), Comment(rawValue: payload))
+        #expect(payload.contains("\"finish_reason\":\"stop\""), Comment(rawValue: payload))
         #expect(payload.contains("data: [DONE]"), Comment(rawValue: payload))
     }
 


### PR DESCRIPTION
## Summary
- Add a governing plan for #1452 streaming/non-streaming VLM preflight-budget parity.
- Inspect the first media-bearing stream event before emitting SSE so attention-budget refusals return typed JSON before the first SSE byte.
- Add streaming/non-streaming parity fixtures and replay edge coverage for VLM admission inspection.

## Plan or Spec
- Governing parent plan: `docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md`
- Implementation plan: `docs/plans/2026-06-18-issue-1452-streaming-budget-parity.md`
- Closes #1452

## Commands Run
```text
make proto
# pass; no generated artifact changes

MELIX_HOME="$PWD/.runtime/test-home-issue1452" swift test --package-path services/control-plane-swift --filter 'OpenAIHandlerTests/postChatCompletionsRejectsStreamingVLMAttentionBudgetBeforeFirstSSEByte|OpenAIHandlerTests/postChatCompletionsPreservesVLMAttentionBudgetDetailsAcrossStreamModes|OpenAIHandlerTests/postChatCompletionsPreservesFirstVLMTokenAfterStreamingAdmissionInspection|OpenAIHandlerTests/postChatCompletionsPreservesNonAdmissionVLMStreamErrorsAsSSEFrames|OpenAIHandlerTests/postChatCompletionsPreservesEmptyVLMStreamCompletionAfterAdmissionInspection'
# pass: 5 tests

MELIX_HOME="$PWD/.runtime/test-home-issue1452" swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests
# pass: 224 tests

MELIX_HOME="$PWD/.runtime/test-home-issue1452" HOME="$PWD/.swift-home/control-plane-swift" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/control-plane-swift" xcrun swift test --package-path services/control-plane-swift --enable-code-coverage --filter OpenAIHandlerTests
# pass: 224 tests

UV_PYTHON=3.12 UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/HTTPGatewayTests/HTTPGatewayTestSupport.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
# pass: TOTAL 96.73% (296/306)

make swift-test
# pass

env -u MELIX_HOME make py-test
# pass: 4075 passed, 14 skipped

make integration-test
# pass: 120 passed, 1 skipped

UV_PYTHON=3.12 UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/issue1452-after-main-merge/perf/scope/changed-files.json --output .runtime/issue1452-after-main-merge/perf/scope/scope.json
UV_PYTHON=3.12 UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python scripts/pr_scoped_performance_report.py --scope .runtime/issue1452-after-main-merge/perf/scope/scope.json --results-dir .runtime/issue1452-after-main-merge/perf/results --format terminal --output-dir .runtime/issue1452-after-main-merge/perf/report
# pass: Status ok; selected probes 0; regressions 0
```

## Coverage and Metrics
- Changed-line coverage: `96.73%` (`296/306`) for the touched Swift files.
- Local PR scoped performance report: `Status: ok`; changed files `4`; selected probes `0`; regressions `0`; context regressions `0`; verification failures `0`.
- Observability mode: `minimal`; this reuses typed worker error details and existing request lifecycle accounting, with no new runtime metrics or debug diagnostics.
- Probe overhead: `N/A`; no new probe or runtime instrumentation was added.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
