### PR TITLE
docs: define M3 runtime-aware export verification plan

### DIFF
--- a/docs/plans/2026-05-24-m-courtyard-improvement-roadmap.md
+++ b/docs/plans/2026-05-24-m-courtyard-improvement-roadmap.md
@@ -214,7 +214,9 @@ coverage, and retained artifact size.
 #### Plan P3.1: Multi-Target Export Contract
 
 Define and implement a target-aware export contract for Melix managed
-artifacts, Ollama, GGUF, and MLX-compatible local runtimes.
+artifacts, Ollama, GGUF, and MLX-compatible local runtimes. The detailed M3
+execution plan is
+[`2026-06-21-runtime-aware-export-and-serving-verification.md`](2026-06-21-runtime-aware-export-and-serving-verification.md).
 
 ##### Unit U3.1.1: Define Export Target Manifest for Melix, Ollama, GGUF, and MLX
 
@@ -235,7 +237,8 @@ safe-to-delete intermediates.
 
 Require export completion to prove the artifact can be inspected, loaded, and
 used for at least one bounded generation path, then surface actionable
-diagnostics when it cannot.
+diagnostics when it cannot. The detailed M3 execution plan is
+[`2026-06-21-runtime-aware-export-and-serving-verification.md`](2026-06-21-runtime-aware-export-and-serving-verification.md).
 
 ##### Unit U3.2.1: Add Post-Export Load and Generation Smoke Test
 

--- a/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
+++ b/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
@@ -225,14 +225,14 @@ discovered under an export target must receive exactly one retention row with:
 
 Retention classes have these default decisions:
 
-| Retention class | Default decision |
-|---|---|
-| `required` | `retain` |
-| `evidence` | `retain` |
-| `runtime_log` | `delete_after_ttl` after diagnostics complete |
-| `intermediate` | `cleanable` after target verification passes or is explicitly waived |
-| `cache` | `cleanable` after the target manifest records source provenance and digest |
-| `temporary` | `delete_after_success` |
+| Retention class | Default decision | Condition / notes |
+|---|---|---|
+| `required` | `retain` | Always retained. |
+| `evidence` | `retain` | Always retained. |
+| `runtime_log` | `delete_after_ttl` | After diagnostics complete. |
+| `intermediate` | `cleanable` | After target verification passes or is explicitly waived. |
+| `cache` | `cleanable` | After the target manifest records source provenance and digest. |
+| `temporary` | `delete_after_success` | After target verification passes or is explicitly waived. |
 
 Cleanup must preserve target manifests, export reports, smoke receipts,
 diagnostic receipts, redacted evidence excerpts, and required runtime artifacts.

--- a/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
+++ b/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
@@ -1,0 +1,523 @@
+# Runtime-Aware Export And Serving Verification Plan
+
+## Goal
+
+Define the Melix M3 runtime-aware export and serving verification contract for
+issue #1504 so exported adapters and fused models have target-specific
+manifests, retention policy, smoke checks, diagnostics, waiver semantics, and
+serving evidence before a target can be reported as export-complete.
+
+## Architecture
+
+Export planning starts from Melix adapter and derived-model provenance, then
+materializes one target directory per runtime target under the owning project
+workspace. The Python worker owns export materialization, artifact accounting,
+smoke execution, diagnostic parsing, and evidence writing because it already
+owns model-ops job execution. The Swift control plane, CLI, and Desktop consume
+the same target manifests and export evidence; they do not infer export success
+from local files, subprocess exit codes, or ad hoc logs.
+
+M3 is split into two plan issues and four executable unit issues:
+
+- #1505 / P3.1 defines the multi-target export contract.
+- #1506 / U3.1.1 defines export target manifests for Melix, Ollama, GGUF, and
+  MLX-compatible runtimes.
+- #1507 / U3.1.2 implements export artifact layout and retention policy.
+- #1508 / P3.2 defines post-export smoke and diagnostics.
+- #1509 / U3.2.1 adds bounded load and generation smoke checks.
+- #1510 / U3.2.2 adds export failure diagnostics from runtime logs.
+
+## Existing Anchors
+
+- `docs/reference-scans/m-courtyard-lessons.md` identifies multi-target export,
+  post-export smoke tests, export failure diagnostics, and serving exported
+  artifacts as the M3 improvement direction.
+- `docs/plans/2026-05-24-m-courtyard-improvement-roadmap.md` maps #1504 through
+  #1510 into the M3 milestone, plan, and unit hierarchy.
+- `docs/workspace-manifest-contract.md` already defines
+  `WORKSPACE_ARTIFACT_TYPE_EXPORT`, `WORKSPACE_ARTIFACT_TYPE_LOG`, and
+  `WORKSPACE_ARTIFACT_TYPE_EVIDENCE_BUNDLE`.
+- `docs/runbooks/phase-8-lora-adapter-workflow.md` defines current adapter
+  manifests, activation manifests, and manual serving verification expectations.
+- `docs/evidence-telemetry-report-contract.md` defines evidence-mode probe
+  timelines, redaction expectations, `artifact_write`, `export_write`,
+  `model_load`, `adapter_load`, and serving diagnostics bundle boundaries.
+- `services/mlx-worker-python/worker/productization/benchmark_export.py`
+  currently exports benchmark and evaluation bundles; it is not the source of
+  truth for target-specific model export success.
+- `packages/protocol/schema/worker/v1/maintenance.proto` exposes
+  `ExportResults` for current model-ops result export. M3 target export may add
+  new schema fields or a new operation only when a unit issue proves that the
+  existing model-ops operation shape cannot carry the contract cleanly.
+
+## Non-Goals
+
+- Do not copy code, assets, or implementation structure from the reference
+  project.
+- Do not mark a target successful because files exist, a conversion command
+  returned zero, or a bundle was copied.
+- Do not make Desktop or CLI parse runtime logs independently from the shared
+  diagnostic parser.
+- Do not require network publication, Hugging Face upload, or remote registry
+  mutation to prove local export success.
+- Do not delete or rewrite source adapter, dataset, training, or activation
+  evidence during export cleanup.
+- Do not expose absolute local paths, credentials, prompts, dataset rows, raw
+  generation text beyond bounded previews, or private tokens in exported
+  summaries.
+
+## P3.1 Multi-Target Export Contract
+
+P3.1 defines the stable target manifest, export plan, artifact layout, retention
+policy, and report metrics before the executable units implement them.
+
+### Export Target Manifest
+
+Each target directory contains `export-target-manifest.json` with schema
+`melix.export_target_manifest.v1`. The manifest must include:
+
+- `schema_version`
+- `export_id`
+- `target_id`
+- `target_type`
+- `target_runtime`
+- `target_runtime_version`
+- `workspace_project_id`
+- `workspace_manifest_path`
+- `source_adapter_manifest_path`
+- `source_derived_model_manifest_path`
+- `source_training_dataset_manifest_path`
+- `base_model_id`
+- `base_model_revision`
+- `adapter_id`
+- `adapter_snapshot`
+- `activation_mode`
+- `quantization`
+- `generated_files`
+- `required_files`
+- `intermediate_files`
+- `runtime_requirements`
+- `verification_policy`
+- `verification_status`
+- `waiver`
+- `retention_policy`
+- `diagnostic_policy`
+- `evidence`
+- `metrics`
+
+Every `generated_files`, `required_files`, and `intermediate_files` row must
+include:
+
+- `path`: relative to the target directory or a named workspace artifact root
+- `role`
+- `media_type`
+- `byte_size`
+- `sha256`
+- `retention_class`
+- `source_provenance`
+- `redaction_class`
+
+Required `target_type` values are `melix_managed`, `ollama`, `gguf`, and
+`mlx_runtime`. Unknown target types are rejected until a governing plan extends
+the target matrix.
+
+### Target Policies
+
+`melix_managed` targets produce Melix-managed adapter or fused derived-model
+artifacts usable by Melix sessions. Their smoke policy requires manifest
+inspection, local catalog resolvability, load through the selected Melix
+runtime path, and one bounded generation when the target is generation-capable.
+
+`ollama` targets produce an Ollama-compatible model directory or model
+registration bundle. Their smoke policy requires metadata inspection, runtime
+binary/path preflight, load or registration check, and one bounded generation
+with timeout.
+
+`gguf` targets produce a GGUF file plus metadata and provenance for compatible
+local runtimes. Their smoke policy requires header/metadata inspection,
+file-size and digest verification, optional load smoke through a configured
+compatible runtime, and an explicit waiver when no compatible runtime is
+available.
+
+`mlx_runtime` targets produce an MLX-compatible local model or adapter bundle
+for `mlx-lm` or Melix MLX workers. Their smoke policy requires MLX metadata
+inspection, local path preflight, runtime load, and one bounded generation with
+timeout.
+
+### Export Plan Receipt
+
+Before materializing artifacts, export planning writes
+`export-plan-receipt.json` with schema `melix.export_plan_receipt.v1`. It must
+include:
+
+- `schema_version`
+- `export_id`
+- `source_artifacts`
+- `requested_targets`
+- `resolved_targets`
+- `blocked_targets`
+- `target_policies`
+- `estimated_artifact_bytes`
+- `estimated_intermediate_bytes`
+- `workspace_manifest_path`
+- `operator_failures`
+- `metrics`
+
+Required planning metrics:
+
+- `export_planning_latency_ms`
+- `target_count`
+- `blocked_target_count`
+- `estimated_artifact_bytes`
+- `estimated_intermediate_bytes`
+- `manifest_validation_latency_ms`
+
+Planning may block individual targets without blocking all targets. The final
+export report must preserve both successful and blocked target rows.
+
+### Artifact Layout
+
+M3 export artifacts are rooted under the workspace export artifact root when a
+workspace manifest is provided. The default layout is:
+
+```text
+exports/
+  <export-id>/
+    export-plan-receipt.json
+    export-report.json
+    targets/
+      <target-type>/
+        <target-id>/
+          export-target-manifest.json
+          artifacts/
+          intermediates/
+          logs/
+          smoke/
+            smoke-receipt.json
+            generation-preview.txt
+          diagnostics/
+            diagnostics-receipt.json
+            redacted-log-excerpt.txt
+    retention/
+      retention-report.json
+```
+
+The target directory is the only authority for target-relative generated file
+paths. Workspace manifests may link those files as
+`WORKSPACE_ARTIFACT_TYPE_EXPORT`, logs as `WORKSPACE_ARTIFACT_TYPE_LOG`, and
+smoke or diagnostic receipts as `WORKSPACE_ARTIFACT_TYPE_EVIDENCE_BUNDLE`.
+
+### Retention Policy
+
+Retention decisions use schema `melix.export_retention_report.v1`. Every file
+discovered under an export target must receive exactly one retention row with:
+
+- `path`
+- `target_id`
+- `retention_class`: `required`, `evidence`, `runtime_log`, `intermediate`,
+  `cache`, or `temporary`
+- `decision`: `retain`, `cleanable`, `delete_after_success`, or
+  `delete_after_ttl`
+- `byte_size`
+- `sha256`
+- `reason`
+- `safe_to_delete`
+
+Retention classes have these default decisions:
+
+| Retention class | Default decision |
+|---|---|
+| `required` | `retain` |
+| `evidence` | `retain` |
+| `runtime_log` | `delete_after_ttl` after diagnostics complete |
+| `intermediate` | `cleanable` after target verification passes or is explicitly waived |
+| `cache` | `cleanable` after the target manifest records source provenance and digest |
+| `temporary` | `delete_after_success` |
+
+Cleanup must preserve target manifests, export reports, smoke receipts,
+diagnostic receipts, redacted evidence excerpts, and required runtime artifacts.
+Cleanup must never remove source adapter manifests, training manifests, dataset
+version manifests, workspace manifests, or release compare evidence.
+
+Required retention metrics:
+
+- `artifact_byte_size`
+- `required_byte_size`
+- `evidence_byte_size`
+- `cleanable_byte_size`
+- `retention_decision_count`
+- `retention_scan_latency_ms`
+
+## P3.2 Post-Export Smoke And Diagnostics
+
+P3.2 defines how export completion is proven for each target and how failures
+become typed operator diagnostics.
+
+### Smoke Receipt
+
+Each target writes `smoke/smoke-receipt.json` with schema
+`melix.export_smoke_receipt.v1`. It must include:
+
+- `schema_version`
+- `export_id`
+- `target_id`
+- `target_type`
+- `policy_id`
+- `status`: `passed`, `failed`, `blocked`, or `waived`
+- `metadata_check`
+- `load_check`
+- `generation_check`
+- `timeout_policy`
+- `output_preview`
+- `diagnostics_receipt_path`
+- `operator_failures`
+- `metrics`
+
+The metadata check is required for every target. The load check is required for
+`melix_managed`, `ollama`, and `mlx_runtime` targets. The generation check is
+required for generation-capable `melix_managed`, `ollama`, and `mlx_runtime`
+targets. GGUF generation may be waived only when no compatible local runtime is
+configured, and the waiver must record the missing runtime capability.
+
+Bounded generation checks must use a repository-owned prompt fixture or a
+synthetic non-private prompt, a fixed token limit, a timeout, and a preview byte
+limit. The preview is diagnostic evidence only; it is not an evaluation score.
+
+Required smoke metrics:
+
+- `metadata_check_latency_ms`
+- `load_smoke_latency_ms`
+- `generation_smoke_latency_ms`
+- `output_preview_byte_count`
+- `timeout_count`
+- `waiver_count`
+
+### Completion Semantics
+
+An export report uses schema `melix.runtime_export_report.v1` and has overall
+status `completed` only when every requested target is in one of these terminal
+states:
+
+- `verified`: target manifest is valid, required files exist with matching
+  digests, smoke policy passed, and retention report is written.
+- `waived`: target manifest is valid, required files exist with matching
+  digests, smoke policy did not pass or could not run, and an explicit waiver
+  is recorded.
+- `blocked`: target was requested but export planning or materialization failed
+  with typed operator failures. Blocked targets prevent overall `completed`
+  status unless the operator requested partial export semantics and the report
+  records `partial_completion_allowed=true`.
+
+The report must not use `completed` for a target when smoke evidence is missing,
+when digest checks are absent, when a runtime log parser is still pending after
+a failure, or when a waiver has no reason and operator identity.
+
+### Waiver Contract
+
+Waivers use schema `melix.export_verification_waiver.v1` and must include:
+
+- `waiver_id`
+- `target_id`
+- `target_type`
+- `waived_checks`
+- `reason`
+- `operator_id`
+- `created_at`
+- `expires_at`
+- `risk_level`: `low`, `medium`, or `high`
+- `replacement_evidence`
+- `follow_up_issue`
+
+Allowed first-slice waiver reasons are:
+
+- `runtime_not_installed`
+- `runtime_incompatible_host`
+- `metadata_only_target`
+- `known_runtime_bug`
+- `operator_manual_verification`
+
+Waivers are not allowed for missing required files, digest mismatch, unsafe
+paths, unsupported target type, missing source provenance, or missing target
+manifest.
+
+### Diagnostics Receipt
+
+Failure diagnostics write `diagnostics/diagnostics-receipt.json` with schema
+`melix.export_diagnostics_receipt.v1`. It must include:
+
+- `schema_version`
+- `export_id`
+- `target_id`
+- `target_type`
+- `parser_policy_id`
+- `status`: `matched`, `unknown`, or `not_applicable`
+- `diagnoses`
+- `redaction_summary`
+- `bounded_log_excerpt_path`
+- `operator_remedies`
+- `metrics`
+
+Required diagnosis codes for #1510:
+
+- `runtime_load_failed`
+- `unsupported_architecture`
+- `duplicate_tensor_name`
+- `missing_blob`
+- `missing_binary`
+- `invalid_runtime_path`
+- `runtime_timeout`
+- `permission_denied`
+- `insufficient_memory`
+- `unknown_failure`
+
+Each diagnosis row must include `code`, `severity`, `matched_pattern_id`,
+`operator_message`, `remediation`, and a redacted evidence pointer. Unknown
+failures preserve bounded redacted excerpts for later parser expansion.
+
+Required diagnostic metrics:
+
+- `diagnostic_parser_coverage`
+- `parsed_failure_count`
+- `unknown_failure_count`
+- `redaction_count`
+- `diagnostic_latency_ms`
+
+## Operator Surfaces
+
+CLI, Desktop, and reports must render export state from the same report and
+receipt files. Planned CLI shape:
+
+```bash
+melix export plan \
+  --workspace-manifest path/to/workspace-manifest.json \
+  --adapter-manifest path/to/train_lora.adapter.json \
+  --derived-model-manifest path/to/activate_adapter.derived_model.json \
+  --target melix_managed \
+  --target ollama \
+  --target gguf \
+  --target mlx_runtime \
+  --output exports/support-chat-v1/export-plan-receipt.json \
+  --json
+```
+
+```bash
+melix export run \
+  --plan exports/support-chat-v1/export-plan-receipt.json \
+  --output-root exports/support-chat-v1 \
+  --smoke-policy bounded-local-v1 \
+  --json
+```
+
+```bash
+melix export diagnose \
+  --target-manifest path/to/export-target-manifest.json \
+  --log exports/support-chat-v1/targets/ollama/support-chat-ollama/logs/runtime.log \
+  --output path/to/diagnostics-receipt.json \
+  --json
+```
+
+Desktop should show per-target status, required/evidence/cleanable byte counts,
+smoke status, waived checks, and typed remedies. It must not hide blocked
+targets behind a single successful export banner.
+
+## Evidence And Source-Of-Truth Rules
+
+- `export-target-manifest.json` is the source of truth for target identity,
+  generated files, runtime requirements, verification policy, and target-local
+  evidence paths.
+- `export-report.json` is the source of truth for overall export status and
+  per-target terminal state.
+- `smoke-receipt.json` is the source of truth for load and generation smoke
+  outcomes.
+- `diagnostics-receipt.json` is the source of truth for typed runtime failure
+  diagnosis.
+- `retention-report.json` is the source of truth for cleanup decisions and byte
+  accounting.
+- `workspace-manifest.json` indexes the artifacts for workspace consumers but
+  does not replace the target manifest or receipts.
+
+Markdown summaries, Desktop cards, and CSV exports are derived views.
+
+## Performance Probes And Metrics
+
+M3 units must add or reuse PR-scoped probes before implementation lands. Probe
+IDs should be scoped to the changed unit:
+
+| Unit | Probe direction |
+|---|---|
+| #1506 | Manifest validation latency, fixture count, schema error count, manifest byte size. |
+| #1507 | Export duration, artifact byte size, cleanable bytes, retention decision count. |
+| #1509 | Load smoke latency, generation latency, preview bytes, timeout count, waiver count. |
+| #1510 | Diagnostic parser coverage, unknown failure count, redaction count, latency. |
+
+Candidate PR-scoped probe names:
+
+- `runtime-export-manifest-validation`
+- `runtime-export-retention-accounting`
+- `runtime-export-smoke-policy`
+- `runtime-export-diagnostic-parser`
+
+Each executable unit must include a `test_command`, `coverage_command`, and
+`probe_command` in `infra/perf/pr_scoped_probes.json` when it touches code. A
+documentation-only slice may record `N/A` metrics with the reason.
+
+## Verification Plan
+
+### #1506 Manifest Unit
+
+- Python schema/fixture tests for all four target types.
+- Manifest validator tests for missing target type, unsafe paths, missing
+  required file digest, unsupported target runtime, and unknown side-channel
+  fields.
+- Swift decoder tests only if CLI or Desktop consumes a new typed schema.
+- Coverage command must include the manifest validator, fixtures, and PR-scoped
+  probe registration tests.
+
+### #1507 Layout And Retention Unit
+
+- Python export layout tests proving one directory per target and source
+  adapter.
+- Retention tests for required artifacts, evidence receipts, runtime logs,
+  intermediates, caches, and temporary files.
+- Cleanup dry-run and apply tests proving required files and evidence survive.
+- Metrics tests for retained and cleanable byte counts.
+
+### #1509 Smoke Unit
+
+- Smoke policy tests for Melix-managed, Ollama, GGUF, and MLX runtime targets.
+- Timeout tests proving bounded generation cannot hang export completion.
+- Waiver tests proving allowed waivers are recorded and disallowed waivers are
+  rejected.
+- CLI/Desktop decoder tests proving smoke status and preview metadata render
+  from the shared receipt.
+
+### #1510 Diagnostics Unit
+
+- Parser fixture tests for each required diagnosis code.
+- Redaction tests for absolute paths, tokens, credentials, and unbounded log
+  excerpts.
+- Unknown failure tests proving bounded excerpts are preserved.
+- CLI/Desktop tests proving typed remedies and redacted evidence pointers are
+  shown from the shared receipt.
+
+## Delivery Order
+
+1. Land #1506 with target manifests, fixtures, and validation metrics.
+2. Land #1507 with layout, retention report, cleanup dry-run, and byte
+   accounting.
+3. Land #1509 with smoke policies and completion gating.
+4. Land #1510 with diagnostic parsers, redaction, and operator remedies.
+5. Add the serve-exported-artifact shortcut only after a verified target can be
+   selected from `export-report.json` without inspecting raw filesystem state.
+
+## Acceptance Checklist For #1504
+
+- Multi-target export and post-export diagnostic plans are linked from the M3
+  roadmap and this document.
+- The implementation units define probes for export duration, artifact size,
+  smoke-test load latency, generation latency, and diagnostic parser coverage.
+- Export completion semantics require target verification or an explicit
+  recorded waiver.
+- Child issues preserve Melix evidence and report source-of-truth rules through
+  target manifests, export reports, smoke receipts, diagnostic receipts,
+  retention reports, and workspace manifest links.


### PR DESCRIPTION
## Summary
- Adds the M3 runtime-aware export and serving verification plan for #1504.
- Links the M3 roadmap P3.1/P3.2 entries to the detailed plan.
- Defines target manifests, retention, smoke, diagnostics, waiver semantics, probes, and source-of-truth evidence for #1505-#1510.

## Plan or Spec
- Governing plan: `docs/plans/2026-05-24-m-courtyard-improvement-roadmap.md`
- New detailed plan: `docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md`
- Issue: Closes #1504

## Commands Run
```text
git diff --check -> passed
git commit -m "docs: define runtime-aware export verification plan" -> passed
  pre-commit: make swift-test -> passed
  pre-commit: make py-test -> 4105 passed, 14 skipped, 2 warnings
  pre-commit: make integration-test -> 122 passed, 1 skipped
  pre-commit performance report -> ok, 0 selected probes, 0 regressions
git fetch origin main && git merge origin/main --no-edit -> passed
git diff --check origin/main...HEAD -> passed
python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-body-issue-1504.md -> passed
python3 - <<'PY' ... # verified #1504 acceptance keywords and #1505-#1510 links in the new plan -> passed
git commit -m "docs: clarify export retention decisions" -> passed
  pre-commit: make swift-test -> passed
  pre-commit: make py-test -> 4106 passed, 14 skipped, 2 warnings
  pre-commit: make integration-test -> 122 passed, 1 skipped
  pre-commit performance report -> ok, 0 selected probes, 0 regressions
```

## Coverage and Metrics
- N/A: documentation-only planning change. No executable code, protocol schema, generated artifact, or runtime path changed.
- Metrics report: N/A for this PR; the new plan defines required metrics for follow-up units, including export duration, artifact byte size, load/generation smoke latency, diagnostic parser coverage, retention byte accounting, timeout count, waiver count, redaction count, and diagnostic latency.

## Known Gaps
- Follow-up implementation remains in child issues #1506, #1507, #1509, and #1510.
- `make bootstrap` and `make proto` were not rerun because this PR is documentation-only and changes no dependencies, protobuf schemas, or generated artifacts.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
