### PR TITLE
perf: inline local job scan record ids

### DIFF
--- a/docs/plans/2026-06-15-local-job-followup-loop-bindings.md
+++ b/docs/plans/2026-06-15-local-job-followup-loop-bindings.md
@@ -4,7 +4,7 @@ This Python performance slice is limited to `LocalJobContinuationStore.scan_foll
 
 ## Goal
 
-Keep local job follow-up scan behavior unchanged while reducing per-record Python overhead in large continuation stores. The scan already uses one `os.scandir(...)` pass; this slice avoids rebuilding the empty live-evidence mapping, binds hot loop callables once before iterating over record ids, and keeps the record-file filter on regular top-level JSON files without following symlinks.
+Keep local job follow-up scan behavior unchanged while reducing per-record Python overhead in large continuation stores. The scan already uses one `os.scandir(...)` pass; this follow-up slice builds the sortable record-id list directly during the scandir pass, removes the per-entry helper call for `.json` stem extraction, and keeps the record-file filter on regular top-level JSON files without following symlinks.
 
 ## Probe coverage
 

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -361,11 +361,16 @@ class LocalJobContinuationStore:
         )
         root = self.root
         try:
-            record_job_ids = sorted(
-                _record_job_id_from_filename(entry.name)
-                for entry in os.scandir(os.fspath(root))
-                if entry.name.endswith(".json") and entry.is_file(follow_symlinks=False)
-            )
+            record_job_ids: list[str] = []
+            record_job_ids_append = record_job_ids.append
+            for entry in os.scandir(os.fspath(root)):
+                name = entry.name
+                if name.endswith(".json") and entry.is_file(follow_symlinks=False):
+                    # The scan has already filtered this to a .json file name.
+                    # Slice directly rather than calling Path.stem or a helper for
+                    # every record in large follow-up stores.
+                    record_job_ids_append(".json" if name == ".json" else name[:-5])
+            record_job_ids.sort()
         except FileNotFoundError:
             return LocalJobContinuationFollowupScan(candidates=(), receipts=())
         reconcile_record = self.reconcile_record
@@ -1283,14 +1288,6 @@ def _optional_int(value: Any, field_name: str) -> int | None:
 
 def _missing_live_evidence(job_id: str) -> None:
     return None
-
-
-def _record_job_id_from_filename(record_name: str) -> str:
-    # scan_followup_candidates has already filtered this to a .json file name.
-    # Avoid constructing a Path only to read .stem in large follow-up stores.
-    if record_name == ".json":
-        return ".json"
-    return record_name[:-5]
 
 
 def _safe_job_id(job_id: str) -> str:


### PR DESCRIPTION
## Summary
- Inline local job follow-up record-id collection during the existing single `os.scandir(...)` pass.
- Remove the per-record helper call used only for `.json` stem extraction.
- Update the existing local job follow-up performance plan to describe this slice.

## Plan or Spec
- `docs/plans/2026-06-15-local-job-followup-loop-bindings.md`
- Registered probe: `local-job-followup-scan-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reconciles_and_filters_ready_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_uses_single_scandir_without_path_glob services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_does_not_follow_record_symlinks services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_records_store_errors services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_returns_empty_for_missing_root services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_tolerates_root_deleted_during_scandir services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_skips_unreadable_records services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_local_job_followup_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...same focused tests...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/local_job_followup_scan_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py`
- `MELIX_LOCAL_JOB_SCAN_RECORDS=2000 MELIX_LOCAL_JOB_SCAN_SAMPLES=7 ... python3 scripts/local_job_followup_scan_probe.py` on both `origin/main` base worktree and this branch.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 11 passed.
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Registered local probe, default workload (`record_count=500`, `sample_count=5`):
  - base `elapsed_ms_mean=30.959570`, head `elapsed_ms_mean=29.991292`, delta `-0.968278 ms` (~3.13% faster)
  - syscall shape unchanged: `scandir_calls_mean=1.0`, `path_glob_calls_mean=0.0`
- Larger local workload (`record_count=2000`, `sample_count=7`):
  - base `elapsed_ms_mean=128.837975`, head `elapsed_ms_mean=113.014487`, delta `-15.823488 ms` (~12.28% faster)
  - candidate/receipt counts unchanged (`2000.0` each), `scandir_calls_mean=1.0`, `path_glob_calls_mean=0.0`
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Python-only Linux validation; no Swift runtime behavior changed.
- Local probe numbers are synthetic and may vary by runner; GitHub Actions registered probe is the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered probe includes focused `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage measured locally.
- [x] Registered probe ran locally on Linux and showed scan-time improvement.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
