### PR TITLE
perf: inline dataset version manifest reads

### DIFF
--- a/docs/plans/2026-06-21-dataset-version-json-load-inline.md
+++ b/docs/plans/2026-06-21-dataset-version-json-load-inline.md
@@ -1,0 +1,54 @@
+# Dataset Version JSON Load Inline Slice
+
+## Goal
+
+Reduce per-version overhead in `list_dataset_versions(...)` by inlining the small manifest JSON read in the hot listing loop.
+
+## Scope
+
+- Change exactly one Python optimization point in `services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+- Preserve dataset version listing semantics, deterministic sorting, missing-root behavior, and manifest payload fields.
+- Keep the existing `os.scandir` manifest-path discovery unchanged.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused:
+
+- `test_command` for dataset version listing behavior, scandir usage, PR-scoped probe selection, and probe script emission.
+- `coverage_command` for the same focused tests plus changed-scope coverage on the touched implementation, test, probe registry, and probe script paths.
+- `probe_command` via `scripts/dataset_version_listing_probe.py`, which measures `elapsed_ms_mean`, `elapsed_ms_min`, and `elapsed_ms_p95` over a synthetic multi-version listing workload.
+
+## Verification
+
+Focused local Linux verification for this slice:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency \
+  services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob \
+  services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/dataset_preparation.py \
+  services/mlx-worker-python/tests/test_dataset_preparation_versioning.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/dataset_version_listing_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py \
+  --registry infra/perf/pr_scoped_probes.json \
+  --probe-id dataset-version-listing-scandir \
+  --base-repo <baseline-worktree> \
+  --head-repo "$PWD" \
+  --output /tmp/dataset_version_listing_probe.json
+```
+
+## Metrics
+
+Accept only if the registered local probe shows a clear non-regression or improvement for `elapsed_ms_mean`; GitHub Actions PR-scoped performance remains the merge gate.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -306,6 +306,13 @@ def test_dataset_version_listing_uses_scandir_without_path_glob(
 
     monkeypatch.setattr("worker.productization.dataset_preparation._read_json", fail_read_json)
 
+    def fail_read_json_file(path: str):  # pragma: no cover - exercised only on regression
+        raise AssertionError(
+            f"list_dataset_versions() should inline manifest JSON loading without _read_json_file({path!s})"
+        )
+
+    monkeypatch.setattr("worker.productization.dataset_preparation._read_json_file", fail_read_json_file)
+
     listing = list_dataset_versions(
         workspace_manifest_path=tmp_path / "workspace-manifest.json",
         output_root=output_root,

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -479,9 +479,11 @@ def list_dataset_versions(
     manifest_path_string = os.fspath(workspace_manifest_path)
     versions: list[dict[str, Any]] = []
     versions_append = versions.append
-    read_json_file = _read_json_file
+    json_loads = json.loads
+    open_file = open
     for manifest_path in _iter_dataset_version_manifest_paths(versions_root):
-        version = read_json_file(manifest_path)
+        with open_file(manifest_path, "rb") as handle:
+            version = json_loads(handle.read())
         version_get = version.get
         versions_append(
             {


### PR DESCRIPTION
## Summary
- Inline dataset version manifest JSON loading inside `list_dataset_versions(...)` to remove one helper call from each manifest iteration.
- Extend the focused dataset version listing regression test so the hot listing path fails if it falls back to `_read_json_file(...)`.
- Add a slice plan documenting the registered `dataset-version-listing-scandir` probe and Linux verification boundary.

## Plan or Spec
- `docs/plans/2026-06-21-dataset-version-json-load-inline.md`
- Registered PR-scoped probe: `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-version-listing-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-dataset-version-json-load-inline-baseline-20260621 --head-repo "$PWD" --output /tmp/dataset_version_listing_probe_1782012957.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 7 passed.
- Changed-scope coverage: 100.00% (`5/5` measurable changed lines covered).
- Local registered probe (`dataset-version-listing-scandir`, 2,500 versions, 7 samples):
  - `elapsed_ms_mean`: base `45.962117` ms → head `43.539009` ms (`-2.423108` ms, `-5.27%`).
  - `elapsed_ms_min`: base `43.186547` ms → head `40.45488` ms (`-6.33%`).
  - `elapsed_ms_p95`: base `46.832017` ms → head `46.260685` ms (`-1.22%`).

## Known Gaps
- This is a Python-only slice validated locally on Linux; no Swift runtime behavior is changed.
- GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Branch synced from `origin/main` before edits.
- [x] Affected path has a registered PR-scoped performance probe with `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows directional improvement.
- [ ] GitHub Actions PR-scoped performance completed successfully.
