### PR TITLE
perf: tune QAT source stats chunk size

### DIFF
--- a/docs/plans/2026-06-22-qat-source-stats-chunk-size.md
+++ b/docs/plans/2026-06-22-qat-source-stats-chunk-size.md
@@ -1,0 +1,38 @@
+# QAT source stats 4 MiB chunk scan
+
+## Scope
+
+This Python-only performance slice is limited to `worker.model_ops.quantization_pipeline._qat_fake_quant_source_stats()`.
+
+The hot path streams QAT source artifact bytes to compute a source digest and fake-quant error proxy.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `quantization-qat-source-scan-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/quantization_pipeline.py`
+- `services/mlx-worker-python/tests/test_quantization_pipeline.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/quantization_qat_source_scan_probe.py`
+
+## Change
+
+`_qat_fake_quant_source_stats()` now reads source artifacts in 4 MiB chunks instead of 1 MiB chunks. QAT source artifacts are typically large tensor/config files, so the larger chunk size reduces Python loop overhead while keeping transient memory bounded for the registered scan.
+
+The digest, byte count, fake-quant mean, and fake-quant max semantics are unchanged because every byte is still streamed through the same hash and translation-table aggregation path.
+
+## Verification plan
+
+1. Run the focused QAT tests selected by the registered probe.
+2. Run the registered changed-scope coverage command and require at least 95% measured coverage for the touched scope.
+3. Run the registered local performance probe on Linux against `origin/main` and `HEAD` via `scripts/pr_scoped_performance_run.py`.
+4. Use GitHub Actions PR-scoped performance as the merge gate after pushing.
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage passes at or above the repository threshold.
+- The registered probe reports improvement or non-regression for `source_stats_elapsed_ms_mean` while preserving `source_stats_byte_count`.
+- CI PR-scoped performance report completes successfully before merge.

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -1282,7 +1282,9 @@ def _qat_fake_quant_source_stats(source_files: list[Path], *, q_bits: int) -> di
     _qat_fake_quant_error_table(q_bits)
     error_byte_table = _qat_fake_quant_error_byte_table(q_bits)
     error_max_possible = max(error_byte_table)
-    chunk_size = 1024 * 1024
+    # QAT source artifacts are large tensor/config files; a 4 MiB chunk reduces
+    # Python loop overhead while keeping transient memory bounded for scans.
+    chunk_size = 4 * 1024 * 1024
     sum_errors = sum
     max_errors = max
     for source_file in source_files:


### PR DESCRIPTION
## Summary
- Increase QAT fake-quant source stats read chunks from 1 MiB to 4 MiB to reduce Python loop overhead while scanning large source artifacts.
- Add a governing plan note for the registered `quantization-qat-source-scan-scandir` probe and validation boundary.

## Plan or Spec
- `docs/plans/2026-06-22-qat-source-stats-chunk-size.md`

## Commands Run
- `PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_quantization_pipeline.py -k fake_quant_source_stats -q` (2 passed, 63 deselected)
- Registered probe `test_command` from `infra/perf/pr_scoped_probes.json` (9 passed)
- Registered probe `coverage_command` from `infra/perf/pr_scoped_probes.json` (9 passed; changed-scope coverage 100%)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id quantization-qat-source-scan-scandir --base-repo /tmp/melix-qat-base-chunk-1782173008 --head-repo "$PWD" --output /tmp/melix-qat-probe-chunk-1782173008.json`

## Coverage and Metrics
- Changed-scope coverage: 100% (`aggregate_measurable_changed_lines=1`, `aggregate_covered_changed_lines=1`).
- Registered local Linux probe (`quantization-qat-source-scan-scandir`):
  - `source_stats_elapsed_ms_mean`: base `34.032117` ms → head `33.680334` ms (`-0.351783` ms, about `1.03%` faster)
  - `source_stats_byte_count`: base/head `4000000.0` bytes
  - `elapsed_ms_mean`: base `26.661967` ms → head `27.176279` ms (unrelated directory scan component noise, about `1.93%` slower and within the 5% warning threshold)
  - `source_stats_peak_bytes_mean`: base `3055278.4` bytes → head `6201427.2` bytes (informational; expected from larger chunk buffer)

## Known Gaps
- This is a Python-only slice verified locally on Linux; no Swift runtime effect is claimed.
- The 4 MiB chunk size intentionally trades higher transient scan memory for lower loop overhead in large artifact scans.
- GitHub Actions PR-scoped performance is still required as the merge gate.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered local performance probe completed locally.
- [ ] GitHub Actions PR-scoped performance completed successfully.
