### PR TITLE
Record managed artifact partial lifecycle receipts

### DIFF
--- a/docs/plans/2026-06-21-managed-artifact-partial-lifecycle.md
+++ b/docs/plans/2026-06-21-managed-artifact-partial-lifecycle.md
@@ -1,0 +1,85 @@
+# Managed Artifact Partial Lifecycle Receipt Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the next executable slice of issue #1258 by making managed download receipts prove whether partial artifact bytes were kept for resume, removed as stale, or rejected before activation.
+
+**Architecture:** Keep the trust boundary in the Python worker download pipeline because it owns artifact materialization and partial files. Extend the existing `melix.download_job.v1` state payload with a small partial-file lifecycle section and surface those fields through the existing model-ops download registry. Do not introduce signing infrastructure, desktop UI, or new protocol messages in this slice.
+
+**Tech Stack:** Python worker model-ops code, pytest, deterministic local download fixtures, Phase 8 local install runbook, PR-scoped performance tooling.
+
+---
+
+## Governing Context
+
+- GitHub issue: `https://github.com/Keith-CY/melix/issues/1258`
+- Existing runbook: `docs/runbooks/phase-8-local-install.md`
+- Existing completed download plan: `docs/plans/2026-03-30-m8-4-resumable-downloads-retries-and-mirrors.md`
+
+Issue #1258 is a broad tracking issue. This PR intentionally implements the current narrow slice for partial lifecycle receipts and leaves signature policy, publish-token minimization, desktop UI, and transport acceleration for later PRs.
+
+## Performance Probes And Metrics
+
+- Runtime hot-path probe: `download-pipeline-directory-size-single-stat` covers the per-snapshot manifest path. Lifecycle fields must not add per-snapshot filesystem probes and should stay on managed/operation receipt payloads so plain-download progress remains non-regressive.
+- Evidence probe: `scripts/m8_download_smoke.py --json` must include stale-partial lifecycle checks.
+- Metrics to record in PR evidence:
+  - focused pytest result for `test_download_pipeline_unit.py` and `test_managed_artifact_receipts.py`
+  - deterministic smoke result for `scripts/m8_download_smoke.py --json`
+  - changed-scope coverage for touched Python files, target `>=95%`
+  - PR-scoped performance report, expected no selected probes or no regressions unless a matching probe exists
+
+## Files
+
+- Modify: `services/mlx-worker-python/worker/model_ops/download_pipeline.py`
+  - add stale partial sweep before resume calculation
+  - add lifecycle fields to all download state payloads
+  - distinguish cancel-kept resumable partials from stall-kept partials
+- Modify: `services/mlx-worker-python/worker/model_ops/job_registry.py`
+  - project lifecycle fields into `snapshot()["downloads"]`
+  - base `resume_ready` on explicit receipt data when present
+- Modify: `services/mlx-worker-python/tests/test_download_pipeline_unit.py`
+  - add failing tests for stale partial removal and terminal cancel/stall lifecycle fields
+- Modify: `services/mlx-worker-python/tests/test_managed_artifact_receipts.py` or `services/mlx-worker-python/tests/test_maintenance_service.py`
+  - add registry-level assertion that stale partial lifecycle is operator-visible
+- Modify: `scripts/m8_download_smoke.py`
+  - add deterministic stale partial fixture
+- Modify: `docs/runbooks/phase-8-local-install.md`
+  - document lifecycle fields and stale partial behavior
+
+## Task 1: Add Failing Unit Coverage
+
+- [ ] Add a test proving an old `download.artifact.partial` is removed before a managed download resumes.
+- [ ] Assert the state payload records `partial_bytes`, `partial_age_ms`, `resume_eligible`, `stale_partial_removed`, `partial_lifecycle`, and `activated`.
+- [ ] Add terminal receipt assertions for cancelled and stalled downloads so cancel and stall no longer look the same in receipt data.
+- [ ] Run focused pytest and confirm the new tests fail for missing fields or stale partial behavior.
+
+## Task 2: Implement Pipeline Receipt Fields
+
+- [ ] Add partial lifecycle derivation in `DownloadPipeline.run` before `_resume_from_bytes`.
+- [ ] Preserve recent partial files for resume, remove only partial files older than configured `melix.stale_partial_after_ms` / `stale_partial_after_ms`.
+- [ ] Include lifecycle fields in managed/operation-receipt prepare, progress, terminal, strict-preflight, and managed hub import payloads.
+- [ ] Keep existing plain downloads working without adding managed artifact lifecycle fields or per-snapshot filesystem probes.
+- [ ] Run focused pytest until green.
+
+## Task 3: Surface Operator Registry State
+
+- [ ] Project the lifecycle fields from job manifests into `ModelOpsJobRegistry._download_registry`.
+- [ ] Update `resume_ready` to use explicit `resume_eligible` when present.
+- [ ] Add or update service-level tests so diagnostics/download snapshots expose the stale-removal result.
+- [ ] Run focused registry tests until green.
+
+## Task 4: Update Smoke And Docs
+
+- [ ] Extend `scripts/m8_download_smoke.py` with a stale partial fixture.
+- [ ] Update `docs/runbooks/phase-8-local-install.md` with the lifecycle receipt fields and behavior.
+- [ ] Run the smoke command and focused tests.
+
+## Task 5: Verification And PR Evidence
+
+- [ ] Run `git diff --check`.
+- [ ] Run focused pytest for the touched Python tests.
+- [ ] Run changed-scope coverage for the touched Python scope and verify `>=95%`.
+- [ ] Run the deterministic download smoke.
+- [ ] Run PR-scoped performance reporting or record `N/A` if no probe selects this scope.
+- [ ] Validate the PR body with `scripts/validate_pr_evidence.py --body-file`.
+- [ ] Commit the focused slice and open a PR against `main`.

--- a/docs/plans/2026-06-21-managed-artifact-partial-lifecycle.md
+++ b/docs/plans/2026-06-21-managed-artifact-partial-lifecycle.md
@@ -56,7 +56,7 @@ Issue #1258 is a broad tracking issue. This PR intentionally implements the curr
 ## Task 2: Implement Pipeline Receipt Fields
 
 - [ ] Add partial lifecycle derivation in `DownloadPipeline.run` before `_resume_from_bytes`.
-- [ ] Preserve recent partial files for resume, remove only partial files older than configured `melix.stale_partial_after_ms` / `stale_partial_after_ms`.
+- [ ] Preserve recent partial files for resume, remove empty or oversized invalid partial files, and remove aged partial files older than configured `melix.stale_partial_after_ms` / `stale_partial_after_ms`.
 - [ ] Include lifecycle fields in managed/operation-receipt prepare, progress, terminal, strict-preflight, and managed hub import payloads.
 - [ ] Keep existing plain downloads working without adding managed artifact lifecycle fields or per-snapshot filesystem probes.
 - [ ] Run focused pytest until green.

--- a/docs/runbooks/phase-8-local-install.md
+++ b/docs/runbooks/phase-8-local-install.md
@@ -122,6 +122,12 @@ The JSON state snapshot records at least these fields:
 - `retry_count`
 - `stall_detection_count`
 - `stall_reason`
+- `partial_bytes`
+- `partial_age_ms`
+- `resume_eligible`
+- `stale_partial_removed`
+- `partial_lifecycle`
+- `activated`
 - `terminal_state`
 
 This state is intended to remain stable enough for later desktop queue recovery and release-gate automation.
@@ -137,6 +143,18 @@ When a request deadline is exceeded while bytes are still progressing, the
 receipt status is `in_progress` rather than `failed`. Failed, stalled, and
 cancelled terminal paths still set `last_error` and a failed
 `artifact_integrity` receipt.
+
+Partial artifacts have an explicit lifecycle in the same receipt. Recent
+partials that end in `failed`, `stalled`, or `cancelled` states remain
+`resume_eligible=true` when they contain fewer bytes than the planned artifact.
+Explicit cancels report `partial_lifecycle=cancelled_kept_for_resume`; no-progress
+stalls report `partial_lifecycle=stalled_kept_for_resume`. A managed download
+request can set `melix.stale_partial_after_ms` or `stale_partial_after_ms` to
+reap abandoned `*.partial` files before resuming. When the sweep removes a
+partial, the prepare receipt records `stale_partial_removed=true`,
+`partial_bytes`, `partial_age_ms`, and `partial_lifecycle=stale_removed`; the
+completed receipt records `partial_lifecycle=completed_activated` and
+`activated=true`.
 
 Managed artifact requests can opt into the current strict install preflight
 with `melix.strict_install_mode=true` or `melix.install_mode=strict`. Strict

--- a/scripts/m8_download_smoke.py
+++ b/scripts/m8_download_smoke.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import tempfile
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -112,6 +114,29 @@ def main() -> int:
         )
         stall_manifest = _latest_manifest_payload(stall_events)
 
+        stale_source = root / "stale-source.bin"
+        stale_bytes = _write_source(stale_source, size=1024)
+        stale_output_dir = root / "stale-partial"
+        stale_output_dir.mkdir()
+        stale_partial_path = stale_output_dir / "download.artifact.partial"
+        stale_partial_path.write_bytes(b"stale-bytes")
+        old_timestamp = time.time() - 60
+        os.utime(stale_partial_path, (old_timestamp, old_timestamp))
+        stale_events = _run_download(
+            service,
+            source_model="mlx-community/stale-partial-smoke",
+            output_dir=str(stale_output_dir),
+            generate_manifest=True,
+            ext={
+                "operation": "download",
+                "source_path": str(stale_source),
+                "melix.target_scope": "hub:mlx-community/stale-partial-smoke@main",
+                "melix.operation_kind": "managed_model_install",
+                "melix.stale_partial_after_ms": "1",
+            },
+        )
+        stale_manifest = _latest_manifest_payload(stale_events)
+
         checks = {
             "retry_success": retry_events[-1].HasField("completed")
             and retry_manifest["retry_count"] == 2
@@ -125,6 +150,12 @@ def main() -> int:
             and stall_events[-1].failed.error.code == "download_stalled"
             and stall_manifest["terminal_state"] == "stalled"
             and stall_manifest["stall_reason"] == "no_progress_timeout",
+            "stale_partial_removed": stale_events[-1].HasField("completed")
+            and stale_manifest["stale_partial_removed"] is True
+            and stale_manifest["partial_lifecycle"] == "completed_activated"
+            and stale_manifest["resume_eligible"] is False
+            and Path(stale_events[-1].completed.output_path).read_bytes() == stale_bytes
+            and not stale_partial_path.exists(),
         }
 
         result = {
@@ -144,6 +175,12 @@ def main() -> int:
                 "status": stall_manifest["status"],
                 "stall_detection_count": stall_manifest["stall_detection_count"],
                 "stall_reason": stall_manifest["stall_reason"],
+            },
+            "stale_partial": {
+                "status": stale_manifest["status"],
+                "partial_lifecycle": stale_manifest["partial_lifecycle"],
+                "stale_partial_removed": stale_manifest["stale_partial_removed"],
+                "resume_eligible": stale_manifest["resume_eligible"],
             },
         }
 

--- a/services/mlx-worker-python/tests/test_download_pipeline_unit.py
+++ b/services/mlx-worker-python/tests/test_download_pipeline_unit.py
@@ -315,7 +315,39 @@ def test_run_removes_stale_partial_before_resume(tmp_path: Path) -> None:
     assert not partial_path.exists()
 
 
-def test_sweep_stale_partial_removes_complete_partial(tmp_path: Path) -> None:
+def test_run_reports_new_partial_progress_after_stale_partial_removal(tmp_path: Path) -> None:
+    pipeline = DownloadPipeline()
+    source_path = tmp_path / "source.gguf"
+    source_path.write_bytes(b"abcdefgh")
+    output_dir = tmp_path / "flat-cache"
+    output_dir.mkdir()
+    partial_path = output_dir / "model.gguf.partial"
+    partial_path.write_bytes(b"old")
+    old_timestamp = time.time() - 30
+    os.utime(partial_path, (old_timestamp, old_timestamp))
+    request = maintenance_pb2.ConvertModelRequest(
+        source_model="mlx-community/vlm",
+        ext={
+            "source_path": str(source_path),
+            "output_filename": "model.gguf",
+            "chunk_bytes": "2",
+            "melix.target_scope": "hub:mlx-community/vlm@main",
+            "melix.operation_kind": "managed_model_install",
+            "melix.stale_partial_after_ms": "1",
+        },
+    )
+
+    result = pipeline.run(request, job_id="job-stale-then-progress", output_dir=output_dir)
+
+    progress_payload = json.loads(result.snapshots[1].manifest_json)
+    assert progress_payload["downloaded_bytes"] == 2
+    assert progress_payload["partial_bytes"] == 2
+    assert progress_payload["resume_eligible"] is True
+    assert progress_payload["stale_partial_removed"] is True
+    assert progress_payload["partial_lifecycle"] == "resume_candidate"
+
+
+def test_sweep_stale_partial_keeps_recent_complete_partial(tmp_path: Path) -> None:
     partial_path = tmp_path / "download.artifact.partial"
     partial_path.write_bytes(b"abcdefgh")
 
@@ -325,8 +357,24 @@ def test_sweep_stale_partial_removes_complete_partial(tmp_path: Path) -> None:
         ext={"melix.stale_partial_after_ms": "60000"},
     )
 
+    assert removed is False
+    assert partial_bytes == 0
+    assert partial_age_ms == 0
+    assert partial_path.read_bytes() == b"abcdefgh"
+
+
+def test_sweep_stale_partial_removes_oversized_partial(tmp_path: Path) -> None:
+    partial_path = tmp_path / "download.artifact.partial"
+    partial_path.write_bytes(b"abcdefghi")
+
+    removed, partial_bytes, partial_age_ms = DownloadPipeline._sweep_stale_partial(
+        partial_path=partial_path,
+        total_bytes=8,
+        ext={"melix.stale_partial_after_ms": "60000"},
+    )
+
     assert removed is True
-    assert partial_bytes == 8
+    assert partial_bytes == 9
     assert partial_age_ms >= 0
     assert not partial_path.exists()
 

--- a/services/mlx-worker-python/tests/test_download_pipeline_unit.py
+++ b/services/mlx-worker-python/tests/test_download_pipeline_unit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import time
 from unittest.mock import Mock
 
 import pytest
@@ -112,6 +113,40 @@ def test_run_reuses_public_ext_across_many_snapshots(
     assert payload["terminal_state"] == "completed"
 
 
+def test_run_derives_partial_lifecycle_without_per_snapshot_file_stat(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pipeline = DownloadPipeline()
+    source_path = tmp_path / "source.bin"
+    source_path.write_bytes(b"abcdef")
+    request = maintenance_pb2.ConvertModelRequest(
+        source_model="mlx-community/demo",
+        ext={
+            "source_path": str(source_path),
+            "chunk_bytes": "1",
+        },
+    )
+    partial_state = Mock(side_effect=AssertionError("snapshot hot path should not stat partial file"))
+    monkeypatch.setattr(
+        DownloadPipeline,
+        "_partial_file_state",
+        staticmethod(partial_state),
+    )
+
+    result = pipeline.run(request, job_id="job-hot-path", output_dir=tmp_path / "output")
+
+    assert result.output_path.read_bytes() == b"abcdef"
+    assert partial_state.call_count == 0
+    running_payload = json.loads(result.snapshots[1].manifest_json)
+    assert "partial_bytes" not in running_payload
+    assert "resume_eligible" not in running_payload
+    assert "partial_lifecycle" not in running_payload
+    completed_payload = json.loads(result.snapshots[-1].manifest_json)
+    assert "partial_bytes" not in completed_payload
+    assert "partial_lifecycle" not in completed_payload
+
+
 def test_run_plain_download_does_not_build_operation_receipts(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -219,6 +254,8 @@ def test_run_resumes_named_artifact_from_preserved_partial(tmp_path: Path) -> No
             "source_path": str(source_path),
             "output_filename": "model.gguf",
             "chunk_bytes": "2",
+            "melix.target_scope": "hub:mlx-community/vlm@main",
+            "melix.operation_kind": "managed_model_install",
         },
     )
 
@@ -229,6 +266,85 @@ def test_run_resumes_named_artifact_from_preserved_partial(tmp_path: Path) -> No
     payload = json.loads(result.snapshots[-1].manifest_json)
     assert payload["resume_used"] is True
     assert payload["resume_from_bytes"] == 4
+    assert payload["partial_bytes"] == 0
+    assert payload["resume_eligible"] is False
+    assert payload["stale_partial_removed"] is False
+    assert payload["partial_lifecycle"] == "completed_activated"
+    assert payload["activated"] is True
+
+
+def test_run_removes_stale_partial_before_resume(tmp_path: Path) -> None:
+    pipeline = DownloadPipeline()
+    source_path = tmp_path / "source.gguf"
+    source_path.write_bytes(b"abcdefgh")
+    output_dir = tmp_path / "flat-cache"
+    output_dir.mkdir()
+    partial_path = output_dir / "model.gguf.partial"
+    partial_path.write_bytes(b"stale")
+    old_timestamp = time.time() - 30
+    os.utime(partial_path, (old_timestamp, old_timestamp))
+    request = maintenance_pb2.ConvertModelRequest(
+        source_model="mlx-community/vlm",
+        ext={
+            "source_path": str(source_path),
+            "output_filename": "model.gguf",
+            "chunk_bytes": "4",
+            "melix.target_scope": "hub:mlx-community/vlm@main",
+            "melix.operation_kind": "managed_model_install",
+            "melix.stale_partial_after_ms": "1",
+        },
+    )
+
+    result = pipeline.run(request, job_id="job-stale-partial", output_dir=output_dir)
+
+    assert result.output_path.read_bytes() == b"abcdefgh"
+    prepare_payload = json.loads(result.snapshots[0].manifest_json)
+    completed_payload = json.loads(result.snapshots[-1].manifest_json)
+    assert prepare_payload["partial_bytes"] == len(b"stale")
+    assert prepare_payload["partial_age_ms"] >= 1
+    assert prepare_payload["resume_eligible"] is False
+    assert prepare_payload["stale_partial_removed"] is True
+    assert prepare_payload["partial_lifecycle"] == "stale_removed"
+    assert prepare_payload["activated"] is False
+    assert completed_payload["resume_used"] is False
+    assert completed_payload["resume_from_bytes"] == 0
+    assert completed_payload["partial_bytes"] == 0
+    assert completed_payload["stale_partial_removed"] is True
+    assert completed_payload["partial_lifecycle"] == "completed_activated"
+    assert completed_payload["activated"] is True
+    assert not partial_path.exists()
+
+
+def test_sweep_stale_partial_removes_complete_partial(tmp_path: Path) -> None:
+    partial_path = tmp_path / "download.artifact.partial"
+    partial_path.write_bytes(b"abcdefgh")
+
+    removed, partial_bytes, partial_age_ms = DownloadPipeline._sweep_stale_partial(
+        partial_path=partial_path,
+        total_bytes=8,
+        ext={"melix.stale_partial_after_ms": "60000"},
+    )
+
+    assert removed is True
+    assert partial_bytes == 8
+    assert partial_age_ms >= 0
+    assert not partial_path.exists()
+
+
+def test_sweep_stale_partial_keeps_recent_partial(tmp_path: Path) -> None:
+    partial_path = tmp_path / "download.artifact.partial"
+    partial_path.write_bytes(b"abcd")
+
+    removed, partial_bytes, partial_age_ms = DownloadPipeline._sweep_stale_partial(
+        partial_path=partial_path,
+        total_bytes=8,
+        ext={"melix.stale_partial_after_ms": "60000"},
+    )
+
+    assert removed is False
+    assert partial_bytes == 0
+    assert partial_age_ms == 0
+    assert partial_path.read_bytes() == b"abcd"
 
 
 def test_managed_download_manifest_records_operation_receipt_fields(tmp_path: Path) -> None:
@@ -437,6 +553,9 @@ def test_terminal_receipts_record_stalled_and_cancelled_integrity_failures(tmp_p
         "state_path": str(state_path),
         "ext": {"melix.artifact_digest": "sha256:abc"},
         "stall_reason": "no_progress_timeout",
+        "partial_path": str(tmp_path / "download.artifact.partial"),
+        "downloaded_bytes": 128,
+        "total_bytes": 1024,
     }
 
     stalled = json.loads(
@@ -449,5 +568,14 @@ def test_terminal_receipts_record_stalled_and_cancelled_integrity_failures(tmp_p
     assert stalled["last_error"] == "no_progress_timeout"
     assert stalled["artifact_integrity"]["status"] == "failed"
     assert stalled["artifact_integrity"]["digest"] == "sha256:abc"
+    assert stalled["partial_bytes"] == 128
+    assert stalled["resume_eligible"] is True
+    assert stalled["stale_partial_removed"] is False
+    assert stalled["partial_lifecycle"] == "stalled_kept_for_resume"
+    assert stalled["activated"] is False
     assert cancelled["last_error"] == "download_cancelled"
     assert cancelled["artifact_integrity"]["failure_reason"] == "download_cancelled"
+    assert cancelled["partial_bytes"] == 128
+    assert cancelled["resume_eligible"] is True
+    assert cancelled["partial_lifecycle"] == "cancelled_kept_for_resume"
+    assert cancelled["activated"] is False

--- a/services/mlx-worker-python/tests/test_managed_artifact_receipts.py
+++ b/services/mlx-worker-python/tests/test_managed_artifact_receipts.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import threading
+import time
 from typing import Any
 
 from packages.protocol.python.worker.v1 import maintenance_pb2
@@ -167,3 +169,47 @@ def test_strict_managed_download_failure_emits_integrity_receipt(tmp_path: Path)
     assert manifest_payload["artifact_integrity"]["failure_reason"] == "missing_artifact_digest"
     assert json.loads((output_dir / "download.state.json").read_text(encoding="utf-8")) == manifest_payload
     assert service._core._job_registry.snapshot()["downloads"][0]["artifact_integrity_status"] == "failed"
+
+
+def test_managed_download_registry_exposes_stale_partial_lifecycle(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+    source_path, source_bytes = _write_download_source_file(tmp_path, size=1024)
+    output_dir = tmp_path / "managed-stale-partial"
+    output_dir.mkdir()
+    partial_path = output_dir / "download.artifact.partial"
+    partial_path.write_bytes(b"old-partial")
+    old_timestamp = time.time() - 60
+    os.utime(partial_path, (old_timestamp, old_timestamp))
+
+    events = list(
+        service.ConvertModel(
+            maintenance_pb2.ConvertModelRequest(
+                source_model="mlx-community/stale-partial-demo",
+                output_dir=str(output_dir),
+                generate_manifest=True,
+                ext={
+                    "operation": "download",
+                    "source_path": str(source_path),
+                    "melix.managed_import": "true",
+                    "melix.target_scope": "hub:mlx-community/stale-partial-demo@main",
+                    "melix.operation_kind": "managed_model_install",
+                    "melix.stale_partial_after_ms": "1",
+                },
+            ),
+            context=None,
+        )
+    )
+
+    manifest_payload = json.loads(
+        [event.manifest.manifest_json for event in events if event.HasField("manifest")][-1]
+    )
+    download = service._core._job_registry.snapshot()["downloads"][0]
+    assert Path(events[-1].completed.output_path).read_bytes() == source_bytes
+    assert manifest_payload["stale_partial_removed"] is True
+    assert manifest_payload["partial_lifecycle"] == "completed_activated"
+    assert download["stale_partial_removed"] is True
+    assert download["partial_lifecycle"] == "completed_activated"
+    assert download["partial_bytes"] == 0
+    assert download["resume_eligible"] is False
+    assert download["activated"] is True
+    assert not partial_path.exists()

--- a/services/mlx-worker-python/worker/model_ops/download_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/download_pipeline.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import tempfile
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,9 @@ _HF_TOKEN_EXT_KEYS = {
     "HUGGINGFACE_HUB_TOKEN",
     "HF_TOKEN",
 }
+_PARTIAL_RESUME_ELIGIBLE_STATES = frozenset(
+    {"running", "retrying", "in_progress", "failed", "stalled", "cancelled"}
+)
 
 
 @dataclass(frozen=True)
@@ -41,6 +45,9 @@ class _DownloadManifestContext:
     base_payload: dict[str, Any]
     pending_artifact_integrity: dict[str, Any] | None
     passed_artifact_integrity: dict[str, Any] | None
+    stale_partial_removed: bool
+    stale_partial_bytes: int
+    stale_partial_age_ms: int
 
 
 @dataclass(frozen=True)
@@ -111,6 +118,11 @@ class DownloadPipeline:
 
         retry_count = 0
         stall_detection_count = 0
+        stale_partial_removed, stale_partial_bytes, stale_partial_age_ms = self._sweep_stale_partial(
+            partial_path=partial_path,
+            total_bytes=total_bytes,
+            ext=ext,
+        )
         resume_from_bytes = self._resume_from_bytes(partial_path=partial_path, total_bytes=total_bytes)
         resume_used = resume_from_bytes > 0
         manifest_context = self._manifest_context(
@@ -122,6 +134,9 @@ class DownloadPipeline:
             state_path=state_path,
             selected_mirror=selected_mirror,
             ext=ext,
+            stale_partial_removed=stale_partial_removed,
+            stale_partial_bytes=stale_partial_bytes,
+            stale_partial_age_ms=stale_partial_age_ms,
         )
         if strict_integrity_preflight:
             self._raise_if_strict_integrity_missing(
@@ -334,6 +349,40 @@ class DownloadPipeline:
             return 0
         return min(partial_path.stat().st_size, total_bytes)
 
+    @classmethod
+    def _sweep_stale_partial(
+        cls,
+        *,
+        partial_path: Path,
+        total_bytes: int,
+        ext: dict[str, str],
+    ) -> tuple[bool, int, int]:
+        max_age_ms = max(
+            0,
+            cls._int(
+                ext.get("melix.stale_partial_after_ms") or ext.get("stale_partial_after_ms"),
+                default=0,
+            ),
+        )
+        if max_age_ms <= 0 or not partial_path.exists():
+            return False, 0, 0
+
+        partial_bytes, partial_age_ms = cls._partial_file_state(partial_path)
+        if partial_bytes <= 0 or (total_bytes > 0 and partial_bytes >= total_bytes):
+            partial_path.unlink(missing_ok=True)
+            return True, partial_bytes, partial_age_ms
+        if partial_age_ms >= max_age_ms:
+            partial_path.unlink(missing_ok=True)
+            return True, partial_bytes, partial_age_ms
+        return False, 0, 0
+
+    @staticmethod
+    def _partial_file_state(partial_path: Path) -> tuple[int, int]:
+        if not partial_path.exists():
+            return 0, 0
+        stat_result = partial_path.stat()
+        return stat_result.st_size, max(0, int((time.time() - stat_result.st_mtime) * 1000))
+
     @staticmethod
     def _selected_mirror(ext: dict[str, str]) -> str:
         explicit = ext.get("mirror_url", "").strip()
@@ -493,6 +542,12 @@ class DownloadPipeline:
             "retry_count": 0,
             "stall_detection_count": 0,
             "stall_reason": "",
+            "partial_bytes": 0,
+            "partial_age_ms": 0,
+            "resume_eligible": False,
+            "stale_partial_removed": False,
+            "partial_lifecycle": "completed_activated",
+            "activated": True,
             "ext": {
                 **public_ext,
                 "melix.hf_repo_id": repo_id,
@@ -602,6 +657,9 @@ class DownloadPipeline:
         state_path: Path,
         selected_mirror: str,
         ext: dict[str, str],
+        stale_partial_removed: bool,
+        stale_partial_bytes: int,
+        stale_partial_age_ms: int,
     ) -> _DownloadManifestContext:
         public_ext = self._public_ext(request.ext)
         receipt_enabled = self.uses_operation_receipt(ext)
@@ -641,6 +699,9 @@ class DownloadPipeline:
                 if receipt_enabled
                 else None
             ),
+            stale_partial_removed=stale_partial_removed,
+            stale_partial_bytes=stale_partial_bytes,
+            stale_partial_age_ms=stale_partial_age_ms,
         )
 
     @staticmethod
@@ -687,7 +748,71 @@ class DownloadPipeline:
                 if terminal_state == "completed"
                 else manifest_context.pending_artifact_integrity
             )
+            payload.update(
+                DownloadPipeline._partial_lifecycle_receipt(
+                    total_bytes=total_bytes,
+                    downloaded_bytes=downloaded_bytes,
+                    terminal_state=terminal_state,
+                    stale_partial_removed=manifest_context.stale_partial_removed,
+                    stale_partial_bytes=manifest_context.stale_partial_bytes,
+                    stale_partial_age_ms=manifest_context.stale_partial_age_ms,
+                )
+            )
         return payload
+
+    @staticmethod
+    def _partial_lifecycle_receipt(
+        *,
+        total_bytes: int,
+        downloaded_bytes: int,
+        terminal_state: str,
+        stale_partial_removed: bool = False,
+        stale_partial_bytes: int = 0,
+        stale_partial_age_ms: int = 0,
+    ) -> dict[str, Any]:
+        partial_bytes = 0
+        partial_age_ms = 0
+        if downloaded_bytes > 0 and (total_bytes == 0 or downloaded_bytes < total_bytes):
+            partial_bytes = downloaded_bytes
+        if stale_partial_removed and terminal_state != "completed":
+            partial_bytes = stale_partial_bytes
+            partial_age_ms = stale_partial_age_ms
+
+        activated = terminal_state == "completed"
+        resume_eligible = (
+            partial_bytes > 0
+            and not activated
+            and not stale_partial_removed
+            and (total_bytes == 0 or partial_bytes < total_bytes)
+            and terminal_state in _PARTIAL_RESUME_ELIGIBLE_STATES
+        )
+
+        if activated:
+            partial_bytes = 0
+            partial_age_ms = 0
+            lifecycle = "completed_activated"
+        elif stale_partial_removed:
+            resume_eligible = False
+            lifecycle = "stale_removed"
+        elif partial_bytes <= 0:
+            lifecycle = "none"
+        elif terminal_state == "cancelled":
+            lifecycle = "cancelled_kept_for_resume"
+        elif terminal_state == "stalled":
+            lifecycle = "stalled_kept_for_resume"
+        elif terminal_state == "failed":
+            lifecycle = "failed_kept_for_resume"
+        else:
+            lifecycle = "resume_candidate" if resume_eligible else "partial_present"
+
+        return {
+            "partial_bytes": partial_bytes,
+            "partial_age_ms": partial_age_ms,
+            "resume_eligible": resume_eligible,
+            "stale_partial_removed": stale_partial_removed,
+            "partial_lifecycle": lifecycle,
+            "activated": activated,
+        }
 
     @staticmethod
     def _write_manifest_json(state_path: Path, payload: dict[str, Any]) -> str:
@@ -722,6 +847,16 @@ class DownloadPipeline:
                 status="failed",
                 failure_reason="download_cancelled",
             )
+        payload.update(
+            DownloadPipeline._partial_lifecycle_receipt(
+                total_bytes=int(payload.get("total_bytes", 0)),
+                downloaded_bytes=int(payload.get("downloaded_bytes", 0)),
+                terminal_state=str(payload.get("terminal_state", payload.get("status", ""))),
+                stale_partial_removed=bool(payload.get("stale_partial_removed", False)),
+                stale_partial_bytes=int(payload.get("partial_bytes", 0)),
+                stale_partial_age_ms=int(payload.get("partial_age_ms", 0)),
+            )
+        )
         return DownloadPipeline._write_manifest_json(Path(str(payload["state_path"])), payload)
 
     @classmethod
@@ -857,6 +992,12 @@ class DownloadPipeline:
             "retry_count": 0,
             "stall_detection_count": 0,
             "stall_reason": "",
+            "partial_bytes": 0,
+            "partial_age_ms": 0,
+            "resume_eligible": False,
+            "stale_partial_removed": False,
+            "partial_lifecycle": "none",
+            "activated": False,
             "ext": public_ext,
             "metrics": {
                 "download.resume_success_rate": 0.0,

--- a/services/mlx-worker-python/worker/model_ops/download_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/download_pipeline.py
@@ -368,7 +368,7 @@ class DownloadPipeline:
             return False, 0, 0
 
         partial_bytes, partial_age_ms = cls._partial_file_state(partial_path)
-        if partial_bytes <= 0 or (total_bytes > 0 and partial_bytes >= total_bytes):
+        if partial_bytes <= 0 or (total_bytes > 0 and partial_bytes > total_bytes):
             partial_path.unlink(missing_ok=True)
             return True, partial_bytes, partial_age_ms
         if partial_age_ms >= max_age_ms:
@@ -774,7 +774,8 @@ class DownloadPipeline:
         partial_age_ms = 0
         if downloaded_bytes > 0 and (total_bytes == 0 or downloaded_bytes < total_bytes):
             partial_bytes = downloaded_bytes
-        if stale_partial_removed and terminal_state != "completed":
+        stale_removal_only = stale_partial_removed and partial_bytes <= 0 and terminal_state != "completed"
+        if stale_removal_only:
             partial_bytes = stale_partial_bytes
             partial_age_ms = stale_partial_age_ms
 
@@ -782,7 +783,7 @@ class DownloadPipeline:
         resume_eligible = (
             partial_bytes > 0
             and not activated
-            and not stale_partial_removed
+            and not stale_removal_only
             and (total_bytes == 0 or partial_bytes < total_bytes)
             and terminal_state in _PARTIAL_RESUME_ELIGIBLE_STATES
         )
@@ -791,7 +792,7 @@ class DownloadPipeline:
             partial_bytes = 0
             partial_age_ms = 0
             lifecycle = "completed_activated"
-        elif stale_partial_removed:
+        elif stale_removal_only:
             resume_eligible = False
             lifecycle = "stale_removed"
         elif partial_bytes <= 0:

--- a/services/mlx-worker-python/worker/model_ops/job_registry.py
+++ b/services/mlx-worker-python/worker/model_ops/job_registry.py
@@ -1238,6 +1238,7 @@ class ModelOpsJobRegistry:
             total_bytes = int(manifest.get("total_bytes", 0))
             partial_path = str(manifest.get("partial_path", ""))
             status = str(manifest.get("terminal_state", manifest.get("status", job["status"])))
+            resume_eligible = bool(manifest.get("resume_eligible", False))
             downloads.append(
                 {
                     "job_id": job["job_id"],
@@ -1266,11 +1267,21 @@ class ModelOpsJobRegistry:
                     "retry_count": int(manifest.get("retry_count", 0)),
                     "stall_detection_count": int(manifest.get("stall_detection_count", 0)),
                     "stall_reason": str(manifest.get("stall_reason", "")),
+                    "partial_bytes": int(manifest.get("partial_bytes", 0)),
+                    "partial_age_ms": int(manifest.get("partial_age_ms", 0)),
+                    "resume_eligible": resume_eligible,
+                    "stale_partial_removed": bool(manifest.get("stale_partial_removed", False)),
+                    "partial_lifecycle": str(manifest.get("partial_lifecycle", "")),
+                    "activated": bool(manifest.get("activated", status == "completed")),
                     "resume_ready": (
-                        partial_path != ""
-                        and downloaded_bytes > 0
-                        and (total_bytes == 0 or downloaded_bytes < total_bytes)
-                        and status in {"failed", "stalled", "running", "retrying"}
+                        resume_eligible
+                        if "resume_eligible" in manifest
+                        else (
+                            partial_path != ""
+                            and downloaded_bytes > 0
+                            and (total_bytes == 0 or downloaded_bytes < total_bytes)
+                            and status in {"failed", "stalled", "running", "retrying"}
+                        )
                     ),
                 }
             )


### PR DESCRIPTION
## Summary
- Add managed artifact partial lifecycle receipts for stale, cancelled, stalled, and activated download states.
- Reap configured stale `*.partial` files before resume, keep recent cancel/stall partials resume-visible, and surface lifecycle fields through model-ops download registry snapshots.
- Extend the deterministic M8 download smoke and Phase 8 local install runbook for the new receipt contract.

## Plan or Spec
- `docs/plans/2026-06-21-managed-artifact-partial-lifecycle.md`
- Governing issue: https://github.com/Keith-CY/melix/issues/1258
- Updated runbook: `docs/runbooks/phase-8-local-install.md`

## Commands Run
```text
make bootstrap
# passed: configured .githooks and uv sync checked 79 packages

make proto
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python python scripts/m8_download_smoke.py --json
# checks: retry_success=true, resume_success=true, stall_classified=true, stale_partial_removed=true

git diff --check origin/main..HEAD
# passed

make swift-test
# passed

make py-test
# 4129 passed, 14 skipped, 2 warnings in 177.02s

make integration-test
# 122 passed, 1 skipped in 544.05s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_download_pipeline_unit.py services/mlx-worker-python/tests/test_managed_artifact_receipts.py -q
# 30 passed in 0.63s
```

## Coverage and Metrics
- Final pre-commit PR-scoped performance after merging current `origin/main`: `.runtime/pre-commit-performance/20260621-075604-968f6c79/report/report.md`
  - Status: `ok`
  - Selected probes: `3`
  - Regressions: `0`
  - Changed-scope coverage: download pipeline `99.0%`, job registry probes `100.0%`.
  - Download pipeline probe: `elapsed_ms_mean` stayed neutral from `37.069ms` to `38.443ms`; `elapsed_ms_min` stayed neutral from `36.636ms` to `37.485ms`.
  - Job registry derived-model probe: `restore_elapsed_ms_mean` stayed neutral from `31.985ms` to `31.692ms`.
  - Job registry restore-sort probe: `restore_elapsed_ms_mean` stayed neutral from `44.277ms` to `44.145ms`.
- Earlier local pre-commit probe `.runtime/pre-commit-performance/20260621-071456-a8c63522/report/report.md` reported a non-reproduced download-pipeline regression. I analyzed it before proceeding: independent rerun `.runtime/perf-rerun-download-pipeline.json` showed no selected-probe regression (`elapsed_ms_mean` base `38.332ms`, head `38.413ms`), and the final pre-commit performance report above is `ok`. The review-fix commit `968f6c79` was created with `MELIX_PRE_COMMIT_ALLOW_PERF_REGRESSION=1` and a non-empty reason to document that diagnosis; the final merge commit `0b70b297` passed pre-commit with an `ok` performance report.
- Observability mode: `evidence`; this extends existing machine-readable download receipts and deterministic smoke evidence.
- Probe overhead: `N/A`; the lifecycle fields are derived inside managed/operation receipt payloads, and no sampled production telemetry or new per-snapshot filesystem probe was added.

## Known Gaps
- This PR does not implement signatures, publish-token minimization, accelerated transport selection, desktop UI, or full release signing policy from issue #1258.
- None for the implemented managed artifact partial-lifecycle slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes; `make proto` passed with no diff.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
