### PR TITLE
perf: inline hub catalog hot string guards

### DIFF
--- a/docs/plans/2026-06-20-hub-catalog-hot-string-guard-inline.md
+++ b/docs/plans/2026-06-20-hub-catalog-hot-string-guard-inline.md
@@ -1,0 +1,21 @@
+# Hub Catalog Hot String Guard Inline
+
+## Scope
+
+This Python-only performance slice is limited to hot Hub catalog string-field guards in `services/mlx-worker-python/worker/model_ops/hub_catalog.py`, specifically `_size_hint_bytes(...)` and `_payload_is_mlx_compatible(...)`.
+
+The affected path is covered by the registered PR-scoped probe `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`. The registry entry has focused `test_command`, `coverage_command`, and `probe_command` entries covering the Hub catalog implementation, focused tests, PR-scoped performance tests, and `scripts/hub_catalog_size_hint_probe.py`.
+
+## Behavior
+
+The Hub catalog path reads the same payload and card-data fields as before. This slice inlines the existing string-type guard for the hot size-hint and MLX-compatibility text fields, avoiding repeated helper calls while preserving the same `str`-only acceptance rule. It does not change accepted model-size syntax, regex fallback behavior, compatibility semantics, or local-fit calculations.
+
+## Verification
+
+Run the registered focused Hub catalog test command, changed-scope coverage command, and the registered `hub-catalog-size-hint-regex-precompile` probe locally on Linux before pushing. Use the GitHub Actions PR-scoped performance report as the merge gate.
+
+Success criteria:
+
+- focused Hub catalog tests pass;
+- changed-scope coverage for touched files remains at least 95%;
+- the registered size-hint probe shows non-regression or improvement for `elapsed_ms_mean` with unchanged `size_hint_calls_mean` and matched-count guard rails.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -1546,15 +1546,11 @@ def test_search_models_treats_gated_auto_as_soft_access_not_blocked() -> None:
     assert model.recommended_action == "download"
 
 
-def test_size_hint_bytes_normalizes_each_payload_text_once(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[object] = []
-    original = hub_catalog_module._string
+def test_size_hint_bytes_preserves_text_field_type_guards(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_if_legacy_string_helper_is_used(_value: object) -> str:
+        raise AssertionError("_size_hint_bytes should inline hot text field string guards")
 
-    def tracked(value: object) -> str:
-        calls.append(value)
-        return original(value)
-
-    monkeypatch.setattr(hub_catalog_module, "_string", tracked)
+    monkeypatch.setattr(hub_catalog_module, "_string", fail_if_legacy_string_helper_is_used)
 
     assert (
         hub_catalog_module._size_hint_bytes(
@@ -1566,7 +1562,21 @@ def test_size_hint_bytes_normalizes_each_payload_text_once(monkeypatch: pytest.M
         )
         == 512 * MB
     )
-    assert calls == [None, "Model", "size: 512 MB", "extra notes"]
+    assert hub_catalog_module._size_hint_bytes(
+        {
+            "description": object(),
+            "readme": None,
+            "cardData": {"description": ["Model size: 512 MB"], "model_size": object()},
+        }
+    ) == 0
+    assert hub_catalog_module._payload_is_mlx_compatible(
+        {"id": "plain/model", "library_name": "mlx", "tags": [object()], "cardData": {}}
+    )
+    assert not hub_catalog_module._payload_is_mlx_compatible(
+        {"id": object(), "library_name": object(), "tags": [object()], "cardData": {"library_name": object()}}
+    )
+    with pytest.raises(AssertionError):
+        hub_catalog_module._string("legacy helper path")
 
 
 def test_search_models_ignores_non_model_size_hints_in_readme_text() -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -513,18 +513,21 @@ def _repo_id_contains_mlx(repo_id: str) -> bool:
 
 
 def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:
-    library_name = _string(payload.get("library_name"))
+    raw_library_name = payload.get("library_name")
+    library_name = raw_library_name if isinstance(raw_library_name, str) else ""
     if library_name and _is_mlx_atom(library_name):
         return True
     if _tag_payload_contains_mlx(payload.get("tags")):
         return True
-    repo_id = _string(payload.get("id") or payload.get("modelId"))
+    raw_repo_id = payload.get("id") or payload.get("modelId")
+    repo_id = raw_repo_id if isinstance(raw_repo_id, str) else ""
     if _repo_id_contains_mlx(repo_id):
         return True
     card_data = payload.get("cardData")
     if not isinstance(card_data, dict):
         return False
-    if not library_name and _is_mlx_atom(_string(card_data.get("library_name"))):
+    raw_card_library_name = card_data.get("library_name")
+    if not library_name and isinstance(raw_card_library_name, str) and _is_mlx_atom(raw_card_library_name):
         return True
     card_tags = card_data.get("tags")
     if not card_tags:
@@ -766,7 +769,8 @@ def _size_hint_bytes(payload: dict[str, Any], *, card_data: dict[str, Any] | Non
     if card_data is None:
         raw_card_data = payload.get("cardData")
         card_data = raw_card_data if isinstance(raw_card_data, dict) else {}
-    direct_card_text = _string(card_data.get("model_size"))
+    raw_direct_card_text = card_data.get("model_size")
+    direct_card_text = raw_direct_card_text if isinstance(raw_direct_card_text, str) else ""
     if direct_card_text:
         direct_card_hint = _direct_card_size_hint_from_text(direct_card_text)
         if direct_card_hint > 0:
@@ -775,9 +779,12 @@ def _size_hint_bytes(payload: dict[str, Any], *, card_data: dict[str, Any] | Non
         if direct_card_hint > 0:
             return direct_card_hint
 
-    description_text = _string(payload.get("description"))
-    readme_text = _string(payload.get("readme"))
-    card_description_text = _string(card_data.get("description"))
+    raw_description_text = payload.get("description")
+    description_text = raw_description_text if isinstance(raw_description_text, str) else ""
+    raw_readme_text = payload.get("readme")
+    readme_text = raw_readme_text if isinstance(raw_readme_text, str) else ""
+    raw_card_description_text = card_data.get("description")
+    card_description_text = raw_card_description_text if isinstance(raw_card_description_text, str) else ""
     if not readme_text and not card_description_text:
         return _size_hint_from_marked_text(description_text) if description_text else 0
     if not description_text and not card_description_text:


### PR DESCRIPTION
## Summary
- Inline the hot `str` type guards in Hub catalog size-hint parsing and MLX compatibility checks.
- Preserve existing `str`-only semantics for non-string payload/card fields while removing repeated `_string(...)` helper calls in the registered probe path.
- Add a focused regression assertion covering the inline guard behavior.

## Plan or Spec
- `docs/plans/2026-06-20-hub-catalog-hot-string-guard-inline.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json` already covers the touched Hub catalog path with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# exit 0; 84 passed; changed-scope coverage TOTAL 23 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-dataset-card-metrics-float-fastpath-20260620 --output /tmp/hub_catalog_hot_string_guard_probe.json
# exit 0; head verification ok; base/head probe ok
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 23 0 100%`).
- Local registered probe `hub-catalog-size-hint-regex-precompile`:
  - `elapsed_ms_mean`: base `1773.1643065999378` ms, head `1761.2839228000666` ms, delta `-11.880383799871197` ms (~0.67% faster).
  - `payload_compatibility_elapsed_ms_mean`: base `201.7729489998601` ms, head `198.11332960016443` ms, delta `-3.659619399695657` ms (~1.81% faster).
  - `size_hint_calls_mean`: base `0.0`, head `0.0`.
  - `matched_hint_count`: base/head `120000.0`.
  - `peak_bytes_mean`: base/head `819.0` bytes.
- CI PR-scoped performance report is required as the final registered probe validation source before merge.

## Known Gaps
- Linux local validation only; no Swift/macOS runtime effects are touched.
- Full repository `make` gates were not run locally for this focused Python slice; GitHub Actions is the broader merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
