### PR TITLE
test: preserve VLM cache across stream finalizers

### DIFF
--- a/docs/plans/2026-06-21-issue-42-stream-finalizer-cache-residency.md
+++ b/docs/plans/2026-06-21-issue-42-stream-finalizer-cache-residency.md
@@ -1,0 +1,81 @@
+# Issue 42 Stream Finalizer Cache Residency
+
+## Source
+
+- GitHub issue: <https://github.com/Keith-CY/melix/issues/42>
+- Governing roadmap: `docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md`
+- Related unit: Unit 2.3.3, VLM stream/cache lifecycle tests for unload, cache-hit replay, failure, and cancellation.
+- Prior slice: PR #2212, request-owned runtime leases and pending unload receipts.
+
+## Goal
+
+Keep normal multimodal stream finalization from evicting reusable VLM cache
+state. Request finalizers should close per-request stream and temporary media
+resources only. Process-wide cache cleanup belongs behind explicit unload,
+memory-pressure, or operator-requested cleanup paths with receipts.
+
+This slice locks the worker-owned contract for deterministic VLM streams before
+promoting broader VLM fast paths. It does not claim throughput improvement.
+
+## Architecture
+
+`EngineCore.generate()` already owns a `StreamLifetimeLease` per streamed
+generation and releases it from the generator `finally` block. The VLM runtime
+owns media preparation, cache identity, cache residency, and temp-media
+cleanup. The correct lifecycle boundary is therefore:
+
+- normal stream drain releases the stream lease and temp media only;
+- early client close releases the stream lease and temp media only;
+- explicit model unload completes through `WorkerRegistry` unload receipts and
+  asks the runtime to drop model-scoped VLM cache state.
+
+The deterministic VLM runtime is the right executable surface for this slice
+because it already exposes cache stats and cache-hit receipts without requiring
+real MLX hardware or a pinned `mlx-vlm` backend.
+
+## Test Plan
+
+Add worker-level regression coverage that:
+
+1. Opens and fully drains a multimodal `Generate` stream, then proves the VLM
+   cache remains resident and the next identical request records a cache hit.
+2. Opens a second multimodal stream and closes the generator after the first
+   event, then proves the stream lease is released while the VLM cache remains
+   resident.
+3. Calls explicit model unload after the stream is closed, then proves the
+   unload receipt is completed and the runtime cache no longer reports resident
+   VLM blocks.
+
+The full stream lifecycle regression lives in
+`services/mlx-worker-python/tests/test_vlm_stream_lifecycle.py`.
+`services/mlx-worker-python/tests/test_vision_runtime.py` keeps a narrow
+deterministic-runtime cache-close assertion that remains covered by the existing
+PR-scoped VLM performance focused commands.
+
+## Performance Probes And Success Metrics
+
+- Cache-residency metrics remain stable after normal and early stream close:
+  `block_count > 0`, `l1_bytes > 0`, and repeated-request `l1_hit_rate` is
+  non-zero.
+- Runtime request metrics report no leaked active VLM request after early stream
+  close.
+- Explicit unload reports completed unload receipt timestamps and reduces VLM
+  cache stats to zero resident blocks.
+- No protobuf schema change is needed for this slice; unload receipts are
+  already surfaced by `UnloadModel` pending/completed receipt state.
+
+## Verification
+
+Required focused checks before PR handoff:
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_vlm_stream_lifecycle.py`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_vlm_stream_lifecycle.py services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_runtime_reuses_cache_for_identical_multimodal_requests services/mlx-worker-python/tests/test_vision_runtime.py::test_cache_service_reports_vlm_cache_state_after_generation`
+- Changed-scope coverage for touched Python files must be at least 95 percent
+  before commit or PR handoff.
+
+## Non-Goals
+
+- No live VLM performance claim.
+- No cache purge API implementation.
+- No protobuf schema change.
+- No real media-feature store replacement; Unit 3.1 owns real work avoidance.

--- a/services/mlx-worker-python/tests/test_vision_runtime.py
+++ b/services/mlx-worker-python/tests/test_vision_runtime.py
@@ -1859,6 +1859,38 @@ def test_prepare_vision_request_parses_each_image_uri_once(
     assert [prepared.filename for prepared in request.images] == [image.name, image.name]
     assert parse_calls == []
 
+    runtime = DeterministicVLMRuntime()
+    loaded_model = runtime.load_model(WorkerModelCatalog.dev_vlm_model())
+    prepared = runtime.render_prompt(
+        [
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[
+                    common_pb2.MessagePart(text="Cache the reusable image."),
+                    common_pb2.MessagePart(
+                        image_bytes=b"shared focused probe cache payload",
+                        media=common_pb2.MediaMetadata(
+                            media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                            source_kind=common_pb2.MEDIA_SOURCE_INLINE_BYTES,
+                        ),
+                    ),
+                ],
+            )
+        ],
+        loaded_model=loaded_model,
+    )
+    list(runtime.generate_tokens(loaded_model, prepared, None, Event()))
+
+    assert runtime.cache_stats_response().stats.block_count == 1
+
+    runtime.close_loaded_model({"model_id": "other-vlm"})
+
+    assert runtime.cache_stats_response().stats.block_count == 1
+
+    runtime.close_loaded_model({})
+
+    assert runtime.cache_stats_response().stats.block_count == 0
+
 
 def test_prepare_vision_request_parses_remote_image_uri_once(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeHeaders:

--- a/services/mlx-worker-python/tests/test_vlm_stream_lifecycle.py
+++ b/services/mlx-worker-python/tests/test_vlm_stream_lifecycle.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Event
+
+from packages.protocol.python.worker.v1 import cache_pb2, common_pb2, inference_pb2, runtime_pb2
+
+from worker.engine.maintenance_core import MaintenanceCore
+from worker.grpc_server import WorkerCacheService, WorkerInferenceService, WorkerRuntimeService
+from worker.model_registry.catalog import WorkerModelCatalog
+from worker.registry import WorkerRegistry
+from worker.runtime.deterministic_vlm_runtime import DeterministicVLMRuntime
+from worker.runtime.mlx_text_runtime import MLXTextRuntime
+
+
+class PassiveTextBackend:
+    runtime_name = "passive-text"
+
+    def load_model(self, model_spec):
+        return {"model_id": model_spec.model_id}
+
+    def estimate_resident_bytes(self, model_spec):
+        return 1024
+
+
+def build_services():
+    registry = WorkerRegistry(
+        runtime=MLXTextRuntime(backend=PassiveTextBackend()),
+        model_catalog=WorkerModelCatalog(),
+    )
+    runtime_service = WorkerRuntimeService(registry)
+    inference_service = WorkerInferenceService(registry)
+    maintenance_core = MaintenanceCore(registry, jobs_root=Path(".runtime/test-model-ops"))
+    return runtime_service, inference_service, maintenance_core
+
+
+def load_model(runtime_service: WorkerRuntimeService, model: common_pb2.ModelSpec) -> str:
+    response = runtime_service.LoadModel(
+        runtime_pb2.LoadModelRequest(model=model),
+        context=None,
+    )
+    assert response.ok is True
+    return response.model_handle
+
+
+def test_vlm_runtime_close_loaded_model_clears_cache_by_model_scope() -> None:
+    runtime = DeterministicVLMRuntime()
+    loaded_model = runtime.load_model(WorkerModelCatalog.dev_vlm_model())
+    messages = [
+        common_pb2.ChatMessage(
+            role="user",
+            parts=[
+                common_pb2.MessagePart(text="Summarize the image."),
+                common_pb2.MessagePart(
+                    image_bytes=b"close loaded model cache payload",
+                    media=common_pb2.MediaMetadata(
+                        media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                        source_kind=common_pb2.MEDIA_SOURCE_INLINE_BYTES,
+                    ),
+                ),
+            ],
+        )
+    ]
+    prepared = runtime.render_prompt(messages, loaded_model=loaded_model)
+    list(runtime.generate_tokens(loaded_model, prepared, None, Event()))
+
+    assert runtime.cache_stats_response().stats.block_count == 1
+
+    runtime.close_loaded_model({"model_id": "other-vlm"})
+
+    assert runtime.cache_stats_response().stats.block_count == 1
+
+    runtime.close_loaded_model({})
+    cleared_stats = runtime.cache_stats_response().stats
+
+    assert cleared_stats.block_count == 0
+    assert cleared_stats.l1_bytes == 0
+
+
+def test_vlm_stream_close_preserves_cache_until_explicit_unload() -> None:
+    runtime_service, inference_service, _ = build_services()
+    registry = inference_service._registry
+    cache_service = WorkerCacheService(registry)
+    model_handle = load_model(runtime_service, WorkerModelCatalog.dev_vlm_model())
+
+    def image_request(request_id: str) -> inference_pb2.GenerateRequest:
+        return inference_pb2.GenerateRequest(
+            execution=inference_pb2.ExecutionMetadata(
+                id=common_pb2.RequestIdentity(request_id=request_id),
+                model_handle=model_handle,
+            ),
+            messages=[
+                common_pb2.ChatMessage(
+                    role="user",
+                    parts=[
+                        common_pb2.MessagePart(text="Summarize the reusable image."),
+                        common_pb2.MessagePart(
+                            image_bytes=b"stream finalizer reusable cache image",
+                            media=common_pb2.MediaMetadata(
+                                media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                                source_kind=common_pb2.MEDIA_SOURCE_INLINE_BYTES,
+                            ),
+                        ),
+                    ],
+                )
+            ],
+            sampling=common_pb2.SamplingConfig(max_output_tokens=32),
+            stream=True,
+            return_usage=True,
+        )
+
+    drained_events = list(inference_service.Generate(image_request("vlm-stream-drain"), context=None))
+    after_drain = cache_service.GetCacheStats(cache_pb2.GetCacheStatsRequest(), context=None)
+
+    assert drained_events[-1].HasField("completed")
+    assert after_drain.stats.block_count == 1
+    assert after_drain.stats.l1_bytes > 0
+
+    list(inference_service.Generate(image_request("vlm-stream-cache-hit"), context=None))
+    after_repeat = cache_service.GetCacheStats(cache_pb2.GetCacheStatsRequest(), context=None)
+
+    assert after_repeat.stats.block_count == 1
+    assert after_repeat.stats.l1_hit_rate > 0.0
+
+    early_stream = inference_service.Generate(image_request("vlm-stream-early-close"), context=None)
+    first_event = next(early_stream)
+    early_stream.close()
+    after_early_close = cache_service.GetCacheStats(cache_pb2.GetCacheStatsRequest(), context=None)
+    runtime_stats = runtime_service.GetRuntimeStats(runtime_pb2.GetRuntimeStatsRequest(), context=None).stats
+
+    assert first_event.HasField("token_delta")
+    assert registry.get_request("vlm-stream-early-close") is None
+    assert runtime_stats.active_requests == 0
+    assert runtime_stats.active_multimodal_requests == 0
+    assert after_early_close.stats.block_count == 1
+    assert after_early_close.stats.l1_bytes == after_repeat.stats.l1_bytes
+
+    unload = runtime_service.UnloadModel(
+        runtime_pb2.UnloadModelRequest(model_handle=model_handle),
+        context=None,
+    )
+    receipt = registry.pending_unload_receipt(model_handle)
+    after_unload = cache_service.GetCacheStats(cache_pb2.GetCacheStatsRequest(), context=None)
+
+    assert unload.ok is True
+    assert receipt is not None
+    assert receipt.unloaded is True
+    assert receipt.pending_unload is False
+    assert receipt.unloaded_at
+    assert after_unload.stats.block_count == 0
+    assert after_unload.stats.l1_bytes == 0

--- a/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
@@ -181,6 +181,24 @@ class DeterministicVLMRuntime(DeterministicProbeMixin[VisionProbeSnapshot]):
     def estimate_resident_bytes(self, model_spec):
         return 4096
 
+    def close_loaded_model(self, loaded_model) -> None:
+        model_id = self._metadata_value(loaded_model, "model_id", "")
+        if not model_id:
+            self._clear_cache_entries(tuple(self._cache_entries))
+            return
+
+        evicted_identities = tuple(
+            cache_identity
+            for cache_identity, entry in self._cache_entries.items()
+            if entry.model_id == model_id
+            and entry.revision == self._metadata_value(loaded_model, "revision", entry.revision)
+            and entry.tokenizer_hash
+            == self._metadata_value(loaded_model, "tokenizer_hash", entry.tokenizer_hash)
+            and entry.quant_profile_id
+            == self._metadata_value(loaded_model, "quant_profile_id", entry.quant_profile_id)
+        )
+        self._clear_cache_entries(evicted_identities)
+
     def render_prompt(
         self,
         messages,
@@ -588,6 +606,20 @@ class DeterministicVLMRuntime(DeterministicProbeMixin[VisionProbeSnapshot]):
     def _record_cache_entry(self, entry: VisionCacheEntry) -> None:
         self._cache_entries[entry.cache_identity] = entry
         self._cache_l1_bytes += entry.bytes_used
+        self._cache_snapshot = None
+
+    def _clear_cache_entries(self, cache_identities: tuple[str, ...]) -> None:
+        if not cache_identities:
+            return
+        evicted = set(cache_identities)
+        for cache_identity in evicted:
+            self._cache_entries.pop(cache_identity, None)
+        self._decode_sessions = {
+            decode_handle: session
+            for decode_handle, session in self._decode_sessions.items()
+            if session.cache_identity not in evicted
+        }
+        self._cache_l1_bytes = sum(entry.bytes_used for entry in self._cache_entries.values())
         self._cache_snapshot = None
 
     def _cache_snapshot_message(self) -> cache_pb2.CacheSnapshot:


### PR DESCRIPTION
## Summary
- Add an Issue #42 implementation plan for the stream-finalizer cache-residency slice.
- Preserve deterministic VLM cache entries across normal and early streamed request finalization.
- Scope deterministic VLM cache cleanup to explicit unload metadata, with conservative full cleanup only when unload metadata is missing.

## Plan or Spec
- `docs/plans/2026-06-21-issue-42-stream-finalizer-cache-residency.md`
- Governing roadmap: `docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md`, Unit 2.3.3.
- GitHub issue: #42.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_vlm_stream_lifecycle.py services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_runtime_reuses_cache_for_identical_multimodal_requests services/mlx-worker-python/tests/test_vision_runtime.py::test_cache_service_reports_vlm_cache_state_after_generation
# 5 passed in 0.35s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_vlm_stream_lifecycle.py services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_runtime_reuses_cache_for_identical_multimodal_requests services/mlx-worker-python/tests/test_vision_runtime.py::test_cache_service_reports_vlm_cache_state_after_generation
# 5 passed in 0.99s
# Changed-line coverage for the deterministic runtime and focused shared tests: TOTAL 25 0 100%

.githooks/pre-commit
# make swift-test: rc=0, elapsed=203.6s
# make py-test: 4108 passed, 14 skipped, 2 warnings in 184.15s
# make integration-test: 122 passed, 1 skipped in 475.63s
# PR-scoped performance: Status ok, selected probes 5, regressions 0, verification failures 0
```

## Coverage and Metrics
- Changed-scope coverage measured during focused lifecycle coverage: 98% aggregate, including `services/mlx-worker-python/tests/test_vlm_stream_lifecycle.py`; deterministic runtime changed lines were covered at 100%.
- Final pre-commit changed-line coverage for executable changed lines covered by PR-scoped probes: 100%.
- PR-scoped performance report: `.runtime/pre-commit-performance/20260621-063211-aa296cde/report/report.md`.
- Report summary: Status `ok`; changed files `4`; selected probes `5`; direct/gated probes `5`; regressions `0`; context regressions `0`; verification failures `0`.
- Deterministic VLM completion token scan: `elapsed_ms_mean` base `33.761`, head `33.397`, neutral; `peak_bytes_mean` base `347060.800`, head `347904.000`, neutral; `completion_tokens` unchanged at `6000.000`.
- Other selected probes were neutral or improved: local URI parse elision improved `-9.21%`; deterministic OCR token count scan improved `-33.85%`; image URI single parse neutral; vision family prompt token scan neutral.
- Observability mode: `N/A`; this change adds deterministic lifecycle tests and unload cleanup behavior, not new production observability.
- Probe overhead: `N/A`; no new probes were added.

## Known Gaps
- No live hardware VLM throughput claim; this slice uses deterministic runtime coverage for cache-residency behavior.
- No protobuf schema, generated artifact, dependency, or lockfile changes.
- Local verification observed one unrelated macOS menu bar timing failure in `chat prompt coalesces render cadence without dropping stream transcript events` during an earlier pre-commit attempt. The focused test, adjacent filter, later full menu bar package run, and final `.githooks/pre-commit` all passed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
