### PR TITLE
perf: avoid dataset source empty strip allocation

### DIFF
--- a/docs/plans/2026-06-20-dataset-source-empty-check-isspace.md
+++ b/docs/plans/2026-06-20-dataset-source-empty-check-isspace.md
@@ -1,0 +1,32 @@
+# Dataset source empty check isspace fast path
+
+This Python-only performance slice is limited to `worker.productization.dataset_preparation._iter_source_records()`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_source_records_probe.py`
+
+## Optimization
+
+Replace `not text.strip()` with `not text or text.isspace()` when detecting empty ingest sources. This preserves the empty/whitespace-only rejection behavior while avoiding allocation of a stripped copy for normal non-empty source files.
+
+## Verification plan
+
+1. Extend the focused ingest failure test to include a whitespace-only text source.
+2. Run the registered focused test command for `dataset-source-records-scandir` locally on Linux.
+3. Run the registered changed-scope coverage command locally on Linux.
+4. Run the registered probe locally via `scripts/pr_scoped_performance_run.py` against `origin/main` and this branch.
+5. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Success criteria
+
+- Focused tests pass and the whitespace-only source remains classified as `DATASET_INGEST_EMPTY_SOURCE`.
+- Changed-scope coverage for touched files remains at or above 95%.
+- The registered local and CI probes show non-regression or improvement for `elapsed_ms_mean` and related source-record metrics.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -311,6 +311,7 @@ def test_dataset_ingest_emits_typed_operator_failures(tmp_path: Path) -> None:
     output_root = tmp_path / "prepared"
     input_root.mkdir()
     (input_root / "empty.txt").write_text("", encoding="utf-8")
+    (input_root / "blank.txt").write_text(" \n\t\n", encoding="utf-8")
     (input_root / "archive.bin").write_bytes(b"\x00\x01")
 
     receipt = prepare_dataset_ingest(
@@ -329,6 +330,7 @@ def test_dataset_ingest_emits_typed_operator_failures(tmp_path: Path) -> None:
         "DATASET_INGEST_UNSUPPORTED_SOURCE",
     }
     assert {failure["id"] for failure in receipt["operator_failures"]} == {
+        "dataset-ingest-empty-source-blank-txt",
         "dataset-ingest-empty-source-empty-txt",
         "dataset-ingest-unsupported-source-archive-bin",
     }

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -551,7 +551,7 @@ def _iter_source_records(
             )
             continue
         text = path.read_text(encoding="utf-8")
-        if not text.strip():
+        if not text or text.isspace():
             operator_failures.append(
                 {
                     "id": _failure_id("empty-source", path.name),


### PR DESCRIPTION
## Summary
- Avoid allocating a stripped copy while rejecting empty dataset ingest sources.
- Preserve whitespace-only source rejection with `not text or text.isspace()`.
- Add a focused regression assertion for whitespace-only `.txt` input.

## Plan or Spec
- `docs/plans/2026-06-20-dataset-source-empty-check-isspace.md`
- Registered PR-scoped probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures
# 1 passed in 0.18s

# Registered focused test command for dataset-source-records-scandir
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...
# 13 passed in 0.90s

# Registered changed-scope coverage command for dataset-source-records-scandir
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json ... && python3 scripts/changed_scope_coverage.py ...
# 13 passed in 0.33s; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/dataset_source_empty_check_isspace_probe.json
# head verification ok; base/head probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Local registered probe `dataset-source-records-scandir`:
  - `elapsed_ms_mean`: base `10.940107428463566`, head `10.560650142906525`, delta `-0.3794572855570415 ms` (`3.47%` faster).
  - `elapsed_ms_p95`: base `11.934607000512187`, head `11.363396999513498`.
  - `source_kind_elapsed_ms_mean`: base `16.29187385749122`, head `14.76794342865365`, delta `-1.5239304288375681 ms` (`9.35%` faster).
  - `file_count_mean`: base/head `6000.0`.
- CI PR-scoped performance remains the merge gate for the registered probe.

## Known Gaps
- None. This is a Linux-verified Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability changes.
- [x] Deferred work and known gaps are stated explicitly.
