### PR TITLE
perf: count required code eval payload fields

### DIFF
--- a/docs/plans/2026-06-19-code-eval-required-field-count.md
+++ b/docs/plans/2026-06-19-code-eval-required-field-count.md
@@ -1,0 +1,37 @@
+# Code Eval Required Field Count Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to the code-evaluation payload JSON
+fast path in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+The behavior stays equivalent: the fast path still accepts only payloads with
+all required string fields and falls back to full JSON decoding for malformed or
+unexpected payloads.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`.
+That probe declares focused `test_command`, `coverage_command`, and
+`probe_command` entries and watches:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_payload_json_probe.py`
+
+## Implementation Plan
+
+1. Keep the existing tokenized JSON field extraction order and fallback rules.
+2. Track required string fields while extracting values so the hot path avoids a
+   separate post-loop dictionary membership pass.
+3. Re-run the registered focused tests, changed-scope coverage command, and
+   registered probe locally on Linux.
+4. Use GitHub Actions and the PR-scoped performance report as the final merge
+   gate.
+
+## Metrics
+
+Primary metric: `elapsed_ms_mean` from `scripts/code_eval_payload_json_probe.py`
+(lower is better). Secondary metrics: `peak_bytes_mean`, `iteration_count`, and
+`payload_bytes`.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -463,6 +463,7 @@ def _extract_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, object]
         field_tokens = _CODE_EVAL_PAYLOAD_FIELD_TOKENS_SORTED_FRIENDLY
 
     payload: dict[str, object] = {}
+    required_string_field_count = 0
     search_start = 0
     field_value_start = _json_field_value_start_for_token
     extract_string = _extract_json_string_field_at
@@ -479,6 +480,8 @@ def _extract_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, object]
             value = extract_string(payload_bytes, value_start)
             if value is not None:
                 payload[key] = value
+                if key != "compile_status":
+                    required_string_field_count += 1
                 search_start = value_start + len(value) + 1
             continue
 
@@ -489,7 +492,7 @@ def _extract_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, object]
         payload[key] = value
         search_start = value_end
 
-    if _code_eval_payload_has_required_string_fields(payload):
+    if required_string_field_count == len(_REQUIRED_CODE_EVAL_PAYLOAD_STRING_KEYS):
         return payload
     return None
 


### PR DESCRIPTION
## Summary
- Count required code-eval payload string fields during tokenized JSON extraction.
- Avoid the extra post-loop dictionary membership pass on the registered payload fast path.
- Add a scoped plan for the Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-19-code-eval-required-field-count.md`
- Registered probe: `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_required_field_check_preserves_fast_path_gate services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 9 passed.
- Changed-scope coverage: 100.00% (4/4 measurable changed lines).
- Local registered probe baseline from `origin/main`: `elapsed_ms_mean=104.03387261820691`, `peak_bytes_mean=60425.0`, `iteration_count=1200.0`, `payload_bytes=55474.0`.
- Local registered probe after change: `elapsed_ms_mean=92.33781243009227`, `peak_bytes_mean=60425.0`, `iteration_count=1200.0`, `payload_bytes=55474.0`.
- Delta: `-11.69606018811464 ms` (`~11.24%` faster, lower is better).

## Known Gaps
- Linux local validation covers the Python path only.
- GitHub Actions PR-scoped performance is required as the registered CI validation source before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows an improvement.
- [ ] PR-scoped performance workflow completed successfully in CI.
- [ ] All required GitHub checks are green.
