### PR TITLE
perf: avoid changed coverage set materialization

### DIFF
--- a/docs/plans/2026-06-22-changed-scope-coverage-sorted-membership.md
+++ b/docs/plans/2026-06-22-changed-scope-coverage-sorted-membership.md
@@ -1,0 +1,35 @@
+# Changed-scope coverage sorted membership
+
+## Goal
+
+Reduce allocation in `scripts/changed_scope_coverage.py` when filtering a small set of changed lines against the sorted `executed_lines` and `missing_lines` arrays emitted by coverage.py.
+
+## Linux-only constraint
+
+This slice is Python-only and locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered changed-scope coverage measured-set probe.
+
+## Touched files
+
+- `scripts/changed_scope_coverage.py`
+- `tests/test_changed_scope_coverage.py`
+
+## Performance probe
+
+Use the existing registered `changed-scope-coverage-measured-set-filter` PR-scoped probe. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for the changed path and validates that no source reads occur when changed-line ranges cannot overlap measured coverage lines.
+
+This slice additionally records a local before/after micro-probe for the overlap case where coverage line lists are sorted and the changed set is small.
+
+## Success metrics
+
+- Focused tests pass.
+- Changed-scope coverage for touched executable lines is at least 95%.
+- Registered probe command completes successfully.
+- Local overlap micro-probe shows lower mean elapsed time for sorted coverage line membership.
+
+## Verification commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+python3 scripts/changed_scope_coverage_measured_probe.py
+```

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from bisect import bisect_left
 from collections.abc import Mapping
 from functools import lru_cache
 import json
@@ -205,6 +206,11 @@ def _line_ranges_may_overlap(
     return False
 
 
+def _sorted_line_list_contains(lines: list[int], line_no: int) -> bool:
+    index = bisect_left(lines, line_no)
+    return index < len(lines) and lines[index] == line_no
+
+
 def _measurable_changed_lines(
     repo_root: Path,
     coverage_payload: dict[str, object],
@@ -232,13 +238,27 @@ def _measurable_changed_lines(
     else:
         if not _line_ranges_may_overlap(changed, executed_lines, missing_lines):
             return [], [], []
-        executed = set(executed_lines)
-        missing = set(missing_lines)
-        measured_changed = [
-            line_no for line_no in changed if line_no in executed or line_no in missing
-        ]
-        executed_lookup = executed
-        missing_lookup = missing
+        if executed_lines and executed_lines[0] > executed_lines[-1]:
+            executed_lookup = set(executed_lines)
+        else:
+            executed_lookup = executed_lines
+        if missing_lines and missing_lines[0] > missing_lines[-1]:
+            missing_lookup = set(missing_lines)
+        else:
+            missing_lookup = missing_lines
+        if isinstance(executed_lookup, list) and isinstance(missing_lookup, list):
+            measured_changed = [
+                line_no
+                for line_no in changed
+                if _sorted_line_list_contains(executed_lookup, line_no)
+                or _sorted_line_list_contains(missing_lookup, line_no)
+            ]
+        else:
+            measured_changed = [
+                line_no
+                for line_no in changed
+                if line_no in executed_lookup or line_no in missing_lookup
+            ]
     if not measured_changed:
         return [], [], []
 
@@ -248,8 +268,20 @@ def _measurable_changed_lines(
         stripped = source_lines[line_no - 1].strip()
         if stripped and not stripped.startswith("#"):
             measurable.append(line_no)
-    covered = [line_no for line_no in measurable if line_no in executed_lookup]
-    missed = [line_no for line_no in measurable if line_no in missing_lookup]
+    if isinstance(executed_lookup, list) and isinstance(missing_lookup, list):
+        covered = [
+            line_no
+            for line_no in measurable
+            if _sorted_line_list_contains(executed_lookup, line_no)
+        ]
+        missed = [
+            line_no
+            for line_no in measurable
+            if _sorted_line_list_contains(missing_lookup, line_no)
+        ]
+    else:
+        covered = [line_no for line_no in measurable if line_no in executed_lookup]
+        missed = [line_no for line_no in measurable if line_no in missing_lookup]
     return measurable, covered, missed
 
 

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -580,6 +580,31 @@ def test_measurable_changed_lines_handles_large_measured_sets_without_union(tmp_
     assert missed == [2]
 
 
+def test_measurable_changed_lines_keeps_reversed_coverage_fallback(tmp_path: Path) -> None:
+    source_path = tmp_path / "foo.py"
+    source_path.write_text("\n".join(f"line_{line_no}" for line_no in range(1, 6)), encoding="utf-8")
+    coverage_payload = {
+        "files": {
+            "foo.py": {
+                "executed_lines": [5, 3, 1],
+                "missing_lines": [4, 2],
+            }
+        }
+    }
+
+    measurable, covered, missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        {2, 3, 6},
+    )
+
+    assert measurable == [2, 3]
+    assert covered == [3]
+    assert missed == [2]
+    assert changed_scope_coverage._sorted_line_list_contains([1, 3, 5], 4) is False
+
+
 def test_changed_scope_coverage_probe_emits_empty_path_metrics() -> None:
     metrics = changed_scope_coverage_probe.run_probe(Path(__file__).resolve().parents[1], path_count=5, samples=2)
 


### PR DESCRIPTION
## Summary
- Avoid materializing `set(executed_lines)` / `set(missing_lines)` for the common sorted coverage.py line-list path in `scripts/changed_scope_coverage.py`.
- Keep the existing set fallback for reversed coverage lists and add regression coverage for that fallback.
- Document the Python-only performance slice plan.

## Plan or Spec
- `docs/plans/2026-06-22-changed-scope-coverage-sorted-membership.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py
# 39 passed in 0.11s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 43 passed in 0.30s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 27 0 100%

python3 scripts/changed_scope_coverage_measured_probe.py
# {"allowlist_parse_count": 10000.0, "allowlist_parse_elapsed_ms_mean": 2.7223127087511654, "elapsed_ms_mean": 0.2226617154000061, "measured_lines_per_path": 500.0, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 27 0 100%`.
- Registered probe: `changed-scope-coverage-measured-set-filter` completed locally with `elapsed_ms_mean=0.2226617154000061`, `source_read_calls_mean=0.0`.
- Local overlap micro-probe against `origin/main`: `old_mean=445.71502500080635 ms`, `new_mean=369.66958570493654 ms`, `delta_ms=-76.04543929586981`, `speedup=1.2057119174434001` across 7 samples.
- CI PR-scoped performance must run the registered probe as merge validation.

## Known Gaps
- Swift runtime effects are not applicable; this is a Python/Linux-local slice.
- The sorted fast path matches coverage.py's sorted line-list output; reversed list fallback remains covered for defensive compatibility.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode changes.
- [x] Deferred work and known gaps are stated explicitly.
