### PR TITLE
Add runtime export diagnostics parser

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -1,0 +1,91 @@
+# Runtime Export Diagnostic Parser
+
+## Scope
+
+This plan implements the #1510 worker-owned slice of runtime export failure
+diagnostics. The parser reads target-local runtime logs and smoke failure
+messages, writes `diagnostics/diagnostics-receipt.json`, and exposes typed
+operator remedies through `export-report.json`.
+
+The slice does not change protobuf schemas. The existing
+`ExportDiagnosticPolicy` and `ExportEvidencePolicy.diagnostics_receipt_path`
+fields are sufficient for the first parser policy.
+
+## Receipt Contract
+
+The diagnostics receipt uses schema `melix.export_diagnostics_receipt.v1` and
+records:
+
+- target identity and `parser_policy_id`
+- parser status: `matched`, `unknown`, or `not_applicable`
+- typed diagnosis rows with code, severity, matched pattern id, operator
+  message, remediation, and redacted evidence pointer
+- bounded redacted log excerpt metadata
+- operator remedies for CLI, Desktop, and reports
+- parser metrics: coverage, parsed failure count, unknown failure count,
+  redaction count, and latency
+
+Supported diagnosis codes for this slice are:
+
+- `runtime_load_failed`
+- `unsupported_architecture`
+- `duplicate_tensor_name`
+- `missing_blob`
+- `missing_binary`
+- `invalid_runtime_path`
+- `runtime_timeout`
+- `permission_denied`
+- `insufficient_memory`
+- `unknown_failure`
+
+## Redaction Policy
+
+The parser writes `diagnostics/redacted-log-excerpt.txt` instead of copying raw
+logs into operator-facing receipts. It redacts:
+
+- absolute host paths, using target-relative labels when a path is under the
+  export target root
+- bearer tokens, API keys, proxy credentials, passwords, and certificate-like
+  secrets
+- full prompt, response, completion, dataset row, private prompt template, and
+  operator-input lines
+- user or operator identity values that are not needed for diagnosis
+
+Unknown failures still receive a bounded redacted excerpt so parser coverage can
+be expanded without leaking credentials or private text.
+
+## Export Integration
+
+Failed or blocked smoke receipts must finish diagnostics before updating the
+target export report. The export report exposes `diagnostic_status`,
+`diagnostic_codes`, and `operator_remedies` from the shared receipt; UI surfaces
+render those fields instead of parsing raw logs independently.
+
+Waived runtime-unavailable checks keep the existing waiver path. Missing binary
+diagnosis is covered by parser fixtures and by non-waivable runtime binary
+failures.
+
+## Metrics And Verification
+
+The PR-scoped performance probe id is `runtime-export-diagnostic-parser`.
+It measures:
+
+- `elapsed_ms_mean`
+- `peak_bytes_mean`
+- `diagnostic_parser_coverage`
+- `parsed_failure_count`
+- `unknown_failure_count`
+- `redaction_count`
+- `diagnostic_latency_ms`
+
+Focused verification:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
+  uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_export_target_diagnostics.py \
+  services/mlx-worker-python/tests/test_export_target_smoke_policy.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+```

--- a/docs/runbooks/runtime-export-smoke-policy.md
+++ b/docs/runbooks/runtime-export-smoke-policy.md
@@ -21,6 +21,33 @@ The target directory receives:
 `export-report.json` is updated with the smoke receipt path, terminal
 verification state, blocker code, waiver id, and report-level `ok` status.
 
+## Diagnostics Evidence
+
+When smoke verification fails or blocks a target, the runner writes
+`diagnostics/diagnostics-receipt.json` before updating `export-report.json`.
+The receipt uses schema `melix.export_diagnostics_receipt.v1` and contains:
+
+- parser status: `matched`, `unknown`, or `not_applicable`
+- typed diagnosis rows for runtime load failures, unsupported architecture,
+  duplicate tensor names, missing blobs, missing binaries, invalid runtime
+  paths, timeouts, permission failures, insufficient memory, and unknown
+  failures
+- operator remedies with redacted evidence pointers for CLI, Desktop, and
+  report surfaces
+- redaction counts, bounded excerpt size, truncation state, and diagnostic
+  parser latency metrics
+
+Operator-facing diagnostics use `diagnostics/redacted-log-excerpt.txt`. The
+parser redacts absolute host paths, credentials, bearer tokens, proxy secrets,
+certificate-like contents, full prompts, full generations, dataset rows,
+private prompt templates, and unnecessary user or operator identity values.
+Paths under the target directory are rewritten as `<target>/...`; other
+absolute paths are replaced with `<absolute-path>`.
+
+`export-report.json` mirrors `diagnostic_status`, `diagnostic_codes`, and
+`operator_remedies` from the diagnostics receipt. UI surfaces should render
+those fields and should not parse raw runtime logs independently.
+
 ## Probe Command
 
 Run the smoke policy probe over the checked-in fixtures:
@@ -34,6 +61,18 @@ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
 The probe reports metadata check latency, load smoke latency, generation smoke
 latency, output preview byte count, timeout count, waiver count, target count,
 and peak bytes.
+
+Run the diagnostic parser probe over the same fixture set:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
+  uv run --project services/mlx-worker-python \
+  python3 scripts/runtime_export_diagnostic_parser_probe.py
+```
+
+The diagnostic probe reports parser coverage, parsed failure count, unknown
+failure count, redaction count, diagnostic latency, target count, and peak
+bytes.
 
 ## Waiver Policy
 

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -6335,5 +6335,78 @@
         "warn_pct": 5.0
       }
     ]
+  },
+  {
+    "id": "runtime-export-diagnostic-parser",
+    "name": "Runtime export diagnostic parser",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/productization/export_target_diagnostics.py",
+      "services/mlx-worker-python/tests/test_export_target_diagnostics.py",
+      "services/mlx-worker-python/tests/test_export_target_smoke_policy.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "services/mlx-worker-python/fixtures/runtime-export/target-manifests.dev.v1/**",
+      "scripts/runtime_export_diagnostic_parser_probe.py",
+      "infra/perf/pr_scoped_probes.json",
+      "docs/plans/2026-06-24-runtime-export-diagnostic-parser.md",
+      "docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md",
+      "docs/runbooks/runtime-export-smoke-policy.md"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/runtime_export_diagnostic_parser_probe.py\"; for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "diagnostic_parser_coverage",
+        "unit": "ratio",
+        "direction": "higher_is_better",
+        "warn_abs": 0.0
+      },
+      {
+        "key": "parsed_failure_count",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
+        "key": "unknown_failure_count",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
+        "key": "redaction_count",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
+        "key": "diagnostic_latency_ms",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "target_count",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
+        "key": "diagnosis_code_count",
+        "unit": "count",
+        "direction": "informational"
+      }
+    ]
   }
 ]

--- a/scripts/runtime_export_diagnostic_parser_probe.py
+++ b/scripts/runtime_export_diagnostic_parser_probe.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import statistics
+import sys
+import tempfile
+import time
+import tracemalloc
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKER_ROOT = ROOT / "services/mlx-worker-python"
+for candidate in (ROOT, WORKER_ROOT):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))  # pragma: no cover - script bootstrap
+
+from worker.productization.export_target_diagnostics import build_diagnostic_metrics_report
+
+
+FIXTURE_ROOT = (
+    ROOT
+    / "services/mlx-worker-python/fixtures/runtime-export/target-manifests.dev.v1"
+)
+
+
+def _env_int(name: str, default: int, minimum: int) -> int:
+    try:
+        value = int(os.environ.get(name, str(default)))
+    except ValueError:
+        value = default
+    return max(minimum, value)
+
+
+def main() -> int:
+    manifests = sorted(FIXTURE_ROOT.glob("*/export-target-manifest.json"))
+    iterations = _env_int("MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS", 30, 1)
+    samples = _env_int("MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES", 5, 1)
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    target_count = 0.0
+    parser_coverage = 0.0
+    parsed_failure_count = 0.0
+    unknown_failure_count = 0.0
+    redaction_count = 0.0
+    diagnostic_latency_ms = 0.0
+    diagnosis_code_count = 0.0
+
+    for _sample in range(samples):
+        tracemalloc.start()
+        try:
+            started = time.perf_counter()
+            for _index in range(iterations):
+                with tempfile.TemporaryDirectory(prefix="melix-export-diagnostics-probe-") as directory:
+                    report = build_diagnostic_metrics_report(manifests, Path(directory))
+                if report.get("ok") is not True:
+                    raise SystemExit("export diagnostic parser probe failed")
+                target_count = float(report["target_count"])
+                parser_coverage = float(report["diagnostic_parser_coverage"])
+                parsed_failure_count = float(report["parsed_failure_count"])
+                unknown_failure_count = float(report["unknown_failure_count"])
+                redaction_count = float(report["redaction_count"])
+                diagnostic_latency_ms = float(report["diagnostic_latency_ms"])
+                diagnosis_code_count = float(report["diagnosis_code_count"])
+            elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+            _, peak_bytes = tracemalloc.get_traced_memory()
+            peak_samples.append(float(peak_bytes))
+        finally:
+            tracemalloc.stop()
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+                "peak_bytes_mean": statistics.fmean(peak_samples),
+                "target_count": target_count,
+                "diagnostic_parser_coverage": parser_coverage,
+                "parsed_failure_count": parsed_failure_count,
+                "unknown_failure_count": unknown_failure_count,
+                "redaction_count": redaction_count,
+                "diagnostic_latency_ms": diagnostic_latency_ms,
+                "diagnosis_code_count": diagnosis_code_count,
+                "iteration_count": float(iterations),
+                "sample_count": float(samples),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 from pathlib import Path
 
@@ -150,6 +151,78 @@ def test_export_target_diagnostics_preserves_bounded_unknown_failure_excerpt(
     assert receipt["redaction_summary"]["truncated"] is True
     assert receipt["redaction_summary"]["excerpt_byte_count"] <= 160
     assert excerpt
+
+
+def test_export_target_diagnostics_reads_only_bounded_log_chunk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+    manifest.diagnostic_policy.bounded_log_excerpt_bytes = 64
+    log_path = target_root / "logs/ollama-create.log"
+    log_path.write_text("runtime load failed " + ("detail " * 2000), encoding="utf-8")
+    original_open = Path.open
+    read_sizes: list[int] = []
+
+    class _TrackingBytes(io.BytesIO):
+        def __enter__(self) -> "_TrackingBytes":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            self.close()
+
+        def read(self, size: int = -1) -> bytes:
+            read_sizes.append(size)
+            return super().read(size)
+
+    def tracking_open(path: Path, mode: str = "r", *args: object, **kwargs: object) -> object:
+        if path == log_path and mode == "rb":
+            return _TrackingBytes(original_open(path, mode, *args, **kwargs).read())
+        return original_open(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", tracking_open)
+
+    receipt = write_export_diagnostics_receipt(layout, manifest)
+
+    assert read_sizes == [128]
+    assert receipt["status"] == "matched"
+
+
+def test_export_target_diagnostics_falls_back_when_path_resolution_raises_oserror(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+    raw_path = target_root / "artifacts/blobs/sha256-777777"
+    (target_root / "logs/ollama-create.log").write_text(
+        f"runtime load failed while opening {raw_path}\n",
+        encoding="utf-8",
+    )
+    original_resolve = Path.resolve
+
+    def raising_resolve(path: Path, *args: object, **kwargs: object) -> Path:
+        if path == raw_path:
+            raise OSError("path cannot be resolved")
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", raising_resolve)
+
+    receipt = write_export_diagnostics_receipt(layout, manifest)
+
+    excerpt = (target_root / "diagnostics/redacted-log-excerpt.txt").read_text(
+        encoding="utf-8"
+    )
+    assert receipt["status"] == "matched"
+    assert str(raw_path) not in excerpt
+    assert "<absolute-path>" in excerpt
 
 
 def test_export_target_diagnostics_not_applicable_without_logs_or_failures(

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from packages.protocol.python.workspace.v1 import export_target_manifest_pb2
+from worker.productization.export_target_diagnostics import (
+    CODE_DUPLICATE_TENSOR_NAME,
+    CODE_INSUFFICIENT_MEMORY,
+    CODE_INVALID_RUNTIME_PATH,
+    CODE_MISSING_BINARY,
+    CODE_MISSING_BLOB,
+    CODE_PERMISSION_DENIED,
+    CODE_RUNTIME_LOAD_FAILED,
+    CODE_RUNTIME_TIMEOUT,
+    CODE_UNKNOWN_FAILURE,
+    CODE_UNSUPPORTED_ARCHITECTURE,
+    EXPORT_DIAGNOSTICS_RECEIPT_SCHEMA_VERSION,
+    build_diagnostic_metrics_report,
+    build_export_diagnostics_receipt,
+    write_export_diagnostics_receipt,
+)
+from worker.productization.export_target_layout import (
+    build_export_target_layout,
+    materialize_export_target_layout,
+)
+from worker.productization.export_target_manifest import validate_export_target_manifest_file
+
+
+FIXTURE_ROOT = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures/runtime-export/target-manifests.dev.v1"
+)
+
+
+@pytest.mark.parametrize(
+    ("expected_code", "log_line"),
+    [
+        (CODE_RUNTIME_LOAD_FAILED, "runtime load failed while opening model"),
+        (CODE_UNSUPPORTED_ARCHITECTURE, "unsupported architecture arm64 required"),
+        (CODE_DUPLICATE_TENSOR_NAME, "duplicate tensor name decoder.layers.0"),
+        (CODE_MISSING_BLOB, "missing blob sha256-777777 not found"),
+        (CODE_MISSING_BINARY, "runtime binary not installed: ollama"),
+        (CODE_INVALID_RUNTIME_PATH, "invalid runtime path /tmp/melix/bad-target"),
+        (CODE_RUNTIME_TIMEOUT, "generation smoke timed out after deadline exceeded"),
+        (CODE_PERMISSION_DENIED, "permission denied opening model weights"),
+        (CODE_INSUFFICIENT_MEMORY, "Metal out of memory during load"),
+    ],
+)
+def test_export_target_diagnostics_parser_matches_common_runtime_failures(
+    tmp_path: Path,
+    expected_code: str,
+    log_line: str,
+) -> None:
+    target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+    (target_root / "logs/ollama-create.log").write_text(log_line + "\n", encoding="utf-8")
+
+    receipt = write_export_diagnostics_receipt(layout, manifest)
+
+    receipt_path = target_root / "diagnostics/diagnostics-receipt.json"
+    excerpt_path = target_root / "diagnostics/redacted-log-excerpt.txt"
+    assert receipt["schema_version"] == EXPORT_DIAGNOSTICS_RECEIPT_SCHEMA_VERSION
+    assert receipt["status"] == "matched"
+    assert receipt["diagnoses"][0]["code"] == expected_code
+    assert receipt["diagnoses"][0]["evidence_path"].startswith(
+        "diagnostics/redacted-log-excerpt.txt#line-"
+    )
+    assert receipt["operator_remedies"][0]["code"] == expected_code
+    assert receipt["metrics"]["parsed_failure_count"] >= 1
+    assert receipt_path.is_file()
+    assert json.loads(receipt_path.read_text(encoding="utf-8")) == receipt
+    assert excerpt_path.read_text(encoding="utf-8").startswith("[logs/ollama-create.log]")
+
+
+def test_export_target_diagnostics_redacts_paths_secrets_private_text_and_identity(
+    tmp_path: Path,
+) -> None:
+    target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+    log_text = "\n".join(
+        [
+            f"failed to load model from {target_root / 'artifacts/blobs/sha256-777777'}",
+            "Authorization: Bearer sk-testsecret123456",
+            "api_key=super-secret-value",
+            "proxy=http://user:secret-proxy-pass@example.test",
+            "prompt: private customer prompt that must not leave the log",
+            "operator_id=chenyu",
+        ]
+    )
+    (target_root / "logs/ollama-create.log").write_text(log_text + "\n", encoding="utf-8")
+
+    receipt = write_export_diagnostics_receipt(layout, manifest)
+
+    excerpt = (target_root / "diagnostics/redacted-log-excerpt.txt").read_text(
+        encoding="utf-8"
+    )
+    encoded_receipt = json.dumps(receipt, sort_keys=True)
+    assert str(target_root) not in excerpt
+    assert str(target_root) not in encoded_receipt
+    assert "<target>/artifacts/blobs/sha256-777777" in excerpt
+    assert "sk-testsecret" not in excerpt
+    assert "super-secret-value" not in excerpt
+    assert "secret-proxy-pass" not in excerpt
+    assert "private customer prompt" not in excerpt
+    assert "chenyu" not in excerpt
+    assert receipt["redaction_summary"]["redacted_absolute_path_count"] >= 1
+    assert receipt["redaction_summary"]["redacted_secret_count"] >= 3
+    assert receipt["redaction_summary"]["redacted_prompt_or_response_count"] == 1
+    assert receipt["redaction_summary"]["redacted_identity_count"] >= 1
+
+
+def test_export_target_diagnostics_preserves_bounded_unknown_failure_excerpt(
+    tmp_path: Path,
+) -> None:
+    target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "melix_managed/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+    manifest.diagnostic_policy.bounded_log_excerpt_bytes = 160
+
+    receipt = write_export_diagnostics_receipt(
+        layout,
+        manifest,
+        failure_checks=[
+            {
+                "check": "load_check",
+                "status": "failed",
+                "failure_code": "opaque_runtime_failure",
+                "failure_message": "unclassified runtime symptom " + ("detail " * 80),
+                "evidence_path": "smoke/smoke-receipt.json",
+            }
+        ],
+    )
+
+    excerpt = (target_root / "diagnostics/redacted-log-excerpt.txt").read_text(
+        encoding="utf-8"
+    )
+    assert receipt["status"] == "unknown"
+    assert receipt["diagnoses"][0]["code"] == CODE_UNKNOWN_FAILURE
+    assert receipt["bounded_log_excerpt_path"] == "diagnostics/redacted-log-excerpt.txt"
+    assert receipt["redaction_summary"]["truncated"] is True
+    assert receipt["redaction_summary"]["excerpt_byte_count"] <= 160
+    assert excerpt
+
+
+def test_export_target_diagnostics_not_applicable_without_logs_or_failures(
+    tmp_path: Path,
+) -> None:
+    _target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "mlx_runtime/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+
+    receipt = build_export_diagnostics_receipt(layout, manifest)
+
+    assert receipt["status"] == "not_applicable"
+    assert receipt["diagnoses"] == []
+    assert receipt["operator_remedies"] == []
+    assert receipt["bounded_log_excerpt_path"] == ""
+    assert receipt["metrics"]["parsed_failure_count"] == 0
+
+
+def test_export_target_diagnostics_metrics_report_covers_supported_codes(
+    tmp_path: Path,
+) -> None:
+    payload = build_diagnostic_metrics_report(
+        sorted(FIXTURE_ROOT.glob("*/export-target-manifest.json")),
+        tmp_path,
+    )
+
+    assert payload["ok"] is True
+    assert payload["target_count"] == 4
+    assert payload["diagnostic_parser_coverage"] == 1.0
+    assert payload["diagnosis_code_count"] == 9
+    assert payload["parsed_failure_count"] >= 9
+    assert payload["unknown_failure_count"] == 1
+    assert payload["redaction_count"] >= 2
+    assert payload["diagnostic_latency_ms"] >= 0
+
+
+def _materialized_manifest(
+    workspace_root: Path,
+    manifest_path: Path,
+) -> tuple[Path, export_target_manifest_pb2.ExportTargetManifest]:
+    export_report = materialize_export_target_layout(
+        manifest_path,
+        workspace_root,
+        create_placeholder_files=True,
+    )
+    target_root = workspace_root / str(export_report["target_root"])
+    manifest, validation_report = validate_export_target_manifest_file(
+        target_root / "export-target-manifest.json",
+        return_manifest=True,
+    )
+    assert validation_report.ok is True
+    return target_root, manifest

--- a/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
+++ b/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
@@ -93,13 +93,28 @@ def test_export_target_smoke_blocks_report_when_required_file_is_missing(
     )
 
     updated_report = json.loads((target_root / "export-report.json").read_text(encoding="utf-8"))
+    diagnostics_receipt = json.loads(
+        (target_root / "diagnostics/diagnostics-receipt.json").read_text(encoding="utf-8")
+    )
+    diagnostics_excerpt = (target_root / "diagnostics/redacted-log-excerpt.txt").read_text(
+        encoding="utf-8"
+    )
 
     assert receipt["status"] == "failed"
     assert receipt["metadata_check"]["status"] == "failed"
     assert receipt["metadata_check"]["failure_code"] == "missing_required_file"
     assert receipt["operator_failures"][0]["diagnostics_receipt_path"] == "diagnostics/diagnostics-receipt.json"
+    assert receipt["diagnostics_status"] == "matched"
+    assert receipt["diagnostic_codes"] == ["missing_blob"]
+    assert receipt["operator_remedies"][0]["code"] == "missing_blob"
+    assert diagnostics_receipt["diagnoses"][0]["code"] == "missing_blob"
+    assert diagnostics_receipt["bounded_log_excerpt_path"] == "diagnostics/redacted-log-excerpt.txt"
+    assert str(tmp_path) not in json.dumps(diagnostics_receipt, sort_keys=True)
+    assert str(tmp_path) not in diagnostics_excerpt
     assert updated_report["verification_terminal_state"] == "blocked"
     assert updated_report["verification_blocker_code"] == "missing_required_file"
+    assert updated_report["diagnostic_codes"] == ["missing_blob"]
+    assert updated_report["operator_remedies"][0]["code"] == "missing_blob"
     assert updated_report["ok"] is False
 
 
@@ -304,6 +319,7 @@ def test_export_target_smoke_failure_boundaries(
         available_runtime_binaries=set(),
     )
     assert non_waivable_runtime_receipt["load_check"]["failure_code"] == "runtime_not_installed"
+    assert non_waivable_runtime_receipt["diagnostic_codes"] == ["missing_binary"]
     assert non_waivable_runtime_receipt["waiver"] == {}
 
     perf_counter_values = iter((0.0, 0.02))
@@ -334,6 +350,11 @@ def test_export_target_smoke_failure_boundaries(
     )
     assert export_target_smoke._terminal_status((blocked_result,)) == "blocked"
     assert export_target_smoke._waiver_id({"waiver": []}) == ""
+    assert export_target_smoke._diagnostic_codes({"diagnoses": "invalid"}) == []
+    assert export_target_smoke._diagnostic_codes(
+        {"diagnoses": ["invalid", {"code": "missing_blob"}, {"code": "missing_blob"}]}
+    ) == ["missing_blob"]
+    assert export_target_smoke._operator_remedies({"operator_remedies": "invalid"}) == []
 
 
 def test_runtime_export_smoke_policy_probe_failure_paths(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1188,6 +1188,18 @@ def test_scope_report_selects_runtime_export_smoke_policy_probe() -> None:
     assert scope["selected_probes"][0]["id"] == "runtime-export-smoke-policy"
 
 
+def test_scope_report_selects_runtime_export_diagnostic_parser_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=[
+            "services/mlx-worker-python/worker/productization/export_target_diagnostics.py"
+        ],
+    )
+
+    assert scope["selected_count"] == 1
+    assert scope["selected_probes"][0]["id"] == "runtime-export-diagnostic-parser"
+
+
 def test_lora_experiment_run_dir_scan_probe_script_smoke(capsys: pytest.CaptureFixture[str]) -> None:
     runpy.run_path(
         str(REPO_ROOT / "scripts/lora_experiment_run_dir_scan_probe.py"),
@@ -3228,6 +3240,31 @@ def test_runtime_export_smoke_policy_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] >= 0
 
 
+def test_runtime_export_diagnostic_parser_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS", "1")
+    monkeypatch.setenv("MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES", "1")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(
+            str(REPO_ROOT / "scripts/runtime_export_diagnostic_parser_probe.py"),
+            run_name="__main__",
+        )
+
+    assert exc_info.value.code == 0
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["target_count"] == 4.0
+    assert metrics["diagnostic_parser_coverage"] == 1.0
+    assert metrics["diagnosis_code_count"] == 9.0
+    assert metrics["parsed_failure_count"] >= 9.0
+    assert metrics["unknown_failure_count"] == 1.0
+    assert metrics["redaction_count"] >= 2.0
+    assert metrics["diagnostic_latency_ms"] >= 0
+    assert metrics["elapsed_ms_mean"] >= 0
+
+
 def test_runtime_utils_top_level_weights_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -3713,6 +3750,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "runtime-export-manifest-validation",
         "runtime-export-layout-retention",
         "runtime-export-smoke-policy",
+        "runtime-export-diagnostic-parser",
         "same-cohort-batching-probe-evidence",
         "runtime-utils-kwarg-signature-cache",
         "runtime-utils-package-version-cache",
@@ -3992,6 +4030,9 @@ def test_registered_probe_registry_entries_validate_commands_and_watch_globs() -
     runtime_export_smoke_probe_command = by_id["runtime-export-smoke-policy"]["probe_command"]
     assert "../head/$SCRIPT" in runtime_export_smoke_probe_command
     assert "${GITHUB_WORKSPACE:-}/head/$SCRIPT" in runtime_export_smoke_probe_command
+    runtime_export_diagnostics_probe_command = by_id["runtime-export-diagnostic-parser"]["probe_command"]
+    assert "../head/$SCRIPT" in runtime_export_diagnostics_probe_command
+    assert "${GITHUB_WORKSPACE:-}/head/$SCRIPT" in runtime_export_diagnostics_probe_command
     runtime_export_smoke_metrics = {
         metric["key"]: metric
         for metric in by_id["runtime-export-smoke-policy"]["metrics"]
@@ -4001,6 +4042,17 @@ def test_registered_probe_registry_entries_validate_commands_and_watch_globs() -
     assert runtime_export_smoke_metrics["load_smoke_latency_ms"]["direction"] == "informational"
     assert runtime_export_smoke_metrics["generation_smoke_latency_ms"]["direction"] == "informational"
     assert runtime_export_smoke_metrics["timeout_count"]["warn_abs"] == 0.0
+    runtime_export_diagnostics_metrics = {
+        metric["key"]: metric
+        for metric in by_id["runtime-export-diagnostic-parser"]["metrics"]
+    }
+    assert runtime_export_diagnostics_metrics["elapsed_ms_mean"]["direction"] == "lower_is_better"
+    assert runtime_export_diagnostics_metrics["diagnostic_parser_coverage"]["direction"] == "higher_is_better"
+    assert runtime_export_diagnostics_metrics["diagnostic_parser_coverage"]["warn_abs"] == 0.0
+    assert runtime_export_diagnostics_metrics["parsed_failure_count"]["direction"] == "informational"
+    assert runtime_export_diagnostics_metrics["unknown_failure_count"]["direction"] == "informational"
+    assert runtime_export_diagnostics_metrics["redaction_count"]["direction"] == "informational"
+    assert runtime_export_diagnostics_metrics["diagnostic_latency_ms"]["direction"] == "lower_is_better"
 
     probe_policy_metrics = {
         metric["key"]: metric for metric in by_id["probe-policy-noop-overhead"]["metrics"]

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -53,7 +53,7 @@ SUPPORTED_DIAGNOSIS_CODES = (
 )
 _KNOWN_DIAGNOSIS_CODES = tuple(code for code in SUPPORTED_DIAGNOSIS_CODES if code != CODE_UNKNOWN_FAILURE)
 
-_ABSOLUTE_PATH_PATTERN = re.compile(r"(?<![A-Za-z0-9_.-])/(?:[^\s:'\"<>|]+/?)+")
+_ABSOLUTE_PATH_PATTERN = re.compile(r"(?<![A-Za-z0-9_.-])/[^\s:'\"<>|]+")
 _BEARER_SECRET_PATTERN = re.compile(
     r"(?i)\b(authorization\s*:\s*bearer\s+)[A-Za-z0-9._~+/=-]+"
 )
@@ -450,7 +450,8 @@ def _collect_source_lines(
         path = _target_relative_path(layout, row.path)
         if not path.is_file():
             continue
-        text = path.read_bytes()[:source_read_bytes].decode("utf-8", errors="replace")
+        with path.open("rb") as source:
+            text = source.read(source_read_bytes).decode("utf-8", errors="replace")
         lines.extend(_split_source_lines(row.path, text))
 
     for check in failure_checks:
@@ -608,7 +609,7 @@ def _redact_absolute_path(
             layout.target_root.resolve(strict=False)
         )
         replacement = f"<target>/{relative.as_posix()}"
-    except ValueError:
+    except (ValueError, OSError):
         pass
     summary.redacted_absolute_path_count += 1
     summary.redaction_count += 1

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -1,0 +1,714 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+
+from packages.protocol.python.workspace.v1 import export_target_manifest_pb2
+from worker.productization.export_target_layout import (
+    ExportTargetLayout,
+    build_export_target_layout,
+    materialize_export_target_layout,
+    _target_relative_path,
+)
+from worker.productization.export_target_manifest import validate_export_target_manifest_file
+
+
+EXPORT_DIAGNOSTICS_RECEIPT_SCHEMA_VERSION = "melix.export_diagnostics_receipt.v1"
+EXPORT_DIAGNOSTICS_METRICS_SCHEMA_VERSION = "melix.export_diagnostics.metrics.v1"
+DEFAULT_PARSER_POLICY_ID = "runtime-export-log-v1"
+DEFAULT_BOUNDED_LOG_BYTES = 8192
+DEFAULT_BOUNDED_LOG_LINES = 120
+_SOURCE_READ_MULTIPLIER = 2
+
+DIAGNOSTIC_STATUS_MATCHED = "matched"
+DIAGNOSTIC_STATUS_UNKNOWN = "unknown"
+DIAGNOSTIC_STATUS_NOT_APPLICABLE = "not_applicable"
+
+CODE_RUNTIME_LOAD_FAILED = "runtime_load_failed"
+CODE_UNSUPPORTED_ARCHITECTURE = "unsupported_architecture"
+CODE_DUPLICATE_TENSOR_NAME = "duplicate_tensor_name"
+CODE_MISSING_BLOB = "missing_blob"
+CODE_MISSING_BINARY = "missing_binary"
+CODE_INVALID_RUNTIME_PATH = "invalid_runtime_path"
+CODE_RUNTIME_TIMEOUT = "runtime_timeout"
+CODE_PERMISSION_DENIED = "permission_denied"
+CODE_INSUFFICIENT_MEMORY = "insufficient_memory"
+CODE_UNKNOWN_FAILURE = "unknown_failure"
+
+SUPPORTED_DIAGNOSIS_CODES = (
+    CODE_RUNTIME_LOAD_FAILED,
+    CODE_UNSUPPORTED_ARCHITECTURE,
+    CODE_DUPLICATE_TENSOR_NAME,
+    CODE_MISSING_BLOB,
+    CODE_MISSING_BINARY,
+    CODE_INVALID_RUNTIME_PATH,
+    CODE_RUNTIME_TIMEOUT,
+    CODE_PERMISSION_DENIED,
+    CODE_INSUFFICIENT_MEMORY,
+    CODE_UNKNOWN_FAILURE,
+)
+_KNOWN_DIAGNOSIS_CODES = tuple(code for code in SUPPORTED_DIAGNOSIS_CODES if code != CODE_UNKNOWN_FAILURE)
+
+_ABSOLUTE_PATH_PATTERN = re.compile(r"(?<![A-Za-z0-9_.-])/(?:[^\s:'\"<>|]+/?)+")
+_BEARER_SECRET_PATTERN = re.compile(
+    r"(?i)\b(authorization\s*:\s*bearer\s+)[A-Za-z0-9._~+/=-]+"
+)
+_NAMED_SECRET_PATTERN = re.compile(
+    r"(?i)\b(api[_-]?key|access[_-]?token|token|password|secret)\s*[:=]\s*['\"]?[^'\"\s,;]+['\"]?"
+)
+_URL_CREDENTIAL_PATTERN = re.compile(r"(?i)(https?://[^:\s/@]+:)[^@\s]+(@)")
+_OPENAI_KEY_PATTERN = re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b")
+_CERTIFICATE_PATTERN = re.compile(r"-----BEGIN [^-]+-----.+?-----END [^-]+-----")
+_PRIVATE_TEXT_LINE_PATTERN = re.compile(
+    r"(?i)^\s*(prompt|response|completion|generated text|dataset row|private prompt template|operator input)\s*[:=]"
+)
+_IDENTITY_PATTERN = re.compile(
+    r"(?i)\b(user|operator)(?:[_-]?(?:id|name))?\s*[:=]\s*['\"]?[^'\"\s,;]+['\"]?"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _DiagnosisPattern:
+    code: str
+    severity: str
+    pattern_id: str
+    expressions: tuple[re.Pattern[str], ...]
+    operator_message: str
+    remediation: str
+
+    def matches(self, text: str) -> bool:
+        return any(expression.search(text) for expression in self.expressions)
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceLine:
+    source_path: str
+    text: str
+
+
+@dataclass(slots=True)
+class _RedactionSummary:
+    excerpt_byte_count: int = 0
+    excerpt_line_count: int = 0
+    truncated: bool = False
+    redaction_count: int = 0
+    redacted_absolute_path_count: int = 0
+    redacted_secret_count: int = 0
+    redacted_prompt_or_response_count: int = 0
+    redacted_identity_count: int = 0
+
+    def payload(self, *, policy_id: str) -> dict[str, object]:
+        return {
+            "policy_id": policy_id,
+            "excerpt_byte_count": self.excerpt_byte_count,
+            "excerpt_line_count": self.excerpt_line_count,
+            "truncated": self.truncated,
+            "redaction_count": self.redaction_count,
+            "redacted_absolute_path_count": self.redacted_absolute_path_count,
+            "redacted_secret_count": self.redacted_secret_count,
+            "redacted_prompt_or_response_count": self.redacted_prompt_or_response_count,
+            "redacted_identity_count": self.redacted_identity_count,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _Excerpt:
+    path: str
+    text: str
+    line_numbers: dict[int, int]
+    summary: _RedactionSummary
+
+
+def _compile(*patterns: str) -> tuple[re.Pattern[str], ...]:
+    return tuple(re.compile(pattern, re.IGNORECASE) for pattern in patterns)
+
+
+_DIAGNOSIS_PATTERNS = (
+    _DiagnosisPattern(
+        code=CODE_UNSUPPORTED_ARCHITECTURE,
+        severity="error",
+        pattern_id="unsupported-architecture-v1",
+        expressions=_compile(
+            r"unsupported architecture",
+            r"bad cpu type",
+            r"mach-o.+wrong architecture",
+            r"not supported on this architecture",
+            r"arm64.+required",
+        ),
+        operator_message="The target runtime cannot load this artifact on the current host architecture.",
+        remediation="Use an Apple Silicon compatible runtime binary or export for a compatible target architecture.",
+    ),
+    _DiagnosisPattern(
+        code=CODE_DUPLICATE_TENSOR_NAME,
+        severity="error",
+        pattern_id="duplicate-tensor-name-v1",
+        expressions=_compile(
+            r"duplicate tensor(?: name)?",
+            r"tensor .+ already exists",
+            r"duplicated key",
+        ),
+        operator_message="The runtime reported duplicate tensor names while loading the export.",
+        remediation="Regenerate the export from a clean adapter snapshot and inspect the conversion step that writes tensor names.",
+    ),
+    _DiagnosisPattern(
+        code=CODE_MISSING_BLOB,
+        severity="error",
+        pattern_id="missing-blob-v1",
+        expressions=_compile(
+            r"missing blob",
+            r"blob .+ not found",
+            r"no such blob",
+            r"sha256[-:][A-Fa-f0-9]+.+not found",
+            r"missing required smoke files:.+(blob|sha256|artifact)",
+        ),
+        operator_message="The target artifact references a blob or required artifact that is not present.",
+        remediation="Re-run target materialization and verify required artifact digests before runtime load.",
+    ),
+    _DiagnosisPattern(
+        code=CODE_MISSING_BINARY,
+        severity="error",
+        pattern_id="missing-runtime-binary-v1",
+        expressions=_compile(
+            r"command not found",
+            r"binary not found",
+            r"executable file not found",
+            r"runtime binary not installed",
+            r"no such file or directory:.+\b(ollama|mlx_lm|llama-cli|llama\.cpp)",
+        ),
+        operator_message="The target runtime binary is missing or not available on PATH.",
+        remediation="Install the required runtime binary or configure the export target to use an available local runtime.",
+    ),
+    _DiagnosisPattern(
+        code=CODE_INVALID_RUNTIME_PATH,
+        severity="error",
+        pattern_id="invalid-runtime-path-v1",
+        expressions=_compile(
+            r"invalid runtime path",
+            r"invalid model path",
+            r"path does not exist",
+            r"not a directory",
+        ),
+        operator_message="The runtime was invoked with a path that is invalid for this target.",
+        remediation="Use target-relative manifest paths and regenerate the export report before retrying the runtime load.",
+    ),
+    _DiagnosisPattern(
+        code=CODE_RUNTIME_TIMEOUT,
+        severity="error",
+        pattern_id="runtime-timeout-v1",
+        expressions=_compile(
+            r"timed out",
+            r"\btimeout\b",
+            r"deadline exceeded",
+            r"exceeded timeout",
+        ),
+        operator_message="The runtime did not finish the load or generation smoke check within the configured timeout.",
+        remediation="Inspect runtime logs for slow startup, reduce the target artifact size, or increase the verified timeout policy.",
+    ),
+    _DiagnosisPattern(
+        code=CODE_PERMISSION_DENIED,
+        severity="error",
+        pattern_id="permission-denied-v1",
+        expressions=_compile(
+            r"permission denied",
+            r"operation not permitted",
+            r"\bEACCES\b",
+        ),
+        operator_message="The runtime cannot read or execute a required export path because of local permissions.",
+        remediation="Fix file permissions for the target directory and retry the smoke check from the same worktree.",
+    ),
+    _DiagnosisPattern(
+        code=CODE_INSUFFICIENT_MEMORY,
+        severity="error",
+        pattern_id="insufficient-memory-v1",
+        expressions=_compile(
+            r"out of memory",
+            r"\bOOM\b",
+            r"cannot allocate memory",
+            r"memory pressure",
+            r"metal.+out of memory",
+        ),
+        operator_message="The host did not have enough memory for the runtime load or generation check.",
+        remediation="Free memory, choose a smaller or more quantized target, or retry on a host with more memory.",
+    ),
+    _DiagnosisPattern(
+        code=CODE_RUNTIME_LOAD_FAILED,
+        severity="error",
+        pattern_id="runtime-load-failed-v1",
+        expressions=_compile(
+            r"failed to load model",
+            r"model load failed",
+            r"runtime load failed",
+            r"error loading model",
+            r"load failed",
+        ),
+        operator_message="The target runtime failed while loading the exported artifact.",
+        remediation="Inspect the redacted runtime evidence, then regenerate or repair the target artifact before retrying.",
+    ),
+)
+
+
+def write_export_diagnostics_receipt(
+    layout: ExportTargetLayout,
+    manifest: export_target_manifest_pb2.ExportTargetManifest,
+    *,
+    failure_checks: Iterable[object] = (),
+    now: float | None = None,
+) -> dict[str, object]:
+    receipt = build_export_diagnostics_receipt(
+        layout,
+        manifest,
+        failure_checks=failure_checks,
+        now=now,
+    )
+    receipt_path = _target_relative_path(
+        layout,
+        manifest.evidence.diagnostics_receipt_path or "diagnostics/diagnostics-receipt.json",
+    )
+    _write_json(receipt_path, receipt)
+    return receipt
+
+
+def build_export_diagnostics_receipt(
+    layout: ExportTargetLayout,
+    manifest: export_target_manifest_pb2.ExportTargetManifest,
+    *,
+    failure_checks: Iterable[object] = (),
+    now: float | None = None,
+) -> dict[str, object]:
+    del now
+    started = time.perf_counter()
+    bounded_bytes = int(manifest.diagnostic_policy.bounded_log_excerpt_bytes) or DEFAULT_BOUNDED_LOG_BYTES
+    source_lines = _collect_source_lines(
+        layout,
+        manifest,
+        failure_checks=failure_checks,
+        bounded_bytes=bounded_bytes,
+    )
+    excerpt = _build_redacted_excerpt(
+        layout,
+        source_lines,
+        bounded_bytes=bounded_bytes,
+        bounded_lines=DEFAULT_BOUNDED_LOG_LINES,
+    )
+    if excerpt.text:
+        excerpt_path = _target_relative_path(layout, excerpt.path)
+        excerpt_path.parent.mkdir(parents=True, exist_ok=True)
+        excerpt_path.write_text(excerpt.text, encoding="utf-8")
+
+    diagnoses = _diagnoses_from_excerpt(source_lines, excerpt.line_numbers, excerpt.path)
+    if not diagnoses and source_lines:
+        diagnoses = [
+            {
+                "code": CODE_UNKNOWN_FAILURE,
+                "severity": "error",
+                "matched_pattern_id": "unknown-failure-fallback-v1",
+                "operator_message": "The export target failed, but no known runtime diagnostic pattern matched.",
+                "remediation": "Use the bounded redacted excerpt to extend the parser or inspect target-local runtime logs.",
+                "evidence_path": excerpt.path,
+            }
+        ]
+
+    if not source_lines:
+        status = DIAGNOSTIC_STATUS_NOT_APPLICABLE
+    elif any(diagnosis["code"] != CODE_UNKNOWN_FAILURE for diagnosis in diagnoses):
+        status = DIAGNOSTIC_STATUS_MATCHED
+    else:
+        status = DIAGNOSTIC_STATUS_UNKNOWN
+
+    diagnostic_latency_ms = (time.perf_counter() - started) * 1000.0
+    required_codes = {
+        str(code)
+        for code in manifest.diagnostic_policy.required_diagnosis_codes
+        if str(code) in _KNOWN_DIAGNOSIS_CODES
+    }
+    matched_codes = {
+        str(diagnosis["code"])
+        for diagnosis in diagnoses
+        if diagnosis["code"] != CODE_UNKNOWN_FAILURE
+    }
+    coverage = _diagnostic_coverage(required_codes, matched_codes, status)
+    redaction_summary = excerpt.summary.payload(policy_id=manifest.evidence.redaction_policy_id or "export-diagnostics-redaction-v1")
+    metrics = {
+        "schema_version": EXPORT_DIAGNOSTICS_METRICS_SCHEMA_VERSION,
+        "diagnostic_parser_coverage": coverage,
+        "parsed_failure_count": sum(
+            1 for diagnosis in diagnoses if diagnosis["code"] != CODE_UNKNOWN_FAILURE
+        ),
+        "unknown_failure_count": sum(
+            1 for diagnosis in diagnoses if diagnosis["code"] == CODE_UNKNOWN_FAILURE
+        ),
+        "redaction_count": redaction_summary["redaction_count"],
+        "diagnostic_latency_ms": diagnostic_latency_ms,
+    }
+    return {
+        "schema_version": EXPORT_DIAGNOSTICS_RECEIPT_SCHEMA_VERSION,
+        "export_id": manifest.export_id,
+        "target_id": manifest.target_id,
+        "target_type": export_target_manifest_pb2.ExportTargetType.Name(manifest.target_type),
+        "parser_policy_id": manifest.diagnostic_policy.parser_policy_id or DEFAULT_PARSER_POLICY_ID,
+        "status": status,
+        "diagnoses": diagnoses,
+        "redaction_summary": redaction_summary,
+        "bounded_log_excerpt_path": excerpt.path if excerpt.text else "",
+        "operator_remedies": _operator_remedies(diagnoses),
+        "metrics": metrics,
+    }
+
+
+def build_diagnostic_metrics_report(
+    manifest_paths: Iterable[Path],
+    workspace_root: Path | str,
+    *,
+    now: float | None = None,
+) -> dict[str, object]:
+    started = time.perf_counter()
+    receipts: list[dict[str, object]] = []
+    errors: list[str] = []
+    root = Path(workspace_root)
+
+    for index, manifest_path in enumerate(manifest_paths):
+        export_report = materialize_export_target_layout(
+            manifest_path,
+            root,
+            create_placeholder_files=True,
+            now=now,
+        )
+        if export_report.get("ok") is not True:
+            errors.extend(str(error) for error in export_report.get("errors", []))
+            continue
+        target_root = root / str(export_report["target_root"])
+        manifest, validation_report = validate_export_target_manifest_file(
+            target_root / "export-target-manifest.json",
+            return_manifest=True,
+        )
+        if not validation_report.ok:
+            errors.extend(str(error) for error in validation_report.errors)
+            continue
+        layout = build_export_target_layout(root, manifest)
+        try:
+            receipts.append(
+                write_export_diagnostics_receipt(
+                    layout,
+                    manifest,
+                    failure_checks=_fixture_failure_checks(index),
+                    now=now,
+                )
+            )
+        except Exception as exc:  # pragma: no cover - aggregate probe errors
+            errors.append(str(exc))
+
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    metrics = [
+        receipt["metrics"]
+        for receipt in receipts
+        if isinstance(receipt.get("metrics"), dict)
+    ]
+    matched_codes = {
+        str(diagnosis["code"])
+        for receipt in receipts
+        for diagnosis in receipt.get("diagnoses", [])
+        if isinstance(diagnosis, dict) and diagnosis.get("code") != CODE_UNKNOWN_FAILURE
+    }
+    parser_coverage = len(matched_codes & set(_KNOWN_DIAGNOSIS_CODES)) / len(_KNOWN_DIAGNOSIS_CODES)
+    return {
+        "schema_version": EXPORT_DIAGNOSTICS_METRICS_SCHEMA_VERSION,
+        "ok": not errors and parser_coverage == 1.0,
+        "target_count": len(receipts),
+        "diagnostic_policy_latency_ms": elapsed_ms,
+        "diagnostic_parser_coverage": parser_coverage,
+        "parsed_failure_count": sum(int(metric.get("parsed_failure_count", 0)) for metric in metrics),
+        "unknown_failure_count": sum(int(metric.get("unknown_failure_count", 0)) for metric in metrics),
+        "redaction_count": sum(int(metric.get("redaction_count", 0)) for metric in metrics),
+        "diagnostic_latency_ms": sum(float(metric.get("diagnostic_latency_ms", 0.0)) for metric in metrics),
+        "diagnosis_code_count": len(matched_codes),
+        "errors": errors,
+        "receipts": receipts,
+    }
+
+
+def _collect_source_lines(
+    layout: ExportTargetLayout,
+    manifest: export_target_manifest_pb2.ExportTargetManifest,
+    *,
+    failure_checks: Iterable[object],
+    bounded_bytes: int,
+) -> list[_SourceLine]:
+    lines: list[_SourceLine] = []
+    seen_paths: set[str] = set()
+    source_read_bytes = max(bounded_bytes * _SOURCE_READ_MULTIPLIER, bounded_bytes)
+
+    for row in (*manifest.generated_files, *manifest.required_files, *manifest.intermediate_files):
+        if not _is_runtime_log_row(row):
+            continue
+        if row.path in seen_paths:
+            continue
+        seen_paths.add(row.path)
+        path = _target_relative_path(layout, row.path)
+        if not path.is_file():
+            continue
+        text = path.read_bytes()[:source_read_bytes].decode("utf-8", errors="replace")
+        lines.extend(_split_source_lines(row.path, text))
+
+    for check in failure_checks:
+        failure_message = _check_value(check, "failure_message")
+        failure_code = _check_value(check, "failure_code")
+        status = _check_value(check, "status")
+        if not failure_message and not failure_code:
+            continue
+        if status and status not in {"failed", "blocked"}:
+            continue
+        check_name = _check_value(check, "check") or _check_value(check, "name") or "smoke_failure"
+        evidence_path = _check_value(check, "evidence_path") or manifest.evidence.smoke_receipt_path
+        text = f"{check_name}: {failure_code}: {failure_message}".strip()
+        lines.extend(_split_source_lines(evidence_path or "smoke/smoke-receipt.json", text))
+
+    return lines
+
+
+def _is_runtime_log_row(row: export_target_manifest_pb2.ExportTargetFile) -> bool:
+    return (
+        row.role == export_target_manifest_pb2.EXPORT_TARGET_FILE_ROLE_RUNTIME_LOG
+        or row.retention_class == export_target_manifest_pb2.EXPORT_RETENTION_CLASS_RUNTIME_LOG
+        or row.path.startswith("logs/")
+    )
+
+
+def _split_source_lines(source_path: str, text: str) -> list[_SourceLine]:
+    if not text:
+        return []
+    return [_SourceLine(source_path=source_path, text=line) for line in text.splitlines()]
+
+
+def _check_value(check: object, name: str) -> str:
+    if isinstance(check, Mapping):
+        value = check.get(name, "")
+    else:
+        value = getattr(check, name, "")
+    return str(value) if value is not None else ""
+
+
+def _build_redacted_excerpt(
+    layout: ExportTargetLayout,
+    source_lines: list[_SourceLine],
+    *,
+    bounded_bytes: int,
+    bounded_lines: int,
+) -> _Excerpt:
+    summary = _RedactionSummary()
+    if not source_lines:
+        return _Excerpt(path="", text="", line_numbers={}, summary=summary)
+
+    output_lines: list[str] = []
+    line_numbers: dict[int, int] = {}
+    used_bytes = 0
+    for index, source_line in enumerate(source_lines):
+        if len(output_lines) >= bounded_lines:
+            summary.truncated = True
+            break
+        redacted = _redact_text(source_line.text, layout, summary)
+        rendered = f"[{source_line.source_path}] {redacted}"
+        rendered_bytes = (rendered + "\n").encode("utf-8")
+        if used_bytes + len(rendered_bytes) > bounded_bytes:
+            remaining = max(0, bounded_bytes - used_bytes)
+            if remaining > 0:
+                clipped = rendered_bytes[:remaining].decode("utf-8", errors="ignore")
+                output_lines.append(clipped)
+                line_numbers[index] = len(output_lines)
+                used_bytes += len(clipped.encode("utf-8"))
+            summary.truncated = True
+            break
+        output_lines.append(rendered)
+        line_numbers[index] = len(output_lines)
+        used_bytes += len(rendered_bytes)
+
+    text = "\n".join(output_lines)
+    if text:
+        text += "\n"
+    encoded_text = text.encode("utf-8")
+    if len(encoded_text) > bounded_bytes:
+        text = encoded_text[:bounded_bytes].decode("utf-8", errors="ignore")
+        summary.truncated = True
+    summary.excerpt_byte_count = len(text.encode("utf-8"))
+    summary.excerpt_line_count = len(output_lines)
+    if len(source_lines) > len(output_lines):
+        summary.truncated = True
+    return _Excerpt(
+        path="diagnostics/redacted-log-excerpt.txt",
+        text=text,
+        line_numbers=line_numbers,
+        summary=summary,
+    )
+
+
+def _redact_text(
+    text: str,
+    layout: ExportTargetLayout,
+    summary: _RedactionSummary,
+) -> str:
+    if _PRIVATE_TEXT_LINE_PATTERN.search(text):
+        summary.redacted_prompt_or_response_count += 1
+        summary.redaction_count += 1
+        return "<redacted-private-preview>"
+
+    text = _CERTIFICATE_PATTERN.sub(lambda _match: _record_secret(summary), text)
+    text = _BEARER_SECRET_PATTERN.sub(
+        lambda match: match.group(1) + _record_secret(summary),
+        text,
+    )
+    text = _NAMED_SECRET_PATTERN.sub(
+        lambda match: f"{match.group(1)}=<redacted-secret>{_record_secret_count_only(summary)}",
+        text,
+    )
+    text = _URL_CREDENTIAL_PATTERN.sub(
+        lambda match: match.group(1) + _record_secret(summary) + match.group(2),
+        text,
+    )
+    text = _OPENAI_KEY_PATTERN.sub(lambda _match: _record_secret(summary), text)
+    text = _IDENTITY_PATTERN.sub(
+        lambda match: _record_identity(summary, match.group(1)),
+        text,
+    )
+    return _ABSOLUTE_PATH_PATTERN.sub(
+        lambda match: _redact_absolute_path(match.group(0), layout, summary),
+        text,
+    )
+
+
+def _record_secret(summary: _RedactionSummary) -> str:
+    summary.redacted_secret_count += 1
+    summary.redaction_count += 1
+    return "<redacted-secret>"
+
+
+def _record_secret_count_only(summary: _RedactionSummary) -> str:
+    _record_secret(summary)
+    return ""
+
+
+def _record_identity(summary: _RedactionSummary, key: str) -> str:
+    summary.redacted_identity_count += 1
+    summary.redaction_count += 1
+    return f"{key}=<redacted-identity>"
+
+
+def _redact_absolute_path(
+    raw_path: str,
+    layout: ExportTargetLayout,
+    summary: _RedactionSummary,
+) -> str:
+    trimmed_path = raw_path.rstrip(".,)")
+    suffix = raw_path[len(trimmed_path):]
+    replacement = "<absolute-path>"
+    try:
+        relative = Path(trimmed_path).resolve(strict=False).relative_to(
+            layout.target_root.resolve(strict=False)
+        )
+        replacement = f"<target>/{relative.as_posix()}"
+    except ValueError:
+        pass
+    summary.redacted_absolute_path_count += 1
+    summary.redaction_count += 1
+    return replacement + suffix
+
+
+def _diagnoses_from_excerpt(
+    source_lines: list[_SourceLine],
+    line_numbers: dict[int, int],
+    excerpt_path: str,
+) -> list[dict[str, object]]:
+    diagnoses: list[dict[str, object]] = []
+    seen_codes: set[str] = set()
+    for index, line_number in line_numbers.items():
+        text = source_lines[index].text
+        for pattern in _DIAGNOSIS_PATTERNS:
+            if pattern.code in seen_codes:
+                continue
+            if not pattern.matches(text):
+                continue
+            seen_codes.add(pattern.code)
+            diagnoses.append(
+                {
+                    "code": pattern.code,
+                    "severity": pattern.severity,
+                    "matched_pattern_id": pattern.pattern_id,
+                    "operator_message": pattern.operator_message,
+                    "remediation": pattern.remediation,
+                    "evidence_path": f"{excerpt_path}#line-{line_number}",
+                }
+            )
+            break
+    return diagnoses
+
+
+def _operator_remedies(diagnoses: list[dict[str, object]]) -> list[dict[str, object]]:
+    remedies: list[dict[str, object]] = []
+    for diagnosis in diagnoses:
+        code = str(diagnosis["code"])
+        remedies.append(
+            {
+                "code": code,
+                "title": code.replace("_", " ").title(),
+                "message": str(diagnosis["operator_message"]),
+                "remediation": str(diagnosis["remediation"]),
+                "evidence_path": str(diagnosis["evidence_path"]),
+            }
+        )
+    return remedies
+
+
+def _diagnostic_coverage(
+    required_codes: set[str],
+    matched_codes: set[str],
+    status: str,
+) -> float:
+    if required_codes:
+        return len(required_codes & matched_codes) / len(required_codes)
+    if status == DIAGNOSTIC_STATUS_UNKNOWN:
+        return 0.0
+    return 1.0
+
+
+def _fixture_failure_checks(index: int) -> list[dict[str, object]]:
+    if index == 1:
+        return [
+            {
+                "check": "load_check",
+                "status": "failed",
+                "failure_code": CODE_RUNTIME_LOAD_FAILED,
+                "failure_message": (
+                    "unclassified runtime failure for /tmp/melix/private/export "
+                    "Authorization: Bearer sk-testsecret0000 prompt: private"
+                ),
+                "evidence_path": "smoke/smoke-receipt.json",
+            }
+        ]
+    samples = {
+        CODE_RUNTIME_LOAD_FAILED: "runtime load failed while opening model",
+        CODE_UNSUPPORTED_ARCHITECTURE: "unsupported architecture arm64 required",
+        CODE_DUPLICATE_TENSOR_NAME: "duplicate tensor name decoder.layers.0",
+        CODE_MISSING_BLOB: "missing blob sha256-777777 not found",
+        CODE_MISSING_BINARY: "runtime binary not installed: ollama",
+        CODE_INVALID_RUNTIME_PATH: "invalid runtime path /tmp/melix/bad-target",
+        CODE_RUNTIME_TIMEOUT: "generation smoke timed out after deadline exceeded",
+        CODE_PERMISSION_DENIED: "permission denied opening model weights",
+        CODE_INSUFFICIENT_MEMORY: "Metal out of memory during load",
+    }
+    return [
+        {
+            "check": "load_check",
+            "status": "failed",
+            "failure_code": code,
+            "failure_message": message,
+            "evidence_path": "smoke/smoke-receipt.json",
+        }
+        for code, message in samples.items()
+    ]
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/services/mlx-worker-python/worker/productization/export_target_smoke.py
+++ b/services/mlx-worker-python/worker/productization/export_target_smoke.py
@@ -13,6 +13,7 @@ from worker.productization.export_target_layout import (
     build_export_target_layout,
     _target_relative_path,
 )
+from worker.productization.export_target_diagnostics import write_export_diagnostics_receipt
 from worker.productization.export_target_manifest import validate_export_target_manifest_file
 
 
@@ -135,6 +136,16 @@ def run_export_target_smoke(
 
     checks = (metadata_check, load_check, generation_check)
     status = _terminal_status(checks)
+    diagnostics_receipt = (
+        write_export_diagnostics_receipt(
+            layout,
+            manifest,
+            failure_checks=_diagnostic_failure_check_payloads(checks),
+            now=current_time,
+        )
+        if status in {CHECK_STATUS_FAILED, CHECK_STATUS_BLOCKED}
+        else {}
+    )
     preview_payload = _output_preview_payload(preview_path, layout, preview_limit)
     receipt = {
         "schema_version": EXPORT_SMOKE_RECEIPT_SCHEMA_VERSION,
@@ -152,12 +163,15 @@ def run_export_target_smoke(
         },
         "output_preview": preview_payload,
         "diagnostics_receipt_path": diagnostics_receipt_path,
+        "diagnostics_status": diagnostics_receipt.get("status", ""),
+        "diagnostic_codes": _diagnostic_codes(diagnostics_receipt),
+        "operator_remedies": diagnostics_receipt.get("operator_remedies", []),
         "operator_failures": [
             payload
             for payload in (
-                _operator_failure_payload("metadata_check", metadata_check),
-                _operator_failure_payload("load_check", load_check),
-                _operator_failure_payload("generation_check", generation_check),
+                _operator_failure_payload("metadata_check", metadata_check, diagnostics_receipt),
+                _operator_failure_payload("load_check", load_check, diagnostics_receipt),
+                _operator_failure_payload("generation_check", generation_check, diagnostics_receipt),
             )
             if payload is not None
         ],
@@ -467,15 +481,38 @@ def _check_payload(result: _CheckResult) -> dict[str, object]:
 def _operator_failure_payload(
     check_name: str,
     result: _CheckResult,
+    diagnostics_receipt: dict[str, object] | None = None,
 ) -> dict[str, object] | None:
     if result.status != CHECK_STATUS_FAILED:
         return None
-    return {
+    payload = {
         "check": check_name,
         "failure_code": result.failure_code,
         "failure_message": result.failure_message,
         "diagnostics_receipt_path": result.diagnostics_receipt_path,
     }
+    remedies = _operator_remedies(diagnostics_receipt or {})
+    if remedies:
+        payload["operator_remedy_code"] = str(remedies[0].get("code", ""))
+        payload["operator_remedy"] = str(remedies[0].get("remediation", ""))
+    return payload
+
+
+def _diagnostic_failure_check_payloads(
+    checks: tuple[_CheckResult, _CheckResult, _CheckResult],
+) -> list[dict[str, object]]:
+    names = ("metadata_check", "load_check", "generation_check")
+    return [
+        {
+            "check": name,
+            "status": check.status,
+            "failure_code": check.failure_code,
+            "failure_message": check.failure_message,
+            "evidence_path": check.evidence_path,
+        }
+        for name, check in zip(names, checks)
+        if check.status in {CHECK_STATUS_FAILED, CHECK_STATUS_BLOCKED}
+    ]
 
 
 def _update_export_report(
@@ -500,6 +537,9 @@ def _update_export_report(
             "diagnostics_receipt_path": manifest.evidence.diagnostics_receipt_path
             if status in {CHECK_STATUS_FAILED, CHECK_STATUS_BLOCKED}
             else "",
+            "diagnostic_status": str(receipt.get("diagnostics_status", "")),
+            "diagnostic_codes": receipt.get("diagnostic_codes", []),
+            "operator_remedies": receipt.get("operator_remedies", []),
             "verification_terminal_state": terminal_state,
             "verification_blocker_code": _first_failure_code(receipt),
             "waiver_id": _waiver_id(receipt),
@@ -516,6 +556,27 @@ def _first_failure_code(receipt: dict[str, object]) -> str:
         if isinstance(first, dict):
             return str(first.get("failure_code", ""))
     return ""
+
+
+def _diagnostic_codes(receipt: dict[str, object]) -> list[str]:
+    diagnoses = receipt.get("diagnoses", [])
+    if not isinstance(diagnoses, list):
+        return []
+    codes: list[str] = []
+    for diagnosis in diagnoses:
+        if not isinstance(diagnosis, dict):
+            continue
+        code = str(diagnosis.get("code", ""))
+        if code and code not in codes:
+            codes.append(code)
+    return codes
+
+
+def _operator_remedies(receipt: dict[str, object]) -> list[dict[str, object]]:
+    remedies = receipt.get("operator_remedies", [])
+    if not isinstance(remedies, list):
+        return []
+    return [remedy for remedy in remedies if isinstance(remedy, dict)]
 
 
 def _failure_code(exc: Exception) -> str:


### PR DESCRIPTION
## Summary
- Adds a runtime export diagnostics parser that classifies export failures into typed diagnosis codes, remedies, redacted evidence pointers, and bounded unknown-failure excerpts.
- Wires diagnostic receipts into runtime export smoke evidence and registers a PR-scoped diagnostic parser performance probe.
- Updates the runtime export smoke runbook and adds a governing implementation plan for issue #1510.

Closes #1510.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`
- `docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md`
- `docs/plans/2026-05-24-m-courtyard-improvement-roadmap.md`
- `docs/runbooks/runtime-export-smoke-policy.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 25 passed in 0.40s

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/melix-pr-scoped-probes.json
# passed

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# emitted diagnostic parser metrics successfully

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# 19 passed; changed-scope coverage TOTAL 73 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 27 passed in 0.48s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 25 passed in 0.43s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# emitted diagnostic parser metrics successfully after review fixes

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# 21 passed; changed-scope coverage TOTAL 45 0 100%

.githooks/pre-commit
# make swift-test passed
# make py-test passed: 4428 passed, 14 skipped, 2 warnings in 192.01s
# make integration-test passed: 123 passed, 1 skipped in 708.53s
# PR-scoped performance report status: ok; direct/gated regressions: 0

.githooks/pre-commit
# review-fix gate passed
# make swift-test passed in 191.0s
# make py-test passed: 4430 passed, 14 skipped, 2 warnings in 188.28s
# make integration-test passed: 123 passed, 1 skipped in 409.96s
# PR-scoped performance report status: ok; direct/gated regressions: 0
```

## Coverage and Metrics
- Manual changed-scope coverage: `TOTAL 73 0 100%`.
- Review-fix changed-scope coverage: `TOTAL 45 0 100%`.
- Pre-commit direct diagnostic parser changed-line coverage: `96.0%`.
- Pre-commit performance report: `.runtime/pre-commit-performance/20260624-133806-f63da256/report/report.md`.
- Performance report status: `ok`; changed files: 9; selected probes: 138; direct/gated probes: 3; direct/gated regressions: 0; verification failures: 0.
- Review-fix pre-commit performance report: `.runtime/pre-commit-performance/20260624-143614-f7c7f2a7/report/report.md`.
- Review-fix performance report status: `ok`; changed files: 2; selected probes: 1; direct/gated probes: 1; regressions: 0; context regressions: 0; verification failures: 0.
- `runtime-export-diagnostic-parser` direct probe metrics:
  - `elapsed_ms_mean`: base `2032.262`, head `2015.701`, delta `-16.561` (`-0.81%`), neutral.
  - `peak_bytes_mean`: base `605285.600`, head `603670.000`, delta `-1615.600` (`-0.27%`), neutral.
  - `diagnostic_parser_coverage`: base `1.000`, head `1.000`.
  - `parsed_failure_count`: base `27`, head `27`.
  - `unknown_failure_count`: base `1`, head `1`.
  - `redaction_count`: base `5`, head `5`.
  - `diagnostic_latency_ms`: base `6.497`, head `6.462`.
  - `diagnosis_code_count`: base `9`, head `9`.
- Review-fix `runtime-export-diagnostic-parser` direct probe metrics:
  - `elapsed_ms_mean`: base `1977.987`, head `1974.552`, delta `-3.435` (`-0.17%`), neutral.
  - `peak_bytes_mean`: base `607612.000`, head `610158.800`, delta `+2546.800` (`+0.42%`), neutral.
  - `diagnostic_parser_coverage`: base `1.000`, head `1.000`.
  - `parsed_failure_count`: base `27`, head `27`.
  - `unknown_failure_count`: base `1`, head `1`.
  - `redaction_count`: base `5`, head `5`.
  - `diagnostic_latency_ms`: base `6.415`, head `6.677`, delta `+0.263` (`+4.09%`), neutral.
  - `target_count`: base `4`, head `4`.
  - `diagnosis_code_count`: base `9`, head `9`.
- Observability mode: `evidence`; the diagnostics receipt records typed failure evidence and redacted pointers under the export target. Probe overhead is tracked by the PR-scoped diagnostic parser probe.

## Known Gaps
None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
