### PR TITLE
test: cover VLM stream cache lifecycle

### DIFF
--- a/docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md
+++ b/docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md
@@ -373,6 +373,18 @@ Executable unit issues:
   route-policy tokens in override receipts, treats transcription, speech, and
   image routes as media-aware before model-modality admission, and avoids
   injecting legacy top-level image fallbacks into assistant-only histories.
+- Unit 2.3.3 proves VLM stream/cache lifecycle invariants at the worker/server
+  boundary before any later real feature-cache or direct-decode promotion. The
+  fixture scope covers drained stream cache reuse, cache-hit replay with a fresh
+  request-local stream boundary, early stream close, backend failure,
+  cancellation, model switch, warmup/wake, and explicit unload. Success is
+  measured by idle request counters, zero leaked multimodal requests, stable
+  model-scoped cache ownership until unload, and cleared cache bytes after the
+  owning model unloads.
+- Unit 2.3.3 uses the existing VLM cache-stat probe surface rather than adding a
+  speed gate. The changed-scope performance report should include the
+  deterministic VLM/cache lifecycle probe or an explicit `N/A` if the scoped PR
+  performance selector does not yet expose a dedicated lifecycle probe.
 
 ## Verification Policy
 

--- a/services/mlx-worker-python/tests/test_vlm_stream_lifecycle.py
+++ b/services/mlx-worker-python/tests/test_vlm_stream_lifecycle.py
@@ -11,6 +11,7 @@ from worker.model_registry.catalog import WorkerModelCatalog
 from worker.registry import WorkerRegistry
 from worker.runtime.deterministic_vlm_runtime import DeterministicVLMRuntime
 from worker.runtime.mlx_text_runtime import MLXTextRuntime
+from worker.runtime.temp_media_lifecycle import TempMediaSession
 
 
 class PassiveTextBackend:
@@ -23,9 +24,10 @@ class PassiveTextBackend:
         return 1024
 
 
-def build_services():
+def build_services(vlm_runtime: DeterministicVLMRuntime | None = None):
     registry = WorkerRegistry(
         runtime=MLXTextRuntime(backend=PassiveTextBackend()),
+        vlm_runtime=vlm_runtime,
         model_catalog=WorkerModelCatalog(),
     )
     runtime_service = WorkerRuntimeService(registry)
@@ -41,6 +43,55 @@ def load_model(runtime_service: WorkerRuntimeService, model: common_pb2.ModelSpe
     )
     assert response.ok is True
     return response.model_handle
+
+
+def vlm_model(model_id: str) -> common_pb2.ModelSpec:
+    model = WorkerModelCatalog.dev_vlm_model()
+    model.model_id = model_id
+    model.model_path = f"models/{model_id}"
+    return model
+
+
+def image_request(
+    *,
+    model_handle: str,
+    request_id: str,
+    payload: bytes = b"stream lifecycle reusable cache image",
+    prompt: str = "Summarize the reusable image.",
+    return_usage: bool = True,
+) -> inference_pb2.GenerateRequest:
+    return inference_pb2.GenerateRequest(
+        execution=inference_pb2.ExecutionMetadata(
+            id=common_pb2.RequestIdentity(request_id=request_id),
+            model_handle=model_handle,
+        ),
+        messages=[
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[
+                    common_pb2.MessagePart(text=prompt),
+                    common_pb2.MessagePart(
+                        image_bytes=payload,
+                        media=common_pb2.MediaMetadata(
+                            media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                            source_kind=common_pb2.MEDIA_SOURCE_INLINE_BYTES,
+                        ),
+                    ),
+                ],
+            )
+        ],
+        sampling=common_pb2.SamplingConfig(max_output_tokens=32),
+        stream=True,
+        return_usage=return_usage,
+    )
+
+
+def completed_event(events: list[inference_pb2.ExecuteEvent]) -> inference_pb2.Completed:
+    return next(event.completed for event in events if event.HasField("completed"))
+
+
+def runtime_error_event(events: list[inference_pb2.ExecuteEvent]) -> inference_pb2.ErrorEvent:
+    return next(event.error for event in events if event.HasField("error"))
 
 
 def test_vlm_runtime_close_loaded_model_clears_cache_by_model_scope() -> None:
@@ -149,3 +200,208 @@ def test_vlm_stream_close_preserves_cache_until_explicit_unload() -> None:
     assert receipt.unloaded_at
     assert after_unload.stats.block_count == 0
     assert after_unload.stats.l1_bytes == 0
+
+
+def test_vlm_cache_hit_replay_uses_fresh_request_local_stream_boundary() -> None:
+    runtime_service, inference_service, _ = build_services()
+    runtime = inference_service._registry.vlm_runtime
+    model_handle = load_model(runtime_service, WorkerModelCatalog.dev_vlm_model())
+
+    first_events = list(
+        inference_service.Generate(
+            image_request(model_handle=model_handle, request_id="vlm-cache-boundary-first"),
+            context=None,
+        )
+    )
+    second_events = list(
+        inference_service.Generate(
+            image_request(model_handle=model_handle, request_id="vlm-cache-boundary-second"),
+            context=None,
+        )
+    )
+
+    first_completed = completed_event(first_events)
+    second_completed = completed_event(second_events)
+    first_seqs = [event.seq for event in first_events]
+    second_seqs = [event.seq for event in second_events]
+
+    assert first_events[0].request_id == "vlm-cache-boundary-first"
+    assert second_events[0].request_id == "vlm-cache-boundary-second"
+    assert first_seqs[0] == 1
+    assert second_seqs[0] == 1
+    assert first_completed.parser_metrics["response_id"] == "vlm-cache-boundary-first"
+    assert second_completed.parser_metrics["response_id"] == "vlm-cache-boundary-second"
+    assert first_completed.parser_metrics["stream_mode"] == "true"
+    assert second_completed.parser_metrics["stream_mode"] == "true"
+    assert first_completed.assistant_text == second_completed.assistant_text
+    assert runtime.last_probe_snapshot().cache_hit is True
+
+
+def test_vlm_model_switch_keeps_cache_scopes_isolated_until_each_unload() -> None:
+    runtime_service, inference_service, _ = build_services()
+    registry = inference_service._registry
+    cache_service = WorkerCacheService(registry)
+    first_handle = load_model(runtime_service, vlm_model("melix-test-vlm-switch-a"))
+    second_handle = load_model(runtime_service, vlm_model("melix-test-vlm-switch-b"))
+
+    list(
+        inference_service.Generate(
+            image_request(model_handle=first_handle, request_id="vlm-switch-a"),
+            context=None,
+        )
+    )
+    list(
+        inference_service.Generate(
+            image_request(model_handle=second_handle, request_id="vlm-switch-b"),
+            context=None,
+        )
+    )
+    switched_stats = cache_service.GetCacheStats(cache_pb2.GetCacheStatsRequest(), context=None)
+
+    assert switched_stats.stats.block_count == 2
+    assert {prefix.scope.model_id for prefix in switched_stats.snapshot.hot_prefixes} == {
+        "melix-test-vlm-switch-a",
+        "melix-test-vlm-switch-b",
+    }
+    assert registry.vlm_runtime.last_probe_snapshot().cache_hit is False
+
+    unload_first = runtime_service.UnloadModel(
+        runtime_pb2.UnloadModelRequest(model_handle=first_handle),
+        context=None,
+    )
+    after_first_unload = cache_service.GetCacheStats(cache_pb2.GetCacheStatsRequest(), context=None)
+
+    assert unload_first.ok is True
+    assert after_first_unload.stats.block_count == 1
+    assert [prefix.scope.model_id for prefix in after_first_unload.snapshot.hot_prefixes] == [
+        "melix-test-vlm-switch-b"
+    ]
+
+    list(
+        inference_service.Generate(
+            image_request(model_handle=second_handle, request_id="vlm-switch-b-replay"),
+            context=None,
+        )
+    )
+    after_replay = cache_service.GetCacheStats(cache_pb2.GetCacheStatsRequest(), context=None)
+
+    assert registry.vlm_runtime.last_probe_snapshot().cache_hit is True
+    assert after_replay.stats.block_count == 1
+    assert after_replay.stats.l1_hit_rate > 0.0
+
+
+def test_vlm_warmup_wake_releases_stream_and_resume_uses_fresh_boundary() -> None:
+    runtime_service, inference_service, _ = build_services()
+    registry = inference_service._registry
+    cache_service = WorkerCacheService(registry)
+    model_handle = load_model(runtime_service, WorkerModelCatalog.dev_vlm_model())
+    payload = b"warmup wake resume image"
+    synthetic_messages = image_request(
+        model_handle=model_handle,
+        request_id="unused-warmup-request",
+        payload=payload,
+    ).messages
+
+    warmup = runtime_service.WarmupModel(
+        runtime_pb2.WarmupModelRequest(
+            model_handle=model_handle,
+            synthetic_messages=synthetic_messages,
+        ),
+        context=None,
+    )
+    after_warmup_stats = runtime_service.GetRuntimeStats(runtime_pb2.GetRuntimeStatsRequest(), context=None).stats
+    after_warmup_cache = cache_service.GetCacheStats(cache_pb2.GetCacheStatsRequest(), context=None)
+    resumed_events = list(
+        inference_service.Generate(
+            image_request(
+                model_handle=model_handle,
+                request_id="vlm-warmup-resume",
+                payload=payload,
+            ),
+            context=None,
+        )
+    )
+    resumed_completed = completed_event(resumed_events)
+    after_resume_stats = runtime_service.GetRuntimeStats(runtime_pb2.GetRuntimeStatsRequest(), context=None).stats
+
+    assert warmup.ok is True
+    assert after_warmup_stats.active_requests == 0
+    assert after_warmup_stats.active_multimodal_requests == 0
+    assert after_warmup_cache.stats.block_count == 1
+    assert resumed_events[0].seq == 1
+    assert resumed_completed.parser_metrics["response_id"] == "vlm-warmup-resume"
+    assert registry.vlm_runtime.last_probe_snapshot().cache_hit is True
+    assert after_resume_stats.active_requests == 0
+    assert after_resume_stats.active_multimodal_requests == 0
+
+
+class StageThenFailTempMediaSession(TempMediaSession):
+    def write_bytes(self, relative_name: str, payload: bytes) -> Path:
+        path = super().write_bytes(relative_name, payload)
+        raise OSError(f"staging failed after {path.name}")
+
+
+def test_vlm_failed_generation_cleans_staged_temp_media_and_releases_stream(tmp_path: Path) -> None:
+    sessions: list[StageThenFailTempMediaSession] = []
+
+    def session_factory(**kwargs) -> StageThenFailTempMediaSession:
+        session = StageThenFailTempMediaSession(**kwargs)
+        sessions.append(session)
+        return session
+
+    runtime = DeterministicVLMRuntime(
+        temp_root=tmp_path,
+        temp_media_session_factory=session_factory,
+    )
+    runtime_service, inference_service, _ = build_services(vlm_runtime=runtime)
+    model_handle = load_model(runtime_service, WorkerModelCatalog.dev_vlm_model())
+
+    events = list(
+        inference_service.Generate(
+            image_request(model_handle=model_handle, request_id="vlm-staging-failure"),
+            context=None,
+        )
+    )
+    error = runtime_error_event(events).error
+    stats = runtime_service.GetRuntimeStats(runtime_pb2.GetRuntimeStatsRequest(), context=None).stats
+    probe = runtime.last_probe_snapshot()
+
+    assert error.code == "runtime_error"
+    assert "staging failed after image-0.bin" in error.message
+    assert sessions[0].session_root is not None
+    assert not sessions[0].session_root.exists()
+    assert probe.temp_media_artifact_count == 1
+    assert probe.temp_media_artifact_bytes == len(b"stream lifecycle reusable cache image")
+    assert probe.temp_media_cleanup_failure_count == 0
+    assert stats.active_requests == 0
+    assert stats.active_multimodal_requests == 0
+
+
+def test_vlm_abort_cleans_temp_media_and_releases_request_state() -> None:
+    runtime_service, inference_service, _ = build_services()
+    registry = inference_service._registry
+    model_handle = load_model(runtime_service, WorkerModelCatalog.dev_vlm_model())
+    stream = inference_service.Generate(
+        image_request(model_handle=model_handle, request_id="vlm-abort-cleanup"),
+        context=None,
+    )
+
+    first_event = next(stream)
+    abort = inference_service.Abort(
+        inference_pb2.AbortRequest(request_id="vlm-abort-cleanup"),
+        context=None,
+    )
+    remaining_events = list(stream)
+    completed = completed_event(remaining_events)
+    stats = runtime_service.GetRuntimeStats(runtime_pb2.GetRuntimeStatsRequest(), context=None).stats
+    probe = registry.vlm_runtime.last_probe_snapshot()
+
+    assert first_event.HasField("token_delta")
+    assert abort.ok is True
+    assert completed.finish_reason == "cancelled"
+    assert registry.get_request("vlm-abort-cleanup") is None
+    assert stats.active_requests == 0
+    assert stats.active_multimodal_requests == 0
+    assert probe.temp_media_artifact_count == 1
+    assert probe.temp_media_artifact_bytes == len(b"stream lifecycle reusable cache image")
+    assert probe.temp_media_cleanup_failure_count == 0

--- a/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
@@ -516,8 +516,8 @@ class DeterministicVLMRuntime(DeterministicProbeMixin[VisionProbeSnapshot]):
             temp_root=self._temp_root,
             prefix="melix-vlm-",
         )
-        self._stage_temp_media(prepared_request, temp_media_session)
         try:
+            self._stage_temp_media(prepared_request, temp_media_session)
             sleep_if_configured("vlm")
             if cancel_event.is_set():
                 return


### PR DESCRIPTION
## Summary
- Add deterministic VLM lifecycle coverage for cache-hit replay, model switch isolation, explicit unload ownership, wake/resume, failed staging, and cancellation.
- Move deterministic VLM temp-media staging under the existing cleanup `try/finally` so partially staged artifacts are cleaned when staging fails.
- Update the Issue 42 multimodal fast-path plan with the Unit 2.3.3 lifecycle fixture scope, success metrics, and probe expectations.

Closes #1455

## Plan or Spec
- `docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md` (Unit 2.3.3 execution note added for VLM stream/cache lifecycle tests).

## Commands Run
```text
make proto
# passed: ./scripts/proto_gen.sh

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_vlm_stream_lifecycle.py -q
# 7 passed in 0.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file=.runtime/coverage/issue1455-latestmain.coverage -m pytest -q services/mlx-worker-python/tests/test_vlm_stream_lifecycle.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file=.runtime/coverage/issue1455-latestmain.coverage -o .runtime/coverage/issue1455-latestmain.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json .runtime/coverage/issue1455-latestmain.json services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py services/mlx-worker-python/tests/test_vlm_stream_lifecycle.py
# 7 passed in 0.57s; TOTAL 100.00% 124/124

git diff --check origin/main...HEAD
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_completion_token_count_scans_without_split_list services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_completion_token_count_reuses_last_response_scan services/mlx-worker-python/tests/test_vision_runtime.py::test_vlm_generate_reuses_prompt_token_count_for_probe_and_event services/mlx-worker-python/tests/test_vision_runtime.py::test_generate_streams_vlm_response_from_file_image_uri services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_vlm_completion_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_vlm_completion_token_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once
# 10 passed in 0.22s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/deterministic_vlm_completion_token_probe.py --json
# {"completion_tokens": 6000, "elapsed_ms_mean": 30.584541335701942, "iterations": 400, "peak_bytes_mean": 348786.6, "prompt_token_count_calls_mean": 400.0, "samples": 5, "split_calls_mean": 0.0, "token_count_calls_mean": 1.0}

git commit -m "test: cover vlm stream cache lifecycle"
# pre-commit gate passed: make swift-test rc=0, make py-test rc=0, make integration-test rc=0, scoped performance report ok
```

Pre-commit gate details:
```text
make swift-test
# passed: protocol 1 test; text worker 241 tests; control-plane core 509 tests; RequestCoordinator shards passed; OpenAI handler 224 tests; REST compatibility 46 tests; worker clients 127 tests; macOS menubar 831 tests

make py-test
# 4213 passed, 14 skipped, 2 warnings in 172.40s

make integration-test
# 122 passed, 1 skipped in 762.42s

.runtime/pre-commit-performance/20260622-060206-29a602ba/report/report.md
# Status ok; selected probes 1; regressions 0; context regressions 0; verification failures 0
```

## Coverage and Metrics
- Changed-line coverage: `100.00%` (`124/124`) for `deterministic_vlm_runtime.py` and `test_vlm_stream_lifecycle.py`, measured against `origin/main` after merging the latest main.
- Pre-commit performance report: `.runtime/pre-commit-performance/20260622-060206-29a602ba/report/report.md`
  - Status: `ok`
  - Selected probes: `1`
  - Regressions: `0`
  - Context regressions: `0`
  - Verification failures: `0`
  - Direct probe: deterministic VLM completion token scan, targeted tests passed, coverage passed (`100.0%`).
- Performance metrics from the pre-commit report:
  - `split_calls_mean`: base `0.000`, head `0.000`, delta `+0.000`, neutral.
  - `elapsed_ms_mean`: base `31.042`, head `32.145`, delta `+1.102` (`+3.55%`), neutral.
  - `peak_bytes_mean`: base `347969.000`, head `348786.600`, delta `+817.600` (`+0.23%`), neutral.
  - `prompt_token_count_calls_mean`: base `400.000`, head `400.000`, delta `+0.000`, neutral.
  - `completion_tokens`: base `6000.000`, head `6000.000`, delta `+0.000`, neutral.
- Observability mode: `evidence`; this change extends deterministic lifecycle evidence through existing VLM cache/probe receipts and does not add production metrics.
- Probe overhead: existing direct deterministic VLM completion token scan only; no new runtime instrumentation or production overhead.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
