### PR TITLE
perf: skip casefold for whitespace tool turns

### DIFF
--- a/docs/plans/2026-06-22-tool-registry-whitespace-precasefold-performance.md
+++ b/docs/plans/2026-06-22-tool-registry-whitespace-precasefold-performance.md
@@ -1,0 +1,29 @@
+# Tool Registry Whitespace Pre-Casefold Performance Slice
+
+## Context
+
+The agentic tool selector scans the current user turn for keyword hints when vector selection is unavailable. Whitespace-only turns cannot match any tool keyword, but the selector previously casefolded the string before checking `isspace()`, allocating and scanning text that can be rejected directly.
+
+## Slice
+
+Move the whitespace-only guard in `_keyword_tool_matches()` before `casefold()` so empty/blank turns return the fallback local-compute selection without allocating a normalized string.
+
+## Probe Coverage
+
+The existing registered PR-scoped probe `tool-registry-select-name-index-cache` covers `services/mlx-worker-python/worker/runtime/tool_registry.py` and runs focused tool-registry tests, coverage, and `scripts/tool_registry_select_probe.py`.
+
+This slice extends that probe with:
+
+- `whitespace_turn_planning_elapsed_ms_mean` (`lower_is_better`)
+- `whitespace_turn_selected_schema_bytes_mean` (`informational`)
+
+## Verification Plan
+
+- Focused regression test: `test_agentic_tool_selection_whitespace_turn_skips_casefold`.
+- Changed-scope coverage through the registered probe coverage command.
+- Registered local probe run on Linux for old/new timing comparison.
+- GitHub Actions PR-scoped performance report before merge.
+
+## Expected Outcome
+
+Whitespace-only selector planning should avoid `casefold()` and improve the registered whitespace-turn probe metric while preserving the same fallback selection behavior.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4798,6 +4798,17 @@
         "key": "always_only_selected_schema_bytes_mean",
         "unit": "bytes",
         "direction": "informational"
+      },
+      {
+        "key": "whitespace_turn_planning_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "whitespace_turn_selected_schema_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
       }
     ]
   },

--- a/scripts/tool_registry_select_probe.py
+++ b/scripts/tool_registry_select_probe.py
@@ -12,6 +12,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
+from worker.runtime import tool_registry as tool_registry_module  # noqa: E402
 from worker.runtime.tool_registry import (  # noqa: E402
     ToolSelectionInput,
     ToolRegistryError,
@@ -44,6 +45,8 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     current_capacity_selected_schema_bytes_samples: list[float] = []
     always_only_planning_elapsed_samples: list[float] = []
     always_only_selected_schema_bytes_samples: list[float] = []
+    whitespace_turn_planning_elapsed_samples: list[float] = []
+    whitespace_turn_selected_schema_bytes_samples: list[float] = []
     checksum = 0
 
     for _ in range(sample_count):
@@ -173,6 +176,27 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         )
         checksum += always_only_schema_bytes
 
+        whitespace_turn_schema_bytes = 0
+        keyword_match_cache_clear = tool_registry_module._keyword_tool_matches.cache_clear
+        whitespace_turn_started = time.perf_counter()
+        for _index in range(selector_iterations):
+            keyword_match_cache_clear()
+            selection_result = select_agentic_tools_for_turn(
+                ToolSelectionInput(
+                    current_user_turn=" \t\n  ",
+                    vector_available=False,
+                    max_selected_tools=4,
+                )
+            )
+            whitespace_turn_schema_bytes += int(selection_result.receipt["selected_schema_bytes"])
+        whitespace_turn_planning_elapsed_samples.append(
+            (time.perf_counter() - whitespace_turn_started) * 1000.0
+        )
+        whitespace_turn_selected_schema_bytes_samples.append(
+            float(whitespace_turn_schema_bytes / selector_iterations)
+        )
+        checksum += whitespace_turn_schema_bytes
+
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
         "select_calls_mean": float(iterations),
@@ -203,6 +227,12 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         ),
         "always_only_selected_schema_bytes_mean": statistics.fmean(
             always_only_selected_schema_bytes_samples
+        ),
+        "whitespace_turn_planning_elapsed_ms_mean": statistics.fmean(
+            whitespace_turn_planning_elapsed_samples
+        ),
+        "whitespace_turn_selected_schema_bytes_mean": statistics.fmean(
+            whitespace_turn_selected_schema_bytes_samples
         ),
         "checksum": float(checksum),
         "iterations": float(iterations),

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -755,6 +755,24 @@ def test_agentic_tool_selection_uses_keyword_fallback_when_vector_unavailable() 
     ]
 
 
+def test_agentic_tool_selection_whitespace_turn_skips_casefold() -> None:
+    class CasefoldFailingWhitespace(str):
+        def casefold(self) -> str:  # pragma: no cover - must not be called
+            raise AssertionError("whitespace-only turns should skip casefold")
+
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn=CasefoldFailingWhitespace(" \t\n  "),
+            vector_available=False,
+            max_selected_tools=4,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute",)
+    assert result.receipt["selection_mode"] == "fallback"
+    assert result.receipt["fallback_reason"] == "no_keyword_match"
+
+
 def test_agentic_tool_selection_skips_empty_context_keyword_scan(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -633,9 +633,9 @@ def _recent_user_turns_keyword_context(recent_user_turns: tuple[str, ...]) -> st
 def _keyword_tool_matches(text: str) -> tuple[str, ...]:
     if not text:
         return ()
-    normalized_text = text.casefold()
-    if normalized_text.isspace():
+    if text.isspace():
         return ()
+    normalized_text = text.casefold()
     boundary_text = ""
     matches: list[str] = []
     append_match = matches.append


### PR DESCRIPTION
## Summary
- Skip `casefold()` for whitespace-only tool-selection turns before keyword matching.
- Add a regression test proving whitespace-only turns keep fallback behavior without calling `casefold()`.
- Extend the registered `tool-registry-select-name-index-cache` PR-scoped probe with whitespace-turn metrics.

## Plan or Spec
- `docs/plans/2026-06-22-tool-registry-whitespace-precasefold-performance.md`
- Registered probe: `tool-registry-select-name-index-cache`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_whitespace_turn_skips_casefold services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_uses_keyword_fallback_when_vector_unavailable`
- Registered test command for `tool-registry-select-name-index-cache`: `87 passed in 0.94s`
- Registered coverage command for `tool-registry-select-name-index-cache`: `TOTAL 21 0 100%`
- Registered local probe command for `tool-registry-select-name-index-cache`
- Old/new local microprobe: `/tmp/measure_whitespace_selector.py` against `origin/main` and this branch
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: `aggregate_measurable_changed_lines=21`, `aggregate_covered_changed_lines=21`, `TOTAL 21 0 100%`.
- Registered local probe (new): `whitespace_turn_planning_elapsed_ms_mean=30.427436000900343`, `whitespace_turn_selected_schema_bytes_mean=261.0`.
- Old/new local whitespace microprobe (7 samples x 20000 iterations, uncached keyword matcher):
  - old mean: `85.28793814392495 ms`
  - new mean: `83.26486799549977 ms`
  - delta: `-2.0230701484251767 ms`
  - speedup: `1.0242968036475422x`

## Known Gaps
- Local validation is Linux-only. This is a Python worker/tool-registry slice, so local Linux tests and registered local probe are applicable.
- Final performance validation must come from the GitHub Actions PR-scoped performance report for `tool-registry-select-name-index-cache`.

## Evidence Checklist
- [x] Registered probe covers the changed path.
- [x] Focused regression test added.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe was run.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
