### PR TITLE
perf: bind embedding digest math helpers

### DIFF
--- a/docs/plans/2026-06-06-embedding-project-digest-sha-binding.md
+++ b/docs/plans/2026-06-06-embedding-project-digest-sha-binding.md
@@ -19,6 +19,16 @@ The registry entry includes focused `test_command`, `coverage_command`, and `pro
 5. Verify the zero-norm contract inside the registered project-digest probe, then run focused embedding tests, changed-scope coverage, and the registered probe locally on Linux.
 6. Use PR-scoped performance CI as the merge gate.
 
+## 2026-06-19 local binding follow-up
+
+A follow-up Python-only micro-slice keeps the same registered probe and behavior
+contract while narrowing interpreter overhead in `_project_digest()` and
+`_project_digest_expanded()`. The `math.sqrt` and `round` callables are bound
+through module/default locals so repeated deterministic embedding projection
+avoids extra global lookups on both the default 8-dimension and expanded-vector
+paths while leaving the digest unpacker and scale globals patchable for the
+zero-norm regression probe.
+
 ## Success metrics
 
 Success is measured by the registered probe's `elapsed_ms_mean` and `default_dimension_elapsed_ms_mean` moving lower without changing checksum values. Behavior parity is measured by `test_project_digest_preserves_legacy_projection_values` and the existing embedding runtime tests.

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -7,6 +7,8 @@ import struct
 import unicodedata
 
 _SHA256 = hashlib.sha256
+_SQRT = math.sqrt
+_ROUND = round
 _UNPACK_DIGEST_UINT32 = struct.Struct("<8I").unpack
 _DIGEST_UINT32_SCALE = 2.0 / 0xFFFFFFFF
 
@@ -45,20 +47,35 @@ class DeterministicEmbeddingBackend:
     def embed_text(self, text: str, dimensions: int) -> list[float]:
         raise NotImplementedError
 
-    def _project_digest(self, seed_text: str, dimensions: int) -> list[float]:
+    def _project_digest(
+        self,
+        seed_text: str,
+        dimensions: int,
+        *,
+        _sha256=_SHA256,
+        _sqrt=_SQRT,
+        _round=_ROUND,
+    ) -> list[float]:
         base_values = [
             raw * _DIGEST_UINT32_SCALE - 1.0
-            for raw in _UNPACK_DIGEST_UINT32(_SHA256(seed_text.encode("utf-8")).digest())
+            for raw in _UNPACK_DIGEST_UINT32(_sha256(seed_text.encode("utf-8")).digest())
         ]
         if dimensions == 8:
-            l2_norm = math.sqrt(sum(value * value for value in base_values))
+            l2_norm = _sqrt(sum(value * value for value in base_values))
             if l2_norm == 0.0:
                 return [0.0] * 8
             inverse_l2_norm = 1.0 / l2_norm
-            return [round(value * inverse_l2_norm, 6) for value in base_values]
+            return [_round(value * inverse_l2_norm, 6) for value in base_values]
         return self._project_digest_expanded(base_values, dimensions)
 
-    def _project_digest_expanded(self, base_values: list[float], dimensions: int) -> list[float]:
+    def _project_digest_expanded(
+        self,
+        base_values: list[float],
+        dimensions: int,
+        *,
+        _sqrt=_SQRT,
+        _round=_ROUND,
+    ) -> list[float]:
         full_repeats, remainder = divmod(dimensions, 8)
         squared_sum = sum(value * value for value in base_values) * full_repeats
         if remainder == 1:
@@ -69,11 +86,11 @@ class DeterministicEmbeddingBackend:
                 value = base_values[index]
                 squared_sum += value * value
 
-        l2_norm = math.sqrt(squared_sum)
+        l2_norm = _sqrt(squared_sum)
         if l2_norm == 0.0:
             return [0.0] * dimensions
         inverse_l2_norm = 1.0 / l2_norm
-        normalized_base = [round(value * inverse_l2_norm, 6) for value in base_values]
+        normalized_base = [_round(value * inverse_l2_norm, 6) for value in base_values]
         if remainder == 0:
             if full_repeats == 1:
                 return normalized_base


### PR DESCRIPTION
## Summary
- Bind deterministic embedding projection math helpers (`sqrt`, `round`, SHA constructor) through module/default locals to reduce repeated global lookup overhead.
- Keep digest unpacker and scale globals patchable for the zero-norm regression probe.
- Document the local-binding follow-up in the embedding project digest performance plan.

## Plan or Spec
- Updated `docs/plans/2026-06-06-embedding-project-digest-sha-binding.md` with the 2026-06-19 local binding follow-up.
- Registered probe coverage: `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json` already includes focused `test_command`, `coverage_command`, and `probe_command` entries for this path.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-project-digest-allocation --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-embedding-digest-local-bindings-20260619 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-hub-size-hint-direct-marker-20260619 --output /tmp/embedding-digest-probe-result.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 20 passed.
- Changed-scope coverage: 100.00% (`8/8` measurable changed lines covered).
- Registered local probe `deterministic-embedding-project-digest-allocation`:
  - `elapsed_ms_mean`: base `19.014366` ms → head `16.608488` ms (`-2.405878` ms, ~12.65% faster)
  - `default_dimension_elapsed_ms_mean`: base `128.553194` ms → head `121.702367` ms (`-6.850827` ms, ~5.33% faster)
  - `peak_bytes_mean`: base/head `74840.888889` bytes (no regression)
  - `default_dimension_peak_bytes_mean`: base/head `1261.333333` bytes (no regression)
  - Checksums unchanged: `checksum=8.325108`, `default_dimension_checksum=213.60249`

## Known Gaps
- Linux local validation covers the Python behavior and registered probe. Final merge is gated on GitHub Actions, including the PR-scoped performance workflow/report.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe was run locally with base/head comparison.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
