### PR TITLE
perf: return early after vector tool selection

### DIFF
--- a/docs/plans/2026-06-18-tool-registry-vector-early-return-performance.md
+++ b/docs/plans/2026-06-18-tool-registry-vector-early-return-performance.md
@@ -1,0 +1,38 @@
+# Tool Registry Vector Selection Early Return Performance Slice
+
+## Scope
+
+This slice optimizes `select_agentic_tools_for_turn()` when vector routing yields
+at least one valid tool. In that path the selected tool set is already final:
+keyword fallback is intentionally bypassed, so the function can build and return
+the selection receipt immediately instead of carrying vector state through the
+remaining fallback branch and final dispatch.
+
+Behavior remains unchanged: selected tools keep the same registry order, source
+receipts, fallback reasons, vector availability, and schema-byte accounting.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+That registry entry includes focused tool-registry behavior tests,
+changed-scope coverage, and `scripts/tool_registry_select_probe.py`. The probe
+reports `selector_planning_elapsed_ms_mean`, whose mixed selection workload
+includes the vector-hit path optimized by this slice.
+
+## Verification plan
+
+- Run the registered focused test command for the tool-registry selection probe.
+- Run the registered changed-scope coverage command for the same probe.
+- Run `scripts/tool_registry_select_probe.py` locally on Linux against the base
+  and head implementations with repeated samples, comparing selector planning
+  metrics and ensuring selected schema bytes remain stable.
+- Use the GitHub Actions PR-scoped performance workflow as the final registered
+  probe validation before merge.
+
+## Expected outcome
+
+Returning immediately after a valid vector selection avoids one extra branch and
+the final shared return path for vector-hit requests. The expected benefit is
+primarily visible in `selector_planning_elapsed_ms_mean`; unrelated selection
+and config metrics may remain within normal measurement noise.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -517,8 +517,14 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
         for tool_name in selection_input.vector_selected_tool_ids:
             add_tool(tool_name, "vector")
         if has_vector_selection:
-            selection_mode = "vector"
-            fallback_reason = ""
+            return _build_tool_selection_result(
+                registry,
+                selected_names,
+                selected_sources,
+                selection_input,
+                "vector",
+                "",
+            )
 
     if selection_mode != "vector":
         current_matches = _keyword_tool_matches(selection_input.current_user_turn)


### PR DESCRIPTION
## Summary
- Return immediately after `select_agentic_tools_for_turn()` gets a valid vector-selected tool set.
- Add a focused performance plan for the vector-hit selector path.

## Plan or Spec
- `docs/plans/2026-06-18-tool-registry-vector-early-return-performance.md`
- Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_preserves_always_available_tools_with_vector_hits services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_uses_builtin_name_set_for_membership services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_uses_keyword_fallback_when_vector_unavailable`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` (base and head comparison)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 85 passed.
- Changed-scope coverage: `TOTAL 1 0 100%`; changed line 520 in `tool_registry.py` covered.
- Local Linux probe comparison (`MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000`, `MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5`):
  - base `selector_planning_elapsed_ms_mean=34.89261697977781`
  - head `selector_planning_elapsed_ms_mean=34.16175451129675`
  - delta `-0.73086246848106 ms` (`~2.09%` faster)
  - selected schema bytes stayed stable at `565.99625`.
- Registered PR-scoped performance CI is required before merge.

## Known Gaps
- Python slice only; Swift runtime effects are not involved.
- Local measurements are Linux probe evidence; final registered probe validation must come from GitHub Actions.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe command ran locally on Linux.
- [ ] PR-scoped performance workflow completed successfully in CI.
