### PR TITLE
perf: skip normalization for exact single tool selects

### DIFF
--- a/docs/plans/2026-06-21-tool-registry-single-select-direct.md
+++ b/docs/plans/2026-06-21-tool-registry-single-select-direct.md
@@ -1,0 +1,53 @@
+# Tool Registry Single Select Direct Path
+
+## Context
+
+The registered PR-scoped probe `tool-registry-select-name-index-cache` covers
+`services/mlx-worker-python/worker/runtime/tool_registry.py` with focused tests,
+changed-scope coverage, and `scripts/tool_registry_select_probe.py`.
+
+Baseline probe on Linux from `origin/main` (`833522dc`):
+
+```json
+{"elapsed_ms_mean": 21.74097859824542, "raw_single_config_elapsed_ms_mean": 16.803036801866256, "missing_selection_elapsed_ms_mean": 17.886221403023228, "selector_planning_elapsed_ms_mean": 39.658428795519285}
+```
+
+## Slice
+
+Optimize only the exact single-tool `ToolRegistry.select()` path. When the
+single requested name is already an exact registry key, skip the `str.strip()`
+normalization and go directly through the existing name index, cache lookup, and
+single-tool registry construction.
+
+## Behavior Contract
+
+- Exact tool names keep the same selection result.
+- Whitespace-padded names continue to normalize through the existing fallback.
+- Missing names keep raising `ToolRegistryError`.
+- Returned configs and registries remain isolated snapshots.
+
+## Verification Plan
+
+1. Add a focused regression test using a string subclass whose `strip()` raises
+   to prove exact single names bypass normalization.
+2. Run the registered focused test command for `tool-registry-select-name-index-cache`.
+3. Run the registered changed-scope coverage command.
+4. Run `scripts/tool_registry_select_probe.py` locally on Linux before and after
+   the change and accept only if the direction is positive or bounded and
+   explainable.
+
+## Local Results
+
+Post-change registered coverage command passed with 86 tests and 100% changed-line
+coverage for the touched scope.
+
+Post-change probe on Linux:
+
+```json
+{"elapsed_ms_mean": 21.13232919946313, "raw_single_config_elapsed_ms_mean": 14.889508800115436, "missing_selection_elapsed_ms_mean": 15.133375799632631, "selector_planning_elapsed_ms_mean": 37.36919840448536}
+```
+
+Primary registered probe metric improved from `21.74097859824542 ms` to
+`21.13232919946313 ms` (`-0.60864939878229 ms`, about `2.80%` faster). The
+raw single-config submetric improved from `16.803036801866256 ms` to
+`14.889508800115436 ms` (`-1.91352800175082 ms`, about `11.39%` faster).

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -366,6 +366,21 @@ def test_tool_registry_select_caches_single_name_fast_path() -> None:
     assert registry.select(["visit"]) is selected
 
 
+def test_tool_registry_exact_single_name_select_skips_normalization() -> None:
+    class StripFailingName(str):
+        def strip(self, chars: str | None = None) -> str:
+            raise AssertionError("exact single-name selection should not strip")
+
+    registry = ToolRegistry(built_in_tool_registry().tools)
+
+    selected = registry.select((StripFailingName("visit"),))
+
+    assert selected.names() == ("visit",)
+    assert registry.select([StripFailingName("visit")]) is selected
+    with pytest.raises(AssertionError, match="exact single-name selection"):
+        StripFailingName("visit").strip()
+
+
 def test_tool_registry_select_single_name_returns_self_for_single_tool_registry() -> None:
     registry = ToolRegistry((built_in_tool_registry().tools[0],))
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -297,6 +297,25 @@ class ToolRegistry:
 
         if len(names) == 1:
             raw_name = names[0]
+            tool_by_name = self._tool_by_name
+            missing_tool_sentinel = _MISSING_TOOL_SENTINEL
+            tool = tool_by_name.get(raw_name, missing_tool_sentinel)
+            if tool is not missing_tool_sentinel:
+                requested_names = (raw_name,)
+                cached_selection = self._selection_cache.get(requested_names)
+                if cached_selection is not None:
+                    return cached_selection
+                selection = ToolRegistry(
+                    (cast(ToolDescriptor, tool),),
+                    schema_version=self._schema_version,
+                    toolset_version=self._toolset_version,
+                    parser=self._parser,
+                    parser_contract_version=self._parser_contract_version,
+                )
+                if len(self._selection_cache) >= _SELECTION_CACHE_MAX_SIZE:
+                    self._selection_cache.clear()
+                self._selection_cache[requested_names] = selection
+                return selection
             normalized_name = raw_name.strip()
             if normalized_name:
                 requested_names = (normalized_name,)
@@ -307,8 +326,8 @@ class ToolRegistry:
                     if isinstance(names, tuple) and names != requested_names:
                         self._selection_cache[names] = cached_selection
                     return cached_selection
-                tool = self._tool_by_name.get(normalized_name, _MISSING_TOOL_SENTINEL)
-                if tool is _MISSING_TOOL_SENTINEL:
+                tool = tool_by_name.get(normalized_name, missing_tool_sentinel)
+                if tool is missing_tool_sentinel:
                     raise ToolRegistryError(
                         f"Unknown tool registry entry requested: {normalized_name}"
                     )


### PR DESCRIPTION
## Summary
- Add a direct exact-name path for single-tool `ToolRegistry.select()` calls before normalization.
- Keep whitespace-normalized fallback behavior unchanged for padded or missing names.
- Add a focused regression test proving exact single names bypass `strip()`.

## Plan or Spec
- `docs/plans/2026-06-21-tool-registry-single-select-direct.md`
- Registered PR-scoped probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` (baseline on `origin/main`)
- Registered test command for `tool-registry-select-name-index-cache`: `86 passed in 0.95s`
- Registered coverage command for `tool-registry-select-name-index-cache`: `86 passed`; changed-scope coverage `TOTAL 25 0 100%`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` (post-change)
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: `100%` (`25/25` changed measurable lines covered).
- Baseline probe (`origin/main` / `833522dc`): `elapsed_ms_mean=21.74097859824542`, `raw_single_config_elapsed_ms_mean=16.803036801866256`, `missing_selection_elapsed_ms_mean=17.886221403023228`, `selector_planning_elapsed_ms_mean=39.658428795519285`.
- Post-change probe: `elapsed_ms_mean=21.13232919946313`, `raw_single_config_elapsed_ms_mean=14.889508800115436`, `missing_selection_elapsed_ms_mean=15.133375799632631`, `selector_planning_elapsed_ms_mean=37.36919840448536`.
- Primary delta: `elapsed_ms_mean -0.6086493987822905 ms` (`2.7995492292670345%` faster).
- Raw single-config delta: `-1.9135280017508194 ms` (`11.387989113600527%` faster).
- CI must run the registered PR-scoped performance workflow before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime path is changed in this slice.
- Registered CI probe validation is still required before merging.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branch creation.
- [x] Affected path has registered focused test, coverage, and probe commands.
- [x] Focused regression coverage added before accepting the optimization.
- [x] Local focused tests passed.
- [x] Local changed-scope coverage passed at >=95%.
- [x] Local registered probe improved the primary metric.
- [ ] GitHub Actions / PR-scoped performance probe passed.
