### PR TITLE
perf: elide startup log tail search window

### DIFF
--- a/docs/plans/2026-06-22-startup-log-tail-length-cache.md
+++ b/docs/plans/2026-06-22-startup-log-tail-length-cache.md
@@ -1,0 +1,26 @@
+# Startup log tail scan search-window elision
+
+## Context
+
+`worker.productization.startup_signals._seek_last_nonempty_line_bounds(...)`
+walks startup logs backward in fixed-size chunks to find the last non-empty
+line used in startup failure reports. The registered PR-scoped performance
+probe `startup-signals-lazy-worker-log-excerpts` already covers this path with
+focused tests, coverage, and a tail-scan workload containing substantial
+trailing whitespace.
+
+## Optimization Slice
+
+Defer computing the full chunk search window until after the trailing-whitespace
+phase has found payload bytes. Whitespace-only chunks now skip the otherwise
+unused `len(chunk)` dispatch and continue directly to the previous chunk. This
+keeps the newline search and returned bounds unchanged while trimming a tiny
+amount of overhead from long trailing-whitespace scans.
+
+## Verification
+
+- Focused startup-signal regression tests.
+- Changed-scope coverage for `startup_signals.py`, its tests, the registered
+  probe script, and the PR-scoped probe registry tests.
+- Local Linux run of the registered `startup-signals-lazy-worker-log-excerpts`
+  probe before and after the change.

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -471,13 +471,14 @@ def _seek_last_nonempty_line_bounds(handle: Any, *, chunk_size: int) -> tuple[in
         start = position - read_size
         handle.seek(start)
         chunk = handle.read(read_size)
-        search_end = len(chunk)
         if payload_end == 0:
             search_end = len(chunk.rstrip(_BYTE_WHITESPACE))
             if search_end == 0:
                 position = start
                 continue
             payload_end = start + search_end
+        else:
+            search_end = len(chunk)
         newline_index = chunk.rfind(b"\n", 0, search_end)
         if newline_index < 0:
             newline_index = chunk.rfind(b"\r", 0, search_end)


### PR DESCRIPTION
## Summary
- Defers the startup log tail scan's full chunk-length search window until after trailing-whitespace chunks have been skipped.
- Keeps startup failure excerpt behavior unchanged while trimming a small amount of overhead from long trailing-whitespace log tails.

## Plan or Spec
- `docs/plans/2026-06-22-startup-log-tail-length-cache.md`

## Commands Run
```text
# Baseline before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py
# exit 0; tail_scan_elapsed_ms_mean=152.194139; tail_scan_peak_bytes_mean=21436.2

# Focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# exit 0; 48 passed in 1.72s

# Changed-scope coverage via registered coverage_command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
# exit 0; TOTAL 1 0 100%

# Registered local probe after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py
# exit 0; tail_scan_elapsed_ms_mean=145.814889; tail_scan_peak_bytes_mean=21436.2

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered probe: `startup-signals-lazy-worker-log-excerpts` (already present in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command`).
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Local Linux probe delta: `old_mean=152.194139ms`, `new_mean=145.814889ms`, `delta_ms=-6.379250`, `speedup=1.043749x` (`4.192%` lower) for `tail_scan_elapsed_ms_mean`.
- CI is required for the registered PR-scoped probe validation before merge.

## Known Gaps
- None for this Python-only slice. No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
