### PR TITLE
perf: fast-path benchmark queue string records

### DIFF
--- a/docs/plans/2026-06-19-benchmark-queue-from-dict-string-fastpath.md
+++ b/docs/plans/2026-06-19-benchmark-queue-from-dict-string-fastpath.md
@@ -1,0 +1,33 @@
+# Benchmark queue from-dict string fast path
+
+## Scope
+
+This slice targets the Linux-verifiable Python hot path in
+`services/mlx-worker-python/worker/productization/benchmark_queue.py` where
+`BenchmarkQueueRecord.from_dict()` decodes persisted queue JSON records during
+cold `BenchmarkQueueStore.list_records()` scans.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`benchmark-queue-cache` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes:
+
+- `test_command` for `test_benchmark_queue.py` and focused PR-scoped performance tests.
+- `coverage_command` with changed-scope coverage for benchmark queue and probe code.
+- `probe_command` that emits command JSON metrics from `_probe_benchmark_queue_cache()`.
+
+## Optimization
+
+Persisted benchmark queue records normally arrive from JSON with already-string
+`suite_ids` and `parameters`. The previous decode path always routed through
+`tuple(map(str, ...))` and a per-item `str()` dictionary comprehension. This
+slice adds exact-string fast paths for the common JSON shape while preserving
+fallback coercion for mixed or pair-iterable inputs.
+
+## Validation Plan
+
+Run the registered focused tests, changed-scope coverage, and the registered
+probe locally on Linux. CI remains the authoritative registered PR-scoped probe
+validation after the PR is opened.

--- a/services/mlx-worker-python/tests/test_benchmark_queue.py
+++ b/services/mlx-worker-python/tests/test_benchmark_queue.py
@@ -51,6 +51,55 @@ def test_benchmark_queue_record_uses_slots_without_instance_dict() -> None:
     assert hasattr(record, "__dict__") is False
 
 
+def test_benchmark_queue_record_from_dict_preserves_string_fast_path_and_coerces_fallback() -> None:
+    record = BenchmarkQueueRecord.from_dict(
+        {
+            "queue_item_id": "queue-1",
+            "job_kind": "benchmark",
+            "model_id": "melix-dev-text",
+            "suite_ids": ["smoke", "latency"],
+            "parameters": {"sample_size": "32", "batch_factor": "2"},
+            "status": "queued",
+            "created_at_unix_ms": 100,
+            "updated_at_unix_ms": 100,
+        }
+    )
+
+    assert record.suite_ids == ("smoke", "latency")
+    assert record.parameters == {"sample_size": "32", "batch_factor": "2"}
+
+    coerced = BenchmarkQueueRecord.from_dict(
+        {
+            "queue_item_id": "queue-2",
+            "job_kind": "benchmark",
+            "model_id": "melix-dev-text",
+            "suite_ids": ["smoke", 42],
+            "parameters": {"sample_size": 32, 7: "lucky"},
+            "status": "queued",
+            "created_at_unix_ms": 100,
+            "updated_at_unix_ms": 100,
+        }
+    )
+
+    assert coerced.suite_ids == ("smoke", "42")
+    assert coerced.parameters == {"sample_size": "32", "7": "lucky"}
+
+    pair_parameters = BenchmarkQueueRecord.from_dict(
+        {
+            "queue_item_id": "queue-3",
+            "job_kind": "benchmark",
+            "model_id": "melix-dev-text",
+            "suite_ids": ["smoke"],
+            "parameters": [("sample_size", 16)],
+            "status": "queued",
+            "created_at_unix_ms": 100,
+            "updated_at_unix_ms": 100,
+        }
+    )
+
+    assert pair_parameters.parameters == {"sample_size": "16"}
+
+
 def test_list_records_is_stable_by_created_time_then_id(tmp_path: Path) -> None:
     store = BenchmarkQueueStore()
     queue_root = tmp_path / "queue"

--- a/services/mlx-worker-python/worker/productization/benchmark_queue.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_queue.py
@@ -11,6 +11,29 @@ import stat
 _RECORD_SORT_KEY = attrgetter("created_at_unix_ms", "queue_item_id")
 
 
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if isinstance(value, list):
+        for item in value:
+            if type(item) is not str:
+                break
+        else:
+            return tuple(value)
+    return tuple(map(str, value))  # type: ignore[arg-type]
+
+
+def _string_dict(value: object) -> dict[str, str]:
+    if isinstance(value, dict):
+        if not value:
+            return {}
+        for key, item in value.items():
+            if type(key) is not str or type(item) is not str:
+                break
+        else:
+            return dict(value)
+        return {str(key): str(item) for key, item in value.items()}
+    return {str(key): str(item) for key, item in dict(value).items()}  # type: ignore[arg-type]
+
+
 @dataclass(frozen=True, slots=True)
 class _RecordCacheEntry:
     metadata_key: tuple[int, int, int, int]
@@ -45,19 +68,12 @@ class BenchmarkQueueRecord:
 
     @staticmethod
     def from_dict(payload: dict[str, object]) -> BenchmarkQueueRecord:
-        raw_suite_ids = payload.get("suite_ids", ())
-        raw_parameters = payload.get("parameters", {})
-        parameter_items = (
-            raw_parameters.items()
-            if isinstance(raw_parameters, dict)
-            else dict(raw_parameters).items()
-        )
         return BenchmarkQueueRecord(
             queue_item_id=str(payload["queue_item_id"]),
             job_kind=str(payload["job_kind"]),
             model_id=str(payload["model_id"]),
-            suite_ids=tuple(map(str, raw_suite_ids)),
-            parameters={str(key): str(value) for key, value in parameter_items},
+            suite_ids=_string_tuple(payload.get("suite_ids", ())),
+            parameters=_string_dict(payload.get("parameters", {})),
             status=str(payload["status"]),
             created_at_unix_ms=int(payload["created_at_unix_ms"]),
             updated_at_unix_ms=int(payload["updated_at_unix_ms"]),


### PR DESCRIPTION
## Summary
- Adds exact-string fast paths for `BenchmarkQueueRecord.from_dict()` when persisted queue JSON already contains string `suite_ids` and `parameters`.
- Preserves fallback coercion for mixed-type suites, mixed dict keys/values, and pair-iterable parameter payloads.
- Adds regression coverage for the common string shape and fallback coercion paths.

## Plan or Spec
- `docs/plans/2026-06-19-benchmark-queue-from-dict-string-fastpath.md`
- Registered PR-scoped probe: `benchmark-queue-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Focused registered test command (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
# 28 passed in 16.58s

# Changed-scope coverage command (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_queue.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 26 0 100%

# Registered probe implementation, repeated locally via the same _probe_benchmark_queue_cache() function (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_benchmark_queue_probe.py
# old samples were collected from origin/main; new samples from this branch.
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 26 0 100%`.
- Local Linux registered probe samples (`benchmark-queue-cache`, 5 runs each):
  - `cold_elapsed_ms`: old_mean=`5.664220`, new_mean=`5.297756`, delta_ms=`-0.366464`, speedup=`6.47%`.
  - `warm_elapsed_ms_mean`: old_mean=`0.779930`, new_mean=`0.677044`, delta_ms=`-0.102887`, speedup=`13.19%`.
  - `warm_json_loads_mean`: old_mean=`0.0`, new_mean=`0.0`, unchanged.
- CI PR-scoped performance workflow is required for the authoritative registered probe report before merge.

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime effect is claimed for this slice.
- Micro-probe timings are noisy, so merge should wait for the registered PR-scoped CI probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
