### PR TITLE
Document post-export smoke diagnostics plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@ These are the authoritative interface and architecture definitions. Do not move 
 
 | Plan | What It Covers |
 |---|---|
+| [Runtime-Aware Export And Serving Verification Plan](plans/2026-06-21-runtime-aware-export-and-serving-verification.md) | M3 export target manifests, layout, retention, post-export smoke policy, diagnostics, waiver semantics, and serving evidence |
 | [Export Artifact Layout And Retention Policy](plans/2026-06-24-export-artifact-layout-retention.md) | Runtime export target layout, retention reports, cleanup dry-run/apply behavior, and byte-accounting metrics |
 
 ---

--- a/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
+++ b/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
@@ -117,39 +117,41 @@ include:
 - `source_provenance`
 - `redaction_class`
 
-Required `target_type` values are `melix_managed`, `ollama`, `gguf`, and
-`mlx_runtime`. Unknown target types are rejected until a governing plan extends
-the target matrix.
+Required `target_type` values use the protobuf JSON enum names
+`EXPORT_TARGET_TYPE_MELIX_MANAGED`, `EXPORT_TARGET_TYPE_OLLAMA`,
+`EXPORT_TARGET_TYPE_GGUF`, and `EXPORT_TARGET_TYPE_MLX_RUNTIME`. Unknown
+target types are rejected until a governing plan extends the target matrix.
 
 ### Target Policies
 
-`melix_managed` targets produce Melix-managed adapter or fused derived-model
-artifacts usable by Melix sessions. Their smoke policy requires manifest
-inspection, local catalog resolvability, load through the selected Melix
-runtime path, and one bounded generation when the target is generation-capable.
+`EXPORT_TARGET_TYPE_MELIX_MANAGED` targets produce Melix-managed adapter or
+fused derived-model artifacts usable by Melix sessions. Their smoke policy
+requires manifest inspection, local catalog resolvability, load through the
+selected Melix runtime path, and one bounded generation when the target is
+generation-capable.
 
-`ollama` targets produce an Ollama-compatible model directory or model
-registration bundle. Their smoke policy requires metadata inspection, runtime
-binary/path preflight, load or registration check, and one bounded generation
-with timeout.
+`EXPORT_TARGET_TYPE_OLLAMA` targets produce an Ollama-compatible model
+directory or model registration bundle. Their smoke policy requires metadata
+inspection, runtime binary/path preflight, load or registration check, and one
+bounded generation with timeout.
 
-`gguf` targets produce a GGUF file plus metadata and provenance for compatible
-local runtimes. Their smoke policy requires header/metadata inspection,
-file-size and digest verification, optional load smoke through a configured
-compatible runtime, and an explicit waiver when no compatible runtime is
-available.
+`EXPORT_TARGET_TYPE_GGUF` targets produce a GGUF file plus metadata and
+provenance for compatible local runtimes. Their smoke policy requires
+header/metadata inspection, file-size and digest verification, optional load
+smoke through a configured compatible runtime, and an explicit waiver when no
+compatible runtime is available.
 
-`mlx_runtime` targets produce an MLX-compatible local model or adapter bundle
-for `mlx-lm` or Melix MLX workers. Their smoke policy requires MLX metadata
-inspection, local path preflight, runtime load, and one bounded generation with
-timeout.
+`EXPORT_TARGET_TYPE_MLX_RUNTIME` targets produce an MLX-compatible local model
+or adapter bundle for `mlx-lm` or Melix MLX workers. Their smoke policy requires
+MLX metadata inspection, local path preflight, runtime load, and one bounded
+generation with timeout.
 
 ### Target Matrix And Unit Boundaries
 
 P3.1 fixes the export target matrix before implementation starts. The first
 schema-backed implementation slice must support exactly these targets:
 
-`melix_managed`
+`EXPORT_TARGET_TYPE_MELIX_MANAGED`
 
 - Produced artifact: Melix-managed adapter package or fused derived-model
   artifact.
@@ -163,7 +165,7 @@ schema-backed implementation slice must support exactly these targets:
   required runtime artifacts, and classify temporary fusion outputs as cleanable
   after verification or waiver.
 
-`ollama`
+`EXPORT_TARGET_TYPE_OLLAMA`
 
 - Produced artifact: Ollama-compatible model directory, blob set, or
   registration bundle.
@@ -176,7 +178,7 @@ schema-backed implementation slice must support exactly these targets:
   evidence under `targets/ollama/<target-id>/`; keep manifests and smoke
   evidence while classifying transient import/cache files as cleanable.
 
-`gguf`
+`EXPORT_TARGET_TYPE_GGUF`
 
 - Produced artifact: GGUF file plus metadata and provenance for compatible
   local runtimes.
@@ -190,7 +192,7 @@ schema-backed implementation slice must support exactly these targets:
   `targets/gguf/<target-id>/artifacts/`; retain the GGUF file and evidence, and
   classify conversion scratch files as cleanable.
 
-`mlx_runtime`
+`EXPORT_TARGET_TYPE_MLX_RUNTIME`
 
 - Produced artifact: MLX-compatible local model or adapter bundle for `mlx-lm`
   or Melix MLX workers.
@@ -351,10 +353,14 @@ runtime cache state, ad hoc stdout, or files outside the target directory.
 
 | Target type | Metadata check | Load check | Generation check | Waiver boundary |
 |---|---|---|---|---|
-| `melix_managed` | Validate manifest, required file digests, activation mode, quantization, and catalog-resolvable target identity. | Load through the selected Melix runtime path or model catalog without mutating source adapter evidence. | Required when the target is generation-capable; use a synthetic prompt, fixed token cap, timeout, and preview byte cap. | `metadata_only_target` only for metadata-only exports; runtime failures require diagnostics before waiver. |
-| `ollama` | Validate generated model metadata, registration inputs, required blobs, runtime binary/path preflight, and target-local log path. | Prove load or registration through the configured local Ollama runtime with bounded timeout. | Required after load or registration succeeds. | `runtime_not_installed`, `runtime_incompatible_host`, `known_runtime_bug`, or `operator_manual_verification` with replacement evidence. |
-| `gguf` | Validate GGUF header, declared metadata, byte size, digest, quantization, and compatible runtime requirements. | Required when a compatible local runtime is configured; otherwise the load check is `waived`. | Required only when the configured compatible runtime supports generation. | No-compatible-runtime cases may use `runtime_not_installed` or `runtime_incompatible_host`; digest, header, and metadata failures are never waivable. |
-| `mlx_runtime` | Validate MLX config, tokenizer, weight inventory, adapter or fused mode, runtime path, and required file digests. | Load with `mlx-lm` or the selected Melix MLX worker path using a bounded timeout. | Required for generation-capable targets with the same fixed prompt, token cap, timeout, and preview byte cap as Melix-managed targets. | `runtime_not_installed`, `runtime_incompatible_host`, `known_runtime_bug`, or `operator_manual_verification` with replacement evidence. |
+| `EXPORT_TARGET_TYPE_MELIX_MANAGED` | Validate manifest, required file digests, activation mode, quantization, and catalog-resolvable target identity. | Load through the selected Melix runtime path or model catalog without mutating source adapter evidence. | Required when the target is generation-capable; use a synthetic prompt, fixed token cap, timeout, and preview byte cap. | `EXPORT_WAIVER_REASON_METADATA_ONLY_TARGET` only for metadata-only exports; runtime failures require diagnostics before waiver. |
+| `EXPORT_TARGET_TYPE_OLLAMA` | Validate generated model metadata, registration inputs, required blobs, runtime binary/path preflight, and target-local log path. | Prove load or registration through the configured local Ollama runtime with bounded timeout. | Required after load or registration succeeds. | `EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED`, `EXPORT_WAIVER_REASON_RUNTIME_INCOMPATIBLE_HOST`, `EXPORT_WAIVER_REASON_KNOWN_RUNTIME_BUG`, or `EXPORT_WAIVER_REASON_OPERATOR_MANUAL_VERIFICATION` with replacement evidence. |
+| `EXPORT_TARGET_TYPE_GGUF` | Validate GGUF header, declared metadata, byte size, digest, quantization, and compatible runtime requirements. | Required when a compatible local runtime is configured; otherwise the load check is recorded as waived. | Required only when the configured compatible runtime supports generation. | No-compatible-runtime cases may use `EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED` or `EXPORT_WAIVER_REASON_RUNTIME_INCOMPATIBLE_HOST`; digest, header, and metadata failures are never waivable. |
+| `EXPORT_TARGET_TYPE_MLX_RUNTIME` | Validate MLX config, tokenizer, weight inventory, adapter or fused mode, runtime path, and required file digests. | Load with `mlx-lm` or the selected Melix MLX worker path using a bounded timeout. | Required for generation-capable targets with the same fixed prompt, token cap, timeout, and preview byte cap as Melix-managed targets. | `EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED`, `EXPORT_WAIVER_REASON_RUNTIME_INCOMPATIBLE_HOST`, `EXPORT_WAIVER_REASON_KNOWN_RUNTIME_BUG`, or `EXPORT_WAIVER_REASON_OPERATOR_MANUAL_VERIFICATION` with replacement evidence. |
+
+The target type and waiver reason values in this matrix use the protobuf JSON
+enum names from `workspace/v1/export_target_manifest.proto`. Target directory
+slugs remain lower snake case, such as `targets/ollama/<target-id>/`.
 
 The first implementation slice for #1509 should use a policy id such as
 `bounded-local-v1`. The policy owns default timeout values, preview byte caps,
@@ -399,10 +405,13 @@ Each `metadata_check`, `load_check`, and `generation_check` entry must include
 when diagnostics are applicable. The receipt records target-relative paths only.
 
 The metadata check is required for every target. The load check is required for
-`melix_managed`, `ollama`, and `mlx_runtime` targets. The generation check is
-required for generation-capable `melix_managed`, `ollama`, and `mlx_runtime`
-targets. GGUF generation may be waived only when no compatible local runtime is
-configured, and the waiver must record the missing runtime capability.
+`EXPORT_TARGET_TYPE_MELIX_MANAGED`, `EXPORT_TARGET_TYPE_OLLAMA`, and
+`EXPORT_TARGET_TYPE_MLX_RUNTIME` targets. The generation check is required for
+generation-capable `EXPORT_TARGET_TYPE_MELIX_MANAGED`,
+`EXPORT_TARGET_TYPE_OLLAMA`, and `EXPORT_TARGET_TYPE_MLX_RUNTIME` targets.
+`EXPORT_TARGET_TYPE_GGUF` generation may be waived only when no compatible
+local runtime is configured, and the waiver must record the missing runtime
+capability.
 
 Bounded generation checks must use a repository-owned prompt fixture or a
 synthetic non-private prompt, a fixed token limit, a timeout, and a preview byte
@@ -473,11 +482,11 @@ Waivers use schema `melix.export_verification_waiver.v1` and must include:
 
 Allowed first-slice waiver reasons are:
 
-- `runtime_not_installed`
-- `runtime_incompatible_host`
-- `metadata_only_target`
-- `known_runtime_bug`
-- `operator_manual_verification`
+- `EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED`
+- `EXPORT_WAIVER_REASON_RUNTIME_INCOMPATIBLE_HOST`
+- `EXPORT_WAIVER_REASON_METADATA_ONLY_TARGET`
+- `EXPORT_WAIVER_REASON_KNOWN_RUNTIME_BUG`
+- `EXPORT_WAIVER_REASON_OPERATOR_MANUAL_VERIFICATION`
 
 Waivers are not allowed for missing required files, digest mismatch, unsafe
 paths, unsupported target type, missing source provenance, or missing target
@@ -562,10 +571,10 @@ melix export plan \
   --workspace-manifest path/to/workspace-manifest.json \
   --adapter-manifest path/to/train_lora.adapter.json \
   --derived-model-manifest path/to/activate_adapter.derived_model.json \
-  --target melix_managed \
-  --target ollama \
-  --target gguf \
-  --target mlx_runtime \
+  --target EXPORT_TARGET_TYPE_MELIX_MANAGED \
+  --target EXPORT_TARGET_TYPE_OLLAMA \
+  --target EXPORT_TARGET_TYPE_GGUF \
+  --target EXPORT_TARGET_TYPE_MLX_RUNTIME \
   --output exports/support-chat-v1/export-plan-receipt.json \
   --json
 ```
@@ -650,9 +659,10 @@ outputs regenerated by `make proto`. The Python worker owns the first validator
 and fixture metrics report under `worker.productization` because export
 materialization is worker-owned; CLI and Desktop consumption remains follow-up
 work unless a later unit needs new operator surfaces. Checked-in fixtures must
-cover `melix_managed`, `ollama`, `gguf`, and `mlx_runtime` without `ext` fields
-or target-specific side-channel keys. The registered PR-scoped probe for this
-unit is `runtime-export-manifest-validation`, measuring validation latency,
+cover `EXPORT_TARGET_TYPE_MELIX_MANAGED`, `EXPORT_TARGET_TYPE_OLLAMA`,
+`EXPORT_TARGET_TYPE_GGUF`, and `EXPORT_TARGET_TYPE_MLX_RUNTIME` without `ext`
+fields or target-specific side-channel keys. The registered PR-scoped probe for
+this unit is `runtime-export-manifest-validation`, measuring validation latency,
 fixture count, schema error count, and manifest byte size.
 
 ### #1507 Layout And Retention Unit

--- a/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
+++ b/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
@@ -341,6 +341,38 @@ land.
 P3.2 defines how export completion is proven for each target and how failures
 become typed operator diagnostics.
 
+### P3.2 Target Smoke Matrix
+
+P3.2 consumes the target directories and retention contract produced by #1507.
+Each target smoke runner reads the target manifest, writes evidence only under
+the target-local `smoke/` and `diagnostics/` directories, and updates the
+export report from those receipts. The runner must not infer success from
+runtime cache state, ad hoc stdout, or files outside the target directory.
+
+| Target type | Metadata check | Load check | Generation check | Waiver boundary |
+|---|---|---|---|---|
+| `melix_managed` | Validate manifest, required file digests, activation mode, quantization, and catalog-resolvable target identity. | Load through the selected Melix runtime path or model catalog without mutating source adapter evidence. | Required when the target is generation-capable; use a synthetic prompt, fixed token cap, timeout, and preview byte cap. | `metadata_only_target` only for metadata-only exports; runtime failures require diagnostics before waiver. |
+| `ollama` | Validate generated model metadata, registration inputs, required blobs, runtime binary/path preflight, and target-local log path. | Prove load or registration through the configured local Ollama runtime with bounded timeout. | Required after load or registration succeeds. | `runtime_not_installed`, `runtime_incompatible_host`, `known_runtime_bug`, or `operator_manual_verification` with replacement evidence. |
+| `gguf` | Validate GGUF header, declared metadata, byte size, digest, quantization, and compatible runtime requirements. | Required when a compatible local runtime is configured; otherwise the load check is `waived`. | Required only when the configured compatible runtime supports generation. | No-compatible-runtime cases may use `runtime_not_installed` or `runtime_incompatible_host`; digest, header, and metadata failures are never waivable. |
+| `mlx_runtime` | Validate MLX config, tokenizer, weight inventory, adapter or fused mode, runtime path, and required file digests. | Load with `mlx-lm` or the selected Melix MLX worker path using a bounded timeout. | Required for generation-capable targets with the same fixed prompt, token cap, timeout, and preview byte cap as Melix-managed targets. | `runtime_not_installed`, `runtime_incompatible_host`, `known_runtime_bug`, or `operator_manual_verification` with replacement evidence. |
+
+The first implementation slice for #1509 should use a policy id such as
+`bounded-local-v1`. The policy owns default timeout values, preview byte caps,
+token caps, and the synthetic prompt fixture. The plan intentionally does not
+standardize those numeric defaults in the planning slice; #1509 must pick
+conservative defaults, test them, and record them in the receipt.
+
+Smoke status is target-local:
+
+- `passed`: metadata, required file digest, required load, and required
+  generation checks passed.
+- `failed`: one required check ran and failed with a typed failure or linked
+  diagnostics receipt.
+- `blocked`: a required check could not start because an earlier materialization
+  or preflight requirement failed.
+- `waived`: an allowed waiver records the skipped checks, reason, operator
+  identity, replacement evidence, expiry, and follow-up issue when applicable.
+
 ### Smoke Receipt
 
 Each target writes `smoke/smoke-receipt.json` with schema
@@ -361,6 +393,11 @@ Each target writes `smoke/smoke-receipt.json` with schema
 - `operator_failures`
 - `metrics`
 
+Each `metadata_check`, `load_check`, and `generation_check` entry must include
+`status`, `started_at`, `ended_at`, `duration_ms`, `timeout_ms`,
+`failure_code`, `failure_message`, `evidence_path`, and `diagnostics_receipt_path`
+when diagnostics are applicable. The receipt records target-relative paths only.
+
 The metadata check is required for every target. The load check is required for
 `melix_managed`, `ollama`, and `mlx_runtime` targets. The generation check is
 required for generation-capable `melix_managed`, `ollama`, and `mlx_runtime`
@@ -370,6 +407,10 @@ configured, and the waiver must record the missing runtime capability.
 Bounded generation checks must use a repository-owned prompt fixture or a
 synthetic non-private prompt, a fixed token limit, a timeout, and a preview byte
 limit. The preview is diagnostic evidence only; it is not an evaluation score.
+`output_preview` records byte count, content type, truncation status, digest,
+and the target-relative `smoke/generation-preview.txt` path; it must not contain
+full prompt text, full generated text, credentials, dataset rows, or private
+operator input.
 
 Required smoke metrics:
 
@@ -399,6 +440,20 @@ states:
 The report must not use `completed` for a target when smoke evidence is missing,
 when digest checks are absent, when a runtime log parser is still pending after
 a failure, or when a waiver has no reason and operator identity.
+
+Every export report target row must attach:
+
+- `target_manifest_path`
+- `retention_report_path`
+- `smoke_receipt_path`
+- `diagnostics_receipt_path` when present
+- `verification_terminal_state`
+- `verification_blocker_code`
+- `waiver_id` when a waiver is used
+
+The export report may summarize sensitive paths for operators, but the
+machine-readable evidence paths remain target-relative so workspace exports do
+not leak absolute host paths.
 
 ### Waiver Contract
 
@@ -445,6 +500,12 @@ Failure diagnostics write `diagnostics/diagnostics-receipt.json` with schema
 - `operator_remedies`
 - `metrics`
 
+The diagnostics parser consumes target-local runtime logs, bounded subprocess
+stderr/stdout captures, and smoke failure messages. It writes one receipt per
+target and must finish before a failed smoke receipt can become a terminal
+export-report row. CLI and Desktop render remedies from this receipt; they do
+not parse raw logs independently.
+
 Required diagnosis codes for #1510:
 
 - `runtime_load_failed`
@@ -461,6 +522,27 @@ Required diagnosis codes for #1510:
 Each diagnosis row must include `code`, `severity`, `matched_pattern_id`,
 `operator_message`, `remediation`, and a redacted evidence pointer. Unknown
 failures preserve bounded redacted excerpts for later parser expansion.
+
+### Log Redaction And Evidence Bounds
+
+Runtime log diagnostics use the workspace redaction policy and the target
+manifest redaction classes. The parser must redact or omit:
+
+- absolute host paths, replacing them with target-relative evidence pointers
+  when the path is under the target directory;
+- credentials, bearer tokens, API keys, proxy secrets, certificate contents, and
+  shell environment values that can carry secrets;
+- full prompts, full generations, dataset rows, private prompt templates, and
+  operator-entered free text beyond bounded previews;
+- user identity strings when they are not required to explain the failure.
+
+Unknown failures preserve `diagnostics/redacted-log-excerpt.txt` with byte and
+line caps chosen by #1510. The receipt records `excerpt_byte_count`,
+`excerpt_line_count`, `truncated`, `redaction_count`,
+`redacted_absolute_path_count`, `redacted_secret_count`, and
+`redacted_prompt_or_response_count`. Raw logs can remain in the target-local
+`logs/` directory according to retention policy, but exported summaries and
+operator-facing evidence use only redacted excerpts.
 
 Required diagnostic metrics:
 
@@ -596,11 +678,24 @@ and diagnostics units use.
 ### #1509 Smoke Unit
 
 - Smoke policy tests for Melix-managed, Ollama, GGUF, and MLX runtime targets.
+- Smoke receipt fixture tests for `passed`, `failed`, `blocked`, and `waived`
+  terminal states.
 - Timeout tests proving bounded generation cannot hang export completion.
 - Waiver tests proving allowed waivers are recorded and disallowed waivers are
   rejected.
+- Export-report gating tests proving targets cannot be marked verified without
+  manifest validation, digest checks, smoke receipt, retention report, and
+  diagnostics when a smoke failure occurs.
 - CLI/Desktop decoder tests proving smoke status and preview metadata render
   from the shared receipt.
+
+#1509 implementation lands the worker-owned smoke policy runner and receipt
+fixtures for the four target types. The registered PR-scoped probe for this
+unit is `runtime-export-smoke-policy`, measuring metadata check latency, load
+smoke latency, generation smoke latency, output preview byte count, timeout
+count, and waiver count. This unit may add CLI or Desktop decoding only when it
+is needed to prove that operator surfaces consume the shared receipt instead of
+raw logs or ad hoc status strings.
 
 ### #1510 Diagnostics Unit
 
@@ -608,8 +703,38 @@ and diagnostics units use.
 - Redaction tests for absolute paths, tokens, credentials, and unbounded log
   excerpts.
 - Unknown failure tests proving bounded excerpts are preserved.
+- Export-report attachment tests proving diagnostics receipts are linked to
+  failed smoke receipts and target rows.
 - CLI/Desktop tests proving typed remedies and redacted evidence pointers are
   shown from the shared receipt.
+
+#1510 implementation lands the worker-owned diagnostic parser, redaction
+fixtures, and receipt writer. The registered PR-scoped probe for this unit is
+`runtime-export-diagnostic-parser`, measuring parser coverage, parsed failure
+count, unknown failure count, redaction count, and diagnostic latency. This unit
+does not add new export target types or change retention cleanup semantics.
+
+### P3.2 Acceptance Closure For #1508
+
+#1508 is complete when this document is the governing contract for post-export
+smoke and diagnostics and the executable units can proceed without inventing
+target-specific smoke, waiver, diagnostic, redaction, or probe semantics during
+implementation.
+
+Acceptance mapping:
+
+| #1508 acceptance criterion | Governing section in this plan |
+|---|---|
+| The plan defines target-specific load and generation smoke policies. | `P3.2 Target Smoke Matrix`, `Smoke Receipt`, and `#1509 Smoke Unit`. |
+| The plan defines runtime log diagnostics and redaction rules. | `Diagnostics Receipt`, `Log Redaction And Evidence Bounds`, and `#1510 Diagnostics Unit`. |
+| The unit issues cover both smoke checks and diagnostic parsers. | `P3.2 Target Smoke Matrix`, `Verification Plan`, and `Delivery Order` assign smoke checks to #1509 and diagnostics to #1510. |
+| The plan records smoke-test latency and diagnostic parser coverage metrics. | `Smoke Receipt`, `Diagnostics Receipt`, and `Performance Probes And Metrics`. |
+
+This #1508 slice is documentation-only. It does not change protobuf schemas,
+fixtures, worker code, CLI commands, or Desktop surfaces. Runtime metrics for
+this slice are therefore `N/A`; the required measurement points are specified
+above and must become executable probes in #1509 and #1510 before code changes
+land.
 
 ## Delivery Order
 

--- a/docs/runbooks/runtime-export-target-manifest.md
+++ b/docs/runbooks/runtime-export-target-manifest.md
@@ -157,3 +157,49 @@ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
 
 The probe reports layout materialization latency, target count, retained bytes,
 cleanable bytes, deleted file count, and retention decision count.
+
+## Post-Export Smoke And Diagnostics
+
+The #1508 plan defines the target-local evidence contract consumed by the
+#1509 smoke runner and #1510 diagnostic parser. After #1507 materializes a
+target directory, export verification writes:
+
+- `smoke/smoke-receipt.json`: metadata, load, and generation check outcomes.
+- `smoke/generation-preview.txt`: bounded diagnostic preview for generation
+  capable targets.
+- `diagnostics/diagnostics-receipt.json`: typed runtime failure diagnoses and
+  operator remedies.
+- `diagnostics/redacted-log-excerpt.txt`: bounded, redacted excerpts for
+  matched or unknown runtime failures.
+
+Every smoke and diagnostic evidence path is relative to the target directory.
+Operator summaries may display friendly labels, but exported reports must not
+depend on absolute host paths.
+
+The first smoke policy matrix covers these targets:
+
+| Target type | Required smoke policy |
+|---|---|
+| `EXPORT_TARGET_TYPE_MELIX_MANAGED` | Manifest and digest inspection, Melix catalog/runtime load, and bounded generation when the target is generation-capable. |
+| `EXPORT_TARGET_TYPE_OLLAMA` | Generated metadata inspection, runtime binary/path preflight, local load or registration, and bounded generation. |
+| `EXPORT_TARGET_TYPE_GGUF` | GGUF header, metadata, byte-size, and digest inspection; local load and generation only when a compatible runtime is configured. |
+| `EXPORT_TARGET_TYPE_MLX_RUNTIME` | MLX config, tokenizer, weight inventory, runtime path preflight, bounded load, and bounded generation. |
+
+Waivers are allowed only for configured runtime unavailability, incompatible
+hosts, metadata-only targets, known runtime bugs, or operator manual
+verification with replacement evidence. Waivers are not allowed for unsafe
+paths, missing required files, digest mismatches, unsupported target types,
+missing source provenance, or a missing target manifest.
+
+Diagnostic receipts cover common runtime failures such as load failure,
+unsupported architecture, duplicate tensor names, missing blobs, missing
+binaries, invalid runtime paths, timeout, permission denial, insufficient
+memory, and unknown failures. CLI, Desktop, Markdown summaries, and CSV exports
+must render typed remedies from `diagnostics-receipt.json`; they must not parse
+raw runtime logs independently.
+
+Redaction follows the workspace manifest policy and the target manifest
+redaction classes. Exported summaries and operator-facing evidence must omit or
+redact credentials, bearer tokens, API keys, proxy secrets, certificates,
+absolute host paths, full prompts, full responses, dataset rows, private prompt
+templates, and unnecessary user identity strings.


### PR DESCRIPTION
## Summary
- Define the P3.2 post-export smoke and diagnostics contract for #1508.
- Add target-specific smoke policies, diagnostics/redaction bounds, waiver semantics, and follow-up probe expectations for #1509 and #1510.
- Link the M3 runtime-aware export plan from the docs active-plan index.

## Plan or Spec
- Closes #1508
- Governing plan/spec: `docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md`

## Commands Run
```text
git diff --check: passed
python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-body-issue-1508.md: passed
git commit -m "Document post-export smoke diagnostics plan": passed; pre-commit hook completed full local gate
git commit -m "Align export plan enum names": passed; pre-commit hook completed full local gate
make swift-test: passed via pre-commit; protocol 1 test passed; text worker 241 tests passed; control-plane core groups 510 tests passed; control-plane worker clients 127 tests passed; macOS menubar 831 tests passed
make py-test: passed via latest pre-commit; 4401 passed, 14 skipped, 2 warnings in 171.65s
make integration-test: passed via latest pre-commit; 123 passed, 1 skipped in 416.22s
latest pre-commit PR-scoped performance report: passed; status ok, regressions 0, verification failures 0
```

## Coverage and Metrics
- Documentation-only planning slice; no executable code changed.
- Changed-scope coverage from pre-commit selected probes: 100.0% for `runtime-export-manifest-validation` and 100.0% for `runtime-export-layout-retention` with 0 measurable changed executable lines.
- Latest performance report: `.runtime/pre-commit-performance/20260624-090101-f487cdc2/report/report.md`
- `runtime-export-manifest-validation`: elapsed_ms_mean base 1189.992 ms, head 1187.291 ms, delta -0.23%, status neutral; schema_error_count 0; manifest_byte_size unchanged; fixture_count unchanged.
- `runtime-export-layout-retention`: elapsed_ms_mean base 2600.224 ms, head 2599.136 ms, delta -0.04%, status neutral; retained_byte_size unchanged; cleanable_byte_size unchanged; retention_decision_count unchanged; deleted_file_count unchanged; target_count unchanged.
- Metrics contract added for follow-up executable units: load smoke latency, generation smoke latency, output preview byte count, timeout count, waiver count, diagnostic parser coverage, parsed failure count, unknown failure count, redaction count, and diagnostic latency.

## Known Gaps
- Follow-up #1509 must implement the smoke runner, receipts, completion gating, tests, and `runtime-export-smoke-policy` PR-scoped probe.
- Follow-up #1510 must implement the diagnostic parser, redaction fixtures, receipt writer, tests, and `runtime-export-diagnostic-parser` PR-scoped probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
