### PR TITLE
perf: lazily strip code eval code blocks

### DIFF
--- a/docs/plans/2026-06-18-code-eval-codeblock-lazy-strip.md
+++ b/docs/plans/2026-06-18-code-eval-codeblock-lazy-strip.md
@@ -1,0 +1,47 @@
+# Code eval code-block lazy strip performance slice
+
+## Scope
+
+This Python-only performance slice is limited to `extract_candidate_code(...)` in
+`services/mlx-worker-python/worker/engine/code_eval_runner.py`. The code-block
+path should avoid allocating a fully stripped copy of large model responses before
+the last fenced block is located. Plain text responses keep the existing stripped
+return value, and whitespace-only responses still report `empty_prediction`.
+
+## Registered PR-scoped probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`code-eval-code-block-last-match-streaming` in `infra/perf/pr_scoped_probes.json`.
+The probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_code_block_extract_probe.py`
+
+## Implementation plan
+
+1. Preserve the empty/whitespace-only behavior without allocating a stripped copy
+   on normal code-block responses.
+2. Use the original response string for fenced-block `rfind`, count, slicing, and
+   content-start detection.
+3. Strip only the extracted candidate or plain-text fallback.
+4. Add regression coverage for leading/trailing whitespace around a fenced Python
+   block.
+
+## Verification plan
+
+- Run the registered focused tests.
+- Run the registered changed-scope coverage command.
+- Run the registered code-block extraction probe locally on Linux and compare the
+  before/after `elapsed_ms_mean` and `peak_bytes_mean` values.
+- Use GitHub Actions and the PR-scoped performance workflow as the final merge
+  gate.
+
+## Expected outcome
+
+The code-block hot path should reduce or hold peak allocation by avoiding a
+full-response `strip()` copy when model output includes outer whitespace, and it
+should show lower or neutral `elapsed_ms_mean` on the synthetic multi-block
+extraction probe.

--- a/scripts/code_eval_code_block_extract_probe.py
+++ b/scripts/code_eval_code_block_extract_probe.py
@@ -23,7 +23,7 @@ def _build_response(block_count: int) -> str:
             f"analysis chunk {index}\n```{tag}\ndef candidate_{index}():\n    return {index}\n```"
         )
     trailing_commentary = "\n".join(f"post answer note {index}" for index in range(block_count))
-    return "\n\n".join(blocks) + "\n" + trailing_commentary
+    return "\n  " + "\n\n".join(blocks) + "\n" + trailing_commentary + "   \n\t"
 
 
 def main() -> None:

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -50,6 +50,10 @@ def test_extract_candidate_code_handles_empty_plaintext_and_code_blocks() -> Non
         "print('hi')",
         "parsed_code_block",
     )
+    assert code_eval_runner.extract_candidate_code("\n  ```python\nprint('wrapped')\n```   \n\t") == (
+        "print('wrapped')",
+        "parsed_code_block",
+    )
     assert code_eval_runner.extract_candidate_code("```python\n\n```") == (
         "",
         "parsed_code_block",

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -50,28 +50,27 @@ class CodeEvaluationResult:
 
 
 def extract_candidate_code(raw_response: str) -> tuple[str, str]:
-    normalized = raw_response.strip()
-    if not normalized:
+    if not raw_response or raw_response.isspace():
         return "", "empty_prediction"
 
     fence = "```"
-    closing = normalized.rfind(fence)
+    closing = raw_response.rfind(fence)
     if closing >= 0:
-        opening = normalized.rfind(fence, 0, closing)
+        opening = raw_response.rfind(fence, 0, closing)
         if opening >= 0:
-            content_start = _code_block_content_start(normalized, opening + 3)
-            candidate = normalized[content_start:closing].strip()
+            content_start = _code_block_content_start(raw_response, opening + 3)
+            candidate = raw_response[content_start:closing].strip()
             if candidate:
                 return candidate, "parsed_code_block"
-            if normalized.count(fence) % 2 == 0:
+            if raw_response.count(fence) % 2 == 0:
                 return candidate, "parsed_code_block"
             closing = opening
-            opening = normalized.rfind(fence, 0, closing)
+            opening = raw_response.rfind(fence, 0, closing)
             if opening >= 0:
-                content_start = _code_block_content_start(normalized, opening + 3)
-                return normalized[content_start:closing].strip(), "parsed_code_block"
+                content_start = _code_block_content_start(raw_response, opening + 3)
+                return raw_response[content_start:closing].strip(), "parsed_code_block"
 
-    return normalized, "parsed_code"
+    return raw_response.strip(), "parsed_code"
 
 
 def _code_block_content_start(text: str, start: int) -> int:


### PR DESCRIPTION
## Summary
- Avoid a full-response `strip()` before locating fenced code blocks in `extract_candidate_code(...)`.
- Keep whitespace-only and plain-text fallback behavior unchanged.
- Extend the registered code-block extraction probe fixture to include outer whitespace around a large multi-block response.

## Plan or Spec
- `docs/plans/2026-06-18-code-eval-codeblock-lazy-strip.md`
- Registered PR-scoped probe: `code-eval-code-block-last-match-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline focused tests/probe on origin/main before changes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# exit 0; 4 passed in 1.02s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py
# exit 0; {"block_count": 2500.0, "elapsed_ms_mean": 0.032648444175720215, "extracted_chars_mean": 37.0, "peak_bytes_mean": 245.0, "sample_count": 7.0}

# Manual old-vs-new comparison using the updated outer-whitespace probe fixture
python3 - <<'PY'
# loads origin/main code_eval_runner.py and compares it against this branch
PY
# exit 0; {'old_elapsed_ms_mean': 0.11835919900072946, 'new_elapsed_ms_mean': 0.09872857481241226, 'delta_ms': -0.019630624188317194, 'speedup': 1.1988342708847572, 'old_peak_bytes_mean': 233368.0, 'new_peak_bytes_mean': 261.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# exit 0; 4 passed in 0.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# exit 0; 4 passed in 0.25s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# exit 0; Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py
# exit 0; TOTAL 12 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py
# exit 0; {"block_count": 2500.0, "elapsed_ms_mean": 0.04147485430751528, "extracted_chars_mean": 37.0, "peak_bytes_mean": 245.0, "sample_count": 7.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Manual old-vs-new comparison on updated outer-whitespace fixture: `old_mean=0.11835919900072946ms`, `new_mean=0.09872857481241226ms`, `speedup=1.1988342708847572`, `delta_ms=-0.019630624188317194`, `old_peak=233368.0 bytes`, `new_peak=261.0 bytes`.
- Registered local probe on branch: `elapsed_ms_mean=0.04147485430751528`, `peak_bytes_mean=245.0`, `block_count=2500.0`.
- CI PR-scoped performance workflow is required for the final registered probe report before merge.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance report is still required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; probe overhead changes are N/A because this only adjusts a synthetic probe fixture.
- [x] Deferred work and known gaps are stated explicitly.
