### PR TITLE
Add external runtime source descriptors

### DIFF
--- a/docs/plans/2026-06-24-cross-runtime-model-inventory.md
+++ b/docs/plans/2026-06-24-cross-runtime-model-inventory.md
@@ -451,6 +451,22 @@ The unit must:
 #1513 must not broaden Desktop UI beyond showing requested/effective source
 roots from the shared receipt.
 
+Implementation note for #1513:
+
+- `WorkerModelCatalog.registry_snapshot_payload()` now emits
+  `source_descriptors` alongside the existing `roots` and `models` fields so
+  current Swift snapshot parsing remains backward-compatible while CLI and
+  Desktop can consume requested and effective source roots from the shared
+  receipt path.
+- The first implemented descriptor set covers `melix_managed_root`,
+  `huggingface_cache`, `modelscope_cache`, `ollama_store`, and
+  `lm_studio_store`. Hugging Face cache descriptors mark the existing
+  `HubCatalog.search_models` path as searchable and define pull states for
+  cancelled and partial-cleanup follow-up receipts.
+- The #1513 fixture scope verifies the five descriptor rows, Hugging Face cache
+  model discovery, external requested roots, missing Hugging Face cache root
+  isolation, and propagation through generated maintenance manifests.
+
 ### #1514 Scan Receipts And Classification
 
 #1514 owns the shared scan receipt and discovered-model classification output.

--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -1274,6 +1274,7 @@ def test_raw_model_spec_loads_config_payload_when_not_supplied(
     hf_refs.mkdir(parents=True, exist_ok=True)
     (hf_refs / "main").write_text("abc123\n", encoding="utf-8")
     missing_hf_cache = tmp_path / "missing-hf-cache"
+    lower_priority_hf_home = tmp_path / "lower-priority-hf-home"
     modelscope_root = tmp_path / "modelscope-cache"
     ollama_root = tmp_path / "ollama-models"
     lm_studio_root = tmp_path / "lm-studio-models"
@@ -1282,7 +1283,7 @@ def test_raw_model_spec_loads_config_payload_when_not_supplied(
             "MELIX_MODEL_ROOTS": os.pathsep.join([str(managed_root), str(hf_cache)]),
             "MELIX_MANAGED_MODEL_ROOT": None,
             "HUGGINGFACE_HUB_CACHE": str(missing_hf_cache),
-            "HF_HOME": None,
+            "HF_HOME": str(lower_priority_hf_home),
             "MODELSCOPE_CACHE": str(modelscope_root),
             "MODELSCOPE_HOME": None,
             "OLLAMA_MODELS": str(ollama_root),
@@ -1315,6 +1316,7 @@ def test_raw_model_spec_loads_config_payload_when_not_supplied(
     assert descriptors["melix_managed_root"]["effective_roots"] == [str(managed_root.resolve())]
     assert descriptors["melix_managed_root"]["catalog_policy"]["searchable"] is False
     assert descriptors["huggingface_cache"]["requested_roots"] == [str(hf_cache), str(missing_hf_cache)]
+    assert str(lower_priority_hf_home / "hub") not in descriptors["huggingface_cache"]["requested_roots"]
     assert descriptors["huggingface_cache"]["effective_roots"] == [
         str(hf_cache.resolve()),
         str(missing_hf_cache.resolve()),
@@ -1340,6 +1342,30 @@ def test_raw_model_spec_loads_config_payload_when_not_supplied(
         "mlx-community/DescriptorTiny",
         "mlx-community/ManagedTiny",
     ]
+
+    no_hf_env_catalog = WorkerModelCatalog(
+        environment={
+            "MELIX_MODEL_ROOTS": str(managed_root),
+            "MELIX_MANAGED_MODEL_ROOT": None,
+        }
+    )
+    no_hf_descriptors = _source_descriptors_by_kind(no_hf_env_catalog.registry_snapshot_payload())
+    assert no_hf_descriptors["huggingface_cache"]["requested_roots"] == []
+    assert no_hf_descriptors["huggingface_cache"]["effective_roots"] == []
+
+    default_hf_home = tmp_path / "default-hf-home"
+    default_hf_cache = default_hf_home / ".cache" / "huggingface" / "hub"
+    default_hf_cache.mkdir(parents=True)
+    default_hf_catalog = WorkerModelCatalog(
+        environment={
+            "HOME": str(default_hf_home),
+            "MELIX_MODEL_ROOTS": str(managed_root),
+            "MELIX_MANAGED_MODEL_ROOT": None,
+        }
+    )
+    default_hf_descriptors = _source_descriptors_by_kind(default_hf_catalog.registry_snapshot_payload())
+    assert default_hf_descriptors["huggingface_cache"]["requested_roots"] == [str(default_hf_cache.resolve())]
+    assert default_hf_descriptors["huggingface_cache"]["effective_roots"] == [str(default_hf_cache.resolve())]
 
     nested_model_dir = tmp_path / "nested-context-model"
     _write_model_config(

--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -1280,10 +1280,15 @@ def test_raw_model_spec_loads_config_payload_when_not_supplied(
     descriptor_catalog = WorkerModelCatalog(
         environment={
             "MELIX_MODEL_ROOTS": os.pathsep.join([str(managed_root), str(hf_cache)]),
+            "MELIX_MANAGED_MODEL_ROOT": None,
             "HUGGINGFACE_HUB_CACHE": str(missing_hf_cache),
+            "HF_HOME": None,
             "MODELSCOPE_CACHE": str(modelscope_root),
+            "MODELSCOPE_HOME": None,
             "OLLAMA_MODELS": str(ollama_root),
             "LM_STUDIO_MODELS": str(lm_studio_root),
+            "LMSTUDIO_MODELS": None,
+            "LM_STUDIO_HOME": None,
         }
     )
     descriptor_payload = descriptor_catalog.registry_snapshot_payload()

--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -83,6 +83,16 @@ def _write_weights(variant_dir: Path) -> None:
     (variant_dir / "model.safetensors").write_bytes(b"weights")
 
 
+def _source_descriptors_by_kind(payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    descriptors = payload["source_descriptors"]
+    assert isinstance(descriptors, list)
+    return {
+        descriptor["source_kind"]: descriptor
+        for descriptor in descriptors
+        if isinstance(descriptor, dict)
+    }
+
+
 def test_read_text_prefix_reads_only_requested_prefix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     target = tmp_path / "README.md"
     target.write_text("placeholder", encoding="utf-8")
@@ -516,7 +526,6 @@ def test_huggingface_cache_snapshot_skips_incomplete_indexed_weights(tmp_path: P
     (snapshot_dir / "model-00001-of-00001.safetensors").write_bytes(b"weights")
 
     assert [model.model_id for model in catalog.registry_snapshot(rescan=True).models] == ["org/demo-mlx"]
-
 
 
 def test_has_model_weight_files_returns_false_when_scandir_raises_oserror(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -1251,6 +1260,81 @@ def test_raw_model_spec_loads_config_payload_when_not_supplied(
     assert model.model_kind == "text"
     assert model.ext["melix.model_path"] == str(model_dir.resolve())
     assert config_load_count == 1
+
+    managed_root = tmp_path / "descriptor-managed-root"
+    _write_registry_manifest(
+        managed_root / "huggingface" / "mlx-community" / "ManagedTiny" / "main",
+        model_id="mlx-community/ManagedTiny",
+    )
+    hf_cache = tmp_path / "descriptor-hf-cache"
+    hf_snapshot = hf_cache / "models--mlx-community--DescriptorTiny" / "snapshots" / "abc123"
+    hf_refs = hf_cache / "models--mlx-community--DescriptorTiny" / "refs"
+    _write_model_config(hf_snapshot, {"model_type": "qwen3", "architectures": ["Qwen3ForCausalLM"]})
+    _write_weights(hf_snapshot)
+    hf_refs.mkdir(parents=True, exist_ok=True)
+    (hf_refs / "main").write_text("abc123\n", encoding="utf-8")
+    missing_hf_cache = tmp_path / "missing-hf-cache"
+    modelscope_root = tmp_path / "modelscope-cache"
+    ollama_root = tmp_path / "ollama-models"
+    lm_studio_root = tmp_path / "lm-studio-models"
+    descriptor_catalog = WorkerModelCatalog(
+        environment={
+            "MELIX_MODEL_ROOTS": os.pathsep.join([str(managed_root), str(hf_cache)]),
+            "HUGGINGFACE_HUB_CACHE": str(missing_hf_cache),
+            "MODELSCOPE_CACHE": str(modelscope_root),
+            "OLLAMA_MODELS": str(ollama_root),
+            "LM_STUDIO_MODELS": str(lm_studio_root),
+        }
+    )
+    descriptor_payload = descriptor_catalog.registry_snapshot_payload()
+    descriptors = _source_descriptors_by_kind(descriptor_payload)
+    roots = {root["root_path"]: root for root in descriptor_payload["roots"]}
+
+    assert set(descriptors) == {
+        "melix_managed_root",
+        "huggingface_cache",
+        "modelscope_cache",
+        "ollama_store",
+        "lm_studio_store",
+    }
+    for descriptor in descriptors.values():
+        assert descriptor["schema_version"] == "melix.model_inventory_source_descriptor.v1"
+        assert descriptor["path_policy"]
+        assert descriptor["discovery_policy"]
+        assert descriptor["receipt_policy"]["schema_version"] == "melix.model_inventory_receipt.v1"
+        assert "requested_roots" in descriptor["redaction_policy"]["path_fields"]
+        assert "source_scan_latency_ms" in descriptor["metrics_policy"]["timers"]
+        assert "not_found" in descriptor["failure_modes"]
+
+    assert descriptors["melix_managed_root"]["requested_roots"] == [str(managed_root)]
+    assert descriptors["melix_managed_root"]["effective_roots"] == [str(managed_root.resolve())]
+    assert descriptors["melix_managed_root"]["catalog_policy"]["searchable"] is False
+    assert descriptors["huggingface_cache"]["requested_roots"] == [str(hf_cache), str(missing_hf_cache)]
+    assert descriptors["huggingface_cache"]["effective_roots"] == [
+        str(hf_cache.resolve()),
+        str(missing_hf_cache.resolve()),
+    ]
+    assert descriptors["huggingface_cache"]["catalog_policy"]["searchable"] is True
+    assert descriptors["huggingface_cache"]["catalog_policy"]["search_method"] == "HubCatalog.search_models"
+    assert "cancelled" in descriptors["huggingface_cache"]["pull_policy"]["states"]
+    assert "partial_cleanup_pending" in descriptors["huggingface_cache"]["pull_policy"]["states"]
+    assert descriptors["modelscope_cache"]["discovery_policy"]["scanner"] == (
+        "descriptor_only_until_source_specific_scanner_lands"
+    )
+    assert descriptors["modelscope_cache"]["requested_roots"] == [str(modelscope_root)]
+    assert descriptors["modelscope_cache"]["effective_roots"] == []
+    assert descriptors["ollama_store"]["ownership"] == "external_read_only"
+    assert descriptors["ollama_store"]["requested_roots"] == [str(ollama_root)]
+    assert descriptors["ollama_store"]["effective_roots"] == []
+    assert descriptors["lm_studio_store"]["pull_policy"]["supports_pull"] is False
+    assert descriptors["lm_studio_store"]["requested_roots"] == [str(lm_studio_root)]
+    assert descriptors["lm_studio_store"]["effective_roots"] == []
+    assert roots[str(missing_hf_cache.resolve())]["accessible"] is False
+    assert roots[str(missing_hf_cache.resolve())]["error_code"] == "not_found"
+    assert [model["model_id"] for model in descriptor_payload["models"]] == [
+        "mlx-community/DescriptorTiny",
+        "mlx-community/ManagedTiny",
+    ]
 
     nested_model_dir = tmp_path / "nested-context-model"
     _write_model_config(

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import hashlib
 import json
 import os
@@ -56,6 +56,19 @@ _REGISTRY_SCAN_PRUNED_DIR_NAMES = frozenset({"blobs", ".git", "__pycache__"})
 _HF_CACHE_REPO_PREFIX = "models--"
 _HF_CACHE_REPO_PREFIX_LEN = len(_HF_CACHE_REPO_PREFIX)
 _HF_CACHE_PRUNED_SUBTREE_NAMES = frozenset({"snapshots", "refs"})
+_MODEL_INVENTORY_SOURCE_DESCRIPTOR_SCHEMA = "melix.model_inventory_source_descriptor.v1"
+_SOURCE_KIND_MELIX_MANAGED_ROOT = "melix_managed_root"
+_SOURCE_KIND_HUGGINGFACE_CACHE = "huggingface_cache"
+_SOURCE_KIND_MODELSCOPE_CACHE = "modelscope_cache"
+_SOURCE_KIND_OLLAMA_STORE = "ollama_store"
+_SOURCE_KIND_LM_STUDIO_STORE = "lm_studio_store"
+_MODEL_INVENTORY_SOURCE_KINDS = (
+    _SOURCE_KIND_MELIX_MANAGED_ROOT,
+    _SOURCE_KIND_HUGGINGFACE_CACHE,
+    _SOURCE_KIND_MODELSCOPE_CACHE,
+    _SOURCE_KIND_OLLAMA_STORE,
+    _SOURCE_KIND_LM_STUDIO_STORE,
+)
 _MODEL_WEIGHT_FILE_SUFFIXES = (".safetensors", ".npz")
 _GEMMA4_QAT_AUTOMATIC_ORG = "mlx-community"
 _GEMMA4_QAT_AUTOMATIC_SCOPE = "mlx-community-gemma4-q4"
@@ -85,10 +98,49 @@ class RegistryRootSnapshot:
 
 
 @dataclass(frozen=True, slots=True)
+class ModelInventorySourceDescriptor:
+    descriptor_id: str
+    source_kind: str
+    display_name: str
+    ownership: str
+    requested_roots: tuple[str, ...]
+    effective_roots: tuple[str, ...]
+    path_policy: Mapping[str, object]
+    discovery_policy: Mapping[str, object]
+    receipt_policy: Mapping[str, object]
+    redaction_policy: Mapping[str, object]
+    failure_modes: tuple[str, ...]
+    catalog_policy: Mapping[str, object] = field(default_factory=dict)
+    pull_policy: Mapping[str, object] = field(default_factory=dict)
+    metrics_policy: Mapping[str, object] = field(default_factory=dict)
+    schema_version: str = _MODEL_INVENTORY_SOURCE_DESCRIPTOR_SCHEMA
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "descriptor_id": self.descriptor_id,
+            "source_kind": self.source_kind,
+            "display_name": self.display_name,
+            "ownership": self.ownership,
+            "requested_roots": list(self.requested_roots),
+            "effective_roots": list(self.effective_roots),
+            "path_policy": dict(self.path_policy),
+            "discovery_policy": dict(self.discovery_policy),
+            "receipt_policy": dict(self.receipt_policy),
+            "redaction_policy": dict(self.redaction_policy),
+            "failure_modes": list(self.failure_modes),
+            "catalog_policy": dict(self.catalog_policy),
+            "pull_policy": dict(self.pull_policy),
+            "metrics_policy": dict(self.metrics_policy),
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class RegistrySnapshot:
     roots: tuple[RegistryRootSnapshot, ...]
     models: tuple[common_pb2.ModelSpec, ...]
     scanned_at_unix_ms: int
+    source_descriptors: tuple[ModelInventorySourceDescriptor, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -583,6 +635,86 @@ def _sorted_child_directories(root: Path, *, name_prefix: str | None = None) -> 
     except OSError:
         return ()
     return tuple(root / name for name in sorted(child_names))
+
+
+def _inventory_receipt_policy(*, source_kind: str) -> dict[str, object]:
+    return {
+        "schema_version": "melix.model_inventory_receipt.v1",
+        "source_kind": source_kind,
+        "root_fields": [
+            "root_id",
+            "root_path",
+            "root_order",
+            "accessible",
+            "error_code",
+            "error_message",
+            "discovered_model_ids",
+        ],
+        "model_fields": [
+            "model_id",
+            "model_path",
+            "revision",
+            "melix.source_kind",
+            "melix.registry_root_id",
+            "melix.registry_relative_path",
+        ],
+        "scan_fields": [
+            "scanned_at_unix_ms",
+            "requested_roots",
+            "effective_roots",
+            "descriptor_id",
+        ],
+    }
+
+
+def _inventory_redaction_policy() -> dict[str, object]:
+    return {
+        "path_fields": [
+            "requested_roots",
+            "effective_roots",
+            "root_path",
+            "model_path",
+            "melix.model_path",
+            "melix.registry_root_path",
+            "melix.registry_descriptor_path",
+        ],
+        "redaction": "preserve_basename_and_digest_absolute_prefix",
+        "digest": "sha256",
+        "secret_fields": [
+            "token",
+            "authorization",
+            "cookie",
+            "api_key",
+        ],
+    }
+
+
+def _inventory_metrics_policy() -> dict[str, object]:
+    return {
+        "counters": [
+            "source_count",
+            "requested_source_root_count",
+            "effective_source_root_count",
+            "invalid_source_count",
+            "redaction_count",
+            "discovered_model_count",
+            "usable_model_count",
+            "unsupported_model_count",
+            "incomplete_model_count",
+            "ambiguous_model_count",
+        ],
+        "timers": [
+            "source_scan_latency_ms",
+            "catalog_scan_latency_ms",
+            "classification_latency_ms",
+            "pull_cancel_latency_ms",
+            "partial_artifact_cleanup_latency_ms",
+        ],
+        "sizes": [
+            "discovery_receipt_byte_size",
+            "catalog_result_count",
+        ],
+    }
 
 
 def _iter_relative_file_paths_sorted(root: Path, *, prefix: str = "") -> Iterable[tuple[Path, str]]:
@@ -2132,6 +2264,10 @@ class WorkerModelCatalog:
         snapshot = self.registry_snapshot(rescan=rescan, registry_roots=registry_roots)
         return {
             "scanned_at_unix_ms": snapshot.scanned_at_unix_ms,
+            "source_descriptors": [
+                descriptor.to_payload()
+                for descriptor in snapshot.source_descriptors
+            ],
             "roots": [
                 {
                     "root_id": root.root_id,
@@ -2163,12 +2299,371 @@ class WorkerModelCatalog:
 
     def _refresh_registry_snapshot(self, registry_roots: tuple[str, ...]) -> RegistrySnapshot:
         self._prune_text_prefix_cache()
-        roots, discovered_models = self._scan_registry_roots(registry_roots)
+        roots, discovered_models, hf_cache_roots = self._scan_registry_roots(registry_roots)
         _apply_gemma4_qat_companion_metadata(discovered_models.values())
         return RegistrySnapshot(
             roots=tuple(roots),
             models=tuple(discovered_models[model_id] for model_id in sorted(discovered_models)),
             scanned_at_unix_ms=int(time.time() * 1000),
+            source_descriptors=self._source_descriptors_for_registry_roots(
+                registry_roots,
+                hf_cache_roots=hf_cache_roots,
+            ),
+        )
+
+    def _source_descriptors_for_registry_roots(
+        self,
+        registry_roots: tuple[str, ...],
+        *,
+        hf_cache_roots: frozenset[str] = frozenset(),
+    ) -> tuple[ModelInventorySourceDescriptor, ...]:
+        effective_roots_by_kind: dict[str, list[str]] = {
+            source_kind: []
+            for source_kind in _MODEL_INVENTORY_SOURCE_KINDS
+        }
+        for root in registry_roots:
+            effective_roots_by_kind[
+                self._source_kind_for_registry_root(root, hf_cache_roots=hf_cache_roots)
+            ].append(root)
+
+        requested_roots_by_kind = self._requested_roots_by_source_kind(
+            effective_roots_by_kind=effective_roots_by_kind,
+            hf_cache_roots=hf_cache_roots,
+        )
+        return (
+            self._melix_managed_root_source_descriptor(
+                requested_roots=tuple(requested_roots_by_kind[_SOURCE_KIND_MELIX_MANAGED_ROOT]),
+                effective_roots=tuple(effective_roots_by_kind[_SOURCE_KIND_MELIX_MANAGED_ROOT]),
+            ),
+            self._huggingface_cache_source_descriptor(
+                requested_roots=tuple(requested_roots_by_kind[_SOURCE_KIND_HUGGINGFACE_CACHE]),
+                effective_roots=tuple(effective_roots_by_kind[_SOURCE_KIND_HUGGINGFACE_CACHE]),
+            ),
+            self._external_runtime_source_descriptor(
+                descriptor_id="modelscope-cache",
+                source_kind=_SOURCE_KIND_MODELSCOPE_CACHE,
+                display_name="ModelScope cache snapshots",
+                env_vars=("MODELSCOPE_CACHE", "MODELSCOPE_HOME"),
+                requested_roots=tuple(requested_roots_by_kind[_SOURCE_KIND_MODELSCOPE_CACHE]),
+                effective_roots=tuple(effective_roots_by_kind[_SOURCE_KIND_MODELSCOPE_CACHE]),
+                store_layout="ModelScope cache snapshot directories",
+            ),
+            self._external_runtime_source_descriptor(
+                descriptor_id="ollama-store",
+                source_kind=_SOURCE_KIND_OLLAMA_STORE,
+                display_name="Ollama model store",
+                env_vars=("OLLAMA_MODELS",),
+                requested_roots=tuple(requested_roots_by_kind[_SOURCE_KIND_OLLAMA_STORE]),
+                effective_roots=tuple(effective_roots_by_kind[_SOURCE_KIND_OLLAMA_STORE]),
+                store_layout="Ollama manifest and blob store",
+            ),
+            self._external_runtime_source_descriptor(
+                descriptor_id="lm-studio-store",
+                source_kind=_SOURCE_KIND_LM_STUDIO_STORE,
+                display_name="LM Studio model store",
+                env_vars=("LM_STUDIO_MODELS", "LMSTUDIO_MODELS", "LM_STUDIO_HOME"),
+                requested_roots=tuple(requested_roots_by_kind[_SOURCE_KIND_LM_STUDIO_STORE]),
+                effective_roots=tuple(effective_roots_by_kind[_SOURCE_KIND_LM_STUDIO_STORE]),
+                store_layout="LM Studio local model directories",
+            ),
+        )
+
+    def _source_kind_for_registry_root(
+        self,
+        root_path: str,
+        *,
+        hf_cache_roots: frozenset[str] = frozenset(),
+    ) -> str:
+        root = _canonical_registry_root_path(root_path)
+        if root in self._source_requested_root_set(_SOURCE_KIND_HUGGINGFACE_CACHE):
+            return _SOURCE_KIND_HUGGINGFACE_CACHE
+        if root in self._source_requested_root_set(_SOURCE_KIND_MODELSCOPE_CACHE):
+            return _SOURCE_KIND_MODELSCOPE_CACHE
+        if root in self._source_requested_root_set(_SOURCE_KIND_OLLAMA_STORE):
+            return _SOURCE_KIND_OLLAMA_STORE
+        if root in self._source_requested_root_set(_SOURCE_KIND_LM_STUDIO_STORE):
+            return _SOURCE_KIND_LM_STUDIO_STORE
+        if root in hf_cache_roots:
+            return _SOURCE_KIND_HUGGINGFACE_CACHE
+        return _SOURCE_KIND_MELIX_MANAGED_ROOT
+
+    def _requested_roots_by_source_kind(
+        self,
+        *,
+        effective_roots_by_kind: Mapping[str, list[str]],
+        hf_cache_roots: frozenset[str],
+    ) -> dict[str, list[str]]:
+        requested: dict[str, list[str]] = {
+            source_kind: []
+            for source_kind in _MODEL_INVENTORY_SOURCE_KINDS
+        }
+        for root in self._split_env_paths(_REGISTRY_ROOTS_ENV_KEY):
+            requested[
+                self._source_kind_for_registry_root(root, hf_cache_roots=hf_cache_roots)
+            ].append(root)
+        managed_root = self._environment.get(_MANAGED_MODEL_ROOT_ENV_KEY, "").strip()
+        if managed_root:
+            requested[_SOURCE_KIND_MELIX_MANAGED_ROOT].append(managed_root)
+        else:
+            default_managed_root = self._default_managed_model_root()
+            if default_managed_root is not None:
+                requested[_SOURCE_KIND_MELIX_MANAGED_ROOT].append(os.fspath(default_managed_root))
+
+        env_hf_cache = self._environment.get("HUGGINGFACE_HUB_CACHE", "").strip()
+        env_hf_home = self._environment.get("HF_HOME", "").strip()
+        if env_hf_cache:
+            requested[_SOURCE_KIND_HUGGINGFACE_CACHE].append(env_hf_cache)
+        elif env_hf_home:
+            requested[_SOURCE_KIND_HUGGINGFACE_CACHE].append(
+                os.fspath(Path(env_hf_home).expanduser() / "hub")
+            )
+        else:
+            default_hf_cache = self._default_huggingface_cache_root()
+            if default_hf_cache is not None:
+                requested[_SOURCE_KIND_HUGGINGFACE_CACHE].append(os.fspath(default_hf_cache))
+
+        for key in ("MODELSCOPE_CACHE", "MODELSCOPE_HOME"):
+            requested[_SOURCE_KIND_MODELSCOPE_CACHE].extend(self._split_env_paths(key))
+        requested[_SOURCE_KIND_OLLAMA_STORE].extend(self._split_env_paths("OLLAMA_MODELS"))
+        for key in ("LM_STUDIO_MODELS", "LMSTUDIO_MODELS", "LM_STUDIO_HOME"):
+            requested[_SOURCE_KIND_LM_STUDIO_STORE].extend(self._split_env_paths(key))
+
+        for source_kind, effective_roots in effective_roots_by_kind.items():
+            requested[source_kind].extend(effective_roots)
+
+        return {
+            source_kind: self._dedupe_requested_roots(roots)
+            for source_kind, roots in requested.items()
+        }
+
+    def _source_requested_root_set(self, source_kind: str) -> set[str]:
+        if source_kind == _SOURCE_KIND_HUGGINGFACE_CACHE:
+            roots = []
+            env_hf_cache = self._environment.get("HUGGINGFACE_HUB_CACHE", "").strip()
+            env_hf_home = self._environment.get("HF_HOME", "").strip()
+            if env_hf_cache:
+                roots.append(env_hf_cache)
+            if env_hf_home:
+                roots.append(os.fspath(Path(env_hf_home).expanduser() / "hub"))
+            default_hf_cache = self._default_huggingface_cache_root()
+            if default_hf_cache is not None:
+                roots.append(os.fspath(default_hf_cache))
+            return {
+                _canonical_registry_root_path(root)
+                for root in roots
+                if root.strip()
+            }
+        if source_kind == _SOURCE_KIND_MODELSCOPE_CACHE:
+            keys = ("MODELSCOPE_CACHE", "MODELSCOPE_HOME")
+        elif source_kind == _SOURCE_KIND_OLLAMA_STORE:
+            keys = ("OLLAMA_MODELS",)
+        elif source_kind == _SOURCE_KIND_LM_STUDIO_STORE:
+            keys = ("LM_STUDIO_MODELS", "LMSTUDIO_MODELS", "LM_STUDIO_HOME")
+        else:
+            keys = ()
+        return {
+            _canonical_registry_root_path(root)
+            for key in keys
+            for root in self._split_env_paths(key)
+        }
+
+    def _split_env_paths(self, key: str) -> list[str]:
+        raw = self._environment.get(key, "")
+        if not raw.strip():
+            return []
+        return [
+            part.strip()
+            for part in raw.split(os.pathsep)
+            if part.strip()
+        ]
+
+    def _dedupe_requested_roots(self, roots: Iterable[str]) -> list[str]:
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for root in roots:
+            normalized = root.strip()
+            if not normalized:
+                continue
+            canonical = _canonical_registry_root_path(normalized)
+            if canonical in seen:
+                continue
+            seen.add(canonical)
+            deduped.append(normalized)
+        return deduped
+
+    def _melix_managed_root_source_descriptor(
+        self,
+        *,
+        requested_roots: tuple[str, ...],
+        effective_roots: tuple[str, ...],
+    ) -> ModelInventorySourceDescriptor:
+        return ModelInventorySourceDescriptor(
+            descriptor_id="melix-managed-root",
+            source_kind=_SOURCE_KIND_MELIX_MANAGED_ROOT,
+            display_name="Melix-managed model roots",
+            ownership="melix_owned",
+            requested_roots=requested_roots,
+            effective_roots=effective_roots,
+            path_policy={
+                "configured_by": [
+                    _REGISTRY_ROOTS_ENV_KEY,
+                    _MANAGED_MODEL_ROOT_ENV_KEY,
+                    "MELIX_HOME",
+                    "HOME",
+                ],
+                "resolution": "expanduser.resolve(strict=false)",
+                "dedupe": "canonical_path_first_wins",
+                "scan_scope": "recursive_manifest_and_mlx_directory_scan",
+                "writable": True,
+            },
+            discovery_policy={
+                "scanner": "WorkerModelCatalog.registry_snapshot",
+                "admission": "manifest_or_mlx_directory",
+                "invalid_source_isolation": "per_root",
+                "missing_roots": "reported_in_roots_without_poisoning_valid_roots",
+            },
+            receipt_policy=_inventory_receipt_policy(
+                source_kind=_SOURCE_KIND_MELIX_MANAGED_ROOT,
+            ),
+            redaction_policy=_inventory_redaction_policy(),
+            failure_modes=(
+                "not_found",
+                "permission_denied",
+                "manifest_invalid",
+                "invalid_layout",
+                "scan_io_error",
+            ),
+            catalog_policy={
+                "searchable": False,
+                "browse_surface": "local_filesystem",
+            },
+            pull_policy={
+                "supports_pull": False,
+                "admission": "managed_downloads_recorded_after_fetch",
+            },
+            metrics_policy=_inventory_metrics_policy(),
+        )
+
+    def _huggingface_cache_source_descriptor(
+        self,
+        *,
+        requested_roots: tuple[str, ...],
+        effective_roots: tuple[str, ...],
+    ) -> ModelInventorySourceDescriptor:
+        return ModelInventorySourceDescriptor(
+            descriptor_id="huggingface-cache",
+            source_kind=_SOURCE_KIND_HUGGINGFACE_CACHE,
+            display_name="Hugging Face cache snapshots",
+            ownership="external_read_only",
+            requested_roots=requested_roots,
+            effective_roots=effective_roots,
+            path_policy={
+                "configured_by": [
+                    "HUGGINGFACE_HUB_CACHE",
+                    "HF_HOME",
+                    "HOME",
+                    _REGISTRY_ROOTS_ENV_KEY,
+                ],
+                "resolution": "expanduser.resolve(strict=false)",
+                "dedupe": "canonical_path_first_wins",
+                "layout": "models--<org>--<name>/snapshots/<revision>",
+                "writable": False,
+            },
+            discovery_policy={
+                "scanner": "WorkerModelCatalog._scan_huggingface_cache_models",
+                "admission": "config_plus_weight_files_plus_mlx_signal",
+                "revision_receipt": "refs/<name> mapped to snapshot id when available",
+                "invalid_source_isolation": "per_root",
+                "missing_roots": "reported_in_roots_without_poisoning_valid_roots",
+            },
+            receipt_policy=_inventory_receipt_policy(
+                source_kind=_SOURCE_KIND_HUGGINGFACE_CACHE,
+            ),
+            redaction_policy=_inventory_redaction_policy(),
+            failure_modes=(
+                "not_found",
+                "permission_denied",
+                "invalid_cache_repo",
+                "snapshot_incomplete",
+                "metadata_not_mlx",
+                "scan_io_error",
+            ),
+            catalog_policy={
+                "searchable": True,
+                "discovery_backend": "huggingface_hub",
+                "search_method": "HubCatalog.search_models",
+                "card_method": "HubCatalog.get_model_card",
+                "mlx_filter": "filter=mlx",
+            },
+            pull_policy={
+                "supports_pull": True,
+                "states": [
+                    "queued",
+                    "resolving",
+                    "downloading",
+                    "verifying",
+                    "admitted",
+                    "cancel_requested",
+                    "cancelled",
+                    "failed",
+                    "partial_cleanup_pending",
+                    "partial_cleanup_done",
+                ],
+                "cancel_semantics": "best_effort_transport_cancel_then_partial_cleanup",
+                "partial_artifacts": "receipt_records_bytes_and_cleanup_state",
+            },
+            metrics_policy=_inventory_metrics_policy(),
+        )
+
+    def _external_runtime_source_descriptor(
+        self,
+        *,
+        descriptor_id: str,
+        source_kind: str,
+        display_name: str,
+        env_vars: tuple[str, ...],
+        requested_roots: tuple[str, ...],
+        effective_roots: tuple[str, ...],
+        store_layout: str,
+    ) -> ModelInventorySourceDescriptor:
+        return ModelInventorySourceDescriptor(
+            descriptor_id=descriptor_id,
+            source_kind=source_kind,
+            display_name=display_name,
+            ownership="external_read_only",
+            requested_roots=requested_roots,
+            effective_roots=effective_roots,
+            path_policy={
+                "configured_by": list(env_vars) + [_REGISTRY_ROOTS_ENV_KEY],
+                "resolution": "expanduser.resolve(strict=false)",
+                "dedupe": "canonical_path_first_wins",
+                "layout": store_layout,
+                "writable": False,
+            },
+            discovery_policy={
+                "scanner": "descriptor_only_until_source_specific_scanner_lands",
+                "admission": "reported_as_requested_and_effective_roots_only",
+                "invalid_source_isolation": "per_source",
+                "missing_roots": "kept_out_of_model_admission_for_other_sources",
+            },
+            receipt_policy=_inventory_receipt_policy(source_kind=source_kind),
+            redaction_policy=_inventory_redaction_policy(),
+            failure_modes=(
+                "not_found",
+                "permission_denied",
+                "invalid_layout",
+                "unsupported_manifest",
+                "scan_io_error",
+            ),
+            catalog_policy={
+                "searchable": False,
+                "browse_surface": "external_runtime_store",
+            },
+            pull_policy={
+                "supports_pull": False,
+                "admission": "external_runtime_owned_artifacts_are_read_only",
+            },
+            metrics_policy=_inventory_metrics_policy(),
         )
 
     def _prune_text_prefix_cache(self) -> None:
@@ -2179,9 +2674,10 @@ class WorkerModelCatalog:
     def _scan_registry_roots(
         self,
         registry_roots: tuple[str, ...],
-    ) -> tuple[list[RegistryRootSnapshot], dict[str, common_pb2.ModelSpec]]:
+    ) -> tuple[list[RegistryRootSnapshot], dict[str, common_pb2.ModelSpec], frozenset[str]]:
         roots: list[RegistryRootSnapshot] = []
         discovered_models: dict[str, common_pb2.ModelSpec] = {}
+        hf_cache_roots: set[str] = set()
 
         for index, root_path in enumerate(registry_roots, start=1):
             root_id = _stable_registry_root_id(root_path)
@@ -2201,6 +2697,8 @@ class WorkerModelCatalog:
 
             accepted_model_ids: list[str] = []
             manifest_paths, plain_local_model_dirs, hf_cache_repo_dirs = WorkerModelCatalog._scan_registry_root_tree_with_hf_repos(root)
+            if hf_cache_repo_dirs:
+                hf_cache_roots.add(root_path)
             for manifest_path in manifest_paths:
                 relative_path = manifest_path.parent.relative_to(root)
                 if _path_derived_registry_identity(relative_path.parts) is None:
@@ -2244,7 +2742,7 @@ class WorkerModelCatalog:
                 )
             )
 
-        return roots, discovered_models
+        return roots, discovered_models, frozenset(hf_cache_roots)
 
     def _configured_registry_roots(self) -> list[str]:
         configured: list[str] = []

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -2410,18 +2410,9 @@ class WorkerModelCatalog:
             if default_managed_root is not None:
                 requested[_SOURCE_KIND_MELIX_MANAGED_ROOT].append(os.fspath(default_managed_root))
 
-        env_hf_cache = (self._environment.get("HUGGINGFACE_HUB_CACHE") or "").strip()
-        env_hf_home = (self._environment.get("HF_HOME") or "").strip()
-        if env_hf_cache:
-            requested[_SOURCE_KIND_HUGGINGFACE_CACHE].append(env_hf_cache)
-        elif env_hf_home:
-            requested[_SOURCE_KIND_HUGGINGFACE_CACHE].append(
-                os.fspath(Path(env_hf_home).expanduser() / "hub")
-            )
-        else:
-            default_hf_cache = self._default_huggingface_cache_root()
-            if default_hf_cache is not None:
-                requested[_SOURCE_KIND_HUGGINGFACE_CACHE].append(os.fspath(default_hf_cache))
+        requested[_SOURCE_KIND_HUGGINGFACE_CACHE].extend(
+            self._requested_huggingface_cache_roots()
+        )
 
         for key in ("MODELSCOPE_CACHE", "MODELSCOPE_HOME"):
             requested[_SOURCE_KIND_MODELSCOPE_CACHE].extend(self._split_env_paths(key))
@@ -2442,19 +2433,9 @@ class WorkerModelCatalog:
         if cached is not None:
             return cached
         if source_kind == _SOURCE_KIND_HUGGINGFACE_CACHE:
-            roots = []
-            env_hf_cache = (self._environment.get("HUGGINGFACE_HUB_CACHE") or "").strip()
-            env_hf_home = (self._environment.get("HF_HOME") or "").strip()
-            if env_hf_cache:
-                roots.append(env_hf_cache)
-            if env_hf_home:
-                roots.append(os.fspath(Path(env_hf_home).expanduser() / "hub"))
-            default_hf_cache = self._default_huggingface_cache_root()
-            if default_hf_cache is not None:
-                roots.append(os.fspath(default_hf_cache))
             root_set = {
                 _canonical_registry_root_path(root)
-                for root in roots
+                for root in self._requested_huggingface_cache_roots()
                 if root.strip()
             }
         elif source_kind == _SOURCE_KIND_MODELSCOPE_CACHE:
@@ -2473,6 +2454,20 @@ class WorkerModelCatalog:
             }
         self._source_requested_root_sets_cache[source_kind] = root_set
         return root_set
+
+    def _requested_huggingface_cache_roots(self) -> list[str]:
+        env_hf_cache = (self._environment.get("HUGGINGFACE_HUB_CACHE") or "").strip()
+        if env_hf_cache:
+            return [env_hf_cache]
+
+        env_hf_home = (self._environment.get("HF_HOME") or "").strip()
+        if env_hf_home:
+            return [os.fspath(Path(env_hf_home).expanduser() / "hub")]
+
+        default_hf_cache = self._default_huggingface_cache_root()
+        if default_hf_cache is not None:
+            return [os.fspath(default_hf_cache)]
+        return []
 
     def _split_env_paths(self, key: str) -> list[str]:
         raw = self._environment.get(key) or ""

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -2188,6 +2188,7 @@ class WorkerModelCatalog:
         self._json_file_cache: dict[Path, tuple[int, int, dict[str, object]]] = {}
         self._text_prefix_cache: dict[Path, tuple[int, int, int, int, str]] = {}
         self._registry_snapshot_cache: dict[tuple[str, ...], RegistrySnapshot] = {}
+        self._source_requested_root_sets_cache: dict[str, set[str]] = {}
         self._runtime_models_snapshot: RegistrySnapshot | None = None
         self._runtime_models_overlay_revision = 0
         self._overlay_revision = 0
@@ -2401,7 +2402,7 @@ class WorkerModelCatalog:
             requested[
                 self._source_kind_for_registry_root(root, hf_cache_roots=hf_cache_roots)
             ].append(root)
-        managed_root = self._environment.get(_MANAGED_MODEL_ROOT_ENV_KEY, "").strip()
+        managed_root = (self._environment.get(_MANAGED_MODEL_ROOT_ENV_KEY) or "").strip()
         if managed_root:
             requested[_SOURCE_KIND_MELIX_MANAGED_ROOT].append(managed_root)
         else:
@@ -2409,8 +2410,8 @@ class WorkerModelCatalog:
             if default_managed_root is not None:
                 requested[_SOURCE_KIND_MELIX_MANAGED_ROOT].append(os.fspath(default_managed_root))
 
-        env_hf_cache = self._environment.get("HUGGINGFACE_HUB_CACHE", "").strip()
-        env_hf_home = self._environment.get("HF_HOME", "").strip()
+        env_hf_cache = (self._environment.get("HUGGINGFACE_HUB_CACHE") or "").strip()
+        env_hf_home = (self._environment.get("HF_HOME") or "").strip()
         if env_hf_cache:
             requested[_SOURCE_KIND_HUGGINGFACE_CACHE].append(env_hf_cache)
         elif env_hf_home:
@@ -2437,10 +2438,13 @@ class WorkerModelCatalog:
         }
 
     def _source_requested_root_set(self, source_kind: str) -> set[str]:
+        cached = self._source_requested_root_sets_cache.get(source_kind)
+        if cached is not None:
+            return cached
         if source_kind == _SOURCE_KIND_HUGGINGFACE_CACHE:
             roots = []
-            env_hf_cache = self._environment.get("HUGGINGFACE_HUB_CACHE", "").strip()
-            env_hf_home = self._environment.get("HF_HOME", "").strip()
+            env_hf_cache = (self._environment.get("HUGGINGFACE_HUB_CACHE") or "").strip()
+            env_hf_home = (self._environment.get("HF_HOME") or "").strip()
             if env_hf_cache:
                 roots.append(env_hf_cache)
             if env_hf_home:
@@ -2448,12 +2452,12 @@ class WorkerModelCatalog:
             default_hf_cache = self._default_huggingface_cache_root()
             if default_hf_cache is not None:
                 roots.append(os.fspath(default_hf_cache))
-            return {
+            root_set = {
                 _canonical_registry_root_path(root)
                 for root in roots
                 if root.strip()
             }
-        if source_kind == _SOURCE_KIND_MODELSCOPE_CACHE:
+        elif source_kind == _SOURCE_KIND_MODELSCOPE_CACHE:
             keys = ("MODELSCOPE_CACHE", "MODELSCOPE_HOME")
         elif source_kind == _SOURCE_KIND_OLLAMA_STORE:
             keys = ("OLLAMA_MODELS",)
@@ -2461,14 +2465,17 @@ class WorkerModelCatalog:
             keys = ("LM_STUDIO_MODELS", "LMSTUDIO_MODELS", "LM_STUDIO_HOME")
         else:
             keys = ()
-        return {
-            _canonical_registry_root_path(root)
-            for key in keys
-            for root in self._split_env_paths(key)
-        }
+        if source_kind != _SOURCE_KIND_HUGGINGFACE_CACHE:
+            root_set = {
+                _canonical_registry_root_path(root)
+                for key in keys
+                for root in self._split_env_paths(key)
+            }
+        self._source_requested_root_sets_cache[source_kind] = root_set
+        return root_set
 
     def _split_env_paths(self, key: str) -> list[str]:
-        raw = self._environment.get(key, "")
+        raw = self._environment.get(key) or ""
         if not raw.strip():
             return []
         return [
@@ -2746,11 +2753,11 @@ class WorkerModelCatalog:
 
     def _configured_registry_roots(self) -> list[str]:
         configured: list[str] = []
-        raw = self._environment.get(_REGISTRY_ROOTS_ENV_KEY, "")
+        raw = self._environment.get(_REGISTRY_ROOTS_ENV_KEY) or ""
         if raw.strip():
             configured.extend(raw.split(os.pathsep))
 
-        managed_root = self._environment.get(_MANAGED_MODEL_ROOT_ENV_KEY, "").strip()
+        managed_root = (self._environment.get(_MANAGED_MODEL_ROOT_ENV_KEY) or "").strip()
         if managed_root:
             configured.append(managed_root)
         else:
@@ -2768,7 +2775,7 @@ class WorkerModelCatalog:
             return self._configured_registry_roots()
 
         requested_roots = list(registry_roots)
-        managed_root = self._environment.get(_MANAGED_MODEL_ROOT_ENV_KEY, "").strip()
+        managed_root = (self._environment.get(_MANAGED_MODEL_ROOT_ENV_KEY) or "").strip()
         if managed_root:
             requested_roots.append(managed_root)
         else:
@@ -2781,17 +2788,17 @@ class WorkerModelCatalog:
         return self._normalized_registry_roots(requested_roots)
 
     def _default_huggingface_cache_root(self) -> Path | None:
-        env_cache = self._environment.get("HUGGINGFACE_HUB_CACHE", "").strip()
+        env_cache = (self._environment.get("HUGGINGFACE_HUB_CACHE") or "").strip()
         if env_cache:
             return Path(env_cache).expanduser().resolve()
 
-        env_hf_home = self._environment.get("HF_HOME", "").strip()
+        env_hf_home = (self._environment.get("HF_HOME") or "").strip()
         if env_hf_home:
             return (Path(env_hf_home).expanduser() / "hub").resolve()
 
         if self._uses_explicit_environment and "HOME" not in self._environment:
             return None
-        home = self._environment.get("HOME", "").strip()
+        home = (self._environment.get("HOME") or "").strip()
         root = (Path(home).expanduser() if home else Path.home()) / ".cache" / "huggingface" / "hub"
         resolved = root.resolve()
         return resolved if resolved.is_dir() else None
@@ -2803,9 +2810,9 @@ class WorkerModelCatalog:
             and "HOME" not in self._environment
         ):
             return None
-        home = self._environment.get("MELIX_HOME", "").strip()
+        home = (self._environment.get("MELIX_HOME") or "").strip()
         if not home:
-            home = self._environment.get("HOME", "").strip()
+            home = (self._environment.get("HOME") or "").strip()
             root = (Path(home).expanduser() if home else Path.home()) / ".melix"
         else:
             root = Path(home).expanduser()


### PR DESCRIPTION
## Summary
- Add `source_descriptors` to the Python registry snapshot payload so cross-runtime inventory consumers can distinguish Melix-managed roots, Hugging Face cache roots, and descriptor-only ModelScope/Ollama/LM Studio stores.
- Describe each source's ownership, requested/effective roots, discovery/search/pull policy, receipt/redaction/metrics policy, and failure modes without changing protobuf schemas or Swift parsing contracts.
- Update the cross-runtime inventory plan with the #1513 implementation note and add fixture coverage for descriptor shape, missing external cache isolation, Hugging Face discovery, and Hugging Face cache root priority.

Closes #1513.

## Plan or Spec
- `docs/plans/2026-06-24-cross-runtime-model-inventory.md`
- `docs/plans/2026-05-24-m-courtyard-improvement-roadmap.md`
- `docs/reference-scans/m-courtyard-lessons.md`

## Commands Run
```text
make git-hooks-install
# Passed; configured .githooks.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q
# Passed: 123 passed in 0.38s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_maintenance_service.py -q
# Passed: 207 passed, 2 warnings in 9.05s.

git diff --check
# Passed.

make proto
# Passed: ./scripts/proto_gen.sh; no generated artifact diff.

git commit -m "Add external runtime source descriptors"
# Passed pre-commit full gate on macOS 256 GiB host:
# - make swift-test: passed.
# - make py-test: passed, 4435 passed, 14 skipped, 2 warnings in 183.20s.
# - make integration-test: passed, 123 passed, 1 skipped in 777.06s.
# - Scoped performance report: Status ok, 0 regressions.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q
# Passed after review feedback fix: 123 passed in 0.40s.

git diff --check
# Passed after review feedback fix.

git commit -m "Address source descriptor review feedback"
# Passed pre-commit full gate on macOS 256 GiB host:
# - make swift-test: passed.
# - make py-test: passed, 4435 passed, 14 skipped, 2 warnings in 189.88s.
# - make integration-test: passed, 123 passed, 1 skipped in 423.05s.
# - Scoped performance report: Status ok, 0 regressions.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_model_registry_catalog.py -q
# Passed after Hugging Face cache root priority fix: 123 passed in 0.39s.

git diff --check
# Passed after Hugging Face cache root priority fix.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python coverage json -o /tmp/melix-issue1513-coverage.json
# Passed manual coverage sanity check: changed helper lines for explicit hub cache, default HF_HOME/hub, and no-default roots were executed.

git commit -m "Align Hugging Face cache root priority"
# Passed pre-commit full gate on macOS 256 GiB host:
# - make swift-test: passed.
# - make py-test: passed, 4435 passed, 14 skipped, 2 warnings in 173.26s.
# - make integration-test: passed, 123 passed, 1 skipped in 407.27s.
# - Scoped performance report: Status ok, 0 regressions, 100.0% changed-line coverage.
```

## Coverage and Metrics
- Latest changed-line coverage from both selected PR-scoped probes: `100.0%` aggregate (`25` measurable changed lines, `25` covered, `0` missed) for the Hugging Face cache root priority fix.
- Local pre-commit performance report: `.runtime/pre-commit-performance/20260624-193631-75c5275b/report/report.md`
- Review-fix pre-commit performance report: `.runtime/pre-commit-performance/20260624-200117-ccef9784/report/report.md` (`Status: ok`, `Regressions: 0`, `Verification failures: 0`, `Coverage: 96.0%`).
- Hugging Face priority review-fix pre-commit performance report: `.runtime/pre-commit-performance/20260624-205500-de2fdf92/report/report.md` (`Status: ok`, `Regressions: 0`, `Verification failures: 0`, `Coverage: 100.0%`).
- Model registry plain-local generation-config stat elision:
  - latest `elapsed_ms_mean`: base `54.011`, head `53.778`, delta `-0.233` (`-0.43%`), status `neutral`
  - `generation_config_stat_calls_mean`: base `0.000`, head `0.000`, status `neutral`
  - `manifest_is_file_calls_mean`: base `0.000`, head `0.000`, status `neutral`
  - `config_load_calls_mean`: base `400.000`, head `400.000`, status `neutral`
  - `manifest_parse_calls_mean`: base `0.000`, head `0.000`, status `neutral`
- Model registry README base_model source fast path:
  - latest `new_elapsed_ms_mean`: base `0.041`, head `0.041`, delta `-0.000` (`-0.23%`), status `neutral`
  - `delta_ms`: base `-1.079`, head `-1.076`, delta `+0.003` (`-0.31%`), status `neutral`
  - `speedup`: base `27.097`, head `27.078`, delta `-0.019` (`-0.07%`), status `neutral`
  - `new_peak_bytes_mean`: base `381.000`, head `381.000`, status `neutral`
- Earlier review-fix scoped performance against `ccef9784`:
  - Model registry plain-local generation-config stat elision: `elapsed_ms_mean` base `62.346`, head `54.621`, delta `-7.725` (`-12.39%`), status `improvement`; all stat/manifest call counters remained neutral.
  - Model registry README base_model source fast path: `new_elapsed_ms_mean` base `0.042`, head `0.042`, delta `+0.000` (`+0.04%`), status `neutral`; `speedup` base `26.808`, head `26.991`, status `neutral`.
- Observability mode: `minimal`; descriptor metadata is added to registry snapshots using existing payload plumbing.
- Probe overhead: measured by existing direct PR-scoped model-registry probes; no new production metrics, debug artifacts, or evidence-mode probes were added.

## Known Gaps
- #1514 owns scan receipt/classification output and source-specific scanners for external runtime stores.
- ModelScope, Ollama, and LM Studio are descriptor-only in this slice; they declare requested roots and policies but do not yet scan or import models.
- No protocol schema/generated artifact changes.
- No dependency or lockfile changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A is stated: no protocol schema changes.
- [x] Dependency changes include updated lockfiles, or N/A is stated: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
