### PR TITLE
perf: branch on embedding projection norm

### DIFF
--- a/docs/plans/2026-06-18-embedding-project-default-norm-branch.md
+++ b/docs/plans/2026-06-18-embedding-project-default-norm-branch.md
@@ -1,0 +1,49 @@
+# Embedding project default-dimension norm branch slice
+
+## Scope
+
+This Python-only performance slice is limited to
+`services/mlx-worker-python/worker/runtime/embedding_backends.py` and the
+registered deterministic embedding projection path. It preserves deterministic
+embedding values while replacing the default-dimension zero-norm guard's
+exception path with an explicit norm check.
+
+No protocol, Swift, macOS, model registry, runtime admission, or generated
+protobuf behavior changes are included.
+
+## Registered performance probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `deterministic-embedding-project-digest-allocation` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` fields, and watches:
+
+- `services/mlx-worker-python/worker/runtime/embedding_backends.py`
+- `services/mlx-worker-python/tests/test_embedding_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/deterministic_embedding_project_digest_probe.py`
+
+## Optimization slice
+
+1. Keep the digest projection base-value construction unchanged.
+2. For the `dimensions == 8` hot path, compute `l2_norm` once, branch on
+   `0.0`, and then divide by the norm for ordinary non-zero vectors.
+3. Keep the zero-vector fallback identical (`[0.0] * 8`).
+4. Verify with the registered focused tests, changed-scope coverage, and the
+   registered local probe on Linux.
+5. Use GitHub Actions PR-scoped performance as the final merge gate.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-project-digest-allocation --base-repo <baseline-worktree> --head-repo "$PWD" --output /tmp/embedding_project_digest_probe.json
+```
+
+## Expected metrics
+
+The primary target is lower `elapsed_ms_mean` for expanded projection and no
+behavior/checksum drift. `default_dimension_elapsed_ms_mean` should remain flat
+or improve. Peak byte metrics are accepted only when they stay within the
+registered probe threshold and the primary elapsed metric improves.

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -51,10 +51,10 @@ class DeterministicEmbeddingBackend:
             for raw in _UNPACK_DIGEST_UINT32(_SHA256(seed_text.encode("utf-8")).digest())
         ]
         if dimensions == 8:
-            try:
-                inverse_l2_norm = 1.0 / math.sqrt(sum(value * value for value in base_values))
-            except ZeroDivisionError:
+            l2_norm = math.sqrt(sum(value * value for value in base_values))
+            if l2_norm == 0.0:
                 return [0.0] * 8
+            inverse_l2_norm = 1.0 / l2_norm
             return [round(value * inverse_l2_norm, 6) for value in base_values]
         return self._project_digest_expanded(base_values, dimensions)
 


### PR DESCRIPTION
## Summary
- Replace the deterministic embedding default-dimension zero-norm exception guard with an explicit norm branch.
- Keep deterministic projection output/checksums unchanged while avoiding the ordinary non-zero-vector exception frame path.
- Add the governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-18-embedding-project-default-norm-branch.md`
- Registered probe: `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
# 20 passed in 16.79s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
# 20 passed in 50.09s; changed-line coverage 100.00% (3/3)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-project-digest-allocation --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-embedding-project-base-tuple-20260618 --head-repo "$PWD" --output /tmp/embedding_project_digest_probe2.json
# head verification ok; base/head probe ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (3/3 measurable changed lines) for `services/mlx-worker-python/worker/runtime/embedding_backends.py`.
- Registered local probe (`deterministic-embedding-project-digest-allocation`, Linux):
  - `elapsed_ms_mean`: base 16.708409 ms → head 15.963150 ms (delta -0.745259 ms, ~4.46% faster)
  - `default_dimension_elapsed_ms_mean`: base 118.555891 ms → head 118.181199 ms (delta -0.374692 ms, ~0.32% faster)
  - `peak_bytes_mean`: base 74840.888889 bytes → head 74840.888889 bytes (flat)
  - `default_dimension_peak_bytes_mean`: base 1237.333333 bytes → head 1261.333333 bytes (~1.94% higher, within registered 5% threshold)
  - Checksums unchanged: `checksum=8.325108`, `default_dimension_checksum=213.60249`.
- CI PR-scoped performance is still required as the final registered probe validation before merge.

## Known Gaps
- None for the Python slice. Swift/macOS runtime validation is not applicable.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability/debug mode changes.
- [x] Deferred work and known gaps are stated explicitly.
