### PR TITLE
perf: fast-path hub size hint newline scan

### DIFF
--- a/docs/plans/2026-06-22-hub-catalog-size-hint-newline-fastpath.md
+++ b/docs/plans/2026-06-22-hub-catalog-size-hint-newline-fastpath.md
@@ -1,0 +1,34 @@
+# Hub Catalog Size Hint Newline Fast Path
+
+## Goal
+
+Reduce Python-level scanning in the Hub catalog explicit size-hint parser for the common README/card line form where the `Model size` value ends at `\n`.
+
+## Touched Files
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Registered Probe
+
+Registered PR-scoped probe: `hub-catalog-size-hint-regex-precompile`.
+
+The probe already watches the Hub catalog parser, its focused tests, and `scripts/hub_catalog_size_hint_probe.py`; it includes focused `test_command`, `coverage_command`, and `probe_command` entries. This slice relies on:
+
+- `elapsed_ms_mean` — lower is better.
+- `size_hint_calls_mean` — structural guard rail for regex fallback calls.
+- `matched_hint_count` and `checksum` — behavior guard rails.
+
+## Implementation Slice
+
+Use `str.find("\n", value_start)` before the existing generic line-terminator loop in `_direct_explicit_size_hint_from_text`. This keeps the existing fallback for non-LF Unicode/legacy line separators while shifting the common README path to a C-level search.
+
+## Verification Plan
+
+1. Run the focused Hub catalog tests and PR-scoped performance tests from the registered probe.
+2. Run changed-scope coverage for the registered files and require at least 95% measured coverage.
+3. Run `scripts/hub_catalog_size_hint_probe.py` on Linux before and after the change and compare `elapsed_ms_mean` with unchanged guard rails.
+4. Run `git diff --check` before commit.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -886,10 +886,14 @@ def _direct_explicit_size_hint_from_text(text: str) -> int:
     while value_start < text_length and text[value_start].isspace():
         value_start += 1
 
+    newline_index = text.find("\n", value_start)
+    if newline_index >= 0:
+        return _direct_size_hint_from_text(text[value_start:newline_index])
+
     value_end = value_start
     while (
         value_end < text_length
-        and text[value_end] not in "\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029"
+        and text[value_end] not in "\r\v\f\x1c\x1d\x1e\x85\u2028\u2029"
     ):
         value_end += 1
     return _direct_size_hint_from_text(text[value_start:value_end])


### PR DESCRIPTION
## Summary
- Fast-path Hub catalog explicit size-hint parsing when the value line ends with the common `\n` separator.
- Preserve the existing generic line-terminator fallback for CR/legacy/Unicode separators.
- Add the slice plan for the newline fast path and registered probe evidence.

## Plan or Spec
- `docs/plans/2026-06-22-hub-catalog-size-hint-newline-fastpath.md`
- Registered PR-scoped probe: `hub-catalog-size-hint-regex-precompile`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py` (baseline on `origin/main` before edit)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py` (head)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 85 passed.
- Changed-scope coverage: 100.00% (`TOTAL 3 0 100%`).
- Local Linux probe baseline: `elapsed_ms_mean=1786.9683456025086`, `checksum=1545732096.0`, `matched_hint_count=120000.0`, `size_hint_calls_mean=0.0`.
- Local Linux probe head: `elapsed_ms_mean=1735.4312873911113`, `checksum=1545732096.0`, `matched_hint_count=120000.0`, `size_hint_calls_mean=0.0`.
- Delta: `-51.537058 ms`, speedup `1.029697x`, improvement `2.884%`.

## Known Gaps
- This is a Python-only slice verified locally on Linux. CI must run the registered PR-scoped performance workflow before merge.
- The compatibility sub-metric is informational/noisier for this slice and is not the optimization target.

## Evidence Checklist
- [x] Registered PR-scoped probe exists with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows lower target elapsed time with unchanged guard rails.
- [x] `git diff --check` passed.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
