### PR TITLE
perf: inline trajectory manifest clean text checks

### DIFF
--- a/docs/plans/2026-06-21-trajectory-manifest-clean-text-inline.md
+++ b/docs/plans/2026-06-21-trajectory-manifest-clean-text-inline.md
@@ -1,0 +1,21 @@
+# Trajectory manifest clean-text inline checks
+
+This Python-only performance slice is limited to the clean normalized-manifest fast path in `worker.trajectory_provenance._fast_trajectory_provenance_from_snapshot_manifest()`.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped performance probe `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_trajectory_provenance.py`
+- `scripts/trajectory_manifest_json_load_probe.py`
+
+## Slice
+
+The current fast path validates five required exact-string manifest fields by calling `_is_clean_manifest_text()` repeatedly. This slice keeps the same fallback boundary but inlines the exact-string and leading/trailing whitespace checks in the hot path so normalized JSON manifests avoid per-field Python helper calls.
+
+The fallback path remains responsible for missing fields, non-string values, whitespace-normalized values, dict subclasses, source aliases, and the public copy-preserving API.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and local registered probe on Linux before opening the PR. GitHub Actions PR-scoped performance remains the merge gate for the registered base-vs-head report.

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -276,29 +276,53 @@ def test_load_trajectory_provenance_from_snapshot_manifest_fast_paths_clean_text
     }
 
 
+@pytest.mark.parametrize(
+    ("field", "fallback_key", "fallback_value"),
+    [
+        ("source_dataset_id", "trajectory_dataset_id", "agentic-snapshot"),
+        ("version", "trajectory_dataset_version", "2026-05-25"),
+        (
+            "trajectory_schema_version",
+            "trajectory_schema_version",
+            "melix.agentic_tool_trace.v1",
+        ),
+        ("trajectory_split", "trajectory_split", "train"),
+        ("trajectory_trace_digest", "trajectory_trace_digest", "abc123"),
+    ],
+)
 def test_load_trajectory_provenance_from_snapshot_manifest_fast_path_falls_back_for_defaulted_required_fields(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    fallback_key: str,
+    fallback_value: str,
 ) -> None:
     manifest_path = tmp_path / "manifest.json"
-    manifest_path.write_bytes(
-        json.dumps(
-            {
-                "format": "agentic_tool_trace",
-                "source_dataset_id": "agentic-snapshot",
-                "version": "2026-05-25",
-                "trajectory_trace_digest": "abc123",
-            }
-        ).encode("utf-8")
-    )
-
-    assert load_trajectory_provenance_from_snapshot_manifest(manifest_path) == {
-        "trajectory_dataset_id": "agentic-snapshot",
-        "trajectory_dataset_version": "2026-05-25",
+    payload = {
+        "format": "agentic_tool_trace",
+        "source_dataset_id": "agentic-snapshot",
+        "version": "2026-05-25",
         "trajectory_schema_version": "melix.agentic_tool_trace.v1",
-        "trajectory_snapshot_manifest_path": str(manifest_path),
         "trajectory_split": "train",
         "trajectory_trace_digest": "abc123",
     }
+    payload[field] = f" {fallback_value} "
+    manifest_path.write_bytes(json.dumps(payload).encode("utf-8"))
+    strip_calls = 0
+    original_strip = trajectory_provenance_module._strip_manifest_text
+
+    def tracked_strip(value: object) -> str:
+        nonlocal strip_calls
+        strip_calls += 1
+        return original_strip(value)
+
+    monkeypatch.setattr(trajectory_provenance_module, "_strip_manifest_text", tracked_strip)
+
+    provenance = load_trajectory_provenance_from_snapshot_manifest(manifest_path)
+
+    assert strip_calls > 0
+    assert provenance[fallback_key] == fallback_value
+    assert provenance["trajectory_snapshot_manifest_path"] == str(manifest_path)
 
 
 def test_load_trajectory_provenance_from_snapshot_manifest_reuses_path_text(

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -146,18 +146,44 @@ def _fast_trajectory_provenance_from_snapshot_manifest(
     manifest_get = manifest.get
     if manifest_get("format") != "agentic_tool_trace":
         return None
-    is_clean_text = _is_clean_manifest_text
     dataset_id = manifest_get("source_dataset_id")
+    if (
+        type(dataset_id) is not str
+        or dataset_id == ""
+        or dataset_id[0].isspace()
+        or dataset_id[-1].isspace()
+    ):
+        return None
     dataset_version = manifest_get("version")
+    if (
+        type(dataset_version) is not str
+        or dataset_version == ""
+        or dataset_version[0].isspace()
+        or dataset_version[-1].isspace()
+    ):
+        return None
     schema_version = manifest_get("trajectory_schema_version")
+    if (
+        type(schema_version) is not str
+        or schema_version == ""
+        or schema_version[0].isspace()
+        or schema_version[-1].isspace()
+    ):
+        return None
     split = manifest_get("trajectory_split")
+    if (
+        type(split) is not str
+        or split == ""
+        or split[0].isspace()
+        or split[-1].isspace()
+    ):
+        return None
     trace_digest = manifest_get("trajectory_trace_digest")
-    if not (
-        is_clean_text(dataset_id)
-        and is_clean_text(dataset_version)
-        and is_clean_text(schema_version)
-        and is_clean_text(split)
-        and is_clean_text(trace_digest)
+    if (
+        type(trace_digest) is not str
+        or trace_digest == ""
+        or trace_digest[0].isspace()
+        or trace_digest[-1].isspace()
     ):
         return None
     provenance: dict[str, Any] = {


### PR DESCRIPTION
## Summary
- Inline required-field clean-text checks in the trajectory manifest load fast path to avoid repeated helper calls for normalized JSON manifests.
- Extend fallback coverage so whitespace-normalized required fields still route through the generic path.

## Plan or Spec
- `docs/plans/2026-06-21-trajectory-manifest-clean-text-inline.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_fast_paths_clean_text services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_fast_path_falls_back_for_defaulted_required_fields services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reuses_path_text services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_accepts_dict_subclass services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 15 passed in 0.72s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q <same focused selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
# 15 passed in 1.00s; changed_line_coverage=100.00%; TOTAL 9 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
# old_mean_ms=1367.850267200265, new_mean_ms=703.7863852019655, delta_ms=-664.0638819982996, speedup=1.9435588638273151

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id trajectory-manifest-json-load --base-repo /tmp/melix-base-trajectory-manifest-clean-text-inline --head-repo "$PWD" --output /tmp/trajectory-manifest-clean-text-inline-pr-probe.json
# head verification ok; coverage=100.0%; base new_mean_ms=728.5399266023887; head new_mean_ms=701.7092511989176
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/trajectory_provenance.py` = 100.00% (9/9 changed measurable lines).
- Registered local probe: `trajectory-manifest-json-load`.
  - Direct probe: `old_mean_ms=1367.850267200265`, `new_mean_ms=703.7863852019655`, `delta_ms=-664.0638819982996`, `speedup=1.9435588638273151`.
  - PR-scoped local base/head run: base `new_mean_ms=728.5399266023887`, head `new_mean_ms=701.7092511989176`, delta `-26.8306754034711 ms`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux-only; no Swift/runtime effect is claimed.
- Full repository test suite was not run for this Python-only hot-path slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability/debug mode changes.
- [x] Deferred work and known gaps are stated explicitly.
