### PR TITLE
perf: batch empty changed-scope coverage output

### DIFF
--- a/docs/plans/2026-06-19-changed-scope-empty-output-write.md
+++ b/docs/plans/2026-06-19-changed-scope-empty-output-write.md
@@ -1,0 +1,41 @@
+# Changed-scope Empty Output Write Slice
+
+## Scope
+
+This Python performance slice is limited to the empty-path fast path in
+`scripts/changed_scope_coverage.py`. The path is exercised when the
+`MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON` allowlist filters every requested file
+out of a changed-scope coverage run.
+
+## Probe Coverage
+
+The affected path is covered by the registered PR-scoped probe
+`changed-scope-coverage-empty-path-short-circuit` in
+`infra/perf/pr_scoped_probes.json`. The registry entry already includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `scripts/changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_probe.py`
+- `tests/test_changed_scope_coverage.py`
+- PR-scoped performance registry validation tests
+
+## Implementation Plan
+
+1. Preserve the current empty-path output contract exactly.
+2. Replace the four separate `print()` calls in the empty-path branch with one
+   `sys.stdout.write()` call containing the complete output block.
+3. Run the registered focused test command, changed-scope coverage command, and
+   registered probe locally on Linux.
+4. Accept the slice only if behavior stays identical and the registered probe is
+   neutral-to-improved for the empty-allowlist metric.
+
+## Metrics
+
+Primary metric: `main_empty_allowlist_elapsed_ms_mean` from the registered
+`changed-scope-coverage-empty-path-short-circuit` probe.
+
+Secondary guard metrics:
+
+- `main_empty_allowlist_coverage_read_calls_mean` must remain zero.
+- `source_read_calls_mean` must remain zero.
+- `elapsed_ms_mean` should remain neutral for the measurable-lines helper.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -262,10 +262,12 @@ def main() -> int:
     repo_root = Path.cwd()
     paths = _filter_coverage_paths(args.paths, _coverage_path_allowlist(os.environ))
     if not paths:
-        print("aggregate_measurable_changed_lines=0")
-        print("aggregate_covered_changed_lines=0")
-        print("aggregate_missed_changed_lines=0")
-        print("TOTAL 0 0 100%")
+        sys.stdout.write(
+            "aggregate_measurable_changed_lines=0\n"
+            "aggregate_covered_changed_lines=0\n"
+            "aggregate_missed_changed_lines=0\n"
+            "TOTAL 0 0 100%\n"
+        )
         return 0
 
     coverage_payload = json.loads(Path(args.coverage_json).read_text(encoding="utf-8"))

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -220,9 +220,12 @@ def test_main_short_circuits_empty_filtered_paths_without_reading_coverage(
 
     assert changed_scope_coverage.main() == 0
 
-    output = capsys.readouterr().out
-    assert "aggregate_measurable_changed_lines=0" in output
-    assert "TOTAL 0 0 100%" in output
+    assert capsys.readouterr().out == (
+        "aggregate_measurable_changed_lines=0\n"
+        "aggregate_covered_changed_lines=0\n"
+        "aggregate_missed_changed_lines=0\n"
+        "TOTAL 0 0 100%\n"
+    )
 
 
 def test_coverage_path_allowlist_rejects_invalid_json() -> None:


### PR DESCRIPTION
## Summary
- Batch the empty-path changed-scope coverage output into one `sys.stdout.write()` call.
- Tighten the regression assertion so the empty allowlist output contract remains byte-for-byte stable.
- Document the slice plan and registered probe coverage.

## Plan or Spec
- Plan: `docs/plans/2026-06-19-changed-scope-empty-output-write.md`
- Registered probe: `changed-scope-coverage-empty-path-short-circuit` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH=. uv run pytest tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py -q` → 42 passed
- `PYTHONPATH=. uv run pytest tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py -q && uv run coverage json -o coverage.json && MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON='["scripts/changed_scope_coverage.py","scripts/changed_scope_coverage_probe.py","tests/test_changed_scope_coverage.py","services/mlx-worker-python/tests/test_pr_scoped_performance.py"]' uv run scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py` → TOTAL 2 0 100%
- `PYTHONPATH=. uv run python3 scripts/changed_scope_coverage_probe.py --samples 7 --paths 300 --json` → succeeded
- Additional local baseline/head microprobe using `origin/main:scripts/changed_scope_coverage.py` vs this branch over 2,000 samples.

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`
- Registered local probe output: `{"elapsed_ms_mean": 0.2062471051301275, "main_empty_allowlist_coverage_read_calls_mean": 0.0, "main_empty_allowlist_elapsed_ms_mean": 0.8109967623438153, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}`
- Additional repeated baseline/head microprobe:
  - `origin/main` mean `0.340433 ms`, median `0.314831 ms`, p95 `0.445856 ms`
  - branch mean `0.326348 ms`, median `0.309515 ms`, p95 `0.430998 ms`
  - mean delta `-0.014085 ms` (`~4.14%` faster)
- CI PR-scoped performance workflow is required for the registered probe validation before merge.

## Known Gaps
- This is a small Python fast-path micro-optimization; local Linux validation covers behavior and the registered Python probe, but CI remains the source of truth for PR-scoped reporting.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally.
- [ ] GitHub Actions and registered PR-scoped performance report completed successfully.
