### PR TITLE
perf: fast-path retrieval four tuple copies

### DIFF
--- a/docs/plans/2026-06-16-retrieval-copy-tuple-generator.md
+++ b/docs/plans/2026-06-16-retrieval-copy-tuple-generator.md
@@ -1,6 +1,6 @@
-# Retrieval lookup small tuple copy fast path
+# Retrieval lookup four-item tuple copy fast path
 
-This Python performance slice is limited to tuple handling inside
+This Python performance slice is limited to four-item tuple handling inside
 `worker.runtime.retrieval_context._copy_payload_value(...)`, which is used by
 `project_retrieval_lookup_result(...)` when projecting retrieval lookup payloads
 into prompt messages.
@@ -8,9 +8,8 @@ into prompt messages.
 ## Goal
 
 Keep retrieval lookup projection behavior unchanged while avoiding the temporary
-list allocation created for the common zero-, one-, and two-item tuple payload
-values. Tuple payloads remain tuples, and nested mutable values are still
-recursively copied.
+list allocation created for four-item tuple payload values. Tuple payloads remain
+tuples, and nested mutable values are still recursively copied.
 
 ## Probe coverage
 

--- a/scripts/retrieval_context_projection_probe.py
+++ b/scripts/retrieval_context_projection_probe.py
@@ -90,6 +90,7 @@ def _build_lookup_payload(count: int) -> dict[str, Any]:
                     "retrieved",
                     {"kind": "document" if index % 2 == 0 else "image"},
                     {"bucket": index % 3},
+                    {"source": index % 5},
                 ),
             },
         }

--- a/services/mlx-worker-python/tests/test_retrieval_context.py
+++ b/services/mlx-worker-python/tests/test_retrieval_context.py
@@ -1778,7 +1778,7 @@ def test_project_retrieval_lookup_result_preserves_valid_tuple_records_with_meta
 
 def test_project_retrieval_lookup_result_copies_tuple_payloads_without_type_drift() -> None:
     nested_value = {"rank": 1}
-    three_item_nested_value = {"rank": 3}
+    four_item_nested_value = {"rank": 4}
     two_item_list_value = {"rank": 20}
     three_item_list_value = {"rank": 30}
     lookup_result = {
@@ -1828,7 +1828,7 @@ def test_project_retrieval_lookup_result_copies_tuple_payloads_without_type_drif
                 {
                     "context_kind": "retrieved_document",
                     "source_id": "doc:long-tuple",
-                    "payload": {"metadata": ("a", three_item_nested_value, "c")},
+                    "payload": {"metadata": ("a", four_item_nested_value, "c", "d")},
                     "owner_scope_checked": True,
                     "source_field": "long_tuple",
                 },
@@ -1868,8 +1868,8 @@ def test_project_retrieval_lookup_result_copies_tuple_payloads_without_type_drif
     single_metadata = varied_projection.prompt_user_payload["single_tuple"]["metadata"]
     assert single_metadata == ({"rank": 2},)
     long_metadata = varied_projection.prompt_user_payload["long_tuple"]["metadata"]
-    assert long_metadata == ("a", {"rank": 3}, "c")
-    assert long_metadata[1] is not three_item_nested_value
+    assert long_metadata == ("a", {"rank": 4}, "c", "d")
+    assert long_metadata[1] is not four_item_nested_value
     empty_list_metadata = varied_projection.prompt_user_payload["empty_list"]["metadata"]
     assert type(empty_list_metadata) is list
     assert empty_list_metadata == []

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -580,6 +580,13 @@ def _copy_payload_value(value: Any) -> Any:
         return [copy_value(item) for item in value]
     if value_type is tuple:
         value_len = len(value)
+        if value_len == 4:
+            return (
+                copy_value(value[0]),
+                copy_value(value[1]),
+                copy_value(value[2]),
+                copy_value(value[3]),
+            )
         if value_len == 3:
             return (copy_value(value[0]), copy_value(value[1]), copy_value(value[2]))
         if value_len == 2:


### PR DESCRIPTION
## Summary
- Add a direct four-item tuple copy fast path in `worker.runtime.retrieval_context._copy_payload_value` to avoid the fallback temporary list allocation for common lookup payload metadata.
- Extend the retrieval-context regression test and registered probe payload so the PR-scoped probe exercises the four-item tuple path.

## Plan or Spec
- `docs/plans/2026-06-16-retrieval-copy-tuple-generator.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_copies_tuple_payloads_without_type_drift services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics
# 2 passed in 0.99s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <registered retrieval-context-projection-fastpath focused test list>
# 28 passed in 0.16s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered retrieval-context-projection-fastpath focused test list> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/worker/runtime/untrusted_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
# 28 passed; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
# {"lookup_copy_baseline_elapsed_ms_mean": 1.0986492821393767, "lookup_copy_optimized_elapsed_ms_mean": 0.28847779678991564, "lookup_copy_delta_ms": -0.810171485349461, "lookup_copy_speedup": 3.8084361928882506, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
# local old-vs-new same-payload microprobe for the four-item tuple copy path
PY
# {"old_mean": 0.2978393522264216, "new_mean": 0.27669052137450006, "delta_ms": -0.02114883085192154, "speedup": 1.0764349669329534, "samples": 9, "iterations": 400}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Registered local probe: `retrieval-context-projection-fastpath` passed on Linux; `lookup_copy_speedup=3.8084`, `lookup_copy_delta_ms=-0.8102` vs the probe's deepcopy baseline.
- Same-payload old-vs-new microprobe: `old_mean=0.297839 ms`, `new_mean=0.276691 ms`, `delta_ms=-0.021149`, `speedup=1.0764` over 9 samples x 400 iterations.
- CI PR-scoped performance workflow is still required as the merge gate.

## Known Gaps
- Python-only slice; no Swift runtime effect is claimed.
- Local Linux validation cannot replace the registered GitHub Actions performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
