### PR TITLE
perf: fast path retrieval store record dict access

### DIFF
--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -313,13 +313,22 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
             continue
 
         if type(record) is dict:
-            source_id = record_get("source_id")
-            payload = record_get("payload")
-            owner_scope_checked = record_get("owner_scope_checked")
-            segment_id = record_get("segment_id", "")
-            source_field = record_get("source_field", "")
-            reason = record_get("reason", "")
-            corrective_action = record_get("corrective_action", "")
+            try:
+                source_id = record["source_id"]
+                payload = record["payload"]
+                owner_scope_checked = record["owner_scope_checked"]
+                segment_id = record["segment_id"]
+                source_field = record["source_field"]
+                reason = record["reason"]
+                corrective_action = record["corrective_action"]
+            except KeyError:
+                source_id = record_get("source_id")
+                payload = record_get("payload")
+                owner_scope_checked = record_get("owner_scope_checked")
+                segment_id = record_get("segment_id", "")
+                source_field = record_get("source_field", "")
+                reason = record_get("reason", "")
+                corrective_action = record_get("corrective_action", "")
             if (
                 isinstance(source_id, str)
                 and isinstance(payload, dict)


### PR DESCRIPTION
## Summary
- Fast-path complete exact-dict retrieval store records by reading required fields with direct indexing before falling back to the existing `.get()` path for missing-key records.
- Keeps malformed/missing-key behavior unchanged while reducing per-record lookup overhead on the registered retrieval-context projection path.

## Plan or Spec
- Governing spec: `docs/unified-agentic-tool-runtime-contract.md` (`project_retrieval_store_records` / retrieval context projection contract).
- Registered probe: `infra/perf/pr_scoped_probes.json` entry `retrieval-context-projection-fastpath` already covers `services/mlx-worker-python/worker/runtime/retrieval_context.py` with focused `test_command`, `coverage_command`, and `probe_command`.

## Commands Run
```text
# baseline comparison from origin/main worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" MELIX_RETRIEVAL_CONTEXT_PROJECTION_SAMPLES=7 MELIX_RETRIEVAL_CONTEXT_PROJECTION_ITERATIONS=1000 uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
exit 0; origin/main store_optimized_elapsed_ms_mean=0.15178772687379802

# candidate comparison from this branch
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" MELIX_RETRIEVAL_CONTEXT_PROJECTION_SAMPLES=7 MELIX_RETRIEVAL_CONTEXT_PROJECTION_ITERATIONS=1000 uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
exit 0; branch store_optimized_elapsed_ms_mean=0.14015604183077812

# registered focused test command from retrieval-context-projection-fastpath
bash /tmp/retrieval_test.sh
exit 0; 28 passed in 1.06s

# registered changed-scope coverage command from retrieval-context-projection-fastpath
bash /tmp/retrieval_coverage.sh
exit 0; TOTAL 16 0 100%

# registered probe command from retrieval-context-projection-fastpath
bash /tmp/retrieval_probe.sh
exit 0; store_optimized_elapsed_ms_mean=0.13592132067840015; store_speedup=2.3027169795199343

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 16 0 100%` for `services/mlx-worker-python/worker/runtime/retrieval_context.py` changed lines.
- Local Linux registered probe (final branch run):
  - `baseline_elapsed_ms_mean=0.9873720767375614`
  - `optimized_elapsed_ms_mean=0.12114405066573194`
  - `speedup=8.150396749254973`
  - `store_baseline_elapsed_ms_mean=0.31298833300492596`
  - `store_optimized_elapsed_ms_mean=0.13592132067840015`
  - `store_delta_ms=-0.1770670123265258`
  - `store_speedup=2.3027169795199343`
- Base-vs-branch local comparison with 7 samples / 1000 iterations: `store_optimized_elapsed_ms_mean` improved from `0.15178772687379802 ms` to `0.14015604183077812 ms` (`delta=-0.0116316850430199 ms`, about `7.66%` lower).
- CI PR-scoped performance validation is still required before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this slice used the registered focused retrieval-context commands plus GitHub Actions.
- No Swift runtime effect is claimed for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or not needed because behavior is unchanged.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
