### PR TITLE
perf: short-circuit exact JSON typed scores

### DIFF
--- a/docs/plans/2026-06-18-evaluation-json-root-equality-fastpath.md
+++ b/docs/plans/2026-06-18-evaluation-json-root-equality-fastpath.md
@@ -1,0 +1,36 @@
+# Evaluation JSON Root Equality Fast Path Performance Slice
+
+## Scope
+
+This Python performance slice is limited to
+`services/mlx-worker-python/worker/productization/evaluation_final_result.py`.
+`_json_typed_score()` now returns `1.0` immediately when the expected JSON value
+and actual JSON value are exactly equal before entering dict/list child scoring.
+
+The behavior is unchanged because exact equality already implies a perfect typed
+score. Ignored-path handling still matters for non-identical payloads, so the
+slice only short-circuits the exact-match case.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`evaluation-final-result-json-typed-score-aggregate` in
+`infra/perf/pr_scoped_probes.json`.
+
+The registry entry already includes focused `test_command`, `coverage_command`,
+and `probe_command` entries for `evaluation_final_result.py`, its focused tests,
+and `scripts/evaluation_json_typed_score_probe.py`.
+
+## Plan
+
+1. Add a regression test proving exact root matches do not iterate dict children.
+2. Add one equality fast path at the top of `_json_typed_score()`.
+3. Run the focused evaluation final-result tests, changed-scope coverage, and the
+   registered evaluation JSON typed-score probe locally on Linux.
+4. Use GitHub Actions and the registered PR-scoped performance report as the
+   merge gate.
+
+## Success Metric
+
+The registered probe should report lower `elapsed_ms_mean` for the JSON typed
+score workload while preserving `score_checksum`.

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -16,11 +16,25 @@ from worker.productization.evaluation_final_result import (
     EvaluationProfileDefinition,
     _local_source_metadata,
     _last_nonblank_text_line,
+    _json_typed_score,
     extract_final_result,
     materialize_hf_evaluation_dataset,
     materialize_local_evaluation_dataset,
     score_final_result,
 )
+
+
+def test_json_typed_score_short_circuits_exact_root_match_before_child_iteration() -> None:
+    class _NoItemsDict(dict[str, object]):
+        def items(self):  # type: ignore[override]
+            raise AssertionError("exact root matches should not iterate children")
+
+    expected = _NoItemsDict({"answer": {"value": 42}, "metadata": ["kept"]})
+    actual = {"answer": {"value": 42}, "metadata": ["kept"]}
+
+    assert _json_typed_score(expected=expected, actual=actual, ignored_paths=()) == 1.0
+    with pytest.raises(AssertionError, match="exact root matches"):
+        _json_typed_score(expected=expected, actual={"answer": {"value": 0}}, ignored_paths=())
 
 
 def test_write_jsonl_rows_streams_each_row_without_joining_the_full_payload(

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -489,6 +489,8 @@ def _matches_json_schema_pattern(pattern_properties: Any, key: str) -> bool:
 
 
 def _json_typed_score(*, expected: Any, actual: Any, ignored_paths: Collection[str], path: str = "") -> float:
+    if expected == actual:
+        return 1.0
     if isinstance(expected, dict):
         total = 0.0
         count = 0


### PR DESCRIPTION
## Summary
- Add an exact-root equality fast path to `_json_typed_score()` before dict/list child scoring.
- Add a focused regression proving exact root matches do not iterate dict children.
- Document the slice and registered probe coverage in `docs/plans/2026-06-18-evaluation-json-root-equality-fastpath.md`.

## Plan or Spec
- Plan: `docs/plans/2026-06-18-evaluation-json-root-equality-fastpath.md`
- Registered probe: `evaluation-final-result-json-typed-score-aggregate` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_json_typed_score_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_json_typed_score_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 42 passed.
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Local Linux registered probe baseline before change: `elapsed_ms_mean=14.806628040969372`, `peak_bytes_mean=713702.6`, `score_checksum=35.0`.
- Local Linux registered probe after change: `elapsed_ms_mean=12.596040777862072`, `peak_bytes_mean=713702.6`, `score_checksum=35.0`.
- Delta: `-2.2105872631073 ms` mean elapsed, approximately `1.18x` faster for the registered JSON typed-score workload.

## Known Gaps
- Local validation was performed on Linux for the Python slice; CI is still required for the registered PR-scoped performance workflow and repository gates.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally and preserved checksum.
- [ ] GitHub Actions completed successfully.
