### PR TITLE
perf: avoid Path metadata copy for audio local URIs

### DIFF
--- a/docs/plans/2026-06-21-audio-uri-path-metadata-ospath.md
+++ b/docs/plans/2026-06-21-audio-uri-path-metadata-ospath.md
@@ -1,0 +1,65 @@
+# Audio URI Path Metadata Ospath Slice
+
+## Objective
+
+Reduce small but repeated path metadata overhead in the MLX audio local-URI
+preprocessing hot path. The transcription runtime already avoids reading local
+`audio_uri` bytes before handing the filesystem path to the STT backend; this
+slice keeps that behavior and avoids extra `Path` property parsing when filling
+`PreparedAudioInput.local_path`, `format`, and `filename`.
+
+## Scope
+
+- Affected code path: `services/mlx-worker-python/worker/runtime/audio_preprocessing.py`.
+- Registered PR-scoped probe: `mlx-audio-local-uri-zero-copy-preprocess`.
+- Probe coverage: focused test, coverage, and command-json probe entries already
+  exist in `infra/perf/pr_scoped_probes.json`.
+
+## Implementation
+
+Use the filesystem string produced by `os.fspath(path)` as the single source for
+local URI metadata in `prepare_audio_input(...)`, then derive optional suffix and
+basename through `os.path.splitext(...)` and `os.path.basename(...)`. This keeps
+`_path_from_uri(...)` semantics unchanged and preserves the existing local URI
+zero-copy contract.
+
+## Verification Plan
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_audio_runtime.py::test_audio_preprocessing_zero_copy_uri_skips_exists_probe \
+  services/mlx-worker-python/tests/test_audio_runtime.py::test_audio_preprocessing_prepared_input_uses_slots \
+  services/mlx-worker-python/tests/test_audio_runtime.py::test_audio_preprocessing_rejects_missing_and_unsupported_inputs \
+  services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_transcription_runtime_uses_local_uri_path_without_reading_bytes \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_local_uri_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_emits_metrics
+```
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_audio_runtime.py::test_audio_preprocessing_zero_copy_uri_skips_exists_probe \
+  services/mlx-worker-python/tests/test_audio_runtime.py::test_audio_preprocessing_prepared_input_uses_slots \
+  services/mlx-worker-python/tests/test_audio_runtime.py::test_audio_preprocessing_rejects_missing_and_unsupported_inputs \
+  services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_transcription_runtime_uses_local_uri_path_without_reading_bytes \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_local_uri_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_emits_metrics && \
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && \
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/runtime/audio_preprocessing.py \
+  services/mlx-worker-python/tests/test_mlx_audio_runtime.py \
+  services/mlx-worker-python/tests/test_audio_runtime.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/mlx_audio_local_uri_probe.py
+```
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_audio_local_uri_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py \
+  --registry infra/perf/pr_scoped_probes.json \
+  --probe-id mlx-audio-local-uri-zero-copy-preprocess \
+  --base-repo /root/.hermes/profiles/coder/workspace/melix \
+  --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-audio-uri-path-metadata-ospath-20260621 \
+  --output /tmp/mlx-audio-uri-path-metadata-probe.json
+```

--- a/services/mlx-worker-python/worker/runtime/audio_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/audio_preprocessing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 from pathlib import Path
 from time import perf_counter
 from urllib.parse import unquote, urlparse
@@ -52,13 +53,13 @@ def prepare_audio_input(request, *, read_uri_bytes: bool = True) -> PreparedAudi
                 input_bytes = path.stat().st_size
         except OSError as exc:
             raise AudioPreprocessError(f"Missing local audio input: {request.audio_uri}") from exc
-        local_path = str(path)
+        local_path = os.fspath(path)
         source_kind = "uri"
         reference = request.audio_uri
         if not format_name:
-            format_name = path.suffix.lstrip(".")
+            format_name = os.path.splitext(local_path)[1].lstrip(".")
         if not filename:
-            filename = path.name
+            filename = os.path.basename(local_path)
     else:
         raise AudioPreprocessError("No audio input provided.")
 


### PR DESCRIPTION
## Summary
- Replace repeated `Path` metadata property lookups in the MLX audio local URI preprocessing path with metadata derived from the already-needed filesystem string.
- Keep the zero-copy local URI contract intact: local paths are forwarded without reading bytes.

## Plan or Spec
- `docs/plans/2026-06-21-audio-uri-path-metadata-ospath.md`
- Registered PR-scoped probe: `mlx-audio-local-uri-zero-copy-preprocess`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_audio_runtime.py::test_audio_preprocessing_zero_copy_uri_skips_exists_probe services/mlx-worker-python/tests/test_audio_runtime.py::test_audio_preprocessing_prepared_input_uses_slots services/mlx-worker-python/tests/test_audio_runtime.py::test_audio_preprocessing_rejects_missing_and_unsupported_inputs services/mlx-worker-python/tests/test_audio_runtime.py::test_audio_catalog_models_expose_backend_metadata_and_real_backend_entries services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_mlx_audio_transcription_runtime_uses_local_uri_path_without_reading_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_local_uri_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_covers_audio_catalog_metadata_assertions services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_local_uri_probe_script_main_covers_checked_in_file`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json ...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_audio_local_uri_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id mlx-audio-local-uri-zero-copy-preprocess --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-audio-uri-path-metadata-ospath-20260621 --output /tmp/mlx-audio-uri-path-metadata-probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 10 passed.
- Changed-scope coverage: 100% for changed lines (`aggregate_measurable_changed_lines=4`, `aggregate_covered_changed_lines=4`).
- Registered local probe (`mlx-audio-local-uri-zero-copy-preprocess`): base `elapsed_ms_mean=0.174918`, head `elapsed_ms_mean=0.167873` (~4.03% faster, `delta=-0.007045 ms`).
- Probe memory metric: base `peak_bytes_mean=2354`, head `peak_bytes_mean=2410` (~2.38% higher, within the registered 5% warning threshold).
- Zero-copy guard metrics remained unchanged: `local_uri_read_bytes_calls_mean=0.0`, `local_uri_exists_calls_mean=0.0`.

## Known Gaps
- Linux-local validation covers the Python MLX worker path only.
- CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before starting the slice.
- [x] Confirmed the affected path is covered by a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Added a governing plan under `docs/plans/`.
- [x] Ran focused tests locally.
- [x] Ran changed-scope coverage locally.
- [x] Ran the registered probe locally against base and head.
- [ ] GitHub Actions completed successfully, including the PR-scoped performance workflow.
