### PR TITLE
perf: bind trajectory fast manifest helpers

### DIFF
--- a/docs/plans/2026-06-19-trajectory-fast-manifest-binding-performance.md
+++ b/docs/plans/2026-06-19-trajectory-fast-manifest-binding-performance.md
@@ -1,0 +1,52 @@
+# Trajectory Fast Manifest Binding Performance Slice
+
+## Scope
+
+This slice keeps the trajectory provenance behavior unchanged and narrows the
+hot path inside `services/mlx-worker-python/worker/trajectory_provenance.py`.
+The target is the clean JSON manifest fast path used by
+`load_trajectory_provenance_from_snapshot_manifest` after reading a snapshot
+`manifest.json` as bytes.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`.
+That probe includes:
+
+- focused tests via `services/mlx-worker-python/tests/test_trajectory_provenance.py`
+- changed-scope coverage for `worker.trajectory_provenance`
+- probe command via `scripts/trajectory_manifest_json_load_probe.py`
+
+## Implementation Plan
+
+1. Preserve the existing bytes-based manifest load and clean-manifest fast path.
+2. Bind repeated hot-loop helpers (`manifest.get` and clean-text predicate) to
+   local variables inside `_fast_trajectory_provenance_from_snapshot_manifest`.
+3. Run focused trajectory provenance tests, changed-scope coverage, and the
+   registered trajectory manifest JSON probe locally on Linux.
+4. Let the PR-scoped performance workflow validate the same registered probe in
+   CI before merge.
+
+## Linux Probe Notes
+
+Pre-change local probe from the synced `origin/main` worktree:
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
+MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" \
+MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_SAMPLES=7 \
+MELIX_TRAJECTORY_MANIFEST_JSON_PROBE_ITERATIONS=3000 \
+uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
+
+old_mean_ms=2253.113, new_mean_ms=1177.632, speedup=1.913x, delta_ms=-1075.481
+```
+
+Initial post-change local probe:
+
+```text
+old_mean_ms=2273.054, new_mean_ms=1167.748, speedup=1.947x, delta_ms=-1105.306
+```
+
+The authoritative merge gate remains the registered PR-scoped performance CI
+report.

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -151,10 +151,12 @@ def _fast_trajectory_provenance_from_snapshot_manifest(
     *,
     snapshot_manifest_path: str | None,
 ) -> dict[str, Any] | None:
-    if manifest.get("format") != "agentic_tool_trace":
+    manifest_get = manifest.get
+    if manifest_get("format") != "agentic_tool_trace":
         return None
+    is_clean_text = _is_clean_manifest_text
     for key in _FAST_MANIFEST_REQUIRED_KEYS:
-        if not _is_clean_manifest_text(manifest.get(key)):
+        if not is_clean_text(manifest_get(key)):
             return None
     provenance: dict[str, Any] = {
         "trajectory_dataset_id": manifest["source_dataset_id"],
@@ -166,7 +168,7 @@ def _fast_trajectory_provenance_from_snapshot_manifest(
     if snapshot_manifest_path is not None:
         provenance["trajectory_snapshot_manifest_path"] = snapshot_manifest_path
     for source_key, target_key in _FAST_MANIFEST_OPTIONAL_FIELD_MAP:
-        value = manifest.get(source_key)
+        value = manifest_get(source_key)
         if value is not None and value != "":
             provenance[target_key] = value
     return provenance


### PR DESCRIPTION
## Summary
- Bind `manifest.get` and the clean-text predicate locally inside the trajectory manifest clean fast path.
- Keep the existing bytes-based JSON load and provenance output semantics unchanged.
- Add a short performance-slice plan for this registered probe path.

## Plan or Spec
- `docs/plans/2026-06-19-trajectory-fast-manifest-binding-performance.md`
- Registered probe: `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_fast_paths_clean_text services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reuses_path_text services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_accepts_dict_subclass services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` — 10 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py` — 100.00% changed-line coverage
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`5/5` measurable changed lines covered)
- Local registered probe (default scale): `old_mean_ms=1540.996`, `new_mean_ms=764.310`, `delta_ms=-776.685`, `speedup=2.016x`, `peak_bytes_mean=49580.0`
- Pre-change local probe at larger local sampling (recorded in the plan): `old_mean_ms=2253.113`, `new_mean_ms=1177.632`, `speedup=1.913x`
- Initial post-change larger local sampling (recorded in the plan): `old_mean_ms=2273.054`, `new_mean_ms=1167.748`, `speedup=1.947x`
- CI required: the PR-scoped performance workflow must run the registered `trajectory-manifest-json-load` probe before merge.

## Known Gaps
- Linux local validation covers Python behavior and probe metrics only.
- Runtime effect should be treated as accepted only after the registered PR-scoped performance CI report completes successfully.

## Evidence Checklist
- [x] Synced from `origin/main` before branching
- [x] Confirmed registered probe has focused test, coverage, and probe commands
- [x] Focused tests passed locally
- [x] Changed-scope coverage passed locally
- [x] Registered probe ran locally
- [ ] PR-scoped performance CI completed successfully
- [ ] All PR checks green
