### PR TITLE
perf: speed deterministic embedding single cycles

### DIFF
--- a/docs/plans/2026-06-21-deterministic-embedding-cycle-extend-list.md
+++ b/docs/plans/2026-06-21-deterministic-embedding-cycle-extend-list.md
@@ -1,0 +1,27 @@
+# Deterministic embedding single-cycle detection scan
+
+## Context
+
+The registered PR-scoped probe `deterministic-embedding-duplicate-input-cache` covers
+`worker/runtime/deterministic_embedding_runtime.py` and measures repeated embedding
+input batches, including multi-input cycles and single-input cycles.
+
+## Slice
+
+For repeated single-input cycles, keep the existing duplicate-input semantics but
+avoid validating the cycle by allocating one-item slices for every remaining
+input. Once the repeated cycle candidate length is known to be `1`, scan the
+remaining inputs by index and return immediately when all entries equal the first
+input. Multi-input cycle validation remains unchanged.
+
+## Validation
+
+- Focused embedding runtime tests from the registered probe.
+- Changed-scope coverage command from the registered probe.
+- Local Linux run of `scripts/deterministic_embedding_duplicate_probe.py` before
+  and after the code change.
+
+## Known boundary
+
+This is a Python worker optimization and is locally verifiable on Linux. No Swift
+runtime effect is claimed for this slice.

--- a/services/mlx-worker-python/tests/test_embedding_runtime.py
+++ b/services/mlx-worker-python/tests/test_embedding_runtime.py
@@ -8,7 +8,10 @@ from packages.protocol.python.worker.v1 import common_pb2, inference_pb2, runtim
 from worker.grpc_server import WorkerInferenceService, WorkerRuntimeService
 from worker.model_registry.catalog import WorkerModelCatalog
 from worker.registry import WorkerRegistry
-from worker.runtime.deterministic_embedding_runtime import DeterministicEmbeddingRuntime
+from worker.runtime.deterministic_embedding_runtime import (
+    DeterministicEmbeddingRuntime,
+    _repeated_input_cycle_length,
+)
 from worker.runtime.embedding_backends import (
     BERTEmbeddingBackend,
     DeterministicEmbeddingBackend,
@@ -444,6 +447,12 @@ def test_embed_runtime_replays_single_input_cycles_without_generator_reentry() -
     assert vectors[0] is not vectors[-1]
     vectors[0][0] = 99.0
     assert vectors[-1] == [1.0, 1.0]
+
+
+def test_repeated_input_cycle_length_rejects_partial_single_input_cycles() -> None:
+    inputs = ["same-document"] * 1024 + ["different-document"]
+
+    assert _repeated_input_cycle_length(inputs) == 0
 
 
 def test_load_model_rejects_unsupported_embedding_backend() -> None:

--- a/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
@@ -23,6 +23,12 @@ def _repeated_input_cycle_length(inputs: Sequence[str]) -> int:
         return 0
     if cycle_length == 0 or input_count % cycle_length != 0:
         return 0
+    if cycle_length == 1:
+        first_input = inputs[0]
+        for index in range(1, input_count):
+            if inputs[index] != first_input:
+                return 0
+        return 1
     cycle = inputs[:cycle_length]
     for index in range(cycle_length, input_count, cycle_length):
         if inputs[index : index + cycle_length] != cycle:
@@ -76,7 +82,7 @@ class DeterministicEmbeddingRuntime:
                 vector = embed_text(backend, text, dimensions)
                 append_vector(vector)
             cycle_vectors = tuple(vectors)
-            for _ in range(len(inputs) // cycle_length - 1):
+            for _ in range(input_count // cycle_length - 1):
                 vectors.extend(vector.copy() for vector in cycle_vectors)
             return vectors
 


### PR DESCRIPTION
## Summary
- Optimize deterministic embedding repeated single-input cycle detection by scanning by index instead of allocating one-item slices for each remaining input.
- Add regression coverage for partial single-input cycles so the fast path still rejects non-uniform tails.

## Plan or Spec
- `docs/plans/2026-06-21-deterministic-embedding-cycle-extend-list.md`
- Registered PR-scoped probe: `deterministic-embedding-duplicate-input-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_duplicate_probe.py
# baseline: elapsed_ms_mean=18.059844, peak_bytes_mean=3016990.4, single_cycle_elapsed_ms_mean=33.258917, single_cycle_peak_bytes_mean=2619813.6, embed_text_calls_mean=512.0, single_cycle_embed_text_calls_mean=1.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics
# 20 passed in 0.85s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_duplicate_probe.py
# TOTAL 11 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_duplicate_probe.py
# after: elapsed_ms_mean=17.821235, peak_bytes_mean=3016990.4, single_cycle_elapsed_ms_mean=24.356785, single_cycle_peak_bytes_mean=2619813.6, embed_text_calls_mean=512.0, single_cycle_embed_text_calls_mean=1.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Registered local probe (`deterministic_embedding_duplicate_probe.py`):
  - General repeated-cycle path: `elapsed_ms_mean` 18.059844 -> 17.821235 ms (delta -0.238609 ms, ~1.32% faster); `peak_bytes_mean` unchanged at 3016990.4; `embed_text_calls_mean` unchanged at 512.0.
  - Single-input cycle path: `single_cycle_elapsed_ms_mean` 33.258917 -> 24.356785 ms (delta -8.902132 ms, ~26.77% faster); `single_cycle_peak_bytes_mean` unchanged at 2619813.6; `single_cycle_embed_text_calls_mean` unchanged at 1.0.
- CI PR-scoped performance report is required as the registered validation source before merge.

## Known Gaps
- Linux-local Python validation only; no Swift runtime effect is claimed.
- CI must complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
