### PR TITLE
perf(worker): avoid PurePath allocation in export path validation

### DIFF
--- a/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
+++ b/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
@@ -212,6 +212,14 @@ retention report, cleanup dry-run/apply behavior, and byte-accounting metrics.
 Neither unit may introduce a fifth target type or a target-specific side
 channel without updating this plan first.
 
+The manifest validator's safe relative path gate is on the per-file validation
+hot path. It must preserve the same rejection semantics while using direct
+string checks for absolute, Windows-drive, UNC, empty-component, and parent
+component shapes instead of allocating `PurePath` helper objects for every file
+row. The registered `runtime-export-manifest-validation` PR-scoped probe remains
+the evidence source for this Python slice and includes focused test, coverage,
+and `command_json` probe commands in `infra/perf/pr_scoped_probes.json`.
+
 ### Export Plan Receipt
 
 Before materializing artifacts, export planning writes

--- a/services/mlx-worker-python/tests/test_export_target_manifest_contract.py
+++ b/services/mlx-worker-python/tests/test_export_target_manifest_contract.py
@@ -189,6 +189,23 @@ def test_export_target_manifest_safe_relative_path_rejects_invalid_shapes(
     assert expected in str(_safe_relative_path_error(path_value))
 
 
+def test_export_target_manifest_safe_relative_path_uses_string_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import worker.productization.export_target_manifest as target
+
+    def fail_pure_path(*_args: object, **_kwargs: object) -> None:  # pragma: no cover
+        raise AssertionError("safe relative path checks should not allocate PurePath helpers")
+
+    monkeypatch.setattr(target, "PurePosixPath", fail_pure_path)
+    monkeypatch.setattr(target, "PureWindowsPath", fail_pure_path)
+
+    assert target._safe_relative_path_error("artifacts/model.gguf") is None
+    assert "parent-directory" in str(target._safe_relative_path_error("artifacts/../model.gguf"))
+    assert "Windows absolute" in str(target._safe_relative_path_error("C:/Models/model.gguf"))
+    assert "absolute" in str(target._safe_relative_path_error("/tmp/export.bin"))
+
+
 def test_export_target_manifest_rejects_file_row_contract_violations(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/export_target_manifest.py
+++ b/services/mlx-worker-python/worker/productization/export_target_manifest.py
@@ -379,24 +379,27 @@ def _append_path_error(errors: list[str], field_name: str, path_value: str) -> N
 
 
 def _safe_relative_path_error(path_value: str) -> str | None:
-    if path_value != path_value.strip():
-        return "leading or trailing whitespace is not allowed"
     if not path_value:
         return "path is empty"
+    if path_value[0].isspace() or path_value[-1].isspace():
+        return "leading or trailing whitespace is not allowed"
     if "\\" in path_value:
         return "backslashes are not allowed"
 
-    windows_path = PureWindowsPath(path_value)
-    if windows_path.is_absolute() or windows_path.drive or path_value.startswith("\\\\"):
+    if (
+        len(path_value) >= 2
+        and path_value[1] == ":"
+        and path_value[0].isascii()
+        and path_value[0].isalpha()
+    ) or path_value.startswith("//"):
         return "Windows absolute, drive, or UNC paths are not allowed"
 
-    posix_path = PurePosixPath(path_value)
-    if posix_path.is_absolute():
+    if path_value[0] == "/":
         return "absolute paths are not allowed"
     if path_value == ".":
         return "current-directory paths are not allowed"
     if "//" in path_value:
         return "empty path components are not allowed"
-    if any(part in ("", "..") for part in posix_path.parts):
+    if ".." in path_value.split("/"):
         return "empty or parent-directory path components are not allowed"
     return None


### PR DESCRIPTION
## Summary
- Optimize runtime export manifest safe-relative-path validation by replacing per-row `PurePath` helper allocations with direct string checks.
- Add a regression test that fails if the validator calls `PurePosixPath` or `PureWindowsPath` on the hot path.
- Document the validator hot-path constraint in the runtime-aware export plan.

## Plan or Spec
- `docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md`
- Registered PR-scoped probe: `runtime-export-manifest-validation` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe on origin/main-equivalent worktree before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_manifest_validation_probe.py
exit 0; {"elapsed_ms_mean": 2543.2790362014202, "fixture_count": 4.0, "iteration_count": 250.0, "manifest_byte_size": 21400.0, "peak_bytes_mean": 35070.2, "sample_count": 5.0, "schema_error_count": 0.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py::test_export_target_manifest_safe_relative_path_uses_string_checks services/mlx-worker-python/tests/test_export_target_manifest_contract.py::test_export_target_manifest_safe_relative_path_rejects_invalid_shapes
exit 0; 5 passed in 0.07s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
exit 0; 36 passed in 1.07s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_manifest.py services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_manifest_metrics_report.py scripts/runtime_export_manifest_validation_probe.py
exit 0; 36 passed in 0.76s; TOTAL 13 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_manifest_validation_probe.py
exit 0; {"elapsed_ms_mean": 2191.0298437986057, "fixture_count": 4.0, "iteration_count": 250.0, "manifest_byte_size": 21400.0, "peak_bytes_mean": 35862.8, "sample_count": 5.0, "schema_error_count": 0.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 13 0 100%`).
- Registered local probe (`runtime-export-manifest-validation`): old_mean=`2543.279036` ms, new_mean=`2191.029844` ms, delta=`-352.249192` ms, speedup=`1.160769x` / `13.85%` faster.
- Peak memory mean changed from `35070.2` bytes to `35862.8` bytes (`+792.6` bytes); latency is the acceptance metric for this slice.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local verification is Linux/Python-only. No Swift runtime effect is claimed.
- CI must publish the registered PR-scoped probe report before this PR is merged.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped `command_json` probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
