### PR TITLE
perf: fast path lowercase MLX repo ids

### DIFF
--- a/docs/plans/2026-06-18-hub-catalog-repo-id-lowercase-fastpath.md
+++ b/docs/plans/2026-06-18-hub-catalog-repo-id-lowercase-fastpath.md
@@ -1,0 +1,43 @@
+# Hub catalog lowercase repo-id MLX fast path
+
+## Scope
+
+This Python performance slice is limited to Hub catalog MLX compatibility checks in
+`services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+
+The change preserves existing case-insensitive repo-id matching semantics while
+adding a lower-case `mlx` substring fast path before allocating a lower-cased
+repo id. This targets common Hub repo ids that already contain lower-case `mlx`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`hub-catalog-size-hint-regex-precompile` in
+`infra/perf/pr_scoped_probes.json`.
+
+The registry entry already provides focused `test_command`, `coverage_command`,
+and `probe_command` entries for `hub_catalog.py`, its focused tests, and
+`scripts/hub_catalog_size_hint_probe.py`. The relevant metric for this slice is
+`payload_compatibility_elapsed_ms_mean`; the probe also records
+`elapsed_ms_mean` for the adjacent size-hint path sharing the same file.
+
+## Plan
+
+1. Keep the existing repo-id case-insensitivity regression tests as the behavior
+   guard for `_payload_is_mlx_compatible()` and `_is_mlx_compatible()`.
+2. Add one helper that checks for a lower-case `mlx` substring before falling
+   back to the existing lower-case comparison.
+3. Run the focused Hub catalog tests, changed-scope coverage, and the registered
+   Hub catalog probe locally on Linux.
+4. Use GitHub Actions and the registered PR-scoped performance report as the
+   merge gate.
+
+## Verification
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
+```

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -508,6 +508,10 @@ def _base_models(value: Any) -> list[str]:
     return []
 
 
+def _repo_id_contains_mlx(repo_id: str) -> bool:
+    return "mlx" in repo_id or "mlx" in repo_id.lower()
+
+
 def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:
     library_name = _string(payload.get("library_name"))
     if library_name and _is_mlx_atom(library_name):
@@ -515,7 +519,7 @@ def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:
     if _tag_payload_contains_mlx(payload.get("tags")):
         return True
     repo_id = _string(payload.get("id") or payload.get("modelId"))
-    if "mlx" in repo_id.lower():
+    if _repo_id_contains_mlx(repo_id):
         return True
     card_data = payload.get("cardData")
     if not isinstance(card_data, dict):
@@ -541,8 +545,7 @@ def _is_mlx_compatible(
         return True
     if _is_mlx_atom(library_name):
         return True
-    lowered_repo_id = repo_id.lower()
-    if "mlx" in lowered_repo_id:
+    if _repo_id_contains_mlx(repo_id):
         return True
     card_tags = card_data.get("tags")
     if not card_tags:


### PR DESCRIPTION
## Summary
- Adds a lowercase `mlx` repo-id fast path before falling back to the existing case-insensitive comparison in Hub catalog MLX compatibility checks.
- Reuses the helper from both `_payload_is_mlx_compatible()` and `_is_mlx_compatible()` while preserving existing mixed-case behavior.

## Plan or Spec
- `docs/plans/2026-06-18-hub-catalog-repo-id-lowercase-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 84 passed in 1.25s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# 84 passed in 0.44s; TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# {"elapsed_ms_mean": 1837.9112409427762, "payload_compatibility_elapsed_ms_mean": 201.56748853623867, "payload_compatibility_calls_mean": 200000.0, "size_hint_calls_mean": 0.0, ...}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Registered probe: `hub-catalog-size-hint-regex-precompile` has `test_command`, `coverage_command`, and `probe_command` entries.
- Local Linux baseline probe before change: `payload_compatibility_elapsed_ms_mean=205.6880509480834`, `elapsed_ms_mean=1823.2980206608772`.
- Local Linux candidate probe after change: `payload_compatibility_elapsed_ms_mean=201.56748853623867`, `elapsed_ms_mean=1837.9112409427762`.
- Target metric delta: `payload_compatibility_elapsed_ms_mean` improved by `-4.12056241184473 ms` (`~2.00%` faster). Adjacent size-hint elapsed moved `+14.613220281898975 ms` (`~0.80%` slower), below the registered 5% warning threshold and outside the targeted repo-id compatibility path.
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- None. CI remains the registered probe validation source for the PR before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability/debug mode changes.
- [x] Deferred work and known gaps are stated explicitly.
