### PR TITLE
perf: avoid command summary partition payload

### DIFF
--- a/docs/plans/2026-06-18-pr-scoped-command-summary-index-scan.md
+++ b/docs/plans/2026-06-18-pr-scoped-command-summary-index-scan.md
@@ -11,7 +11,8 @@ The affected path is already covered by the registered `pr-scoped-performance-sc
 ## Implementation plan
 
 - Preserve the existing compact single-line summary semantics.
-- Use a single whole-command `strip()` before first-line selection so trailing blank heredoc lines are eliminated without allocating and scanning the remaining payload separately.
+- Keep the existing single whole-command `strip()` before first-line selection so trailing blank heredoc lines are eliminated.
+- Replace tuple-producing `partition("\n")` with a direct newline index lookup so the summary path does not allocate the unused remaining payload.
 - Keep the behavior tests under `test_command_summary_keeps_ci_heartbeats_compact` as the regression guard.
 
 ## Verification plan

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -78,10 +78,11 @@ def _summarize_command(command: str, *, max_length: int = 180) -> str:
     if not command:
         return "<empty command>"
 
-    first_line, separator, _remaining_lines = command.partition("\n")
-    summary = first_line.rstrip()
-    if separator:
-        summary = f"{summary} ..."
+    newline_index = command.find("\n")
+    if newline_index < 0:
+        summary = command
+    else:
+        summary = f"{command[:newline_index].rstrip()} ..."
     if len(summary) > max_length:
         return f"{summary[: max_length - 4]} ..."
     return summary


### PR DESCRIPTION
## Summary
- Replace `_summarize_command()`'s tuple-producing `partition("\n")` path with a direct newline index lookup.
- Keep CI heartbeat command summaries byte-for-byte compatible while avoiding allocation of the unused remaining command payload.

## Plan or Spec
- `docs/plans/2026-06-18-pr-scoped-command-summary-index-scan.md`

## Commands Run
```text
# Baseline registered probe on origin/main before the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/melix_scope_probe_run.py
# exit 0; command_summary_ms_mean=11.085737, build_scope_report_ms_mean=2.046296

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact
# exit 0; 1 passed in 0.87s

python3 /tmp/melix_run_probe_command.py pr-scoped-performance-scope-matcher test_command
# exit 0; 20 passed in 16.75s

python3 /tmp/melix_run_probe_command.py pr-scoped-performance-scope-matcher coverage_command
# exit 0; 20 passed in 49.95s; changed-scope coverage TOTAL 4 0 100%

python3 /tmp/melix_run_probe_command.py pr-scoped-performance-scope-matcher probe_command
# exit 0; command_summary_ms_mean=9.879107, build_scope_report_ms_mean=2.020489

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`services/mlx-worker-python/worker/productization/pr_scoped_performance.py`, 4/4 measurable changed lines covered).
- Registered probe: `pr-scoped-performance-scope-matcher`.
- Local Linux probe delta: `command_summary_ms_mean` 11.085737 ms → 9.879107 ms (`delta=-1.206630 ms`, `speedup=10.885%`).
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this Python tooling slice used the registered focused test, coverage, and probe commands.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing registered PR-scoped performance probe; no new runtime observability or probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
