### PR TITLE
perf: fast path code block newline skip

### DIFF
--- a/docs/plans/2026-06-18-code-eval-codeblock-newline-fastpath.md
+++ b/docs/plans/2026-06-18-code-eval-codeblock-newline-fastpath.md
@@ -1,0 +1,39 @@
+# Code Evaluation Code Block Newline Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to `extract_candidate_code(...)` in
+`services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+The parser already targets the last fenced code block and recognizes lowercase
+and mixed-case `python` language tags. After stripping that tag, the common
+model-output shape has a single newline before the code body. This slice handles
+that one-newline case directly before falling back to the existing generic
+whitespace loop, preserving behavior for spaces, tabs, CRLF-style whitespace,
+and non-`python` tags.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`code-eval-code-block-last-match-streaming` in
+`infra/perf/pr_scoped_probes.json`. The registry entry has focused
+`test_command`, `coverage_command`, and `probe_command` values and measures
+last-block extraction elapsed time, peak traced bytes, block count, and extracted
+character count.
+
+## Verification plan
+
+- Run the registered focused `test_command` locally on Linux.
+- Run the registered changed-scope `coverage_command` locally on Linux.
+- Run the registered `probe_command` locally on Linux and compare against the
+  current `origin/main` worktree baseline.
+- Use GitHub Actions PR-scoped performance as the merge gate after opening the
+  PR.
+
+## Expected outcome
+
+Avoid one `str.isspace()` loop iteration for the common ` ```python\n... ` code
+block form while leaving fallback whitespace semantics unchanged. The expected
+local signal is a lower `elapsed_ms_mean` in
+`code-eval-code-block-last-match-streaming` with unchanged `peak_bytes_mean`,
+`block_count`, and `extracted_chars_mean`.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -80,6 +80,8 @@ def _code_block_content_start(text: str, start: int) -> int:
     elif _starts_with_python_tag_ignore_case(text, start):
         start += _PYTHON_CODE_BLOCK_TAG_LENGTH
     text_length = len(text)
+    if start < text_length and text[start] == "\n":
+        start += 1
     while start < text_length and text[start].isspace():
         start += 1
     return start


### PR DESCRIPTION
## Summary
- Adds a Python code-eval fast path for the common fenced block shape where a `python` tag is followed by a single newline before code content.
- Preserves the existing generic whitespace fallback for spaces, tabs, CRLF-style whitespace, and other edge cases.
- Documents the slice and registered probe expectations.

## Plan or Spec
- `docs/plans/2026-06-18-code-eval-codeblock-newline-fastpath.md`
- Registered PR-scoped probe: `code-eval-code-block-last-match-streaming`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py` (5 post-change samples)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 4 passed.
- Changed-scope coverage: 100.00% (`TOTAL 2 0 100%`).
- Local Linux baseline probe from `origin/main` worktree: `elapsed_ms_mean=0.03740337810346058`, `peak_bytes_mean=245`, `block_count=2500`, `extracted_chars_mean=37`, `sample_count=7`.
- Local Linux post-change probe samples:
  - `elapsed_ms_mean=0.03170368394681385`, `peak_bytes_mean=245`
  - `elapsed_ms_mean=0.031742134264537265`, `peak_bytes_mean=245`
  - `elapsed_ms_mean=0.03599468618631363`, `peak_bytes_mean=245`
  - `elapsed_ms_mean=0.03216734954289028`, `peak_bytes_mean=245`
  - `elapsed_ms_mean=0.03427692822047642`, `peak_bytes_mean=245`
- Mean of post-change elapsed samples: about `0.03318 ms`, about `11.3%` faster than the recorded local baseline; traced peak bytes unchanged at `245`.
- CI PR-scoped performance run: https://github.com/Keith-CY/melix/actions/runs/27750423270 (`success`).
- CI registered probe artifact (`code-eval-code-block-last-match-streaming`): base `elapsed_ms_mean=0.042633857138493374`, head `elapsed_ms_mean=0.04250642857885266`, peak bytes unchanged at `245`; head is ~`0.3%` faster.

## Known Gaps
- Local validation is Linux/Python-only. GitHub Actions PR-scoped performance completed successfully and was used as the merge gate.

## Evidence Checklist
- [x] Path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage meets the 95% requirement.
- [x] Local registered probe was run and compared with baseline.
- [x] GitHub Actions and PR-scoped performance probe completed successfully.
