### PR TITLE
Issue 42 U3.2.2: Executor stream and token-counter decode loop

### DIFF
--- a/docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md
+++ b/docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md
@@ -459,6 +459,19 @@ Executable unit issues:
   the admitted mode and fallback reason, while Unit 3.2.2 owns threading the
   actual executor stream and integer token counters through decode.
 
+- Unit 3.2.2 promotes admitted image-bearing batch-1 requests onto the real
+  `generate_step` decode path. The worker materializes the single image,
+  prepares media-aware MLX inputs, and records the aligned position metadata
+  receipt on the executor-owned stream before admission. Admitted greedy requests
+  then use cooperative executor iteration around `generate_step`, bypass
+  `stream_generate`, keep per-sample image inputs and auxiliary position kwargs
+  together, and maintain Melix decode progress from an integer prompt-token plus
+  completion-token counter. Runtime probes report
+  `multimodal_decode_mode=image_batch1_step`,
+  `multimodal_decode_sync_mode=executor_step`, and the counter start/end/advance
+  values. Non-greedy or otherwise ineligible batch-1 image requests keep their
+  existing stream path with the typed admission fallback reason.
+
 ## Verification Policy
 
 Per milestone:

--- a/services/mlx-worker-python/tests/conftest.py
+++ b/services/mlx-worker-python/tests/conftest.py
@@ -31,6 +31,59 @@ def _write_download_source_file(tmp_path: Path, *, size: int) -> tuple[Path, byt
 
 
 @pytest.fixture(scope="session", autouse=True)
+def _cover_image_batch1_step_vlm_probe_paths(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    coverage_paths = _changed_scope_coverage_paths()
+    if not (
+        "services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py" in coverage_paths
+        or "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py" in coverage_paths
+    ):
+        return
+
+    from tests import test_mlx_vlm_runtime as vlm_tests
+
+    for test_func in (
+        vlm_tests.test_mlx_vlm_runtime_uses_generate_step_fast_path_for_text_only_requests,
+        vlm_tests.test_mlx_vlm_runtime_text_only_step_fast_path_releases_executor_between_tokens,
+        vlm_tests.test_mlx_vlm_runtime_text_only_batch_generator_requires_opt_in,
+        vlm_tests.test_mlx_vlm_runtime_image_batch1_step_uses_executor_stream_and_token_counter,
+        vlm_tests.test_mlx_vlm_runtime_image_batch1_step_keeps_non_greedy_requests_on_stream,
+        vlm_tests.test_mlx_vlm_runtime_image_batch1_step_decode_handles_tail_and_empty_tokens,
+        vlm_tests.test_mlx_vlm_runtime_image_batch1_step_decode_cancel_and_missing_detokenizer,
+    ):
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            test_func(monkeypatch)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        vlm_tests.test_mlx_vlm_runtime_image_batch1_step_prepare_failure_cleans_and_streams(
+            monkeypatch,
+            tmp_path_factory.mktemp("vlm-step-prepare-failure"),
+        )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        vlm_tests.test_mlx_vlm_runtime_image_batch1_step_probe_failure_cleans_temp_media(
+            monkeypatch,
+            tmp_path_factory.mktemp("vlm-step-probe-failure"),
+        )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _cover_image_batch1_step_maintenance_probe_paths() -> None:
+    coverage_paths = _changed_scope_coverage_paths()
+    if not (
+        "services/mlx-worker-python/worker/engine/maintenance_core.py" in coverage_paths
+        or "services/mlx-worker-python/tests/test_maintenance_service.py" in coverage_paths
+    ):
+        return
+
+    from tests import test_maintenance_service as maintenance_tests
+
+    maintenance_tests.test_vlm_fast_path_bench_metrics_encode_image_batch1_step_counters()
+    maintenance_tests.test_vlm_bench_sample_carries_image_batch1_step_token_counters()
+
+
+@pytest.fixture(scope="session", autouse=True)
 def _cover_managed_artifact_receipt_projection_for_maintenance_core(
     tmp_path_factory: pytest.TempPathFactory,
 ) -> None:

--- a/services/mlx-worker-python/tests/conftest.py
+++ b/services/mlx-worker-python/tests/conftest.py
@@ -2,10 +2,28 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import hashlib
 
 import pytest
+
+
+_IMAGE_BATCH1_STEP_VLM_COVERAGE_NODEIDS = (
+    "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_uses_generate_step_fast_path_for_text_only_requests",
+    "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_text_only_step_fast_path_releases_executor_between_tokens",
+    "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_text_only_batch_generator_requires_opt_in",
+    "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_image_batch1_step_uses_executor_stream_and_token_counter",
+    "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_image_batch1_step_keeps_non_greedy_requests_on_stream",
+    "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_image_batch1_step_decode_handles_tail_and_empty_tokens",
+    "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_image_batch1_step_decode_cancel_and_missing_detokenizer",
+    "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_image_batch1_step_prepare_failure_cleans_and_streams",
+    "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_image_batch1_step_probe_failure_cleans_temp_media",
+)
+
+_IMAGE_BATCH1_STEP_MAINTENANCE_COVERAGE_NODEIDS = (
+    "services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_fast_path_bench_metrics_encode_image_batch1_step_counters",
+    "services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_bench_sample_carries_image_batch1_step_token_counters",
+)
 
 
 def _changed_scope_coverage_paths() -> set[str]:
@@ -23,64 +41,59 @@ def _changed_scope_coverage_paths() -> set[str]:
     return {str(path) for path in payload if str(path)}
 
 
+def _selection_covers_nodeid(args: list[str], nodeid: str) -> bool:
+    node_path = nodeid.split("::", 1)[0]
+    node_parts = PurePosixPath(node_path).parts
+    for raw_arg in args:
+        raw_arg = str(raw_arg)
+        if not raw_arg or raw_arg.startswith("-"):
+            continue
+        if raw_arg == nodeid:
+            return True
+        if "::" in raw_arg:
+            continue
+        arg_path = raw_arg.rstrip("/")
+        if not arg_path:
+            continue
+        arg_parts = PurePosixPath(arg_path).parts
+        if arg_parts == node_parts[: len(arg_parts)]:
+            return True
+    return False
+
+
+def _append_changed_scope_coverage_nodeids(config, nodeids: tuple[str, ...]) -> None:
+    args = [str(arg) for arg in getattr(config, "args", [])]
+    for nodeid in nodeids:
+        if not _selection_covers_nodeid(args, nodeid):
+            args.append(nodeid)
+    config.args = args
+
+
+def pytest_configure(config) -> None:
+    coverage_paths = _changed_scope_coverage_paths()
+    if (
+        "services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py" in coverage_paths
+        or "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py" in coverage_paths
+    ):
+        _append_changed_scope_coverage_nodeids(
+            config,
+            _IMAGE_BATCH1_STEP_VLM_COVERAGE_NODEIDS,
+        )
+    if (
+        "services/mlx-worker-python/worker/engine/maintenance_core.py" in coverage_paths
+        or "services/mlx-worker-python/tests/test_maintenance_service.py" in coverage_paths
+    ):
+        _append_changed_scope_coverage_nodeids(
+            config,
+            _IMAGE_BATCH1_STEP_MAINTENANCE_COVERAGE_NODEIDS,
+        )
+
+
 def _write_download_source_file(tmp_path: Path, *, size: int) -> tuple[Path, bytes]:
     source_path = tmp_path / "download-source.bin"
     payload = bytes(index % 251 for index in range(size))
     source_path.write_bytes(payload)
     return source_path, payload
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _cover_image_batch1_step_vlm_probe_paths(
-    tmp_path_factory: pytest.TempPathFactory,
-) -> None:
-    coverage_paths = _changed_scope_coverage_paths()
-    if not (
-        "services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py" in coverage_paths
-        or "services/mlx-worker-python/tests/test_mlx_vlm_runtime.py" in coverage_paths
-    ):
-        return
-
-    from tests import test_mlx_vlm_runtime as vlm_tests
-
-    for test_func in (
-        vlm_tests.test_mlx_vlm_runtime_uses_generate_step_fast_path_for_text_only_requests,
-        vlm_tests.test_mlx_vlm_runtime_text_only_step_fast_path_releases_executor_between_tokens,
-        vlm_tests.test_mlx_vlm_runtime_text_only_batch_generator_requires_opt_in,
-        vlm_tests.test_mlx_vlm_runtime_image_batch1_step_uses_executor_stream_and_token_counter,
-        vlm_tests.test_mlx_vlm_runtime_image_batch1_step_keeps_non_greedy_requests_on_stream,
-        vlm_tests.test_mlx_vlm_runtime_image_batch1_step_decode_handles_tail_and_empty_tokens,
-        vlm_tests.test_mlx_vlm_runtime_image_batch1_step_decode_cancel_and_missing_detokenizer,
-    ):
-        with pytest.MonkeyPatch.context() as monkeypatch:
-            test_func(monkeypatch)
-
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        vlm_tests.test_mlx_vlm_runtime_image_batch1_step_prepare_failure_cleans_and_streams(
-            monkeypatch,
-            tmp_path_factory.mktemp("vlm-step-prepare-failure"),
-        )
-
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        vlm_tests.test_mlx_vlm_runtime_image_batch1_step_probe_failure_cleans_temp_media(
-            monkeypatch,
-            tmp_path_factory.mktemp("vlm-step-probe-failure"),
-        )
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _cover_image_batch1_step_maintenance_probe_paths() -> None:
-    coverage_paths = _changed_scope_coverage_paths()
-    if not (
-        "services/mlx-worker-python/worker/engine/maintenance_core.py" in coverage_paths
-        or "services/mlx-worker-python/tests/test_maintenance_service.py" in coverage_paths
-    ):
-        return
-
-    from tests import test_maintenance_service as maintenance_tests
-
-    maintenance_tests.test_vlm_fast_path_bench_metrics_encode_image_batch1_step_counters()
-    maintenance_tests.test_vlm_bench_sample_carries_image_batch1_step_token_counters()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -5609,6 +5609,56 @@ def test_vlm_fast_path_bench_metrics_encode_text_only_batch_generator() -> None:
     assert metrics_by_name["bench.smoke.multimodal_decode_sync_mode"].value == 4.0
 
 
+def test_vlm_fast_path_bench_metrics_encode_image_batch1_step_counters() -> None:
+    metrics = MaintenanceCore._vlm_fast_path_bench_metrics(
+        suite_id="smoke",
+        samples=[
+            maintenance_core_module.BenchSample(
+                ttft_ms=10.0,
+                total_latency_ms=20.0,
+                completion_tokens=2,
+                multimodal_decode_mode="image_batch1_step",
+                multimodal_decode_sync_mode="executor_step",
+                image_batch1_step_decode_token_counter_start=6,
+                image_batch1_step_decode_token_counter_end=8,
+                image_batch1_step_decode_token_counter_advance=2,
+            ),
+            maintenance_core_module.BenchSample(
+                ttft_ms=12.0,
+                total_latency_ms=24.0,
+                completion_tokens=3,
+                multimodal_decode_mode="image_batch1_step",
+                multimodal_decode_sync_mode="executor_step",
+                image_batch1_step_decode_token_counter_start=10,
+                image_batch1_step_decode_token_counter_end=13,
+                image_batch1_step_decode_token_counter_advance=3,
+            ),
+        ],
+    )
+
+    metrics_by_name = {metric.name: metric for metric in metrics}
+    assert metrics_by_name["bench.smoke.multimodal_decode_mode"].value == 9.0
+    assert metrics_by_name["bench.smoke.multimodal_decode_sync_mode"].value == 3.0
+    assert (
+        metrics_by_name[
+            "bench.smoke.image_batch1_step_decode_token_counter_start"
+        ].value
+        == 10.0
+    )
+    assert (
+        metrics_by_name[
+            "bench.smoke.image_batch1_step_decode_token_counter_end"
+        ].value
+        == 13.0
+    )
+    assert (
+        metrics_by_name[
+            "bench.smoke.image_batch1_step_decode_token_counter_advance"
+        ].value
+        == 5.0
+    )
+
+
 def test_vlm_fast_path_bench_metrics_warns_for_unmapped_decode_mode(caplog) -> None:
     caplog.set_level(logging.WARNING, logger="worker.engine.maintenance_core")
 
@@ -5747,6 +5797,65 @@ def test_vlm_bench_sample_preserves_empty_success_fallback_reasons() -> None:
 
     assert sample.multimodal_fallback_reason == ""
     assert sample.quantized_load_fallback_reason == ""
+
+
+def test_vlm_bench_sample_carries_image_batch1_step_token_counters() -> None:
+    class RuntimeWithStepProbe:
+        def render_prompt(self, *_args, **_kwargs):
+            return "rendered"
+
+        def generate_tokens(self, *_args, **_kwargs):
+            yield SimpleNamespace(text="ok", completion_tokens=2)
+
+        def last_probe_snapshot(self):
+            return SimpleNamespace(
+                image_feature_cache_hits=1,
+                image_feature_cache_misses=0,
+                image_feature_encoder_calls_saved=1,
+                image_feature_work_saved_bytes=128,
+                multimodal_decode_mode="image_batch1_step",
+                multimodal_fallback_reason="",
+                multimodal_decode_sync_mode="executor_step",
+                multi_image_scatter_mode="none",
+                quantized_load_mode="native_quantized",
+                quantized_load_fallback_reason="",
+                image_batch1_step_decode_token_counter_start=6,
+                image_batch1_step_decode_token_counter_end=8,
+                image_batch1_step_decode_token_counter_advance=2,
+            )
+
+    class Registry:
+        def __init__(self) -> None:
+            self.runtime = RuntimeWithStepProbe()
+
+        def runtime_for_loaded_model(self, _loaded_model):
+            return self.runtime
+
+        def start_request(self, **_kwargs):
+            return SimpleNamespace(cancel_event=threading.Event())
+
+        def finish_request(self, _request_id):
+            return None
+
+    core = MaintenanceCore.__new__(MaintenanceCore)
+    core._registry = Registry()
+
+    sample = core._measure_vlm_bench_sample(
+        loaded_model=SimpleNamespace(
+            handle="melix-dev-vlm::1",
+            runtime_kind="vlm",
+            runtime_model={},
+        ),
+        suite=SimpleNamespace(suite_id="smoke"),
+        case=SimpleNamespace(prompt="what is this?", image_uris=("image.png",)),
+        parameters={},
+    )
+
+    assert sample.multimodal_decode_mode == "image_batch1_step"
+    assert sample.multimodal_decode_sync_mode == "executor_step"
+    assert sample.image_batch1_step_decode_token_counter_start == 6
+    assert sample.image_batch1_step_decode_token_counter_end == 8
+    assert sample.image_batch1_step_decode_token_counter_advance == 2
 
 
 def test_benchmark_partial_prefix_cache_profile_uses_a_shorter_warmup_prompt(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -896,7 +896,7 @@ def test_mlx_vlm_runtime_uses_generate_step_fast_path_for_text_only_requests(
         _ = revision
         return SimpleNamespace(config=SimpleNamespace(model_type="gemma4")), FakeProcessor()
 
-    def fake_stream_generate(*args, **kwargs):
+    def fake_stream_generate(*args, **kwargs):  # pragma: no cover - failure guard
         _ = args
         _ = kwargs
         nonlocal stream_calls
@@ -1416,6 +1416,778 @@ def test_mlx_vlm_runtime_text_only_step_fast_path_releases_executor_between_toke
         ("step-1", owner_thread_id),
         ("step-2", owner_thread_id),
     ]
+
+
+def test_mlx_vlm_runtime_image_batch1_step_uses_executor_stream_and_token_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_mlx_core(monkeypatch)
+    _install_fake_mlx_vlm_prepare_inputs(monkeypatch)
+    sys.modules["mlx_vlm.utils"].prepare_inputs = lambda processor, **kwargs: vars(
+        processor(
+            kwargs["prompts"],
+            **{key: value for key, value in kwargs.items() if key != "prompts"},
+        )
+    )
+    checkpoints: list[tuple[str, int]] = []
+    apply_calls: list[tuple[str, int]] = []
+    prepare_calls: list[dict[str, object]] = []
+    generate_step_calls: list[dict[str, object]] = []
+    stream_generate_calls = 0
+    release_seen = Event()
+
+    class FakeDetokenizer:
+        def __init__(self) -> None:
+            self.text = ""
+            self.last_segment = ""
+
+        def __copy__(self):
+            copy = FakeDetokenizer()
+            copy.text = self.text
+            copy.last_segment = self.last_segment
+            return copy
+
+        def reset(self) -> None:
+            self.text = ""
+            self.last_segment = ""
+
+        def add_token(self, token: int) -> None:
+            self.last_segment = {201: "Image ", 202: "step"}.get(token, "")
+            self.text += self.last_segment
+
+        def finalize(self) -> None:
+            self.last_segment = ""
+
+    class FakeProcessor:
+        chat_template = "{{ prompt }}"
+        eos_token = "<eos>"
+        pad_token = None
+
+        def __init__(self) -> None:
+            self.detokenizer = FakeDetokenizer()
+            self.image_processor = object()
+
+        def __call__(self, prompts, **kwargs):
+            import mlx.core as mx
+
+            prepare_calls.append({"prompts": prompts, **dict(kwargs)})
+            assert prompts == ["formatted::Describe."]
+            assert kwargs["images"]
+            assert kwargs["return_tensors"] == "mlx"
+            return SimpleNamespace(
+                input_ids=mx.array([[1, 2, 3, 4, 5, 6]]),
+                attention_mask=mx.array([[1, 1, 1, 1, 1, 1]]),
+                pixel_values=mx.array([[[9]]]),
+                position_ids=mx.array([[0, 1, 2, 3, 4, 5]]),
+                rope_deltas=mx.array([[0]]),
+            )
+
+        def stopping_criteria(self, token: int) -> bool:
+            return token == 0
+
+    def fake_load(model_path: str, revision: str = "main"):
+        _ = model_path
+        _ = revision
+        return (
+            SimpleNamespace(config=SimpleNamespace(model_type="gemma4", image_token_index=256)),
+            FakeProcessor(),
+        )
+
+    def fake_apply_chat_template(_processor, _config, prompt, **kwargs):
+        apply_calls.append((prompt, kwargs.get("num_images", -1)))
+        return f"formatted::{prompt}"
+
+    def fake_stream_generate(*args, **kwargs):
+        _ = args
+        _ = kwargs
+        nonlocal stream_generate_calls
+        stream_generate_calls += 1
+        raise AssertionError("admitted image batch-1 step path should not call stream_generate")
+
+    def fake_generate_step(input_ids, model, pixel_values, mask, **kwargs):
+        checkpoints.append(("step-1", get_ident()))
+        generate_step_calls.append(
+            {
+                "input_ids_shape": tuple(input_ids.shape),
+                "model": model,
+                "pixel_values_shape": tuple(pixel_values.shape),
+                "mask_shape": tuple(mask.shape),
+                "position_ids_shape": tuple(kwargs["position_ids"].shape),
+                "rope_deltas_shape": tuple(kwargs["rope_deltas"].shape),
+                "max_tokens": kwargs["max_tokens"],
+                "temperature": kwargs["temperature"],
+                "top_p": kwargs["top_p"],
+                "top_k": kwargs["top_k"],
+                "prefill_step_size": kwargs["prefill_step_size"],
+            }
+        )
+        yield 201, [-0.1]
+        assert release_seen.is_set()
+        checkpoints.append(("step-2", get_ident()))
+        yield 202, [-0.2]
+
+    monkeypatch.setattr(mlx_vlm_runtime_module, "_installed_package_version", lambda name: f"{name}-version")
+    monkeypatch.setattr(mlx_vlm_runtime_module, "_mlx_peak_memory_gb", lambda _mx_module: 7.0)
+    executor = MLXRuntimeExecutor(stream_factory=lambda: object())
+    runtime = MLXVLMRuntime(
+        backend=AutoMLXVLMBackend(
+            load_fn=fake_load,
+            stream_generate_fn=fake_stream_generate,
+            apply_chat_template_fn=fake_apply_chat_template,
+            generate_step_fn=fake_generate_step,
+        ),
+        executor=executor,
+    )
+
+    try:
+        loaded_model = runtime.load_model(imported_gemma4_vlm_model())
+        prepared = runtime.render_prompt(
+            [
+                common_pb2.ChatMessage(
+                    role="user",
+                    parts=[
+                        common_pb2.MessagePart(text="Describe."),
+                        common_pb2.MessagePart(
+                            image_bytes=b"fake-image-payload",
+                            media=common_pb2.MediaMetadata(
+                                media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                                source_kind=common_pb2.MEDIA_SOURCE_INLINE_BYTES,
+                                filename="sample.jpg",
+                                format="jpg",
+                            ),
+                        ),
+                    ],
+                )
+            ],
+            loaded_model=loaded_model,
+        )
+        iterator = runtime.generate_tokens(
+            loaded_model,
+            prepared,
+            common_pb2.SamplingConfig(
+                temperature=0.0,
+                top_p=1.0,
+                top_k=0,
+                max_output_tokens=8,
+            ),
+            Event(),
+        )
+
+        first_event = next(iterator)
+        owner_thread_id = checkpoints[-1][1]
+        assert first_event.text == "Image "
+        assert executor.run(lambda: release_seen.set()) is None
+        remaining_events = list(iterator)
+    finally:
+        executor.shutdown()
+
+    assert [event.text for event in remaining_events] == ["step"]
+    assert stream_generate_calls == 0
+    assert apply_calls == [("Describe.", 1)]
+    assert len(prepare_calls) == 1
+    assert generate_step_calls == [
+        {
+            "input_ids_shape": (1, 6),
+            "model": loaded_model["model"],
+            "pixel_values_shape": (1, 1, 1),
+            "mask_shape": (1, 6),
+            "position_ids_shape": (1, 6),
+            "rope_deltas_shape": (1, 1),
+            "max_tokens": 8,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "top_k": 0,
+            "prefill_step_size": None,
+        }
+    ]
+    assert checkpoints == [
+        ("step-1", owner_thread_id),
+        ("step-2", owner_thread_id),
+    ]
+    probe = runtime.last_probe_snapshot()
+    assert probe.multimodal_decode_mode == "image_batch1_step"
+    assert probe.multimodal_decode_sync_mode == "executor_step"
+    assert probe.image_batch1_step_admission_reason == ""
+    assert probe.position_metadata_receipt["vision_metadata_guard"] == "aligned"
+    assert probe.position_metadata_receipt["vision_metadata_reuse_allowed"] is True
+    assert probe.image_batch1_step_decode_token_counter_start == 6
+    assert probe.image_batch1_step_decode_token_counter_end == 8
+    assert probe.image_batch1_step_decode_token_counter_advance == 2
+    assert probe.temp_media_artifact_count == 1
+    assert probe.temp_media_artifact_bytes == len(b"fake-image-payload")
+
+
+def test_mlx_vlm_runtime_image_batch1_step_keeps_non_greedy_requests_on_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_mlx_core(monkeypatch)
+    _install_fake_mlx_vlm_prepare_inputs(monkeypatch)
+    sys.modules["mlx_vlm.utils"].prepare_inputs = lambda processor, **kwargs: vars(
+        processor(
+            kwargs["prompts"],
+            **{key: value for key, value in kwargs.items() if key != "prompts"},
+        )
+    )
+    stream_calls: list[dict[str, object]] = []
+    generate_step_calls = 0
+
+    class FakeDetokenizer:
+        def __copy__(self):
+            return FakeDetokenizer()
+
+        def reset(self) -> None:
+            pass
+
+        def add_token(self, token: int) -> None:  # pragma: no cover - stream fallback does not detokenize
+            _ = token
+
+        def finalize(self) -> None:  # pragma: no cover - stream fallback does not detokenize
+            pass
+
+    class FakeProcessor:
+        chat_template = "{{ prompt }}"
+        eos_token = "<eos>"
+        pad_token = None
+
+        def __init__(self) -> None:
+            self.detokenizer = FakeDetokenizer()
+            self.image_processor = object()
+
+        def __call__(self, prompts, **kwargs):  # pragma: no cover - non-greedy must not pre-prepare inputs
+            import mlx.core as mx
+
+            _ = prompts
+            _ = kwargs
+            return SimpleNamespace(
+                input_ids=mx.array([[1, 2, 3, 4, 5, 6]]),
+                attention_mask=mx.array([[1, 1, 1, 1, 1, 1]]),
+                pixel_values=mx.array([[[9]]]),
+                position_ids=mx.array([[0, 1, 2, 3, 4, 5]]),
+                rope_deltas=mx.array([[0]]),
+            )
+
+    def fake_load(model_path: str, revision: str = "main"):
+        _ = model_path
+        _ = revision
+        return (
+            SimpleNamespace(config=SimpleNamespace(model_type="gemma4", image_token_index=256)),
+            FakeProcessor(),
+        )
+
+    def fake_stream_generate(*args, **kwargs):
+        _ = args
+        stream_calls.append(dict(kwargs))
+        yield SimpleNamespace(text="stream", prompt_tokens=6, generation_tokens=1)
+
+    def fake_generate_step(*args, **kwargs):  # pragma: no cover - failure guard
+        _ = args
+        _ = kwargs
+        nonlocal generate_step_calls
+        generate_step_calls += 1
+        raise AssertionError("non-greedy image batch-1 requests should stay on stream path")
+
+    monkeypatch.setattr(mlx_vlm_runtime_module, "_installed_package_version", lambda name: f"{name}-version")
+    runtime = MLXVLMRuntime(
+        backend=AutoMLXVLMBackend(
+            load_fn=fake_load,
+            stream_generate_fn=fake_stream_generate,
+            apply_chat_template_fn=lambda *_args, **_kwargs: "formatted::Describe.",
+            generate_step_fn=fake_generate_step,
+        )
+    )
+    loaded_model = runtime.load_model(imported_gemma4_vlm_model())
+    prepared = runtime.render_prompt(
+        [
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[
+                    common_pb2.MessagePart(text="Describe."),
+                    common_pb2.MessagePart(
+                        image_bytes=b"fake-image-payload",
+                        media=common_pb2.MediaMetadata(
+                            media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                            source_kind=common_pb2.MEDIA_SOURCE_INLINE_BYTES,
+                            filename="sample.jpg",
+                            format="jpg",
+                        ),
+                    ),
+                ],
+            )
+        ],
+        loaded_model=loaded_model,
+    )
+
+    events = list(
+        runtime.generate_tokens(
+            loaded_model,
+            prepared,
+            common_pb2.SamplingConfig(
+                temperature=0.7,
+                top_p=0.9,
+                top_k=8,
+                max_output_tokens=8,
+            ),
+            Event(),
+        )
+    )
+
+    assert [event.text for event in events] == ["stream"]
+    assert len(stream_calls) == 1
+    assert generate_step_calls == 0
+    probe = runtime.last_probe_snapshot()
+    assert probe.multimodal_decode_mode == "native_quantized"
+    assert probe.multimodal_decode_sync_mode == "executor_stream"
+    assert probe.multimodal_fallback_reason == "image_batch1_step_non_greedy_sampling"
+    assert probe.image_batch1_step_admission_reason == "image_batch1_step_non_greedy_sampling"
+
+
+def test_mlx_vlm_runtime_image_batch1_step_prepare_failure_cleans_and_streams(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_fake_mlx_core(monkeypatch)
+    _install_fake_mlx_vlm_prepare_inputs(monkeypatch)
+    prepare_calls: list[dict[str, object]] = []
+    stream_image_paths: list[str] = []
+    sessions: list[TempMediaSession] = []
+    generate_step_calls = 0
+
+    def failing_prepare_inputs(_processor, **kwargs):
+        prepare_calls.append(dict(kwargs))
+        raise RuntimeError("image step prepare failed")
+
+    sys.modules["mlx_vlm.utils"].prepare_inputs = failing_prepare_inputs
+
+    class FakeProcessor:
+        chat_template = "{{ prompt }}"
+        eos_token = "<eos>"
+        pad_token = None
+
+        def __init__(self) -> None:
+            self.image_processor = object()
+
+    def fake_load(model_path: str, revision: str = "main"):
+        _ = model_path
+        _ = revision
+        return (
+            SimpleNamespace(config=SimpleNamespace(model_type="gemma4", image_token_index=256)),
+            FakeProcessor(),
+        )
+
+    def fake_stream_generate(*args, **kwargs):
+        _ = args
+        image_paths = list(kwargs["image"])
+        assert len(image_paths) == 1
+        assert Path(image_paths[0]).exists()
+        stream_image_paths.extend(image_paths)
+        yield SimpleNamespace(text="stream", prompt_tokens=6, generation_tokens=1)
+
+    def fake_generate_step(*args, **kwargs):
+        _ = args
+        _ = kwargs
+        nonlocal generate_step_calls
+        generate_step_calls += 1
+        raise AssertionError("prepare failures should keep image batch-1 requests on stream path")
+
+    def session_factory(**kwargs) -> TempMediaSession:
+        session = TempMediaSession(**kwargs)
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(mlx_vlm_runtime_module, "_installed_package_version", lambda name: f"{name}-version")
+    runtime = MLXVLMRuntime(
+        backend=AutoMLXVLMBackend(
+            load_fn=fake_load,
+            stream_generate_fn=fake_stream_generate,
+            apply_chat_template_fn=lambda *_args, **_kwargs: "formatted::Describe.",
+            generate_step_fn=fake_generate_step,
+        ),
+        temp_root=tmp_path,
+        temp_media_session_factory=session_factory,
+    )
+    loaded_model = runtime.load_model(imported_gemma4_vlm_model())
+    prepared = runtime.render_prompt(
+        [
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[
+                    common_pb2.MessagePart(text="Describe."),
+                    common_pb2.MessagePart(
+                        image_bytes=b"fake-image-payload",
+                        media=common_pb2.MediaMetadata(
+                            media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                            source_kind=common_pb2.MEDIA_SOURCE_INLINE_BYTES,
+                            filename="sample.jpg",
+                            format="jpg",
+                        ),
+                    ),
+                ],
+            )
+        ],
+        loaded_model=loaded_model,
+    )
+
+    events = list(
+        runtime.generate_tokens(
+            loaded_model,
+            prepared,
+            common_pb2.SamplingConfig(
+                temperature=0.0,
+                top_p=1.0,
+                top_k=0,
+                max_output_tokens=8,
+            ),
+            Event(),
+        )
+    )
+
+    assert [event.text for event in events] == ["stream"]
+    assert len(prepare_calls) == 1
+    assert generate_step_calls == 0
+    assert len(stream_image_paths) == 1
+    assert not Path(stream_image_paths[0]).exists()
+    assert len(sessions) == 2
+    for session in sessions:
+        assert session.session_root is not None
+        assert not session.session_root.exists()
+        cleanup_report = session.cleanup()
+        assert cleanup_report.artifact_count == 1
+        assert cleanup_report.artifact_bytes == len(b"fake-image-payload")
+        assert cleanup_report.cleanup_failure_count == 0
+    probe = runtime.last_probe_snapshot()
+    assert probe.multimodal_decode_mode == "native_quantized"
+    assert probe.multimodal_decode_sync_mode == "executor_stream"
+    assert probe.multimodal_fallback_reason == "image_batch1_step_position_receipt_unaligned"
+    assert probe.image_batch1_step_admission_reason == "image_batch1_step_position_receipt_unaligned"
+    assert probe.position_metadata_receipt["vision_metadata_guard"] == "missing_position_metadata"
+    assert probe.position_metadata_receipt["vision_metadata_reuse_allowed"] is False
+    assert probe.temp_media_artifact_count == 1
+    assert probe.temp_media_artifact_bytes == len(b"fake-image-payload")
+
+
+def test_mlx_vlm_runtime_image_batch1_step_probe_failure_cleans_temp_media(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_fake_mlx_core(monkeypatch)
+    _install_fake_mlx_vlm_prepare_inputs(monkeypatch)
+    sys.modules["mlx_vlm.utils"].prepare_inputs = lambda processor, **kwargs: vars(
+        processor(
+            kwargs["prompts"],
+            **{key: value for key, value in kwargs.items() if key != "prompts"},
+        )
+    )
+    sessions: list[TempMediaSession] = []
+
+    class FakeDetokenizer:
+        def __copy__(self):  # pragma: no cover - probe fails before decode
+            return FakeDetokenizer()
+
+        def reset(self) -> None:  # pragma: no cover - no-op fake
+            pass
+
+        def add_token(self, token: int) -> None:
+            _ = token
+
+        def finalize(self) -> None:
+            pass
+
+    class FakeProcessor:
+        chat_template = "{{ prompt }}"
+        eos_token = "<eos>"
+        pad_token = None
+
+        def __init__(self) -> None:
+            self.detokenizer = FakeDetokenizer()
+            self.image_processor = object()
+
+        def __call__(self, prompts, **kwargs):
+            import mlx.core as mx
+
+            _ = prompts
+            _ = kwargs
+            return SimpleNamespace(
+                input_ids=mx.array([[1, 2, 3, 4, 5, 6]]),
+                attention_mask=mx.array([[1, 1, 1, 1, 1, 1]]),
+                pixel_values=mx.array([[[9]]]),
+                position_ids=mx.array([[0, 1, 2, 3, 4, 5]]),
+                rope_deltas=mx.array([[0]]),
+            )
+
+    def fake_load(model_path: str, revision: str = "main"):
+        _ = model_path
+        _ = revision
+        return (
+            SimpleNamespace(config=SimpleNamespace(model_type="gemma4", image_token_index=256)),
+            FakeProcessor(),
+        )
+
+    def session_factory(**kwargs) -> TempMediaSession:
+        session = TempMediaSession(**kwargs)
+        sessions.append(session)
+        return session
+
+    runtime = MLXVLMRuntime(
+        backend=AutoMLXVLMBackend(
+            load_fn=fake_load,
+            stream_generate_fn=lambda *args, **kwargs: iter(()),
+            apply_chat_template_fn=lambda *_args, **_kwargs: "formatted::Describe.",
+            generate_step_fn=lambda *args, **kwargs: iter(()),
+        ),
+        temp_root=tmp_path,
+        temp_media_session_factory=session_factory,
+    )
+    loaded_model = runtime.load_model(imported_gemma4_vlm_model())
+    prepared = runtime.render_prompt(
+        [
+            common_pb2.ChatMessage(
+                role="user",
+                parts=[
+                    common_pb2.MessagePart(text="Describe."),
+                    common_pb2.MessagePart(
+                        image_bytes=b"fake-image-payload",
+                        media=common_pb2.MediaMetadata(
+                            media_type=common_pb2.MEDIA_TYPE_IMAGE,
+                            source_kind=common_pb2.MEDIA_SOURCE_INLINE_BYTES,
+                            filename="sample.jpg",
+                            format="jpg",
+                        ),
+                    ),
+                ],
+            )
+        ],
+        loaded_model=loaded_model,
+    )
+
+    def raise_probe(*args, **kwargs):
+        _ = args
+        _ = kwargs
+        raise RuntimeError("probe failed")
+
+    monkeypatch.setattr(runtime, "_record_fast_path_probe", raise_probe)
+
+    with pytest.raises(RuntimeError, match="probe failed"):
+        list(
+            runtime.generate_tokens(
+                loaded_model,
+                prepared,
+                common_pb2.SamplingConfig(
+                    temperature=0.0,
+                    top_p=1.0,
+                    top_k=0,
+                    max_output_tokens=8,
+                ),
+                Event(),
+            )
+        )
+
+    assert len(sessions) == 1
+    session = sessions[0]
+    assert session.session_root is not None
+    assert not session.session_root.exists()
+    probe = runtime.last_probe_snapshot()
+    assert probe.temp_media_artifact_count == 1
+    assert probe.temp_media_artifact_bytes == len(b"fake-image-payload")
+    assert probe.temp_media_cleanup_failure_count == 0
+
+
+def test_mlx_vlm_runtime_image_batch1_step_decode_handles_tail_and_empty_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_mlx_core(monkeypatch)
+
+    class FakeDetokenizer:
+        def __init__(self) -> None:
+            self.text = ""
+            self.last_segment = ""
+
+        def __copy__(self):
+            return FakeDetokenizer()
+
+        def reset(self) -> None:
+            self.text = ""
+            self.last_segment = ""
+
+        def add_token(self, token: int) -> None:
+            self.last_segment = {201: "Image ", 202: "", 203: "step"}.get(token, "")
+            self.text += self.last_segment
+
+        def finalize(self) -> None:
+            self.last_segment = " tail"
+
+    class FakeProcessor:
+        def __init__(self) -> None:
+            self.detokenizer = FakeDetokenizer()
+
+        def stopping_criteria(self, token: int) -> bool:
+            return token == 0
+
+    def fake_generate_step(*args, **kwargs):
+        _ = args
+        _ = kwargs
+        yield ["bad", 201, 202], [-0.1, -0.2]
+        yield 0, [-0.3]
+
+    monkeypatch.setattr(mlx_vlm_runtime_module, "_mlx_peak_memory_gb", lambda _mx_module: 7.0)
+    runtime = MLXVLMRuntime(
+        backend=AutoMLXVLMBackend(
+            load_fn=lambda *args, **kwargs: None,
+            generate_step_fn=fake_generate_step,
+        )
+    )
+    loaded_model = {
+        "model": SimpleNamespace(config=SimpleNamespace(model_type="gemma4")),
+        "processor": FakeProcessor(),
+    }
+    prepared_request = PreparedVisionRequest(
+        prompt_text="Describe.",
+        images=[],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=0,
+        preprocess_peak_memory_bytes=0,
+        multimodal_hash_hex="image-step-decode-tail",
+    )
+    import mlx.core as mx
+
+    step_inputs = mlx_vlm_runtime_module._ImageBatch1StepInputs(
+        media_paths=mlx_vlm_runtime_module.MaterializedMediaPaths(
+            image_paths=("/tmp/image.jpg",),
+            video_paths=(),
+        ),
+        inputs={
+            "input_ids": mx.array([[1, 2, 3, 4, 5, 6]]),
+            "attention_mask": mx.array([[1, 1, 1, 1, 1, 1]]),
+            "pixel_values": mx.array([[[9]]]),
+            "position_ids": mx.array([[0, 1, 2, 3, 4, 5]]),
+            "rope_deltas": mx.array([[0]]),
+        },
+        prompt_tokens=6,
+        position_metadata_receipt={
+            "vision_metadata_guard": "aligned",
+            "vision_metadata_reuse_allowed": True,
+        },
+        started_at=time.perf_counter(),
+    )
+
+    events = list(
+        runtime._generate_image_batch1_step_events(
+            loaded_model=loaded_model,
+            prepared_request=prepared_request,
+            step_inputs=step_inputs,
+            sampling=common_pb2.SamplingConfig(max_output_tokens=8),
+            cancel_event=Event(),
+            prompt_tokens=6,
+            prefill_step_size=None,
+            speculative_fallback_reason="",
+        )
+    )
+
+    assert [event.text for event in events] == ["Image ", " tail"]
+    assert events[0].token_ids == (201,)
+    assert events[0].token_logprobs == (-0.1, -0.2)
+    assert events[-1].raw_text == "Image  tail"
+    assert events[-1].completion_tokens == 2
+    assert [event.peak_memory for event in events] == [7.0, 7.0]
+    probe = runtime.last_probe_snapshot()
+    assert probe.multimodal_decode_mode == "image_batch1_step"
+    assert probe.image_batch1_step_decode_token_counter_start == 6
+    assert probe.image_batch1_step_decode_token_counter_end == 8
+    assert probe.image_batch1_step_decode_token_counter_advance == 2
+
+
+def test_mlx_vlm_runtime_image_batch1_step_decode_cancel_and_missing_detokenizer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_mlx_core(monkeypatch)
+
+    class FakeDetokenizer:
+        def __copy__(self):
+            return FakeDetokenizer()
+
+        def reset(self) -> None:
+            pass
+
+        def add_token(self, token: int) -> None:
+            _ = token
+
+        def finalize(self) -> None:
+            pass
+
+    def fake_generate_step(*args, **kwargs):
+        _ = args
+        _ = kwargs
+        yield 201, [-0.1]
+
+    runtime = MLXVLMRuntime(
+        backend=AutoMLXVLMBackend(
+            load_fn=lambda *args, **kwargs: None,
+            generate_step_fn=fake_generate_step,
+        )
+    )
+    import mlx.core as mx
+
+    step_inputs = mlx_vlm_runtime_module._ImageBatch1StepInputs(
+        media_paths=mlx_vlm_runtime_module.MaterializedMediaPaths(
+            image_paths=("/tmp/image.jpg",),
+            video_paths=(),
+        ),
+        inputs={
+            "input_ids": mx.array([[1, 2, 3, 4, 5, 6]]),
+            "attention_mask": mx.array([[1, 1, 1, 1, 1, 1]]),
+            "pixel_values": mx.array([[[9]]]),
+        },
+        prompt_tokens=6,
+        position_metadata_receipt={},
+        started_at=time.perf_counter(),
+    )
+    prepared_request = PreparedVisionRequest(
+        prompt_text="Describe.",
+        images=[],
+        videos=[],
+        video_frame_policies=[],
+        preprocess_latency_ms=0.0,
+        preprocess_input_bytes=0,
+        preprocess_peak_memory_bytes=0,
+        multimodal_hash_hex="image-step-decode-cancel",
+    )
+    cancel_event = Event()
+    cancel_event.set()
+
+    events = list(
+        runtime._generate_image_batch1_step_events(
+            loaded_model={
+                "model": SimpleNamespace(config=SimpleNamespace(model_type="gemma4")),
+                "processor": SimpleNamespace(detokenizer=FakeDetokenizer()),
+            },
+            prepared_request=prepared_request,
+            step_inputs=step_inputs,
+            sampling=common_pb2.SamplingConfig(max_output_tokens=8),
+            cancel_event=cancel_event,
+            prompt_tokens=6,
+            prefill_step_size=None,
+            speculative_fallback_reason="",
+        )
+    )
+    assert events == []
+
+    with pytest.raises(RuntimeError, match="isolated streaming detokenizer"):
+        list(
+            runtime._generate_image_batch1_step_events(
+                loaded_model={
+                    "model": SimpleNamespace(config=SimpleNamespace(model_type="gemma4")),
+                    "processor": SimpleNamespace(),
+                },
+                prepared_request=prepared_request,
+                step_inputs=step_inputs,
+                sampling=common_pb2.SamplingConfig(max_output_tokens=8),
+                cancel_event=Event(),
+                prompt_tokens=6,
+                prefill_step_size=None,
+                speculative_fallback_reason="",
+            )
+        )
 
 
 def test_mlx_vlm_runtime_text_only_step_uses_isolated_detokenizer() -> None:
@@ -5427,7 +6199,8 @@ def _assert_mlx_vlm_runtime_uses_generate_step_for_mtp_when_available(
         )
     )
 
-    assert apply_calls == ["Describe.", "Say hello."]
+    assert apply_calls[0] == "Describe."
+    assert apply_calls[-1] == "Say hello."
     assert [event.text for event in stream_events] == ["stream"]
     assert stream_generate_calls[0]["prefill_step_size"] == stream_attention_receipt["selected_prefill_step_size"]
     assert stream_generate_calls[0]["model"] is not loaded_model["model"]

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -147,6 +147,9 @@ class BenchSample:
     multimodal_decode_mode: str = "baseline"
     multimodal_fallback_reason: str = "not_reported"
     multimodal_decode_sync_mode: str = "baseline"
+    image_batch1_step_decode_token_counter_start: int = 0
+    image_batch1_step_decode_token_counter_end: int = 0
+    image_batch1_step_decode_token_counter_advance: int = 0
     multi_image_scatter_mode: str = "none"
     quantized_load_mode: str = "fallback"
     quantized_load_fallback_reason: str = "not_reported"
@@ -4014,6 +4017,21 @@ class MaintenanceCore:
                 if probe is not None
                 else "not_reported"
             ),
+            image_batch1_step_decode_token_counter_start=self._probe_counter(
+                probe,
+                "image_batch1_step_decode_token_counter_start",
+                0,
+            ),
+            image_batch1_step_decode_token_counter_end=self._probe_counter(
+                probe,
+                "image_batch1_step_decode_token_counter_end",
+                0,
+            ),
+            image_batch1_step_decode_token_counter_advance=self._probe_counter(
+                probe,
+                "image_batch1_step_decode_token_counter_advance",
+                0,
+            ),
             multi_image_scatter_mode=str(
                 getattr(probe, "multi_image_scatter_mode", "none")
                 if probe is not None
@@ -4165,6 +4183,7 @@ class MaintenanceCore:
                         "text_only_step": 6.0,
                         "text_only_batch_generator": 7.0,
                         "image_batch1_step_admission": 8.0,
+                        "image_batch1_step": 9.0,
                     },
                 ),
                 unit="code",
@@ -4213,6 +4232,45 @@ class MaintenanceCore:
                     },
                 ),
                 unit="code",
+            ),
+            BenchMetricSpec(
+                suite=suite_id,
+                name=f"bench.{suite_id}.image_batch1_step_decode_token_counter_start",
+                value=float(
+                    max(
+                        (
+                            sample.image_batch1_step_decode_token_counter_start
+                            for sample in samples
+                        ),
+                        default=0,
+                    )
+                ),
+                unit="tok",
+            ),
+            BenchMetricSpec(
+                suite=suite_id,
+                name=f"bench.{suite_id}.image_batch1_step_decode_token_counter_end",
+                value=float(
+                    max(
+                        (
+                            sample.image_batch1_step_decode_token_counter_end
+                            for sample in samples
+                        ),
+                        default=0,
+                    )
+                ),
+                unit="tok",
+            ),
+            BenchMetricSpec(
+                suite=suite_id,
+                name=f"bench.{suite_id}.image_batch1_step_decode_token_counter_advance",
+                value=float(
+                    sum(
+                        sample.image_batch1_step_decode_token_counter_advance
+                        for sample in samples
+                    )
+                ),
+                unit="tok",
             ),
             BenchMetricSpec(
                 suite=suite_id,

--- a/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_vlm_runtime.py
@@ -89,6 +89,9 @@ class VisionProbeSnapshot:
     multimodal_decode_sync_mode: str = "baseline"
     multi_image_scatter_mode: str = "none"
     image_batch1_step_admission_reason: str = ""
+    image_batch1_step_decode_token_counter_start: int = 0
+    image_batch1_step_decode_token_counter_end: int = 0
+    image_batch1_step_decode_token_counter_advance: int = 0
     multimodal_position_slice_fallback_count: int = 0
     quantized_load_mode: str = "fallback"
     quantized_load_fallback_reason: str = "not_reported"

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -2204,6 +2204,17 @@ class MLXVLMRuntime:
         )
         image_batch1_temp_media_session: TempMediaSession | None = None
         image_batch1_step_inputs: _ImageBatch1StepInputs | None = None
+
+        def cleanup_image_batch1_temp_media_session(session: TempMediaSession) -> None:
+            cleanup_report = session.cleanup()
+            self._last_probe = replace(
+                self._last_probe,
+                temp_media_artifact_count=cleanup_report.artifact_count,
+                temp_media_artifact_bytes=cleanup_report.artifact_bytes,
+                temp_media_cleanup_latency_ms=cleanup_report.cleanup_latency_ms,
+                temp_media_cleanup_failure_count=cleanup_report.cleanup_failure_count,
+            )
+
         if self._should_prepare_image_batch1_step_inputs(
             prepared_request=prepared_request,
             sampling=sampling,
@@ -2221,14 +2232,7 @@ class MLXVLMRuntime:
                 )
                 prompt_tokens = image_batch1_step_inputs.prompt_tokens
             except Exception:
-                cleanup_report = image_batch1_temp_media_session.cleanup()
-                self._last_probe = replace(
-                    self._last_probe,
-                    temp_media_artifact_count=cleanup_report.artifact_count,
-                    temp_media_artifact_bytes=cleanup_report.artifact_bytes,
-                    temp_media_cleanup_latency_ms=cleanup_report.cleanup_latency_ms,
-                    temp_media_cleanup_failure_count=cleanup_report.cleanup_failure_count,
-                )
+                cleanup_image_batch1_temp_media_session(image_batch1_temp_media_session)
                 image_batch1_temp_media_session = None
         try:
             self._ensure_fast_path_probe(
@@ -2255,14 +2259,7 @@ class MLXVLMRuntime:
             )
         except Exception:
             if image_batch1_temp_media_session is not None:
-                cleanup_report = image_batch1_temp_media_session.cleanup()
-                self._last_probe = replace(
-                    self._last_probe,
-                    temp_media_artifact_count=cleanup_report.artifact_count,
-                    temp_media_artifact_bytes=cleanup_report.artifact_bytes,
-                    temp_media_cleanup_latency_ms=cleanup_report.cleanup_latency_ms,
-                    temp_media_cleanup_failure_count=cleanup_report.cleanup_failure_count,
-                )
+                cleanup_image_batch1_temp_media_session(image_batch1_temp_media_session)
                 image_batch1_temp_media_session = None
             raise
         enforce_attention_prefill_policy(attention_policy)
@@ -2361,14 +2358,7 @@ class MLXVLMRuntime:
                 return
         finally:
             if image_batch1_temp_media_session is not None:
-                cleanup_report = image_batch1_temp_media_session.cleanup()
-                self._last_probe = replace(
-                    self._last_probe,
-                    temp_media_artifact_count=cleanup_report.artifact_count,
-                    temp_media_artifact_bytes=cleanup_report.artifact_bytes,
-                    temp_media_cleanup_latency_ms=cleanup_report.cleanup_latency_ms,
-                    temp_media_cleanup_failure_count=cleanup_report.cleanup_failure_count,
-                )
+                cleanup_image_batch1_temp_media_session(image_batch1_temp_media_session)
 
         temp_media_session = self._temp_media_session_factory(
             temp_root=self._temp_root,

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -304,6 +304,15 @@ class MaterializedMediaPaths:
     video_paths: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class _ImageBatch1StepInputs:
+    media_paths: MaterializedMediaPaths
+    inputs: dict[str, Any]
+    prompt_tokens: int
+    position_metadata_receipt: dict[str, object]
+    started_at: float
+
+
 class _Gemma4TextBackedModelShim:
     def __init__(self, language_model: Any) -> None:
         self.language_model = language_model
@@ -2183,17 +2192,6 @@ class MLXVLMRuntime:
             prepared_request=prepared_request,
             execution_ext=execution_ext,
         )
-        self._ensure_fast_path_probe(
-            loaded_model,
-            prepared_request,
-            attention_policy=attention_policy,
-            image_batch1_step_supported=self._backend.generate_step_fn is not None,
-            image_batch1_step_greedy_sampling=self._sampling_is_greedy(sampling),
-        )
-        enforce_attention_prefill_policy(attention_policy)
-        if cancel_event.is_set():
-            return
-
         prompt_tokens = (
             attention_policy.prompt_tokens
             if attention_policy is not None
@@ -2204,62 +2202,173 @@ class MLXVLMRuntime:
             if attention_policy is not None and attention_policy.prefill_chunk_mode == "auto_chunk"
             else None
         )
-        text_only_batch_generator_unsupported_reason = (
-            self._text_only_batch_generator_unsupported_reason(
+        image_batch1_temp_media_session: TempMediaSession | None = None
+        image_batch1_step_inputs: _ImageBatch1StepInputs | None = None
+        if self._should_prepare_image_batch1_step_inputs(
+            prepared_request=prepared_request,
+            sampling=sampling,
+        ):
+            image_batch1_temp_media_session = self._temp_media_session_factory(
+                temp_root=self._temp_root,
+                prefix="melix-vlm-",
+            )
+            try:
+                image_batch1_step_inputs = self._prepare_image_batch1_step_inputs(
+                    loaded_model=loaded_model,
+                    prepared_request=prepared_request,
+                    temp_media_session=image_batch1_temp_media_session,
+                    prompt_tokens=prompt_tokens,
+                )
+                prompt_tokens = image_batch1_step_inputs.prompt_tokens
+            except Exception:
+                cleanup_report = image_batch1_temp_media_session.cleanup()
+                self._last_probe = replace(
+                    self._last_probe,
+                    temp_media_artifact_count=cleanup_report.artifact_count,
+                    temp_media_artifact_bytes=cleanup_report.artifact_bytes,
+                    temp_media_cleanup_latency_ms=cleanup_report.cleanup_latency_ms,
+                    temp_media_cleanup_failure_count=cleanup_report.cleanup_failure_count,
+                )
+                image_batch1_temp_media_session = None
+        try:
+            self._ensure_fast_path_probe(
+                loaded_model,
+                prepared_request,
+                attention_policy=attention_policy,
+                seq_len=(
+                    image_batch1_step_inputs.prompt_tokens
+                    if image_batch1_step_inputs is not None
+                    else None
+                ),
+                position_ids=(
+                    image_batch1_step_inputs.inputs.get("position_ids")
+                    if image_batch1_step_inputs is not None
+                    else None
+                ),
+                rope_deltas=(
+                    image_batch1_step_inputs.inputs.get("rope_deltas")
+                    if image_batch1_step_inputs is not None
+                    else None
+                ),
+                image_batch1_step_supported=self._backend.generate_step_fn is not None,
+                image_batch1_step_greedy_sampling=self._sampling_is_greedy(sampling),
+            )
+        except Exception:
+            if image_batch1_temp_media_session is not None:
+                cleanup_report = image_batch1_temp_media_session.cleanup()
+                self._last_probe = replace(
+                    self._last_probe,
+                    temp_media_artifact_count=cleanup_report.artifact_count,
+                    temp_media_artifact_bytes=cleanup_report.artifact_bytes,
+                    temp_media_cleanup_latency_ms=cleanup_report.cleanup_latency_ms,
+                    temp_media_cleanup_failure_count=cleanup_report.cleanup_failure_count,
+                )
+                image_batch1_temp_media_session = None
+            raise
+        enforce_attention_prefill_policy(attention_policy)
+        try:
+            if cancel_event.is_set():
+                return
+
+            text_only_batch_generator_unsupported_reason = (
+                self._text_only_batch_generator_unsupported_reason(
+                    loaded_model=loaded_model,
+                    prepared_request=prepared_request,
+                    sampling=sampling,
+                    execution_ext=execution_ext,
+                )
+            )
+            if self._can_use_text_only_batch_generator(
                 loaded_model=loaded_model,
                 prepared_request=prepared_request,
                 sampling=sampling,
                 execution_ext=execution_ext,
-            )
-        )
-        if self._can_use_text_only_batch_generator(
-            loaded_model=loaded_model,
-            prepared_request=prepared_request,
-            sampling=sampling,
-            execution_ext=execution_ext,
-        ):
-            yield from self._generate_text_only_batch_generator_events(
-                loaded_model=loaded_model,
-                prepared_request=prepared_request,
-                sampling=sampling,
-                cancel_event=cancel_event,
-                prompt_tokens=prompt_tokens,
-                prefill_step_size=selected_prefill_step_size,
-            )
-            return
-        if self._can_use_text_only_step_fast_path(
-            loaded_model=loaded_model,
-            prepared_request=prepared_request,
-        ):
-
-            def text_only_backend_events():
-                # Must run on the executor-owned thread so the MLX runtime is
-                # initialized inside the same stream ownership context used for
-                # the subsequent token generation work.
-                self._backend._ensure_runtime()
-                if cancel_event.is_set():
-                    return
-                yield from self._generate_text_only_step_events(
+            ):
+                yield from self._generate_text_only_batch_generator_events(
                     loaded_model=loaded_model,
                     prepared_request=prepared_request,
                     sampling=sampling,
                     cancel_event=cancel_event,
                     prompt_tokens=prompt_tokens,
                     prefill_step_size=selected_prefill_step_size,
-                    speculative_fallback_reason=speculative_fallback_reason,
-                    text_only_batch_generator_unsupported_reason=(
-                        text_only_batch_generator_unsupported_reason
-                    ),
                 )
+                return
+            if self._can_use_text_only_step_fast_path(
+                loaded_model=loaded_model,
+                prepared_request=prepared_request,
+            ):
 
-            event_iterable = (
-                text_only_backend_events()
-                if self._executor is None
-                else self._executor.iterate_cooperatively(text_only_backend_events)
-            )
-            for event in event_iterable:
-                yield event
-            return
+                def text_only_backend_events():
+                    # Must run on the executor-owned thread so the MLX runtime is
+                    # initialized inside the same stream ownership context used for
+                    # the subsequent token generation work.
+                    self._backend._ensure_runtime()
+                    if cancel_event.is_set():
+                        return
+                    yield from self._generate_text_only_step_events(
+                        loaded_model=loaded_model,
+                        prepared_request=prepared_request,
+                        sampling=sampling,
+                        cancel_event=cancel_event,
+                        prompt_tokens=prompt_tokens,
+                        prefill_step_size=selected_prefill_step_size,
+                        speculative_fallback_reason=speculative_fallback_reason,
+                        text_only_batch_generator_unsupported_reason=(
+                            text_only_batch_generator_unsupported_reason
+                        ),
+                    )
+
+                event_iterable = (
+                    text_only_backend_events()
+                    if self._executor is None
+                    else self._executor.iterate_cooperatively(text_only_backend_events)
+                )
+                for event in event_iterable:
+                    yield event
+                return
+
+            if self._can_use_image_batch1_step_fast_path(
+                loaded_model=loaded_model,
+                prepared_request=prepared_request,
+                step_inputs=image_batch1_step_inputs,
+            ):
+                assert image_batch1_step_inputs is not None
+
+                def image_batch1_backend_events():
+                    # Must run on the executor-owned thread so the MLX runtime,
+                    # VLM input preparation, and token loop share the same stream.
+                    self._backend._ensure_runtime()
+                    if cancel_event.is_set():
+                        return
+                    yield from self._generate_image_batch1_step_events(
+                        loaded_model=loaded_model,
+                        prepared_request=prepared_request,
+                        step_inputs=image_batch1_step_inputs,
+                        sampling=sampling,
+                        cancel_event=cancel_event,
+                        prompt_tokens=prompt_tokens,
+                        prefill_step_size=selected_prefill_step_size,
+                        speculative_fallback_reason=speculative_fallback_reason,
+                    )
+
+                event_iterable = (
+                    image_batch1_backend_events()
+                    if self._executor is None
+                    else self._executor.iterate_cooperatively(image_batch1_backend_events)
+                )
+                for event in event_iterable:
+                    yield event
+                return
+        finally:
+            if image_batch1_temp_media_session is not None:
+                cleanup_report = image_batch1_temp_media_session.cleanup()
+                self._last_probe = replace(
+                    self._last_probe,
+                    temp_media_artifact_count=cleanup_report.artifact_count,
+                    temp_media_artifact_bytes=cleanup_report.artifact_bytes,
+                    temp_media_cleanup_latency_ms=cleanup_report.cleanup_latency_ms,
+                    temp_media_cleanup_failure_count=cleanup_report.cleanup_failure_count,
+                )
 
         temp_media_session = self._temp_media_session_factory(
             temp_root=self._temp_root,
@@ -2820,6 +2929,223 @@ class MLXVLMRuntime:
         if event is not None:
             yield event
 
+    def _generate_image_batch1_step_events(
+        self,
+        *,
+        loaded_model,
+        prepared_request: PreparedVisionRequest,
+        step_inputs: _ImageBatch1StepInputs,
+        sampling,
+        cancel_event: Event,
+        prompt_tokens: int,
+        prefill_step_size: int | None,
+        speculative_fallback_reason: str,
+    ):
+        import mlx.core as mx
+
+        started_at = step_inputs.started_at
+        inputs = step_inputs.inputs
+        input_ids = inputs["input_ids"]
+        mask = inputs.get("attention_mask")
+        pixel_values = inputs.get("pixel_values")
+        prompt_tokens = step_inputs.prompt_tokens or int(
+            getattr(input_ids, "shape", [0, prompt_tokens])[-1] or prompt_tokens
+        )
+        position_receipt = step_inputs.position_metadata_receipt
+
+        detokenizer = _isolated_streaming_detokenizer(loaded_model["processor"])
+        if detokenizer is None:
+            raise RuntimeError("The VLM processor does not expose an isolated streaming detokenizer.")
+        tokenizer = (
+            loaded_model["processor"].tokenizer
+            if hasattr(loaded_model["processor"], "tokenizer")
+            else loaded_model["processor"]
+        )
+        stopping_criteria = getattr(tokenizer, "stopping_criteria", None)
+        first_token_at: float | None = None
+        completion_tokens = 0
+        cumulative_raw_text = ""
+        peak_memory_gb: float | None = None
+
+        def cached_peak_memory_gb() -> float:
+            nonlocal peak_memory_gb
+            if peak_memory_gb is None:
+                peak_memory_gb = _mlx_peak_memory_gb(mx)
+            return peak_memory_gb
+
+        def finalized_text_event():
+            nonlocal cumulative_raw_text
+            detokenizer.finalize()
+            text = str(getattr(detokenizer, "last_segment", "") or "")
+            if not text:
+                return None
+            cumulative_raw_text += text
+            finished_at = time.perf_counter()
+            generation_elapsed = max(0.0, finished_at - (first_token_at or finished_at))
+            return RuntimeTokenEvent(
+                text=text,
+                raw_text=cumulative_raw_text,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                prompt_tps=0.0,
+                generation_tps=(completion_tokens / generation_elapsed) if generation_elapsed > 0 else 0.0,
+                peak_memory=cached_peak_memory_gb(),
+                finish_reason="stop",
+                speculative_fallback_count=1 if speculative_fallback_reason else None,
+                speculative_num_draft_tokens=0 if speculative_fallback_reason else None,
+                speculative_draft_model_configured=False if speculative_fallback_reason else None,
+            )
+
+        step_kwargs: dict[str, Any] = {
+            "max_tokens": int(getattr(sampling, "max_output_tokens", 0) or 64),
+            "temperature": float(getattr(sampling, "temperature", 0.0)),
+            "top_p": float(getattr(sampling, "top_p", 1.0)),
+            "top_k": int(getattr(sampling, "top_k", 0)),
+        }
+        if _callable_accepts_kwarg(
+            self._backend.generate_step_fn,
+            "prefill_step_size",
+        ):
+            step_kwargs["prefill_step_size"] = prefill_step_size
+        step_kwargs.update(
+            {
+                key: value
+                for key, value in inputs.items()
+                if key not in {"input_ids", "pixel_values", "attention_mask"}
+            }
+        )
+
+        for token, logprobs in self._backend.generate_step_fn(
+            input_ids,
+            loaded_model["model"],
+            pixel_values,
+            mask,
+            **step_kwargs,
+        ):
+            if cancel_event.is_set():
+                return
+            if first_token_at is None:
+                first_token_at = time.perf_counter()
+                self._last_probe = replace(
+                    self._last_probe,
+                    preprocess_latency_ms=prepared_request.preprocess_latency_ms,
+                    preprocess_input_bytes=prepared_request.preprocess_input_bytes,
+                    preprocess_peak_memory_bytes=prepared_request.preprocess_peak_memory_bytes,
+                    first_token_latency_ms=max(0.0, (first_token_at - started_at) * 1000.0),
+                    video_effective_frame_count=prepared_request.effective_video_frame_count,
+                    video_requested_frame_budget=prepared_request.requested_video_frame_budget,
+                    video_window_ms=prepared_request.effective_video_window_ms,
+                    cache_identity="",
+                    cache_scope_id="",
+                    cache_hit=False,
+                    multimodal_decode_mode="image_batch1_step",
+                    multimodal_fallback_reason="",
+                    multimodal_decode_sync_mode="executor_step",
+                    position_metadata_receipt=position_receipt,
+                    image_batch1_step_decode_token_counter_start=prompt_tokens,
+                    image_batch1_step_decode_token_counter_end=prompt_tokens,
+                    image_batch1_step_decode_token_counter_advance=0,
+                )
+
+            token_values = token if isinstance(token, list) else [token]
+            for token_value in token_values:
+                try:
+                    token_id = int(token_value)
+                except (TypeError, ValueError):
+                    continue
+                if callable(stopping_criteria) and stopping_criteria(token_id):
+                    event = finalized_text_event()
+                    if event is not None:
+                        yield event
+                    return
+                decode_position = prompt_tokens + completion_tokens
+                completion_tokens += 1
+                detokenizer.add_token(token_id)
+                self._last_probe = replace(
+                    self._last_probe,
+                    image_batch1_step_decode_token_counter_end=decode_position + 1,
+                    image_batch1_step_decode_token_counter_advance=completion_tokens,
+                )
+                text = str(getattr(detokenizer, "last_segment", "") or "")
+                if not text:
+                    continue
+                cumulative_raw_text += text
+                now = time.perf_counter()
+                generation_elapsed = max(0.0, now - (first_token_at or now))
+                yield RuntimeTokenEvent(
+                    text=text,
+                    raw_text=cumulative_raw_text,
+                    token_ids=(token_id,),
+                    token_logprobs=_float_tuple(logprobs),
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    prompt_tps=0.0,
+                    generation_tps=(completion_tokens / generation_elapsed) if generation_elapsed > 0 else 0.0,
+                    peak_memory=cached_peak_memory_gb(),
+                    finish_reason="stop",
+                    speculative_fallback_count=1 if speculative_fallback_reason else None,
+                    speculative_num_draft_tokens=0 if speculative_fallback_reason else None,
+                    speculative_draft_model_configured=False if speculative_fallback_reason else None,
+                )
+
+        event = finalized_text_event()
+        if event is not None:
+            yield event
+
+    def _prepare_image_batch1_step_inputs(
+        self,
+        *,
+        loaded_model,
+        prepared_request: PreparedVisionRequest,
+        temp_media_session: TempMediaSession,
+        prompt_tokens: int,
+    ) -> _ImageBatch1StepInputs:
+        from mlx_vlm.utils import prepare_inputs
+
+        started_at = time.perf_counter()
+        media_paths = self._materialize_media(prepared_request, temp_media_session)
+        formatted_prompt = self._backend.apply_chat_template_fn(
+            loaded_model["processor"],
+            loaded_model["model"].config,
+            prepared_request.prompt_text,
+            num_images=len(media_paths.image_paths),
+        )
+        add_special_tokens = (
+            getattr(loaded_model["processor"], "chat_template", None) is None
+            if getattr(loaded_model["model"].config, "model_type", "") in _GEMMA_CHAT_TEMPLATE_MODEL_TYPES
+            else True
+        )
+        input_kwargs: dict[str, Any] = {
+            "images": list(media_paths.image_paths),
+            "prompts": [formatted_prompt],
+            "image_token_index": getattr(loaded_model["model"].config, "image_token_index", None),
+            "add_special_tokens": add_special_tokens,
+            "return_tensors": "mlx",
+        }
+        apply_resize_shape_to_stream_kwargs(input_kwargs, prepared_request)
+
+        def prepare_on_executor() -> dict[str, Any]:
+            self._backend._ensure_runtime()
+            return prepare_inputs(loaded_model["processor"], **input_kwargs)
+
+        inputs = self._run_on_executor(prepare_on_executor)
+        prompt_tokens = int(getattr(inputs["input_ids"], "shape", [0, prompt_tokens])[-1] or prompt_tokens)
+        position_receipt = self._position_metadata_receipt(
+            loaded_model=loaded_model,
+            prepared_request=prepared_request,
+            fallback_reason="",
+            seq_len=prompt_tokens,
+            position_ids=inputs.get("position_ids"),
+            rope_deltas=inputs.get("rope_deltas"),
+        )
+        return _ImageBatch1StepInputs(
+            media_paths=media_paths,
+            inputs=inputs,
+            prompt_tokens=prompt_tokens,
+            position_metadata_receipt=position_receipt,
+            started_at=started_at,
+        )
+
     def _can_use_text_only_step_fast_path(
         self,
         *,
@@ -2831,6 +3157,41 @@ class MLXVLMRuntime:
             and not prepared_request.images
             and not prepared_request.videos
             and _supports_isolated_streaming_detokenizer(loaded_model["processor"])
+        )
+
+    def _can_use_image_batch1_step_fast_path(
+        self,
+        *,
+        loaded_model,
+        prepared_request: PreparedVisionRequest,
+        step_inputs: _ImageBatch1StepInputs | None,
+    ) -> bool:
+        _ = loaded_model
+        probe = self._last_probe
+        return (
+            step_inputs is not None
+            and self._backend.generate_step_fn is not None
+            and len(prepared_request.images) == 1
+            and not prepared_request.videos
+            and probe.multimodal_decode_mode == "image_batch1_step_admission"
+            and probe.image_batch1_step_admission_reason == ""
+        )
+
+    @staticmethod
+    def _is_image_batch1_step_candidate(prepared_request: PreparedVisionRequest) -> bool:
+        return len(prepared_request.images) == 1 and not prepared_request.videos
+
+    def _should_prepare_image_batch1_step_inputs(
+        self,
+        *,
+        prepared_request: PreparedVisionRequest,
+        sampling,
+    ) -> bool:
+        return (
+            self._is_image_batch1_step_candidate(prepared_request)
+            and self._backend.generate_step_fn is not None
+            and self._sampling_is_greedy(sampling)
+            and all(str(getattr(image, "sha256_hex", "") or "") for image in prepared_request.images)
         )
 
     def _can_use_text_only_batch_generator(
@@ -3202,6 +3563,9 @@ class MLXVLMRuntime:
         prepared_request: PreparedVisionRequest,
         *,
         attention_policy: AttentionPrefillPolicyDecision | None = None,
+        seq_len: int | None = None,
+        position_ids: object | None = None,
+        rope_deltas: object | None = None,
         image_batch1_step_supported: bool | None = None,
         image_batch1_step_greedy_sampling: bool | None = None,
     ) -> None:
@@ -3230,7 +3594,10 @@ class MLXVLMRuntime:
             loaded_model,
             prepared_request,
             signature=signature,
+            seq_len=seq_len,
             attention_policy=attention_policy,
+            position_ids=position_ids,
+            rope_deltas=rope_deltas,
             image_batch1_step_supported=image_batch1_step_supported,
             image_batch1_step_greedy_sampling=image_batch1_step_greedy_sampling,
         )

--- a/services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py
+++ b/services/mlx-worker-python/worker/runtime/multimodal_fast_paths.py
@@ -645,6 +645,10 @@ class MultimodalFastPathController:
             return "image_batch1_step_media_route_ineligible"
         if any(not str(getattr(image, "sha256_hex", "") or "") for image in prepared_request.images):
             return "image_batch1_step_cache_receipt_missing"
+        if greedy_sampling is False:
+            return "image_batch1_step_non_greedy_sampling"
+        if backend_step_supported is False:
+            return "image_batch1_step_backend_unsupported"
         if not isinstance(position_receipt, dict):
             return "image_batch1_step_position_receipt_missing"
         if (
@@ -652,10 +656,6 @@ class MultimodalFastPathController:
             or not bool(position_receipt.get("vision_metadata_reuse_allowed"))
         ):
             return "image_batch1_step_position_receipt_unaligned"
-        if greedy_sampling is False:
-            return "image_batch1_step_non_greedy_sampling"
-        if backend_step_supported is False:
-            return "image_batch1_step_backend_unsupported"
         return ""
 
     def _image_feature_entry(


### PR DESCRIPTION
## Summary
- Closes #1460.
- Adds the eligible batch-1 single-image VLM decode path that prepares media-aware MLX inputs on the executor, then runs `generate_step` through the executor-owned cooperative stream instead of `stream_generate`.
- Threads an integer completion-token counter through the image batch-1 decode loop and reports start/end/advance metrics into VLM bench samples.
- Keeps non-greedy, unsupported, prepare-failure, and probe-failure requests on the existing stream path, with temp-media cleanup covered by tests.
- Addresses review feedback by using pytest selection augmentation for scoped coverage instead of manually executing tests from an autouse fixture, and by centralizing image batch-1 temp-media cleanup in a local helper.

## Plan or Spec
- `docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md` Unit 3.2.2.
- Issue: #1460.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python -m py_compile services/mlx-worker-python/tests/conftest.py services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
# pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_image_batch1_step_uses_executor_stream_and_token_counter services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_image_batch1_step_keeps_non_greedy_requests_on_stream services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_image_batch1_step_prepare_failure_cleans_and_streams services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_image_batch1_step_probe_failure_cleans_temp_media services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_image_batch1_step_decode_handles_tail_and_empty_tokens services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_image_batch1_step_decode_cancel_and_missing_detokenizer services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_fast_path_bench_metrics_encode_image_batch1_step_counters services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_bench_sample_carries_image_batch1_step_token_counters
# 8 passed in 0.19s

git diff --check
# pass

# Pre-commit gate after review cleanup and latest origin/main merge:
make swift-test
# pass, elapsed 202.3s
make py-test
# 4297 passed, 14 skipped, 2 warnings in 171.40s
make integration-test
# 123 passed, 1 skipped in 428.65s
# scoped performance report: .runtime/pre-commit-performance/20260623-171135-9e040a35/report/report.md, status ok, 0 regressions

# GitHub PR checks on head 35495163:
ci-pr / actionlint-and-diffcheck
ci-pr / python-tests
ci-pr / integration-tests
ci-pr / swift-tests-report
pr-evidence
pr-scoped-performance / scope
pr-scoped-performance / report
# all pass
```

## Coverage and Metrics
- Feature implementation changed-scope worker coverage: 98% (`158` measurable changed lines, `155` covered, `3` missed).
- Review cleanup changed-scope coverage before merging latest main: 95% (`43` measurable changed lines, `41` covered, `2` missed); VLM cleanup helper lines were 100% covered.
- Final pre-commit scoped performance report: `.runtime/pre-commit-performance/20260623-171135-9e040a35/report/report.md`, status `ok`, 0 regressions.
- GitHub PR-scoped performance report on head `35495163`: passed, including `scope`, all selected probes, and `report`.
- Observability mode: minimal runtime probe counters plus evidence-mode benchmark metrics. Probe overhead is one integer counter update per emitted token on the eligible image batch-1 path; existing ineligible stream paths are unchanged.

## Known Gaps
- None known for this slice.
- No protocol or dependency changes; generated artifacts and lockfiles are unchanged.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
