### PR TITLE
perf: fast-path model load path access

### DIFF
--- a/docs/plans/2026-06-22-model-load-model-path-attr-fastpath.md
+++ b/docs/plans/2026-06-22-model-load-model-path-attr-fastpath.md
@@ -1,0 +1,22 @@
+# Model Load Model Path Attribute Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to model-load trust policy custom-loader detection in `services/mlx-worker-python/worker/model_load_trust.py`.
+
+Repeated local model-load trust checks read `ModelSpec.model_path` before probing `config.json`. Earlier slices removed unnecessary `Path.expanduser()` and `Path` join work for plain paths. This slice removes the remaining generic `getattr(..., "model_path", "")` lookup in the hot path and uses the typed protobuf field directly.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `model-load-config-json-bytes` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries and selects this probe when `worker/model_load_trust.py` changes.
+
+## Implementation plan
+
+1. Preserve the existing model-load trust behavior tests for custom-loader detection, config byte loading, stat-keyed caching, tilde expansion, plain-path fast paths, and missing config handling.
+2. Update `_read_model_config()` to read `model_spec.model_path` directly instead of using a dynamic attribute fallback.
+3. Run the registered focused tests, changed-scope coverage, and local PR-scoped probe on Linux.
+4. Use GitHub Actions PR-scoped performance as the final registered probe validation before merge.
+
+## Expected outcome
+
+The repeated-resolution probe should show a small latency reduction for the typed `ModelSpec` hot path without changing custom-loader detection receipts, tilde-path behavior, or missing-config behavior.

--- a/services/mlx-worker-python/worker/model_load_trust.py
+++ b/services/mlx-worker-python/worker/model_load_trust.py
@@ -229,7 +229,7 @@ def _auto_map_has_custom_loader(auto_map: dict[Any, Any]) -> bool:
 
 
 def _read_model_config(model_spec: common_pb2.ModelSpec) -> dict[str, Any] | None:
-    model_path = str(getattr(model_spec, "model_path", "") or "").strip()
+    model_path = str(model_spec.model_path or "").strip()
     if not model_path:
         return None
     if model_path[0] == "~":


### PR DESCRIPTION
## Summary
- Fast-path model-load trust config probing by reading the typed `ModelSpec.model_path` field directly instead of using a dynamic `getattr` fallback.
- Add a scoped plan for the model-load path-access performance slice.

## Plan or Spec
- `docs/plans/2026-06-22-model-load-model-path-attr-fastpath.md`

## Commands Run
```text
# Focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...
Result: 16 passed in 1.87s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_load_trust.py services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/model_load_config_json_bytes_probe.py
Result: 16 passed in 0.85s; TOTAL 1 0 100%

# Registered local probe script
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/model_load_config_json_bytes_probe.py
Result: {"config_padding_bytes": 4096, "elapsed_ms_mean": 7.904843277564006, "elapsed_ms_min": 7.825737993698567, "iterations": 300, "peak_bytes_mean": 2695.4285714285716, "rejections_mean": 300.0, "samples": 7}

# Local registered base-vs-head probe runner
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id model-load-config-json-bytes --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-model-load-stat-local-bindings-20260622 --output /tmp/model-load-config-json-bytes-result.json
Result: tests pass, coverage 100%; base elapsed_ms_mean=7.8948444237799515, head elapsed_ms_mean=7.958194860423516; peak bytes unchanged.

# Extended alternating local samples used to reduce short-probe noise
Base (5x, samples=9, iterations=1200): mean elapsed_ms_mean=32.66079331127306
Head (5x, samples=9, iterations=1200): mean elapsed_ms_mean=32.462092534923514
Delta: -0.19870077634954697 ms (-0.6083770668269844%)
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` for `services/mlx-worker-python/worker/model_load_trust.py` changed line 232.
- Registered probe: `model-load-config-json-bytes` is already declared in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.
- Local extended probe delta: `old_mean=32.66079331127306 ms`, `new_mean=32.462092534923514 ms`, `speedup=0.6083770668269844%`, `delta_ms=-0.19870077634954697`.
- Local short registered runner was neutral/noisy (`old_mean=7.8948444237799515 ms`, `new_mean=7.958194860423516 ms`, `delta_ms=+0.06335043664356437`) with unchanged peak bytes; CI PR-scoped performance is required as the registered validation source before merge.

## Known Gaps
- No Swift runtime validation is applicable; this is a Python-only path and was locally verified on Linux.
- The default 300-iteration local registered probe is noisy at this small delta; merge should wait for the GitHub Actions PR-scoped performance report to complete successfully.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability-mode changes; existing PR-scoped probe is reused.
- [x] Deferred work and known gaps are stated explicitly.
