### PR TITLE
perf: guard hub repo id lowercase scan

### DIFF
--- a/docs/plans/2026-06-20-hub-repo-id-lowercase-guard.md
+++ b/docs/plans/2026-06-20-hub-repo-id-lowercase-guard.md
@@ -1,0 +1,34 @@
+# Hub catalog repo-id lowercase guard performance slice
+
+## Scope
+
+This Python-only performance slice is limited to Hub catalog MLX repo-id detection in
+`services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.
+That probe watches the Hub catalog module, focused Hub tests, PR-scoped
+performance tests, and `scripts/hub_catalog_size_hint_probe.py`; it defines
+focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Change
+
+`_repo_id_contains_mlx(...)` now avoids allocating `repo_id.lower()` for plain
+lowercase repository ids that do not contain `mlx`. It keeps the existing fast
+path for lowercase `mlx` matches and still falls back to a lowercase copy when an
+uppercase `M`, `L`, or `X` means a mixed-case `MLX` match is possible.
+
+## Verification plan
+
+- Run the registered focused test command for `hub-catalog-size-hint-regex-precompile`.
+- Run the registered changed-scope coverage command and require at least 95% coverage.
+- Run the registered probe locally on Linux against `origin/main` and this slice,
+  then compare `payload_compatibility_elapsed_ms_mean`.
+- Use the PR-scoped performance workflow as the CI merge gate.
+
+## Linux boundary
+
+This slice changes Python code and is locally verifiable on Linux. No Swift
+runtime performance claims are made.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -21,6 +21,7 @@ from worker.model_ops.hub_catalog import (
     _local_fit_evidence,
     _payload_is_mlx_compatible,
     _quantization_summary,
+    _repo_id_contains_mlx,
     _size_hint_from_text,
     _string_list,
 )
@@ -114,6 +115,12 @@ def test_mlx_library_atom_detection_preserves_mixed_case_without_lowercase_copy(
         card_data={},
         lowered_tags={"text-generation"},
     ) is True
+
+
+def test_mlx_repo_id_detection_preserves_case_insensitive_matches() -> None:
+    assert _repo_id_contains_mlx("plain/model") is False
+    assert _repo_id_contains_mlx("owner/model-mlx-suffix") is True
+    assert _repo_id_contains_mlx("owner/model-MLX-suffix") is True
 
 
 class FakeHTTPResponse:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -509,7 +509,9 @@ def _base_models(value: Any) -> list[str]:
 
 
 def _repo_id_contains_mlx(repo_id: str) -> bool:
-    return "mlx" in repo_id or "mlx" in repo_id.lower()
+    return "mlx" in repo_id or (
+        ("M" in repo_id or "L" in repo_id or "X" in repo_id) and "mlx" in repo_id.lower()
+    )
 
 
 def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary
- Guard Hub repo-id MLX detection so plain lowercase ids without `mlx` skip the `repo_id.lower()` allocation.
- Add focused coverage for lowercase, lowercase-MLX, and uppercase-MLX repo-id cases.
- Document the Python-only performance slice and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-06-20-hub-repo-id-lowercase-guard.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- Baseline: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py` from `origin/main`
- Candidate: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py` from this branch
- `git diff --check`

## Coverage and Metrics
- Focused tests: 85 passed.
- Changed-scope coverage: 100.00% (`TOTAL 5 0 100%`).
- Registered local Linux probe:
  - baseline `payload_compatibility_elapsed_ms_mean=201.09615420224145`
  - candidate `payload_compatibility_elapsed_ms_mean=197.03369480121182`
  - delta `-4.06245940102963 ms`, speedup `1.0206x`
  - baseline `elapsed_ms_mean=1776.1317999989842`; candidate `elapsed_ms_mean=1776.9508011988364`

## Known Gaps
- This is a Python-only Linux-verified slice; no Swift runtime performance claim is made.
- CI PR-scoped performance remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local Linux probe shows the targeted compatibility metric improved.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
