### PR TITLE
perf: fast path singleton tool selection receipts

### DIFF
--- a/docs/plans/2026-06-18-tool-selection-singleton-receipt-fastpath.md
+++ b/docs/plans/2026-06-18-tool-selection-singleton-receipt-fastpath.md
@@ -1,0 +1,32 @@
+# Tool Selection Singleton Receipt Fast Path
+
+## Slice
+
+Optimize the Python agentic tool selection receipt builder for the common
+single-tool result (`local_compute` only) without changing selection semantics.
+This slice is intentionally limited to `worker/runtime/tool_registry.py`.
+
+## Registered Probe
+
+Affected path coverage uses the existing registered PR-scoped probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries and runs `scripts/tool_registry_select_probe.py`.
+
+## Plan
+
+1. Preserve the existing branch that skips optional keyword/vector scans when
+   `max_selected_tools == 1`.
+2. In `_build_tool_selection_result`, avoid tuple creation plus a list
+   comprehension over `selected_registry.names()` when the normalized selected
+   list contains exactly one tool.
+3. Reuse `registry.select((selected_name,))` and build the one receipt entry
+   directly from `selected_sources`.
+4. Verify focused tests, changed-scope coverage, and the registered probe on
+   Linux before creating the PR.
+
+## Success Metrics
+
+The registered probe should show a lower `always_only_planning_elapsed_ms_mean`
+for the max-one-tool path, with no regression in selected schema bytes or
+selection receipt behavior.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -558,7 +558,16 @@ def _build_tool_selection_result(
     selection_mode: str,
     fallback_reason: str,
 ) -> ToolSelectionResult:
-    selected_registry = registry.select(tuple(selected_names))
+    if len(selected_names) == 1:
+        selected_name = selected_names[0]
+        selected_registry = registry.select((selected_name,))
+        selected_tools = [{"tool_id": selected_name, "source": selected_sources[selected_name]}]
+    else:
+        selected_registry = registry.select(tuple(selected_names))
+        selected_tools = [
+            {"tool_id": tool_name, "source": selected_sources[tool_name]}
+            for tool_name in selected_registry.names()
+        ]
     registry_metrics = registry.metrics()
     selected_metrics = selected_registry.metrics()
     selected_tool_count = selected_metrics.tool_count
@@ -568,10 +577,7 @@ def _build_tool_selection_result(
         "selection_mode": selection_mode,
         "vector_available": selection_input.vector_available,
         "fallback_reason": fallback_reason,
-        "selected_tools": [
-            {"tool_id": tool_name, "source": selected_sources[tool_name]}
-            for tool_name in selected_registry.names()
-        ],
+        "selected_tools": selected_tools,
         "dropped_tool_count": max(0, registry_metrics.tool_count - selected_tool_count),
         "full_schema_bytes": registry_metrics.schema_bytes,
         "selected_schema_bytes": selected_metrics.schema_bytes,


### PR DESCRIPTION
## Summary
- Add a singleton fast path in `_build_tool_selection_result` so single-tool selections build the receipt entry directly.
- Keep multi-tool receipt generation unchanged.
- Document the slice and validation plan under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-06-18-tool-selection-singleton-receipt-fastpath.md`
- Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin main --prune`
- `git worktree add -b perf/cron-python-slice-20260618234618 /root/.hermes/profiles/coder/workspace/worktrees/melix-cron-perf-20260618234618 origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=40000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` (base and head quick comparison)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-select-name-index-cache --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-cron-perf-20260618234618-base --head-repo "$PWD" --output /tmp/tool-registry-select-result.json`
- `git diff --check`

## Coverage and Metrics
- Focused coverage from registered runner: `85 passed in 2.21s`; changed-line coverage `TOTAL 6 0 100%`.
- Registered local probe (`tool-registry-select-name-index-cache`) completed for base and head on Linux.
- Main targeted metric improved: `always_only_planning_elapsed_ms_mean` `28.6715 ms -> 24.5718 ms` (`-4.0997 ms`, ~14.3% faster).
- `current_capacity_planning_elapsed_ms_mean` `34.5449 ms -> 33.5179 ms` (~3.0% faster).
- `elapsed_ms_mean` `21.6779 ms -> 21.7523 ms` (~0.34% slower, within noise); CI registered probe report remains the merge gate.

## Known Gaps
- This is a Python-only slice verified locally on Linux.
- CI must run the PR-scoped performance workflow and publish the registered probe report before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before creating the worktree.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests and changed-line coverage passed locally.
- [x] Registered probe ran locally against base and head.
- [ ] GitHub Actions passed.
- [ ] PR-scoped performance report completed successfully.
