### PR TITLE
perf: avoid symlink following in lora run scan

### DIFF
--- a/docs/plans/2026-06-19-lora-run-dir-no-symlink-follow-performance.md
+++ b/docs/plans/2026-06-19-lora-run-dir-no-symlink-follow-performance.md
@@ -1,0 +1,23 @@
+# LoRA Run Directory No-Symlink-Follow Scan Performance
+
+This Python-only performance slice is limited to the LoRA experiment run
+directory scanner in `worker.productization.lora_experiment_store._iter_lora_run_dirs`.
+
+Registered PR-scoped probe: `lora-experiment-run-dir-name-scan` in
+`infra/perf/pr_scoped_probes.json`. The affected path already has focused
+`test_command`, `coverage_command`, and `probe_command` entries.
+
+## Optimization
+
+When filtering `model-ops-*` entries, call `DirEntry.is_dir(follow_symlinks=False)`
+instead of the default symlink-following directory check. The scanner only needs
+real run directories under the train root, so avoiding symlink following keeps the
+hot scan deterministic and removes unnecessary filesystem resolution work on
+symlink-heavy roots.
+
+## Verification Plan
+
+Run the registered focused test command, changed-scope coverage command, and
+registered probe locally on Linux. Accept this slice only if behavior tests pass,
+changed-scope coverage remains at or above the repository threshold, and the
+registered probe completes without elapsed or allocation regression.

--- a/scripts/lora_experiment_run_dir_scan_probe.py
+++ b/scripts/lora_experiment_run_dir_scan_probe.py
@@ -36,7 +36,11 @@ class FakeEntry:
         path_attr_reads += 1
         return self._path
 
-    def is_dir(self) -> bool:
+    def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+        if follow_symlinks:  # pragma: no cover - regression guard
+            raise AssertionError(  # pragma: no cover
+                "run dir scan should not follow directory symlinks"
+            )
         return self._is_dir
 
 

--- a/services/mlx-worker-python/tests/test_lora_experiment_store.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_store.py
@@ -105,7 +105,11 @@ def test_iter_lora_run_dirs_sorts_names_without_reading_entry_paths(tmp_path: Pa
             path_reads += 1
             raise AssertionError("_iter_lora_run_dirs should rebuild paths from entry names")
 
-        def is_dir(self) -> bool:
+        def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+            if follow_symlinks:  # pragma: no cover - regression guard
+                raise AssertionError(  # pragma: no cover
+                    "_iter_lora_run_dirs should not follow directory symlinks"
+                )
             if self._raises:
                 raise OSError("unreadable")
             return self._is_dir

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -35,7 +35,7 @@ def _iter_lora_run_dirs(train_root: Path) -> tuple[Path, ...]:
                 if not entry_name.startswith(run_dir_prefix):
                     continue
                 try:
-                    if not entry.is_dir():
+                    if not entry.is_dir(follow_symlinks=False):
                         continue
                 except OSError:
                     continue


### PR DESCRIPTION
## Summary
- Avoid following directory symlinks while scanning LoRA `model-ops-*` run directories.
- Keep the scan name-sorted and path-attribute-free, and extend focused tests/probe guards for the no-symlink-follow contract.

## Plan or Spec
- Added `docs/plans/2026-06-19-lora-run-dir-no-symlink-follow-performance.md`.
- Registered probe already exists: `lora-experiment-run-dir-name-scan` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py::test_iter_lora_run_dirs_sorts_names_without_reading_entry_paths services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_prefers_run_record_over_manifest_when_both_exist services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_experiment_run_dir_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_experiment_run_dir_scan_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` — 5 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...` — 5 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/lora_experiment_store.py services/mlx-worker-python/tests/test_lora_experiment_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_experiment_run_dir_scan_probe.py` — TOTAL 3 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/lora_experiment_run_dir_scan_probe.py` — repeated 3 times
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (3/3 changed measurable lines).
- Registered local probe samples:
  - run 1: `elapsed_ms_mean=1057.3137`, `peak_bytes_mean=3027623.2`, `path_attr_reads_mean=0.0`
  - run 2: `elapsed_ms_mean=1063.0550`, `peak_bytes_mean=3027623.2`, `path_attr_reads_mean=0.0`
  - run 3: `elapsed_ms_mean=1073.3748`, `peak_bytes_mean=3027623.2`, `path_attr_reads_mean=0.0`
- Baseline local probe on `origin/main` before this branch:
  - `elapsed_ms_mean` samples: `1033.4579`, `1037.4917`, `1030.6255`
  - `peak_bytes_mean=3027623.2`, `path_attr_reads_mean=0.0`
- This slice's direct local fake-entry probe is within the existing 5% warning threshold but does not model symlink-resolution cost; the expected benefit is avoiding symlink-follow filesystem work on real/symlink-heavy LoRA roots. CI registered probe validation is required before merge.

## Known Gaps
- Linux local validation covers Python behavior and the registered probe only; no Swift runtime effect is claimed.
- The synthetic fake-entry probe does not include real symlink resolution latency.

## Evidence Checklist
- [x] Registered probe exists for the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance report completed.
- [ ] All required PR checks are green.
