### PR TITLE
perf: fast-path report evidence dict rows

### DIFF
--- a/docs/plans/2026-06-22-report-evidence-dict-list-exact-dict-fastpath.md
+++ b/docs/plans/2026-06-22-report-evidence-dict-list-exact-dict-fastpath.md
@@ -1,0 +1,38 @@
+# Report evidence `_dict_list` exact-dict fast path
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.productization.report_evidence_gate._dict_list`. The helper is called
+repeatedly while analyzing report evidence payload sections that are normally
+already `list[dict]` values decoded from JSON.
+
+## Optimization
+
+Keep the existing semantics for non-list values, mixed lists, and `dict`
+subclasses, but make the all-plain-`dict` path cheaper by checking exact dict
+rows before falling back to the slower `isinstance(..., dict)` subclass check.
+The fallback still filters malformed mixed lists exactly as before.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`report-evidence-gate-run-kind-set-membership` in
+`infra/perf/pr_scoped_probes.json`. The probe has focused `test_command`,
+`coverage_command`, and `probe_command` entries and reports
+`dict_list_elapsed_ms_mean` in addition to the overall gate timings.
+
+## Verification plan
+
+1. Run the registered focused pytest command locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run the registered probe command locally on Linux.
+4. Run `scripts/pr_scoped_performance_run.py` for
+   `report-evidence-gate-run-kind-set-membership` against `origin/main` and
+   `HEAD` and use the registered CI report as the merge gate.
+
+## Expected performance signal
+
+The primary expected improvement is lower `dict_list_elapsed_ms_mean` from the
+exact-`dict` fast path. Overall `elapsed_ms_mean` may improve slightly, while
+other sub-metrics should remain directionally stable.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -861,6 +861,12 @@ def test_report_evidence_gate_covers_invalid_payload_and_edge_summaries(tmp_path
     assert report_evidence_gate_module._dict_list(dict_rows) is dict_rows
     assert report_evidence_gate_module._dict_list([dict_rows[0], "skip", dict_rows[1]]) == dict_rows
 
+    class DictRow(dict[str, object]):
+        pass
+
+    subclass_rows: list[object] = [DictRow({"phase": "subclass"}), {"phase": "plain"}]
+    assert report_evidence_gate_module._dict_list(subclass_rows) is subclass_rows
+
     markdown = render_pr_evidence_markdown(
         {
             **gate,

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -532,6 +532,6 @@ def _dict_list(value: object) -> list[dict[str, object]]:
     if not isinstance(value, list):
         return []
     for item in value:
-        if not isinstance(item, dict):
+        if type(item) is not dict and not isinstance(item, dict):
             return [item for item in value if isinstance(item, dict)]
     return cast(list[dict[str, object]], value)


### PR DESCRIPTION
## Summary
- Fast-path `_dict_list` for exact built-in `dict` rows before falling back to the more expensive `isinstance` subclass check.
- Preserve existing behavior for dict subclasses and mixed invalid payload rows.
- Add a focused plan note for this report evidence gate performance slice.

## Plan or Spec
- `docs/plans/2026-06-22-report-evidence-dict-list-exact-dict-fastpath.md`
- Registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_covers_invalid_payload_and_edge_summaries
# 1 passed in 0.16s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <24 report-evidence/pr-scoped focused tests>
# 24 passed in 0.92s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <24 report-evidence/pr-scoped focused tests>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
# 24 passed in 0.36s; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py > /tmp/report_evidence_dict_list_probe_local.json
# ok; dict_list_elapsed_ms_mean=38.452768593560904

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id report-evidence-gate-run-kind-set-membership --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-report-evidence-dict-list-exact-dict-20260622 --output /tmp/report_evidence_dict_list_pr_scoped.json
# ok; head verification 24 passed in 0.40s; TOTAL 5 0 100%

git diff --check
# ok
```

## Coverage and Metrics
- Changed-line coverage: `TOTAL 5 0 100%`.
- Direct head probe: `dict_list_elapsed_ms_mean=38.452768593560904`, `dict_list_checksum=10240000.0`, `dict_list_identity_hits=5000.0`, `sample_count=5.0`.
- Local registered PR-scoped comparison (`report-evidence-gate-run-kind-set-membership`):
  - `dict_list_elapsed_ms_mean`: base `45.02958579687402` ms, head `40.843102196231484` ms, delta `-4.186483600642536` ms, improvement `9.30%`.
  - `elapsed_ms_mean`: base `949.2038769996725` ms, head `952.5257539760787` ms, delta `+3.321876976406201` ms (`-0.35%` overall; within broader probe noise while the targeted phase improves).
- CI is still required as the authoritative registered probe validation for this PR.

## Known Gaps
- Full repository gates were not run locally; this slice ran the focused registered probe tests, changed-scope coverage, direct local probe, and local PR-scoped comparison.
- Overall `elapsed_ms_mean` in the broad probe was slightly slower locally while the targeted `_dict_list` phase improved; CI registered probe output should be used as the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: this changes evidence-gate helper performance only; no production observability mode change.
- [x] Deferred work and known gaps are stated explicitly.
