### PR TITLE
perf: fast-path trajectory manifest byte reads

### DIFF
--- a/docs/plans/2026-06-22-trajectory-manifest-open-fastpath.md
+++ b/docs/plans/2026-06-22-trajectory-manifest-open-fastpath.md
@@ -1,0 +1,22 @@
+# Trajectory Manifest Open Fast Path
+
+This Python-only performance slice is limited to `worker.trajectory_provenance.load_trajectory_provenance_from_snapshot_manifest`.
+
+## Scope
+
+The manifest loader is a hot path for agentic trajectory provenance extraction. The current implementation materializes a `Path` for string inputs and then delegates to `Path.read_bytes()`. This slice keeps the same JSON parsing and provenance projection behavior while reading the manifest through `open(..., "rb")`, which accepts both `str` and `Path` inputs and avoids the extra `Path` allocation/delegation for string paths.
+
+## Registered performance probe
+
+The affected path is covered by registered PR-scoped probe `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`. The probe includes focused tests, changed-scope coverage, and `scripts/trajectory_manifest_json_load_probe.py`.
+
+## Verification plan
+
+1. Run the registered focused test command for `trajectory-manifest-json-load` locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run the registered probe command locally on Linux and record old/new metrics.
+4. Use GitHub Actions PR-scoped performance as the final registered probe validation and merge gate.
+
+## Metrics expectation
+
+The expected improvement is small but directional: lower `new_mean_ms`/`elapsed_ms_mean` for manifest JSON loading by avoiding `Path.read_bytes()` delegation while preserving the existing byte-loading JSON parser behavior.

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 _JSON_LOADS = json.loads
-_PATH_READ_BYTES = Path.read_bytes
+_OPEN = open
 _STR = str
 
 
@@ -309,13 +309,12 @@ def _trajectory_provenance_from_snapshot_manifest(
 def load_trajectory_provenance_from_snapshot_manifest(
     manifest_path: Path | str,
 ) -> dict[str, Any]:
-    read_bytes = _PATH_READ_BYTES
+    open_file = _OPEN
     loads = _JSON_LOADS
     extract_provenance = _trajectory_provenance_from_snapshot_manifest
-    if not isinstance(manifest_path, Path):
-        manifest_path = Path(manifest_path)
     manifest_path_text = _STR(manifest_path)
-    payload = loads(read_bytes(manifest_path))
+    with open_file(manifest_path, "rb") as file:
+        payload = loads(file.read())
     if type(payload) is dict:
         return extract_provenance(
             payload,


### PR DESCRIPTION
## Summary
- Fast-path trajectory manifest loading through `open(..., "rb")` for both `str` and `Path` inputs.
- Avoids materializing a `Path` only to call `Path.read_bytes()` before JSON decoding.
- Adds the governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-22-trajectory-manifest-open-fastpath.md`
- Registered probe: `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_fast_paths_clean_text services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_fast_path_falls_back_for_defaulted_required_fields services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reuses_path_text services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_accepts_dict_subclass services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q ...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 15 passed.
- Changed-scope coverage: 100.00% (`4/4` measurable changed lines covered).
- Registered local probe `trajectory-manifest-json-load`: `old_mean_ms=1348.042620`, `new_mean_ms=693.406197`, `delta_ms=-654.636424`, `speedup=1.944088`, `sample_count=5`, `iteration_count=2000`, `component_count=64`.
- CI PR-scoped performance is required as the final registered probe validation source before merge.

## Known Gaps
- Python-only slice validated locally on Linux. No Swift runtime effects are claimed.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally with directional improvement.
- [ ] GitHub Actions PR-scoped performance completed successfully.
