### PR TITLE
perf: trim PR scope command summary formatting overhead

### DIFF
--- a/docs/plans/2026-06-18-pr-scoped-command-summary-index-scan.md
+++ b/docs/plans/2026-06-18-pr-scoped-command-summary-index-scan.md
@@ -11,8 +11,9 @@ The affected path is already covered by the registered `pr-scoped-performance-sc
 ## Implementation plan
 
 - Preserve the existing compact single-line summary semantics.
-- Keep the existing single whole-command `strip()` before first-line selection so trailing blank heredoc lines are eliminated.
-- Replace tuple-producing `partition("\n")` with a direct newline index lookup so the summary path does not allocate the unused remaining payload.
+- Preserve the existing whole-command `strip()` before first-line selection so trailing blank heredoc lines are eliminated.
+- Keep the direct newline index lookup and use simple string concatenation for the summary suffix/truncation suffix to avoid f-string formatting overhead in the hot heartbeat loop.
+- Guard very small `max_length` values before suffix concatenation so the helper never uses negative slicing for compact custom limits.
 - Keep the behavior tests under `test_command_summary_keeps_ci_heartbeats_compact` as the regression guard.
 
 ## Verification plan

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -5322,12 +5322,15 @@ def test_command_and_verification_helpers_cover_skip_and_failure_paths(
 def test_command_summary_keeps_ci_heartbeats_compact() -> None:
     assert _summarize_command("python3 - <<'PY'\nprint('x')\nPY") == "python3 - <<'PY' ..."
     assert _summarize_command(" \n  python3 - <<'PY'  \nprint('x')") == "python3 - <<'PY' ..."
+    assert _summarize_command(" \n  python3 - <<'PY'  \n" + "print('x')\n" * 1000) == "python3 - <<'PY' ..."
     assert _summarize_command(" \n ") == "<empty command>"
     assert _summarize_command("python3 -m pytest\n \t\n") == "python3 -m pytest"
 
     long_summary = _summarize_command("python3 -c " + "x" * 300, max_length=80)
     assert len(long_summary) <= 80
     assert long_summary.endswith(" ...")
+    assert _summarize_command("python3 -c " + "x" * 300, max_length=4) == "pyth"
+    assert _summarize_command("python3 -c " + "x" * 300, max_length=0) == ""
 
 
 def test_run_command_emits_heartbeat_for_silent_command(

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -82,9 +82,13 @@ def _summarize_command(command: str, *, max_length: int = 180) -> str:
     if newline_index < 0:
         summary = command
     else:
-        summary = f"{command[:newline_index].rstrip()} ..."
+        summary = command[:newline_index].rstrip() + " ..."
     if len(summary) > max_length:
-        return f"{summary[: max_length - 4]} ..."
+        if max_length <= 0:
+            return ""
+        if max_length <= 4:
+            return summary[:max_length]
+        return summary[: max_length - 4] + " ..."
     return summary
 
 


### PR DESCRIPTION
## Summary
- Optimizes the PR-scoped performance command-summary hot path by replacing two f-string suffix constructions with direct string concatenation.
- Adds long multiline heredoc regression coverage to preserve compact heartbeat summaries for long commands.
- Guards very small custom `max_length` values so truncation never uses negative slicing.

## Plan or Spec
- `docs/plans/2026-06-18-pr-scoped-command-summary-index-scan.md`
- Registered probe: `pr-scoped-performance-scope-matcher` in `infra/perf/pr_scoped_probes.json` (already has focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# Baseline probe on origin/main before changes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/probe_pr_scope_matcher.py
# exit 0; command_summary_ms_mean=9.983889, build_scope_report_ms_mean=2.043664

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_run_command_emits_heartbeat_for_silent_command
# exit 0; 2 passed in 1.86s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_infra_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_exact_force_all_skips_wildcard_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_force_selects_all_on_pr_scope_script_change services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_changed_paths_force_all_wildcards_handles_empty_matchers services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_changed_paths_force_all_wildcards_short_circuits_on_match services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_matches_any_glob_uses_explicit_short_circuit services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_coverage_paths_for_probe_uses_explicit_glob_matcher services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_empty_direct_paths_skips_probe_matching services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_deduplicates_repeated_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_exact_only_intersects_changed_paths services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_match_probe_indexes_reuses_cached_frozenset_without_copying services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_pattern_reuses_cached_regex services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_glob_matching_exact_path_skips_regex_compile services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_compiled_glob_matching_preserves_prefix_short_circuit services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_json_probe_rejects_missing_command_and_non_numeric_metrics
# exit 0; 20 passed in 14.24s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same registered pr-scoped-performance-scope-matcher tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0; 20 passed in 49.01s; TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/run_scope_matcher_probe.py
# exit 0; command_summary_ms_mean=9.964352, build_scope_report_ms_mean=2.037396

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 6 0 100%` for `services/mlx-worker-python/worker/productization/pr_scoped_performance.py` and `services/mlx-worker-python/tests/test_pr_scoped_performance.py`.
- Registered local Linux probe (`pr-scoped-performance-scope-matcher`):
  - baseline `command_summary_ms_mean=9.983889`
  - latest rerun after the review guard update `command_summary_ms_mean=9.964352`
  - delta `-0.019537 ms`, speedup `0.196%`
  - earlier final rerun before the review guard update: `command_summary_ms_mean=9.69109` (`-0.292799 ms`, `2.933%` faster)
- Earlier rejected attempt (`lstrip` / explicit leading index scan) regressed `command_summary_ms_mean` to about `11.9 ms`; it was not kept.
- CI registered PR-scoped performance report is required before merge.

## Known Gaps
- CI must run the registered PR-scoped performance workflow and publish the probe report before merge.
- No Swift runtime validation is relevant; this is a Python-only PR-scoped performance runner slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
