### PR TITLE
perf: skip plain path expansion in weight sizing

### DIFF
--- a/docs/plans/2026-05-11-runtime-utils-top-level-weight-streaming.md
+++ b/docs/plans/2026-05-11-runtime-utils-top-level-weight-streaming.md
@@ -45,3 +45,16 @@ while avoiding extra string checks for common non-weight files in flat bundles.
 Validation remains the focused runtime-utils pytest selection, changed-scope
 coverage for `runtime_utils.py`, `test_runtime_utils.py`, and the registered probe
 script, plus the local and CI `runtime-utils-top-level-weight-streaming` probe.
+
+## 2026-06-21 Plain-path expanduser fast path
+
+This follow-up Python slice keeps the same registered probe and narrows only the
+resident-byte entrypoint before the top-level scan. Plain absolute or relative
+model paths no longer call `Path.expanduser()`; `~`-prefixed paths keep the
+previous user-expansion behavior. This preserves indexed, flat-bundle, and
+single-file resident-byte semantics while removing repeated user-home expansion
+work from local model scan probes.
+
+Validation remains the focused runtime-utils pytest selection, changed-scope
+coverage for `runtime_utils.py`, `test_runtime_utils.py`, and the registered probe
+script, plus the local and CI `runtime-utils-top-level-weight-streaming` probe.

--- a/services/mlx-worker-python/tests/test_runtime_utils.py
+++ b/services/mlx-worker-python/tests/test_runtime_utils.py
@@ -266,6 +266,36 @@ def test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards(tmp_pat
     assert runtime_utils.estimate_model_weight_resident_bytes(str(bundle)) == 18
 
 
+def test_estimate_model_weight_resident_bytes_skips_expanduser_for_plain_paths(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = tmp_path / "plain-model"
+    bundle.mkdir()
+    (bundle / "model.safetensors").write_bytes(b"weights")
+
+    def fail_expanduser(self: Path):  # pragma: no cover - must stay uncalled for this regression
+        _ = self
+        raise AssertionError("plain model paths should not call Path.expanduser")
+
+    monkeypatch.setattr(runtime_utils.Path, "expanduser", fail_expanduser)
+
+    assert runtime_utils.estimate_model_weight_resident_bytes(str(bundle)) == len(b"weights")
+
+
+def test_estimate_model_weight_resident_bytes_expands_tilde_paths(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    bundle = home / "tilde-model"
+    bundle.mkdir(parents=True)
+    (bundle / "model.safetensors").write_bytes(b"weights")
+    monkeypatch.setenv("HOME", str(home))
+
+    assert runtime_utils.estimate_model_weight_resident_bytes("~/tilde-model") == len(b"weights")
+
+
 def test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights(tmp_path) -> None:
     bundle = tmp_path / "flat-model"
     bundle.mkdir()

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -137,9 +137,12 @@ def clear_installed_package_version_cache() -> None:
 
 def estimate_model_weight_resident_bytes(model_path: str) -> int:
     """Estimate model resident bytes from local weight artifacts."""
-    if not str(model_path or "").strip():
+    raw_model_path = model_path or ""
+    if not raw_model_path.strip():
         return 0
-    root = Path(model_path).expanduser()
+    root = Path(raw_model_path)
+    if raw_model_path[0] == "~":
+        root = root.expanduser()
     try:
         if root.is_file():
             return _weight_file_size(root)


### PR DESCRIPTION
## Summary
- Skip `Path.expanduser()` for plain model paths in `estimate_model_weight_resident_bytes(...)` while keeping `~`-prefixed expansion behavior.
- Add regression coverage for both plain-path fast path and tilde-path compatibility.
- Update the runtime-utils top-level weight streaming plan with the follow-up slice and validation path.

## Plan or Spec
- `docs/plans/2026-05-11-runtime-utils-top-level-weight-streaming.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_skips_expanduser_for_plain_paths services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_expands_tilde_paths services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics
# 11 passed in 0.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused selection as above> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_top_level_weights_probe.py
# TOTAL 18 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RUNTIME_UTILS_WEIGHT_FILES=6000 MELIX_RUNTIME_UTILS_WEIGHT_ITERATIONS=10 MELIX_RUNTIME_UTILS_WEIGHT_SAMPLES=9 uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py
# {"checksum": 269920.0, "elapsed_ms_mean": 409.7739805535336, "expected_bytes": 26992.0, "file_count": 6000.0, "iterations": 10.0, "peak_bytes_mean": 2034.6666666666667}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 18 0 100%`.
- Registered probe: `runtime-utils-top-level-weight-streaming`.
- Local base-vs-head probe comparison on Linux (`MELIX_RUNTIME_UTILS_WEIGHT_FILES=6000`, `ITERATIONS=10`, `SAMPLES=9`):
  - base `elapsed_ms_mean=410.60165266713335`, head `elapsed_ms_mean=407.9010479989746`, `delta_ms=-2.7006046681587463`, `speedup=1.0066207348115603`.
  - base `peak_bytes_mean=2034.6666666666667`, head `peak_bytes_mean=2034.6666666666667`, `peak_delta=0.0`.
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice.
- Local validation is Linux-only. No Swift runtime behavior is changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; probe overhead unchanged by this PR.
- [x] Deferred work and known gaps are stated explicitly.
