### PR TITLE
perf(worker): fast decode common hub cursors

### DIFF
--- a/docs/plans/2026-06-23-hub-catalog-cursor-common-decode.md
+++ b/docs/plans/2026-06-23-hub-catalog-cursor-common-decode.md
@@ -1,0 +1,37 @@
+# Hub catalog cursor common decode slice
+
+## Scope
+
+This Python-only performance slice is limited to the Hub catalog `Link` header
+cursor decoder in `services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+It preserves existing query-boundary scanning behavior and narrows only the
+common Hugging Face cursor decode path.
+
+## Probe coverage
+
+The affected path is already covered by the registered PR-scoped performance
+probe `hub-catalog-next-cursor-fast-parse` in
+`infra/perf/pr_scoped_probes.json`. The registration includes focused
+`test_command`, `coverage_command`, and `probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_next_cursor_probe.py`
+
+## Implementation plan
+
+1. Add a fast decode branch for cursor values containing only the common
+   `%2F` / `%2B` escapes plus `+` spaces.
+2. Keep the existing manual percent decoder and `urllib.parse.unquote_plus`
+   fallback for uncommon percent escapes, UTF-8, and malformed values.
+3. Add a focused regression test for lowercase common cursor escapes.
+4. Run focused tests, changed-scope coverage, and the registered probe locally
+   on Linux, then use GitHub Actions PR-scoped performance as the merge gate.
+
+## Expected signal
+
+The registered probe repeatedly parses Hugging Face-style next-cursor Link
+headers whose cursor value contains `%2F`, `%2B`, and `+`. The expected signal is
+lower `elapsed_ms_mean` by using CPython string replace operations for the common
+ASCII cursor escape set while preserving fallback behavior for other encodings.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -810,6 +810,18 @@ def test_next_cursor_from_link_accepts_cursor_at_query_start() -> None:
     assert hub_catalog_module._next_cursor_from_link(link_header) == "page/start"
 
 
+def test_next_cursor_from_link_decodes_plus_space_cursor_without_percent_escape() -> None:
+    link_header = '<https://huggingface.co/api/models?cursor=page+start&limit=10>; rel="next"'
+
+    assert hub_catalog_module._next_cursor_from_link(link_header) == "page start"
+
+
+def test_next_cursor_from_link_decodes_common_lowercase_cursor_escapes() -> None:
+    link_header = '<https://huggingface.co/api/models?cursor=page%2fstart%2bbatch+ok>; rel="next"'
+
+    assert hub_catalog_module._next_cursor_from_link(link_header) == "page/start+batch ok"
+
+
 def test_next_cursor_from_link_preserves_utf8_and_malformed_percent_decoding() -> None:
     unicode_header = '<https://huggingface.co/api/models?cursor=page%E2%9C%93+ok>; rel="next"'
     malformed_header = '<https://huggingface.co/api/models?cursor=page%ZZ+ok>; rel="next"'

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -388,6 +388,19 @@ def _cursor_query_value(url: str, start: int, end: int) -> str:
 def _unquote_plus_ascii_cursor(value: str) -> str:
     if "%" not in value and "+" not in value:
         return value
+    if "%" not in value:
+        return value.replace("+", " ")
+
+    common_cursor = (
+        value.replace("+", " ")
+        .replace("%2F", "/")
+        .replace("%2f", "/")
+        .replace("%2B", "+")
+        .replace("%2b", "+")
+    )
+    if "%" not in common_cursor:
+        return common_cursor
+
     hex_digits = _URL_HEX_DIGITS
     output: list[str] = []
     append = output.append


### PR DESCRIPTION
## Summary
- Add a common-path decoder for Hugging Face Hub cursor values containing `%2F`, `%2B`, and `+` space escapes.
- Preserve existing fallback behavior for UTF-8, malformed percent escapes, and uncommon encoded values.
- Add focused regression coverage and a governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-23-hub-catalog-cursor-common-decode.md`
- Registered probe: `hub-catalog-next-cursor-fast-parse` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_next_cursor_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_next_cursor_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-next-cursor-fast-parse --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/hub-catalog-next-cursor-fast-parse.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `87 passed in 0.39s`
- Changed-scope coverage: `TOTAL 11 0 100%`
- Registered local probe comparison:
  - base `elapsed_ms_mean=675.1881235977635`
  - head `elapsed_ms_mean=517.523639992578`
  - delta `-157.6644836051855 ms`
  - speedup `1.30x` (~23.35% lower elapsed time)
  - `cursor_parse_calls_mean` unchanged at `50000.0`
  - `peak_bytes_mean` unchanged at `832.0`

## Known Gaps
- This is a Python-only slice verified locally on Linux. GitHub Actions PR-scoped performance is still required as the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at or above 95%.
- [x] Registered probe was run locally against `origin/main` and `HEAD`.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
- [ ] PR checks are green before merge.
