### PR TITLE
perf: share dataset quality length loop

### DIFF
--- a/docs/plans/2026-06-20-dataset-quality-lengths-single-loop.md
+++ b/docs/plans/2026-06-20-dataset-quality-lengths-single-loop.md
@@ -1,0 +1,26 @@
+# Dataset Quality Output Length Single-Loop Slice
+
+## Scope
+
+This Python-only performance slice is limited to dataset quality output length collection in `services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+
+The implementation keeps dataset quality summary semantics unchanged while avoiding duplicated train/validation loop bodies in `_append_sample_output_lengths(...)`. The helper now iterates the two row collections through one shared hot loop, preserving train rows before validation rows and all existing completion/message fallback behavior.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries and watches:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_versioning.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_quality_lengths_probe.py`
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, and registered local probe on Linux before pushing. GitHub Actions PR-scoped performance remains the final registered probe validation and merge gate.
+
+## Metrics
+
+Use `scripts/dataset_quality_lengths_probe.py` with the registered default dataset (`12,000` train rows, `3,000` validation rows, seven samples) and a higher-sample local comparison when needed. Primary metrics are `elapsed_ms_mean`, `elapsed_ms_min`, and `elapsed_ms_p95`; output length statistics remain informational parity checks.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -113,6 +113,10 @@ def test_dataset_version_writes_schema_backed_package_and_quality_summary(
     assert quality["pii_mask_count"] == 1
     assert quality["dedup_ratio"] == 0
     assert quality["metrics"]["quality_scoring_latency_ms"] >= 0
+    assert _sample_output_lengths(
+        [{"messages": "not-a-list"}],
+        [{"messages": [{"content": "hello"}, "skip-me"]}],
+    ) == [0, 5]
 
 
 def test_dataset_version_failed_segment_partition_fast_paths_empty_failures() -> None:

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1090,38 +1090,23 @@ def _append_sample_output_lengths(
 ) -> None:
     append = lengths.append
     str_ = str
-    for row in train_rows:
-        if "completion" in row:
-            append(len(str_(row["completion"])))
-            continue
-        messages = row.get("messages", [])
-        if not isinstance(messages, list):
-            append(0)
-            continue
-        total = 0
-        for item in messages:
-            try:
-                content = item.get("content", "")
-            except AttributeError:
+    for rows in (train_rows, validation_rows):
+        for row in rows:
+            if "completion" in row:
+                append(len(str_(row["completion"])))
                 continue
-            total += len(str_(content))
-        append(total)
-    for row in validation_rows:
-        if "completion" in row:
-            append(len(str_(row["completion"])))
-            continue
-        messages = row.get("messages", [])
-        if not isinstance(messages, list):
-            append(0)
-            continue
-        total = 0
-        for item in messages:
-            try:
-                content = item.get("content", "")
-            except AttributeError:
+            messages = row.get("messages", [])
+            if not isinstance(messages, list):
+                append(0)
                 continue
-            total += len(str_(content))
-        append(total)
+            total = 0
+            for item in messages:
+                try:
+                    content = item.get("content", "")
+                except AttributeError:
+                    continue
+                total += len(str_(content))
+            append(total)
 
 
 def _p95(values: list[int]) -> int:


### PR DESCRIPTION
## Summary
- Share the dataset quality output-length loop across train and validation rows instead of maintaining duplicate loop bodies.
- Add focused regression coverage for non-list messages and non-dict message entries through the registered dataset version test path.
- Add a small plan note for the Python-only dataset quality length slice.

## Plan or Spec
- `docs/plans/2026-06-20-dataset-quality-lengths-single-loop.md`
- Registered PR-scoped probe: `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_fast_paths_empty_failures services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_preserves_failed_id_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_fast_paths_empty_failures services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_preserves_failed_id_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py`
- `MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=50 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `7 passed in 0.14s`.
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Registered local probe (default): `elapsed_ms_mean=2.177245`, `elapsed_ms_min=2.092733`, `elapsed_ms_p95=2.249257`, `row_count=15000`.
- Local 50-sample comparison against `origin/main`: baseline mean across three runs `2.271547 ms`; head mean across three runs `2.216356 ms`; delta `-0.055191 ms` (~`2.43%` faster). Latest head 50-sample run: `elapsed_ms_mean=2.238569`, `elapsed_ms_min=2.075160`, `elapsed_ms_p95=2.823272`.
- GitHub Actions PR-scoped performance is required for final registered probe validation before merge.

## Known Gaps
- Linux local validation covers this Python slice. No Swift runtime effect is claimed.
- The local improvement is small and should be treated as directional until the registered CI probe report completes.

## Evidence Checklist
- [x] Started from synced `origin/main` in an isolated worktree.
- [x] Confirmed affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Ran focused local tests.
- [x] Ran changed-scope coverage.
- [x] Ran the registered local probe.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
