### PR TITLE
perf: trim code eval code block slices

### DIFF
--- a/docs/plans/2026-06-20-code-eval-code-block-strip-slice.md
+++ b/docs/plans/2026-06-20-code-eval-code-block-strip-slice.md
@@ -1,0 +1,31 @@
+# Code eval code-block stripped-slice extraction
+
+This Python-only performance slice is limited to `extract_candidate_code(...)` in `worker.engine.code_eval_runner`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `code-eval-code-block-last-match-streaming` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_code_block_extract_probe.py`
+
+## Slice
+
+Avoid constructing a temporary code-block substring and then calling `.strip()` on it. Instead, compute stripped slice boundaries first and allocate only the final extracted candidate string.
+
+## Verification plan
+
+1. Run the focused code-eval extraction tests from the registered probe.
+2. Run the changed-scope coverage command from the registered probe.
+3. Run the registered probe locally on Linux and compare this branch against `origin/main` with `scripts/pr_scoped_performance_run.py`.
+4. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Success criteria
+
+- Code block extraction behavior remains unchanged for empty, tagged, case-insensitive, trailing-commentary, and multi-block responses.
+- Changed-scope coverage for the touched Python path remains at or above the repository threshold.
+- The registered local and CI probes show non-regression for peak bytes, with elapsed time reported as informational.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -58,6 +58,14 @@ def test_extract_candidate_code_handles_empty_plaintext_and_code_blocks() -> Non
         "",
         "parsed_code_block",
     )
+    assert code_eval_runner.extract_candidate_code("```\n   print('trimmed')\n```") == (
+        "print('trimmed')",
+        "parsed_code_block",
+    )
+    assert code_eval_runner.extract_candidate_code("```   print('inline-trimmed')\n```") == (
+        "print('inline-trimmed')",
+        "parsed_code_block",
+    )
     assert code_eval_runner.extract_candidate_code(
         "first attempt:\n```python\nprint('old')\n```\nfinal answer:\n```python\nprint('new')\n```"
     ) == ("print('new')", "parsed_code_block")

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -59,7 +59,7 @@ def extract_candidate_code(raw_response: str) -> tuple[str, str]:
         opening = raw_response.rfind(fence, 0, closing)
         if opening >= 0:
             content_start = _code_block_content_start(raw_response, opening + 3)
-            candidate = raw_response[content_start:closing].strip()
+            candidate = _stripped_slice(raw_response, content_start, closing)
             if candidate:
                 return candidate, "parsed_code_block"
             if raw_response.count(fence) % 2 == 0:
@@ -68,9 +68,15 @@ def extract_candidate_code(raw_response: str) -> tuple[str, str]:
             opening = raw_response.rfind(fence, 0, closing)
             if opening >= 0:
                 content_start = _code_block_content_start(raw_response, opening + 3)
-                return raw_response[content_start:closing].strip(), "parsed_code_block"
+                return _stripped_slice(raw_response, content_start, closing), "parsed_code_block"
 
     return raw_response.strip(), "parsed_code"
+
+
+def _stripped_slice(text: str, start: int, end: int) -> str:
+    while end > start and text[end - 1].isspace():
+        end -= 1
+    return text[start:end]
 
 
 def _code_block_content_start(text: str, start: int) -> int:


### PR DESCRIPTION
## Summary
- Optimizes `extract_candidate_code()` code-block extraction by trimming slice bounds before allocating the candidate string.
- Adds regression coverage for code fences whose candidate starts after whitespace.
- Documents the registered probe-backed slice plan.

## Plan or Spec
- `docs/plans/2026-06-20-code-eval-code-block-strip-slice.md`
- Registered PR-scoped probe: `code-eval-code-block-last-match-streaming`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_code_block_extract_probe.py`
- `python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-code-block-last-match-streaming --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/code_eval_code_block_probe_result.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 4 passed.
- Changed-scope coverage: 100.00% (`TOTAL 8 0 100%`).
- Registered local probe comparison:
  - `elapsed_ms_mean`: base `0.08154299991604473`, head `0.033468429007500945` (informational)
  - `peak_bytes_mean`: base `245.0`, head `198.0` (lower is better)

## Known Gaps
- Linux local validation covers the Python code path and registered probe. GitHub Actions remains the merge gate for the PR-scoped performance report.

## Evidence Checklist
- [x] Registered probe covers the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally against `origin/main` and this branch.
- [ ] PR-scoped performance workflow passed in CI.
