### PR TITLE
perf: skip stale HF cache snapshot stat checks

### DIFF
--- a/scripts/real_model_support.py
+++ b/scripts/real_model_support.py
@@ -295,10 +295,12 @@ def _huggingface_cache_model_path(
     latest_snapshot_name: str | None = None
     with os.scandir(snapshots_root) as entries:
         for entry in entries:
+            entry_name = entry.name
+            if latest_snapshot_name is not None and entry_name <= latest_snapshot_name:
+                continue
             if not entry.is_dir(follow_symlinks=False):
                 continue
-            if latest_snapshot_name is None or entry.name > latest_snapshot_name:
-                latest_snapshot_name = entry.name
+            latest_snapshot_name = entry_name
     if latest_snapshot_name is None:
         return None
     fallback = snapshots_root / latest_snapshot_name

--- a/tests/test_real_model_support.py
+++ b/tests/test_real_model_support.py
@@ -325,6 +325,66 @@ def test_hf_cache_snapshot_fallback_does_not_follow_symlinked_directories(
     assert source.source_resolution_mode == "hf_cache_snapshot"
 
 
+def test_hf_cache_snapshot_fallback_skips_stale_names_before_is_dir(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home = tmp_path / "home"
+    snapshots_root = (
+        home
+        / ".cache"
+        / "huggingface"
+        / "hub"
+        / "models--mlx-community--Qwen3.5-0.8B-OptiQ-4bit"
+        / "snapshots"
+    )
+    snapshots_root.mkdir(parents=True)
+    latest_snapshot = snapshots_root / "zzz"
+    latest_snapshot.mkdir()
+    is_dir_calls: list[str] = []
+
+    class _FakeEntry:
+        def __init__(self, name: str, is_directory: bool = True) -> None:
+            self.name = name
+            self._is_directory = is_directory
+
+        def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+            if follow_symlinks:
+                raise AssertionError("HF cache snapshot scan should not follow symlinks")
+            is_dir_calls.append(self.name)
+            return self._is_directory
+
+    class _FakeScandir:
+        def __enter__(self):
+            return iter(
+                (
+                    _FakeEntry("zzz"),
+                    _FakeEntry("aaa"),
+                    _FakeEntry("not-a-directory", is_directory=False),
+                    _FakeEntry("mno"),
+                )
+            )
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    def fake_scandir(path: Path):
+        assert path == snapshots_root
+        return _FakeScandir()
+
+    monkeypatch.setattr(real_model_support_module.os, "scandir", fake_scandir)
+
+    source = resolve_real_small_text_model_source(
+        environment={"HOME": str(home)},
+        allow_managed_root=False,
+        allow_hf_cache=True,
+    )
+
+    assert source.live is False
+    assert source.local_model_path == str(latest_snapshot.resolve())
+    assert is_dir_calls == ["zzz"]
+
+
 def test_runtime_model_preflight_marks_real_local_weights(tmp_path: Path) -> None:
     model_dir = tmp_path / "qwen-real-small"
     model_dir.mkdir()


### PR DESCRIPTION
## Summary
- Optimize the Hugging Face cache snapshot fallback scan by comparing each entry name before calling `DirEntry.is_dir()`.
- Add a regression test proving stale lexicographic candidates are skipped before stat-like directory checks while preserving no-symlink-follow behavior.

## Plan or Spec
- Governing probe: `infra/perf/pr_scoped_probes.json` entry `real-model-support-hf-cache-latest-snapshot`.
- N/A for docs/spec update: this is an implementation-only optimization that preserves the existing HF cache fallback behavior and workflow.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_does_not_follow_symlinked_directories tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_skips_stale_names_before_is_dir tests/test_real_model_support.py::test_runtime_model_preflight_short_circuits_common_exact_weight_file services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics
# 8 passed in 2.85s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_does_not_follow_symlinked_directories tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_skips_stale_names_before_is_dir tests/test_real_model_support.py::test_runtime_model_preflight_short_circuits_common_exact_weight_file services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics
# 8 passed in 3.28s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/real_model_support.py tests/test_real_model_support.py scripts/real_model_support_hf_cache_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 33 1 97%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/real_model_support_hf_cache_probe.py
# {"hf_cache_elapsed_ms_mean": 17.519747, "hf_cache_peak_bytes_mean": 4121.0, "sample_count": 7.0, "selected_latest_snapshot": 5999.0, "snapshot_count": 6000.0, "weight_file_count": 20000.0, "weight_scan_elapsed_ms_mean": 0.028708}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 33 1 97%`.
- Registered probe: `real-model-support-hf-cache-latest-snapshot`.
- Local three-run old/new probe comparison for `hf_cache_elapsed_ms_mean`:
  - old mean: `17.009908 ms`
  - new mean: `16.773245 ms`
  - delta: `-0.236662 ms` (`1.39%` faster)
- Latest local registered probe output on this branch: `hf_cache_elapsed_ms_mean=17.519747`, `hf_cache_peak_bytes_mean=4121.0`, `weight_scan_elapsed_ms_mean=0.028708`.
- CI PR-scoped performance report is required as the merge validation source.

## Known Gaps
- Full repository gates were not run locally; this slice used the registered focused test/coverage/probe commands.
- Local Linux validates the Python path only; no Swift runtime behavior is changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is explained.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
