### PR TITLE
[Issue 42 U3.3.2] Preserve native quantized multimodal tensors

### DIFF
--- a/docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md
+++ b/docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md
@@ -499,6 +499,16 @@ Executable unit issues:
   fixtures cover cross-shard index and header metadata, native MTP
   sanitize-before-load, Gemma4 text-only exports, and text-backed fallback
   loads.
+- Unit 3.3.2 keeps native quantized multimodal loads conservative around
+  precision-sensitive non-language tensors. The native MTP and Gemma4 loader
+  predicates share the same preservation policy: vision towers, projectors, and
+  decode/output heads stay high precision unless the artifact explicitly marks
+  the module as quantized. Image batch-1 step decode casts prepared
+  `pixel_values` to the vision patch-embed dtype when that dtype is available,
+  avoiding accidental coupling to quantized language embedding dtype. Focused
+  fixtures pin projector/output skip behavior, explicit quantized metadata
+  override behavior, optional-head weight preservation after sanitize, and the
+  pixel dtype selection contract.
 
 ## Verification Policy
 

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -5241,6 +5241,7 @@ def _assert_image_batch1_step_pixel_values_cast_to_vision_patch_embed_dtype() ->
             )
         ),
         vision_tower=SimpleNamespace(
+            weight=SimpleNamespace(dtype="float32-root"),
             patch_embed=SimpleNamespace(weight=SimpleNamespace(dtype="float16-vision"))
         ),
     )
@@ -5268,6 +5269,26 @@ def _assert_image_batch1_step_pixel_values_cast_to_vision_patch_embed_dtype() ->
 
     failing_pixels = FailingPixels()
     assert _cast_pixel_values_to_vision_dtype(model, failing_pixels) is failing_pixels
+
+    tuple_pixel_a = FakePixels()
+    tuple_pixel_b = SimpleNamespace(dtype="float16-vision")
+    tuple_pixels = _cast_pixel_values_to_vision_dtype(model, (tuple_pixel_a, tuple_pixel_b))
+
+    assert isinstance(tuple_pixels, tuple)
+    assert tuple_pixels[0].dtype == "float16-vision"
+    assert tuple_pixels[0].source is tuple_pixel_a
+    assert tuple_pixel_a.cast_to == ["float16-vision"]
+    assert tuple_pixels[1] is tuple_pixel_b
+
+    list_pixel_a = FakePixels()
+    list_pixel_b = SimpleNamespace(dtype="float16-vision")
+    list_pixels = _cast_pixel_values_to_vision_dtype(model, [list_pixel_a, list_pixel_b])
+
+    assert isinstance(list_pixels, list)
+    assert list_pixels[0].dtype == "float16-vision"
+    assert list_pixels[0].source is list_pixel_a
+    assert list_pixel_a.cast_to == ["float16-vision"]
+    assert list_pixels[1] is list_pixel_b
 
 
 def test_image_batch1_step_pixel_values_cast_to_vision_patch_embed_dtype() -> None:

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -47,10 +47,12 @@ from worker.runtime.mlx_vlm_runtime import (
     _gemma4_loaded_execution_mode,
     _gemma4_multimodal_weight_presence,
     _combine_image_feature_payloads,
+    _cast_pixel_values_to_vision_dtype,
     _image_argument_paths,
     _isolated_streaming_detokenizer,
     _mlx_peak_memory_gb,
     _patch_gemma4_scaled_linear_quantization,
+    _vision_patch_embed_dtype,
     _select_image_feature_rows,
     _split_image_feature_payloads,
 )
@@ -67,6 +69,7 @@ from worker.runtime.native_mtp import mlx_lm_loader as native_mtp_loader_module
 from worker.runtime.quantized_tensor_metadata import (
     EMPTY_QUANTIZED_TENSOR_METADATA,
     QuantizedTensorMetadata,
+    native_multimodal_quantization_preserves_precision,
     quantized_tensor_metadata_from_model_dir,
     quantized_tensor_metadata_from_index_payload,
     quantized_tensor_metadata_from_safetensor_headers,
@@ -1457,6 +1460,17 @@ def test_mlx_vlm_runtime_image_batch1_step_uses_executor_stream_and_token_counte
     stream_generate_calls = 0
     release_seen = Event()
 
+    class FakePixelValues:
+        shape = (1, 1, 1)
+        dtype = "int4-language"
+
+        def __init__(self) -> None:
+            self.cast_to: list[object] = []
+
+        def astype(self, dtype):
+            self.cast_to.append(dtype)
+            return SimpleNamespace(shape=self.shape, dtype=dtype, source=self)
+
     class FakeDetokenizer:
         def __init__(self) -> None:
             self.text = ""
@@ -1498,7 +1512,7 @@ def test_mlx_vlm_runtime_image_batch1_step_uses_executor_stream_and_token_counte
             return SimpleNamespace(
                 input_ids=mx.array([[1, 2, 3, 4, 5, 6]]),
                 attention_mask=mx.array([[1, 1, 1, 1, 1, 1]]),
-                pixel_values=mx.array([[[9]]]),
+                pixel_values=FakePixelValues(),
                 position_ids=mx.array([[0, 1, 2, 3, 4, 5]]),
                 rope_deltas=mx.array([[0]]),
             )
@@ -1510,7 +1524,12 @@ def test_mlx_vlm_runtime_image_batch1_step_uses_executor_stream_and_token_counte
         _ = model_path
         _ = revision
         return (
-            SimpleNamespace(config=SimpleNamespace(model_type="gemma4", image_token_index=256)),
+            SimpleNamespace(
+                config=SimpleNamespace(model_type="gemma4", image_token_index=256),
+                vision_tower=SimpleNamespace(
+                    patch_embed=SimpleNamespace(weight=SimpleNamespace(dtype="float16-vision"))
+                ),
+            ),
             FakeProcessor(),
         )
 
@@ -1532,6 +1551,9 @@ def test_mlx_vlm_runtime_image_batch1_step_uses_executor_stream_and_token_counte
                 "input_ids_shape": tuple(input_ids.shape),
                 "model": model,
                 "pixel_values_shape": tuple(pixel_values.shape),
+                "pixel_values_dtype": pixel_values.dtype,
+                "pixel_values_source_dtype": pixel_values.source.dtype,
+                "pixel_values_cast_to": tuple(pixel_values.source.cast_to),
                 "mask_shape": tuple(mask.shape),
                 "position_ids_shape": tuple(kwargs["position_ids"].shape),
                 "rope_deltas_shape": tuple(kwargs["rope_deltas"].shape),
@@ -1611,6 +1633,9 @@ def test_mlx_vlm_runtime_image_batch1_step_uses_executor_stream_and_token_counte
             "input_ids_shape": (1, 6),
             "model": loaded_model["model"],
             "pixel_values_shape": (1, 1, 1),
+            "pixel_values_dtype": "float16-vision",
+            "pixel_values_source_dtype": "int4-language",
+            "pixel_values_cast_to": ("float16-vision",),
             "mask_shape": (1, 6),
             "position_ids_shape": (1, 6),
             "rope_deltas_shape": (1, 1),
@@ -2504,6 +2529,65 @@ def test_quantized_tensor_metadata_model_dir_scans_top_level_headers_and_bad_ent
     assert not metadata.tensor_names
 
 
+def _assert_native_multimodal_quantization_preserves_precision_without_explicit_scales() -> None:
+    empty_metadata = QuantizedTensorMetadata({})
+    indexed_metadata = quantized_tensor_metadata_from_index_payload(
+        {
+            "weight_map": {
+                "vision_tower.patch_embed.weight": "model.safetensors",
+                "vision_tower.patch_embed.scales": "model.safetensors",
+                "language_model.lm_head.weight": "model.safetensors",
+                "language_model.lm_head.scales": "model.safetensors",
+            }
+        }
+    )
+
+    assert native_multimodal_quantization_preserves_precision(
+        "vision_tower.patch_embed",
+        metadata=empty_metadata,
+        weights={"vision_tower.patch_embed.weight": object()},
+    ) is True
+    assert native_multimodal_quantization_preserves_precision(
+        "projector",
+        metadata=empty_metadata,
+        weights={"projector.weight": object()},
+    ) is True
+    assert native_multimodal_quantization_preserves_precision(
+        "language_model.lm_head",
+        metadata=empty_metadata,
+        weights={"language_model.lm_head.weight": object()},
+    ) is True
+    assert native_multimodal_quantization_preserves_precision(
+        "model.visual.patch_embed",
+        metadata=empty_metadata,
+        weights={"model.visual.patch_embed.weight": object()},
+    ) is True
+    assert native_multimodal_quantization_preserves_precision(
+        "vision_tower.patch_embed",
+        metadata=indexed_metadata,
+        weights={},
+    ) is False
+    assert native_multimodal_quantization_preserves_precision(
+        "language_model.lm_head",
+        metadata=indexed_metadata,
+        weights={},
+    ) is False
+    assert native_multimodal_quantization_preserves_precision(
+        "language_model.layers.0.q_proj",
+        metadata=empty_metadata,
+        weights={},
+    ) is False
+    assert native_multimodal_quantization_preserves_precision(
+        "",
+        metadata=empty_metadata,
+        weights={},
+    ) is False
+
+
+def test_native_multimodal_quantization_preserves_precision_without_explicit_scales() -> None:
+    _assert_native_multimodal_quantization_preserves_precision_without_explicit_scales()
+
+
 def test_native_mtp_weight_key_detection_preserves_string_and_custom_keys() -> None:
     class CustomKey:
         def __str__(self) -> str:
@@ -2691,6 +2775,8 @@ def test_native_mtp_patched_loader_uses_scandir_model_weight_listing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    _assert_native_multimodal_quantization_preserves_precision_without_explicit_scales()
+
     import worker.runtime.native_mtp.mlx_lm_loader as loader_module
 
     model_dir = tmp_path / "patched-model"
@@ -2704,6 +2790,8 @@ def test_native_mtp_patched_loader_uses_scandir_model_weight_listing(
                     "language_model.layers.0.q_proj.weight": "model.safetensors",
                     "language_model.layers.0.q_proj.scales": "mtp.safetensors",
                     "language_model.mtp.fc.weight": "mtp.safetensors",
+                    "projector.weight": "model.safetensors",
+                    "language_model.lm_head.weight": "model.safetensors",
                 }
             }
         ),
@@ -2723,6 +2811,14 @@ def test_native_mtp_patched_loader_uses_scandir_model_weight_listing(
             self.args = args
             self.loaded_weights: list[tuple[str, object]] = []
             self.q_proj = SimpleNamespace(
+                to_quantized=lambda: None,
+                weight=SimpleNamespace(size=64),
+            )
+            self.projector = SimpleNamespace(
+                to_quantized=lambda: None,
+                weight=SimpleNamespace(size=64),
+            )
+            self.lm_head = SimpleNamespace(
                 to_quantized=lambda: None,
                 weight=SimpleNamespace(size=64),
             )
@@ -2756,11 +2852,15 @@ def test_native_mtp_patched_loader_uses_scandir_model_weight_listing(
     fake_nn = SimpleNamespace(
         Module=SimpleNamespace(is_module=lambda value: False),
         QuantizedLinear=type("QuantizedLinear", (), {}),
-        quantize=lambda model, *, group_size, bits, mode, class_predicate: quantized_paths.append(
-            "language_model.layers.0.q_proj"
-        )
-        if class_predicate("language_model.layers.0.q_proj", model.q_proj)
-        else None,
+        quantize=lambda model, *, group_size, bits, mode, class_predicate: quantized_paths.extend(
+            path
+            for path, module in (
+                ("language_model.layers.0.q_proj", model.q_proj),
+                ("projector", model.projector),
+                ("language_model.lm_head", model.lm_head),
+            )
+            if class_predicate(path, module)
+        ),
     )
     fake_utils = SimpleNamespace(
         load_model=lambda *args, **kwargs: ("original", {}),
@@ -5122,6 +5222,58 @@ def test_gemma4_scaled_linear_patch_accepts_newer_language_api(monkeypatch: pyte
     assert hasattr(FakeScaledLinear, "to_quantized")
 
 
+def _assert_image_batch1_step_pixel_values_cast_to_vision_patch_embed_dtype() -> None:
+    class FakePixels:
+        dtype = "int4-language"
+
+        def __init__(self) -> None:
+            self.cast_to: list[object] = []
+
+        def astype(self, dtype):
+            self.cast_to.append(dtype)
+            return SimpleNamespace(dtype=dtype, source=self)
+
+    pixels = FakePixels()
+    model = SimpleNamespace(
+        language_model=SimpleNamespace(
+            model=SimpleNamespace(
+                embed_tokens=SimpleNamespace(weight=SimpleNamespace(dtype="int4-language"))
+            )
+        ),
+        vision_tower=SimpleNamespace(
+            patch_embed=SimpleNamespace(weight=SimpleNamespace(dtype="float16-vision"))
+        ),
+    )
+
+    assert _vision_patch_embed_dtype(model) == "float16-vision"
+    cast_pixels = _cast_pixel_values_to_vision_dtype(model, pixels)
+
+    assert cast_pixels.dtype == "float16-vision"
+    assert cast_pixels.source is pixels
+    assert pixels.cast_to == ["float16-vision"]
+    assert _vision_patch_embed_dtype(SimpleNamespace()) is None
+    assert _cast_pixel_values_to_vision_dtype(model, None) is None
+
+    same_dtype_pixels = SimpleNamespace(dtype="float16-vision")
+    assert _cast_pixel_values_to_vision_dtype(model, same_dtype_pixels) is same_dtype_pixels
+
+    no_astype_pixels = SimpleNamespace(dtype="float32-language")
+    assert _cast_pixel_values_to_vision_dtype(model, no_astype_pixels) is no_astype_pixels
+
+    class FailingPixels:
+        dtype = "float32-language"
+
+        def astype(self, _dtype):
+            raise TypeError("unsupported dtype")
+
+    failing_pixels = FailingPixels()
+    assert _cast_pixel_values_to_vision_dtype(model, failing_pixels) is failing_pixels
+
+
+def test_image_batch1_step_pixel_values_cast_to_vision_patch_embed_dtype() -> None:
+    _assert_image_batch1_step_pixel_values_cast_to_vision_patch_embed_dtype()
+
+
 def _assert_gemma4_shared_kv_patch_removes_unused_kv_modules_from_shared_layers() -> None:
     layers = []
     for _index in range(5):
@@ -5391,6 +5543,14 @@ def _assert_gemma4_text_backed_loader_patches_shared_kv_layers(
                     to_quantized=lambda: None,
                     weight=SimpleNamespace(size=64),
                 )
+                self.projector = SimpleNamespace(
+                    to_quantized=lambda: None,
+                    weight=SimpleNamespace(size=64),
+                )
+                self.lm_head = SimpleNamespace(
+                    to_quantized=lambda: None,
+                    weight=SimpleNamespace(size=64),
+                )
 
             def load_weights(self, weights):
                 calls["load_weights"] = list(weights)
@@ -5421,6 +5581,8 @@ def _assert_gemma4_text_backed_loader_patches_shared_kv_layers(
         def fake_quantize(model, *, group_size, bits, mode, class_predicate):
             calls["quantize"] = (group_size, bits, mode)
             assert class_predicate("language_model.model.layers.0.q_proj", model.q_proj) is True
+            assert class_predicate("projector", model.projector) is False
+            assert class_predicate("language_model.lm_head", model.lm_head) is False
 
         patch_context.setattr(nn, "quantize", fake_quantize)
         patch_context.setattr(
@@ -5767,6 +5929,10 @@ def test_gemma4_text_only_language_model_quantizes_from_presanitize_metadata(
             "language_model.layers.0.q_proj",
             SimpleNamespace(to_quantized=lambda: None, weight=SimpleNamespace(size=64)),
         ) is True
+        assert class_predicate(
+            "language_model.lm_head",
+            SimpleNamespace(to_quantized=lambda: None, weight=SimpleNamespace(size=64)),
+        ) is False
 
     metadata = quantized_tensor_metadata_from_index_payload(
         {
@@ -6674,6 +6840,10 @@ def test_mlx_vlm_runtime_uses_generate_step_for_mtp_when_available(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    _assert_image_batch1_step_pixel_values_cast_to_vision_patch_embed_dtype()
+    with monkeypatch.context() as patch_context:
+        test_mlx_vlm_runtime_image_batch1_step_uses_executor_stream_and_token_counter(patch_context)
+
     current_signature_path = tmp_path / "current-signature"
     legacy_signature_path = tmp_path / "legacy-signature"
     current_signature_path.mkdir()

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -59,6 +59,7 @@ from worker.runtime.runtime_utils import (
 from worker.runtime.quantized_tensor_metadata import (
     EMPTY_QUANTIZED_TENSOR_METADATA,
     QuantizedTensorMetadata,
+    native_multimodal_quantization_preserves_precision,
     quantized_scales_present,
     quantized_tensor_metadata_from_model_dir,
 )
@@ -1337,6 +1338,55 @@ def _gemma4_multimodal_weight_presence(weight_names: Iterable[str]) -> tuple[boo
     return _GEMMA4_PRESENCE_NONE
 
 
+def _vision_patch_embed_dtype(model: Any) -> Any | None:
+    for candidate in _vision_patch_embed_candidates(model):
+        dtype = _module_weight_dtype(candidate)
+        if dtype is not None:
+            return dtype
+    return None
+
+
+def _vision_patch_embed_candidates(model: Any) -> tuple[Any, ...]:
+    vision_roots = (
+        getattr(model, "vision_tower", None),
+        getattr(model, "vision_model", None),
+        getattr(model, "visual", None),
+    )
+    candidates: list[Any] = []
+    for root in vision_roots:
+        if root is None:
+            continue
+        candidates.append(root)
+        for attr in ("patch_embed", "patch_embedding", "embeddings", "conv1", "proj"):
+            candidate = getattr(root, attr, None)
+            if candidate is not None:
+                candidates.append(candidate)
+    return tuple(candidates)
+
+
+def _module_weight_dtype(module: Any) -> Any | None:
+    weight = getattr(module, "weight", None)
+    dtype = getattr(weight, "dtype", None)
+    if dtype is not None:
+        return dtype
+    return getattr(module, "dtype", None)
+
+
+def _cast_pixel_values_to_vision_dtype(model: Any, pixel_values: Any) -> Any:
+    if pixel_values is None:
+        return pixel_values
+    dtype = _vision_patch_embed_dtype(model)
+    if dtype is None or getattr(pixel_values, "dtype", None) == dtype:
+        return pixel_values
+    astype = getattr(pixel_values, "astype", None)
+    if not callable(astype):
+        return pixel_values
+    try:
+        return astype(dtype)
+    except (TypeError, ValueError, RuntimeError):
+        return pixel_values
+
+
 def _mlx_peak_memory_gb(mx_module: Any) -> float:
     get_peak_memory = getattr(mx_module, "get_peak_memory", None)
     if callable(get_peak_memory):
@@ -1959,6 +2009,12 @@ class AutoMLXVLMBackend:
                     return quantization[path]
                 if not hasattr(module, "to_quantized"):
                     return False
+                if native_multimodal_quantization_preserves_precision(
+                    path,
+                    metadata=quantized_metadata,
+                    weights=weights,
+                ):
+                    return False
                 if hasattr(module, "weight") and module.weight.size % 64 != 0:
                     return False
                 return quantized_scales_present(
@@ -2011,6 +2067,12 @@ class AutoMLXVLMBackend:
                 if path in quantization:
                     return quantization[path]
                 if not hasattr(module, "to_quantized"):
+                    return False
+                if native_multimodal_quantization_preserves_precision(
+                    path,
+                    metadata=quantized_metadata,
+                    weights=weights,
+                ):
                     return False
                 if hasattr(module, "weight") and module.weight.size % 64 != 0:
                     return False
@@ -3151,6 +3213,12 @@ class MLXVLMRuntime:
             return prepare_inputs(loaded_model["processor"], **input_kwargs)
 
         inputs = self._run_on_executor(prepare_on_executor)
+        if "pixel_values" in inputs:
+            inputs = dict(inputs)
+            inputs["pixel_values"] = _cast_pixel_values_to_vision_dtype(
+                loaded_model["model"],
+                inputs.get("pixel_values"),
+            )
         prompt_tokens = int(getattr(inputs["input_ids"], "shape", [0, prompt_tokens])[-1] or prompt_tokens)
         position_receipt = self._position_metadata_receipt(
             loaded_model=loaded_model,

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -1356,11 +1356,11 @@ def _vision_patch_embed_candidates(model: Any) -> tuple[Any, ...]:
     for root in vision_roots:
         if root is None:
             continue
-        candidates.append(root)
         for attr in ("patch_embed", "patch_embedding", "embeddings", "conv1", "proj"):
             candidate = getattr(root, attr, None)
             if candidate is not None:
                 candidates.append(candidate)
+        candidates.append(root)
     return tuple(candidates)
 
 
@@ -1376,15 +1376,25 @@ def _cast_pixel_values_to_vision_dtype(model: Any, pixel_values: Any) -> Any:
     if pixel_values is None:
         return pixel_values
     dtype = _vision_patch_embed_dtype(model)
-    if dtype is None or getattr(pixel_values, "dtype", None) == dtype:
+    if dtype is None:
         return pixel_values
-    astype = getattr(pixel_values, "astype", None)
-    if not callable(astype):
-        return pixel_values
-    try:
-        return astype(dtype)
-    except (TypeError, ValueError, RuntimeError):
-        return pixel_values
+
+    def cast_array(array: Any) -> Any:
+        if getattr(array, "dtype", None) == dtype:
+            return array
+        astype = getattr(array, "astype", None)
+        if not callable(astype):
+            return array
+        try:
+            return astype(dtype)
+        except (TypeError, ValueError, RuntimeError):
+            return array
+
+    if isinstance(pixel_values, list):
+        return [cast_array(array) for array in pixel_values]
+    if isinstance(pixel_values, tuple):
+        return tuple(cast_array(array) for array in pixel_values)
+    return cast_array(pixel_values)
 
 
 def _mlx_peak_memory_gb(mx_module: Any) -> float:

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Callable, Type
 
 from worker.runtime.quantized_tensor_metadata import (
+    native_multimodal_quantization_preserves_precision,
     quantized_scales_present,
     quantized_tensor_metadata_from_model_dir,
 )
@@ -191,6 +192,12 @@ def apply() -> bool:
                 if p in config["quantization"]:
                     return config["quantization"][p]
                 if not hasattr(m, "to_quantized"):
+                    return False
+                if native_multimodal_quantization_preserves_precision(
+                    p,
+                    metadata=quantized_metadata,
+                    weights=weights,
+                ):
                     return False
                 return quantized_scales_present(
                     p,

--- a/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
+++ b/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
@@ -51,6 +51,24 @@ class QuantizedTensorMetadata:
 
 EMPTY_QUANTIZED_TENSOR_METADATA = QuantizedTensorMetadata({})
 MAX_SAFETENSORS_HEADER_BYTES = 100 * 1024 * 1024
+_NATIVE_MULTIMODAL_HIGH_PRECISION_PREFIXES = (
+    "audio_tower",
+    "embed_audio",
+    "embed_vision",
+    "multi_modal_projector",
+    "multimodal_projector",
+    "projector",
+    "vision_model",
+    "vision_projector",
+    "vision_tower",
+    "visual",
+)
+_NATIVE_MULTIMODAL_HIGH_PRECISION_SUFFIXES = (
+    ".lm_head",
+    ".output",
+    ".output_layer",
+    ".score",
+)
 
 
 def _load_json_payload(path: Path) -> dict[str, Any]:
@@ -127,6 +145,47 @@ def quantized_scales_present(
 ) -> bool:
     scales_key = f"{prefix}.scales"
     return metadata.has_tensor(scales_key) or scales_key in weights
+
+
+def native_multimodal_quantization_preserves_precision(
+    prefix: str,
+    *,
+    metadata: QuantizedTensorMetadata,
+    weights: Mapping[str, object],
+) -> bool:
+    """Return whether native multimodal quantization should keep a module high precision.
+
+    Vision towers, multimodal projectors, and output heads often need the dtype
+    they were exported with. They are only safe to quantize when the artifact
+    explicitly includes quantized scale metadata for that module.
+    """
+
+    normalized = str(prefix or "").strip()
+    if not normalized:
+        return False
+    if not _native_multimodal_high_precision_module(normalized):
+        return False
+    return not quantized_scales_present(
+        normalized,
+        metadata=metadata,
+        weights=weights,
+    )
+
+
+def _native_multimodal_high_precision_module(prefix: str) -> bool:
+    segments = tuple(segment for segment in prefix.split(".") if segment)
+    for index, segment in enumerate(segments):
+        if segment in _NATIVE_MULTIMODAL_HIGH_PRECISION_PREFIXES:
+            return True
+        if (
+            segment in {"model", "language_model"}
+            and index + 1 < len(segments)
+            and segments[index + 1] in _NATIVE_MULTIMODAL_HIGH_PRECISION_PREFIXES
+        ):
+            return True
+        if segment in {"lm_head", "output", "output_layer", "score"}:
+            return True
+    return prefix.endswith(_NATIVE_MULTIMODAL_HIGH_PRECISION_SUFFIXES)
 
 
 def _safetensors_header_tensor_names(path: Path) -> tuple[str, ...]:

--- a/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
+++ b/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
@@ -185,7 +185,7 @@ def _native_multimodal_high_precision_module(prefix: str) -> bool:
             return True
         if segment in {"lm_head", "output", "output_layer", "score"}:
             return True
-    return prefix.endswith(_NATIVE_MULTIMODAL_HIGH_PRECISION_SUFFIXES)
+    return False
 
 
 def _safetensors_header_tensor_names(path: Path) -> tuple[str, ...]:


### PR DESCRIPTION
## Summary
- Preserve high-precision native multimodal modules during quantized MLX loads: vision/projector/audio/output-head modules now skip auto-quantization unless explicit scale tensors are present.
- Apply the shared preservation policy in both native MTP and Gemma4 VLM/text-backed loader paths, while keeping explicit quantization config overrides authoritative.
- Cast image batch-1 `pixel_values` to the vision patch-embed weight dtype before generate-step execution, so vision inputs do not inherit quantized language embedding dtype.
- Update the Issue 42 U3.3.2 plan notes and add fixtures for native MTP, Gemma4, and image batch-1 dtype behavior.

Closes #1463

## Plan or Spec
- `docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md`

## Commands Run
```text
make proto
# pass

make swift-test
# pass before commit

make py-test
# pass: 4384 passed, 14 skipped, 2 warnings

make integration-test
# pass: 123 passed, 1 skipped

git diff --check
# pass

git diff --cached --check
# pass before commit

make git-hooks-install
git config --get core.hooksPath
# pass: .githooks

git commit -m "Preserve native quantized multimodal tensors"
# first formal hook attempt: make swift-test, make py-test, and make integration-test passed;
# blocked by a noisy Native MTP loader scoped performance regression.

UV_CACHE_DIR="$PWD/.uv-cache" UV_PYTHON=3.12 uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts.pre_commit_gate import run_performance_report, staged_changed_files
root = Path.cwd()
outcome = run_performance_report(root, staged_changed_files(root, base_ref='HEAD'), base_ref='HEAD')
print(f'PERF_STATUS={outcome.status}')
print(f'PERF_REPORT_DIR={outcome.report_dir}')
print(f'PERF_SELECTED_PROBES={outcome.selected_probe_count}')
if outcome.status != 'ok':
    raise SystemExit(1)
PY
# pass: PERF_STATUS=ok, PERF_SELECTED_PROBES=5

MELIX_PRE_COMMIT_ALLOW_PERF_REGRESSION=1 MELIX_PRE_COMMIT_PERF_REGRESSION_REASON="Native MTP loader scoped probe reported noisy model-listing delta variance on an unrelated helper path; repeated scoped reports show unchanged counts, stable memory, neutral key and weight-load metrics, and the PR code only adds quantization predicate checks outside safetensor listing/load loops." git commit -m "Preserve native quantized multimodal tensors"
# pass: make swift-test, make py-test, and make integration-test passed; hook recorded the analyzed Native MTP loader probe noise and created commit 01685f12.

git merge --no-edit origin/main
# pass: merged current origin/main without conflicts.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_CACHE_DIR="$PWD/.uv-cache" uv run --project services/mlx-worker-python --extra mlx pytest -q \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_multimodal_quantization_preserves_precision_without_explicit_scales \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_image_batch1_step_pixel_values_cast_to_vision_patch_embed_dtype \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_image_batch1_step_uses_executor_stream_and_token_counter \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_uses_generate_step_for_mtp_when_available \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_text_only_language_model_quantizes_from_presanitize_metadata \
  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_text_backed_loader_uses_tokenizer_for_text_only_exports
# pass: 7 passed, 2 warnings

UV_CACHE_DIR="$PWD/.uv-cache" UV_PYTHON=3.12 uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts.pre_commit_gate import run_performance_report
import subprocess
root = Path.cwd()
changed = [line.strip() for line in subprocess.check_output(['git', 'diff', '--name-only', 'origin/main...HEAD'], cwd=root, text=True).splitlines() if line.strip()]
outcome = run_performance_report(root, changed, base_ref='origin/main')
print(f'PERF_STATUS={outcome.status}')
print(f'PERF_REPORT_DIR={outcome.report_dir}')
print(f'PERF_SELECTED_PROBES={outcome.selected_probe_count}')
if outcome.status != 'ok':
    raise SystemExit(1)
PY
# pass: PERF_STATUS=ok, PERF_SELECTED_PROBES=5

git fetch origin main
git status --short --branch
# pass: origin/main current; branch ahead 2.
```

## Coverage and Metrics
- Changed-line coverage after merge: `98%` (`126` measurable changed lines, `124` covered, `2` missed) from `.runtime/pre-commit-performance/20260624-084112-54de03a5/report/report.md`.
- Merge-after-origin-main scoped performance report: `.runtime/pre-commit-performance/20260624-084112-54de03a5/report/report.md`, status `ok`, 5 selected probes, 0 regressions.
- Pre-commit full gate report: `.runtime/pre-commit-performance/20260624-083843-e8d8f8bf/report/report.md`; full tests passed, and the hook allowed a noisy Native MTP loader synthetic probe regression after analysis. The allowed probe path measures safetensor listing/load helper loops; this PR changes quantization predicates outside those listing/load loops, and the merge-after-origin-main report is `ok`.
- Observability mode: `off` for production runtime observability; no new runtime metrics or debug artifacts. Existing PR-scoped performance probes were reused for evidence, with no new probe overhead added by this change.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
