### PR TITLE
perf: bind local job follow-up projection loop

### DIFF
--- a/docs/plans/2026-06-22-local-job-followup-projection-loop-bindings.md
+++ b/docs/plans/2026-06-22-local-job-followup-projection-loop-bindings.md
@@ -1,0 +1,20 @@
+# Local job follow-up projection loop bindings
+
+## Scope
+
+This slice keeps the local job continuation scan behavior unchanged and narrows only the projection loop in `project_local_job_session_followups()`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `local-job-followup-scan-scandir` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for the local job continuation module, tests, registry selection, and `scripts/local_job_followup_scan_probe.py`.
+
+## Optimization
+
+The projection loop now binds the per-claim projection helper and list append methods once before iterating over scanned follow-up claims. This avoids repeated attribute/global lookups in large follow-up batches while preserving the existing copied receipt/refusal output contract.
+
+## Verification plan
+
+1. Run the focused local job continuation tests from the registered probe.
+2. Run changed-scope coverage from the registered probe and remove generated `coverage.json` afterwards.
+3. Run `scripts/local_job_followup_scan_probe.py` locally on Linux and compare the local projection/scan metrics with the pre-change baseline.
+4. Use the PR-scoped performance workflow as the merge gate before squash merging.

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -897,12 +897,16 @@ def project_local_job_session_followups(
     )
     projections: list[LocalJobSessionFollowupProjection] = []
     followup_messages: list[dict[str, Any]] = []
+    project_claim = _project_local_job_session_followup_claim
+    projections_append = projections.append
+    followup_messages_append = followup_messages.append
 
     for claim in claim_batch.claims:
-        projection = _project_local_job_session_followup_claim(claim)
-        projections.append(projection)
-        if projection.followup_message is not None:
-            followup_messages.append(projection.followup_message)
+        projection = project_claim(claim)
+        projections_append(projection)
+        followup_message = projection.followup_message
+        if followup_message is not None:
+            followup_messages_append(followup_message)
 
     return LocalJobSessionFollowupProjectionBatch(
         claim_batch=claim_batch,


### PR DESCRIPTION
## Summary
- Binds the local job follow-up projection helper and list append methods once before the per-claim loop.
- Keeps the scan, prompt-context projection, copied receipt, and refusal output contracts unchanged.
- Adds a slice plan documenting the registered probe and verification path.

## Plan or Spec
- `docs/plans/2026-06-22-local-job-followup-projection-loop-bindings.md`
- Registered PR-scoped probe: `local-job-followup-scan-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin` / verified `main` at `origin/main` before branching.
- Baseline probe on `origin/main` branch (3 local Linux runs): `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py`
- Candidate probe after implementation (3 local Linux runs): same command.
- Focused tests from registered probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (13 tests)
- Changed-scope coverage from registered probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && ... changed_scope_coverage.py ...`
- Final registered probe sanity run: same probe command.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 13 passed.
- Changed-scope coverage: 100.00% (8/8 measurable changed lines covered) for `services/mlx-worker-python/worker/runtime/local_job_continuation.py`.
- Local Linux probe, 3-run mean comparison:
  - Scan elapsed: old_mean=27.959535 ms, new_mean=27.115557 ms, delta=-0.843978 ms, speedup=1.0311x.
  - Projection elapsed: old_mean=149.466631 ms, new_mean=148.343901 ms, delta=-1.122730 ms, speedup=1.0076x.
  - Syscall shape remained stable: `scandir_calls_mean=1.0`, `path_glob_calls_mean=0.0`, `path_exists_calls_mean=0.0`.
- Final post-change probe sanity run: `elapsed_ms_mean=25.131859`, `projection_elapsed_ms_mean=141.277929`, `candidate_count_mean=500.0`, `projection_count_mean=250.0`.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- This is a Python-only local optimization validated on Linux; no Swift runtime path is touched.
- The local speedup is intentionally small because this slice only removes loop lookup overhead in an already optimized path.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branch creation.
- [x] Affected path has a registered PR-scoped performance probe with test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage passed at >=95%.
- [x] Registered probe ran locally with improved direction.
- [ ] GitHub Actions, including PR-scoped performance, completed successfully.
