### PR TITLE
perf: split dataset quality output length rows

### DIFF
--- a/docs/plans/2026-06-21-dataset-quality-output-length-row-helper.md
+++ b/docs/plans/2026-06-21-dataset-quality-output-length-row-helper.md
@@ -1,0 +1,23 @@
+# Dataset Quality Output Length Row Helper
+
+This Python-only performance slice is limited to `worker.productization.dataset_preparation._append_sample_output_lengths()`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`. The probe entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for the dataset quality output-length path.
+
+## Change
+
+`_append_sample_output_lengths()` previously iterated over a temporary `(train_rows, validation_rows)` tuple and kept the per-row extraction loop nested under that outer loop. This slice keeps output semantics unchanged while moving the row loop into `_append_rows_output_lengths()` and calling it once for train rows and once for validation rows. The goal is to remove the outer tuple iteration from the hot path and keep local `append`/`str` bindings scoped to the direct row pass.
+
+## Verification Plan
+
+1. Run the registered local probe on `origin/main` before the change and on `HEAD` after the change.
+2. Run the registered focused tests for `dataset-quality-lengths-chain`.
+3. Run the registered changed-scope coverage command and confirm at least 95% coverage for the touched scope.
+4. Run `git diff --check`.
+5. Use GitHub Actions and the registered PR-scoped performance report as the merge gate.
+
+## Validation Boundary
+
+Linux-local Python behavior and probe metrics are valid for this slice. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1090,25 +1090,32 @@ def _append_sample_output_lengths(
     train_rows: list[dict[str, Any]],
     validation_rows: list[dict[str, Any]],
 ) -> None:
+    _append_rows_output_lengths(lengths, train_rows)
+    _append_rows_output_lengths(lengths, validation_rows)
+
+
+def _append_rows_output_lengths(
+    lengths: list[int],
+    rows: list[dict[str, Any]],
+) -> None:
     append = lengths.append
     str_ = str
-    for rows in (train_rows, validation_rows):
-        for row in rows:
-            if "completion" in row:
-                append(len(str_(row["completion"])))
+    for row in rows:
+        if "completion" in row:
+            append(len(str_(row["completion"])))
+            continue
+        messages = row.get("messages", [])
+        if not isinstance(messages, list):
+            append(0)
+            continue
+        total = 0
+        for item in messages:
+            try:
+                content = item.get("content", "")
+            except AttributeError:
                 continue
-            messages = row.get("messages", [])
-            if not isinstance(messages, list):
-                append(0)
-                continue
-            total = 0
-            for item in messages:
-                try:
-                    content = item.get("content", "")
-                except AttributeError:
-                    continue
-                total += len(str_(content))
-            append(total)
+            total += len(str_(content))
+        append(total)
 
 
 def _p95(values: list[int]) -> int:


### PR DESCRIPTION
## Summary
- Split the dataset quality output-length append loop into a direct per-row helper for train and validation rows.
- Keep sample output length semantics unchanged while avoiding the temporary `(train_rows, validation_rows)` outer loop in the hot path.

## Plan or Spec
- `docs/plans/2026-06-21-dataset-quality-output-length-row-helper.md`
- Registered PR-scoped probe: `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
# baseline: elapsed_ms_mean=2.241947, elapsed_ms_min=2.122709, elapsed_ms_p95=2.433511, mean_output_length=51.999, p95_output_length=100.0, row_count=15000.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_fast_paths_empty_failures services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_preserves_failed_id_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 7 passed in 0.95s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_fast_paths_empty_failures services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_preserves_failed_id_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py
# TOTAL 18 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
# after: elapsed_ms_mean=2.162809, elapsed_ms_min=2.082233, elapsed_ms_p95=2.270376, mean_output_length=51.999, p95_output_length=100.0, row_count=15000.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 18 0 100%`.
- Registered local probe (`dataset_quality_lengths_probe.py`):
  - `elapsed_ms_mean` 2.241947 -> 2.162809 ms (delta -0.079138 ms, ~3.53% faster).
  - `elapsed_ms_p95` 2.433511 -> 2.270376 ms (delta -0.163135 ms, ~6.70% faster).
  - Output metrics unchanged: `mean_output_length=51.999`, `p95_output_length=100.0`, `row_count=15000.0`.
- CI PR-scoped performance report is required as the registered validation source before merge.

## Known Gaps
- Linux-local Python validation only; no Swift runtime effect is claimed.
- CI must complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
