### PR TITLE
perf: check model config path edge chars

### DIFF
--- a/docs/plans/2026-06-20-model-load-config-json-bytes.md
+++ b/docs/plans/2026-06-20-model-load-config-json-bytes.md
@@ -12,6 +12,10 @@ The affected path is covered by the registered PR-scoped probe `model-load-confi
 
 `_read_model_config()` previously loaded `config.json` with `Path.read_text(encoding="utf-8")` before calling `json.loads()`. Python's JSON decoder accepts UTF-8 bytes directly, so this slice reads `config.json` with `Path.read_bytes()` and lets `json.loads()` decode during parse. The expected benefit is lower intermediate string allocation and slightly lower policy-resolution latency for repeated model-load trust checks on custom-loader model directories.
 
+## Follow-up Slice: Plain Path Character Guards
+
+The 2026-06-21 follow-up keeps the same registered probe and narrows the optimization to the hot plain-path config lookup. `_read_model_config()` now checks the first and last character of the already-normalized non-empty `model_path` instead of calling `str.startswith("~")` and `str.endswith(os.sep)`. This preserves tilde expansion and plain-path behavior while shaving method-call overhead from repeated trust-policy resolution.
+
 ## Verification Plan
 
 1. Add regression coverage proving the trust policy reads `config.json` through `Path.read_bytes()` without using `Path.read_text()`.

--- a/services/mlx-worker-python/worker/model_load_trust.py
+++ b/services/mlx-worker-python/worker/model_load_trust.py
@@ -231,12 +231,12 @@ def _read_model_config(model_spec: common_pb2.ModelSpec) -> dict[str, Any] | Non
     model_path = str(getattr(model_spec, "model_path", "") or "").strip()
     if not model_path:
         return None
-    if model_path.startswith("~"):
+    if model_path[0] == "~":
         config_path = Path(model_path).expanduser() / "config.json"
         config_path_text = str(config_path)
         stat_path: str | os.PathLike[str] = config_path
     else:
-        separator = "" if model_path.endswith(os.sep) else os.sep
+        separator = "" if model_path[-1] == os.sep else os.sep
         config_path_text = f"{model_path}{separator}config.json"
         stat_path = config_path_text
     try:


### PR DESCRIPTION
## Summary
- Optimize the model config trust-policy path hot path by checking the first/last normalized path characters directly.
- Keep tilde expansion and trailing-separator behavior unchanged for `_read_model_config()`.
- Update the model-load config bytes plan with this follow-up slice.

## Plan or Spec
- `docs/plans/2026-06-20-model-load-config-json-bytes.md`
- Registered PR-scoped probe: `model-load-config-json-bytes`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_load_trust.py::test_worker_rejects_custom_loader_metadata_without_explicit_trust services/mlx-worker-python/tests/test_model_load_trust.py::test_worker_trusted_custom_loader_receipt_passes_trust_remote_code services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_reads_config_json_bytes_without_text_decode services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_caches_config_json_by_file_stat services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_auto_map_custom_loader_scan_avoids_string_coercion_for_strings services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_auto_map_custom_loader_scan_preserves_blank_string_behavior services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_auto_map_custom_loader_scan_preserves_non_string_fallback services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_skips_expanduser_for_plain_model_path services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_stats_plain_config_path_without_path_join services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_expands_tilde_model_path services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_treats_missing_config_json_as_absent services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_load_config_json_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_load_config_json_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` (exit 0; 15 passed)
- Registered coverage command for `model-load-config-json-bytes` (exit 0; changed-line coverage 100%)
- Registered probe command for `model-load-config-json-bytes` (exit 0)
- Baseline/head comparison with `MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_ITERATIONS=5000 MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_SAMPLES=5`
- `git diff --check` (exit 0)

## Coverage and Metrics
- Focused tests: 15 passed.
- Changed-scope coverage: 2/2 changed measurable lines covered, 100%.
- Local registered probe (default): `elapsed_ms_mean=8.06894214890365`, `elapsed_ms_min=7.9890170018188655`, `peak_bytes_mean=2688.5714285714284`, `rejections_mean=300.0`.
- Baseline/head repeated local probe: baseline `elapsed_ms_mean=147.76692139857914 ms`; head `elapsed_ms_mean=145.03983940230682 ms`; delta `-2.727081996272318 ms`; speedup about `1.88%` on Linux with 5,000 iterations x 5 samples.
- CI registered PR-scoped performance validation is required before merge.

## Known Gaps
- This is a Python slice and was locally verified on Linux; CI remains the authoritative registered PR-scoped validation before merge.
- The measured gain is small and should be treated as hot-path overhead reduction rather than a large algorithmic improvement.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally and showed directionally lower mean latency in repeated baseline/head comparison.
- [ ] GitHub Actions completed successfully.
- [ ] Registered PR-scoped performance workflow completed successfully.
