### PR TITLE
perf: streamline training target cache hits

### DIFF
--- a/docs/plans/2026-06-19-training-target-cache-none-check.md
+++ b/docs/plans/2026-06-19-training-target-cache-none-check.md
@@ -1,0 +1,35 @@
+# Training target-module cache hit check slice
+
+## Scope
+
+This Python-only performance slice is limited to the cached target-module
+resolution path in `worker.model_ops.training_config._resolve_target_modules`.
+The behavior remains unchanged: cached target-module tuples are still copied to a
+fresh list for callers, preserving mutation isolation.
+
+## Registered Probe
+
+The affected path is covered by the existing registered PR-scoped probe
+`training-config-target-module-cache` in `infra/perf/pr_scoped_probes.json`.
+That registry entry already includes focused `test_command`, `coverage_command`,
+and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/training_config.py`
+- `services/mlx-worker-python/tests/test_lora_model_ops.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/training_config_target_modules_probe.py`
+
+## Optimization
+
+The hot probe prewarms the target-module cache, then repeatedly exercises the
+cache-hit path. Cache values are always immutable tuples; missing entries are
+represented by `None` from `dict.get()`. This slice replaces the generic
+`isinstance(cached_targets, tuple)` guard with a direct `cached_targets is not
+None` check on the cache-hit path, avoiding a repeated runtime type check while
+keeping the cache-miss behavior unchanged.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, and local
+registered probe on Linux before opening the PR. The PR-scoped performance
+workflow remains the merge gate for the registered probe result in CI.

--- a/services/mlx-worker-python/worker/model_ops/training_config.py
+++ b/services/mlx-worker-python/worker/model_ops/training_config.py
@@ -1218,7 +1218,7 @@ def _resolve_target_modules(raw_value: str, *, profile: dict[str, object]) -> li
         cache = {}
         profile[_NORMALIZED_TARGET_MODULES_CACHE_KEY] = cache
     cached_targets = cache.get(raw_value)
-    if isinstance(cached_targets, tuple):
+    if cached_targets is not None:
         # Cache stores immutable tuples; list() produces a fresh copy per call so
         # callers can safely iterate without risk of mutating shared cache state.
         return list(cached_targets)


### PR DESCRIPTION
## Summary
- Replaces the cached target-module tuple type check with a direct cache-hit sentinel check in `_resolve_target_modules`.
- Keeps mutation isolation unchanged by still returning a fresh `list()` from the cached tuple.
- Adds a focused plan for the training target-module cache-hit performance slice.

## Plan or Spec
- `docs/plans/2026-06-19-training-target-cache-none-check.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_training_config_helper_resolution_paths_and_limits services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_config_target_module_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_config_target_modules_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 4 passed in 2.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_training_config_helper_resolution_paths_and_limits services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_config_target_module_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_config_target_modules_probe_script_smoke services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_config.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/training_config_target_modules_probe.py
# 4 passed in 0.85s; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/training_config_target_modules_probe.py
# {"case_count": 4.0, "checksum": 900000.0, "elapsed_ms_mean": 420.82579859665464, "iteration_count": 50000.0, "peak_bytes_mean": 810.2857142857143}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 1 0 100%`).
- Registered local probe: `training_config_target_modules_probe.py`.
- Baseline local probe on `origin/main` before the change: `elapsed_ms_mean=422.5124815212829`, `peak_bytes_mean=392.0`, `checksum=900000.0`.
- Head local probe after the change: `elapsed_ms_mean=420.82579859665464`, `peak_bytes_mean=810.2857142857143`, `checksum=900000.0`.
- Local delta: `elapsed_ms_mean -1.6866829246282578 ms` (`~0.40%` faster); peak bytes increased by `418.28571428571433` bytes and remains below the registered `warn_abs=1024` threshold.
- CI source of truth: the PR-scoped performance workflow must run the registered `training-config-target-module-cache` probe before merge.

## Known Gaps
- Linux local validation only; no Swift/runtime effect is claimed for this Python-only slice.
- The local speedup is intentionally small because this is a single cache-hit guard micro-slice; CI registered probe is the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead change N/A.
- [x] Deferred work and known gaps are stated explicitly.
