### PR TITLE
perf: cache stream assembler channel names

### DIFF
--- a/docs/plans/2026-06-22-stream-assembler-channel-name-cache.md
+++ b/docs/plans/2026-06-22-stream-assembler-channel-name-cache.md
@@ -1,0 +1,26 @@
+# Stream Assembler Channel Name Cache Performance Slice
+
+This Python-only performance slice is limited to `worker.runtime.stream_assembler.RequestStreamAssembler._pipe_channel_name()`.
+
+## Scope
+
+The stream assembler repeatedly normalizes Harmony-style pipe channel headers while draining streamed chunks. The parser-mode workload commonly repeats a small set of headers such as `analysis metadata` and `final metadata` across many samples, so this slice memoizes channel-name normalization with a small bounded cache.
+
+No stream parsing behavior changes: whitespace trimming, first-token extraction, lowercase normalization, legacy hidden-channel handling, visible channels, and unknown-channel accounting remain unchanged.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `stream-assembler-parser-mode-cache` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/stream_assembler.py`
+- `services/mlx-worker-python/tests/test_stream_assembler.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/stream_assembler_parser_mode_probe.py`
+
+## Verification Plan
+
+1. Capture the local Linux registered-probe baseline on `origin/main`.
+2. Add a focused regression test proving repeated header normalization uses the cache while preserving normalized output.
+3. Apply the bounded `lru_cache` to `_pipe_channel_name()`.
+4. Run the registered focused test command, changed-scope coverage command, and registered probe locally on Linux.
+5. Use GitHub Actions PR-scoped performance as the merge gate before merging.

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -15,6 +15,21 @@ from worker.runtime.stream_assembler import (
 )
 
 
+def test_pipe_channel_name_caches_repeated_headers() -> None:
+    RequestStreamAssembler._pipe_channel_name.cache_clear()
+
+    assert RequestStreamAssembler._pipe_channel_name(" analysis metadata\n") == "analysis"
+    assert RequestStreamAssembler._pipe_channel_name(" analysis metadata\n") == "analysis"
+    assert RequestStreamAssembler._pipe_channel_name("FINAL metadata") == "final"
+    assert RequestStreamAssembler._pipe_channel_name("   ") == ""
+
+    cache_info = RequestStreamAssembler._pipe_channel_name.cache_info()
+    assert cache_info.hits == 1
+    assert cache_info.misses == 3
+
+    RequestStreamAssembler._pipe_channel_name.cache_clear()
+
+
 @pytest.fixture(scope="module", autouse=True)
 def _token_count_routing_probe() -> None:
     assembler = RequestStreamAssembler(

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -1451,6 +1451,7 @@ class RequestStreamAssembler:
         )
 
     @staticmethod
+    @lru_cache(maxsize=16)
     def _pipe_channel_name(header: str) -> str:
         stripped = header.strip()
         if not stripped:


### PR DESCRIPTION
## Summary
- Cache repeated Harmony pipe channel-name normalization in `RequestStreamAssembler._pipe_channel_name()` with a small bounded `lru_cache`.
- Add a focused regression test that proves repeated header normalization hits the cache while preserving existing normalization behavior.
- Document the slice and registered probe coverage in `docs/plans/2026-06-22-stream-assembler-channel-name-cache.md`.

## Plan or Spec
- `docs/plans/2026-06-22-stream-assembler-channel-name-cache.md`
- Registered PR-scoped probe: `stream-assembler-parser-mode-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_parser_mode_probe.py`
- `MELIX_STREAM_ASSEMBLER_PARSER_MODE_SAMPLES=512 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_parser_mode_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 95 passed.
- Changed-scope coverage: 100.00% (11/11 changed measurable lines).
- Local Linux registered probe, 3 repeated runs with `MELIX_STREAM_ASSEMBLER_PARSER_MODE_SAMPLES=512`:
  - base mean: 3.678062948912005 ms
  - head mean: 3.642812415212878 ms
  - delta: -0.03525053369912712 ms (-0.9583994126461173%)
- Single post-change registered probe run: `elapsed_ms_mean=3.590842406254069`, `channel_name_calls_mean=13.0`, `tool_call_count=10.0`.
- GitHub Actions PR-scoped performance is required for final registered probe validation before merge.

## Known Gaps
- Linux local validation covers Python behavior and synthetic registered probe metrics only.
- The improvement is intentionally small and bounded to repeated Harmony channel headers; CI PR-scoped performance remains the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance completed successfully.
- [ ] PR checks are green before merge.
