### PR TITLE
perf: skip empty benchmark parameter sorts

### DIFF
--- a/docs/plans/2026-06-22-maintenance-parameter-empty-default-fastpath.md
+++ b/docs/plans/2026-06-22-maintenance-parameter-empty-default-fastpath.md
@@ -1,0 +1,36 @@
+# Maintenance benchmark parameter empty-default fast path
+
+## Scope
+
+Optimize one Python hot path in `MaintenanceCore` benchmark parameter normalization:
+when integer or string normalization produces no usable values, return the caller
+provided default tuple before sorting an empty set.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`maintenance-benchmark-parameter-normalization-single-convert` in
+`infra/perf/pr_scoped_probes.json`.
+
+The probe already defines focused `test_command`, `coverage_command`, and
+`probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/engine/maintenance_core.py`
+- `services/mlx-worker-python/tests/test_maintenance_service.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/maintenance_benchmark_parameter_normalization_probe.py`
+
+## Verification plan
+
+1. Add regression assertions that empty integer and string normalization return
+   the default tuple without invoking the module-level `sorted` lookup.
+2. Run the registered focused test command locally on Linux.
+3. Run the registered changed-scope coverage command locally on Linux.
+4. Run the registered probe command locally on Linux and compare against the
+   pre-change baseline.
+
+## Expected behavior
+
+Behavior remains unchanged for non-empty normalized values and for default
+fallbacks. The slice only removes unnecessary empty-sort/list work on default
+fallback paths.

--- a/scripts/maintenance_benchmark_parameter_normalization_probe.py
+++ b/scripts/maintenance_benchmark_parameter_normalization_probe.py
@@ -105,6 +105,21 @@ def _run_native_sample(value_count: int, iterations: int) -> tuple[float, int]:
     return elapsed_ms, checksum
 
 
+def _run_empty_default_sample(value_count: int, iterations: int) -> tuple[float, int]:
+    empty_ints = [0 for _ in range(value_count)]
+    empty_strings = [" " for _ in range(value_count)]
+    checksum = 0
+    started = time.perf_counter()
+    for _ in range(iterations):
+        positive_values = MaintenanceCore._positive_sorted_values(empty_ints, default=(32,))
+        normalized_strings = MaintenanceCore._normalized_string_values(empty_strings, default=("default",))
+        if positive_values != (32,) or normalized_strings != ("default",):
+            raise SystemExit("unexpected empty-default benchmark parameter normalization output")
+        checksum += len(positive_values) + len(normalized_strings)
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    return elapsed_ms, checksum
+
+
 def main() -> int:
     value_count = int(os.environ.get("MELIX_MAINTENANCE_PARAMETER_PROBE_VALUE_COUNT", "3000"))
     iterations = int(os.environ.get("MELIX_MAINTENANCE_PARAMETER_PROBE_ITERATIONS", "80"))
@@ -115,8 +130,10 @@ def main() -> int:
     string_call_samples: list[float] = []
     calls_per_value_samples: list[float] = []
     native_elapsed_samples: list[float] = []
+    empty_default_elapsed_samples: list[float] = []
     checksum = 0
     native_checksum = 0
+    empty_default_checksum = 0
 
     for _ in range(sample_count):
         tracemalloc.start()
@@ -137,6 +154,11 @@ def main() -> int:
         calls_per_value_samples.append((int_calls + string_calls) / (int_values + string_values))
         native_elapsed_ms, native_checksum = _run_native_sample(value_count, iterations)
         native_elapsed_samples.append(native_elapsed_ms)
+        empty_default_elapsed_ms, empty_default_checksum = _run_empty_default_sample(
+            value_count,
+            iterations,
+        )
+        empty_default_elapsed_samples.append(empty_default_elapsed_ms)
 
     print(
         json.dumps(
@@ -144,6 +166,11 @@ def main() -> int:
                 "calls_per_value_mean": round(statistics.fmean(calls_per_value_samples), 6),
                 "checksum": float(checksum),
                 "elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+                "empty_default_checksum": float(empty_default_checksum),
+                "empty_default_elapsed_ms_mean": round(
+                    statistics.fmean(empty_default_elapsed_samples),
+                    6,
+                ),
                 "int_conversion_calls_mean": round(statistics.fmean(int_call_samples), 6),
                 "iteration_count": float(iterations),
                 "native_checksum": float(native_checksum),

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -5870,6 +5870,18 @@ def test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs(
     assert MaintenanceCore._positive_sorted_values([8, 0, 4, 8], default=(32,)) == (4, 8)
     assert MaintenanceCore._positive_sorted_values([False, True, 2], default=(32,)) == (1, 2)
 
+    with monkeypatch.context() as empty_int_context:
+        sorted_calls = 0
+
+        def counted_sorted(values):  # pragma: no cover - must not be called on empty fallback
+            nonlocal sorted_calls
+            sorted_calls += 1
+            return builtins.sorted(values)
+
+        empty_int_context.setattr(maintenance_core_module, "sorted", counted_sorted, raising=False)
+        assert MaintenanceCore._positive_sorted_values([0, -1], default=(32,)) == (32,)
+        assert sorted_calls == 0
+
     class CountedString:
         def __init__(self, value: str) -> None:
             self.value = value
@@ -5889,6 +5901,20 @@ def test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs(
         [" warm ", "", "cold"],
         default=("default",),
     ) == ("cold", "warm")
+
+    with monkeypatch.context() as empty_string_context:
+        sorted_calls = 0
+
+        def counted_sorted(values):  # pragma: no cover - must not be called on empty fallback
+            nonlocal sorted_calls
+            sorted_calls += 1
+            return builtins.sorted(values)
+
+        empty_string_context.setattr(maintenance_core_module, "sorted", counted_sorted, raising=False)
+        assert MaintenanceCore._normalized_string_values([" ", ""], default=("default",)) == (
+            "default",
+        )
+        assert sorted_calls == 0
 
     MaintenanceCore._shape_benchmark_prompt.cache_clear()
     MaintenanceCore._benchmark_prompt_token_count.cache_clear()

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -3148,6 +3148,8 @@ def test_maintenance_parameter_normalization_probe_script_emits_metrics(
     assert metrics["string_conversion_calls_mean"] == 24.0
     assert metrics["native_checksum"] > 0.0
     assert metrics["elapsed_ms_mean"] >= 0
+    assert metrics["empty_default_checksum"] > 0.0
+    assert metrics["empty_default_elapsed_ms_mean"] >= 0
     assert metrics["native_elapsed_ms_mean"] >= 0
     assert metrics["peak_bytes_mean"] > 0
 

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -3008,7 +3008,9 @@ class MaintenanceCore:
             parsed = value if type(value) is int else int(value)
             if parsed > 0:
                 normalized_values.add(parsed)
-        return tuple(sorted(normalized_values)) or default
+        if not normalized_values:
+            return default
+        return tuple(sorted(normalized_values))
 
     @staticmethod
     def _normalized_string_values(values, *, default: tuple[str, ...]) -> tuple[str, ...]:
@@ -3018,7 +3020,9 @@ class MaintenanceCore:
             normalized = raw_value.strip()
             if normalized:
                 normalized_values.add(normalized)
-        return tuple(sorted(normalized_values)) or default
+        if not normalized_values:
+            return default
+        return tuple(sorted(normalized_values))
 
     @staticmethod
     def _benchmark_matrix_request_count(


### PR DESCRIPTION
## Summary
- Skip `sorted(empty_set)` and empty tuple allocation in benchmark integer/string normalization default fallback paths.
- Add regression assertions proving empty fallback paths return defaults without invoking the module-level `sorted` lookup.
- Extend the local probe script with an empty-default metric path for this slice.

## Plan or Spec
- `docs/plans/2026-06-22-maintenance-parameter-empty-default-fastpath.md`

## Commands Run
```text
# Baseline registered probe before the code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_MAINTENANCE_PARAMETER_PROBE_VALUE_COUNT=3000 MELIX_MAINTENANCE_PARAMETER_PROBE_ITERATIONS=80 MELIX_MAINTENANCE_PARAMETER_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/maintenance_benchmark_parameter_normalization_probe.py
# exit 0; elapsed_ms_mean=857.109117, native_elapsed_ms_mean=53.593115, peak_bytes_mean=814389.0

# Registered focused test command
bash /tmp/melix_test_cmd.sh
# exit 0; 4 passed

# Registered changed-scope coverage command
bash /tmp/melix_cov_cmd.sh
# exit 0; aggregate changed-line coverage 97% (34/35 covered); maintenance_core.py 100%, test_maintenance_service.py 100%, test_pr_scoped_performance.py 100%, probe script 94.12% with only defensive failure line missed

# Registered probe command
bash /tmp/melix_probe_cmd.sh
# exit 0; elapsed_ms_mean=824.429429, native_elapsed_ms_mean=56.265426, peak_bytes_mean=814408.2

# Updated local probe script with empty-default metric
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/maintenance_benchmark_parameter_normalization_probe.py
# exit 0; elapsed_ms_mean=815.959386, empty_default_elapsed_ms_mean=17.341829, native_elapsed_ms_mean=54.2826

# Old-vs-new empty-default microprobe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
# Embedded old helper bodies vs current MaintenanceCore helpers over 7 samples.
PY
# exit 0; old_empty_default.mean=19.061157 ms, new_empty_default.mean=18.454892 ms

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered changed-scope coverage: 97% aggregate (34/35 changed lines covered), above the 95% gate.
- Registered probe baseline vs head: elapsed_ms_mean 857.109117 ms -> 824.429429 ms (delta -32.679688 ms, ~3.81% faster); native_elapsed_ms_mean 53.593115 ms -> 56.265426 ms; peak_bytes_mean 814389.0 -> 814408.2 bytes.
- Empty-default microprobe: old mean 19.061157 ms -> new mean 18.454892 ms (delta -0.606265 ms, ~3.18% faster) with matching checksum.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Linux local validation covers Python behavior and probes only. No Swift runtime effect is involved in this slice.
- The registered CI probe remains the authoritative PR-scoped performance validation before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
