### PR TITLE
perf(worker): avoid strip allocation for trust source fallback

### DIFF
--- a/docs/plans/2026-06-23-model-load-non-empty-fastpath.md
+++ b/docs/plans/2026-06-23-model-load-non-empty-fastpath.md
@@ -1,0 +1,22 @@
+# Model load trust non-empty source fast path
+
+## Goal
+
+Avoid allocating stripped copies while resolving model-load trust policy source
+fields on the hot path.
+
+## Slice
+
+- Keep model-load trust behavior unchanged for non-empty, empty, and
+  whitespace-only policy sources.
+- Replace the helper-level `strip()` truthiness check with an allocation-free
+  non-empty/`isspace()` guard.
+- Validate through the registered `model-load-config-json-bytes` PR-scoped
+  performance probe because the affected helper is exercised by
+  `resolve_model_load_trust_policy`.
+
+## Verification
+
+- Focused model-load trust tests, including the helper fallback behavior.
+- Changed-scope coverage for `model_load_trust.py` and related tests.
+- Local Linux registered probe before/after comparison.

--- a/services/mlx-worker-python/tests/test_model_load_trust.py
+++ b/services/mlx-worker-python/tests/test_model_load_trust.py
@@ -30,6 +30,12 @@ class RecordingTextBackend:
         return 4096
 
 
+def test_trust_policy_non_empty_source_fast_path_preserves_blank_fallback() -> None:
+    assert model_load_trust_module._non_empty("request", "fallback") == "request"
+    assert model_load_trust_module._non_empty("", "fallback") == "fallback"
+    assert model_load_trust_module._non_empty(" \t\n", "fallback") == "fallback"
+
+
 def test_worker_rejects_custom_loader_metadata_without_explicit_trust(tmp_path: Path) -> None:
     backend = RecordingTextBackend()
     service = WorkerRuntimeService(

--- a/services/mlx-worker-python/worker/model_load_trust.py
+++ b/services/mlx-worker-python/worker/model_load_trust.py
@@ -331,4 +331,4 @@ def _route_name(route_class: int) -> str:
 
 
 def _non_empty(value: str, fallback: str) -> str:
-    return value if value.strip() else fallback
+    return value if value and not value.isspace() else fallback


### PR DESCRIPTION
## Summary
- Avoid allocating stripped copies in the model-load trust `_non_empty` helper by using an explicit non-empty/`isspace()` guard.
- Add a focused regression test for non-empty, empty, and whitespace-only fallback behavior.
- Document the slice and registered probe validation plan.

## Plan or Spec
- `docs/plans/2026-06-23-model-load-non-empty-fastpath.md`
- Registered probe: `model-load-config-json-bytes` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/model_load_config_json_bytes_probe.py` (baseline on `origin/main`)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_non_empty_source_fast_path_preserves_blank_fallback services/mlx-worker-python/tests/test_model_load_trust.py::test_worker_rejects_custom_loader_metadata_without_explicit_trust services/mlx-worker-python/tests/test_model_load_trust.py::test_worker_trusted_custom_loader_receipt_passes_trust_remote_code services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_common_loader_fast_path_skips_normalized_membership services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_reads_config_json_bytes_with_direct_open services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_caches_config_json_by_file_stat services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_caches_auto_map_detection_by_file_stat services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_auto_map_custom_loader_scan_avoids_string_coercion_for_strings services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_auto_map_custom_loader_scan_preserves_blank_string_behavior services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_auto_map_custom_loader_scan_preserves_non_string_fallback services/mlx-worker-python/tests/test_model_load_trust.py::test_route_class_runtime_kind_map_preserves_supported_defaults services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_skips_expanduser_for_plain_model_path services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_stats_plain_config_path_without_path_join services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_expands_tilde_model_path services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_treats_missing_config_json_as_absent services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_treats_blank_model_path_as_absent services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_load_config_json_bytes_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_load_config_json_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_load_trust.py services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/model_load_config_json_bytes_probe.py`
- `MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_ITERATIONS=2000 MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/model_load_config_json_bytes_probe.py` (baseline and candidate)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 17 passed.
- Changed-scope coverage: TOTAL 5 0 100%.
- Registered local probe default run: baseline `elapsed_ms_mean=5.7613`, candidate `elapsed_ms_mean=5.8685` (noisy default sample; within threshold).
- Registered local probe stabilized run (`iterations=2000`, `samples=5`): baseline `elapsed_ms_mean=41.8241`, candidate `elapsed_ms_mean=41.3252`, delta `-0.4989 ms`, speedup `1.012x`; `peak_bytes_mean=4057.0` unchanged.
- CI PR-scoped performance must validate the registered probe again before merge.

## Known Gaps
- Linux local validation only; this slice is Python-only and does not claim Swift runtime effects.
- The local default probe run was noisy, so the decision uses the larger stabilized sample and requires CI probe confirmation.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe was run locally against baseline and candidate.
- [ ] GitHub Actions and PR-scoped performance report are green.
