### PR TITLE
fix: guard worker unload with runtime leases

### DIFF
--- a/docs/plans/2026-06-20-issue-40-cache-residency-leases.md
+++ b/docs/plans/2026-06-20-issue-40-cache-residency-leases.md
@@ -1,0 +1,82 @@
+# Issue 40 Cache Residency Lease Hardening
+
+## Goal
+
+Implement the latest issue #40 cache/residency hardening slice by giving request-owned runtime state an explicit lease boundary and making unload attempts observable when they are blocked by active work.
+
+## Context
+
+Issue #40 was closed by PR #1710 with the main runtime cache reuse milestone. Later watch notes added smaller hardening slices. This plan covers the 2026-06-19 watch finding:
+
+- request-owned runtime state needs explicit lifetime boundaries
+- destructive unload must be refused while an endpoint lease or scheduler request is active
+- pending unload receipts must report `abort_requested`, `pending_unload`, `released_at`, and `unloaded_at`
+
+## Architecture
+
+Add registry-owned lease accounting keyed by loaded-model handle. Main response paths acquire a request/stream lifetime lease before using `runtime_model` and release it in `finally`. `UnloadModel` will no longer close a model while active leases exist; it records a pending unload receipt, optionally requests abort when `force=true`, and completes the unload automatically when the final lease is released.
+
+The implementation intentionally keeps this as a worker-runtime contract instead of changing public HTTP API shape. Existing proto response fields are sufficient because `UnloadModelResponse.error.details` can carry the pending receipt when unload is refused or deferred.
+
+## Files
+
+- Modify `services/mlx-worker-python/worker/registry.py`
+  - add `RequestRuntimeLease`, `StreamLifetimeLease`, and `ModelUnloadReceipt`
+  - track active leases by model handle
+  - add `acquire_request_runtime_lease`
+  - add `request_model_unload`
+  - complete pending unload on final lease release
+- Modify `services/mlx-worker-python/worker/engine/engine_core.py`
+  - wrap text generation with `StreamLifetimeLease`
+- Modify `services/mlx-worker-python/worker/engine/speech_core.py`
+  - wrap streaming speech with `StreamLifetimeLease`
+  - wrap non-streaming speech with `RequestRuntimeLease`
+- Modify `services/mlx-worker-python/worker/engine/transcription_core.py`
+  - wrap non-streaming transcription with `RequestRuntimeLease`
+- Modify `services/mlx-worker-python/worker/engine/image_generation_core.py`
+  - wrap image generation with `RequestRuntimeLease`
+- Modify `services/mlx-worker-python/worker/engine/image_edit_core.py`
+  - wrap image editing with `RequestRuntimeLease`
+- Modify `services/mlx-worker-python/worker/grpc_server.py`
+  - use `request_model_unload` so busy/pending/not-found outcomes are distinguishable
+- Modify `services/mlx-worker-python/tests/test_runtime_edges.py`
+  - add registry tests for pending unload receipts and automatic unload after lease release
+  - add service-level coverage for active-request unload refusal
+
+## Behavioral Contract
+
+- Acquiring a lease increments the existing active-request counters and pins the loaded model against unload.
+- Releasing a lease decrements counters and, if a pending unload exists and no leases remain, closes the runtime model and removes residency accounting.
+- `request_model_unload(handle, force=false)`:
+  - unknown handle: `found=false`, `unloaded=false`, `pending_unload=false`
+  - no active lease: closes immediately, `unloaded=true`, `unloaded_at` set
+  - active lease: leaves the model loaded, `pending_unload=true`, `released_at=""`, `unloaded_at=""`
+- `request_model_unload(handle, force=true)` additionally sets `abort_requested=true` and signals cancel events for active requests on that handle.
+- `UnloadModel` returns `ok=false` with a retriable `unload_pending` error while a lease blocks destructive unload. Error details include the pending receipt fields.
+
+## Tests
+
+1. Add a failing registry test proving an active lease blocks unload, records pending receipt fields, and keeps `model_resident_bytes` non-zero.
+2. Add a failing registry test proving `force=true` requests abort for active requests and automatic close happens when the lease is released.
+3. Add a failing service test proving gRPC `UnloadModel` distinguishes `unload_pending` from `not_found`.
+4. Run the focused Python tests:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest \
+  services/mlx-worker-python/tests/test_runtime_edges.py \
+  services/mlx-worker-python/tests/test_runtime_service.py \
+  -q
+```
+
+## Metrics
+
+- Coverage: changed Python lines in `worker/registry.py`, the touched endpoint cores, and `worker/grpc_server.py` must be at least 95%.
+- Runtime safety: active leases must keep `runtime_stats().model_resident_bytes` non-zero until the final release.
+- Receipt quality: pending unload details must include `abort_requested`, `pending_unload`, `released_at`, and `unloaded_at`.
+
+## Out of Scope
+
+- Reworking all benchmark/evaluation helper paths in this slice.
+- Adding new proto fields for lease receipts.
+- Implementing disk cache snapshot persistence or cache compression.
+- Claiming new issue #40 TTFT wins; this is a safety/residency hardening slice.

--- a/docs/plans/2026-06-20-issue-40-cache-residency-leases.md
+++ b/docs/plans/2026-06-20-issue-40-cache-residency-leases.md
@@ -47,6 +47,7 @@ The implementation intentionally keeps this as a worker-runtime contract instead
 
 - Acquiring a lease increments the existing active-request counters and pins the loaded model against unload.
 - Releasing a lease decrements counters and, if a pending unload exists and no leases remain, closes the runtime model and removes residency accounting.
+- Completed unload receipts are retained in a bounded recent-history FIFO so short post-release polling can observe completion without unbounded worker memory growth.
 - `request_model_unload(handle, force=false)`:
   - unknown handle: `found=false`, `unloaded=false`, `pending_unload=false`
   - no active lease: closes immediately, `unloaded=true`, `unloaded_at` set

--- a/services/mlx-worker-python/tests/test_runtime_edges.py
+++ b/services/mlx-worker-python/tests/test_runtime_edges.py
@@ -804,6 +804,28 @@ def test_registry_capabilities_and_request_lifecycle() -> None:
     second_counted_lease.close()
     assert registry.runtime_stats().model_resident_bytes == 0
 
+    registry._completed_unload_receipt_limit = 2
+    retained_receipt_handles = []
+    for _ in range(3):
+        retained_loaded = registry.load_model(WorkerModelCatalog.dev_text_model())
+        retained_receipt = registry.request_model_unload(retained_loaded.handle)
+
+        assert retained_receipt.unloaded is True
+        retained_receipt_handles.append(retained_loaded.handle)
+
+    assert registry.pending_unload_receipt(retained_receipt_handles[0]) is None
+    assert registry.pending_unload_receipt(retained_receipt_handles[1]) is not None
+    assert registry.pending_unload_receipt(retained_receipt_handles[2]) is not None
+
+    registry._completed_unload_receipt_limit = 0
+    unretained_loaded = registry.load_model(WorkerModelCatalog.dev_text_model())
+    unretained_receipt = registry.request_model_unload(unretained_loaded.handle)
+
+    assert unretained_receipt.unloaded is True
+    assert registry.pending_unload_receipt(unretained_loaded.handle) is None
+    assert registry.pending_unload_receipt(retained_receipt_handles[1]) is None
+    assert registry.pending_unload_receipt(retained_receipt_handles[2]) is None
+
     vision_state = registry.start_request("req-vision", runtime_kind="ocr")
     transcription_state = registry.start_request("req-transcription", runtime_kind="transcription")
     speech_state = registry.start_request("req-speech", runtime_kind="speech")

--- a/services/mlx-worker-python/tests/test_runtime_edges.py
+++ b/services/mlx-worker-python/tests/test_runtime_edges.py
@@ -728,6 +728,19 @@ def test_registry_capabilities_and_request_lifecycle() -> None:
     assert registry.abort_request("req-stream") is False
     assert registry.unload_model(stream_loaded.handle) is True
 
+    pending_loaded = registry.load_model(WorkerModelCatalog.dev_text_model())
+    direct_loaded = registry.load_model(WorkerModelCatalog.dev_text_model())
+    pending_lease = registry.acquire_request_runtime_lease(
+        pending_loaded,
+        request_id="req-pending-sentinel",
+        runtime_kind="text",
+    )
+    pending_lease.__enter__()
+    assert registry.request_model_unload(pending_loaded.handle).pending_unload is True
+    assert registry.unload_model(direct_loaded.handle) is True
+    pending_lease.close()
+    assert registry.pending_unload_receipt(pending_loaded.handle) is not None
+
     first = registry.load_model(WorkerModelCatalog.dev_text_model())
     second = registry.load_model(WorkerModelCatalog.dev_text_model())
     third = registry.load_model(WorkerModelCatalog.dev_text_model())

--- a/services/mlx-worker-python/tests/test_runtime_edges.py
+++ b/services/mlx-worker-python/tests/test_runtime_edges.py
@@ -379,6 +379,39 @@ def test_runtime_service_handles_failures_and_state_transitions() -> None:
     draining_stats = runtime_service.GetRuntimeStats(runtime_pb2.GetRuntimeStatsRequest(), context=None)
     assert draining_stats.stats.worker_state == "draining"
 
+    active_model_handle = load_default_model(runtime_service)
+    active_loaded_model = registry.get_loaded_model(active_model_handle)
+    assert active_loaded_model is not None
+
+    with registry.acquire_request_runtime_lease(
+        active_loaded_model,
+        request_id="req-active-service",
+        runtime_kind="text",
+    ):
+        pending = runtime_service.UnloadModel(
+            runtime_pb2.UnloadModelRequest(model_handle=active_model_handle, force=True),
+            context=None,
+        )
+
+        assert pending.ok is False
+        assert pending.error.code == "unload_pending"
+        assert pending.error.retriable is True
+        assert pending.error.details["model_handle"] == active_model_handle
+        assert pending.error.details["abort_requested"] == "true"
+        assert pending.error.details["pending_unload"] == "true"
+        assert pending.error.details["released_at"] == ""
+        assert pending.error.details["unloaded_at"] == ""
+        assert registry.get_loaded_model(active_model_handle) is active_loaded_model
+
+    active_receipt = registry.pending_unload_receipt(active_model_handle)
+    assert active_receipt is not None
+    assert active_receipt.unloaded is True
+    assert active_receipt.pending_unload is False
+    assert active_receipt.abort_requested is True
+    assert active_receipt.released_at
+    assert active_receipt.unloaded_at
+    assert registry.get_loaded_model(active_model_handle) is None
+
     found = runtime_service.UnloadModel(
         runtime_pb2.UnloadModelRequest(model_handle=model_handle),
         context=None,
@@ -508,6 +541,30 @@ def test_worker_registry_avoids_rescanning_loaded_models_for_resident_bytes() ->
     assert registry.unload_model("missing-handle") is False
     assert registry.runtime_stats().model_resident_bytes == 0
 
+    class ClosingRuntime:
+        runtime_name = "closing-runtime"
+
+        def __init__(self) -> None:
+            self.closed_models: list[dict[str, str]] = []
+
+        def load_model(self, model_spec):
+            return {"model_id": model_spec.model_id}
+
+        def estimate_resident_bytes(self, model_spec):
+            _ = model_spec
+            return 1024
+
+        def close_loaded_model(self, loaded_model) -> None:
+            self.closed_models.append(loaded_model)
+
+    closing_runtime = ClosingRuntime()
+    closing_registry = WorkerRegistry(runtime=closing_runtime)  # type: ignore[arg-type]
+    closing_loaded = closing_registry.load_model(WorkerModelCatalog.dev_text_model())
+
+    assert closing_registry.unload_model(closing_loaded.handle) is True
+    assert closing_runtime.closed_models == [closing_loaded.runtime_model]
+    assert closing_registry.unload_model(closing_loaded.handle) is False
+
     applicable_registry = build_registry(backend=ApplicableBackend())
     applicable_loaded = applicable_registry.load_model(WorkerModelCatalog.dev_text_model())
     applicable_stats = applicable_registry.runtime_stats()
@@ -540,7 +597,6 @@ def test_worker_registry_closes_runtime_model_on_unload() -> None:
     assert registry.unload_model(loaded.handle) is True
     assert runtime.closed_models == [loaded.runtime_model]
     assert registry.unload_model(loaded.handle) is False
-
 
 
 def test_worker_registry_reuses_sorted_handles_across_listing_calls(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -589,6 +645,164 @@ def test_registry_capabilities_and_request_lifecycle() -> None:
 
     registry.finish_request("req-1")
     assert registry.get_request("req-1") is None
+
+    leased_model = registry.load_model(WorkerModelCatalog.dev_text_model())
+    with registry.acquire_request_runtime_lease(
+        leased_model,
+        request_id="req-active-lease",
+        runtime_kind="text",
+    ):
+        assert registry.unload_model(leased_model.handle) is False
+        receipt = registry.request_model_unload(leased_model.handle)
+
+        assert receipt.found is True
+        assert receipt.unloaded is False
+        assert receipt.pending_unload is True
+        assert receipt.abort_requested is False
+        assert receipt.released_at == ""
+        assert receipt.unloaded_at == ""
+        assert registry.get_loaded_model(leased_model.handle) is leased_model
+        assert registry.runtime_stats().model_resident_bytes == leased_model.estimated_resident_bytes
+
+    completed = registry.pending_unload_receipt(leased_model.handle)
+    assert completed is not None
+    assert completed.pending_unload is False
+    assert completed.released_at
+    assert completed.unloaded_at
+    assert completed.unloaded is True
+    assert registry.get_loaded_model(leased_model.handle) is None
+    assert registry.runtime_stats().model_resident_bytes == 0
+
+    force_loaded = registry.load_model(WorkerModelCatalog.dev_text_model())
+    with registry.acquire_request_runtime_lease(
+        force_loaded,
+        request_id="req-abort",
+        runtime_kind="text",
+    ) as force_lease:
+        receipt = registry.request_model_unload(force_loaded.handle, force=True)
+
+        assert receipt.found is True
+        assert receipt.unloaded is False
+        assert receipt.pending_unload is True
+        assert receipt.abort_requested is True
+        assert force_lease.cancel_event.is_set() is True
+        assert registry.abort_request("req-abort") is True
+
+    force_receipt = registry.pending_unload_receipt(force_loaded.handle)
+    assert force_receipt is not None
+    assert force_receipt.abort_requested is True
+    assert force_receipt.pending_unload is False
+    assert force_receipt.unloaded is True
+    assert force_receipt.released_at
+    assert force_receipt.unloaded_at
+    assert registry.abort_request("req-abort") is False
+
+    guarded_loaded = registry.load_model(WorkerModelCatalog.dev_text_model())
+    guarded_lease = registry.acquire_request_runtime_lease(
+        guarded_loaded,
+        request_id="req-guarded",
+        runtime_kind="text",
+    )
+
+    with pytest.raises(RuntimeError, match="has not been entered"):
+        _ = guarded_lease.state
+
+    guarded_lease.__enter__()
+    assert registry.abort_request("req-guarded") is True
+    guarded_lease.close()
+    guarded_lease.close()
+
+    assert registry.abort_request("req-guarded") is False
+    assert registry.unload_model(guarded_loaded.handle) is True
+
+    stream_loaded = registry.load_model(WorkerModelCatalog.dev_text_model())
+    with registry.acquire_stream_lifetime_lease(
+        stream_loaded,
+        request_id="req-stream",
+        runtime_kind="text",
+    ) as stream_lease:
+        assert stream_lease.cancel_event.is_set() is False
+        assert registry.abort_request("req-stream") is True
+        assert stream_lease.cancel_event.is_set() is True
+
+    assert registry.abort_request("req-stream") is False
+    assert registry.unload_model(stream_loaded.handle) is True
+
+    first = registry.load_model(WorkerModelCatalog.dev_text_model())
+    second = registry.load_model(WorkerModelCatalog.dev_text_model())
+    third = registry.load_model(WorkerModelCatalog.dev_text_model())
+
+    first_lease = registry.acquire_request_runtime_lease(
+        first,
+        request_id="req-reused-id",
+        runtime_kind="text",
+    )
+    first_lease.__enter__()
+    second_lease = registry.acquire_request_runtime_lease(
+        second,
+        request_id="req-reused-id",
+        runtime_kind="text",
+    )
+    second_lease.__enter__()
+    first_lease.close()
+    third_lease = registry.acquire_request_runtime_lease(
+        third,
+        request_id="req-third",
+        runtime_kind="text",
+    )
+    third_lease.__enter__()
+
+    first_receipt = registry.request_model_unload(first.handle)
+    second_receipt = registry.request_model_unload(second.handle, force=True)
+
+    assert first_receipt.unloaded is True
+    assert second_receipt.pending_unload is True
+    assert second_lease.cancel_event.is_set() is True
+    assert third_lease.cancel_event.is_set() is False
+    assert registry.abort_request("req-reused-id") is True
+
+    registry.start_request("req-third", runtime_kind="text")
+    assert registry.request_model_unload(third.handle).unloaded is True
+    registry.finish_request("req-third")
+    second_lease.close()
+    third_lease.close()
+
+    second_completed = registry.pending_unload_receipt(second.handle)
+    assert second_completed is not None
+    assert second_completed.unloaded is True
+
+    counted_loaded = registry.load_model(WorkerModelCatalog.dev_text_model())
+    first_counted_lease = registry.acquire_request_runtime_lease(
+        counted_loaded,
+        request_id="req-count-a",
+        runtime_kind="text",
+    )
+    second_counted_lease = registry.acquire_request_runtime_lease(
+        counted_loaded,
+        request_id="req-count-b",
+        runtime_kind="text",
+    )
+    first_counted_lease.__enter__()
+    second_counted_lease.__enter__()
+
+    pending = registry.request_model_unload(counted_loaded.handle)
+    assert pending.pending_unload is True
+
+    registry.finish_request("req-count-a")
+    assert registry.get_loaded_model(counted_loaded.handle) is counted_loaded
+    count_receipt = registry.pending_unload_receipt(counted_loaded.handle)
+    assert count_receipt is not None
+    assert count_receipt.pending_unload is True
+
+    registry.finish_request("req-count-b")
+    count_completed = registry.pending_unload_receipt(counted_loaded.handle)
+    assert count_completed is not None
+    assert count_completed.unloaded is True
+    assert registry.get_loaded_model(counted_loaded.handle) is None
+
+    first_counted_lease.close()
+    second_counted_lease.close()
+    assert registry.runtime_stats().model_resident_bytes == 0
 
     vision_state = registry.start_request("req-vision", runtime_kind="ocr")
     transcription_state = registry.start_request("req-transcription", runtime_kind="transcription")

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -215,9 +215,14 @@ class EngineCore:
 
         runtime = self._registry.runtime_for_loaded_model(loaded_model)
         generate_tokens = runtime.generate_tokens
-        state = self._registry.start_request(request_id, runtime_kind=loaded_model.runtime_kind)
-        cancel_event = state.cancel_event
-        allocate_seq = state.allocate_seq
+        lease = self._registry.acquire_stream_lifetime_lease(
+            loaded_model,
+            request_id=request_id,
+            runtime_kind=loaded_model.runtime_kind,
+        )
+        lease.__enter__()
+        cancel_event = lease.cancel_event
+        allocate_seq = lease.state.allocate_seq
         plain_text_fast_path = self._plain_text_fast_path(request)
         compat_receipt = None if plain_text_fast_path else self._compat_policy_receipt(execution_ext)
         assembler = (
@@ -609,7 +614,7 @@ class EngineCore:
         finally:
             if loaded_model.runtime_kind in {"ocr", "vlm"} and hasattr(runtime, "last_probe_snapshot"):
                 self._registry.record_vision_probe(loaded_model.runtime_kind, runtime.last_probe_snapshot())
-            self._registry.finish_request(request_id)
+            lease.close()
 
     def prefill(self, request: inference_pb2.PrefillRequest) -> inference_pb2.PrefillResponse:
         request_id = request.execution.id.request_id
@@ -630,8 +635,12 @@ class EngineCore:
                 ),
             )
 
-        self._registry.start_request(request_id, runtime_kind=loaded_model.runtime_kind)
-        self._registry.set_request_phase(request_id, "prefill")
+        self._registry.acquire_request_runtime_lease(
+            loaded_model,
+            request_id=request_id,
+            runtime_kind=loaded_model.runtime_kind,
+            phase="prefill",
+        ).__enter__()
 
         try:
             prefill_kwargs = {

--- a/services/mlx-worker-python/worker/engine/image_edit_core.py
+++ b/services/mlx-worker-python/worker/engine/image_edit_core.py
@@ -50,15 +50,19 @@ class ImageEditCore:
                 message=f"Image model {loaded_model.spec.model_id} does not support editing workflows.",
             )
 
-        state = self._registry.start_request(request_id, runtime_kind="image")
         try:
-            result = self._registry.image_generation_runtime.edit_image(
-                loaded_model.runtime_model,
-                request,
-                job_id=job_id,
-                images_root=self._images_root,
-                cancel_event=state.cancel_event,
-            )
+            with self._registry.acquire_request_runtime_lease(
+                loaded_model,
+                request_id=request_id,
+                runtime_kind="image",
+            ) as lease:
+                result = self._registry.image_generation_runtime.edit_image(
+                    loaded_model.runtime_model,
+                    request,
+                    job_id=job_id,
+                    images_root=self._images_root,
+                    cancel_event=lease.cancel_event,
+                )
         except ImageGenerationCancelled as exc:
             return self._terminal_response(
                 request=request,
@@ -89,9 +93,6 @@ class ImageEditCore:
                 code="runtime_error",
                 message=str(exc),
             )
-        finally:
-            self._registry.finish_request(request_id)
-
         self._registry.record_image_probe(
             self._registry.image_generation_runtime.last_probe_snapshot()
         )

--- a/services/mlx-worker-python/worker/engine/image_generation_core.py
+++ b/services/mlx-worker-python/worker/engine/image_generation_core.py
@@ -46,15 +46,19 @@ class ImageGenerationCore:
                 message=f"Image model {loaded_model.spec.model_id} does not support generation workflows.",
             )
 
-        state = self._registry.start_request(request_id, runtime_kind="image")
         try:
-            result = self._registry.image_generation_runtime.generate_images(
-                loaded_model.runtime_model,
-                request,
-                job_id=job_id,
-                images_root=self._images_root,
-                cancel_event=state.cancel_event,
-            )
+            with self._registry.acquire_request_runtime_lease(
+                loaded_model,
+                request_id=request_id,
+                runtime_kind="image",
+            ) as lease:
+                result = self._registry.image_generation_runtime.generate_images(
+                    loaded_model.runtime_model,
+                    request,
+                    job_id=job_id,
+                    images_root=self._images_root,
+                    cancel_event=lease.cancel_event,
+                )
         except ImageGenerationCancelled as exc:
             return self._terminal_response(
                 request=request,
@@ -82,8 +86,6 @@ class ImageGenerationCore:
                 code="runtime_error",
                 message=str(exc),
             )
-        finally:
-            self._registry.finish_request(request_id)
 
         self._registry.record_image_probe(
             self._registry.image_generation_runtime.last_probe_snapshot()

--- a/services/mlx-worker-python/worker/engine/speech_core.py
+++ b/services/mlx-worker-python/worker/engine/speech_core.py
@@ -25,23 +25,25 @@ class SpeechCore:
                 )
             )
 
-        self._registry.start_request(request.id.request_id, runtime_kind="speech")
-        try:
+        with self._registry.acquire_request_runtime_lease(
+            loaded_model,
+            request_id=request.id.request_id,
+            runtime_kind="speech",
+        ):
             runtime = self._registry.runtime_for_loaded_model(loaded_model)
-            result = runtime.speak(
-                loaded_model.runtime_model,
-                request,
-            )
-            if hasattr(runtime, "last_probe_snapshot"):
-                self._registry.record_speech_probe(
-                    runtime.last_probe_snapshot()
+            try:
+                result = runtime.speak(
+                    loaded_model.runtime_model,
+                    request,
                 )
-        except Exception as exc:  # pragma: no cover - defensive branch
-            return inference_pb2.SpeakResponse(
-                error=common_pb2.ErrorStatus(code="runtime_error", message=str(exc))
-            )
-        finally:
-            self._registry.finish_request(request.id.request_id)
+                if hasattr(runtime, "last_probe_snapshot"):
+                    self._registry.record_speech_probe(
+                        runtime.last_probe_snapshot()
+                    )
+            except Exception as exc:  # pragma: no cover - defensive branch
+                return inference_pb2.SpeakResponse(
+                    error=common_pb2.ErrorStatus(code="runtime_error", message=str(exc))
+                )
 
         return inference_pb2.SpeakResponse(
             audio_bytes=result.audio_bytes,
@@ -61,7 +63,12 @@ class SpeechCore:
             )
             return
 
-        self._registry.start_request(request.id.request_id, runtime_kind="speech")
+        lease = self._registry.acquire_stream_lifetime_lease(
+            loaded_model,
+            request_id=request.id.request_id,
+            runtime_kind="speech",
+        )
+        lease.__enter__()
         stream_committed = False
         try:
             runtime = self._registry.runtime_for_loaded_model(loaded_model)
@@ -92,7 +99,7 @@ class SpeechCore:
                 raise
             yield self._stream_error("runtime_error", str(exc))
         finally:
-            self._registry.finish_request(request.id.request_id)
+            lease.close()
 
     @staticmethod
     def _stream_error(code: str, message: str) -> inference_pb2.SpeakStreamEvent:

--- a/services/mlx-worker-python/worker/engine/transcription_core.py
+++ b/services/mlx-worker-python/worker/engine/transcription_core.py
@@ -24,23 +24,25 @@ class TranscriptionCore:
                 )
             )
 
-        self._registry.start_request(request.id.request_id, runtime_kind="transcription")
-        try:
+        with self._registry.acquire_request_runtime_lease(
+            loaded_model,
+            request_id=request.id.request_id,
+            runtime_kind="transcription",
+        ):
             runtime = self._registry.runtime_for_loaded_model(loaded_model)
-            transcript = runtime.transcribe(
-                loaded_model.runtime_model,
-                request,
-            )
-            if hasattr(runtime, "last_probe_snapshot"):
-                self._registry.record_transcription_probe(
-                    runtime.last_probe_snapshot()
+            try:
+                transcript = runtime.transcribe(
+                    loaded_model.runtime_model,
+                    request,
                 )
-        except Exception as exc:  # pragma: no cover - defensive branch
-            return inference_pb2.TranscribeResponse(
-                error=common_pb2.ErrorStatus(code="runtime_error", message=str(exc))
-            )
-        finally:
-            self._registry.finish_request(request.id.request_id)
+                if hasattr(runtime, "last_probe_snapshot"):
+                    self._registry.record_transcription_probe(
+                        runtime.last_probe_snapshot()
+                    )
+            except Exception as exc:  # pragma: no cover - defensive branch
+                return inference_pb2.TranscribeResponse(
+                    error=common_pb2.ErrorStatus(code="runtime_error", message=str(exc))
+                )
 
         return inference_pb2.TranscribeResponse(
             text=transcript.text,

--- a/services/mlx-worker-python/worker/grpc_server.py
+++ b/services/mlx-worker-python/worker/grpc_server.py
@@ -213,10 +213,25 @@ class WorkerRuntimeService(runtime_pb2_grpc.RuntimeServiceServicer):
         return response
 
     def UnloadModel(self, request, context):
-        found = self._registry.unload_model(request.model_handle)
+        receipt = self._registry.request_model_unload(
+            request.model_handle,
+            force=bool(request.force),
+        )
+        if receipt.unloaded:
+            return runtime_pb2.UnloadModelResponse(ok=True)
+        if receipt.pending_unload:
+            return runtime_pb2.UnloadModelResponse(
+                ok=False,
+                error=common_pb2.ErrorStatus(
+                    code="unload_pending",
+                    message="Model unload is pending until active request leases are released.",
+                    retriable=True,
+                    details=receipt.details,
+                ),
+            )
         return runtime_pb2.UnloadModelResponse(
-            ok=found,
-            error=common_pb2.ErrorStatus(code="not_found", message="Unknown model handle.") if not found else None,
+            ok=False,
+            error=common_pb2.ErrorStatus(code="not_found", message="Unknown model handle."),
         )
 
     def WarmupModel(self, request, context):

--- a/services/mlx-worker-python/worker/registry.py
+++ b/services/mlx-worker-python/worker/registry.py
@@ -506,26 +506,40 @@ class WorkerRegistry:
     def unload_model(self, handle: str) -> bool:
         loaded_to_close: LoadedModel | None = None
         with self._lock:
-            loaded = self._loaded_models.get(handle)
-            if loaded is None:
-                return False
-            active_lease_count = self._active_model_lease_counts.get(handle, 0)
-            if active_lease_count > 0:
-                receipt = self._pending_unload_receipts.get(handle)
-                if receipt is None:
-                    self._pending_unload_receipts[handle] = ModelUnloadReceipt(
-                        model_handle=handle,
-                        found=True,
-                        unloaded=False,
-                        pending_unload=True,
-                    )
-                return False
-            self._loaded_models.pop(handle)
-            self._pending_unload_receipts.pop(handle, None)
-            self._completed_unload_receipts.pop(handle, None)
-            self._invalidate_loaded_model_order_locked()
-            self._loaded_model_resident_bytes = max(0, self._loaded_model_resident_bytes - loaded.estimated_resident_bytes)
-            loaded_to_close = loaded
+            if not self._active_model_lease_counts:
+                loaded_to_close = self._loaded_models.pop(handle, None)
+                if loaded_to_close is None:
+                    return False
+                self._invalidate_loaded_model_order_locked()
+                self._loaded_model_resident_bytes = max(
+                    0,
+                    self._loaded_model_resident_bytes - loaded_to_close.estimated_resident_bytes,
+                )
+            else:
+                loaded = self._loaded_models.get(handle)
+                if loaded is None:
+                    return False
+                if self._active_model_lease_counts.get(handle, 0) > 0:
+                    receipt = self._pending_unload_receipts.get(handle)
+                    if receipt is None:
+                        self._pending_unload_receipts[handle] = ModelUnloadReceipt(
+                            model_handle=handle,
+                            found=True,
+                            unloaded=False,
+                            pending_unload=True,
+                        )
+                    return False
+                self._loaded_models.pop(handle)
+                if self._pending_unload_receipts:
+                    self._pending_unload_receipts.pop(handle, None)
+                if self._completed_unload_receipts:
+                    self._completed_unload_receipts.pop(handle, None)
+                self._invalidate_loaded_model_order_locked()
+                self._loaded_model_resident_bytes = max(
+                    0,
+                    self._loaded_model_resident_bytes - loaded.estimated_resident_bytes,
+                )
+                loaded_to_close = loaded
 
         self._close_loaded_model(loaded_to_close)
         return True

--- a/services/mlx-worker-python/worker/registry.py
+++ b/services/mlx-worker-python/worker/registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 import math
 from threading import Event
 from threading import Lock
@@ -47,6 +48,95 @@ class LoadedModel:
     load_trust: common_pb2.ModelLoadTrustPolicy
     prompt_tps: float = 0.0
     generation_tps: float = 0.0
+
+
+@dataclass
+class ModelUnloadReceipt:
+    model_handle: str
+    found: bool
+    unloaded: bool
+    pending_unload: bool
+    abort_requested: bool = False
+    released_at: str = ""
+    unloaded_at: str = ""
+
+    @property
+    def details(self) -> dict[str, str]:
+        return {
+            "model_handle": self.model_handle,
+            "found": _bool_text(self.found),
+            "unloaded": _bool_text(self.unloaded),
+            "pending_unload": _bool_text(self.pending_unload),
+            "abort_requested": _bool_text(self.abort_requested),
+            "released_at": self.released_at,
+            "unloaded_at": self.unloaded_at,
+        }
+
+
+def _bool_text(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+class RequestRuntimeLease:
+    def __init__(
+        self,
+        registry: WorkerRegistry,
+        loaded_model: LoadedModel,
+        *,
+        request_id: str,
+        runtime_kind: str,
+        phase: str = "generate",
+    ) -> None:
+        self._registry = registry
+        self.loaded_model = loaded_model
+        self.request_id = request_id
+        self.runtime_kind = runtime_kind
+        self.phase = phase
+        self._lease_token = object()
+        self._state: RequestState | None = None
+        self._closed = False
+
+    def __enter__(self) -> RequestRuntimeLease:
+        if self._state is None:
+            self._state = self._registry._acquire_request_runtime_lease(
+                self.loaded_model,
+                request_id=self.request_id,
+                runtime_kind=self.runtime_kind,
+                phase=self.phase,
+                lease_token=self._lease_token,
+            )
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    @property
+    def state(self) -> RequestState:
+        if self._state is None:
+            raise RuntimeError("Request runtime lease has not been entered.")
+        return self._state
+
+    @property
+    def cancel_event(self) -> Event:
+        return self.state.cancel_event
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._registry._release_request_runtime_lease(
+            self.loaded_model.handle,
+            request_id=self.request_id,
+            lease_token=self._lease_token,
+        )
+
+
+class StreamLifetimeLease(RequestRuntimeLease):
+    pass
 
 
 @dataclass
@@ -137,6 +227,11 @@ class WorkerRegistry:
         self._loaded_model_resident_bytes = 0
         self._reserved_model_resident_bytes = 0
         self._requests: dict[str, RequestState] = {}
+        self._request_model_handles: dict[str, str] = {}
+        self._request_lease_tokens: dict[str, object] = {}
+        self._active_model_lease_counts: dict[str, int] = {}
+        self._pending_unload_receipts: dict[str, ModelUnloadReceipt] = {}
+        self._completed_unload_receipts: dict[str, ModelUnloadReceipt] = {}
         self._active_request_count = 0
         self._active_prefill_count = 0
         self._active_decode_count = 0
@@ -406,17 +501,111 @@ class WorkerRegistry:
         )
 
     def unload_model(self, handle: str) -> bool:
+        loaded_to_close: LoadedModel | None = None
         with self._lock:
-            loaded = self._loaded_models.pop(handle, None)
+            loaded = self._loaded_models.get(handle)
             if loaded is None:
                 return False
+            active_lease_count = self._active_model_lease_counts.get(handle, 0)
+            if active_lease_count > 0:
+                receipt = self._pending_unload_receipts.get(handle)
+                if receipt is None:
+                    self._pending_unload_receipts[handle] = ModelUnloadReceipt(
+                        model_handle=handle,
+                        found=True,
+                        unloaded=False,
+                        pending_unload=True,
+                    )
+                return False
+            self._loaded_models.pop(handle)
+            self._pending_unload_receipts.pop(handle, None)
+            self._completed_unload_receipts.pop(handle, None)
             self._invalidate_loaded_model_order_locked()
             self._loaded_model_resident_bytes = max(0, self._loaded_model_resident_bytes - loaded.estimated_resident_bytes)
+            loaded_to_close = loaded
+
+        self._close_loaded_model(loaded_to_close)
+        return True
+
+    def request_model_unload(self, handle: str, *, force: bool = False) -> ModelUnloadReceipt:
+        loaded_to_close: LoadedModel | None = None
+        with self._lock:
+            loaded = self._loaded_models.get(handle)
+            if loaded is None:
+                return ModelUnloadReceipt(
+                    model_handle=handle,
+                    found=False,
+                    unloaded=False,
+                    pending_unload=False,
+                    abort_requested=bool(force),
+                )
+
+            active_lease_count = self._active_model_lease_counts.get(handle, 0)
+            if active_lease_count > 0:
+                receipt = self._pending_unload_receipts.get(handle)
+                if receipt is None:
+                    receipt = ModelUnloadReceipt(
+                        model_handle=handle,
+                        found=True,
+                        unloaded=False,
+                        pending_unload=True,
+                        abort_requested=False,
+                    )
+                    self._pending_unload_receipts[handle] = receipt
+                if force:
+                    receipt.abort_requested = True
+                    self._abort_requests_for_model_handle_locked(handle)
+                return receipt
+
+            receipt = self._pop_loaded_model_for_unload_locked(handle, abort_requested=bool(force))
+            loaded_to_close = loaded
+
+        self._close_loaded_model(loaded_to_close)
+        return receipt
+
+    def pending_unload_receipt(self, handle: str) -> ModelUnloadReceipt | None:
+        with self._lock:
+            return self._pending_unload_receipts.get(handle) or self._completed_unload_receipts.get(handle)
+
+    def _pop_loaded_model_for_unload_locked(
+        self,
+        handle: str,
+        *,
+        abort_requested: bool,
+        released_at: str | None = None,
+    ) -> ModelUnloadReceipt:
+        loaded = self._loaded_models.pop(handle)
+        self._invalidate_loaded_model_order_locked()
+        self._loaded_model_resident_bytes = max(0, self._loaded_model_resident_bytes - loaded.estimated_resident_bytes)
+        unloaded_at = _utc_timestamp()
+        receipt = self._pending_unload_receipts.pop(handle, None)
+        if receipt is None:
+            receipt = ModelUnloadReceipt(
+                model_handle=handle,
+                found=True,
+                unloaded=True,
+                pending_unload=False,
+                abort_requested=abort_requested,
+                released_at=released_at or "",
+                unloaded_at=unloaded_at,
+            )
+        else:
+            receipt.found = True
+            receipt.unloaded = True
+            receipt.pending_unload = False
+            receipt.abort_requested = receipt.abort_requested or abort_requested
+            receipt.released_at = released_at or receipt.released_at or unloaded_at
+            receipt.unloaded_at = unloaded_at
+        self._completed_unload_receipts[handle] = receipt
+        return receipt
+
+    @staticmethod
+    def _close_loaded_model(loaded: LoadedModel | None) -> None:
+        if loaded is None:
+            return
         close_loaded_model = getattr(loaded.runtime, "close_loaded_model", None)
         if callable(close_loaded_model):
             close_loaded_model(loaded.runtime_model)
-            return True
-        return True
 
     def _invalidate_loaded_model_order_locked(self) -> None:
         self._sorted_loaded_model_handles = None
@@ -516,13 +705,128 @@ class WorkerRegistry:
 
     def start_request(self, request_id: str, runtime_kind: str = "text") -> RequestState:
         state = RequestState(request_id=request_id, runtime_kind=runtime_kind)
+        loaded_to_close: LoadedModel | None = None
         with self._lock:
             existing = self._requests.get(request_id)
             if existing is not None:
                 self._remove_request_from_counters(existing)
+                old_handle = self._request_model_handles.pop(request_id, None)
+                self._request_lease_tokens.pop(request_id, None)
+                if old_handle is not None:
+                    self._decrement_model_lease_count_locked(old_handle)
+                    loaded_to_close = self._complete_pending_unload_if_unleased_locked(old_handle)
             self._requests[request_id] = state
             self._add_request_to_counters(state)
+        self._close_loaded_model(loaded_to_close)
         return state
+
+    def acquire_request_runtime_lease(
+        self,
+        loaded_model: LoadedModel,
+        *,
+        request_id: str,
+        runtime_kind: str | None = None,
+        phase: str = "generate",
+    ) -> RequestRuntimeLease:
+        return RequestRuntimeLease(
+            self,
+            loaded_model,
+            request_id=request_id,
+            runtime_kind=runtime_kind or loaded_model.runtime_kind,
+            phase=phase,
+        )
+
+    def acquire_stream_lifetime_lease(
+        self,
+        loaded_model: LoadedModel,
+        *,
+        request_id: str,
+        runtime_kind: str | None = None,
+        phase: str = "generate",
+    ) -> StreamLifetimeLease:
+        return StreamLifetimeLease(
+            self,
+            loaded_model,
+            request_id=request_id,
+            runtime_kind=runtime_kind or loaded_model.runtime_kind,
+            phase=phase,
+        )
+
+    def _acquire_request_runtime_lease(
+        self,
+        loaded_model: LoadedModel,
+        *,
+        request_id: str,
+        runtime_kind: str,
+        phase: str,
+        lease_token: object,
+    ) -> RequestState:
+        state = RequestState(request_id=request_id, runtime_kind=runtime_kind, phase=phase)
+        loaded_to_close: LoadedModel | None = None
+        with self._lock:
+            existing = self._requests.get(request_id)
+            if existing is not None:
+                self._remove_request_from_counters(existing)
+                old_handle = self._request_model_handles.pop(request_id, None)
+                self._request_lease_tokens.pop(request_id, None)
+                if old_handle is not None:
+                    self._decrement_model_lease_count_locked(old_handle)
+                    if old_handle != loaded_model.handle:
+                        loaded_to_close = self._complete_pending_unload_if_unleased_locked(old_handle)
+            self._requests[request_id] = state
+            self._request_model_handles[request_id] = loaded_model.handle
+            self._request_lease_tokens[request_id] = lease_token
+            self._active_model_lease_counts[loaded_model.handle] = (
+                self._active_model_lease_counts.get(loaded_model.handle, 0) + 1
+            )
+            self._add_request_to_counters(state)
+        self._close_loaded_model(loaded_to_close)
+        return state
+
+    def _release_request_runtime_lease(self, handle: str, *, request_id: str, lease_token: object) -> None:
+        loaded_to_close: LoadedModel | None = None
+        with self._lock:
+            recorded_handle = self._request_model_handles.get(request_id)
+            recorded_lease_token = self._request_lease_tokens.get(request_id)
+            if recorded_handle != handle or recorded_lease_token is not lease_token:
+                return
+            state = self._requests.pop(request_id, None)
+            if state is not None:
+                self._remove_request_from_counters(state)
+            self._request_model_handles.pop(request_id, None)
+            self._request_lease_tokens.pop(request_id, None)
+            self._decrement_model_lease_count_locked(handle)
+            loaded_to_close = self._complete_pending_unload_if_unleased_locked(handle)
+
+        self._close_loaded_model(loaded_to_close)
+
+    def _decrement_model_lease_count_locked(self, handle: str) -> None:
+        current = self._active_model_lease_counts.get(handle, 0)
+        if current <= 1:
+            self._active_model_lease_counts.pop(handle, None)
+        else:
+            self._active_model_lease_counts[handle] = current - 1
+
+    def _abort_requests_for_model_handle_locked(self, handle: str) -> None:
+        for request_id, active_handle in tuple(self._request_model_handles.items()):
+            if active_handle != handle:
+                continue
+            state = self._requests.get(request_id)
+            if state is not None:
+                state.cancel_event.set()
+
+    def _complete_pending_unload_if_unleased_locked(self, handle: str) -> LoadedModel | None:
+        active_count = self._active_model_lease_counts.get(handle, 0)
+        pending = self._pending_unload_receipts.get(handle)
+        if active_count != 0 or pending is None or handle not in self._loaded_models:
+            return None
+        loaded = self._loaded_models.get(handle)
+        self._pop_loaded_model_for_unload_locked(
+            handle,
+            abort_requested=pending.abort_requested,
+            released_at=_utc_timestamp(),
+        )
+        return loaded
 
     def get_request(self, request_id: str) -> RequestState | None:
         with self._lock:
@@ -537,10 +841,17 @@ class WorkerRegistry:
                 self._add_request_to_counters(state)
 
     def finish_request(self, request_id: str) -> None:
+        loaded_to_close: LoadedModel | None = None
         with self._lock:
             state = self._requests.pop(request_id, None)
             if state is not None:
                 self._remove_request_from_counters(state)
+            handle = self._request_model_handles.pop(request_id, None)
+            self._request_lease_tokens.pop(request_id, None)
+            if handle is not None:
+                self._decrement_model_lease_count_locked(handle)
+                loaded_to_close = self._complete_pending_unload_if_unleased_locked(handle)
+        self._close_loaded_model(loaded_to_close)
 
     def abort_request(self, request_id: str) -> bool:
         with self._lock:

--- a/services/mlx-worker-python/worker/registry.py
+++ b/services/mlx-worker-python/worker/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import math
@@ -34,6 +35,7 @@ from worker.runtime.runtime_utils import callable_accepts_kwarg
 
 
 _MULTIMODAL_REQUEST_KINDS = frozenset({"ocr", "vlm", "transcription", "speech", "image"})
+_COMPLETED_UNLOAD_RECEIPT_LIMIT = 256
 
 
 @dataclass(slots=True)
@@ -231,7 +233,8 @@ class WorkerRegistry:
         self._request_lease_tokens: dict[str, object] = {}
         self._active_model_lease_counts: dict[str, int] = {}
         self._pending_unload_receipts: dict[str, ModelUnloadReceipt] = {}
-        self._completed_unload_receipts: dict[str, ModelUnloadReceipt] = {}
+        self._completed_unload_receipt_limit = _COMPLETED_UNLOAD_RECEIPT_LIMIT
+        self._completed_unload_receipts: OrderedDict[str, ModelUnloadReceipt] = OrderedDict()
         self._active_request_count = 0
         self._active_prefill_count = 0
         self._active_decode_count = 0
@@ -596,8 +599,18 @@ class WorkerRegistry:
             receipt.abort_requested = receipt.abort_requested or abort_requested
             receipt.released_at = released_at or receipt.released_at or unloaded_at
             receipt.unloaded_at = unloaded_at
-        self._completed_unload_receipts[handle] = receipt
+        self._remember_completed_unload_receipt_locked(handle, receipt)
         return receipt
+
+    def _remember_completed_unload_receipt_locked(self, handle: str, receipt: ModelUnloadReceipt) -> None:
+        limit = max(0, self._completed_unload_receipt_limit)
+        if limit == 0:
+            self._completed_unload_receipts.clear()
+            return
+        self._completed_unload_receipts[handle] = receipt
+        self._completed_unload_receipts.move_to_end(handle)
+        while len(self._completed_unload_receipts) > limit:
+            self._completed_unload_receipts.popitem(last=False)
 
     @staticmethod
     def _close_loaded_model(loaded: LoadedModel | None) -> None:

--- a/tests/integration/test_mcp_tool_injection.py
+++ b/tests/integration/test_mcp_tool_injection.py
@@ -63,7 +63,10 @@ def test_responses_endpoint_auto_injects_mcp_tools_from_repo_owned_config() -> N
             timeout=10,
         )
         body = response.read().decode("utf-8")
-        metrics = _wait_for_metric(stack.control_plane_metrics_path, "mcp.tool_injection_count")
+        metrics = _wait_for_metric(
+            stack.control_plane_metrics_path,
+            "mcp.tool_injection_success_rate",
+        )
         values = metrics["values"]
 
         assert response.status == 200


### PR DESCRIPTION
## Summary
- Adds registry-owned request and stream lifetime leases around Python worker runtime model use so active requests pin their loaded model until release.
- Makes `UnloadModel` refuse destructive unload while active leases exist, returning retriable `unload_pending` details, and completes pending unload on final release.
- Bounds completed unload receipt retention with FIFO eviction, preserves the direct unload hot path, and hardens the MCP integration metric wait against an existing metrics snapshot race.

## Plan or Spec
- `docs/plans/2026-06-20-issue-40-cache-residency-leases.md`
- GitHub issue #40 latest hardening note from 2026-06-19; issue #40 itself was already closed by #1710, so this PR covers the follow-up executable lease/pending-unload slice.

## Commands Run
```text
git fetch origin main:refs/remotes/origin/main
PASS: origin/main at 7dddc90e

git diff --check origin/main...HEAD
PASS

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_runtime_edges.py
PASS: 43 passed in 0.77s

make swift-test
PASS: rc=0; final stage macOS menubar package completed rc=0 elapsed=165s

make py-test
PASS: 4087 passed, 14 skipped, 2 warnings in 195.44s

make integration-test
PASS: 122 passed, 1 skipped in 644.80s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts.pre_commit_gate import run_performance_report
root = Path.cwd()
changed_files = [line.strip() for line in (root / ".runtime/changed-files-pr.txt").read_text(encoding="utf-8").splitlines() if line.strip()]
outcome = run_performance_report(root, changed_files, base_ref="origin/main")
print(f"PERFORMANCE_OUTCOME status={outcome.status} selected_probe_count={outcome.selected_probe_count} report_dir={outcome.report_dir}")
PY
PASS: status=ok, selected_probe_count=2, report_dir=.runtime/pre-commit-performance/20260619-212216-0e2815f9/report

pre-commit performance probe during `git commit --amend --no-edit`
PASS: status=ok, selected_probe_count=1, report=.runtime/pre-commit-performance/20260619-212001-ab5b203e/report/report.md
```

## Coverage and Metrics
- Full PR-scoped performance report against latest `origin/main`: `.runtime/pre-commit-performance/20260619-212216-0e2815f9/report/report.md`
  - Status: `ok`
  - Changed files: `10`
  - Selected probes: `2`
  - Direct/gated probes: `2`
  - Regressions: `0`
  - Context regressions: `0`
  - Verification failures: `0`
  - Worker registry resident-bytes accumulator: `100.0%` coverage, targeted tests pass.
  - Engine generate usage token elision: `100.0%` coverage, targeted tests pass.
- Direct unload hot-path pre-commit report: `.runtime/pre-commit-performance/20260619-212001-ab5b203e/report/report.md`
  - Status: `ok`
  - Changed files: `1`
  - Selected probes: `1`
  - Direct/gated probes: `1`
  - Coverage: `95.0%`
  - Regressions: `0`
  - Context regressions: `0`
  - Verification failures: `0`
- Observability mode: `minimal`; unload refusals surface through existing gRPC structured error details and registry receipts. No new production telemetry stream was added.
- Probe overhead: `N/A`; no new performance probe or sampled/debug instrumentation was added.

## Known Gaps
- Issue #40 was already closed by #1710; this PR addresses the 2026-06-19 follow-up hardening slice only.
- Disk-backed cache accounting across model switches and broader model-switch quota fixtures remain deferred.
- No protobuf schema changes; `make proto` was not run.
- No dependency changes; no lockfile updates.
- `make bootstrap` was not rerun because the repo-local pre-commit hook was already installed and the full local gate was rerun after merging the latest `origin/main`.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
