### PR TITLE
perf: materialize dataset source paths with map

### DIFF
--- a/docs/plans/2026-06-19-dataset-source-path-map-performance.md
+++ b/docs/plans/2026-06-19-dataset-source-path-map-performance.md
@@ -1,0 +1,24 @@
+# Dataset Source Path Materialization Performance
+
+This Python-only performance slice is limited to dataset source file path
+materialization in `worker.productization.dataset_preparation._iter_source_file_paths`.
+
+Registered PR-scoped probe: `dataset-source-records-scandir` in
+`infra/perf/pr_scoped_probes.json`. The affected path already has focused
+`test_command`, `coverage_command`, and `probe_command` entries.
+
+## Optimization
+
+Keep the existing `os.scandir` stack and deterministic string sort, then
+materialize the final `Path` objects with `list(map(Path, file_paths))` instead
+of a Python list comprehension. This preserves the public helper contract and
+ordering while moving the per-element constructor loop through the C-level map
+iterator on large source trees.
+
+## Verification Plan
+
+Run the registered focused test command, changed-scope coverage command, and
+registered probe locally on Linux. Accept this slice only if behavior tests pass,
+changed-scope coverage remains at or above the repository threshold, and the
+registered probe shows a stable elapsed-time improvement without changing file
+counts or source-kind classification.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -596,7 +596,7 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
         except OSError:
             continue
     file_paths.sort()
-    return [path_cls(path) for path in file_paths]
+    return list(map(path_cls, file_paths))
 
 
 def _classify_source_kind_name(name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Materialize dataset source file `Path` objects with `list(map(Path, file_paths))` after the existing deterministic `os.scandir` string sort.
- Keep the dataset source records slice limited to `worker.productization.dataset_preparation._iter_source_file_paths` and its plan note.

## Plan or Spec
- `docs/plans/2026-06-19-dataset-source-path-map-performance.md`
- Registered PR-scoped probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json` (existing focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_reuses_cached_basename_classification services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_returns_cached_none_without_reclassifying services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_name_cache_clears_at_bound services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py`
- `MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 13 passed.
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Local Linux registered probe equivalent:
  - baseline before change: `elapsed_ms_mean=11.9969`, `source_kind_elapsed_ms_mean=16.1480`, `file_count_mean=6000.0`
  - final after change: `elapsed_ms_mean=10.8302`, `source_kind_elapsed_ms_mean=14.6607`, `file_count_mean=6000.0`
  - elapsed delta: `-1.1668 ms` (`~9.7%` lower)
- CI must run the registered PR-scoped performance workflow and publish the authoritative probe report before merge.

## Known Gaps
- Local verification is Linux-only; this slice touches Python code and does not claim Swift runtime validation.
- The registered command contains a GitHub/head fallback wrapper; locally I ran the same probe script directly with `MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD"` to avoid shell-wrapper approval restrictions in this environment.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage was measured locally.
- [x] Registered probe was run locally on Linux.
- [ ] GitHub Actions, including PR-scoped performance, completed successfully.
