### PR TITLE
perf: scan dataset source files before dirs

### DIFF
--- a/docs/plans/2026-06-19-dataset-source-file-first-scan.md
+++ b/docs/plans/2026-06-19-dataset-source-file-first-scan.md
@@ -1,0 +1,20 @@
+# Dataset Source File-First Scan
+
+## Scope
+
+This Python-only performance slice targets `_iter_source_file_paths()` in `services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+The affected path is already covered by the registered PR-scoped probe `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`, including focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Optimization
+
+The synthetic and expected ingest workload is file-heavy under source directories. The scan loop now tests `DirEntry.is_file(follow_symlinks=False)` before `DirEntry.is_dir(follow_symlinks=False)`, avoiding the directory check on every regular file while preserving the same sorted returned path order and non-following symlink behavior.
+
+## Verification
+
+- Focused dataset ingest tests.
+- Registered changed-scope coverage command for `dataset-source-records-scandir`.
+- Registered local Linux probe command before and after the change.
+
+## Boundary
+
+This slice changes only Python code and is locally verifiable on Linux. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -587,10 +587,10 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
             with scandir(directory) as entries:
                 for entry in entries:
                     try:
-                        if entry.is_dir(follow_symlinks=False):
-                            stack_append(entry.path)
-                        elif entry.is_file(follow_symlinks=False):
+                        if entry.is_file(follow_symlinks=False):
                             file_paths_append(entry.path)
+                        elif entry.is_dir(follow_symlinks=False):
+                            stack_append(entry.path)
                     except OSError:
                         continue
         except OSError:


### PR DESCRIPTION
## Summary
- Optimizes dataset source directory scanning by checking `DirEntry.is_file(follow_symlinks=False)` before `is_dir` in the file-heavy ingest path.
- Adds a focused plan note for the Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-19-dataset-source-file-first-scan.md`
- Registered PR-scoped probe: `dataset-source-records-scandir` already covers the touched Python path with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_reuses_cached_basename_classification services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_returns_cached_none_without_reclassifying services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_name_cache_clears_at_bound services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` -> 13 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json ... && python3 scripts/changed_scope_coverage.py ...` -> TOTAL 3 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=7 MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py`
- Additional comparison: three 400x32-file runs on `origin/main` and this branch.
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100.00% for 3 measurable changed lines.
- Registered local Linux probe default dataset (250 dirs x 24 files, 7 samples):
  - Baseline `elapsed_ms_mean=11.9385816423`, `elapsed_ms_p95=12.7587420866`
  - Branch `elapsed_ms_mean=11.9302129107`, `elapsed_ms_p95=12.4645605683`
  - Delta `elapsed_ms_mean=-0.0083687316 ms`, `elapsed_ms_p95=-0.2941815183 ms`
- Larger comparison (400 dirs x 32 files, 3 runs of 5 samples each):
  - Baseline mean of `elapsed_ms_mean` runs: `29.8227664083 ms`
  - Branch mean of `elapsed_ms_mean` runs: `29.3021795029 ms`
  - Delta `-0.5205869054 ms` (~1.75% lower)
- CI is still required for the registered PR-scoped performance report before merge.

## Known Gaps
- Linux-local verification covers the Python dataset scan path only; no Swift runtime effect is claimed.
- The local probe is filesystem-sensitive, so CI registered probe output is the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions and PR-scoped performance workflow are green.
