### PR TITLE
perf: bind local job scan hot loop helpers

### DIFF
--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -376,6 +376,9 @@ class LocalJobContinuationStore:
         reconcile_record = self.reconcile_record
         receipts_append = receipts.append
         candidates_append = candidates.append
+        candidate_type = LocalJobContinuationFollowupCandidate
+        candidate_receipt = _followup_candidate_scan_receipt
+        unreadable_record_receipt = _unreadable_record_scan_receipt
         for job_id in record_job_ids:
             try:
                 reconciliation = reconcile_record(
@@ -386,22 +389,23 @@ class LocalJobContinuationStore:
                 receipts_append(exc.receipt)
                 continue
             except (json.JSONDecodeError, OSError, ValueError):
-                receipts_append(_unreadable_record_scan_receipt(job_id=job_id))
+                receipts_append(unreadable_record_receipt(job_id=job_id))
                 continue
             if reconciliation is None:
                 continue
-            receipt = _followup_candidate_scan_receipt(reconciliation.record)
+            receipt = candidate_receipt(reconciliation.record)
+            reason = receipt["reason"]
             # Scan-level follow-up state wins for ready or already-claimed records.
             # Otherwise surface reconciliation changes before the generic scan result.
-            if receipt["reason"] == "followup_candidate_ready":
+            if reason == "followup_candidate_ready":
                 receipts_append(receipt)
                 candidates_append(
-                    LocalJobContinuationFollowupCandidate(
+                    candidate_type(
                         record=reconciliation.record,
                         receipt=receipt,
                     )
                 )
-            elif receipt["reason"] == "followup_already_claimed":
+            elif reason == "followup_already_claimed":
                 receipts_append(receipt)
             elif reconciliation.receipt.get("reason") != "record_state_preserved":
                 receipts_append(reconciliation.receipt)


### PR DESCRIPTION
## Summary
- Binds the local-job follow-up scan hot-loop helpers once before iterating records.
- Reuses the computed scan receipt reason instead of repeating dict lookups while preserving scan ordering and reconciliation behavior.

## Plan or Spec
- Governing spec: `docs/unified-agentic-tool-runtime-contract.md` local-job continuation contract.
- Registered PR-scoped probe: `local-job-followup-scan-scandir` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/runtime/local_job_continuation.py` and includes focused `test_command`, `coverage_command`, and `probe_command` entries.
- No behavior or workflow contract changed, so no docs update is required for this micro-optimization.

## Commands Run
```text
# Baseline registered probe on origin/main before the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py
exit 0; elapsed_ms_mean=31.009777; elapsed_ms_min=29.115032; projection_elapsed_ms_mean=151.346019; scandir_calls_mean=1.0; path_glob_calls_mean=0.0

# Focused local-job test file plus probe script smoke
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics
exit 0; 96 passed in 0.25s

# Registered focused test command for local-job-followup-scan-scandir
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reconciles_and_filters_ready_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_uses_single_scandir_without_path_glob services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_does_not_follow_record_symlinks services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_records_store_errors services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_returns_empty_for_missing_root services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_tolerates_root_deleted_during_scandir services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_skips_unreadable_records services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_local_job_followup_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
exit 0; 11 passed in 0.22s

# Registered coverage command for local-job-followup-scan-scandir
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reconciles_and_filters_ready_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_uses_single_scandir_without_path_glob services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_does_not_follow_record_symlinks services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_records_store_errors services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_returns_empty_for_missing_root services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_tolerates_root_deleted_during_scandir services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_skips_unreadable_records services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_local_job_followup_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/local_job_followup_scan_probe.py
exit 0; TOTAL 8 0 100%

# Registered local probe after the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py
exit 0; elapsed_ms_mean=30.022128; elapsed_ms_min=27.681170; projection_elapsed_ms_mean=150.985049; scandir_calls_mean=1.0; path_glob_calls_mean=0.0

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%`.
- Registered probe delta vs local pre-change baseline: `elapsed_ms_mean` 31.009777 ms → 30.022128 ms (`-0.987649 ms`, about `1.03x` faster / `3.18%` lower); `elapsed_ms_min` 29.115032 ms → 27.681170 ms (`-1.433862 ms`); `projection_elapsed_ms_mean` 151.346019 ms → 150.985049 ms (`-0.360970 ms`); `scandir_calls_mean=1.0`, `path_glob_calls_mean=0.0`, `path_exists_calls_mean=0.0` unchanged.
- CI PR-scoped performance workflow must confirm the registered probe report on GitHub before merge.

## Known Gaps
- Linux local validation only. This is a Python worker slice, so Swift runtime effects are not applicable.
- The local probe improvement is intentionally small because this slice only removes repeated helper and receipt lookups in the existing scan hot loop.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or no behavior/doc change is required.
- [x] Protocol changes include regenerated generated artifacts, or this PR has no protocol changes.
- [x] Dependency changes include updated lockfiles, or this PR has no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
