### PR TITLE
Add priority preemption scheduling

### DIFF
--- a/docs/plans/2026-06-21-issue-1386-priority-scheduler.md
+++ b/docs/plans/2026-06-21-issue-1386-priority-scheduler.md
@@ -1,0 +1,80 @@
+# Issue 1386 Priority Scheduler and Preemption Plan
+
+## Goal
+
+Add the first operator-facing priority scheduling and cooperative preemption slice for the shared single-slot inference runtime.
+
+## Current State
+
+The control plane already records queued, admitted, phase, and terminal request progress through `SchedulerReadModel`. `RequestCoordinator` uses `AdmissionGate` to serialize active text execution and supports queued or active cancellation through `AbortRegistry` and worker `abort`. The missing issue 1386 behavior is scheduling policy: queued work is FIFO, priority classes do not influence admission order, and high-priority interactive work does not preempt lower-priority active work.
+
+## End-State Architecture
+
+The best Melix architecture is a scheduler-owned admission boundary that sits above worker dispatch. It should own priority ordering, cooperative preemption, cancellation receipts, and queue metrics while leaving worker-specific generation and streaming in the existing coordinator. Workers continue to receive scheduling hints, but the control plane remains the source of truth for which request owns the scarce inference slot.
+
+This PR implements a small vertical slice in the current `RequestCoordinator` path:
+
+- keep `AdmissionGate` as the concrete slot/batch primitive;
+- add priority-aware queued ordering before admission;
+- add a preemption check before a high-priority request waits behind active lower-priority work;
+- cancel the lower-priority active request through the existing cooperative abort path;
+- record typed cancellation/preemption receipts and metrics in the existing route-selection JSONL evidence stream.
+
+## Scope
+
+In scope:
+
+- priority queue ordering for text chat completions in `RequestCoordinator`;
+- cooperative preemption when an interactive or otherwise higher-priority request arrives behind lower-priority active work;
+- cancellation/preemption receipt payloads with request id, preempting request id, cancellation reason, priority class, wait/run timing, lifecycle, cancel source, and partial-output flag;
+- metrics for scheduler preemption count and cancellation receipt emission;
+- deterministic Swift tests covering priority ordering, preemption, and receipt content.
+
+Out of scope:
+
+- distributed scheduling;
+- hard process kill;
+- UI changes;
+- new public HTTP endpoints;
+- worker protobuf schema changes beyond existing scheduling hints;
+- durable queue persistence across daemon restart.
+
+## Performance Probes
+
+- `scheduler.queue_delay_ms`: existing queue-delay metric must remain populated for admitted work.
+- `scheduler.preemption_count`: increments when active work is preempted.
+- `scheduler.cancellation_receipt_emitted`: increments when a cancellation/preemption receipt is written.
+- `http.abort_ms` and phase-specific abort metrics: existing cancellation latency metrics must remain populated.
+
+## Implementation Slices
+
+### Slice 1: Priority-Aware Admission
+
+- Extend `AdmissionGate` queue entries with `priorityScore`.
+- Sort queued entries by descending priority and FIFO sequence within equal priority.
+- Keep compatible cohort batching constrained to the selected front entry.
+- Preserve existing FIFO behavior when priorities match.
+
+### Slice 2: Cooperative Preemption Receipt
+
+- Track active request priority, lane, start time, and stream output evidence in `RequestCoordinator`.
+- Before a newly queued request waits, compare it with active requests.
+- When the incoming request has higher priority than the lowest active request, call worker `abort`, record terminal state as `requestAborted`, release admission, and write a cancellation receipt.
+- Keep disconnected detached-chat semantics unchanged: ordinary disconnect still uses the resume grace window; explicit scheduler preemption is an owned cancellation path.
+
+### Slice 3: Verification and Evidence
+
+- Add red-green tests in `RequestCoordinatorTests` for:
+  - higher-priority queued work admitted before older lower-priority work;
+  - interactive work preempting lower-priority active work and completing first;
+  - interactive work preempting lower-priority work at the pre-worker-send checkpoint;
+  - cancellation receipt fields and scheduler metrics.
+- Run focused Swift tests, changed-line coverage for touched Swift files, `git diff --check`, and PR evidence validation.
+
+## Acceptance
+
+- A queued high-priority request is admitted before older lower-priority queued work once the slot frees.
+- A high-priority request preempts lower-priority active work through cooperative worker abort and then completes first.
+- The preempted request receives a cancelled completion rather than hanging.
+- Receipts preserve the cancellation reason and partial-output flag.
+- Metrics expose preemption and cancellation receipt emission.

--- a/services/control-plane-swift/Sources/Requests/AdmissionGate.swift
+++ b/services/control-plane-swift/Sources/Requests/AdmissionGate.swift
@@ -32,6 +32,8 @@ public actor AdmissionGate {
         let requestID: String
         let cohortID: String
         let maxBatchSize: UInt32
+        let priorityScore: Double
+        let sequence: UInt64
     }
 
     private struct FrontBatch: Sendable {
@@ -47,6 +49,7 @@ public actor AdmissionGate {
     private var waiters: [String: CheckedContinuation<AdmissionGrant, Never>]
     private var pendingFormationID: UInt64?
     private var nextFormationID: UInt64
+    private var nextQueueSequence: UInt64
 
     public init(batchFormationWindowNanos: UInt64 = AdmissionGate.defaultBatchFormationWindowNanos) {
         self.batchFormationWindowNanos = batchFormationWindowNanos
@@ -55,25 +58,28 @@ public actor AdmissionGate {
         self.queuedEntries = []
         self.waiters = [:]
         self.nextFormationID = 1
+        self.nextQueueSequence = 1
     }
 
     public func nextQueuePosition(
         cohortID: String = "",
-        maxBatchSize: UInt32 = 1
+        maxBatchSize: UInt32 = 1,
+        priorityScore: Double = 0
     ) -> UInt32 {
         if activeRequestIDs.isEmpty {
-            return UInt32(queuedEntries.count + 1)
+            return queuedPosition(forPriorityScore: priorityScore)
         }
         if canJoinActiveBatch(cohortID: cohortID, maxBatchSize: maxBatchSize) {
             return 1
         }
-        return UInt32(queuedEntries.count + 1)
+        return queuedPosition(forPriorityScore: priorityScore)
     }
 
     public func acquire(
         requestID: String,
         cohortID: String = "",
-        maxBatchSize: UInt32 = 1
+        maxBatchSize: UInt32 = 1,
+        priorityScore: Double = 0
     ) async -> AdmissionGrant {
         let normalizedCapacity = normalizedBatchCapacity(maxBatchSize)
         if activeRequestIDs.isEmpty,
@@ -81,7 +87,8 @@ public actor AdmissionGate {
             return await enqueueQueuedRequest(
                 requestID: requestID,
                 cohortID: cohortID,
-                maxBatchSize: normalizedCapacity
+                maxBatchSize: normalizedCapacity,
+                priorityScore: priorityScore
             )
         }
 
@@ -93,7 +100,8 @@ public actor AdmissionGate {
                 return await enqueueQueuedRequest(
                     requestID: requestID,
                     cohortID: cohortID,
-                    maxBatchSize: normalizedCapacity
+                    maxBatchSize: normalizedCapacity,
+                    priorityScore: priorityScore
                 )
             }
             activeRequestIDs = [requestID]
@@ -125,9 +133,13 @@ public actor AdmissionGate {
                 QueueEntry(
                     requestID: requestID,
                     cohortID: cohortID,
-                    maxBatchSize: normalizedBatchCapacity(maxBatchSize)
+                    maxBatchSize: normalizedBatchCapacity(maxBatchSize),
+                    priorityScore: priorityScore,
+                    sequence: nextQueueSequence
                 )
             )
+            nextQueueSequence &+= 1
+            sortQueuedEntriesByPriority()
         }
 
         return await withCheckedContinuation { continuation in
@@ -209,7 +221,8 @@ public actor AdmissionGate {
     private func enqueueQueuedRequest(
         requestID: String,
         cohortID: String,
-        maxBatchSize: UInt32
+        maxBatchSize: UInt32,
+        priorityScore: Double
     ) async -> AdmissionGrant {
         await withCheckedContinuation { continuation in
             if !queuedEntries.contains(where: { $0.requestID == requestID }) {
@@ -217,9 +230,13 @@ public actor AdmissionGate {
                     QueueEntry(
                         requestID: requestID,
                         cohortID: cohortID,
-                        maxBatchSize: maxBatchSize
+                        maxBatchSize: maxBatchSize,
+                        priorityScore: priorityScore,
+                        sequence: nextQueueSequence
                     )
                 )
+                nextQueueSequence &+= 1
+                sortQueuedEntriesByPriority()
             }
             waiters[requestID] = continuation
 
@@ -305,6 +322,22 @@ public actor AdmissionGate {
 
     private func normalizedBatchCapacity(_ capacity: UInt32) -> UInt32 {
         max(capacity, 1)
+    }
+
+    private func queuedPosition(forPriorityScore priorityScore: Double) -> UInt32 {
+        let precedingCount = queuedEntries.filter { entry in
+            entry.priorityScore >= priorityScore
+        }.count
+        return UInt32(precedingCount + 1)
+    }
+
+    private func sortQueuedEntriesByPriority() {
+        queuedEntries.sort { lhs, rhs in
+            if lhs.priorityScore != rhs.priorityScore {
+                return lhs.priorityScore > rhs.priorityScore
+            }
+            return lhs.sequence < rhs.sequence
+        }
     }
 
     private func canJoinActiveBatch(

--- a/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
+++ b/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
@@ -450,6 +450,16 @@ private struct SchedulingPlan: Sendable {
     let accelerationRefusal: AccelerationReceiptValidation?
 }
 
+private struct ActiveSchedulingRecord: Sendable {
+    let requestID: String
+    let priorityScore: Double
+    let priorityClass: String
+    let lane: String
+    let streamLifecycle: String
+    let admittedAt: Date
+    var partialOutputSaved: Bool
+}
+
 private struct ModelAccelerationResolution: Sendable {
     let request: TranslatedChatRequest
     let accelerationRefusal: AccelerationReceiptValidation?
@@ -632,6 +642,7 @@ public actor RequestCoordinator {
     private var disconnectResumeAttemptCount: Double
     private var disconnectResumeSuccessCount: Double
     private var requestPlans: [String: SchedulingPlan]
+    private var activeSchedulingRecords: [String: ActiveSchedulingRecord]
     private var coldTTFTBaselinesByBranch: [String: Double]
     private var schedulingDecisionCount: Double
     private var cacheRouteEligibleCount: Double
@@ -679,6 +690,7 @@ public actor RequestCoordinator {
         self.disconnectResumeAttemptCount = 0
         self.disconnectResumeSuccessCount = 0
         self.requestPlans = [:]
+        self.activeSchedulingRecords = [:]
         self.coldTTFTBaselinesByBranch = [:]
         self.schedulingDecisionCount = 0
         self.cacheRouteEligibleCount = 0
@@ -801,13 +813,18 @@ public actor RequestCoordinator {
         }
         let initialQueuePosition = await admissionGate.nextQueuePosition(
             cohortID: plan.batchCohortID,
-            maxBatchSize: plan.batchMaxSize
+            maxBatchSize: plan.batchMaxSize,
+            priorityScore: Double(priority)
         )
         await schedulerReadModel.recordQueued(
             requestID: request.requestID,
             laneHint: lane,
             priority: priority,
             queuePosition: initialQueuePosition
+        )
+        await preemptLowerPriorityActiveRequestIfNeeded(
+            preemptingRequestID: request.requestID,
+            preemptingPriorityScore: Double(priority)
         )
         let routeStartedAt = now()
         let workerClient = plan.workerClient
@@ -841,7 +858,8 @@ public actor RequestCoordinator {
         let admission = await admissionGate.acquire(
             requestID: request.requestID,
             cohortID: plan.batchCohortID,
-            maxBatchSize: plan.batchMaxSize
+            maxBatchSize: plan.batchMaxSize,
+            priorityScore: Double(priority)
         )
         switch admission.outcome {
         case .cancelled:
@@ -868,18 +886,34 @@ public actor RequestCoordinator {
             mergedIntoBatch: admission.mergedIntoBatch,
             affinityClass: plan.cacheRouteClass.rawValue
         )
-        _ = await modelCatalog?.markModelUsed(id: request.modelID)
-        if !(await abortRegistry.contains(request.requestID)) {
-            await finishRequestTracking(requestID: request.requestID, phase: .requestAborted)
-            return await makeCancelledExecution(requestID: request.requestID, modelID: request.modelID)
-        }
-
         var workerRequest = request.workerRequest
         annotateAdmissionBatchMetadata(
             on: &workerRequest,
             admission: admission,
             plan: plan
         )
+        let requestID = request.requestID
+        let modelID = request.modelID
+        activeWorkerClients[requestID] = workerClient
+        activeSchedulingRecords[requestID] = ActiveSchedulingRecord(
+            requestID: requestID,
+            priorityScore: Double(priority),
+            priorityClass: priorityClass(
+                priorityScore: Double(priority),
+                latencyClass: workerRequest.execution.id.latencyClass
+            ),
+            lane: plan.decodeLane,
+            streamLifecycle: streamLifecycle(from: workerRequest),
+            admittedAt: dispatchStartedAt,
+            partialOutputSaved: false
+        )
+        self.dispatchStartedAt[requestID] = dispatchStartedAt
+
+        _ = await modelCatalog?.markModelUsed(id: request.modelID)
+        if !(await abortRegistry.contains(request.requestID)) {
+            await finishRequestTracking(requestID: request.requestID, phase: .requestAborted)
+            return await makeCancelledExecution(requestID: request.requestID, modelID: request.modelID)
+        }
 
         do {
             let upstream: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>
@@ -896,15 +930,10 @@ public actor RequestCoordinator {
                 upstream = try await workerClient.generate(request: workerRequest)
             }
             if !(await abortRegistry.contains(request.requestID)) {
-                _ = try? await workerClient.abort(requestID: request.requestID)
                 await finishRequestTracking(requestID: request.requestID, phase: .requestAborted)
                 return await makeCancelledExecution(requestID: request.requestID, modelID: request.modelID)
             }
             await metricsStore.increment("requests.inflight")
-            let requestID = request.requestID
-            let modelID = request.modelID
-            activeWorkerClients[requestID] = workerClient
-            self.dispatchStartedAt[requestID] = dispatchStartedAt
             let hub = ResumableExecutionHub(
                 requestID: requestID,
                 modelID: modelID,
@@ -1005,6 +1034,9 @@ public actor RequestCoordinator {
                             }
                             if shouldYieldBeforeObservability {
                                 await hub.yield(outputEvent)
+                            }
+                            if self.isSemanticStreamEvent(outputEvent) {
+                                self.markPartialOutputSaved(requestID: requestID)
                             }
 
                             await self.recordPhaseObservability(
@@ -1164,6 +1196,14 @@ public actor RequestCoordinator {
         }
     }
 
+    private func markPartialOutputSaved(requestID: String) {
+        guard var record = activeSchedulingRecords[requestID] else {
+            return
+        }
+        record.partialOutputSaved = true
+        activeSchedulingRecords[requestID] = record
+    }
+
     private func publishesDecodingPhase(_ event: Melix_Worker_V1_ExecuteEvent) -> Bool {
         switch event.payload {
         case .decodeStarted, .tokenDelta, .reasoningDelta, .toolCallDelta, .annotationDelta, .toolResultDelta, .usageDelta:
@@ -1222,6 +1262,50 @@ public actor RequestCoordinator {
         return true
     }
 
+    private func preemptLowerPriorityActiveRequestIfNeeded(
+        preemptingRequestID: String,
+        preemptingPriorityScore: Double
+    ) async {
+        guard let victim = activeSchedulingRecords.values.min(by: { lhs, rhs in
+            if lhs.priorityScore != rhs.priorityScore {
+                return lhs.priorityScore < rhs.priorityScore
+            }
+            return lhs.admittedAt < rhs.admittedAt
+        }) else {
+            return
+        }
+        guard victim.priorityScore < preemptingPriorityScore else {
+            return
+        }
+        let phase = await schedulerReadModel.progressSnapshot(for: victim.requestID)?.phase ?? .requestAdmitted
+        let startedAt = now()
+        guard await abortRegistry.abort(victim.requestID) else {
+            return
+        }
+        await metricsStore.increment("scheduler.preemption_count")
+        await recordAbortMetrics(phase: phase, startedAt: startedAt)
+        await recordCancellationReceipt(
+            record: victim,
+            preemptingRequestID: preemptingRequestID,
+            cancellationReason: "preempted",
+            cancelSignalSource: "scheduler.preemption"
+        )
+
+        let hasExecutionHub = executionHubs[victim.requestID] != nil
+        if let hub = executionHubs[victim.requestID] {
+            await hub.emitLifecycle(.cancelled)
+        }
+        if let workerClient = activeWorkerClients[victim.requestID] {
+            _ = try? await workerClient.abort(requestID: victim.requestID)
+            if !hasExecutionHub {
+                await finishRequestTracking(requestID: victim.requestID, phase: .requestAborted)
+            }
+            return
+        }
+
+        await finishRequestTracking(requestID: victim.requestID, phase: .requestAborted)
+    }
+
     private func finishRequestTracking(
         requestID: String,
         phase: Melix_Controlplane_V1_RequestPhase? = nil
@@ -1235,6 +1319,7 @@ public actor RequestCoordinator {
         activeWorkerClients.removeValue(forKey: requestID)
         executionHubs.removeValue(forKey: requestID)
         requestPlans.removeValue(forKey: requestID)
+        activeSchedulingRecords.removeValue(forKey: requestID)
         if let phase {
             await schedulerReadModel.recordTerminalState(requestID: requestID, phase: phase)
         }
@@ -2592,6 +2677,62 @@ public actor RequestCoordinator {
             return
         }
         routeSelectionReceiptWriter.append(data)
+    }
+
+    private func recordCancellationReceipt(
+        record: ActiveSchedulingRecord,
+        preemptingRequestID: String,
+        cancellationReason: String,
+        cancelSignalSource: String
+    ) async {
+        let runTimeMs = max(0, now().timeIntervalSince(record.admittedAt) * 1000)
+        await metricsStore.increment("scheduler.cancellation_receipt_emitted")
+        guard let routeSelectionReceiptWriter else {
+            return
+        }
+        let payload: [String: Any] = [
+            "receipt_type": "scheduler.cancellation",
+            "request_id": record.requestID,
+            "preempting_request_id": preemptingRequestID,
+            "cancellation_reason": cancellationReason,
+            "cancel_signal_source": cancelSignalSource,
+            "stream_lifecycle": record.streamLifecycle,
+            "partial_output_saved": record.partialOutputSaved,
+            "priority_class": record.priorityClass,
+            "priority_score": record.priorityScore,
+            "lane": record.lane,
+            "run_time_ms": runTimeMs,
+            "recorded_at_unix_ms": Int64(now().timeIntervalSince1970 * 1000),
+        ]
+        guard JSONSerialization.isValidJSONObject(payload),
+              let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]) else {
+            return
+        }
+        routeSelectionReceiptWriter.append(data)
+    }
+
+    private func priorityClass(priorityScore: Double, latencyClass: String) -> String {
+        let normalizedLatency = latencyClass.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalizedLatency == "interactive" || priorityScore >= 100 {
+            return "interactive"
+        }
+        if priorityScore >= 80 {
+            return "foreground_batch"
+        }
+        if priorityScore >= 20 {
+            return "background_batch"
+        }
+        return "maintenance"
+    }
+
+    private func streamLifecycle(from request: Melix_Worker_V1_GenerateRequest) -> String {
+        let explicit = request.execution.ext["melix.stream_lifecycle"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        if explicit == "ephemeral" || explicit == "detached" {
+            return explicit
+        }
+        return "detached"
     }
 
     private func recordMultimodalBatchingMetrics(for plan: SchedulingPlan) async {

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -409,6 +409,282 @@ struct RequestCoordinatorTests {
         #expect(await workerClient.generatedRequestIDs == ["req-1", "req-2", "req-3"])
     }
 
+    @Test("priority queue admits interactive work before older background work")
+    func priorityQueueAdmitsInteractiveWorkBeforeOlderBackgroundWork() async throws {
+        let workerClient = ControlledCompletionWorkerClient()
+        let schedulerReadModel = SchedulerReadModel()
+        let coordinator = RequestCoordinator(
+            workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+            abortRegistry: AbortRegistry(),
+            schedulerReadModel: schedulerReadModel
+        )
+
+        let activeExecution = try await coordinator.startChatCompletion(
+            makeTranslatedChatRequest(requestID: "req-active", priority: 120, latencyClass: "interactive")
+        )
+        let activeConsumer = Task {
+            var events: [Melix_Worker_V1_ExecuteEvent] = []
+            for try await event in activeExecution.stream {
+                events.append(event)
+            }
+            return events
+        }
+
+        let backgroundTask = Task {
+            try await coordinator.startChatCompletion(
+                makeTranslatedChatRequest(requestID: "req-background", priority: 20, latencyClass: "background")
+            )
+        }
+        let backgroundQueued = await waitForProgress(
+            schedulerReadModel: schedulerReadModel,
+            requestID: "req-background",
+            phase: .requestQueued
+        )
+        #expect(backgroundQueued?.phase == .requestQueued)
+
+        let interactiveTask = Task {
+            try await coordinator.startChatCompletion(
+                makeTranslatedChatRequest(requestID: "req-interactive", priority: 100, latencyClass: "interactive")
+            )
+        }
+        let interactiveQueued = await waitForProgress(
+            schedulerReadModel: schedulerReadModel,
+            requestID: "req-interactive",
+            phase: .requestQueued
+        )
+        #expect(interactiveQueued?.phase == .requestQueued)
+
+        await workerClient.finish(requestID: "req-active", text: "active done")
+        _ = try await activeConsumer.value
+
+        let generatedAfterFirstRelease = try #require(await waitForGeneratedRequestIDs(
+            workerClient,
+            count: 2
+        ))
+        try #require(generatedAfterFirstRelease == ["req-active", "req-interactive"])
+
+        let interactiveExecution = try await interactiveTask.value
+        let interactiveConsumer = Task {
+            var events: [Melix_Worker_V1_ExecuteEvent] = []
+            for try await event in interactiveExecution.stream {
+                events.append(event)
+            }
+            return events
+        }
+        await workerClient.finish(requestID: "req-interactive", text: "interactive done")
+        _ = try await interactiveConsumer.value
+
+        let backgroundExecution = try await backgroundTask.value
+        let backgroundConsumer = Task {
+            var events: [Melix_Worker_V1_ExecuteEvent] = []
+            for try await event in backgroundExecution.stream {
+                events.append(event)
+            }
+            return events
+        }
+        await workerClient.finish(requestID: "req-background", text: "background done")
+        _ = try await backgroundConsumer.value
+
+        #expect(await workerClient.generatedRequestIDs == ["req-active", "req-interactive", "req-background"])
+    }
+
+    @Test("interactive work preempts active lower priority work and writes a cancellation receipt")
+    func interactiveWorkPreemptsActiveLowerPriorityWorkAndWritesCancellationReceipt() async throws {
+        let workerClient = ControlledCompletionWorkerClient()
+        let schedulerReadModel = SchedulerReadModel()
+        let metricsStore = MetricsStore()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-preemption-receipt-\(UUID().uuidString)", isDirectory: true)
+        let receiptPath = directory.appendingPathComponent("scheduler-receipts.jsonl").path
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let coordinator = RequestCoordinator(
+            workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+            abortRegistry: AbortRegistry(),
+            schedulerReadModel: schedulerReadModel,
+            metricsStore: metricsStore,
+            routeSelectionReceiptPath: receiptPath
+        )
+
+        let backgroundExecution = try await coordinator.startChatCompletion(
+            makeTranslatedChatRequest(requestID: "req-background-active", priority: 20, latencyClass: "background")
+        )
+        let backgroundConsumer = Task {
+            var events: [Melix_Worker_V1_ExecuteEvent] = []
+            for try await event in backgroundExecution.stream {
+                events.append(event)
+            }
+            return events
+        }
+        await workerClient.emitToken(requestID: "req-background-active", text: "partial")
+
+        let interactiveTask = Task {
+            try await coordinator.startChatCompletion(
+                makeTranslatedChatRequest(requestID: "req-interactive-preempt", priority: 100, latencyClass: "interactive")
+            )
+        }
+        let generatedAfterPreemptionAttempt = await waitForGeneratedRequestIDs(workerClient, count: 2)
+        try #require(generatedAfterPreemptionAttempt == ["req-background-active", "req-interactive-preempt"])
+
+        let interactiveExecution = try await interactiveTask.value
+        let interactiveConsumer = Task {
+            var events: [Melix_Worker_V1_ExecuteEvent] = []
+            for try await event in interactiveExecution.stream {
+                events.append(event)
+            }
+            return events
+        }
+        await workerClient.finish(requestID: "req-interactive-preempt", text: "interactive done")
+
+        let interactiveEvents = try await interactiveConsumer.value
+        let backgroundEvents = try await backgroundConsumer.value
+        let metrics = await metricsStore.snapshot()
+        let receipts = try #require(await waitForJSONLLines(atPath: receiptPath, expectedCount: 3))
+        let cancellationReceipt = try #require(receipts.first { $0["receipt_type"] as? String == "scheduler.cancellation" })
+
+        #expect(await workerClient.generatedRequestIDs == ["req-background-active", "req-interactive-preempt"])
+        #expect(await workerClient.abortedRequestIDs == ["req-background-active"])
+        #expect(interactiveEvents.last?.completed.finishReason == "stop")
+        #expect(backgroundEvents.last?.completed.finishReason == "cancelled")
+        #expect(cancellationReceipt["request_id"] as? String == "req-background-active")
+        #expect(cancellationReceipt["preempting_request_id"] as? String == "req-interactive-preempt")
+        #expect(cancellationReceipt["cancellation_reason"] as? String == "preempted")
+        #expect(cancellationReceipt["stream_lifecycle"] as? String == "detached")
+        #expect(cancellationReceipt["cancel_signal_source"] as? String == "scheduler.preemption")
+        #expect(cancellationReceipt["partial_output_saved"] as? Bool == true)
+        #expect(cancellationReceipt["priority_class"] as? String == "background_batch")
+        #expect((cancellationReceipt["run_time_ms"] as? Double ?? -1) >= 0)
+        #expect(metrics.values["scheduler.preemption_count", default: 0] == 1)
+        #expect(metrics.values["scheduler.cancellation_receipt_emitted", default: 0] == 1)
+    }
+
+    @Test("foreground preemption receipts preserve explicit lifecycle and maintenance priority")
+    func foregroundPreemptionReceiptsPreserveExplicitLifecycleAndMaintenancePriority() async throws {
+        let workerClient = ControlledCompletionWorkerClient()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-foreground-preemption-receipt-\(UUID().uuidString)", isDirectory: true)
+        let receiptPath = directory.appendingPathComponent("scheduler-receipts.jsonl").path
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let coordinator = RequestCoordinator(
+            workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+            abortRegistry: AbortRegistry(),
+            schedulerReadModel: SchedulerReadModel(),
+            metricsStore: MetricsStore(),
+            routeSelectionReceiptPath: receiptPath
+        )
+
+        let maintenanceExecution = try await coordinator.startChatCompletion(
+            makeTranslatedChatRequest(
+                requestID: "req-maintenance-active",
+                priority: 5,
+                latencyClass: "maintenance",
+                executionExt: ["melix.stream_lifecycle": "ephemeral"]
+            )
+        )
+        let maintenanceConsumer = Task {
+            var events: [Melix_Worker_V1_ExecuteEvent] = []
+            for try await event in maintenanceExecution.stream {
+                events.append(event)
+            }
+            return events
+        }
+
+        let foregroundTask = Task {
+            try await coordinator.startChatCompletion(
+                makeTranslatedChatRequest(
+                    requestID: "req-foreground-preempt",
+                    priority: 80,
+                    latencyClass: "batch"
+                )
+            )
+        }
+
+        let foregroundExecution = try await foregroundTask.value
+        let foregroundConsumer = Task {
+            var events: [Melix_Worker_V1_ExecuteEvent] = []
+            for try await event in foregroundExecution.stream {
+                events.append(event)
+            }
+            return events
+        }
+        await workerClient.finish(requestID: "req-foreground-preempt", text: "foreground done")
+
+        let foregroundEvents = try await foregroundConsumer.value
+        let maintenanceEvents = try await maintenanceConsumer.value
+        let receipts = try #require(await waitForJSONLLines(atPath: receiptPath, expectedCount: 3))
+        let cancellationReceipt = try #require(receipts.first { $0["receipt_type"] as? String == "scheduler.cancellation" })
+
+        #expect(await workerClient.generatedRequestIDs == ["req-maintenance-active", "req-foreground-preempt"])
+        #expect(await workerClient.abortedRequestIDs == ["req-maintenance-active"])
+        #expect(foregroundEvents.last?.completed.finishReason == "stop")
+        #expect(maintenanceEvents.last?.completed.finishReason == "cancelled")
+        #expect(cancellationReceipt["request_id"] as? String == "req-maintenance-active")
+        #expect(cancellationReceipt["preempting_request_id"] as? String == "req-foreground-preempt")
+        #expect(cancellationReceipt["priority_class"] as? String == "maintenance")
+        #expect(cancellationReceipt["stream_lifecycle"] as? String == "ephemeral")
+    }
+
+    @Test("interactive work can preempt lower priority work before worker generate returns")
+    func interactiveWorkCanPreemptLowerPriorityWorkBeforeWorkerGenerateReturns() async throws {
+        let workerClient = SlowFirstGenerateWorkerClient(firstBlockedRequestID: "req-background-before-send")
+        let schedulerReadModel = SchedulerReadModel()
+        let metricsStore = MetricsStore()
+        let coordinator = RequestCoordinator(
+            workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+            abortRegistry: AbortRegistry(),
+            schedulerReadModel: schedulerReadModel,
+            metricsStore: metricsStore
+        )
+
+        let backgroundTask = Task {
+            try await coordinator.startChatCompletion(
+                makeTranslatedChatRequest(
+                    requestID: "req-background-before-send",
+                    priority: 20,
+                    latencyClass: "background"
+                )
+            )
+        }
+        await workerClient.waitUntilGenerateStarted()
+
+        let interactiveTask = Task {
+            try await coordinator.startChatCompletion(
+                makeTranslatedChatRequest(
+                    requestID: "req-interactive-before-send",
+                    priority: 100,
+                    latencyClass: "interactive"
+                )
+            )
+        }
+
+        let generatedIDs = try #require(await waitForGeneratedRequestIDs(workerClient, count: 2))
+        #expect(generatedIDs == ["req-background-before-send", "req-interactive-before-send"])
+
+        let interactiveExecution = try await interactiveTask.value
+        let interactiveConsumer = Task {
+            var events: [Melix_Worker_V1_ExecuteEvent] = []
+            for try await event in interactiveExecution.stream {
+                events.append(event)
+            }
+            return events
+        }
+        await workerClient.finish(requestID: "req-interactive-before-send", text: "interactive done")
+        let interactiveEvents = try await interactiveConsumer.value
+
+        let backgroundExecution = try await backgroundTask.value
+        var backgroundIterator = backgroundExecution.stream.makeAsyncIterator()
+        let backgroundTerminal = try #require(await backgroundIterator.next())
+        let metrics = await metricsStore.snapshot()
+
+        #expect(await workerClient.abortedRequestIDs == ["req-background-before-send"])
+        #expect(interactiveEvents.last?.completed.finishReason == "stop")
+        #expect(backgroundTerminal.completed.finishReason == "cancelled")
+        #expect(metrics.values["scheduler.preemption_count", default: 0] == 1)
+    }
+
     @Test("duplicate request identifiers are rejected while the original request is tracked")
     func duplicateRequestIdentifiersAreRejectedWhileTracked() async throws {
         let workerClient = BlockingWorkerClient()
@@ -4719,6 +4995,41 @@ private func waitForJSONLLines(
     return parseJSONLLines(contents.split(separator: "\n"))
 }
 
+private func waitForGeneratedRequestIDs(
+    _ workerClient: ControlledCompletionWorkerClient,
+    count: Int,
+    attempts: Int = 50
+) async -> [String]? {
+    await waitForGeneratedRequestIDs(count: count, attempts: attempts) {
+        await workerClient.generatedRequestIDs
+    }
+}
+
+private func waitForGeneratedRequestIDs(
+    _ workerClient: SlowFirstGenerateWorkerClient,
+    count: Int,
+    attempts: Int = 50
+) async -> [String]? {
+    await waitForGeneratedRequestIDs(count: count, attempts: attempts) {
+        await workerClient.generatedRequestIDs
+    }
+}
+
+private func waitForGeneratedRequestIDs(
+    count: Int,
+    attempts: Int,
+    snapshot: () async -> [String]
+) async -> [String]? {
+    for _ in 0..<attempts {
+        let ids = await snapshot()
+        if ids.count >= count {
+            return ids
+        }
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    return await snapshot()
+}
+
 private func parseJSONLLines(_ lines: [Substring]) -> [[String: Any]]? {
     var payloads: [[String: Any]] = []
     for line in lines {
@@ -4863,6 +5174,160 @@ private actor SlowDispatchWorkerClient: WorkerRoutingClient {
     func abort(requestID: String) async throws -> Bool {
         abortedRequestIDs.append(requestID)
         continuations.removeValue(forKey: requestID)?.finish()
+        return true
+    }
+
+    func loadModel(
+        request: Melix_Worker_V1_LoadModelRequest
+    ) async throws -> Melix_Worker_V1_LoadModelResponse {
+        var response = Melix_Worker_V1_LoadModelResponse()
+        response.ok = true
+        response.modelHandle = "melix-dev-text::swift"
+        return response
+    }
+}
+
+private actor ControlledCompletionWorkerClient: WorkerRoutingClient {
+    private(set) var generatedRequestIDs: [String] = []
+    private(set) var abortedRequestIDs: [String] = []
+    private var continuations: [String: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>.Continuation] = [:]
+
+    func canDispatchRequests() async -> Bool {
+        true
+    }
+
+    func generate(
+        request: Melix_Worker_V1_GenerateRequest
+    ) async throws -> AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error> {
+        generatedRequestIDs.append(request.execution.id.requestID)
+        let requestID = request.execution.id.requestID
+        return AsyncThrowingStream { continuation in
+            continuations[requestID] = continuation
+        }
+    }
+
+    func emitToken(requestID: String, text: String) {
+        var event = Melix_Worker_V1_ExecuteEvent()
+        event.requestID = requestID
+        event.executionKind = "generate"
+        event.phase = .executionDecoding
+        event.lane = "text.decode.interactive"
+        var delta = Melix_Worker_V1_TokenDelta()
+        delta.text = text
+        event.tokenDelta = delta
+        continuations[requestID]?.yield(event)
+    }
+
+    func finish(requestID: String, text: String) {
+        yieldCompleted(requestID: requestID, text: text, finishReason: "stop", phase: .executionCompleted)
+    }
+
+    func abort(requestID: String) async throws -> Bool {
+        abortedRequestIDs.append(requestID)
+        yieldCompleted(requestID: requestID, text: "", finishReason: "cancelled", phase: .executionAborted)
+        return true
+    }
+
+    private func yieldCompleted(
+        requestID: String,
+        text: String,
+        finishReason: String,
+        phase: Melix_Worker_V1_ExecutionPhase
+    ) {
+        guard let continuation = continuations.removeValue(forKey: requestID) else {
+            return
+        }
+        var event = Melix_Worker_V1_ExecuteEvent()
+        event.requestID = requestID
+        event.executionKind = "generate"
+        event.phase = phase
+        event.lane = "text.decode.interactive"
+        var completed = Melix_Worker_V1_Completed()
+        completed.assistantText = text
+        completed.finishReason = finishReason
+        event.completed = completed
+        continuation.yield(event)
+        continuation.finish()
+    }
+
+    func loadModel(
+        request: Melix_Worker_V1_LoadModelRequest
+    ) async throws -> Melix_Worker_V1_LoadModelResponse {
+        var response = Melix_Worker_V1_LoadModelResponse()
+        response.ok = true
+        response.modelHandle = "melix-dev-text::swift"
+        return response
+    }
+}
+
+private actor SlowFirstGenerateWorkerClient: WorkerRoutingClient {
+    private(set) var generatedRequestIDs: [String] = []
+    private(set) var abortedRequestIDs: [String] = []
+    private let firstBlockedRequestID: String
+    private var continuations: [String: AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error>.Continuation] = [:]
+    private var generateStartedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var firstGenerateGate: CheckedContinuation<Void, Never>?
+    private var firstGenerateStarted = false
+
+    init(firstBlockedRequestID: String) {
+        self.firstBlockedRequestID = firstBlockedRequestID
+    }
+
+    func waitUntilGenerateStarted() async {
+        if firstGenerateStarted {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            generateStartedWaiters.append(continuation)
+        }
+    }
+
+    func canDispatchRequests() async -> Bool {
+        true
+    }
+
+    func generate(
+        request: Melix_Worker_V1_GenerateRequest
+    ) async throws -> AsyncThrowingStream<Melix_Worker_V1_ExecuteEvent, Error> {
+        let requestID = request.execution.id.requestID
+        generatedRequestIDs.append(requestID)
+        if requestID == firstBlockedRequestID {
+            firstGenerateStarted = true
+            await withCheckedContinuation { continuation in
+                firstGenerateGate = continuation
+                let waiters = generateStartedWaiters
+                generateStartedWaiters.removeAll()
+                waiters.forEach { $0.resume() }
+            }
+        }
+        return AsyncThrowingStream { continuation in
+            continuations[requestID] = continuation
+        }
+    }
+
+    func finish(requestID: String, text: String) {
+        guard let continuation = continuations.removeValue(forKey: requestID) else {
+            return
+        }
+        var event = Melix_Worker_V1_ExecuteEvent()
+        event.requestID = requestID
+        event.executionKind = "generate"
+        event.phase = .executionCompleted
+        event.lane = "text.decode.interactive"
+        var completed = Melix_Worker_V1_Completed()
+        completed.assistantText = text
+        completed.finishReason = "stop"
+        event.completed = completed
+        continuation.yield(event)
+        continuation.finish()
+    }
+
+    func abort(requestID: String) async throws -> Bool {
+        abortedRequestIDs.append(requestID)
+        if requestID == firstBlockedRequestID {
+            firstGenerateGate?.resume()
+            firstGenerateGate = nil
+        }
         return true
     }
 
@@ -5709,6 +6174,10 @@ private func makeTranslatedChatRequest(
     restoreSnapshotID: String = "",
     saveBoundarySnapshot: Bool = false,
     preferHotPrefix: Bool = false,
+    lane: String = "text.decode.interactive",
+    priority: Int32 = 100,
+    latencyClass: String = "interactive",
+    latencySensitive: Bool = true,
     executionExt: [String: String] = [:]
 ) -> TranslatedChatRequest {
     var workerRequest = Melix_Worker_V1_GenerateRequest()
@@ -5720,9 +6189,10 @@ private func makeTranslatedChatRequest(
     workerRequest.execution.id.parentRequestID = parentRequestID
     workerRequest.execution.modelHandle = "melix-dev-text::local"
     workerRequest.execution.scheduling = Melix_Worker_V1_SchedulingHints()
-    workerRequest.execution.scheduling.lane = "text.decode.interactive"
-    workerRequest.execution.scheduling.priority = 100
-    workerRequest.execution.scheduling.latencySensitive = true
+    workerRequest.execution.id.latencyClass = latencyClass
+    workerRequest.execution.scheduling.lane = lane
+    workerRequest.execution.scheduling.priority = priority
+    workerRequest.execution.scheduling.latencySensitive = latencySensitive
     workerRequest.execution.cacheHints = Melix_Worker_V1_CacheHints()
     workerRequest.execution.cacheHints.restoreSnapshotID = restoreSnapshotID
     workerRequest.execution.cacheHints.saveBoundarySnapshot = saveBoundarySnapshot


### PR DESCRIPTION
## Summary
- Adds priority-aware admission ordering for shared single-slot text completions.
- Adds cooperative preemption of lower-priority active work with scheduler cancellation receipts and metrics.
- Documents the issue-1386 slice and covers priority ordering, preemption lifecycle, partial-output evidence, and upstream cancel latency receipts.

## Plan or Spec
- `docs/plans/2026-06-21-issue-1386-priority-scheduler.md`
- Closes #1386

## Commands Run
```text
git diff --check origin/main...HEAD
passed

swift test --package-path services/control-plane-swift --filter 'RequestCoordinatorTests/(priorityQueueAdmitsInteractiveWorkBeforeOlderBackgroundWork|interactiveWorkPreemptsActiveLowerPriorityWorkAndWritesCancellationReceipt|foregroundPreemptionReceiptsPreserveExplicitLifecycleAndMaintenancePriority|interactiveWorkCanPreemptLowerPriorityWorkBeforeWorkerGenerateReturns|admittedRequestCancellationBeforeGenerateReturnsYieldsACancelledExecution|secondRequestQueuesUntilTheActiveRequestReleasesAdmission)'
passed: 6 tests

swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'RequestCoordinatorTests/(priorityQueueAdmitsInteractiveWorkBeforeOlderBackgroundWork|interactiveWorkPreemptsActiveLowerPriorityWorkAndWritesCancellationReceipt|foregroundPreemptionReceiptsPreserveExplicitLifecycleAndMaintenancePriority|interactiveWorkCanPreemptLowerPriorityWorkBeforeWorkerGenerateReturns|admittedRequestCancellationBeforeGenerateReturnsYieldsACancelledExecution|secondRequestQueuesUntilTheActiveRequestReleasesAdmission)|EventSubscriptionHubTests'
passed: 24 tests

uv run --python 3.12 python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/Requests/AdmissionGate.swift services/control-plane-swift/Sources/Requests/RequestCoordinator.swift services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
passed: TOTAL 95.17% (552/580)

git commit --amend --no-edit
passed: pre-commit ran make swift-test, make py-test, make integration-test, and scoped performance report

make swift-test
passed in pre-commit: protocol package 1 test; text worker package 241 tests; control-plane package 507 tests; macOS menubar package 831 tests

make py-test
passed in pre-commit: 4106 passed, 14 skipped, 2 warnings

make integration-test
passed in pre-commit: 122 passed, 1 skipped
```

## Coverage and Metrics
- Changed-line coverage: TOTAL 95.17% (552/580), `AdmissionGate.swift` 100.00% (31/31), `RequestCoordinator.swift` 91.24% (125/137), `RequestCoordinatorTests.swift` 96.12% (396/412).
- Runtime metrics: `scheduler.preemption_count`, `scheduler.cancellation_receipt_emitted`; existing abort latency metrics are preserved.
- Cancellation receipt evidence: `stream_lifecycle`, `cancel_signal_source`, `partial_output_saved`, `upstream_cancel_latency_ms`, priority class/score, lane, run time.
- Observability mode: minimal runtime metrics plus JSONL evidence receipts.
- Probe overhead: no new PR-scoped synthetic probe; existing same-cohort batching probe remains neutral.
- Pre-commit performance report: `/Users/chenyu/Documents/github/melix/.runtime/worktrees/issue-1386-priority-scheduler-20260621/.runtime/pre-commit-performance/20260621-064649-2c16a82a/report/report.md`
- Performance report status: ok; regressions: 0; context regressions: 0; verification failures: 0.

## Known Gaps
- No protocol/schema/dependency changes; no generated artifacts or lockfiles.
- Distributed scheduling and hard process killing remain out of scope for #1386; this PR implements shared local single-slot cooperative scheduling.
- `make bootstrap` and `make proto` were not rerun because there are no dependency, hook, or protobuf schema changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
