### PR TITLE
perf: inline serving diagnostics jsonl newlines

### DIFF
--- a/docs/plans/2026-06-19-serving-diagnostics-jsonl-inline-newline.md
+++ b/docs/plans/2026-06-19-serving-diagnostics-jsonl-inline-newline.md
@@ -1,0 +1,35 @@
+# Serving Diagnostics JSONL Inline Newline Performance Slice
+
+## Scope
+
+This slice keeps the serving diagnostics debug queue behavior unchanged while
+reducing the hot JSONL serialization path for empty-attribute events. The writer
+now lets the fast-path extender append a complete JSONL line, including the
+trailing newline, so `_write_jsonl()` avoids one extra `bytearray.extend()` call
+for every fast-path event.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json`.
+The registry entry already provides focused `test_command`, `coverage_command`,
+and `probe_command` coverage for:
+
+- `services/mlx-worker-python/worker/productization/serving_diagnostics.py`
+- `services/mlx-worker-python/tests/test_serving_diagnostics.py`
+- `scripts/serving_diagnostics_queue_probe.py`
+
+## Verification plan
+
+- Run the focused registered serving diagnostics test command locally on Linux.
+- Run the registered changed-scope coverage command locally on Linux.
+- Run `scripts/serving_diagnostics_queue_probe.py` locally on Linux against both
+  `origin/main` and the slice worktree with the same sample count.
+- Use GitHub Actions PR-scoped performance workflow as the final registered CI
+  validation before merge.
+
+## Expected outcome
+
+The serialized JSONL bytes, retained/dropped queue counts, and event payloads
+remain unchanged. The local probe should show a lower `elapsed_ms_mean` and a
+lower `serialization_elapsed_ms_mean`, with `serialized_bytes` unchanged.

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -556,6 +556,26 @@ def test_serving_diagnostics_jsonl_fast_path_reuses_request_id_literal(
     assert calls == ["req-shared-fast-path"]
 
 
+def test_serving_diagnostics_jsonl_extend_fast_path_appends_complete_line() -> None:
+    event = ServingDiagnosticsEvent(
+        request_id="req-inline-newline",
+        phase="decode",
+        event_index=5,
+        status="completed",
+        duration_ms=0.001,
+    )
+    payload = bytearray()
+
+    assert serving_diagnostics_module._extend_empty_attribute_event_json_line_bytes(
+        payload.extend,
+        event,
+        {},
+    ) is True
+
+    assert payload.endswith(b"\n")
+    assert json.loads(payload)["request_id"] == "req-inline-newline"
+
+
 def test_serving_diagnostics_jsonl_writer_extends_fast_path_without_join_helper(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -44,6 +44,10 @@ _EMPTY_EVENT_JSON_DECODE_COMPLETED_REQUEST_PREFIX = (
 _EMPTY_EVENT_JSON_DECODE_COMPLETED_SUFFIX = (
     b',"schema_version":"melix.serving_diagnostics.event.v1","status":"completed"}'
 )
+_EMPTY_EVENT_JSON_DECODE_COMPLETED_SUFFIX_LINE = _EMPTY_EVENT_JSON_DECODE_COMPLETED_SUFFIX + b"\n"
+_EMPTY_EVENT_JSON_GENERIC_STATUS_PREFIX = (
+    b',"schema_version":"melix.serving_diagnostics.event.v1","status":'
+)
 
 
 @lru_cache(maxsize=1024)
@@ -594,7 +598,6 @@ def _write_jsonl(path: Path, rows: Any) -> None:
                 row,
                 request_id_literals,
             ):
-                append_line(newline)
                 continue
             row = row.to_dict()
         append_line(encode(row).encode("utf-8"))
@@ -641,7 +644,7 @@ def _extend_empty_attribute_event_json_line_bytes(
         append_line(event_index_literal)
         append_line(_EMPTY_EVENT_JSON_DECODE_COMPLETED_REQUEST_PREFIX)
         append_line(encoded_request_id)
-        append_line(_EMPTY_EVENT_JSON_DECODE_COMPLETED_SUFFIX)
+        append_line(_EMPTY_EVENT_JSON_DECODE_COMPLETED_SUFFIX_LINE)
         return True
     append_line(b'{"attributes":{},"duration_ms":')
     append_line(duration_literal)
@@ -651,9 +654,9 @@ def _extend_empty_attribute_event_json_line_bytes(
     append_line(_json_string_literal_bytes(phase))
     append_line(b',"request_id":')
     append_line(encoded_request_id)
-    append_line(b',"schema_version":"melix.serving_diagnostics.event.v1","status":')
+    append_line(_EMPTY_EVENT_JSON_GENERIC_STATUS_PREFIX)
     append_line(_json_string_literal_bytes(status))
-    append_line(b"}")
+    append_line(b"}\n")
     return True
 
 


### PR DESCRIPTION
## Summary
- Inline the trailing newline in the serving diagnostics empty-attribute JSONL fast-path extender.
- Remove one extra `bytearray.extend()` call per fast-path event while preserving serialized bytes and queue semantics.
- Add a regression test that the extender emits a complete JSONL line.

## Plan or Spec
- Added `docs/plans/2026-06-19-serving-diagnostics-jsonl-inline-newline.md`.
- Registered probe coverage already exists via `serving-diagnostics-debug-queue-bounds` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/serving_diagnostics_queue_probe.py`
- Baseline probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py`
- Slice probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SERVING_DIAGNOSTICS_QUEUE_SAMPLES=20 uv run --project services/mlx-worker-python python3 scripts/serving_diagnostics_queue_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 52 passed.
- Changed-scope coverage: 100.00% (`TOTAL 11 0 100%`).
- Baseline probe (`origin/main`, 20 samples): `elapsed_ms_mean=5.667473`, `serialization_elapsed_ms_mean=0.986759`, `serialized_bytes=10944.0`.
- Slice probe (20 samples): `elapsed_ms_mean=5.27237`, `serialization_elapsed_ms_mean=0.865776`, `serialized_bytes=10944.0`.
- Local delta: `elapsed_ms_mean -0.395103 ms` (6.97% lower), `serialization_elapsed_ms_mean -0.120983 ms` (12.26% lower), serialized bytes unchanged.

## Known Gaps
- Local validation is Linux/Python only. Final registered PR-scoped performance validation must come from GitHub Actions.

## Evidence Checklist
- [x] Registered probe covers the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% for touched lines.
- [x] Local probe shows lower elapsed and serialization times with unchanged serialized bytes.
- [ ] PR-scoped performance workflow completed successfully in CI.
