### PR TITLE
perf: bind maintenance normalizer helpers locally

### DIFF
--- a/docs/plans/2026-06-22-maintenance-normalizer-local-bindings.md
+++ b/docs/plans/2026-06-22-maintenance-normalizer-local-bindings.md
@@ -1,0 +1,44 @@
+# Maintenance benchmark normalizer local bindings
+
+## Scope
+
+Optimize one Python hot path in `MaintenanceCore` benchmark parameter normalization:
+cache the per-call `set.add` methods and string `strip` descriptor in local
+variables while preserving the existing one-conversion-per-input behavior.
+
+This slice is intentionally limited to:
+
+- `MaintenanceCore._positive_sorted_values(...)`
+- `MaintenanceCore._normalized_string_values(...)`
+
+No benchmark matrix behavior, default fallback behavior, sorting order, or error
+handling changes.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`maintenance-benchmark-parameter-normalization-single-convert` in
+`infra/perf/pr_scoped_probes.json`.
+
+The registry entry already defines focused `test_command`, `coverage_command`,
+and `probe_command` values for:
+
+- `services/mlx-worker-python/worker/engine/maintenance_core.py`
+- `services/mlx-worker-python/tests/test_maintenance_service.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/maintenance_benchmark_parameter_normalization_probe.py`
+
+## Verification plan
+
+1. Run the focused helper/parser regression test command from the registered
+   probe locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run the registered PR-scoped performance probe locally against `origin/main`
+   and this branch.
+4. Use the GitHub Actions PR-scoped performance report as the merge gate.
+
+## Expected behavior
+
+The helpers still return de-duplicated sorted positive integers or non-empty
+trimmed strings, still return the provided default tuple when no values survive,
+and still convert non-native `int`/`str` inputs exactly once per input.

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -3004,10 +3004,11 @@ class MaintenanceCore:
     @staticmethod
     def _positive_sorted_values(values, *, default: tuple[int, ...]) -> tuple[int, ...]:
         normalized_values: set[int] = set()
+        add_normalized_value = normalized_values.add
         for value in values:
             parsed = value if type(value) is int else int(value)
             if parsed > 0:
-                normalized_values.add(parsed)
+                add_normalized_value(parsed)
         if not normalized_values:
             return default
         return tuple(sorted(normalized_values))
@@ -3015,11 +3016,13 @@ class MaintenanceCore:
     @staticmethod
     def _normalized_string_values(values, *, default: tuple[str, ...]) -> tuple[str, ...]:
         normalized_values: set[str] = set()
+        add_normalized_value = normalized_values.add
+        strip = str.strip
         for value in values:
             raw_value = value if type(value) is str else str(value)
-            normalized = raw_value.strip()
+            normalized = strip(raw_value)
             if normalized:
-                normalized_values.add(normalized)
+                add_normalized_value(normalized)
         if not normalized_values:
             return default
         return tuple(sorted(normalized_values))


### PR DESCRIPTION
## Summary
- Bind benchmark parameter normalizer `set.add` methods locally for the integer and string helper loops.
- Bind `str.strip` once per string normalization call while preserving one conversion per non-native value.
- Add a focused plan for this performance slice.

## Plan or Spec
- `docs/plans/2026-06-22-maintenance-normalizer-local-bindings.md`

## Commands Run
```text
# Baseline direct probe before code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/maintenance_benchmark_parameter_normalization_probe.py
# exit 0; elapsed_ms_mean=830.223992, native_elapsed_ms_mean=52.792937, empty_default_elapsed_ms_mean=18.150248

# Direct probe after code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/maintenance_benchmark_parameter_normalization_probe.py
# exit 0; elapsed_ms_mean=826.780058, native_elapsed_ms_mean=52.624658, empty_default_elapsed_ms_mean=17.979913

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_parameter_normalization_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_parameter_normalization_probe_script_emits_metrics
# exit 0; 4 passed in 2.28s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_benchmark_helper_parsers_cover_invalid_and_boundary_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_parameter_normalization_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_parameter_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/maintenance_core.py services/mlx-worker-python/tests/test_maintenance_service.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/maintenance_benchmark_parameter_normalization_probe.py
# exit 0; TOTAL 6 0 100%

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id maintenance-benchmark-parameter-normalization-single-convert --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/maintenance-normalizer-local-bindings-1782107417.json
# exit 0; head verification ok; base/head probes ok
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Registered probe: `maintenance-benchmark-parameter-normalization-single-convert`.
- Local direct probe: old `elapsed_ms_mean=830.223992`, new `elapsed_ms_mean=826.780058`, delta `-3.443934 ms` (~0.41% faster). Native path old `52.792937`, new `52.624658`, delta `-0.168279 ms` (~0.32% faster).
- Local registered PR-scoped probe: base `elapsed_ms_mean=837.289896`, head `821.336511`, delta `-15.953385 ms` (~1.91% faster); base `native_elapsed_ms_mean=55.299891`, head `52.160015`, delta `-3.139876 ms` (~5.68% faster); `calls_per_value_mean` remains `1.0`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice.
- CI is the merge gate for the registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no new runtime observability overhead.
- [x] Deferred work and known gaps are stated explicitly.
