### PR TITLE
perf: scan benchmark summary metrics once

### DIFF
--- a/docs/plans/2026-06-22-benchmark-summary-metric-single-pass.md
+++ b/docs/plans/2026-06-22-benchmark-summary-metric-single-pass.md
@@ -1,0 +1,30 @@
+# Benchmark summary metric single-pass slice
+
+## Scope
+
+This Python-only performance slice is limited to `worker.productization.benchmark_evaluation_report._load_batch_run_summary_bundle(...)`.
+
+## Motivation
+
+Batch run summary bundles expose per-model `metric_fields` dictionaries that may contain both `bench.*` and `eval.*` entries. The previous conversion path scanned the same dictionary twice: once to materialize benchmark metrics and once to materialize evaluation rows. Large scheduled benchmark batches can include many models and many metrics per model, so the duplicate scan adds avoidable per-report overhead.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `benchmark-evaluation-report-running-aggregates` in `infra/perf/pr_scoped_probes.json`. The registry entry already includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`
+- `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+- `scripts/benchmark_evaluation_report.py`
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+
+The probe reports `load_input_ms_mean`, `elapsed_ms_mean`, and `peak_bytes_mean` for the benchmark/evaluation report path.
+
+## Implementation Plan
+
+1. Add a regression test proving batch summary `metric_fields.items()` is scanned once while preserving benchmark and evaluation row output.
+2. Replace the two-pass `metric_fields` handling with one loop that dispatches valid numeric `bench.*` and `eval.*` metrics to their existing output shapes.
+3. Run the focused test, registered coverage command, and registered probe locally on Linux.
+
+## Validation Boundary
+
+This slice changes Python code and is locally verifiable on Linux. The PR-scoped performance workflow remains the merge gate for the registered CI probe result.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -198,6 +198,67 @@ def test_load_report_input_accepts_batch_run_summary_bundle(tmp_path: Path) -> N
     assert metrics["eval.event_extraction.semantic_f1"]["status"] == "ok"
 
 
+def test_batch_summary_bundle_scans_metric_fields_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    class SingleScanMetricFields(dict[str, object]):
+        def __init__(self) -> None:
+            super().__init__(
+                {
+                    "bench.smoke.tokens_per_second": 12.5,
+                    "eval.event_extraction.semantic_f1": 0.9,
+                    "ignored.text": "skip",
+                }
+            )
+            self.item_scans = 0
+
+        def items(self):  # type: ignore[override]
+            self.item_scans += 1
+            if self.item_scans > 1:
+                raise AssertionError("metric_fields items scanned more than once")
+            return super().items()
+
+    metric_fields = SingleScanMetricFields()
+    summary = {
+        "schema_version": "melix.batch.run_summary.v1",
+        "models": [
+            {
+                "model_index": "01",
+                "repo_id": "mlx-community/Smoke-4bit",
+                "status": "succeeded",
+                "benchmark_job_id": "bench-1",
+                "evaluation_job_id": "eval-1",
+                "metric_fields": metric_fields,
+            }
+        ],
+    }
+    (tmp_path / "run-summary.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(benchmark_evaluation_report.json, "loads", lambda _payload: summary)
+
+    bundle = benchmark_evaluation_report._load_batch_run_summary_bundle(tmp_path)
+
+    assert metric_fields.item_scans == 1
+    assert bundle["benchmark_results"] == [
+        {
+            "job_id": "bench-1",
+            "suite": "batch",
+            "model_index": "01",
+            "repo_id": "mlx-community/Smoke-4bit",
+            "metrics": [{"name": "bench.smoke.tokens_per_second", "value": 12.5}],
+        }
+    ]
+    assert bundle["evaluation_summary_rows"] == [
+        {
+            "job_id": "eval-1",
+            "suite_id": "event_extraction",
+            "dataset_id": "batch",
+            "primary_score_name": "semantic_f1",
+            "primary_score_value": 0.9,
+            "sample_size": None,
+            "failure_count": 0,
+            "duration_seconds": None,
+        }
+    ]
+
+
 def test_status_counts_reads_each_row_status_once() -> None:
     class SingleReadStatusRow(dict[str, object]):
         def __init__(self, status: str) -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -345,25 +345,16 @@ def _load_batch_run_summary_bundle(bundle_root: Path) -> dict[str, object]:
         metrics = model.get("metric_fields", {})
         if not isinstance(metrics, dict):
             metrics = {}
-        benchmark_metrics = [
-            {"name": str(name), "value": value}
-            for name, value in metrics.items()
-            if str(name).startswith("bench.") and _float_or_none(value) is not None
-        ]
-        if benchmark_metrics:
-            benchmark_results.append(
-                {
-                    "job_id": model.get("benchmark_job_id", ""),
-                    "suite": "batch",
-                    "model_index": model.get("model_index", ""),
-                    "repo_id": model.get("repo_id", ""),
-                    "metrics": benchmark_metrics,
-                }
-            )
+        benchmark_metrics: list[dict[str, object]] = []
         for name, value in metrics.items():
             metric_name = str(name)
             metric_value = _float_or_none(value)
-            if not metric_name.startswith("eval.") or metric_value is None:
+            if metric_value is None:
+                continue
+            if metric_name.startswith("bench."):
+                benchmark_metrics.append({"name": metric_name, "value": value})
+                continue
+            if not metric_name.startswith("eval."):
                 continue
             parts = metric_name.split(".")
             suite_id = parts[1] if len(parts) > 2 else "batch"
@@ -378,6 +369,16 @@ def _load_batch_run_summary_bundle(bundle_root: Path) -> dict[str, object]:
                     "sample_size": None,
                     "failure_count": 1 if model.get("status") == "failed" else 0,
                     "duration_seconds": model.get("duration_seconds"),
+                }
+            )
+        if benchmark_metrics:
+            benchmark_results.append(
+                {
+                    "job_id": model.get("benchmark_job_id", ""),
+                    "suite": "batch",
+                    "model_index": model.get("model_index", ""),
+                    "repo_id": model.get("repo_id", ""),
+                    "metrics": benchmark_metrics,
                 }
             )
     return {


### PR DESCRIPTION
## Summary
- Scan batch summary `metric_fields` once while preserving benchmark metric and evaluation row output.
- Add a regression test that fails if `metric_fields.items()` is iterated more than once.
- Document the Python-only performance slice and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-06-22-benchmark-summary-metric-single-pass.md`
- Registered PR-scoped probe: `benchmark-evaluation-report-running-aggregates`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py::test_batch_summary_bundle_scans_metric_fields_once` (initial RED: failed with `AssertionError: metric_fields items scanned more than once`)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py::test_batch_summary_bundle_scans_metric_fields_once` (GREEN: 1 passed)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py` (66 passed)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py` (TOTAL 98%; report module 97%, tests 99%)
- Registered probe equivalent via `.runtime_probe_benchmark_report.py`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime_probe_benchmark_report.py`
- `git diff --check`

## Coverage and Metrics
- Baseline (`origin/main` / `220dc2f7`): `load_input_ms_mean=6.81682`, `elapsed_ms_mean=289.892498`, `peak_bytes_mean=13636836.8`, `row_count=5990.0`, `sample_count=5.0`
- Head (`a0f60159`): `load_input_ms_mean=6.58898`, `elapsed_ms_mean=287.328536`, `peak_bytes_mean=13636836.8`, `row_count=5990.0`, `sample_count=5.0`
- Delta: `load_input_ms_mean=-0.22784 ms` (~3.34% faster), `elapsed_ms_mean=-2.563962 ms` (~0.88% faster), peak bytes unchanged.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux-only for this Python path.
- The registered probe command is represented by an equivalent temporary script locally because this CLI guard blocks direct `python3 -c` execution; CI will run the registry command directly.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused regression test added and observed failing before the implementation.
- [x] Focused test suite passed locally.
- [x] Changed-scope coverage command passed locally above 95%.
- [x] Registered probe measured baseline and head locally.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
