### PR TITLE
perf: bind embedding core runtime inputs

### DIFF
--- a/docs/plans/2026-05-24-embedding-core-local-bindings.md
+++ b/docs/plans/2026-05-24-embedding-core-local-bindings.md
@@ -28,3 +28,9 @@ Run the registered focused pytest command, changed-scope coverage command, and
 `embedding-core-inputs-view` probe locally on Linux. Compare the local probe
 against the synced `origin/main` baseline before pushing. CI remains the merge
 gate for the registered PR-scoped performance report.
+
+## 2026-06-19 Slice
+
+The current follow-up binds `loaded_model.runtime_model` and `request.inputs` to
+locals immediately before the runtime call. This preserves the protobuf repeated
+input view, avoids list materialization, and keeps response assembly unchanged.

--- a/services/mlx-worker-python/worker/engine/embedding_core.py
+++ b/services/mlx-worker-python/worker/engine/embedding_core.py
@@ -25,10 +25,12 @@ class EmbeddingCore:
                 )
             )
 
+        runtime_model = loaded_model.runtime_model
+        request_inputs = request.inputs
         try:
             vectors = registry.embedding_runtime.embed_inputs(
-                loaded_model.runtime_model,
-                request.inputs,
+                runtime_model,
+                request_inputs,
             )
         except Exception as exc:  # pragma: no cover - defensive branch
             return inference_pb2.EmbedResponse(


### PR DESCRIPTION
## Summary
- Bind `loaded_model.runtime_model` and `request.inputs` to locals before the embedding runtime call.
- Preserve protobuf repeated-input view forwarding and existing response assembly.

## Plan or Spec
- `docs/plans/2026-05-24-embedding-core-local-bindings.md`
- Registered probe: `embedding-core-inputs-view` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_passes_request_inputs_without_list_materialization services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_returns_stable_vectors_for_loaded_embedding_models services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_runtime_reuses_duplicate_inputs_within_one_request services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_core_inputs_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_embedding_core_inputs_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/embedding_core.py services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/embedding_core_inputs_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_CORE_INPUTS_REPO_ROOT="$PWD" python3 scripts/embedding_core_inputs_probe.py` on synced `origin/main` baseline and this branch.

## Coverage and Metrics
- Focused tests: 7 passed.
- Changed-scope coverage: 100.00% (2/2 changed measurable lines covered).
- Local Linux probe (`embedding_core_inputs_probe.py`, direct python3): baseline `elapsed_ms_mean=5201.470842`, head `elapsed_ms_mean=5061.208046`, delta `-140.262796 ms` (`-2.70%`); baseline `peak_bytes_mean=794448.0`, head `peak_bytes_mean=794512.0`, delta `+64.0 bytes` (`+0.01%`).
- CI PR-scoped performance report is required as the registered probe merge gate.

## Known Gaps
- Local validation is Linux-only Python validation; CI remains the authoritative registered PR-scoped performance gate.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the changed path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local Linux probe captured baseline/head metrics.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
