### PR TITLE
perf: reuse evaluation answer ascii check

### DIFF
--- a/docs/plans/2026-06-20-evaluation-answer-ascii-check-reuse.md
+++ b/docs/plans/2026-06-20-evaluation-answer-ascii-check-reuse.md
@@ -1,0 +1,31 @@
+# Evaluation Answer ASCII Check Reuse
+
+## Scope
+
+This Python-only performance slice is limited to `EvaluationCore._normalized_answer`
+in `services/mlx-worker-python/worker/engine/evaluation_core.py`.
+
+The affected path is already covered by the registered PR-scoped performance probe
+`evaluation-answer-normalization-fast-path`, which includes focused tests,
+changed-scope coverage, and a command-json probe.
+
+## Plan
+
+1. Preserve existing answer normalization semantics for free-text, option,
+   numeric, quoted, and non-ASCII answers.
+2. Reuse the ASCII classification already needed for the whitespace fast path so
+   ASCII free-text answers avoid a second full-string `isascii()` scan before
+   lowercasing.
+3. Keep the change local to the normalization helper and its regression test.
+4. Verify on Linux with the registered focused tests, changed-scope coverage, and
+   registered PR-scoped probe, then use GitHub Actions as the merge gate.
+
+## Validation Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_helpers_cover_numeric_option_and_normalization_paths services/mlx-worker-python/tests/test_evaluation_core.py::test_normalized_answer_skips_extractors_for_free_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_answer_normalization_probe_command_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_persists_agentic_tool_evidence services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_writes_agentic_judge_prompt_snapshot_and_audit services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_prompt_snapshot_rejects_hidden_gold_context services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_forbidden_keys services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_allows_explicit_answer_values services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_extra_payload_fields services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_returns_agentic_judge_artifacts_without_jobs_root services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_injects_agentic_tool_trace_before_scoring
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_helpers_cover_numeric_option_and_normalization_paths services/mlx-worker-python/tests/test_evaluation_core.py::test_normalized_answer_skips_extractors_for_free_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_answer_normalization_probe_command_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_persists_agentic_tool_evidence services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_writes_agentic_judge_prompt_snapshot_and_audit services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_prompt_snapshot_rejects_hidden_gold_context services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_forbidden_keys services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_allows_explicit_answer_values services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_extra_payload_fields services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_returns_agentic_judge_artifacts_without_jobs_root services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_injects_agentic_tool_trace_before_scoring && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py infra/perf/pr_scoped_probes.json
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PYPROBE'
+# Run via the registered `evaluation-answer-normalization-fast-path` probe command.
+PYPROBE
+```

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -3513,6 +3513,7 @@ def test_normalized_answer_skips_extractors_for_free_text(monkeypatch: pytest.Mo
     assert EvaluationCore._normalized_answer("Option C is correct") == "option c is correct"
     assert EvaluationCore._normalized_answer("STRASSE") == "strasse"
     assert EvaluationCore._normalized_answer("Straße") == "strasse"
+    assert EvaluationCore._normalized_answer("Straße\u2003CITY") == "strasse city"
 
     assert numeric_calls == 0
     assert option_calls == 0

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -4125,6 +4125,7 @@ class EvaluationCore:
                 return option
         if stripped and stripped[0] in "+-0123456789" and EvaluationCore._looks_like_numeric(stripped):
             return EvaluationCore._normalized_numeric_literal(stripped)
+        is_ascii = stripped.isascii()
         if (
             "  " in stripped
             or "\t" in stripped
@@ -4133,12 +4134,12 @@ class EvaluationCore:
             or "\f" in stripped
             or "\v" in stripped
             or (
-                not stripped.isascii()
+                not is_ascii
                 and any(character.isspace() and character != " " for character in stripped)
             )
         ):
             stripped = " ".join(stripped.split())
-        if stripped.isascii():
+        if is_ascii:
             return stripped.lower()
         return stripped.casefold()
 


### PR DESCRIPTION
## Summary
- Reuse the existing ASCII classification inside `EvaluationCore._normalized_answer` so ASCII free-text answers avoid a second full-string `isascii()` scan before lowercasing.
- Extend the normalization regression coverage for non-ASCII whitespace collapse to preserve the casefold path.

## Plan or Spec
- `docs/plans/2026-06-20-evaluation-answer-ascii-check-reuse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_helpers_cover_numeric_option_and_normalization_paths services/mlx-worker-python/tests/test_evaluation_core.py::test_normalized_answer_skips_extractors_for_free_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_answer_normalization_probe_command_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_persists_agentic_tool_evidence services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_writes_agentic_judge_prompt_snapshot_and_audit services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_prompt_snapshot_rejects_hidden_gold_context services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_forbidden_keys services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_allows_explicit_answer_values services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_extra_payload_fields services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_returns_agentic_judge_artifacts_without_jobs_root services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_injects_agentic_tool_trace_before_scoring
Result: 17 passed in 4.34s (exit 0)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered evaluation-answer-normalization-fast-path focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py infra/perf/pr_scoped_probes.json
Result: 17 passed in 2.24s; changed-scope coverage 100% (3/3 lines) (exit 0)

Registered probe: evaluation-answer-normalization-fast-path
Baseline before change: {"elapsed_ms_mean": 156.778119, "numeric_extract_calls_mean": 0.0, "option_extract_calls_mean": 0.0, "answer_count": 3000.0, "iteration_count": 80.0}
After change: {"elapsed_ms_mean": 149.782323, "numeric_extract_calls_mean": 0.0, "option_extract_calls_mean": 0.0, "answer_count": 3000.0, "iteration_count": 80.0}
Result: exit 0

git diff --check
Result: exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (3 measurable changed lines, 3 covered, 0 missed).
- Registered PR-scoped probe: `evaluation-answer-normalization-fast-path`.
- Local Linux probe delta: elapsed mean 156.778119 ms -> 149.782323 ms (`-6.995796 ms`, about `4.46%` faster); numeric and option extractor calls remained `0.0`.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Full repository gates were not run locally; this PR uses the focused registered probe/test/coverage slice on Linux.
- No Swift runtime validation is applicable; this is a Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
