### PR TITLE
perf: read model config JSON as bytes

### DIFF
--- a/docs/plans/2026-06-20-model-load-config-json-bytes.md
+++ b/docs/plans/2026-06-20-model-load-config-json-bytes.md
@@ -1,0 +1,26 @@
+# Model Load Config JSON Bytes Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to model-load trust policy custom-loader detection in `services/mlx-worker-python/worker/model_load_trust.py`.
+
+## Probe Coverage
+
+The affected path is covered by the registered PR-scoped probe `model-load-config-json-bytes` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` values and selects this probe when `worker/model_load_trust.py` changes.
+
+## Optimization
+
+`_read_model_config()` previously loaded `config.json` with `Path.read_text(encoding="utf-8")` before calling `json.loads()`. Python's JSON decoder accepts UTF-8 bytes directly, so this slice reads `config.json` with `Path.read_bytes()` and lets `json.loads()` decode during parse. The expected benefit is lower intermediate string allocation and slightly lower policy-resolution latency for repeated model-load trust checks on custom-loader model directories.
+
+## Verification Plan
+
+1. Add regression coverage proving the trust policy reads `config.json` through `Path.read_bytes()` without using `Path.read_text()`.
+2. Register `model-load-config-json-bytes` with focused test, coverage, and command-json probe commands.
+3. Run the focused test command locally on Linux.
+4. Run changed-scope coverage for the changed Python path.
+5. Run the registered probe locally against `origin/main` and this branch before pushing.
+6. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Linux Validation Boundary
+
+This slice only changes Python worker code and is locally verifiable on Linux. No Swift runtime effect is claimed.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5905,5 +5905,47 @@
         "direction": "informational"
       }
     ]
+  },
+  {
+    "id": "model-load-config-json-bytes",
+    "name": "Model load config JSON bytes",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/model_load_trust.py",
+      "services/mlx-worker-python/tests/test_model_load_trust.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/model_load_config_json_bytes_probe.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_load_trust.py::test_worker_rejects_custom_loader_metadata_without_explicit_trust services/mlx-worker-python/tests/test_model_load_trust.py::test_worker_trusted_custom_loader_receipt_passes_trust_remote_code services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_reads_config_json_bytes_without_text_decode services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_load_config_json_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_load_config_json_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_load_trust.py::test_worker_rejects_custom_loader_metadata_without_explicit_trust services/mlx-worker-python/tests/test_model_load_trust.py::test_worker_trusted_custom_loader_receipt_passes_trust_remote_code services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_reads_config_json_bytes_without_text_decode services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_load_config_json_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_load_config_json_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_load_trust.py services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/model_load_config_json_bytes_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PYPROBE'\nfrom __future__ import annotations\nimport json\nimport os\nfrom pathlib import Path\nimport statistics\nimport sys\nimport tempfile\nimport time\nimport tracemalloc\nfrom worker.model_load_trust import ModelLoadTrustRejection, resolve_model_load_trust_policy\nfrom worker.model_registry.catalog import WorkerModelCatalog\nclass _TrustRuntime:\n    runtime_name = \"mlx-lm\"\ndef _env_int(name: str, default: int, minimum: int) -> int:\n    try:\n        value = int(os.environ.get(name, str(default)))\n    except ValueError:\n        value = default\n    return max(minimum, value)\ndef _write_config(model_dir: Path, padding_bytes: int) -> None:\n    payload = {\"architectures\": [\"CustomForCausalLM\"], \"auto_map\": {\"AutoModelForCausalLM\": \"custom.Loader\"}, \"model_type\": \"custom\", \"padding\": \"x\" * padding_bytes}\n    (model_dir / \"config.json\").write_bytes(json.dumps(payload).encode(\"utf-8\"))\ndef _model_spec(model_dir: Path):\n    model = WorkerModelCatalog.dev_text_model()\n    model.model_path = str(model_dir)\n    return model\ndef _run_sample(model, iterations: int) -> tuple[float, int, int]:\n    runtime = _TrustRuntime()\n    rejection_count = 0\n    started = time.perf_counter()\n    tracemalloc.start()\n    for _ in range(iterations):\n        try:\n            resolve_model_load_trust_policy(model, request_policy=None, runtime_kind=\"text\", runtime=runtime)\n        except ModelLoadTrustRejection as exc:\n            if exc.policy.custom_loader_required:\n                rejection_count += 1\n            else:\n                raise\n    _, peak_bytes = tracemalloc.get_traced_memory()\n    tracemalloc.stop()\n    return (time.perf_counter() - started) * 1000.0, peak_bytes, rejection_count\nsamples = _env_int(\"MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_SAMPLES\", 7, 3)\niterations = _env_int(\"MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_ITERATIONS\", 300, 10)\npadding_bytes = _env_int(\"MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_PADDING_BYTES\", 4096, 0)\nelapsed_values = []\npeak_values = []\nrejection_values = []\nwith tempfile.TemporaryDirectory() as tmp:\n    model_dir = Path(tmp) / \"custom-loader-model\"\n    model_dir.mkdir()\n    _write_config(model_dir, padding_bytes)\n    model = _model_spec(model_dir)\n    for _ in range(samples):\n        elapsed_ms, peak_bytes, rejection_count = _run_sample(model, iterations)\n        elapsed_values.append(elapsed_ms)\n        peak_values.append(peak_bytes)\n        rejection_values.append(rejection_count)\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed_values), \"elapsed_ms_min\": min(elapsed_values), \"peak_bytes_mean\": statistics.fmean(peak_values), \"samples\": samples, \"iterations\": iterations, \"config_padding_bytes\": padding_bytes, \"rejections_mean\": statistics.fmean(rejection_values)}, sort_keys=True))\nPYPROBE",
+    "probe_impl": "command_json",
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_min",
+        "unit": "ms",
+        "direction": "informational",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "rejections_mean",
+        "unit": "count",
+        "direction": "informational",
+        "warn_pct": 0.0
+      }
+    ]
   }
 ]

--- a/scripts/model_load_config_json_bytes_probe.py
+++ b/scripts/model_load_config_json_bytes_probe.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+
+from worker.model_load_trust import ModelLoadTrustRejection, resolve_model_load_trust_policy
+from worker.model_registry.catalog import WorkerModelCatalog
+
+
+class _TrustRuntime:
+    runtime_name = "mlx-lm"
+
+
+def _sample_count() -> int:
+    raw = os.environ.get("MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_SAMPLES", "7")
+    try:
+        value = int(raw)
+    except ValueError:
+        value = 7
+    return max(3, value)
+
+
+def _iterations() -> int:
+    raw = os.environ.get("MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_ITERATIONS", "300")
+    try:
+        value = int(raw)
+    except ValueError:
+        value = 300
+    return max(10, value)
+
+
+def _config_padding_bytes() -> int:
+    raw = os.environ.get("MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_PADDING_BYTES", "4096")
+    try:
+        value = int(raw)
+    except ValueError:
+        value = 4096
+    return max(0, value)
+
+
+def _model_spec(model_dir: Path):
+    model = WorkerModelCatalog.dev_text_model()
+    model.model_path = str(model_dir)
+    return model
+
+
+def _write_config(model_dir: Path, *, padding_bytes: int) -> None:
+    payload = {
+        "architectures": ["CustomForCausalLM"],
+        "auto_map": {"AutoModelForCausalLM": "custom.Loader"},
+        "model_type": "custom",
+        "padding": "x" * padding_bytes,
+    }
+    (model_dir / "config.json").write_bytes(json.dumps(payload).encode("utf-8"))
+
+
+def _run_sample(model, iterations: int) -> tuple[float, int, int]:
+    runtime = _TrustRuntime()
+    rejection_count = 0
+    started = time.perf_counter()
+    tracemalloc.start()
+    for _ in range(iterations):
+        try:
+            resolve_model_load_trust_policy(
+                model,
+                request_policy=None,
+                runtime_kind="text",
+                runtime=runtime,
+            )
+        except ModelLoadTrustRejection as exc:
+            if exc.policy.custom_loader_required:
+                rejection_count += 1
+            else:  # pragma: no cover - defensive guard for malformed probe setup.
+                raise
+    _, peak_bytes = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    return elapsed_ms, peak_bytes, rejection_count
+
+
+def main() -> int:
+    samples = _sample_count()
+    iterations = _iterations()
+    padding_bytes = _config_padding_bytes()
+    elapsed_values: list[float] = []
+    peak_values: list[int] = []
+    rejection_values: list[int] = []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        model_dir = Path(tmp) / "custom-loader-model"
+        model_dir.mkdir()
+        _write_config(model_dir, padding_bytes=padding_bytes)
+        model = _model_spec(model_dir)
+        for _ in range(samples):
+            elapsed_ms, peak_bytes, rejection_count = _run_sample(model, iterations)
+            elapsed_values.append(elapsed_ms)
+            peak_values.append(peak_bytes)
+            rejection_values.append(rejection_count)
+
+    metrics = {
+        "elapsed_ms_mean": statistics.fmean(elapsed_values),
+        "elapsed_ms_min": min(elapsed_values),
+        "peak_bytes_mean": statistics.fmean(peak_values),
+        "samples": samples,
+        "iterations": iterations,
+        "config_padding_bytes": padding_bytes,
+        "rejections_mean": statistics.fmean(rejection_values),
+    }
+    print(json.dumps(metrics, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/mlx-worker-python/tests/test_model_load_trust.py
+++ b/services/mlx-worker-python/tests/test_model_load_trust.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
+import worker.model_load_trust as model_load_trust_module
 
 from packages.protocol.python.worker.v1 import common_pb2, runtime_pb2
 
@@ -244,6 +245,41 @@ def test_trust_policy_falls_back_to_vlm_loader_family_without_runtime_contract(t
 
     assert policy.effective_mode == common_pb2.MODEL_LOAD_TRUST_TRUST_REMOTE_CODE
     assert policy.loader_family == "mlx-vlm"
+
+
+def test_trust_policy_reads_config_json_bytes_without_text_decode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _custom_loader_text_model(tmp_path)
+    read_bytes_calls = 0
+    original_read_bytes = model_load_trust_module.Path.read_bytes
+
+    def counted_read_bytes(path: Path) -> bytes:
+        nonlocal read_bytes_calls
+        read_bytes_calls += 1
+        return original_read_bytes(path)
+
+    def fail_read_text(
+        path: Path, *args, **kwargs
+    ) -> str:  # pragma: no cover - only runs on regression.
+        _ = path, args, kwargs
+        raise AssertionError("config.json should be parsed from bytes")
+
+    monkeypatch.setattr(model_load_trust_module.Path, "read_bytes", counted_read_bytes)
+    monkeypatch.setattr(model_load_trust_module.Path, "read_text", fail_read_text)
+
+    with pytest.raises(model_load_trust_module.ModelLoadTrustRejection) as exc_info:
+        resolve_model_load_trust_policy(
+            model,
+            request_policy=None,
+            runtime_kind="text",
+            runtime=RecordingTextBackend(),
+        )
+
+    assert read_bytes_calls == 1
+    assert exc_info.value.policy.custom_loader_required is True
+    assert exc_info.value.policy.custom_loader_detection_source == "config_json:auto_map"
 
 
 def _custom_loader_text_model(tmp_path: Path) -> common_pb2.ModelSpec:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -6505,3 +6505,32 @@ def test_deterministic_vlm_completion_token_probe_script_emits_metrics(
     assert "Prompt: Describe the restored image." in DeterministicVLMRuntime()._response_text(
         restored_request
     )
+
+
+def test_scope_report_selects_model_load_config_json_bytes_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/model_load_trust.py"],
+    )
+
+    assert "model-load-config-json-bytes" in _selected_probe_ids(scope)
+
+
+def test_model_load_config_json_bytes_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_SAMPLES", "3")
+    monkeypatch.setenv("MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_ITERATIONS", "10")
+    monkeypatch.setenv("MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_PADDING_BYTES", "128")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(REPO_ROOT / "scripts/model_load_config_json_bytes_probe.py"), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["samples"] == 3
+    assert metrics["iterations"] == 10
+    assert metrics["config_padding_bytes"] == 128
+    assert metrics["rejections_mean"] == 10
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0

--- a/services/mlx-worker-python/worker/model_load_trust.py
+++ b/services/mlx-worker-python/worker/model_load_trust.py
@@ -223,7 +223,7 @@ def _read_model_config(model_spec: common_pb2.ModelSpec) -> dict[str, Any] | Non
     try:
         if not config_path.is_file():
             return None
-        payload = json.loads(config_path.read_text(encoding="utf-8"))
+        payload = json.loads(config_path.read_bytes())
     except (OSError, json.JSONDecodeError):
         return None
     return payload if isinstance(payload, dict) else None


### PR DESCRIPTION
## Summary
- Read model-load trust `config.json` with `Path.read_bytes()` instead of `Path.read_text()` so `json.loads()` decodes directly from UTF-8 bytes.
- Add a focused regression test proving the path does not use `Path.read_text()`.
- Register the `model-load-config-json-bytes` PR-scoped command-json probe and add its synthetic probe script.

## Plan or Spec
- `docs/plans/2026-06-20-model-load-config-json-bytes.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_load_trust.py::test_worker_rejects_custom_loader_metadata_without_explicit_trust services/mlx-worker-python/tests/test_model_load_trust.py::test_worker_trusted_custom_loader_receipt_passes_trust_remote_code services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_reads_config_json_bytes_without_text_decode services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_load_config_json_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_load_config_json_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 7 passed in 0.45s

rm -f coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_load_trust.py services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/model_load_config_json_bytes_probe.py
# TOTAL 33 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 scripts/model_load_config_json_bytes_probe.py
# {"config_padding_bytes": 4096, "elapsed_ms_mean": 26.682352429946018, "elapsed_ms_min": 26.455266000994015, "iterations": 300, "peak_bytes_mean": 10974.0, "rejections_mean": 300.0, "samples": 7}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_load_config_json_bytes_probe
# 3 passed in 0.13s

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id model-load-config-json-bytes --base-repo /tmp/melix-baseline-model-load-config-json-bytes-fix-1612326 --head-repo "$PWD" --output /tmp/model_load_config_json_bytes_probe_result_fix.json
# head verification: 7 passed; changed-scope coverage TOTAL 0 0 100% for the registry-only amend; base/head probes ok
```

## Coverage and Metrics
- Changed-scope coverage for the code/test/script slice before the registry-only CI fix: 100.00% (`TOTAL 33 0 100%`).
- Registered local probe (`model-load-config-json-bytes`, Linux, final `uv run` probe command):
  - `elapsed_ms_mean`: base `45.53272571398078` ms → head `34.937739570783116` ms (`-10.594986143197666` ms, `-23.268947722900073%`, `1.3032533378907485x`).
  - `elapsed_ms_min`: base `39.88230100367218` ms → head `34.59342299902346` ms.
  - `peak_bytes_mean`: base `15775.857142857143` bytes → head `10886.0` bytes (`-4889.857142857143` bytes, `-30.995825447564545%`).
  - `rejections_mean`: base/head `300.0`.
- CI PR-scoped performance report is required before merge and will be used as the registered validation gate.

## Known Gaps
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally in this Linux slice; GitHub Actions is the broad gate.
- No Swift runtime effect is claimed; this is a Python worker-only change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped command-json probe; probe is synthetic/CI-scoped and not production runtime overhead.
- [x] Deferred work and known gaps are stated explicitly.
