### PR TITLE
perf: direct always-only tool selection receipts

### DIFF
--- a/docs/plans/2026-06-20-tool-selection-always-receipt-direct.md
+++ b/docs/plans/2026-06-20-tool-selection-always-receipt-direct.md
@@ -1,0 +1,29 @@
+# Tool selection always-only direct receipt slice
+
+## Scope
+
+This Python-only performance slice is limited to `select_agentic_tools_for_turn(...)` in `services/mlx-worker-python/worker/runtime/tool_registry.py` when `max_selected_tools` clamps to one.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_select_probe.py`
+
+The primary metric for this slice is `always_only_planning_elapsed_ms_mean`; the broader selector metrics should remain neutral.
+
+## Optimization plan
+
+1. Keep the existing always-only behavior: `local_compute` remains the only selected tool, vector availability is still reported, and keyword/vector scans are skipped.
+2. Replace the generic receipt builder call on the always-only branch with a direct helper that avoids allocating the transient selected-name list and source map.
+3. Run focused tool-registry tests, changed-scope coverage, and the registered probe locally on Linux.
+4. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Expected performance signal
+
+The expected directional signal is lower `always_only_planning_elapsed_ms_mean` from removing per-call transient collection allocation on the `max_selected_tools == 1` hot path. Overall selector metrics may remain neutral because the probe also exercises vector, keyword, registry-selection, and config-template paths.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -469,14 +469,7 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
     registry = agentic_tool_catalog_registry()
     max_selected_tools = max(1, selection_input.max_selected_tools)
     if max_selected_tools == 1:
-        return _build_tool_selection_result(
-            registry,
-            ["local_compute"],
-            {"local_compute": "always"},
-            selection_input,
-            "fallback",
-            "no_keyword_match",
-        )
+        return _build_always_only_tool_selection_result(registry, selection_input)
     selected_sources: dict[str, str] = {}
     selected_names: list[str] = []
     has_vector_selection = False
@@ -547,6 +540,32 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
         selection_input,
         selection_mode,
         fallback_reason,
+    )
+
+
+def _build_always_only_tool_selection_result(
+    registry: ToolRegistry,
+    selection_input: ToolSelectionInput,
+) -> ToolSelectionResult:
+    selected_name = "local_compute"
+    selected_registry = registry.select((selected_name,))
+    registry_metrics = registry.metrics()
+    selected_metrics = selected_registry.metrics()
+    return ToolSelectionResult(
+        registry=selected_registry,
+        receipt={
+            "schema_version": "melix.agentic_tool_selection.v1",
+            "toolset_version": BUILTIN_TOOLSET_VERSION,
+            "selection_mode": "fallback",
+            "vector_available": selection_input.vector_available,
+            "fallback_reason": "no_keyword_match",
+            "selected_tools": [{"tool_id": selected_name, "source": "always"}],
+            "dropped_tool_count": max(
+                0, registry_metrics.tool_count - selected_metrics.tool_count
+            ),
+            "full_schema_bytes": registry_metrics.schema_bytes,
+            "selected_schema_bytes": selected_metrics.schema_bytes,
+        },
     )
 
 


### PR DESCRIPTION
## Summary
- Directly builds the always-only `local_compute` tool-selection receipt when `max_selected_tools` clamps to one.
- Avoids the transient selected-name list and selected-source map on that hot branch while preserving the existing receipt shape.

## Plan or Spec
- `docs/plans/2026-06-20-tool-selection-always-receipt-direct.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics
# 82 passed in 0.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 85 passed in 0.45s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# TOTAL 7 0 100%

MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# head JSON recorded below under Coverage and Metrics

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Registered probe: `tool-registry-select-name-index-cache`.
- Local Linux baseline from `origin/main` vs head:
  - `always_only_planning_elapsed_ms_mean`: old `24.685671`, new `23.247096`, delta `-1.438575 ms`, speedup `1.0619x`.
  - `selector_planning_elapsed_ms_mean`: old `34.870302`, new `34.536774`, delta `-0.333528 ms`, speedup `1.0097x`.
  - `current_capacity_planning_elapsed_ms_mean`: old `33.328817`, new `32.708718`, delta `-0.620099 ms`, speedup `1.0190x`.
  - `elapsed_ms_mean`: old `21.036726`, new `21.461049`, delta `+0.424324 ms` (`+2.02%`); this broader selection-loop metric is not the target branch and stayed within the registered 5% warning threshold.
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- Local validation is Linux-only; no Swift runtime effect is claimed or changed.
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this Python-only slice; GitHub Actions is the full-repo gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
