### PR TITLE
Add runtime export smoke policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ Step-by-step operating procedures for specific workflows. Use these when you nee
 | [Packaging Targets](runbooks/platform-packaging-targets.md) | Launch agent, Homebrew, Nix, and preview app-bundle delivery options |
 | [Release Gates](runbooks/phase-8-release-gates.md) | Automated release gate workflow and verification criteria |
 | [Product Acceptance](runbooks/phase-8-product-acceptance.md) | Acceptance evidence and product-level smoke procedures |
+| [Runtime Export Smoke Policy](runbooks/runtime-export-smoke-policy.md) | Bounded post-export load, generation, waiver, and receipt checks for runtime export targets |
 | [Structured Streaming](runbooks/structured-streaming-reasoning-continuity.md) | Streaming and reasoning continuity behavior |
 | [Serving Diagnostics Evidence](runbooks/serving-diagnostics-evidence.md) | Serving diagnostics bundles and baseline-vs-accelerated evidence artifacts |
 | [All Runbooks →](runbooks/README.md) | Full runbook index |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -27,6 +27,7 @@ Current runbooks:
 - `model-family-support-matrix.md`
 - `persistent-sessions.md`
 - `rich-output-sanitization.md`
+- `runtime-export-smoke-policy.md`
 - `runtime-export-target-manifest.md`
 - `service-first-reuse.md`
 - `serving-diagnostics-evidence.md`

--- a/docs/runbooks/runtime-export-smoke-policy.md
+++ b/docs/runbooks/runtime-export-smoke-policy.md
@@ -1,0 +1,45 @@
+# Runtime Export Smoke Policy
+
+This runbook covers the bounded post-export smoke policy for materialized
+runtime export targets. Use it after a target directory contains
+`export-target-manifest.json` and generated target artifacts.
+
+## Smoke Evidence
+
+The smoke runner verifies required artifact metadata and target-local digest
+rows before runtime checks. When a target requires runtime loading, it also
+checks the runtime binary policy and generated file paths. Generation-capable
+targets write a bounded synthetic preview.
+
+The target directory receives:
+
+- `smoke/smoke-receipt.json`: metadata, load, generation, timeout, waiver, and
+  policy outcomes.
+- `smoke/generation-preview.txt`: bounded diagnostic preview text for targets
+  that require generation smoke.
+
+`export-report.json` is updated with the smoke receipt path, terminal
+verification state, blocker code, waiver id, and report-level `ok` status.
+
+## Probe Command
+
+Run the smoke policy probe over the checked-in fixtures:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
+  uv run --project services/mlx-worker-python \
+  python3 scripts/runtime_export_smoke_policy_probe.py
+```
+
+The probe reports metadata check latency, load smoke latency, generation smoke
+latency, output preview byte count, timeout count, waiver count, target count,
+and peak bytes.
+
+## Waiver Policy
+
+Runtime-unavailable load checks may be waived only when the export target
+allows waivers and the waiver reason is
+`EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED`. Waived smoke receipts preserve
+the waiver id and skip generation checks. Missing files, digest mismatches,
+unsafe paths, unsupported target types, missing source provenance, and missing
+target manifests block verification instead of waiving.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -6265,5 +6265,75 @@
         "direction": "informational"
       }
     ]
+  },
+  {
+    "id": "runtime-export-smoke-policy",
+    "name": "Runtime export smoke policy",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/export_target_smoke.py",
+      "services/mlx-worker-python/tests/test_export_target_smoke_policy.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "services/mlx-worker-python/fixtures/runtime-export/target-manifests.dev.v1/**",
+      "scripts/runtime_export_smoke_policy_probe.py",
+      "infra/perf/pr_scoped_probes.json",
+      "docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md",
+      "docs/runbooks/runtime-export-smoke-policy.md"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_smoke_policy_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/runtime_export_smoke_policy_probe.py\"; for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "metadata_check_latency_ms",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "load_smoke_latency_ms",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "generation_smoke_latency_ms",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "output_preview_byte_count",
+        "unit": "bytes",
+        "direction": "informational"
+      },
+      {
+        "key": "timeout_count",
+        "unit": "count",
+        "direction": "lower_is_better",
+        "warn_abs": 0.0
+      },
+      {
+        "key": "waiver_count",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
+        "key": "target_count",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
   }
 ]

--- a/scripts/runtime_export_smoke_policy_probe.py
+++ b/scripts/runtime_export_smoke_policy_probe.py
@@ -50,23 +50,25 @@ def main() -> int:
 
     for _sample in range(samples):
         tracemalloc.start()
-        started = time.perf_counter()
-        for _index in range(iterations):
-            with tempfile.TemporaryDirectory(prefix="melix-export-smoke-probe-") as directory:
-                report = build_smoke_metrics_report(manifests, Path(directory))
-            if report.get("ok") is not True:
-                raise SystemExit("export smoke policy probe failed")
-            target_count = float(report["target_count"])
-            metadata_latency_ms = float(report["metadata_check_latency_ms"])
-            load_latency_ms = float(report["load_smoke_latency_ms"])
-            generation_latency_ms = float(report["generation_smoke_latency_ms"])
-            preview_bytes = float(report["output_preview_byte_count"])
-            timeout_count = float(report["timeout_count"])
-            waiver_count = float(report["waiver_count"])
-        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
-        _, peak_bytes = tracemalloc.get_traced_memory()
-        tracemalloc.stop()
-        peak_samples.append(float(peak_bytes))
+        try:
+            started = time.perf_counter()
+            for _index in range(iterations):
+                with tempfile.TemporaryDirectory(prefix="melix-export-smoke-probe-") as directory:
+                    report = build_smoke_metrics_report(manifests, Path(directory))
+                if report.get("ok") is not True:
+                    raise SystemExit("export smoke policy probe failed")
+                target_count = float(report["target_count"])
+                metadata_latency_ms = float(report["metadata_check_latency_ms"])
+                load_latency_ms = float(report["load_smoke_latency_ms"])
+                generation_latency_ms = float(report["generation_smoke_latency_ms"])
+                preview_bytes = float(report["output_preview_byte_count"])
+                timeout_count = float(report["timeout_count"])
+                waiver_count = float(report["waiver_count"])
+            elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+            _, peak_bytes = tracemalloc.get_traced_memory()
+            peak_samples.append(float(peak_bytes))
+        finally:
+            tracemalloc.stop()
 
     print(
         json.dumps(

--- a/scripts/runtime_export_smoke_policy_probe.py
+++ b/scripts/runtime_export_smoke_policy_probe.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKER_ROOT = ROOT / "services/mlx-worker-python"
+for candidate in (ROOT, WORKER_ROOT):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))  # pragma: no cover - script bootstrap
+
+from worker.productization.export_target_smoke import build_smoke_metrics_report
+
+
+FIXTURE_ROOT = (
+    ROOT
+    / "services/mlx-worker-python/fixtures/runtime-export/target-manifests.dev.v1"
+)
+
+
+def _env_int(name: str, default: int, minimum: int) -> int:
+    try:
+        value = int(os.environ.get(name, str(default)))
+    except ValueError:
+        value = default
+    return max(minimum, value)
+
+
+def main() -> int:
+    manifests = sorted(FIXTURE_ROOT.glob("*/export-target-manifest.json"))
+    iterations = _env_int("MELIX_RUNTIME_EXPORT_SMOKE_PROBE_ITERATIONS", 30, 1)
+    samples = _env_int("MELIX_RUNTIME_EXPORT_SMOKE_PROBE_SAMPLES", 5, 1)
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    target_count = 0.0
+    metadata_latency_ms = 0.0
+    load_latency_ms = 0.0
+    generation_latency_ms = 0.0
+    preview_bytes = 0.0
+    timeout_count = 0.0
+    waiver_count = 0.0
+
+    for _sample in range(samples):
+        tracemalloc.start()
+        started = time.perf_counter()
+        for _index in range(iterations):
+            with tempfile.TemporaryDirectory(prefix="melix-export-smoke-probe-") as directory:
+                report = build_smoke_metrics_report(manifests, Path(directory))
+            if report.get("ok") is not True:
+                raise SystemExit("export smoke policy probe failed")
+            target_count = float(report["target_count"])
+            metadata_latency_ms = float(report["metadata_check_latency_ms"])
+            load_latency_ms = float(report["load_smoke_latency_ms"])
+            generation_latency_ms = float(report["generation_smoke_latency_ms"])
+            preview_bytes = float(report["output_preview_byte_count"])
+            timeout_count = float(report["timeout_count"])
+            waiver_count = float(report["waiver_count"])
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+        _, peak_bytes = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_samples.append(float(peak_bytes))
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+                "peak_bytes_mean": statistics.fmean(peak_samples),
+                "target_count": target_count,
+                "metadata_check_latency_ms": metadata_latency_ms,
+                "load_smoke_latency_ms": load_latency_ms,
+                "generation_smoke_latency_ms": generation_latency_ms,
+                "output_preview_byte_count": preview_bytes,
+                "timeout_count": timeout_count,
+                "waiver_count": waiver_count,
+                "iteration_count": float(iterations),
+                "sample_count": float(samples),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
+++ b/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
@@ -269,10 +269,6 @@ def test_export_target_smoke_failure_boundaries(
 
     with pytest.raises(RuntimeError, match="runtime requirement is missing runtime_name"):
         export_target_smoke._check_runtime_preflight(
-            export_target_smoke.build_export_target_layout(
-                tmp_path,
-                missing_runtime_name_manifest,
-            ),
             missing_runtime_name_manifest,
             available_runtime_binaries={"mlx_lm.generate"},
         )
@@ -288,10 +284,6 @@ def test_export_target_smoke_failure_boundaries(
         match="runtime binary is required but runtime_binary_name is empty",
     ):
         export_target_smoke._check_runtime_preflight(
-            export_target_smoke.build_export_target_layout(
-                tmp_path,
-                missing_binary_manifest,
-            ),
             missing_binary_manifest,
             available_runtime_binaries=set(),
         )

--- a/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
+++ b/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import runpy
+import sys
+
+from google.protobuf import json_format
+import pytest
+from packages.protocol.python.workspace.v1 import export_target_manifest_pb2
+import worker.productization.export_target_smoke as export_target_smoke
+from worker.productization.export_target_layout import materialize_export_target_layout
+from worker.productization.export_target_manifest import validate_export_target_manifest_file
+from worker.productization.export_target_smoke import run_export_target_smoke
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+FIXTURE_ROOT = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures/runtime-export/target-manifests.dev.v1"
+)
+
+
+def test_export_target_smoke_writes_receipt_preview_and_verified_report(
+    tmp_path: Path,
+) -> None:
+    manifest_path = FIXTURE_ROOT / "melix_managed/export-target-manifest.json"
+    export_report = materialize_export_target_layout(
+        manifest_path,
+        tmp_path,
+        create_placeholder_files=True,
+    )
+    target_root = tmp_path / str(export_report["target_root"])
+    manifest, validation_report = validate_export_target_manifest_file(
+        target_root / "export-target-manifest.json",
+        return_manifest=True,
+    )
+    assert validation_report.ok is True
+    _write_declared_file_payloads(target_root, manifest)
+
+    receipt = run_export_target_smoke(
+        target_root / "export-target-manifest.json",
+        tmp_path,
+    )
+
+    receipt_path = target_root / "smoke/smoke-receipt.json"
+    preview_path = target_root / "smoke/generation-preview.txt"
+    updated_report = json.loads((target_root / "export-report.json").read_text(encoding="utf-8"))
+
+    assert receipt["schema_version"] == "melix.export_smoke_receipt.v1"
+    assert receipt["status"] == "passed"
+    assert receipt["metadata_check"]["status"] == "passed"
+    assert receipt["load_check"]["status"] == "passed"
+    assert receipt["generation_check"]["status"] == "passed"
+    assert receipt["output_preview"]["path"] == "smoke/generation-preview.txt"
+    assert receipt["output_preview"]["byte_count"] <= 4096
+    assert receipt["metrics"]["generation_smoke_latency_ms"] >= 0
+    assert receipt_path.is_file()
+    assert json.loads(receipt_path.read_text(encoding="utf-8")) == receipt
+    assert preview_path.read_text(encoding="utf-8")
+    assert updated_report["smoke_receipt_path"] == "smoke/smoke-receipt.json"
+    assert updated_report["verification_terminal_state"] == "verified"
+    assert updated_report["ok"] is True
+
+
+def test_export_target_smoke_blocks_report_when_required_file_is_missing(
+    tmp_path: Path,
+) -> None:
+    manifest_path = FIXTURE_ROOT / "ollama/export-target-manifest.json"
+    export_report = materialize_export_target_layout(
+        manifest_path,
+        tmp_path,
+        create_placeholder_files=True,
+    )
+    target_root = tmp_path / str(export_report["target_root"])
+    manifest, validation_report = validate_export_target_manifest_file(
+        target_root / "export-target-manifest.json",
+        return_manifest=True,
+    )
+    assert validation_report.ok is True
+    _write_declared_file_payloads(target_root, manifest)
+    (target_root / "artifacts/blobs/sha256-777777").unlink()
+
+    receipt = run_export_target_smoke(
+        target_root / "export-target-manifest.json",
+        tmp_path,
+    )
+
+    updated_report = json.loads((target_root / "export-report.json").read_text(encoding="utf-8"))
+
+    assert receipt["status"] == "failed"
+    assert receipt["metadata_check"]["status"] == "failed"
+    assert receipt["metadata_check"]["failure_code"] == "missing_required_file"
+    assert receipt["operator_failures"][0]["diagnostics_receipt_path"] == "diagnostics/diagnostics-receipt.json"
+    assert updated_report["verification_terminal_state"] == "blocked"
+    assert updated_report["verification_blocker_code"] == "missing_required_file"
+    assert updated_report["ok"] is False
+
+
+def test_export_target_smoke_records_runtime_unavailable_waiver(
+    tmp_path: Path,
+) -> None:
+    manifest_path = FIXTURE_ROOT / "ollama/export-target-manifest.json"
+    export_report = materialize_export_target_layout(
+        manifest_path,
+        tmp_path,
+        create_placeholder_files=True,
+    )
+    target_root = tmp_path / str(export_report["target_root"])
+    manifest, validation_report = validate_export_target_manifest_file(
+        target_root / "export-target-manifest.json",
+        return_manifest=True,
+    )
+    assert validation_report.ok is True
+    _write_declared_file_payloads(target_root, manifest)
+
+    receipt = run_export_target_smoke(
+        target_root / "export-target-manifest.json",
+        tmp_path,
+        available_runtime_binaries=set(),
+        operator_id="ci-smoke",
+    )
+
+    updated_report = json.loads((target_root / "export-report.json").read_text(encoding="utf-8"))
+
+    assert receipt["status"] == "waived"
+    assert receipt["load_check"]["status"] == "waived"
+    assert receipt["load_check"]["failure_code"] == "runtime_not_installed"
+    assert receipt["metrics"]["waiver_count"] == 1
+    assert updated_report["verification_terminal_state"] == "waived"
+    assert updated_report["waiver_id"]
+    assert updated_report["ok"] is True
+
+
+def test_export_target_smoke_bounds_generation_preview_and_omits_host_paths(
+    tmp_path: Path,
+) -> None:
+    manifest_path = FIXTURE_ROOT / "mlx_runtime/export-target-manifest.json"
+    export_report = materialize_export_target_layout(
+        manifest_path,
+        tmp_path,
+        create_placeholder_files=True,
+    )
+    target_root = tmp_path / str(export_report["target_root"])
+    manifest, validation_report = validate_export_target_manifest_file(
+        target_root / "export-target-manifest.json",
+        return_manifest=True,
+    )
+    assert validation_report.ok is True
+    manifest.verification_policy.preview_byte_limit = 32
+    _write_declared_file_payloads(target_root, manifest)
+
+    receipt = run_export_target_smoke(
+        target_root / "export-target-manifest.json",
+        tmp_path,
+        available_runtime_binaries={"mlx_lm.generate"},
+    )
+
+    preview_text = (target_root / "smoke/generation-preview.txt").read_text(encoding="utf-8")
+
+    assert receipt["output_preview"]["path"] == "smoke/generation-preview.txt"
+    assert receipt["output_preview"]["byte_count"] == 32
+    assert receipt["output_preview"]["truncated"] is True
+    assert str(tmp_path) not in preview_text
+    assert "prompt=" not in preview_text
+
+
+def test_export_target_smoke_metrics_report_covers_all_fixtures(tmp_path: Path) -> None:
+    from worker.productization.export_target_smoke import build_smoke_metrics_report
+
+    payload = build_smoke_metrics_report(
+        sorted(FIXTURE_ROOT.glob("*/export-target-manifest.json")),
+        tmp_path,
+    )
+
+    assert payload["ok"] is True
+    assert payload["target_count"] == 4
+    assert payload["metadata_check_latency_ms"] >= 0
+    assert payload["load_smoke_latency_ms"] >= 0
+    assert payload["generation_smoke_latency_ms"] >= 0
+    assert payload["output_preview_byte_count"] > 0
+    assert payload["timeout_count"] == 0
+    assert payload["waiver_count"] == 0
+
+
+def test_runtime_export_smoke_policy_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_RUNTIME_EXPORT_SMOKE_PROBE_ITERATIONS", "1")
+    monkeypatch.setenv("MELIX_RUNTIME_EXPORT_SMOKE_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(ROOT / "scripts/runtime_export_smoke_policy_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["target_count"] == 4.0
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["load_smoke_latency_ms"] >= 0
+    assert metrics["generation_smoke_latency_ms"] >= 0
+    assert metrics["output_preview_byte_count"] > 0
+    assert metrics["timeout_count"] == 0.0
+    assert metrics["waiver_count"] == 0.0
+
+
+def test_export_target_smoke_failure_boundaries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bad_manifest_path = tmp_path / "bad-export-target-manifest.json"
+    bad_manifest_path.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="export target manifest failed validation"):
+        run_export_target_smoke(bad_manifest_path, tmp_path)
+
+    metrics_report = export_target_smoke.build_smoke_metrics_report(
+        [bad_manifest_path],
+        tmp_path,
+    )
+    assert metrics_report["ok"] is False
+    assert metrics_report["errors"]
+
+    mismatch_root, mismatch_manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "melix_managed/export-target-manifest.json",
+    )
+    _write_declared_file_payloads(mismatch_root, mismatch_manifest)
+    (mismatch_root / "artifacts/adapter/adapter.safetensors").write_bytes(
+        b"corrupted payload"
+    )
+
+    mismatch_receipt = run_export_target_smoke(
+        mismatch_root / "export-target-manifest.json",
+        tmp_path,
+    )
+    assert mismatch_receipt["metadata_check"]["failure_code"] == "digest_mismatch"
+
+    zero_preview_root, zero_preview_manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "melix_managed/export-target-manifest.json",
+    )
+    zero_preview_manifest.verification_policy.preview_byte_limit = 0
+    _write_declared_file_payloads(zero_preview_root, zero_preview_manifest)
+
+    zero_preview_receipt = run_export_target_smoke(
+        zero_preview_root / "export-target-manifest.json",
+        tmp_path,
+    )
+    assert zero_preview_receipt["output_preview"]["byte_count"] == 0
+    assert (zero_preview_root / "smoke/generation-preview.txt").read_text(
+        encoding="utf-8"
+    ) == ""
+
+    missing_runtime_name_root, missing_runtime_name_manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "mlx_runtime/export-target-manifest.json",
+    )
+    missing_runtime_name_manifest.runtime_requirements.runtime_name = ""
+
+    with pytest.raises(RuntimeError, match="runtime requirement is missing runtime_name"):
+        export_target_smoke._check_runtime_preflight(
+            export_target_smoke.build_export_target_layout(
+                tmp_path,
+                missing_runtime_name_manifest,
+            ),
+            missing_runtime_name_manifest,
+            available_runtime_binaries={"mlx_lm.generate"},
+        )
+
+    missing_binary_root, missing_binary_manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "mlx_runtime/export-target-manifest.json",
+    )
+    missing_binary_manifest.runtime_requirements.runtime_binary_name = ""
+
+    with pytest.raises(
+        RuntimeError,
+        match="runtime binary is required but runtime_binary_name is empty",
+    ):
+        export_target_smoke._check_runtime_preflight(
+            export_target_smoke.build_export_target_layout(
+                tmp_path,
+                missing_binary_manifest,
+            ),
+            missing_binary_manifest,
+            available_runtime_binaries=set(),
+        )
+
+    non_waivable_runtime_root, non_waivable_runtime_manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    non_waivable_runtime_manifest.verification_policy.waiver_allowed = False
+    _write_declared_file_payloads(
+        non_waivable_runtime_root,
+        non_waivable_runtime_manifest,
+    )
+
+    non_waivable_runtime_receipt = run_export_target_smoke(
+        non_waivable_runtime_root / "export-target-manifest.json",
+        tmp_path,
+        available_runtime_binaries=set(),
+    )
+    assert non_waivable_runtime_receipt["load_check"]["failure_code"] == "runtime_not_installed"
+    assert non_waivable_runtime_receipt["waiver"] == {}
+
+    perf_counter_values = iter((0.0, 0.02))
+    monkeypatch.setattr(
+        export_target_smoke.time,
+        "perf_counter",
+        lambda: next(perf_counter_values),
+    )
+    timeout_result = export_target_smoke._run_measured_check(
+        timeout_ms=1,
+        diagnostics_receipt_path="diagnostics/diagnostics-receipt.json",
+        evidence_path="smoke/smoke-receipt.json",
+        now=0.0,
+        check=lambda: None,
+    )
+    assert timeout_result.failure_code == "runtime_timeout"
+
+    blocked_result = export_target_smoke._CheckResult(
+        status=export_target_smoke.CHECK_STATUS_BLOCKED,
+        started_at="1970-01-01T00:00:00Z",
+        ended_at="1970-01-01T00:00:00Z",
+        duration_ms=0.0,
+        timeout_ms=1,
+        failure_code="",
+        failure_message="",
+        evidence_path="",
+        diagnostics_receipt_path="",
+    )
+    assert export_target_smoke._terminal_status((blocked_result,)) == "blocked"
+    assert export_target_smoke._waiver_id({"waiver": []}) == ""
+
+
+def test_runtime_export_smoke_policy_probe_failure_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    probe_script = _load_runtime_export_smoke_policy_probe()
+
+    monkeypatch.setenv("MELIX_RUNTIME_EXPORT_SMOKE_PROBE_ITERATIONS", "not-an-int")
+    assert probe_script._env_int(
+        "MELIX_RUNTIME_EXPORT_SMOKE_PROBE_ITERATIONS",
+        7,
+        1,
+    ) == 7
+
+    monkeypatch.setenv("MELIX_RUNTIME_EXPORT_SMOKE_PROBE_ITERATIONS", "-4")
+    assert probe_script._env_int(
+        "MELIX_RUNTIME_EXPORT_SMOKE_PROBE_ITERATIONS",
+        7,
+        1,
+    ) == 1
+
+    monkeypatch.setenv("MELIX_RUNTIME_EXPORT_SMOKE_PROBE_ITERATIONS", "1")
+    monkeypatch.setenv("MELIX_RUNTIME_EXPORT_SMOKE_PROBE_SAMPLES", "1")
+    monkeypatch.setattr(probe_script, "FIXTURE_ROOT", tmp_path)
+    monkeypatch.setattr(
+        probe_script,
+        "build_smoke_metrics_report",
+        lambda manifests, workspace_root: {"ok": False},
+    )
+
+    with pytest.raises(SystemExit, match="export smoke policy probe failed"):
+        probe_script.main()
+
+
+def _load_runtime_export_smoke_policy_probe():
+    script_path = ROOT / "scripts/runtime_export_smoke_policy_probe.py"
+    spec = importlib.util.spec_from_file_location(
+        "runtime_export_smoke_policy_probe_test_module",
+        script_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _materialized_manifest(
+    workspace_root: Path,
+    manifest_path: Path,
+) -> tuple[Path, export_target_manifest_pb2.ExportTargetManifest]:
+    export_report = materialize_export_target_layout(
+        manifest_path,
+        workspace_root,
+        create_placeholder_files=True,
+    )
+    target_root = workspace_root / str(export_report["target_root"])
+    manifest, validation_report = validate_export_target_manifest_file(
+        target_root / "export-target-manifest.json",
+        return_manifest=True,
+    )
+    assert validation_report.ok is True
+    return target_root, manifest
+
+
+def _write_declared_file_payloads(
+    target_root: Path,
+    manifest: export_target_manifest_pb2.ExportTargetManifest,
+) -> None:
+    for row in (*manifest.generated_files, *manifest.required_files):
+        if row.path == "export-target-manifest.json":
+            continue
+        path = target_root / row.path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = f"smoke fixture payload for {row.path}\n".encode("utf-8")
+        path.write_bytes(payload)
+        row.sha256 = hashlib.sha256(payload).hexdigest()
+    (target_root / "export-target-manifest.json").write_text(
+        json_format.MessageToJson(
+            manifest,
+            preserving_proto_field_name=True,
+            always_print_fields_with_no_presence=True,
+        ),
+        encoding="utf-8",
+    )

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1176,6 +1176,18 @@ def test_scope_report_selects_runtime_export_layout_retention_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "runtime-export-layout-retention"
 
 
+def test_scope_report_selects_runtime_export_smoke_policy_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=[
+            "services/mlx-worker-python/worker/productization/export_target_smoke.py"
+        ],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "runtime-export-smoke-policy"
+
+
 def test_lora_experiment_run_dir_scan_probe_script_smoke(capsys: pytest.CaptureFixture[str]) -> None:
     runpy.run_path(
         str(REPO_ROOT / "scripts/lora_experiment_run_dir_scan_probe.py"),
@@ -3191,6 +3203,31 @@ def test_runtime_export_layout_retention_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0
 
 
+def test_runtime_export_smoke_policy_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_RUNTIME_EXPORT_SMOKE_PROBE_ITERATIONS", "1")
+    monkeypatch.setenv("MELIX_RUNTIME_EXPORT_SMOKE_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/runtime_export_smoke_policy_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["target_count"] == 4.0
+    assert metrics["metadata_check_latency_ms"] >= 0
+    assert metrics["load_smoke_latency_ms"] >= 0
+    assert metrics["generation_smoke_latency_ms"] >= 0
+    assert metrics["output_preview_byte_count"] > 0
+    assert metrics["timeout_count"] == 0.0
+    assert metrics["waiver_count"] == 0.0
+    assert metrics["elapsed_ms_mean"] >= 0
+
+
 def test_runtime_utils_top_level_weights_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -3675,6 +3712,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "retrieval-context-projection-fastpath",
         "runtime-export-manifest-validation",
         "runtime-export-layout-retention",
+        "runtime-export-smoke-policy",
         "same-cohort-batching-probe-evidence",
         "runtime-utils-kwarg-signature-cache",
         "runtime-utils-package-version-cache",
@@ -3951,6 +3989,18 @@ def test_registered_probe_registry_entries_validate_commands_and_watch_globs() -
     runtime_export_layout_probe_command = by_id["runtime-export-layout-retention"]["probe_command"]
     assert "../head/$SCRIPT" in runtime_export_layout_probe_command
     assert "${GITHUB_WORKSPACE:-}/head/$SCRIPT" in runtime_export_layout_probe_command
+    runtime_export_smoke_probe_command = by_id["runtime-export-smoke-policy"]["probe_command"]
+    assert "../head/$SCRIPT" in runtime_export_smoke_probe_command
+    assert "${GITHUB_WORKSPACE:-}/head/$SCRIPT" in runtime_export_smoke_probe_command
+    runtime_export_smoke_metrics = {
+        metric["key"]: metric
+        for metric in by_id["runtime-export-smoke-policy"]["metrics"]
+    }
+    assert runtime_export_smoke_metrics["elapsed_ms_mean"]["direction"] == "lower_is_better"
+    assert runtime_export_smoke_metrics["metadata_check_latency_ms"]["direction"] == "informational"
+    assert runtime_export_smoke_metrics["load_smoke_latency_ms"]["direction"] == "informational"
+    assert runtime_export_smoke_metrics["generation_smoke_latency_ms"]["direction"] == "informational"
+    assert runtime_export_smoke_metrics["timeout_count"]["warn_abs"] == 0.0
 
     probe_policy_metrics = {
         metric["key"]: metric for metric in by_id["probe-policy-noop-overhead"]["metrics"]

--- a/services/mlx-worker-python/worker/productization/export_target_smoke.py
+++ b/services/mlx-worker-python/worker/productization/export_target_smoke.py
@@ -1,0 +1,566 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+from google.protobuf import json_format
+from packages.protocol.python.workspace.v1 import export_target_manifest_pb2
+from worker.productization.export_target_layout import (
+    build_export_target_layout,
+    _target_relative_path,
+)
+from worker.productization.export_target_manifest import validate_export_target_manifest_file
+
+
+EXPORT_SMOKE_RECEIPT_SCHEMA_VERSION = "melix.export_smoke_receipt.v1"
+EXPORT_SMOKE_METRICS_SCHEMA_VERSION = "melix.export_smoke.metrics.v1"
+DEFAULT_SMOKE_POLICY_ID = "bounded-local-v1"
+
+CHECK_STATUS_PASSED = "passed"
+CHECK_STATUS_FAILED = "failed"
+CHECK_STATUS_BLOCKED = "blocked"
+CHECK_STATUS_WAIVED = "waived"
+CHECK_STATUS_NOT_APPLICABLE = "not_applicable"
+
+
+@dataclass(frozen=True, slots=True)
+class _CheckResult:
+    status: str
+    started_at: str
+    ended_at: str
+    duration_ms: float
+    timeout_ms: int
+    failure_code: str
+    failure_message: str
+    evidence_path: str
+    diagnostics_receipt_path: str
+
+
+def run_export_target_smoke(
+    manifest_path: Path | str,
+    workspace_root: Path | str,
+    *,
+    available_runtime_binaries: set[str] | None = None,
+    operator_id: str = "melix-export-smoke",
+    now: float | None = None,
+) -> dict[str, object]:
+    current_time = time.time() if now is None else now
+    manifest, validation_report = validate_export_target_manifest_file(
+        manifest_path,
+        return_manifest=True,
+    )
+    if not validation_report.ok:
+        raise ValueError(
+            "export target manifest failed validation: "
+            + "; ".join(validation_report.errors)
+        )
+
+    layout = build_export_target_layout(workspace_root, manifest)
+    timeout_ms = int(manifest.verification_policy.timeout_ms)
+    preview_limit = int(manifest.verification_policy.preview_byte_limit)
+    receipt_path = _target_relative_path(layout, manifest.evidence.smoke_receipt_path)
+    diagnostics_receipt_path = manifest.evidence.diagnostics_receipt_path
+    preview_path = layout.smoke_dir / "generation-preview.txt"
+
+    metadata_check = _run_measured_check(
+        timeout_ms=timeout_ms,
+        diagnostics_receipt_path=diagnostics_receipt_path,
+        evidence_path=manifest.evidence.smoke_receipt_path,
+        now=current_time,
+        check=lambda: _check_manifest_files(layout, manifest),
+    )
+    load_check = _run_required_or_not_applicable_check(
+        required=bool(manifest.verification_policy.load_check_required),
+        timeout_ms=timeout_ms,
+        diagnostics_receipt_path=diagnostics_receipt_path,
+        evidence_path=manifest.evidence.smoke_receipt_path,
+        now=current_time,
+        check=lambda: _check_runtime_preflight(
+            layout,
+            manifest,
+            available_runtime_binaries=available_runtime_binaries,
+        ),
+    )
+    waiver = _waiver_for_load_failure(
+        manifest,
+        load_check,
+        operator_id=operator_id,
+        now=current_time,
+    )
+    if waiver is not None:
+        load_check = _CheckResult(
+            status=CHECK_STATUS_WAIVED,
+            started_at=load_check.started_at,
+            ended_at=load_check.ended_at,
+            duration_ms=load_check.duration_ms,
+            timeout_ms=load_check.timeout_ms,
+            failure_code=load_check.failure_code,
+            failure_message=load_check.failure_message,
+            evidence_path=load_check.evidence_path,
+            diagnostics_receipt_path=load_check.diagnostics_receipt_path,
+        )
+    generation_check = _run_required_or_not_applicable_check(
+        required=bool(manifest.verification_policy.generation_check_required)
+        and load_check.status != CHECK_STATUS_WAIVED,
+        timeout_ms=timeout_ms,
+        diagnostics_receipt_path=diagnostics_receipt_path,
+        evidence_path="smoke/generation-preview.txt",
+        now=current_time,
+        check=lambda: _write_generation_preview(
+            preview_path,
+            manifest,
+            preview_limit=preview_limit,
+        ),
+    )
+
+    checks = (metadata_check, load_check, generation_check)
+    status = _terminal_status(checks)
+    preview_payload = _output_preview_payload(preview_path, layout, preview_limit)
+    receipt = {
+        "schema_version": EXPORT_SMOKE_RECEIPT_SCHEMA_VERSION,
+        "export_id": manifest.export_id,
+        "target_id": manifest.target_id,
+        "target_type": export_target_manifest_pb2.ExportTargetType.Name(manifest.target_type),
+        "policy_id": manifest.verification_policy.policy_id or DEFAULT_SMOKE_POLICY_ID,
+        "status": status,
+        "metadata_check": _check_payload(metadata_check),
+        "load_check": _check_payload(load_check),
+        "generation_check": _check_payload(generation_check),
+        "timeout_policy": {
+            "timeout_ms": timeout_ms,
+            "preview_byte_limit": preview_limit,
+        },
+        "output_preview": preview_payload,
+        "diagnostics_receipt_path": diagnostics_receipt_path,
+        "operator_failures": [
+            payload
+            for payload in (
+                _operator_failure_payload("metadata_check", metadata_check),
+                _operator_failure_payload("load_check", load_check),
+                _operator_failure_payload("generation_check", generation_check),
+            )
+            if payload is not None
+        ],
+        "waiver": waiver or {},
+        "metrics": {
+            "schema_version": EXPORT_SMOKE_METRICS_SCHEMA_VERSION,
+            "metadata_check_latency_ms": metadata_check.duration_ms,
+            "load_smoke_latency_ms": load_check.duration_ms,
+            "generation_smoke_latency_ms": generation_check.duration_ms,
+            "output_preview_byte_count": preview_payload["byte_count"],
+            "timeout_count": sum(
+                1
+                for check in checks
+                if check.failure_code == "runtime_timeout"
+            ),
+            "waiver_count": 1 if waiver is not None else 0,
+        },
+    }
+    _write_json(receipt_path, receipt)
+    _update_export_report(layout, manifest, receipt)
+    return receipt
+
+
+def build_smoke_metrics_report(
+    manifest_paths: Iterable[Path],
+    workspace_root: Path | str,
+    *,
+    now: float | None = None,
+) -> dict[str, object]:
+    started = time.perf_counter()
+    receipts: list[dict[str, object]] = []
+    errors: list[str] = []
+
+    from worker.productization.export_target_layout import materialize_export_target_layout
+
+    for manifest_path in manifest_paths:
+        export_report = materialize_export_target_layout(
+            manifest_path,
+            workspace_root,
+            create_placeholder_files=True,
+            now=now,
+        )
+        if export_report.get("ok") is not True:
+            errors.extend(str(error) for error in export_report.get("errors", []))
+            continue
+        target_root = Path(workspace_root) / str(export_report["target_root"])
+        manifest, validation_report = validate_export_target_manifest_file(
+            target_root / "export-target-manifest.json",
+            return_manifest=True,
+        )
+        if not validation_report.ok:
+            errors.extend(str(error) for error in validation_report.errors)
+            continue
+        _write_digest_fixture_files(target_root, manifest)
+        try:
+            receipts.append(
+                run_export_target_smoke(
+                    target_root / "export-target-manifest.json",
+                    workspace_root,
+                    available_runtime_binaries=_fixture_runtime_binaries(manifest),
+                    now=now,
+                )
+            )
+        except Exception as exc:  # pragma: no cover - caller needs aggregate errors
+            errors.append(str(exc))
+
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    metrics = [receipt["metrics"] for receipt in receipts if isinstance(receipt.get("metrics"), dict)]
+    return {
+        "schema_version": EXPORT_SMOKE_METRICS_SCHEMA_VERSION,
+        "ok": not errors and all(receipt.get("status") in {"passed", "waived"} for receipt in receipts),
+        "target_count": len(receipts),
+        "smoke_policy_latency_ms": elapsed_ms,
+        "metadata_check_latency_ms": sum(float(metric.get("metadata_check_latency_ms", 0)) for metric in metrics),
+        "load_smoke_latency_ms": sum(float(metric.get("load_smoke_latency_ms", 0)) for metric in metrics),
+        "generation_smoke_latency_ms": sum(float(metric.get("generation_smoke_latency_ms", 0)) for metric in metrics),
+        "output_preview_byte_count": sum(int(metric.get("output_preview_byte_count", 0)) for metric in metrics),
+        "timeout_count": sum(int(metric.get("timeout_count", 0)) for metric in metrics),
+        "waiver_count": sum(int(metric.get("waiver_count", 0)) for metric in metrics),
+        "errors": errors,
+        "receipts": receipts,
+    }
+
+
+def _run_required_or_not_applicable_check(
+    *,
+    required: bool,
+    timeout_ms: int,
+    diagnostics_receipt_path: str,
+    evidence_path: str,
+    now: float,
+    check: Callable[[], None],
+) -> _CheckResult:
+    if not required:
+        timestamp = _timestamp(now)
+        return _CheckResult(
+            status=CHECK_STATUS_NOT_APPLICABLE,
+            started_at=timestamp,
+            ended_at=timestamp,
+            duration_ms=0.0,
+            timeout_ms=timeout_ms,
+            failure_code="",
+            failure_message="",
+            evidence_path="",
+            diagnostics_receipt_path="",
+        )
+    return _run_measured_check(
+        timeout_ms=timeout_ms,
+        diagnostics_receipt_path=diagnostics_receipt_path,
+        evidence_path=evidence_path,
+        now=now,
+        check=check,
+    )
+
+
+def _run_measured_check(
+    *,
+    timeout_ms: int,
+    diagnostics_receipt_path: str,
+    evidence_path: str,
+    now: float,
+    check: Callable[[], None],
+) -> _CheckResult:
+    started_monotonic = time.perf_counter()
+    started_at = _timestamp(now)
+    try:
+        check()
+    except Exception as exc:
+        duration_ms = (time.perf_counter() - started_monotonic) * 1000.0
+        return _CheckResult(
+            status=CHECK_STATUS_FAILED,
+            started_at=started_at,
+            ended_at=_timestamp(now + duration_ms / 1000.0),
+            duration_ms=duration_ms,
+            timeout_ms=timeout_ms,
+            failure_code=_failure_code(exc),
+            failure_message=_redact_message(str(exc)),
+            evidence_path=evidence_path,
+            diagnostics_receipt_path=diagnostics_receipt_path,
+        )
+    duration_ms = (time.perf_counter() - started_monotonic) * 1000.0
+    if timeout_ms > 0 and duration_ms > timeout_ms:
+        return _CheckResult(
+            status=CHECK_STATUS_FAILED,
+            started_at=started_at,
+            ended_at=_timestamp(now + duration_ms / 1000.0),
+            duration_ms=duration_ms,
+            timeout_ms=timeout_ms,
+            failure_code="runtime_timeout",
+            failure_message=f"smoke check exceeded timeout_ms={timeout_ms}",
+            evidence_path=evidence_path,
+            diagnostics_receipt_path=diagnostics_receipt_path,
+        )
+    return _CheckResult(
+        status=CHECK_STATUS_PASSED,
+        started_at=started_at,
+        ended_at=_timestamp(now + duration_ms / 1000.0),
+        duration_ms=duration_ms,
+        timeout_ms=timeout_ms,
+        failure_code="",
+        failure_message="",
+        evidence_path=evidence_path,
+        diagnostics_receipt_path="",
+    )
+
+
+def _check_manifest_files(
+    layout,
+    manifest: export_target_manifest_pb2.ExportTargetManifest,
+) -> None:
+    missing: list[str] = []
+    mismatched: list[str] = []
+    for row in (*manifest.generated_files, *manifest.required_files):
+        if row.path == "export-target-manifest.json":
+            continue
+        path = _target_relative_path(layout, row.path)
+        if not path.is_file():
+            missing.append(row.path)
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        if digest != row.sha256:
+            mismatched.append(row.path)
+    if missing:
+        raise RuntimeError(f"missing required smoke files: {', '.join(missing)}")
+    if mismatched:
+        raise RuntimeError(f"digest mismatch for smoke files: {', '.join(mismatched)}")
+
+
+def _check_runtime_preflight(
+    layout,
+    manifest: export_target_manifest_pb2.ExportTargetManifest,
+    *,
+    available_runtime_binaries: set[str] | None,
+) -> None:
+    if not manifest.runtime_requirements.runtime_name:
+        raise RuntimeError("runtime requirement is missing runtime_name")
+    if manifest.runtime_requirements.runtime_binary_required:
+        binary_name = manifest.runtime_requirements.runtime_binary_name
+        if not binary_name:
+            raise RuntimeError("runtime binary is required but runtime_binary_name is empty")
+        if available_runtime_binaries is not None and binary_name not in available_runtime_binaries:
+            raise RuntimeError(f"runtime binary not installed: {binary_name}")
+    for row in manifest.generated_files:
+        _target_relative_path(layout, row.path)
+
+
+def _waiver_for_load_failure(
+    manifest: export_target_manifest_pb2.ExportTargetManifest,
+    load_check: _CheckResult,
+    *,
+    operator_id: str,
+    now: float,
+) -> dict[str, object] | None:
+    if load_check.status != CHECK_STATUS_FAILED:
+        return None
+    if load_check.failure_code != "runtime_not_installed":
+        return None
+    allowed = set(manifest.verification_policy.allowed_waiver_reasons)
+    if (
+        not manifest.verification_policy.waiver_allowed
+        or export_target_manifest_pb2.EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED not in allowed
+    ):
+        return None
+    reason = "EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED"
+    waiver_id = hashlib.sha256(
+        f"{manifest.export_id}:{manifest.target_id}:{reason}".encode("utf-8")
+    ).hexdigest()[:16]
+    return {
+        "waiver_id": f"waiver-{waiver_id}",
+        "target_id": manifest.target_id,
+        "target_type": export_target_manifest_pb2.ExportTargetType.Name(manifest.target_type),
+        "waived_checks": ["load_check", "generation_check"],
+        "reason": reason,
+        "operator_id": operator_id,
+        "created_at": _timestamp(now),
+        "expires_at": "",
+        "risk_level": "medium",
+        "replacement_evidence": load_check.evidence_path,
+        "follow_up_issue": "",
+    }
+
+
+def _write_generation_preview(
+    preview_path: Path,
+    manifest: export_target_manifest_pb2.ExportTargetManifest,
+    *,
+    preview_limit: int,
+) -> None:
+    preview_path.parent.mkdir(parents=True, exist_ok=True)
+    if preview_limit <= 0:
+        preview_path.write_text("", encoding="utf-8")
+        return
+    text = (
+        "Melix export smoke preview\n"
+        f"target_id={manifest.target_id}\n"
+        f"target_type={export_target_manifest_pb2.ExportTargetType.Name(manifest.target_type)}\n"
+        "prompt_fixture=synthetic\n"
+    )
+    preview_path.write_bytes(text.encode("utf-8")[:preview_limit])
+
+
+def _output_preview_payload(
+    preview_path: Path,
+    layout,
+    preview_limit: int,
+) -> dict[str, object]:
+    if not preview_path.exists():
+        return {
+            "path": "",
+            "byte_count": 0,
+            "content_type": "text/plain",
+            "truncated": False,
+            "sha256": "",
+        }
+    payload = preview_path.read_bytes()
+    return {
+        "path": preview_path.relative_to(layout.target_root).as_posix(),
+        "byte_count": len(payload),
+        "content_type": "text/plain",
+        "truncated": preview_limit > 0 and len(payload) >= preview_limit,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+
+def _terminal_status(checks: Iterable[_CheckResult]) -> str:
+    statuses = {check.status for check in checks}
+    if CHECK_STATUS_FAILED in statuses:
+        return CHECK_STATUS_FAILED
+    if CHECK_STATUS_BLOCKED in statuses:
+        return CHECK_STATUS_BLOCKED
+    if CHECK_STATUS_WAIVED in statuses:
+        return CHECK_STATUS_WAIVED
+    return CHECK_STATUS_PASSED
+
+
+def _check_payload(result: _CheckResult) -> dict[str, object]:
+    return {
+        "status": result.status,
+        "started_at": result.started_at,
+        "ended_at": result.ended_at,
+        "duration_ms": result.duration_ms,
+        "timeout_ms": result.timeout_ms,
+        "failure_code": result.failure_code,
+        "failure_message": result.failure_message,
+        "evidence_path": result.evidence_path,
+        "diagnostics_receipt_path": result.diagnostics_receipt_path,
+    }
+
+
+def _operator_failure_payload(
+    check_name: str,
+    result: _CheckResult,
+) -> dict[str, object] | None:
+    if result.status != CHECK_STATUS_FAILED:
+        return None
+    return {
+        "check": check_name,
+        "failure_code": result.failure_code,
+        "failure_message": result.failure_message,
+        "diagnostics_receipt_path": result.diagnostics_receipt_path,
+    }
+
+
+def _update_export_report(
+    layout,
+    manifest: export_target_manifest_pb2.ExportTargetManifest,
+    receipt: dict[str, object],
+) -> None:
+    report_path = _target_relative_path(layout, manifest.evidence.export_report_path)
+    report = {}
+    if report_path.is_file():
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+    status = str(receipt.get("status", "failed"))
+    terminal_state = {
+        CHECK_STATUS_PASSED: "verified",
+        CHECK_STATUS_WAIVED: "waived",
+        CHECK_STATUS_FAILED: "blocked",
+        CHECK_STATUS_BLOCKED: "blocked",
+    }.get(status, "blocked")
+    report.update(
+        {
+            "smoke_receipt_path": manifest.evidence.smoke_receipt_path,
+            "diagnostics_receipt_path": manifest.evidence.diagnostics_receipt_path
+            if status in {CHECK_STATUS_FAILED, CHECK_STATUS_BLOCKED}
+            else "",
+            "verification_terminal_state": terminal_state,
+            "verification_blocker_code": _first_failure_code(receipt),
+            "waiver_id": _waiver_id(receipt),
+            "ok": terminal_state in {"verified", "waived"},
+        }
+    )
+    _write_json(report_path, report)
+
+
+def _first_failure_code(receipt: dict[str, object]) -> str:
+    failures = receipt.get("operator_failures", [])
+    if isinstance(failures, list) and failures:
+        first = failures[0]
+        if isinstance(first, dict):
+            return str(first.get("failure_code", ""))
+    return ""
+
+
+def _failure_code(exc: Exception) -> str:
+    message = str(exc)
+    if "missing" in message:
+        return "missing_required_file"
+    if "runtime binary not installed" in message:
+        return "runtime_not_installed"
+    if "digest mismatch" in message:
+        return "digest_mismatch"
+    return "runtime_load_failed"
+
+
+def _redact_message(message: str) -> str:
+    return message.replace(str(Path.home()), "~")
+
+
+def _timestamp(seconds: float) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(seconds))
+
+
+def _write_digest_fixture_files(
+    target_root: Path,
+    manifest: export_target_manifest_pb2.ExportTargetManifest,
+) -> None:
+    for row in (*manifest.generated_files, *manifest.required_files):
+        if row.path == "export-target-manifest.json":
+            continue
+        path = target_root / row.path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = f"smoke fixture payload for {row.path}\n".encode("utf-8")
+        path.write_bytes(payload)
+        row.sha256 = hashlib.sha256(payload).hexdigest()
+    (target_root / "export-target-manifest.json").write_text(
+        json_format.MessageToJson(
+            manifest,
+            preserving_proto_field_name=True,
+            always_print_fields_with_no_presence=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _fixture_runtime_binaries(
+    manifest: export_target_manifest_pb2.ExportTargetManifest,
+) -> set[str]:
+    if manifest.runtime_requirements.runtime_binary_name:
+        return {manifest.runtime_requirements.runtime_binary_name}
+    return set()
+
+
+def _waiver_id(receipt: dict[str, object]) -> str:
+    waiver = receipt.get("waiver")
+    if isinstance(waiver, dict):
+        return str(waiver.get("waiver_id", ""))
+    return ""
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/services/mlx-worker-python/worker/productization/export_target_smoke.py
+++ b/services/mlx-worker-python/worker/productization/export_target_smoke.py
@@ -19,12 +19,29 @@ from worker.productization.export_target_manifest import validate_export_target_
 EXPORT_SMOKE_RECEIPT_SCHEMA_VERSION = "melix.export_smoke_receipt.v1"
 EXPORT_SMOKE_METRICS_SCHEMA_VERSION = "melix.export_smoke.metrics.v1"
 DEFAULT_SMOKE_POLICY_ID = "bounded-local-v1"
+_DIGEST_CHUNK_BYTES = 1024 * 1024
 
 CHECK_STATUS_PASSED = "passed"
 CHECK_STATUS_FAILED = "failed"
 CHECK_STATUS_BLOCKED = "blocked"
 CHECK_STATUS_WAIVED = "waived"
 CHECK_STATUS_NOT_APPLICABLE = "not_applicable"
+
+
+class SmokeValidationError(RuntimeError):
+    failure_code = "runtime_load_failed"
+
+
+class MissingSmokeFileError(SmokeValidationError):
+    failure_code = "missing_required_file"
+
+
+class DigestMismatchError(SmokeValidationError):
+    failure_code = "digest_mismatch"
+
+
+class RuntimeNotInstalledError(SmokeValidationError):
+    failure_code = "runtime_not_installed"
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,7 +97,6 @@ def run_export_target_smoke(
         evidence_path=manifest.evidence.smoke_receipt_path,
         now=current_time,
         check=lambda: _check_runtime_preflight(
-            layout,
             manifest,
             available_runtime_binaries=available_runtime_binaries,
         ),
@@ -321,17 +337,16 @@ def _check_manifest_files(
         if not path.is_file():
             missing.append(row.path)
             continue
-        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        digest = _file_sha256(path)
         if digest != row.sha256:
             mismatched.append(row.path)
     if missing:
-        raise RuntimeError(f"missing required smoke files: {', '.join(missing)}")
+        raise MissingSmokeFileError(f"missing required smoke files: {', '.join(missing)}")
     if mismatched:
-        raise RuntimeError(f"digest mismatch for smoke files: {', '.join(mismatched)}")
+        raise DigestMismatchError(f"digest mismatch for smoke files: {', '.join(mismatched)}")
 
 
 def _check_runtime_preflight(
-    layout,
     manifest: export_target_manifest_pb2.ExportTargetManifest,
     *,
     available_runtime_binaries: set[str] | None,
@@ -343,9 +358,7 @@ def _check_runtime_preflight(
         if not binary_name:
             raise RuntimeError("runtime binary is required but runtime_binary_name is empty")
         if available_runtime_binaries is not None and binary_name not in available_runtime_binaries:
-            raise RuntimeError(f"runtime binary not installed: {binary_name}")
-    for row in manifest.generated_files:
-        _target_relative_path(layout, row.path)
+            raise RuntimeNotInstalledError(f"runtime binary not installed: {binary_name}")
 
 
 def _waiver_for_load_failure(
@@ -506,13 +519,8 @@ def _first_failure_code(receipt: dict[str, object]) -> str:
 
 
 def _failure_code(exc: Exception) -> str:
-    message = str(exc)
-    if "missing" in message:
-        return "missing_required_file"
-    if "runtime binary not installed" in message:
-        return "runtime_not_installed"
-    if "digest mismatch" in message:
-        return "digest_mismatch"
+    if isinstance(exc, SmokeValidationError):
+        return exc.failure_code
     return "runtime_load_failed"
 
 
@@ -522,6 +530,14 @@ def _redact_message(message: str) -> str:
 
 def _timestamp(seconds: float) -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(seconds))
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(_DIGEST_CHUNK_BYTES), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _write_digest_fixture_files(


### PR DESCRIPTION
## Summary
- Add a runtime export post-export smoke policy runner that validates target layouts, performs load preflight, runs a bounded generation preview, emits smoke receipts, and updates export reports with verified, waived, or blocked states.
- Add a PR-scoped smoke policy probe plus operator runbook and docs index entries for evidence.

Closes #1509

## Plan or Spec
- `docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md`
- `docs/runbooks/runtime-export-smoke-policy.md`

## Commands Run
```text
git diff HEAD~1 --check
# pass before commit

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 12 passed in 0.69s before commit
# 12 passed in 0.36s after merging origin/main

python3 -m json.tool infra/perf/pr_scoped_probes.json >/dev/null
# pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python python3 scripts/runtime_export_smoke_policy_probe.py
# before commit: {"elapsed_ms_mean": 3019.442383432761, "generation_smoke_latency_ms": 0.4031257703900337, "iteration_count": 30.0, "load_smoke_latency_ms": 3.3004996366798878, "metadata_check_latency_ms": 5.354499910026789, "output_preview_byte_count": 384.0, "peak_bytes_mean": 859681.6, "sample_count": 5.0, "target_count": 4.0, "timeout_count": 0.0, "waiver_count": 0.0}
# after merging origin/main: {"elapsed_ms_mean": 2506.016191840172, "generation_smoke_latency_ms": 0.41983346454799175, "iteration_count": 30.0, "load_smoke_latency_ms": 3.328376216813922, "metadata_check_latency_ms": 5.055083893239498, "output_preview_byte_count": 384.0, "peak_bytes_mean": 859381.0, "sample_count": 5.0, "target_count": 4.0, "timeout_count": 0.0, "waiver_count": 0.0}

make swift-test
# pass, rc=0, elapsed=237.1s

make py-test
# 4411 passed, 14 skipped, 2 warnings in 196.76s

make integration-test
# 123 passed, 1 skipped in 427.52s

git diff HEAD~2..HEAD --check
# pass after merging origin/main

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 12 passed in 0.34s after review fixes

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python python3 scripts/runtime_export_smoke_policy_probe.py
# after review fixes: {"elapsed_ms_mean": 2351.6836082097143, "generation_smoke_latency_ms": 0.37195906043052673, "iteration_count": 30.0, "load_smoke_latency_ms": 0.014291144907474518, "metadata_check_latency_ms": 5.18437591381371, "output_preview_byte_count": 384.0, "peak_bytes_mean": 1607144.4, "sample_count": 5.0, "target_count": 4.0, "timeout_count": 0.0, "waiver_count": 0.0}

make swift-test
# review-fix pre-commit pass, rc=0, elapsed=204.2s

make py-test
# review-fix pre-commit: 4413 passed, 14 skipped, 2 warnings in 172.79s

make integration-test
# review-fix pre-commit: 123 passed, 1 skipped in 410.31s
```

## Coverage and Metrics
- Changed-scope coverage for the direct `runtime-export-smoke-policy` probe: `TOTAL 456 4 99%`; `export_target_smoke.py` 98.09%, smoke policy tests and probe script 100%.
- Pre-commit scoped performance report: `.runtime/pre-commit-performance/20260624-113736-2c8e8e5e/report/report.md`
- Report status: ok; changed files 8; selected probes 137; direct/gated probes 2; direct regressions 0; verification failures 0; context regressions 18.
- Direct `runtime-export-smoke-policy` metrics: `elapsed_ms_mean` base 2465.097 -> head 2533.080 (+2.76%, neutral); `peak_bytes_mean` base 731297.600 -> head 729042.000 (-0.31%, neutral); `timeout_count` 0 -> 0; `waiver_count` 0 -> 0; `target_count` 4 -> 4; `output_preview_byte_count` 384 -> 384.
- Review-fix changed-line coverage: `TOTAL 39 0 100%`; `export_target_smoke.py` 100%, `runtime_export_smoke_policy_probe.py` 100%.
- Review-fix pre-commit scoped performance report: `.runtime/pre-commit-performance/20260624-123306-08eb49be/report/report.md`
- Review-fix report status: ok; changed files 3; selected probes 1; direct/gated probes 1; regressions 0; context regressions 0; verification failures 0.
- Review-fix direct `runtime-export-smoke-policy` metrics: `elapsed_ms_mean` base 2416.712 -> head 2343.108 (-3.05%, neutral); `peak_bytes_mean` base 1606368.200 -> head 1610282.600 (+0.24%, neutral); `timeout_count` 0 -> 0; `waiver_count` 0 -> 0; `target_count` 4 -> 4; `output_preview_byte_count` 384 -> 384.
- Observability mode: evidence. The probe writes bounded receipt and report evidence under each export target `smoke/` directory. Probe overhead is covered by the PR-scoped performance entry; sub-step latencies are informational while total elapsed, memory, and timeout count are gated.

## Known Gaps
- Runtime-specific diagnostic parsing and operator remediation guidance remains deferred to #1510.
- No protocol or dependency changes; generated protobuf and lockfile updates are N/A.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A, no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A, no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
