### PR TITLE
perf: reuse evaluation json score path prefixes

### DIFF
--- a/docs/plans/2026-06-21-evaluation-json-path-prefix-reuse.md
+++ b/docs/plans/2026-06-21-evaluation-json-path-prefix-reuse.md
@@ -1,0 +1,63 @@
+# Evaluation JSON Path Prefix Reuse Slice
+
+## Goal
+
+Reduce per-field overhead in schema-free final-result JSON scoring by reusing the current path prefix while `_json_typed_score(...)` walks wide dictionaries.
+
+## Scope
+
+- Change exactly one Python optimization point in `services/mlx-worker-python/worker/productization/evaluation_final_result.py`.
+- Preserve recursive scoring semantics for dictionaries, lists, scalar mismatches, exact-root matches, and ignored JSON paths.
+- Keep extraction behavior, JSON parsing/cache behavior, and materialization code unchanged.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `evaluation-final-result-json-typed-score-aggregate` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused:
+
+- `test_command` for final result scoring behavior, PR-scoped probe selection, and probe script emission.
+- `coverage_command` for the same focused tests plus changed-scope coverage on the touched implementation, test, probe registry, and probe script paths.
+- `probe_command` through `scripts/evaluation_json_typed_score_probe.py`, which measures `elapsed_ms_mean`, `peak_bytes_mean`, and checksum correctness over a wide JSON scoring workload.
+
+## Root Cause / Hypothesis
+
+The wide JSON scoring hot path builds a child path for each dictionary key using a per-iteration conditional f-string. In a wide payload this repeats the same parent-prefix decision thousands of times. Reusing a precomputed `child_prefix` per dictionary frame should reduce string formatting overhead without changing which ignored paths are checked.
+
+## Verification
+
+Focused local Linux verification for this slice:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_evaluation_final_result.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/evaluation_final_result.py \
+  services/mlx-worker-python/tests/test_evaluation_final_result.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/evaluation_json_typed_score_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py \
+  --registry infra/perf/pr_scoped_probes.json \
+  --probe-id evaluation-final-result-json-typed-score-aggregate \
+  --base-repo <baseline-worktree> \
+  --head-repo "$PWD" \
+  --output /tmp/evaluation_json_path_prefix_probe.json
+```
+
+## Metrics
+
+Baseline direct probe on `origin/main` before implementation:
+
+```json
+{"elapsed_ms_mean": 19.635496331223596, "iteration_count": 40.0, "key_count": 2000.0, "peak_bytes_mean": 1189429.6666666667, "score_checksum": 35.0}
+```
+
+Accept only if the registered local probe shows non-regression or improvement for `elapsed_ms_mean`; GitHub Actions PR-scoped performance remains the merge gate.

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -599,6 +599,23 @@ def test_score_final_result_aggregates_wide_json_without_losing_ignored_paths() 
     assert score.typed_score == pytest.approx(0.75)
 
 
+def test_json_typed_score_preserves_nested_ignored_paths_with_prefix_reuse() -> None:
+    expected = {
+        "outer": {
+            "kept": "same",
+            "metadata": {"confidence": 1.0, "evidence": ["source"]},
+        }
+    }
+    actual = {
+        "outer": {
+            "kept": "same",
+            "metadata": {"confidence": 0.0, "evidence": ["different"]},
+        }
+    }
+
+    assert _json_typed_score(expected=expected, actual=actual, ignored_paths={"outer.metadata"}) == 1.0
+
+
 def test_score_final_result_recurses_into_partially_different_json_lists() -> None:
     score = score_final_result(
         extracted_result=json.dumps({"scores": [1, 99, 3]}),

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -498,8 +498,9 @@ def _json_typed_score(*, expected: Any, actual: Any, ignored_paths: Collection[s
         actual_get = actual_dict.get if actual_dict is not None else None
         ignored_contains = ignored_paths.__contains__
         score_child = _json_typed_score
+        child_prefix = f"{path}." if path else ""
         for key, expected_value in expected.items():
-            child_path = f"{path}.{key}" if path else key
+            child_path = child_prefix + key
             if ignored_contains(child_path):
                 continue
             actual_value = actual_get(key) if actual_get is not None else None


### PR DESCRIPTION
## Summary
- Reuse the current JSON scoring path prefix once per dictionary frame in `_json_typed_score(...)` instead of rebuilding the parent-prefix conditional for every key.
- Add a regression test covering nested ignored paths through the reused prefix path.
- Add the slice plan and registered-probe evidence under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-06-21-evaluation-json-path-prefix-reuse.md`
- Registered PR-scoped probe: `evaluation-final-result-json-typed-score-aggregate`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_json_typed_score_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_json_typed_score_probe.py --samples 5 --iterations 40 --keys 2000`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-final-result-json-typed-score-aggregate --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-evaluation-json-path-prefix-baseline-20260621 --head-repo "$PWD" --output /tmp/evaluation_json_path_prefix_probe.json`

## Coverage and Metrics
- Focused tests: `44 passed in 1.08s`.
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Direct probe after change: `elapsed_ms_mean=13.365142003749497`, `peak_bytes_mean=713702.6`, `score_checksum=35.0`.
- Registered local probe: base `elapsed_ms_mean=14.869173796614632`, head `elapsed_ms_mean=13.033927595824935`, delta `-1.835246200789697 ms` (~12.34% faster); peak bytes unchanged at `713702.6`; checksum unchanged at `35.0`.

## Known Gaps
- Linux local validation covers the Python path only. GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe shows an improvement.
- [ ] GitHub Actions PR-scoped performance probe is green.
