### PR TITLE
Persist LoRA adapter provenance

### DIFF
--- a/docs/plans/2026-06-24-issue-1503-adapter-provenance.md
+++ b/docs/plans/2026-06-24-issue-1503-adapter-provenance.md
@@ -1,0 +1,92 @@
+# Issue 1503 Adapter Provenance
+
+## Goal
+
+Implement the first executable slice of issue #1503 by writing a schema-backed
+adapter provenance manifest for completed LoRA adapters, preserving mutable
+operator notes separately, and making experiment history/index payloads derive
+comparison and export state from that provenance contract.
+
+## Governing Context
+
+- `docs/reference-scans/m-courtyard-lessons.md`
+- `docs/plans/2026-05-24-m-courtyard-improvement-roadmap.md`
+- Issue #1503, U2.2.2: persist adapter provenance, loss series, and notes.
+
+## Scope
+
+- Add a `melix.lora_adapter_provenance.v1` JSON manifest beside
+  `train_lora.adapter.json` for completed adapters.
+- Record immutable adapter provenance: base model identity, dataset version,
+  sample counts, training hyperparameters, loss series, final metrics, artifact
+  paths, canary receipts, and export eligibility.
+- Store operator notes in a separate mutable
+  `melix.lora_adapter_operator_notes.v1` JSON file referenced by the provenance
+  manifest.
+- Preserve existing adapter package manifests for backward compatibility while
+  adding pointers and write metrics to them.
+- Make LoRA experiment run and group index payloads prefer provenance fields for
+  history/comparison/export projections when the manifest exists.
+
+## Non-Goals
+
+- Desktop note editing UI.
+- New protobuf fields.
+- Runtime export execution or post-export smoke tests.
+- Re-parsing raw training logs after #1502 has already produced structured
+  training events.
+
+## Architecture
+
+The best end state is a single provenance contract owned by model
+productization and consumed by history, comparison, export, publish, and report
+flows. Adapter package manifests remain the low-level artifact receipt; the
+provenance manifest becomes the stable product-facing summary.
+
+This slice keeps the boundary small:
+
+- `worker.productization.lora_adapter_provenance` owns schema construction,
+  export-eligibility computation, loss-series projection, and mutable notes
+  persistence.
+- `LoRATrainingPipeline` writes the provenance and notes files after the adapter
+  package manifest payload is assembled and before the experiment run record is
+  persisted.
+- `LoraExperimentStore` loads provenance by explicit path or sibling default
+  path, then derives history and comparison fields from provenance instead of
+  ad hoc package-manifest keys.
+
+Operator notes are intentionally outside immutable provenance. The provenance
+manifest records the notes schema and path; note contents can change without
+rewriting base model, dataset, hyperparameter, or metric provenance.
+
+## Performance Probes And Metrics
+
+Measurement points:
+
+- Adapter provenance manifest write duration.
+- Operator notes write duration.
+- Loss-series row count.
+- Provenance manifest byte size.
+- Experiment comparison/index provenance load duration, measured during probes
+  without writing volatile timing fields into the deterministic index payload.
+
+Success metrics for this slice:
+
+- Provenance and initial notes writes stay below 50 ms in focused fixtures.
+- Loss series is derived from bounded #1502 structured event previews and does
+  not re-read raw logs.
+- Experiment index rebuild remains deterministic while comparison/index load
+  latency remains measurable outside the persisted payload.
+- Export eligibility is computed from manifest fields and returns explicit
+  blocking reasons when required adapter artifacts or receipts are missing.
+
+## Verification
+
+- Focused provenance schema tests for loss-series projection, export
+  eligibility, and notes immutability.
+- Pipeline manifest test proving provenance and notes files are written for a
+  completed adapter.
+- Experiment store tests proving history/group projections prefer provenance
+  fields.
+- Changed-scope coverage for touched Python files.
+- `git diff --check`.

--- a/services/mlx-worker-python/tests/test_lora_adapter_provenance.py
+++ b/services/mlx-worker-python/tests/test_lora_adapter_provenance.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from worker.productization.lora_adapter_provenance import (
+    ADAPTER_OPERATOR_NOTES_SCHEMA_VERSION,
+    ADAPTER_PROVENANCE_SCHEMA_VERSION,
+    build_adapter_provenance_manifest,
+    build_loss_series,
+    compute_export_eligibility,
+    default_adapter_operator_notes_path,
+    default_adapter_provenance_manifest_path,
+    load_adapter_provenance_payload,
+    load_operator_notes_payload,
+    write_adapter_operator_notes,
+    write_adapter_provenance_artifacts,
+)
+
+
+def _manifest_payload(tmp_path: Path) -> dict[str, object]:
+    return {
+        "job_id": "model-ops-0001",
+        "operation": "train_lora",
+        "artifact_kind": "adapter",
+        "adapter_name": "nightly-adapter",
+        "experiment_group_id": "nightly-qwen",
+        "experiment_group_title": "Nightly Qwen",
+        "source_model": "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+        "source_model_kind": "text",
+        "source_model_revision": "main",
+        "source_model_path": str(tmp_path / "base-model"),
+        "dataset_uri": str(tmp_path / "dataset"),
+        "dataset_id": "dataset-v1",
+        "dataset_format": "chat_messages",
+        "dataset_version": "2026-06-24",
+        "trainer_dataset_sample_count": 12,
+        "trainer_dataset_validation_sample_count": 3,
+        "preset_id": "balanced",
+        "preset_title": "Balanced",
+        "training_mode": "lora",
+        "adapter_algorithm": "lora",
+        "rank": 8,
+        "alpha": 16.0,
+        "dropout": 0.05,
+        "learning_rate_final": 0.0001,
+        "batch_size": 2,
+        "gradient_accumulation": 4,
+        "effective_batch_size": 8,
+        "max_steps": 100,
+        "iters": 100,
+        "target_modules": ["q_proj", "v_proj"],
+        "training_backend": "native",
+        "status": "completed",
+        "training_duration_ms": 1234.0,
+        "tokens_seen": 1024,
+        "examples_seen": 12,
+        "tokens_per_second": 96.0,
+        "peak_memory_gb": 2.5,
+        "loss_final": 0.42,
+        "loss_best": 0.33,
+        "completion_loss": 0.41,
+        "round_trip_passed": True,
+        "grad_norm": 0.7,
+        "weights_path": str(tmp_path / "adapter" / "adapters.safetensors"),
+        "adapter_config_path": str(tmp_path / "adapter" / "adapter_config.json"),
+        "adapter_set_hash": "abc123",
+        "validation_errors": [],
+        "merge_export_canary_result": "pass",
+        "callback_api_drift_result": "pass",
+        "base_config_present": True,
+        "aux_modules_restored": True,
+        "training_log_events": {
+            "schema_version": "melix.training_log_events.v1",
+            "best_validation_loss": 0.37,
+            "final_validation_loss": 0.37,
+        },
+        "training_log_event_preview": [
+            {
+                "event_type": "loss",
+                "step": 1,
+                "total_steps": 2,
+                "loss": 0.55,
+                "learning_rate": 0.0001,
+                "tokens_seen": 512,
+                "examples_seen": 6,
+                "source": "fixture",
+                "line_number": 1,
+            },
+            {
+                "event_type": "validation_loss",
+                "step": 2,
+                "total_steps": 2,
+                "validation_loss": 0.37,
+                "source": "fixture",
+                "line_number": 2,
+            },
+            {"event_type": "stalled_progress", "step": 2},
+        ],
+    }
+
+
+def test_build_adapter_provenance_manifest_records_training_facts_and_loss_series(tmp_path: Path) -> None:
+    adapter_manifest_path = tmp_path / "train_lora.adapter.json"
+    provenance_path = default_adapter_provenance_manifest_path(adapter_manifest_path)
+    notes_path = default_adapter_operator_notes_path(adapter_manifest_path)
+
+    provenance = build_adapter_provenance_manifest(
+        adapter_manifest=_manifest_payload(tmp_path),
+        adapter_manifest_path=adapter_manifest_path,
+        provenance_manifest_path=provenance_path,
+        operator_notes_path=notes_path,
+        operator_notes_payload={"note_count": 0, "updated_at_unix_ms": 123},
+        created_at_unix_ms=123,
+    )
+
+    assert provenance["schema_version"] == ADAPTER_PROVENANCE_SCHEMA_VERSION
+    assert provenance["adapter"]["job_id"] == "model-ops-0001"
+    assert provenance["adapter"]["experiment_group_id"] == "nightly-qwen"
+    assert provenance["base_model"]["model_id"] == "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"
+    assert provenance["dataset"]["version"] == "2026-06-24"
+    assert provenance["dataset"]["train_sample_count"] == 12
+    assert provenance["dataset"]["validation_sample_count"] == 3
+    assert provenance["hyperparameters"]["effective_batch_size"] == 8
+    assert provenance["training"]["loss_series_row_count"] == 2
+    assert [row["event_type"] for row in provenance["training"]["loss_series"]] == [
+        "loss",
+        "validation_loss",
+    ]
+    assert provenance["final_metrics"]["loss_best"] == pytest.approx(0.33)
+    assert provenance["final_metrics"]["validation_loss_best"] == pytest.approx(0.37)
+    assert provenance["operator_notes"]["schema_version"] == ADAPTER_OPERATOR_NOTES_SCHEMA_VERSION
+    assert provenance["operator_notes"]["path"] == str(notes_path)
+    assert provenance["export_eligibility"]["eligible"] is True
+
+
+def test_build_loss_series_ignores_non_loss_events() -> None:
+    series = build_loss_series(
+        {
+            "training_log_event_preview": [
+                {"event_type": "progress", "step": 1},
+                {"event_type": "loss", "step": 2, "loss": "0.4"},
+                {"event_type": "validation_loss", "step": 3, "validation_loss": "0.3"},
+            ]
+        }
+    )
+
+    assert series == [
+        {"event_type": "loss", "step": 2, "loss": 0.4},
+        {"event_type": "validation_loss", "step": 3, "validation_loss": 0.3},
+    ]
+
+
+def test_export_eligibility_reports_blocking_reasons(tmp_path: Path) -> None:
+    manifest = _manifest_payload(tmp_path)
+    manifest.update(
+        {
+            "adapter_set_hash": "",
+            "runtime_unsupported_reason": "unsupported_quantized_base",
+            "merge_export_canary_result": "fail:missing_adapter_weights,eos_token_mismatch",
+        }
+    )
+
+    eligibility = compute_export_eligibility(manifest)
+
+    assert eligibility["eligible"] is False
+    assert eligibility["state"] == "blocked"
+    assert eligibility["blocking_reasons"] == [
+        "missing_adapter_set_hash",
+        "runtime_unsupported:unsupported_quantized_base",
+        "merge_export_canary:missing_adapter_weights",
+        "merge_export_canary:eos_token_mismatch",
+    ]
+
+
+def test_export_eligibility_reports_all_manifest_blockers(tmp_path: Path) -> None:
+    manifest = _manifest_payload(tmp_path)
+    manifest.update(
+        {
+            "status": "failed",
+            "weights_path": "",
+            "adapter_config_path": "",
+            "adapter_set_hash": "",
+            "validation_errors": ["adapter audit failed"],
+            "adapter_unsupported_reason": "unsupported_target_modules",
+            "callback_api_drift_result": "fail:callback_arity_mismatch",
+        }
+    )
+
+    eligibility = compute_export_eligibility(manifest)
+
+    assert eligibility["eligible"] is False
+    assert eligibility["blocking_reasons"] == [
+        "training_not_completed",
+        "missing_adapter_weights_path",
+        "missing_adapter_config_path",
+        "missing_adapter_set_hash",
+        "validation_errors_present",
+        "adapter_unsupported:unsupported_target_modules",
+        "callback_api_drift:callback_arity_mismatch",
+    ]
+
+
+def test_write_artifacts_uses_event_fallback_and_preserves_existing_notes(tmp_path: Path) -> None:
+    adapter_manifest_path = tmp_path / "train_lora.adapter.json"
+    notes_path = default_adapter_operator_notes_path(adapter_manifest_path)
+    provenance_path = default_adapter_provenance_manifest_path(adapter_manifest_path)
+    write_adapter_operator_notes(
+        notes_path=notes_path,
+        notes=["ship after review", {"id": "blank", "text": ""}],
+        adapter_job_id="model-ops-0001",
+        adapter_name="nightly-adapter",
+        provenance_manifest_path=provenance_path,
+        now_unix_ms=100,
+    )
+    manifest = _manifest_payload(tmp_path)
+    manifest.pop("training_log_events")
+    manifest.pop("training_log_event_preview")
+    manifest["training.log_events"] = {"best_validation_loss": 0.29}
+    manifest["training.log_event_preview"] = [
+        "not-a-row",
+        {"event_type": "loss", "step": "not-int", "loss": "not-float"},
+        {
+            "event_type": "validation_loss",
+            "step": "2",
+            "total_steps": "oops",
+            "validation_loss": "0.29",
+            "learning_rate": "not-float",
+        },
+    ]
+
+    result = write_adapter_provenance_artifacts(
+        adapter_manifest=manifest,
+        adapter_manifest_path=adapter_manifest_path,
+        now_unix_ms=123,
+    )
+    provenance = result["provenance"]
+    notes = load_operator_notes_payload(notes_path)
+
+    assert provenance["training"]["event_summary"] == {"best_validation_loss": 0.29}
+    assert provenance["training"]["loss_series"] == [
+        {"event_type": "validation_loss", "step": 2, "validation_loss": 0.29}
+    ]
+    assert provenance["operator_notes"]["note_count"] == 1
+    assert notes["notes"][0]["text"] == "ship after review"
+    assert result["metrics"]["adapter_provenance_manifest_bytes"] > 0
+
+
+def test_loaders_reject_invalid_schema_and_non_mapping_json(tmp_path: Path) -> None:
+    provenance_path = tmp_path / "provenance.json"
+    notes_path = tmp_path / "notes.json"
+
+    provenance_path.write_text(json.dumps(["not", "a", "mapping"]) + "\n", encoding="utf-8")
+    notes_path.write_text(json.dumps({"schema_version": "wrong", "notes": []}) + "\n", encoding="utf-8")
+
+    assert load_adapter_provenance_payload(provenance_path) == {}
+    assert load_operator_notes_payload(notes_path) == {}
+
+
+def test_operator_notes_update_does_not_mutate_provenance_file(tmp_path: Path) -> None:
+    adapter_manifest_path = tmp_path / "train_lora.adapter.json"
+    provenance_path = default_adapter_provenance_manifest_path(adapter_manifest_path)
+    notes_path = default_adapter_operator_notes_path(adapter_manifest_path)
+    provenance_payload = build_adapter_provenance_manifest(
+        adapter_manifest=_manifest_payload(tmp_path),
+        adapter_manifest_path=adapter_manifest_path,
+        provenance_manifest_path=provenance_path,
+        operator_notes_path=notes_path,
+        operator_notes_payload={"note_count": 0, "updated_at_unix_ms": 123},
+        created_at_unix_ms=123,
+    )
+    provenance_path.write_text(json.dumps(provenance_payload, indent=2) + "\n", encoding="utf-8")
+    before = provenance_path.read_text(encoding="utf-8")
+    before_stat = provenance_path.stat()
+
+    notes_payload = write_adapter_operator_notes(
+        notes_path=notes_path,
+        notes=[{"id": "note-1", "text": "Ready for export", "author": "operator"}],
+        adapter_job_id="model-ops-0001",
+        adapter_name="nightly-adapter",
+        provenance_manifest_path=provenance_path,
+        now_unix_ms=456,
+    )
+
+    assert notes_payload["note_count"] == 1
+    assert notes_payload["notes"][0]["text"] == "Ready for export"
+    assert provenance_path.read_text(encoding="utf-8") == before
+    assert provenance_path.stat().st_mtime_ns == before_stat.st_mtime_ns

--- a/services/mlx-worker-python/tests/test_lora_experiment_store.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_store.py
@@ -398,6 +398,61 @@ def test_rebuild_index_prefers_run_record_over_manifest_when_both_exist(tmp_path
     assert provenance_group["latest_export_eligible"] is True
     assert provenance_group["best_known_adapter"]["provenance_manifest_path"] == str(provenance_path)
 
+    bad_manifest_path = _write_manifest(
+        jobs_root,
+        run_id="model-ops-0004",
+        adapter_name="bad-counts",
+        group_id="bad-counts",
+        updated_at_unix_ms=3_000,
+        extra={
+            "created_at_unix_ms": "not-an-int",
+            "trainer_dataset_sample_count": "not-an-int",
+            "trainer_dataset_validation_sample_count": {"bad": "count"},
+            "tokens_per_second": "not-a-float",
+            "peak_memory_gb": {"bad": "float"},
+            "checkpoint_count": "not-an-int",
+            "adapter_operator_note_count": "not-an-int",
+            "loss_best": "not-a-float",
+        },
+    )
+    bad_provenance_path = _write_provenance(
+        bad_manifest_path,
+        run_id="model-ops-0004",
+        group_id="bad-counts",
+        loss_best=0.7,
+        loss_final=0.8,
+    )
+    bad_payload = json.loads(bad_provenance_path.read_text(encoding="utf-8"))
+    bad_payload["dataset"]["train_sample_count"] = "not-an-int"
+    bad_payload["dataset"]["validation_sample_count"] = {"bad": "count"}
+    bad_payload["training"]["tokens_per_second"] = "not-a-float"
+    bad_payload["training"]["peak_memory_gb"] = {"bad": "float"}
+    bad_payload["training"]["loss_series_row_count"] = "not-an-int"
+    bad_payload["operator_notes"]["note_count"] = "not-an-int"
+    bad_payload["adapter"]["checkpoint_count"] = "not-an-int"
+    bad_provenance_path.write_text(
+        json.dumps(bad_payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    payload = LoraExperimentStore().rebuild_index(jobs_root)
+    bad_run = next(run for run in payload["runs"] if run["run_id"] == "model-ops-0004")
+    bad_group = next(group for group in payload["groups"] if group["group_id"] == "bad-counts")
+
+    assert bad_run["created_at_unix_ms"] == 0
+    assert bad_run["updated_at_unix_ms"] == 3_000
+    assert bad_run["train_sample_count"] == 0
+    assert bad_run["validation_sample_count"] == 0
+    assert bad_run["tokens_per_second"] == 0.0
+    assert bad_run["peak_memory_gb"] == 0.0
+    assert bad_run["checkpoint_count"] == 0
+    assert bad_run["loss_series_row_count"] == 0
+    assert bad_run["operator_note_count"] == 0
+    assert bad_group["latest_checkpoint_count"] == 0
+    assert bad_group["latest_loss_series_row_count"] == 0
+    assert bad_group["latest_operator_note_count"] == 0
+    assert bad_group["best_known_adapter"]["checkpoint_count"] == 0
+
 
 def test_rebuild_index_skips_manifest_parse_when_run_record_exists(tmp_path: Path, monkeypatch) -> None:
     jobs_root = tmp_path / "model-ops"

--- a/services/mlx-worker-python/tests/test_lora_experiment_store.py
+++ b/services/mlx-worker-python/tests/test_lora_experiment_store.py
@@ -82,6 +82,91 @@ def _write_manifest(
     return manifest_path
 
 
+def _write_provenance(
+    manifest_path: Path,
+    *,
+    run_id: str,
+    group_id: str = "nightly-qwen",
+    group_title: str = "Nightly Qwen",
+    adapter_name: str = "provenance-adapter",
+    source_model: str = "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+    dataset_uri: str = "/datasets/provenance",
+    dataset_version: str = "dataset-v2",
+    train_sample_count: int = 24,
+    validation_sample_count: int = 6,
+    loss_best: float = 0.21,
+    loss_final: float = 0.25,
+    export_eligible: bool = True,
+    loss_series_row_count: int = 2,
+    note_count: int = 1,
+) -> Path:
+    provenance_path = manifest_path.parent / "train_lora.adapter.provenance.json"
+    notes_path = manifest_path.parent / "train_lora.adapter.notes.json"
+    payload = {
+        "schema_version": "melix.lora_adapter_provenance.v1",
+        "adapter": {
+            "job_id": run_id,
+            "adapter_name": adapter_name,
+            "experiment_group_id": group_id,
+            "experiment_group_title": group_title,
+            "adapter_manifest_path": str(manifest_path),
+            "provenance_manifest_path": str(provenance_path),
+            "checkpoint_count": 3,
+            "latest_checkpoint_path": str(
+                manifest_path.parent / "adapter" / "checkpoint-3" / "adapters.safetensors"
+            ),
+            "resume_ready": True,
+        },
+        "base_model": {"model_id": source_model},
+        "dataset": {
+            "uri": dataset_uri,
+            "version": dataset_version,
+            "train_sample_count": train_sample_count,
+            "validation_sample_count": validation_sample_count,
+        },
+        "hyperparameters": {
+            "preset_id": "balanced",
+            "preset_title": "Balanced",
+            "training_mode": "lora",
+        },
+        "training": {
+            "backend": "native",
+            "status": "completed",
+            "tokens_per_second": 111.0,
+            "peak_memory_gb": 3.5,
+            "loss_series_row_count": loss_series_row_count,
+            "loss_series": [
+                {"event_type": "loss", "step": 1, "loss": 0.4},
+                {"event_type": "validation_loss", "step": 2, "validation_loss": loss_best},
+            ][:loss_series_row_count],
+        },
+        "final_metrics": {
+            "loss_best": loss_best,
+            "loss_final": loss_final,
+            "validation_loss_best": loss_best,
+        },
+        "operator_notes": {
+            "schema_version": "melix.lora_adapter_operator_notes.v1",
+            "path": str(notes_path),
+            "note_count": note_count,
+            "updated_at_unix_ms": 2_000,
+        },
+        "export_eligibility": {
+            "schema_version": "melix.lora_adapter_export_eligibility.v1",
+            "eligible": export_eligible,
+            "state": "eligible" if export_eligible else "blocked",
+            "blocking_reasons": [] if export_eligible else ["missing_adapter_weights_path"],
+        },
+        "created_at_unix_ms": 1_000,
+        "updated_at_unix_ms": 2_000,
+    }
+    provenance_path.write_text(
+        json.dumps(payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return provenance_path
+
+
 def test_iter_lora_run_dirs_sorts_names_without_reading_entry_paths(tmp_path: Path, monkeypatch) -> None:
     train_root = tmp_path / "train_lora"
     path_reads = 0
@@ -260,6 +345,58 @@ def test_rebuild_index_prefers_run_record_over_manifest_when_both_exist(tmp_path
     assert manifest_only_run["saved_eos_token"] == "<eos>"
     assert manifest_only_run["merge_export_canary_result"] == "passed"
     assert manifest_only_run["round_trip_passed"] is True
+
+    provenance_manifest_path = _write_manifest(
+        jobs_root,
+        run_id="model-ops-0003",
+        adapter_name="package-adapter",
+        group_id="package-group",
+        updated_at_unix_ms=2_500,
+        extra={
+            "source_model": "package-model",
+            "dataset_uri": "/datasets/package",
+            "dataset_version": "package-v1",
+            "trainer_dataset_sample_count": 1,
+            "trainer_dataset_validation_sample_count": 0,
+            "loss_best": 9.9,
+            "loss_final": 9.8,
+            "tokens_per_second": 1.0,
+            "peak_memory_gb": 1.0,
+            "adapter_provenance_manifest_path": str(
+                jobs_root
+                / "train_lora"
+                / "model-ops-0003"
+                / "train_lora.adapter.provenance.json"
+            ),
+        },
+    )
+    provenance_path = _write_provenance(provenance_manifest_path, run_id="model-ops-0003")
+    assert lora_experiment_store_module._optional_finite_float("not-a-number", "0.5") == 0.5
+
+    payload = LoraExperimentStore().rebuild_index(jobs_root)
+    provenance_run = next(run for run in payload["runs"] if run["run_id"] == "model-ops-0003")
+    provenance_group = next(group for group in payload["groups"] if group["group_id"] == "nightly-qwen")
+
+    assert provenance_run["adapter_name"] == "provenance-adapter"
+    assert provenance_run["group_id"] == "nightly-qwen"
+    assert provenance_run["group_title"] == "Nightly Qwen"
+    assert provenance_run["source_model"] == "mlx-community/Qwen3.5-0.8B-OptiQ-4bit"
+    assert provenance_run["dataset_uri"] == "/datasets/provenance"
+    assert provenance_run["dataset_version"] == "dataset-v2"
+    assert provenance_run["train_sample_count"] == 24
+    assert provenance_run["validation_sample_count"] == 6
+    assert provenance_run["loss_best"] == 0.21
+    assert provenance_run["loss_final"] == 0.25
+    assert provenance_run["tokens_per_second"] == 111.0
+    assert provenance_run["peak_memory_gb"] == 3.5
+    assert provenance_run["loss_series_row_count"] == 2
+    assert provenance_run["operator_note_count"] == 1
+    assert provenance_run["export_eligible"] is True
+    assert provenance_run["adapter_provenance_manifest_path"] == str(provenance_path)
+    assert provenance_group["best_loss"] == 0.21
+    assert provenance_group["recommended_provenance_manifest_path"] == str(provenance_path)
+    assert provenance_group["latest_export_eligible"] is True
+    assert provenance_group["best_known_adapter"]["provenance_manifest_path"] == str(provenance_path)
 
 
 def test_rebuild_index_skips_manifest_parse_when_run_record_exists(tmp_path: Path, monkeypatch) -> None:

--- a/services/mlx-worker-python/tests/test_training_log_events.py
+++ b/services/mlx-worker-python/tests/test_training_log_events.py
@@ -201,3 +201,69 @@ def test_deterministic_lora_manifest_records_training_log_events(tmp_path: Path)
         "validation_loss",
         "final_summary",
     ]
+
+
+def test_deterministic_lora_manifest_writes_adapter_provenance_and_notes(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    (dataset_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "melix.training_dataset_package.v1",
+                "dataset_id": "melix-dev-dataset",
+                "format": "chat_messages",
+                "sample_count": 1,
+                "version": "dataset-v1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (dataset_dir / "samples.jsonl").write_text(
+        '{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"ok"}]}\n',
+        encoding="utf-8",
+    )
+
+    result = LoRATrainingPipeline(runner=DeterministicLoRARunner()).run(
+        job_id="adapter-provenance",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "receipt-adapter",
+            "dataset_uri": str(dataset_dir),
+            "max_steps": "0",
+        },
+        source_model=common_pb2.ModelSpec(
+            model_id="melix-dev-text",
+            model_path=str(tmp_path / "base-model"),
+            model_kind="text",
+            revision="main",
+            max_context=4096,
+        ),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    manifest = result.manifest
+    provenance_path = Path(manifest["adapter_provenance_manifest_path"])
+    notes_path = Path(manifest["adapter_operator_notes_path"])
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    notes = json.loads(notes_path.read_text(encoding="utf-8"))
+
+    assert manifest["adapter_provenance_schema_version"] == "melix.lora_adapter_provenance.v1"
+    assert provenance["schema_version"] == "melix.lora_adapter_provenance.v1"
+    assert provenance["adapter"]["job_id"] == "adapter-provenance"
+    assert provenance["base_model"]["model_id"] == "melix-dev-text"
+    assert provenance["dataset"]["version"] == "dataset-v1"
+    assert provenance["dataset"]["train_sample_count"] == 1
+    assert provenance["training"]["loss_series_row_count"] == 3
+    assert provenance["final_metrics"]["loss_best"] == pytest.approx(0.33)
+    assert provenance["export_eligibility"]["eligible"] is False
+    assert "merge_export_canary:missing_base_config" in provenance["export_eligibility"]["blocking_reasons"]
+    assert notes["schema_version"] == "melix.lora_adapter_operator_notes.v1"
+    assert notes["notes"] == []
+    assert notes["note_count"] == 0
+    assert manifest["adapter_operator_note_count"] == 0
+    assert manifest["adapter_provenance_loss_series_row_count"] == 3
+    assert manifest["adapter_provenance_manifest_bytes"] > 0
+    assert manifest["adapter_provenance_manifest_write_duration_ms"] >= 0.0
+    assert manifest["adapter_operator_notes_write_duration_ms"] >= 0.0

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -49,6 +49,10 @@ from worker.model_ops.training_preflight import (
     require_trainability_preflight_ready,
     write_trainability_preflight_receipt,
 )
+from worker.productization.lora_adapter_provenance import (
+    ADAPTER_PROVENANCE_SCHEMA_VERSION,
+    write_adapter_provenance_artifacts,
+)
 from worker.productization.lora_experiment_store import LoraExperimentStore
 from worker.trajectory_provenance import (
     adapter_manifest_trajectory_provenance,
@@ -479,6 +483,26 @@ class LoRATrainingPipeline:
                 json.dumps(alignment_manifest, indent=2) + "\n",
                 encoding="utf-8",
             )
+        provenance_result = write_adapter_provenance_artifacts(
+            adapter_manifest=manifest,
+            adapter_manifest_path=manifest_path,
+            now_unix_ms=persisted_at_unix_ms,
+        )
+        provenance = provenance_result["provenance"]
+        manifest.update(
+            {
+                "adapter_provenance_schema_version": ADAPTER_PROVENANCE_SCHEMA_VERSION,
+                "adapter_provenance_manifest_path": str(provenance_result["provenance_path"]),
+                "adapter_operator_notes_path": str(provenance_result["notes_path"]),
+                "adapter_operator_notes_schema_version": provenance["operator_notes"][
+                    "schema_version"
+                ],
+                "adapter_operator_note_count": provenance["operator_notes"]["note_count"],
+                "adapter_export_eligibility": dict(provenance["export_eligibility"]),
+                "adapter_export_eligible": bool(provenance["export_eligibility"]["eligible"]),
+                **dict(provenance_result["metrics"]),
+            }
+        )
         manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
         self._experiment_store.persist_training_run(
             jobs_root=jobs_root,

--- a/services/mlx-worker-python/worker/productization/lora_adapter_provenance.py
+++ b/services/mlx-worker-python/worker/productization/lora_adapter_provenance.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import json
+import math
+from pathlib import Path
+import time
+from typing import Any
+
+
+ADAPTER_PROVENANCE_SCHEMA_VERSION = "melix.lora_adapter_provenance.v1"
+ADAPTER_OPERATOR_NOTES_SCHEMA_VERSION = "melix.lora_adapter_operator_notes.v1"
+ADAPTER_EXPORT_ELIGIBILITY_SCHEMA_VERSION = "melix.lora_adapter_export_eligibility.v1"
+ADAPTER_PROVENANCE_MANIFEST_NAME = "train_lora.adapter.provenance.json"
+ADAPTER_OPERATOR_NOTES_NAME = "train_lora.adapter.notes.json"
+
+
+def default_adapter_provenance_manifest_path(adapter_manifest_path: str | Path) -> Path:
+    return Path(adapter_manifest_path).parent / ADAPTER_PROVENANCE_MANIFEST_NAME
+
+
+def default_adapter_operator_notes_path(adapter_manifest_path: str | Path) -> Path:
+    return Path(adapter_manifest_path).parent / ADAPTER_OPERATOR_NOTES_NAME
+
+
+def write_adapter_provenance_artifacts(
+    *,
+    adapter_manifest: Mapping[str, Any],
+    adapter_manifest_path: Path,
+    now_unix_ms: int | None = None,
+) -> dict[str, Any]:
+    created_at_unix_ms = _int_value(
+        adapter_manifest.get("created_at_unix_ms"),
+        default=now_unix_ms or int(time.time() * 1000),
+    )
+    provenance_path = default_adapter_provenance_manifest_path(adapter_manifest_path)
+    notes_path = default_adapter_operator_notes_path(adapter_manifest_path)
+
+    note_started_at = time.perf_counter()
+    notes_payload = ensure_adapter_operator_notes_file(
+        notes_path=notes_path,
+        adapter_manifest=adapter_manifest,
+        provenance_manifest_path=provenance_path,
+        now_unix_ms=created_at_unix_ms,
+    )
+    note_write_duration_ms = (time.perf_counter() - note_started_at) * 1000.0
+
+    provenance = build_adapter_provenance_manifest(
+        adapter_manifest=adapter_manifest,
+        adapter_manifest_path=adapter_manifest_path,
+        provenance_manifest_path=provenance_path,
+        operator_notes_path=notes_path,
+        operator_notes_payload=notes_payload,
+        created_at_unix_ms=created_at_unix_ms,
+    )
+
+    provenance_started_at = time.perf_counter()
+    provenance_path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(_json_safe(provenance), indent=2, allow_nan=False) + "\n"
+    provenance_path.write_text(encoded, encoding="utf-8")
+    provenance_write_duration_ms = (time.perf_counter() - provenance_started_at) * 1000.0
+
+    return {
+        "provenance": provenance,
+        "provenance_path": provenance_path,
+        "notes_path": notes_path,
+        "metrics": {
+            "adapter_provenance_manifest_write_duration_ms": provenance_write_duration_ms,
+            "adapter_operator_notes_write_duration_ms": note_write_duration_ms,
+            "adapter_provenance_loss_series_row_count": len(
+                provenance["training"]["loss_series"]
+            ),
+            "adapter_provenance_manifest_bytes": len(encoded.encode("utf-8")),
+        },
+    }
+
+
+def build_adapter_provenance_manifest(
+    *,
+    adapter_manifest: Mapping[str, Any],
+    adapter_manifest_path: Path,
+    provenance_manifest_path: Path,
+    operator_notes_path: Path,
+    operator_notes_payload: Mapping[str, Any] | None = None,
+    created_at_unix_ms: int | None = None,
+) -> dict[str, Any]:
+    created_at = _int_value(
+        adapter_manifest.get("created_at_unix_ms"),
+        default=created_at_unix_ms or int(time.time() * 1000),
+    )
+    updated_at = _int_value(adapter_manifest.get("updated_at_unix_ms"), default=created_at)
+    loss_series = build_loss_series(adapter_manifest)
+    training_events = _mapping_value(adapter_manifest.get("training_log_events"))
+    if not training_events:
+        training_events = _mapping_value(adapter_manifest.get("training.log_events"))
+    notes_payload = operator_notes_payload or {}
+    note_count = _int_value(notes_payload.get("note_count"), default=0)
+
+    return {
+        "schema_version": ADAPTER_PROVENANCE_SCHEMA_VERSION,
+        "adapter": {
+            "job_id": _str_value(adapter_manifest.get("job_id")),
+            "adapter_name": _str_value(adapter_manifest.get("adapter_name")),
+            "experiment_group_id": _str_value(adapter_manifest.get("experiment_group_id")),
+            "experiment_group_title": _str_value(adapter_manifest.get("experiment_group_title")),
+            "artifact_kind": _str_value(adapter_manifest.get("artifact_kind")),
+            "adapter_set_hash": _str_value(adapter_manifest.get("adapter_set_hash")),
+            "adapter_manifest_path": str(adapter_manifest_path),
+            "provenance_manifest_path": str(provenance_manifest_path),
+            "output_dir": str(adapter_manifest_path.parent),
+            "weights_path": _str_value(adapter_manifest.get("weights_path")),
+            "adapter_config_path": _str_value(adapter_manifest.get("adapter_config_path")),
+            "target_repo": _str_value(adapter_manifest.get("target_repo")),
+            "checkpoint_count": _int_value(adapter_manifest.get("checkpoint_count")),
+            "latest_checkpoint_path": _str_value(adapter_manifest.get("latest_checkpoint_path")),
+            "resume_source_path": _str_value(adapter_manifest.get("resume_source_path")),
+            "resume_source_job_id": _str_value(adapter_manifest.get("resume_source_job_id")),
+            "resume_source_manifest_path": _str_value(adapter_manifest.get("resume_source_manifest_path")),
+            "resume_ready": bool(adapter_manifest.get("resume_ready", False)),
+        },
+        "base_model": {
+            "model_id": _str_value(adapter_manifest.get("source_model")),
+            "model_kind": _str_value(adapter_manifest.get("source_model_kind")),
+            "revision": _str_value(adapter_manifest.get("source_model_revision")),
+            "model_path": _str_value(adapter_manifest.get("source_model_path")),
+            "adapter_scope": _str_value(adapter_manifest.get("adapter_scope")),
+            "training_surface": _str_value(adapter_manifest.get("training_surface")),
+            "component_model_type": _str_value(adapter_manifest.get("component_model_type")),
+            "component_family": _str_value(adapter_manifest.get("component_family")),
+            "component_model_path": _str_value(adapter_manifest.get("component_model_path")),
+            "quantization_mode": _str_value(adapter_manifest.get("quantization_mode")),
+            "base_quantization_method": _str_value(adapter_manifest.get("base_quantization_method")),
+            "quantized_base_detected": bool(adapter_manifest.get("quantized_base_detected", False)),
+            "quantized_base_kind": _str_value(adapter_manifest.get("quantized_base_kind")),
+            "quantization_profile_id": _str_value(adapter_manifest.get("quantization_profile_id")),
+        },
+        "dataset": {
+            "uri": _str_value(adapter_manifest.get("dataset_uri")),
+            "source_kind": _str_value(adapter_manifest.get("dataset_source_kind")),
+            "dataset_id": _str_value(adapter_manifest.get("dataset_id")),
+            "format": _str_value(adapter_manifest.get("dataset_format")),
+            "trainer_format": _str_value(adapter_manifest.get("trainer_dataset_format")),
+            "version": _str_value(adapter_manifest.get("dataset_version")),
+            "sample_count": _int_value(adapter_manifest.get("dataset_sample_count")),
+            "train_sample_count": _int_value(adapter_manifest.get("trainer_dataset_sample_count")),
+            "validation_sample_count": _int_value(
+                adapter_manifest.get("trainer_dataset_validation_sample_count"),
+                adapter_manifest.get("validation_sample_count"),
+            ),
+            "source_manifest_path": _str_value(adapter_manifest.get("dataset_source_manifest_path")),
+            "normalized_manifest_path": _str_value(adapter_manifest.get("normalized_dataset_manifest_path")),
+        },
+        "hyperparameters": {
+            "preset_id": _str_value(adapter_manifest.get("preset_id")),
+            "preset_title": _str_value(adapter_manifest.get("preset_title")),
+            "training_mode": _str_value(adapter_manifest.get("training_mode")),
+            "training_objective": _str_value(adapter_manifest.get("training_objective")),
+            "adapter_algorithm": _str_value(adapter_manifest.get("adapter_algorithm")),
+            "adapter_family": _str_value(adapter_manifest.get("adapter_family")),
+            "rank": _int_value(adapter_manifest.get("rank")),
+            "alpha": _float_value(adapter_manifest.get("alpha")),
+            "dropout": _float_value(adapter_manifest.get("dropout")),
+            "learning_rate": _float_value(
+                adapter_manifest.get("learning_rate"),
+                adapter_manifest.get("training.learning_rate_final"),
+                adapter_manifest.get("learning_rate_final"),
+            ),
+            "learning_rate_final": _float_value(
+                adapter_manifest.get("learning_rate_final"),
+                adapter_manifest.get("training.learning_rate_final"),
+            ),
+            "batch_size": _int_value(adapter_manifest.get("batch_size")),
+            "gradient_accumulation": _int_value(adapter_manifest.get("gradient_accumulation")),
+            "effective_batch_size": _int_value(adapter_manifest.get("effective_batch_size")),
+            "max_steps": _int_value(adapter_manifest.get("max_steps")),
+            "iters": _int_value(adapter_manifest.get("iters")),
+            "optimizer_steps": _int_value(adapter_manifest.get("optimizer_steps")),
+            "max_seq_length": _int_value(adapter_manifest.get("max_seq_length")),
+            "response_only": bool(adapter_manifest.get("response_only", False)),
+            "gradient_checkpointing": bool(adapter_manifest.get("gradient_checkpointing", False)),
+            "mask_prompt": bool(adapter_manifest.get("mask_prompt", False)),
+            "target_modules": _list_value(adapter_manifest.get("target_modules")),
+            "validation_strategy": _str_value(adapter_manifest.get("validation_strategy")),
+        },
+        "training": {
+            "backend": _str_value(adapter_manifest.get("training_backend")),
+            "status": _str_value(adapter_manifest.get("status", "completed")),
+            "duration_ms": _float_value(
+                adapter_manifest.get("training_duration_ms"),
+                adapter_manifest.get("training.job_duration_ms"),
+            ),
+            "tokens_seen": _int_value(
+                adapter_manifest.get("tokens_seen"),
+                adapter_manifest.get("training.tokens_seen"),
+            ),
+            "examples_seen": _int_value(
+                adapter_manifest.get("examples_seen"),
+                adapter_manifest.get("training.examples_seen"),
+            ),
+            "tokens_per_second": _float_value(
+                adapter_manifest.get("tokens_per_second"),
+                adapter_manifest.get("training.tokens_per_second"),
+            ),
+            "peak_memory_gb": _float_value(
+                adapter_manifest.get("peak_memory_gb"),
+                adapter_manifest.get("training.peak_memory_gb"),
+            ),
+            "event_summary": dict(training_events),
+            "event_preview_limit": _int_value(
+                adapter_manifest.get("training_log_event_preview_limit"),
+                adapter_manifest.get("training.log_event_preview_limit"),
+            ),
+            "loss_series": loss_series,
+            "loss_series_row_count": len(loss_series),
+        },
+        "final_metrics": {
+            "loss_final": _float_value(
+                adapter_manifest.get("loss_final"),
+                adapter_manifest.get("training.loss_final"),
+            ),
+            "loss_best": _float_value(
+                adapter_manifest.get("loss_best"),
+                adapter_manifest.get("training.loss_best"),
+            ),
+            "validation_loss_final": _float_value(training_events.get("final_validation_loss")),
+            "validation_loss_best": _float_value(training_events.get("best_validation_loss")),
+            "learning_rate_final": _float_value(
+                adapter_manifest.get("learning_rate_final"),
+                adapter_manifest.get("training.learning_rate_final"),
+            ),
+            "completion_loss": _float_value(adapter_manifest.get("completion_loss")),
+            "round_trip_passed": bool(adapter_manifest.get("round_trip_passed", False)),
+            "grad_norm": _float_value(adapter_manifest.get("grad_norm")),
+        },
+        "canary_receipts": {
+            "merge_export_canary_result": _str_value(adapter_manifest.get("merge_export_canary_result")),
+            "callback_api_drift_result": _str_value(adapter_manifest.get("callback_api_drift_result")),
+            "source_eos_token": _str_value(adapter_manifest.get("source_eos_token")),
+            "saved_eos_token": _str_value(adapter_manifest.get("saved_eos_token")),
+            "base_config_present": bool(adapter_manifest.get("base_config_present", False)),
+            "tokenizer_config_path": _str_value(adapter_manifest.get("tokenizer_config_path")),
+            "processor_resume_mode": _str_value(adapter_manifest.get("processor_resume_mode")),
+            "aux_modules_restored": bool(adapter_manifest.get("aux_modules_restored", False)),
+        },
+        "operator_notes": {
+            "schema_version": ADAPTER_OPERATOR_NOTES_SCHEMA_VERSION,
+            "path": str(operator_notes_path),
+            "mutable": True,
+            "note_count": note_count,
+            "updated_at_unix_ms": _int_value(notes_payload.get("updated_at_unix_ms"), default=created_at),
+        },
+        "export_eligibility": compute_export_eligibility(adapter_manifest),
+        "created_at_unix_ms": created_at,
+        "updated_at_unix_ms": updated_at,
+    }
+
+
+def build_loss_series(adapter_manifest: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = _sequence_value(adapter_manifest.get("training_log_event_preview"))
+    if not rows:
+        rows = _sequence_value(adapter_manifest.get("training.log_event_preview"))
+    loss_series: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        loss = _float_value(row.get("loss"))
+        validation_loss = _float_value(row.get("validation_loss"))
+        if loss is None and validation_loss is None:
+            continue
+        projected: dict[str, Any] = {
+            "event_type": _str_value(row.get("event_type")),
+            "step": _optional_int_value(row.get("step")),
+            "total_steps": _optional_int_value(row.get("total_steps")),
+            "loss": loss,
+            "validation_loss": validation_loss,
+            "learning_rate": _float_value(row.get("learning_rate")),
+            "tokens_seen": _optional_int_value(row.get("tokens_seen")),
+            "examples_seen": _optional_int_value(row.get("examples_seen")),
+            "duration_ms": _float_value(row.get("duration_ms")),
+            "source": _str_value(row.get("source")),
+            "line_number": _optional_int_value(row.get("line_number")),
+        }
+        loss_series.append(
+            {
+                key: value
+                for key, value in projected.items()
+                if value not in ("", None)
+            }
+        )
+    return loss_series
+
+
+def compute_export_eligibility(adapter_manifest: Mapping[str, Any]) -> dict[str, Any]:
+    blocking_reasons: list[str] = []
+    status = _str_value(adapter_manifest.get("status", "completed"))
+    if status and status != "completed":
+        blocking_reasons.append("training_not_completed")
+    if not _str_value(adapter_manifest.get("weights_path")):
+        blocking_reasons.append("missing_adapter_weights_path")
+    if not _str_value(adapter_manifest.get("adapter_config_path")):
+        blocking_reasons.append("missing_adapter_config_path")
+    if not _str_value(adapter_manifest.get("adapter_set_hash")):
+        blocking_reasons.append("missing_adapter_set_hash")
+    if _non_empty_sequence(adapter_manifest.get("validation_errors")):
+        blocking_reasons.append("validation_errors_present")
+
+    runtime_reason = _str_value(adapter_manifest.get("runtime_unsupported_reason"))
+    if runtime_reason:
+        blocking_reasons.append(f"runtime_unsupported:{runtime_reason}")
+    adapter_reason = _str_value(
+        adapter_manifest.get("adapter_unsupported_reason"),
+        adapter_manifest.get("unsupported_reason"),
+    )
+    if adapter_reason:
+        blocking_reasons.append(f"adapter_unsupported:{adapter_reason}")
+
+    merge_canary = _str_value(adapter_manifest.get("merge_export_canary_result"))
+    if merge_canary.startswith("fail:"):
+        for reason in merge_canary.removeprefix("fail:").split(","):
+            normalized = reason.strip()
+            if normalized:
+                blocking_reasons.append(f"merge_export_canary:{normalized}")
+    callback_drift = _str_value(adapter_manifest.get("callback_api_drift_result"))
+    if callback_drift.startswith("fail:"):
+        blocking_reasons.append(f"callback_api_drift:{callback_drift.removeprefix('fail:')}")
+
+    unique_reasons = list(dict.fromkeys(blocking_reasons))
+    eligible = not unique_reasons
+    return {
+        "schema_version": ADAPTER_EXPORT_ELIGIBILITY_SCHEMA_VERSION,
+        "eligible": eligible,
+        "state": "eligible" if eligible else "blocked",
+        "blocking_reasons": unique_reasons,
+        "computed_from_fields": [
+            "status",
+            "weights_path",
+            "adapter_config_path",
+            "adapter_set_hash",
+            "validation_errors",
+            "runtime_unsupported_reason",
+            "adapter_unsupported_reason",
+            "merge_export_canary_result",
+            "callback_api_drift_result",
+        ],
+    }
+
+
+def ensure_adapter_operator_notes_file(
+    *,
+    notes_path: Path,
+    adapter_manifest: Mapping[str, Any],
+    provenance_manifest_path: Path,
+    now_unix_ms: int | None = None,
+) -> dict[str, Any]:
+    existing = load_operator_notes_payload(notes_path)
+    if existing:
+        return existing
+    return write_adapter_operator_notes(
+        notes_path=notes_path,
+        notes=[],
+        adapter_job_id=_str_value(adapter_manifest.get("job_id")),
+        adapter_name=_str_value(adapter_manifest.get("adapter_name")),
+        provenance_manifest_path=provenance_manifest_path,
+        now_unix_ms=now_unix_ms,
+    )
+
+
+def write_adapter_operator_notes(
+    *,
+    notes_path: Path,
+    notes: Sequence[Mapping[str, Any] | str],
+    adapter_job_id: str = "",
+    adapter_name: str = "",
+    provenance_manifest_path: str | Path = "",
+    now_unix_ms: int | None = None,
+) -> dict[str, Any]:
+    now_ms = now_unix_ms or int(time.time() * 1000)
+    existing = load_operator_notes_payload(notes_path)
+    created_at = _int_value(existing.get("created_at_unix_ms"), default=now_ms) if existing else now_ms
+    payload = {
+        "schema_version": ADAPTER_OPERATOR_NOTES_SCHEMA_VERSION,
+        "adapter_job_id": adapter_job_id or _str_value(existing.get("adapter_job_id") if existing else ""),
+        "adapter_name": adapter_name or _str_value(existing.get("adapter_name") if existing else ""),
+        "provenance_manifest_path": str(provenance_manifest_path)
+        if provenance_manifest_path
+        else _str_value(existing.get("provenance_manifest_path") if existing else ""),
+        "notes": _normalize_notes(notes, now_unix_ms=now_ms),
+        "note_count": 0,
+        "created_at_unix_ms": created_at,
+        "updated_at_unix_ms": now_ms,
+    }
+    payload["note_count"] = len(payload["notes"])
+    notes_path.parent.mkdir(parents=True, exist_ok=True)
+    notes_path.write_text(json.dumps(_json_safe(payload), indent=2, allow_nan=False) + "\n", encoding="utf-8")
+    return payload
+
+
+def load_operator_notes_payload(notes_path: str | Path) -> dict[str, Any]:
+    payload = _load_json_mapping(Path(notes_path))
+    if payload.get("schema_version") != ADAPTER_OPERATOR_NOTES_SCHEMA_VERSION:
+        return {}
+    notes = payload.get("notes")
+    payload["note_count"] = len(notes) if isinstance(notes, list) else 0
+    return payload
+
+
+def load_adapter_provenance_payload(provenance_path: str | Path) -> dict[str, Any]:
+    payload = _load_json_mapping(Path(provenance_path))
+    if payload.get("schema_version") != ADAPTER_PROVENANCE_SCHEMA_VERSION:
+        return {}
+    return payload
+
+
+def _normalize_notes(
+    notes: Sequence[Mapping[str, Any] | str],
+    *,
+    now_unix_ms: int,
+) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for index, note in enumerate(notes, start=1):
+        if isinstance(note, Mapping):
+            text = _str_value(note.get("text"))
+            note_id = _str_value(note.get("id")) or f"note-{index}"
+            author = _str_value(note.get("author"))
+            created_at = _int_value(note.get("created_at_unix_ms"), default=now_unix_ms)
+            updated_at = _int_value(note.get("updated_at_unix_ms"), default=created_at)
+        else:
+            text = _str_value(note)
+            note_id = f"note-{index}"
+            author = ""
+            created_at = now_unix_ms
+            updated_at = now_unix_ms
+        if not text:
+            continue
+        row = {
+            "id": note_id,
+            "text": text,
+            "author": author,
+            "created_at_unix_ms": created_at,
+            "updated_at_unix_ms": updated_at,
+        }
+        normalized.append({key: value for key, value in row.items() if value != ""})
+    return normalized
+
+
+def _load_json_mapping(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _mapping_value(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _sequence_value(value: Any) -> Sequence[Any]:
+    return value if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)) else ()
+
+
+def _list_value(value: Any) -> list[Any]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return list(value)
+    return []
+
+
+def _non_empty_sequence(value: Any) -> bool:
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)) and len(value) > 0
+
+
+def _str_value(*raw_values: Any) -> str:
+    for raw_value in raw_values:
+        if raw_value is None:
+            continue
+        parsed = str(raw_value).strip()
+        if parsed:
+            return parsed
+    return ""
+
+
+def _int_value(*raw_values: Any, default: int = 0) -> int:
+    for raw_value in raw_values:
+        if raw_value is None or raw_value == "":
+            continue
+        try:
+            return int(raw_value)
+        except (TypeError, ValueError):
+            continue
+    return default
+
+
+def _optional_int_value(*raw_values: Any) -> int | None:
+    for raw_value in raw_values:
+        if raw_value is None or raw_value == "":
+            continue
+        try:
+            return int(raw_value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _float_value(*raw_values: Any) -> float | None:
+    for raw_value in raw_values:
+        if raw_value is None or raw_value == "":
+            continue
+        try:
+            parsed = float(raw_value)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(parsed):
+            return parsed
+    return None
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, float) and math.isfinite(value) is False:
+        return None
+    return value

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -113,7 +113,7 @@ class LoraExperimentStore:
 
         runs = sorted(
             runs_by_id.values(),
-            key=lambda item: (int(item.get("updated_at_unix_ms", 0)), str(item.get("run_id", ""))),
+            key=lambda item: (_int_value(item.get("updated_at_unix_ms")), str(item.get("run_id", ""))),
             reverse=True,
         )
         groups = self._build_group_payloads(runs)
@@ -140,7 +140,7 @@ class LoraExperimentStore:
         for group_id, group_runs in grouped_runs.items():
             latest_run = group_runs[0]
             latest_key = (
-                int(latest_run.get("updated_at_unix_ms", 0)),
+                _int_value(latest_run.get("updated_at_unix_ms")),
                 str(latest_run.get("run_id", "")),
             )
             best_run = latest_run
@@ -150,7 +150,7 @@ class LoraExperimentStore:
                 -latest_key[0],
             )
             for run in group_runs[1:]:
-                run_updated_at = int(run.get("updated_at_unix_ms", 0))
+                run_updated_at = _int_value(run.get("updated_at_unix_ms"))
                 run_key_latest = (run_updated_at, str(run.get("run_id", "")))
                 if run_key_latest > latest_key:
                     latest_run = run
@@ -178,7 +178,7 @@ class LoraExperimentStore:
                     "latest_preset_title": str(latest_run.get("preset_title", "")),
                     "latest_tokens_per_second": _optional_finite_float(latest_run.get("tokens_per_second")) or 0.0,
                     "latest_peak_memory_gb": _optional_finite_float(latest_run.get("peak_memory_gb")) or 0.0,
-                    "latest_checkpoint_count": int(latest_run.get("checkpoint_count", 0)),
+                    "latest_checkpoint_count": _int_value(latest_run.get("checkpoint_count")),
                     "latest_checkpoint_path": str(latest_run.get("latest_checkpoint_path", "")),
                     "latest_resume_source_path": str(latest_run.get("resume_source_path", "")),
                     "latest_resume_ready": bool(latest_run.get("resume_ready", False)),
@@ -199,8 +199,8 @@ class LoraExperimentStore:
                     ),
                     "latest_export_eligible": bool(latest_run.get("export_eligible", False)),
                     "best_export_eligible": bool(best_run.get("export_eligible", False)),
-                    "latest_loss_series_row_count": int(latest_run.get("loss_series_row_count", 0)),
-                    "latest_operator_note_count": int(latest_run.get("operator_note_count", 0)),
+                    "latest_loss_series_row_count": _int_value(latest_run.get("loss_series_row_count")),
+                    "latest_operator_note_count": _int_value(latest_run.get("operator_note_count")),
                     "best_known_adapter": {
                         "run_id": str(best_run.get("run_id", "")),
                         "manifest_path": str(best_run.get("manifest_path", "")),
@@ -208,18 +208,18 @@ class LoraExperimentStore:
                             best_run.get("adapter_provenance_manifest_path", "")
                         ),
                         "adapter_name": str(best_run.get("adapter_name", "")),
-                        "checkpoint_count": int(best_run.get("checkpoint_count", 0)),
+                        "checkpoint_count": _int_value(best_run.get("checkpoint_count")),
                         "latest_checkpoint_path": str(best_run.get("latest_checkpoint_path", "")),
                         "resume_ready": bool(best_run.get("resume_ready", False)),
                         "loss_best": best_loss if best_loss is not None else 0.0,
                         "export_eligible": bool(best_run.get("export_eligible", False)),
                     },
-                    "updated_at_unix_ms": int(latest_run.get("updated_at_unix_ms", 0)),
+                    "updated_at_unix_ms": _int_value(latest_run.get("updated_at_unix_ms")),
                 }
             )
 
         groups.sort(
-            key=lambda item: (int(item.get("updated_at_unix_ms", 0)), str(item.get("group_id", ""))),
+            key=lambda item: (_int_value(item.get("updated_at_unix_ms")), str(item.get("group_id", ""))),
             reverse=True,
         )
         return groups
@@ -258,10 +258,10 @@ class LoraExperimentStore:
             or f"{source_model}:{adapter_name}"
         )
         if "created_at_unix_ms" in manifest:
-            created_at_unix_ms = int(manifest.get("created_at_unix_ms", 0))
+            created_at_unix_ms = _int_value(manifest.get("created_at_unix_ms"))
         else:
             created_at_unix_ms = int(manifest_path.stat().st_mtime * 1000)
-        updated_at_unix_ms = int(manifest.get("updated_at_unix_ms", created_at_unix_ms))
+        updated_at_unix_ms = _int_value(manifest.get("updated_at_unix_ms"), default=created_at_unix_ms)
         payload = {
             "schema_version": _RUN_SCHEMA_VERSION,
             "run_id": manifest_job_id,
@@ -279,25 +279,26 @@ class LoraExperimentStore:
             "source_model": source_model,
             "dataset_uri": str(dataset.get("uri") or manifest.get("dataset_uri", "")),
             "dataset_version": str(dataset.get("version") or manifest.get("dataset_version", "")),
-            "train_sample_count": int(dataset.get("train_sample_count", manifest.get("trainer_dataset_sample_count", 0)) or 0),
-            "validation_sample_count": int(
+            "train_sample_count": _int_value(
+                dataset.get("train_sample_count"),
+                manifest.get("trainer_dataset_sample_count"),
+            ),
+            "validation_sample_count": _int_value(
                 dataset.get(
                     "validation_sample_count",
                     manifest.get("trainer_dataset_validation_sample_count", manifest.get("validation_sample_count", 0)),
-                )
-                or 0
+                ),
             ),
             "preset_id": str(hyperparameters.get("preset_id") or manifest.get("preset_id", "")),
             "preset_title": str(hyperparameters.get("preset_title") or manifest.get("preset_title", "")),
             "training_mode": str(hyperparameters.get("training_mode") or manifest.get("training_mode", "")),
             "training_backend": str(training.get("backend") or manifest.get("training_backend", "")),
             "status": str(training.get("status") or manifest.get("status", "completed")),
-            "checkpoint_count": int(
+            "checkpoint_count": _int_value(
                 adapter.get(
                     "checkpoint_count",
                     manifest.get("checkpoint_count", manifest.get("experiment.checkpoint_count", 0)),
                 )
-                or 0
             ),
             "latest_checkpoint_path": str(
                 adapter.get(
@@ -316,20 +317,20 @@ class LoraExperimentStore:
                 adapter.get("resume_source_manifest_path") or manifest.get("resume_source_manifest_path", "")
             ),
             "resume_ready": bool(adapter.get("resume_ready", manifest.get("resume_ready", manifest.get("experiment.resume_ready", False)))),
-            "tokens_per_second": float(
+            "tokens_per_second": _optional_finite_float(
                 training.get(
                     "tokens_per_second",
                     manifest.get("tokens_per_second", manifest.get("training.tokens_per_second", 0.0)),
                 )
-                or 0.0
-            ),
-            "peak_memory_gb": float(
+            )
+            or 0.0,
+            "peak_memory_gb": _optional_finite_float(
                 training.get(
                     "peak_memory_gb",
                     manifest.get("peak_memory_gb", manifest.get("training.peak_memory_gb", 0.0)),
                 )
-                or 0.0
-            ),
+            )
+            or 0.0,
             "loss_final": _optional_finite_float(
                 final_metrics.get("loss_final"),
                 _manifest_optional_float(manifest, "loss_final", "training.loss_final"),
@@ -339,7 +340,7 @@ class LoraExperimentStore:
                 _manifest_optional_float(manifest, "loss_best", "training.loss_best"),
             ),
             "validation_loss_best": _optional_finite_float(final_metrics.get("validation_loss_best")),
-            "loss_series_row_count": int(training.get("loss_series_row_count", 0) or 0),
+            "loss_series_row_count": _int_value(training.get("loss_series_row_count")),
             "loss_series": _list_value(training.get("loss_series")),
             "base_model": base_model,
             "dataset_provenance": dataset,
@@ -356,7 +357,10 @@ class LoraExperimentStore:
                 operator_notes.get("path")
                 or manifest.get("adapter_operator_notes_path", "")
             ),
-            "operator_note_count": int(operator_notes.get("note_count", manifest.get("adapter_operator_note_count", 0)) or 0),
+            "operator_note_count": _int_value(
+                operator_notes.get("note_count"),
+                manifest.get("adapter_operator_note_count"),
+            ),
             "manifest_path": str(manifest_path),
             "output_dir": str(manifest_path.parent),
             "created_at_unix_ms": created_at_unix_ms,
@@ -385,7 +389,7 @@ class LoraExperimentStore:
     def _checkpoint_lineage_entry(run: dict[str, Any]) -> dict[str, Any]:
         return {
             "run_id": str(run.get("run_id", "")),
-            "checkpoint_count": int(run.get("checkpoint_count", 0)),
+            "checkpoint_count": _int_value(run.get("checkpoint_count")),
             "latest_checkpoint_path": str(run.get("latest_checkpoint_path", "")),
             "resume_source_path": str(run.get("resume_source_path", "")),
             "resume_source_job_id": str(run.get("resume_source_job_id", "")),
@@ -440,6 +444,16 @@ class LoraExperimentStore:
             return
         self._cached_payloads[path] = (signature, payload)
 
+
+def _int_value(*values: Any, default: int = 0) -> int:
+    for candidate in values:
+        if candidate is None or candidate == "":
+            continue
+        try:
+            return int(candidate)
+        except (TypeError, ValueError):
+            continue
+    return default
 
 
 def _manifest_optional_float(manifest: dict[str, Any], *keys: str) -> float | None:

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -6,6 +6,10 @@ import os
 from pathlib import Path
 from typing import Any
 
+from worker.productization.lora_adapter_provenance import (
+    default_adapter_provenance_manifest_path,
+)
+
 
 _RUN_SCHEMA_VERSION = "melix.lora_experiment_run.v1"
 _INDEX_SCHEMA_VERSION = "melix.lora_experiment_index.v1"
@@ -187,14 +191,28 @@ class LoraExperimentStore:
                     "best_run_id": str(best_run.get("run_id", "")),
                     "best_loss": best_loss if best_loss is not None else 0.0,
                     "recommended_manifest_path": str(best_run.get("manifest_path", "")),
+                    "recommended_provenance_manifest_path": str(
+                        best_run.get("adapter_provenance_manifest_path", "")
+                    ),
+                    "latest_provenance_manifest_path": str(
+                        latest_run.get("adapter_provenance_manifest_path", "")
+                    ),
+                    "latest_export_eligible": bool(latest_run.get("export_eligible", False)),
+                    "best_export_eligible": bool(best_run.get("export_eligible", False)),
+                    "latest_loss_series_row_count": int(latest_run.get("loss_series_row_count", 0)),
+                    "latest_operator_note_count": int(latest_run.get("operator_note_count", 0)),
                     "best_known_adapter": {
                         "run_id": str(best_run.get("run_id", "")),
                         "manifest_path": str(best_run.get("manifest_path", "")),
+                        "provenance_manifest_path": str(
+                            best_run.get("adapter_provenance_manifest_path", "")
+                        ),
                         "adapter_name": str(best_run.get("adapter_name", "")),
                         "checkpoint_count": int(best_run.get("checkpoint_count", 0)),
                         "latest_checkpoint_path": str(best_run.get("latest_checkpoint_path", "")),
                         "resume_ready": bool(best_run.get("resume_ready", False)),
                         "loss_best": best_loss if best_loss is not None else 0.0,
+                        "export_eligible": bool(best_run.get("export_eligible", False)),
                     },
                     "updated_at_unix_ms": int(latest_run.get("updated_at_unix_ms", 0)),
                 }
@@ -207,10 +225,38 @@ class LoraExperimentStore:
         return groups
 
     def _build_run_payload(self, *, manifest: dict[str, Any], manifest_path: Path) -> dict[str, Any]:
-        manifest_job_id = str(manifest.get("job_id", "")).strip() or manifest_path.parent.name
-        adapter_name = str(manifest.get("adapter_name", "")).strip() or "melix-adapter"
-        source_model = str(manifest.get("source_model", "")).strip()
-        group_id = str(manifest.get("experiment_group_id", "")).strip() or f"{source_model}:{adapter_name}"
+        provenance = self._load_adapter_provenance(
+            manifest=manifest,
+            manifest_path=manifest_path,
+        )
+        adapter = _dict_value(provenance.get("adapter"))
+        base_model = _dict_value(provenance.get("base_model"))
+        dataset = _dict_value(provenance.get("dataset"))
+        hyperparameters = _dict_value(provenance.get("hyperparameters"))
+        training = _dict_value(provenance.get("training"))
+        final_metrics = _dict_value(provenance.get("final_metrics"))
+        operator_notes = _dict_value(provenance.get("operator_notes"))
+        export_eligibility = _dict_value(provenance.get("export_eligibility"))
+
+        manifest_job_id = (
+            str(adapter.get("job_id", "")).strip()
+            or str(manifest.get("job_id", "")).strip()
+            or manifest_path.parent.name
+        )
+        adapter_name = (
+            str(adapter.get("adapter_name", "")).strip()
+            or str(manifest.get("adapter_name", "")).strip()
+            or "melix-adapter"
+        )
+        source_model = (
+            str(base_model.get("model_id", "")).strip()
+            or str(manifest.get("source_model", "")).strip()
+        )
+        group_id = (
+            str(adapter.get("experiment_group_id", "")).strip()
+            or str(manifest.get("experiment_group_id", "")).strip()
+            or f"{source_model}:{adapter_name}"
+        )
         if "created_at_unix_ms" in manifest:
             created_at_unix_ms = int(manifest.get("created_at_unix_ms", 0))
         else:
@@ -221,37 +267,96 @@ class LoraExperimentStore:
             "run_id": manifest_job_id,
             "group_id": group_id,
             "group_title": str(
-                manifest.get(
+                adapter.get("experiment_group_title")
+                or manifest.get(
                     "experiment_group_title",
-                    group_id if str(manifest.get("experiment_group_id", "")).strip() else adapter_name,
+                    group_id
+                    if str(adapter.get("experiment_group_id") or manifest.get("experiment_group_id", "")).strip()
+                    else adapter_name,
                 )
             ),
             "adapter_name": adapter_name,
             "source_model": source_model,
-            "dataset_uri": str(manifest.get("dataset_uri", "")),
-            "preset_id": str(manifest.get("preset_id", "")),
-            "preset_title": str(manifest.get("preset_title", "")),
-            "training_mode": str(manifest.get("training_mode", "")),
-            "training_backend": str(manifest.get("training_backend", "")),
-            "status": str(manifest.get("status", "completed")),
-            "checkpoint_count": int(manifest.get("checkpoint_count", manifest.get("experiment.checkpoint_count", 0))),
+            "dataset_uri": str(dataset.get("uri") or manifest.get("dataset_uri", "")),
+            "dataset_version": str(dataset.get("version") or manifest.get("dataset_version", "")),
+            "train_sample_count": int(dataset.get("train_sample_count", manifest.get("trainer_dataset_sample_count", 0)) or 0),
+            "validation_sample_count": int(
+                dataset.get(
+                    "validation_sample_count",
+                    manifest.get("trainer_dataset_validation_sample_count", manifest.get("validation_sample_count", 0)),
+                )
+                or 0
+            ),
+            "preset_id": str(hyperparameters.get("preset_id") or manifest.get("preset_id", "")),
+            "preset_title": str(hyperparameters.get("preset_title") or manifest.get("preset_title", "")),
+            "training_mode": str(hyperparameters.get("training_mode") or manifest.get("training_mode", "")),
+            "training_backend": str(training.get("backend") or manifest.get("training_backend", "")),
+            "status": str(training.get("status") or manifest.get("status", "completed")),
+            "checkpoint_count": int(
+                adapter.get(
+                    "checkpoint_count",
+                    manifest.get("checkpoint_count", manifest.get("experiment.checkpoint_count", 0)),
+                )
+                or 0
+            ),
             "latest_checkpoint_path": str(
-                manifest.get("latest_checkpoint_path", manifest.get("experiment.latest_checkpoint_path", ""))
+                adapter.get(
+                    "latest_checkpoint_path",
+                    manifest.get("latest_checkpoint_path", manifest.get("experiment.latest_checkpoint_path", "")),
+                )
             ),
             "resume_source_path": str(
-                manifest.get("resume_source_path", manifest.get("experiment.resume_source_path", ""))
+                adapter.get(
+                    "resume_source_path",
+                    manifest.get("resume_source_path", manifest.get("experiment.resume_source_path", "")),
+                )
             ),
-            "resume_source_job_id": str(manifest.get("resume_source_job_id", "")),
-            "resume_source_manifest_path": str(manifest.get("resume_source_manifest_path", "")),
-            "resume_ready": bool(manifest.get("resume_ready", manifest.get("experiment.resume_ready", False))),
+            "resume_source_job_id": str(adapter.get("resume_source_job_id") or manifest.get("resume_source_job_id", "")),
+            "resume_source_manifest_path": str(
+                adapter.get("resume_source_manifest_path") or manifest.get("resume_source_manifest_path", "")
+            ),
+            "resume_ready": bool(adapter.get("resume_ready", manifest.get("resume_ready", manifest.get("experiment.resume_ready", False)))),
             "tokens_per_second": float(
-                manifest.get("tokens_per_second", manifest.get("training.tokens_per_second", 0.0))
+                training.get(
+                    "tokens_per_second",
+                    manifest.get("tokens_per_second", manifest.get("training.tokens_per_second", 0.0)),
+                )
+                or 0.0
             ),
             "peak_memory_gb": float(
-                manifest.get("peak_memory_gb", manifest.get("training.peak_memory_gb", 0.0))
+                training.get(
+                    "peak_memory_gb",
+                    manifest.get("peak_memory_gb", manifest.get("training.peak_memory_gb", 0.0)),
+                )
+                or 0.0
             ),
-            "loss_final": _manifest_optional_float(manifest, "loss_final", "training.loss_final"),
-            "loss_best": _manifest_optional_float(manifest, "loss_best", "training.loss_best"),
+            "loss_final": _optional_finite_float(
+                final_metrics.get("loss_final"),
+                _manifest_optional_float(manifest, "loss_final", "training.loss_final"),
+            ),
+            "loss_best": _optional_finite_float(
+                final_metrics.get("loss_best"),
+                _manifest_optional_float(manifest, "loss_best", "training.loss_best"),
+            ),
+            "validation_loss_best": _optional_finite_float(final_metrics.get("validation_loss_best")),
+            "loss_series_row_count": int(training.get("loss_series_row_count", 0) or 0),
+            "loss_series": _list_value(training.get("loss_series")),
+            "base_model": base_model,
+            "dataset_provenance": dataset,
+            "hyperparameters": hyperparameters,
+            "export_eligibility": export_eligibility,
+            "export_eligible": bool(export_eligibility.get("eligible", False)),
+            "export_blocking_reasons": _list_value(export_eligibility.get("blocking_reasons")),
+            "adapter_provenance_manifest_path": str(
+                provenance.get("adapter_provenance_manifest_path")
+                or manifest.get("adapter_provenance_manifest_path", "")
+                or (default_adapter_provenance_manifest_path(manifest_path) if provenance else "")
+            ),
+            "adapter_operator_notes_path": str(
+                operator_notes.get("path")
+                or manifest.get("adapter_operator_notes_path", "")
+            ),
+            "operator_note_count": int(operator_notes.get("note_count", manifest.get("adapter_operator_note_count", 0)) or 0),
             "manifest_path": str(manifest_path),
             "output_dir": str(manifest_path.parent),
             "created_at_unix_ms": created_at_unix_ms,
@@ -260,6 +365,20 @@ class LoraExperimentStore:
         for key in _LORA_CANARY_RECEIPT_KEYS:
             if key in manifest:
                 payload[key] = manifest[key]
+        return payload
+
+    def _load_adapter_provenance(
+        self,
+        *,
+        manifest: dict[str, Any],
+        manifest_path: Path,
+    ) -> dict[str, Any]:
+        provenance_path = str(manifest.get("adapter_provenance_manifest_path", "")).strip()
+        candidate_path = Path(provenance_path) if provenance_path else default_adapter_provenance_manifest_path(manifest_path)
+        payload = self._load_payload(candidate_path)
+        if payload.get("schema_version") != "melix.lora_adapter_provenance.v1":
+            return {}
+        payload["adapter_provenance_manifest_path"] = str(candidate_path)
         return payload
 
     @staticmethod
@@ -338,16 +457,25 @@ def _best_loss_value(item: dict[str, Any]) -> float | None:
     return None
 
 
-def _optional_finite_float(value: Any) -> float | None:
-    if value is None or value == "":
-        return None
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError):
-        return None
-    if not math.isfinite(parsed):
-        return None
-    return parsed
+def _optional_finite_float(*values: Any) -> float | None:
+    for candidate in values:
+        if candidate is None or candidate == "":
+            continue
+        try:
+            parsed = float(candidate)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(parsed):
+            return parsed
+    return None
+
+
+def _dict_value(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _list_value(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
 
 
 def _json_safe(value: Any) -> Any:


### PR DESCRIPTION
## Summary
- Adds a schema-backed `melix.lora_adapter_provenance.v1` manifest beside completed LoRA adapter package manifests, with base model, dataset, hyperparameters, bounded loss series, final metrics, canary receipts, and export eligibility.
- Persists mutable operator notes in a separate `melix.lora_adapter_operator_notes.v1` file so note edits do not mutate immutable training provenance.
- Updates LoRA experiment history/group projections to prefer provenance fields for comparison, export eligibility, note count, and loss-series summaries, with defensive numeric parsing for malformed manifest/provenance values.

## Plan or Spec
- Closes #1503.
- Governing plan: `docs/plans/2026-06-24-issue-1503-adapter-provenance.md`.
- Governing roadmap/spec context: `docs/plans/2026-05-24-m-courtyard-improvement-roadmap.md` and `docs/reference-scans/m-courtyard-lessons.md`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_lora_adapter_provenance.py services/mlx-worker-python/tests/test_training_log_events.py services/mlx-worker-python/tests/test_lora_experiment_store.py -q
# 32 passed in 0.10s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_training_log_events.py services/mlx-worker-python/tests/test_lora_experiment_store.py services/mlx-worker-python/tests/test_lora_adapter_provenance.py -q
# 53 passed in 0.16s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage-issue-1503.json --diff-from origin/main services/mlx-worker-python/worker/productization/lora_adapter_provenance.py services/mlx-worker-python/worker/productization/lora_experiment_store.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
# TOTAL 97.85% (228/233 changed executable lines covered)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_prefers_run_record_over_manifest_when_both_exist
# 1 passed in 0.05s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_prefers_run_record_over_manifest_when_both_exist services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_skips_manifest_parse_when_run_record_exists services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_returns_groups_comparison_and_export_payloads services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_sorts_groups_by_latest_run_then_group_id services/mlx-worker-python/tests/test_lora_experiment_store.py::test_rebuild_index_sorts_runs_by_updated_at_then_run_id && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o .runtime/coverage-review-fix.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python scripts/python_changed_line_coverage.py --coverage-json .runtime/coverage-review-fix.json --diff-from HEAD~1 services/mlx-worker-python/worker/productization/lora_experiment_store.py services/mlx-worker-python/tests/test_lora_experiment_store.py
# 5 passed in 8.04s; TOTAL 39 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_lora_adapter_provenance.py services/mlx-worker-python/tests/test_training_log_events.py services/mlx-worker-python/tests/test_lora_experiment_store.py -q
# 31 passed in 0.13s after review-fix hardening

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx ruff format --check services/mlx-worker-python/worker/productization/lora_adapter_provenance.py services/mlx-worker-python/worker/productization/lora_experiment_store.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_adapter_provenance.py services/mlx-worker-python/tests/test_lora_experiment_store.py services/mlx-worker-python/tests/test_training_log_events.py
# Failed: ruff is not installed in the locked uv environment (Failed to spawn: ruff)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx ruff check services/mlx-worker-python/worker/productization/lora_adapter_provenance.py services/mlx-worker-python/worker/productization/lora_experiment_store.py services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_adapter_provenance.py services/mlx-worker-python/tests/test_lora_experiment_store.py services/mlx-worker-python/tests/test_training_log_events.py
# Failed: ruff is not installed in the locked uv environment (Failed to spawn: ruff)

git diff --check --cached
# passed

make git-hooks-install && .githooks/pre-commit
# first run: make swift-test passed; make py-test passed (4344 passed, 14 skipped); make integration-test passed (123 passed, 1 skipped); performance report blocked commit with verification_failed due targeted coverage 50.0% for lora-experiment-run-dir-name-scan; no regressions.

uv run --frozen --project services/mlx-worker-python --extra mlx python scripts/pre_commit_gate.py
# second run after focused coverage fix: make swift-test passed (completed rc=0 elapsed=211.7s); make py-test passed (4343 passed, 14 skipped); make integration-test passed (123 passed, 1 skipped); PR scoped performance report Status: ok.

uv run --frozen --project services/mlx-worker-python --extra mlx python scripts/pre_commit_gate.py
# review-fix run after hardening numeric parsing: make swift-test passed (completed rc=0 elapsed=158.0s); make py-test passed (4343 passed, 14 skipped); make integration-test passed (123 passed, 1 skipped); PR scoped performance report Status: ok.
```

## Coverage and Metrics
- Changed-line coverage for the original executable Python scope: `97.85%` total (`228/233` covered).
  - `services/mlx-worker-python/worker/productization/lora_adapter_provenance.py`: `97.40%` (`187/192`)
  - `services/mlx-worker-python/worker/productization/lora_experiment_store.py`: `100.00%` (`37/37`)
  - `services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py`: `100.00%` (`4/4`)
- Review-fix changed-line coverage from `HEAD~1`: `100.00%` total (`39/39` covered) for `lora_experiment_store.py` and its test.
- Latest pre-commit PR scoped performance report: `.runtime/pre-commit-performance/20260624-010527-01724d77/report/report.md`, Status `ok`, regressions `0`, context regressions `0`, verification failures `0`.
- Latest `lora-experiment-run-dir-name-scan`: targeted tests pass, coverage `100.0%`; `elapsed_ms_mean` base `170.671`, head `167.595`, delta `-1.80%`; `peak_bytes_mean` unchanged; `path_attr_reads_mean` unchanged at `0.000`.
- Prior full-scope pre-commit PR scoped performance report: `.runtime/pre-commit-performance/20260624-004151-b3da755b/report/report.md`, Status `ok`, regressions `0`, context regressions `0`, verification failures `0`.
- Prior `lora-experiment-run-dir-name-scan`: targeted tests pass, coverage `100.0%`; `elapsed_ms_mean` base `168.520`, head `168.171`, delta `-0.21%`; `peak_bytes_mean` unchanged; `path_attr_reads_mean` unchanged at `0.000`.
- Prior `lora-reward-summary-candidate-minmax`: targeted tests pass, coverage `100.0%`; `elapsed_ms_mean` base `20.140`, head `19.727`, delta `-2.05%`; `sorted_calls_mean` unchanged at `0.000`.
- Observability mode: evidence/minimal persisted manifest metrics. The package manifest records provenance manifest path, notes path/count, export eligibility, manifest write duration, notes write duration, loss-series row count, and manifest byte size. Probe overhead: covered by the PR scoped probes above; no deferred debug artifacts are required.

## Known Gaps
- Desktop operator note editing UI is out of scope for this slice.
- Runtime export execution and post-export smoke tests are out of scope; this slice computes manifest-backed export eligibility and blocking reasons.
- No protobuf or dependency changes.
- Ruff formatting/check commands could not run because `ruff` is absent from the locked uv environment; formatting-sensitive checks were covered by `git diff --check --cached` and the full pre-commit gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
