### PR TITLE
perf: bind benchmark report probe helpers locally

### DIFF
--- a/docs/plans/2026-06-20-benchmark-evaluation-probe-local-bindings.md
+++ b/docs/plans/2026-06-20-benchmark-evaluation-probe-local-bindings.md
@@ -1,0 +1,20 @@
+# Benchmark Evaluation Probe Local-Binding Slice
+
+## Scope
+
+This Python-only performance slice is limited to `worker.productization.benchmark_evaluation_report._collect_benchmark_probe_metrics`.
+
+## Optimization
+
+The benchmark/evaluation report hot path scans large request-row bundles and aggregates fixed probe keys. The behavior remains unchanged while the inner aggregation loop now binds the fixed probe-key containers and helper callables to locals once per call. This avoids repeated module-global lookups in the row/key loop without changing label generation, numeric conversion, or aggregate finalization.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`, including focused `test_command`, `coverage_command`, and `probe_command` entries. Local Linux verification uses that registered probe; GitHub Actions PR-scoped performance remains the merge gate.
+
+## Verification Plan
+
+- Run the focused benchmark evaluation report tests.
+- Run the registered changed-scope coverage command and require at least 95% for the touched scope.
+- Run the registered probe locally on Linux against the current worktree.
+- Run the PR-scoped performance workflow in CI and merge only after green checks and an acceptable registered probe report.

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -2554,10 +2554,15 @@ def _collect_benchmark_probe_metrics(
 ) -> None:
     aggregate_pairs: dict[_ProbeAggregateKey, _NumericAggregate] = {}
     matrix_label_cache: dict[tuple[object, object, object, object, object], str] = {}
+    request_probe_keys = _REQUEST_PROBE_KEY_SET
+    agentic_tool_metric_keys = _AGENTIC_TOOL_METRIC_KEYS
+    float_or_none = _float_or_none
+    update_pair = _update_probe_aggregate_pairs
+    benchmark_label = _benchmark_probe_label
     for row in _dict_rows(rows):
         label = ""
         for key, raw_value in row.items():
-            if key not in _REQUEST_PROBE_KEY_SET:
+            if key not in request_probe_keys:
                 continue
             raw_value_type = type(raw_value)
             if raw_value_type is float:
@@ -2565,15 +2570,15 @@ def _collect_benchmark_probe_metrics(
             elif raw_value_type is int or raw_value_type is bool:
                 value = float(raw_value)
             else:
-                value = _float_or_none(raw_value)
+                value = float_or_none(raw_value)
             if value is not None:
                 if not label:
-                    label = _benchmark_probe_label(
+                    label = benchmark_label(
                         row,
                         label_cache=label_cache,
                         matrix_label_cache=matrix_label_cache,
                     )
-                _update_probe_aggregate_pairs(
+                update_pair(
                     aggregate_pairs,
                     label=label,
                     key=key,
@@ -2582,15 +2587,16 @@ def _collect_benchmark_probe_metrics(
         raw_tool_metrics = row.get("agentic_tool_metrics")
         if isinstance(raw_tool_metrics, dict):
             if not label:
-                label = _benchmark_probe_label(
+                label = benchmark_label(
                     row,
                     label_cache=label_cache,
                     matrix_label_cache=matrix_label_cache,
                 )
-            for key in _AGENTIC_TOOL_METRIC_KEYS:
-                value = _float_or_none(raw_tool_metrics.get(key))
+            raw_tool_metrics_get = raw_tool_metrics.get
+            for key in agentic_tool_metric_keys:
+                value = float_or_none(raw_tool_metrics_get(key))
                 if value is not None:
-                    _update_probe_aggregate_pairs(
+                    update_pair(
                         aggregate_pairs,
                         label=label,
                         key=key,


### PR DESCRIPTION
## Summary
- Optimizes `benchmark_evaluation_report._collect_benchmark_probe_metrics` by binding the fixed probe-key containers and helper callables once per aggregation call.
- Keeps probe label generation, numeric conversion, and aggregate finalization behavior unchanged.
- Adds the governing performance-slice plan for this Python-only change.

## Plan or Spec
- `docs/plans/2026-06-20-benchmark-evaluation-probe-local-bindings.md`
- Registered PR-scoped probe: `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
git fetch origin && git reset --hard origin/main
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# 65 passed in 0.37s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# 65 passed in 0.45s; TOTAL 98%; benchmark_evaluation_report.py 97%; test_benchmark_evaluation_report.py 99%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-evaluation-report-running-aggregates --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-benchmark-sample-builder-local-bindings-20260620-base --head-repo "$PWD" --output /tmp/benchmark_eval_probe_compare.json
# head verification ok; base probe ok; head probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 98% total from the registered coverage command; touched production file `benchmark_evaluation_report.py` reported 97%.
- Registered local Linux probe (`benchmark-evaluation-report-running-aggregates`):
  - `elapsed_ms_mean`: base `398.802013 ms`, head `345.750292 ms`, delta `-53.051721 ms` (`13.30%` lower; lower is better)
  - `load_input_ms_mean`: base `7.833076 ms`, head `7.079255 ms`, delta `-0.753821 ms` (`9.62%` lower; lower is better)
  - `peak_bytes_mean`: base `13,636,836.8`, head `13,636,841.6`, delta `+4.8 bytes` (effectively flat)
- GitHub Actions PR-scoped performance remains the required merge-gate validation.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally for this narrow Python slice.
- Local validation is Linux-only; no Swift runtime effect is claimed or expected for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence; no new probe overhead beyond the existing registered PR-scoped probe.
- [x] Deferred work and known gaps are stated explicitly.
