### PR TITLE
perf(worker): streamline export retention summaries

### DIFF
--- a/docs/plans/2026-06-25-runtime-export-retention-single-pass.md
+++ b/docs/plans/2026-06-25-runtime-export-retention-single-pass.md
@@ -1,0 +1,34 @@
+# Runtime Export Retention Single-Pass Summary Slice
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.productization.export_target_layout.build_export_retention_report()` and
+its target-relative path helper. It preserves retention decisions and report
+payloads while reusing the resolved target root and avoiding separate
+post-processing passes for retained, cleanable, deleted, and missing file
+summaries.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`runtime-export-layout-retention` in `infra/perf/pr_scoped_probes.json`. The
+probe includes focused `test_command`, `coverage_command`, and `probe_command`
+entries and measures layout materialization plus retention-report aggregation.
+
+## Implementation Plan
+
+1. Resolve the export target root once per retention report and reuse it for
+   target-relative path validation.
+2. Keep `_decide_file()` behavior and decision order unchanged.
+3. Replace the four derived list comprehensions in
+   `build_export_retention_report()` with one summary loop that accumulates byte
+   sizes, file counts, and decision payloads.
+4. Run the registered focused tests, changed-scope coverage, and local Linux
+   registered probe before opening the PR.
+5. Use GitHub Actions PR-scoped performance as the final merge gate.
+
+## Validation Boundary
+
+This slice touches Python code only and is locally verifiable on Linux. It does
+not claim Swift runtime effects.

--- a/services/mlx-worker-python/worker/productization/export_target_layout.py
+++ b/services/mlx-worker-python/worker/productization/export_target_layout.py
@@ -178,29 +178,43 @@ def build_export_retention_report(
     now: float | None = None,
 ) -> dict[str, object]:
     current_time = time.time() if now is None else now
-    decisions: list[_FileDecision] = []
+    resolved_target_root = layout.target_root.resolve()
+    retained_byte_size = 0
+    cleanable_byte_size = 0
+    deleted_byte_size = 0
+    retained_file_count = 0
+    cleanable_file_count = 0
+    deleted_file_count = 0
+    missing_file_count = 0
+    retention_decision_count = 0
+    decision_payloads: list[dict[str, object]] = []
     for section, rows in _file_sections(manifest):
         for row in rows:
-            decisions.append(
-                _decide_file(
-                    layout,
-                    manifest,
-                    section,
-                    row,
-                    apply_cleanup=apply_cleanup,
-                    now=current_time,
-                )
+            decision = _decide_file(
+                layout,
+                manifest,
+                section,
+                row,
+                resolved_target_root=resolved_target_root,
+                apply_cleanup=apply_cleanup,
+                now=current_time,
             )
-
-    retained = [decision for decision in decisions if decision.decision == RETENTION_DECISION_RETAIN]
-    cleanable = [
-        decision
-        for decision in decisions
-        if decision.decision
-        in {RETENTION_DECISION_CLEANABLE, RETENTION_DECISION_DELETE_AFTER_TTL}
-    ]
-    deleted = [decision for decision in decisions if decision.deleted]
-    missing = [decision for decision in decisions if not decision.exists]
+            retention_decision_count += 1
+            if decision.decision == RETENTION_DECISION_RETAIN:
+                retained_byte_size += decision.byte_size
+                retained_file_count += 1
+            elif decision.decision in {
+                RETENTION_DECISION_CLEANABLE,
+                RETENTION_DECISION_DELETE_AFTER_TTL,
+            }:
+                cleanable_byte_size += decision.byte_size
+                cleanable_file_count += 1
+            if decision.deleted:
+                deleted_byte_size += decision.byte_size
+                deleted_file_count += 1
+            if not decision.exists:
+                missing_file_count += 1
+            decision_payloads.append(_decision_payload(decision))
 
     payload = {
         "schema_version": EXPORT_RETENTION_REPORT_SCHEMA_VERSION,
@@ -209,15 +223,15 @@ def build_export_retention_report(
         "target_type": layout.target_type_segment,
         "target_root": _relative_to_workspace(layout, layout.target_root),
         "mode": "apply" if apply_cleanup else "dry_run",
-        "retained_byte_size": sum(decision.byte_size for decision in retained),
-        "cleanable_byte_size": sum(decision.byte_size for decision in cleanable),
-        "deleted_byte_size": sum(decision.byte_size for decision in deleted),
-        "retention_decision_count": len(decisions),
-        "retained_file_count": len(retained),
-        "cleanable_file_count": len(cleanable),
-        "deleted_file_count": len(deleted),
-        "missing_file_count": len(missing),
-        "decisions": [_decision_payload(decision) for decision in decisions],
+        "retained_byte_size": retained_byte_size,
+        "cleanable_byte_size": cleanable_byte_size,
+        "deleted_byte_size": deleted_byte_size,
+        "retention_decision_count": retention_decision_count,
+        "retained_file_count": retained_file_count,
+        "cleanable_file_count": cleanable_file_count,
+        "deleted_file_count": deleted_file_count,
+        "missing_file_count": missing_file_count,
+        "decisions": decision_payloads,
     }
     return payload
 
@@ -413,10 +427,11 @@ def _decide_file(
     section: str,
     row: export_target_manifest_pb2.ExportTargetFile,
     *,
+    resolved_target_root: Path | None = None,
     apply_cleanup: bool,
     now: float,
 ) -> _FileDecision:
-    path = _target_relative_path(layout, row.path)
+    path = _target_relative_path(layout, row.path, resolved_root=resolved_target_root)
     exists = path.exists()
     decision, reason = _retention_decision(manifest, row, path, exists, now)
     deleted = False
@@ -520,12 +535,17 @@ def _path_segment(value: str) -> str:
     return segment or "unnamed"
 
 
-def _target_relative_path(layout: ExportTargetLayout, relative_path: str) -> Path:
+def _target_relative_path(
+    layout: ExportTargetLayout,
+    relative_path: str,
+    *,
+    resolved_root: Path | None = None,
+) -> Path:
     if not relative_path:
         raise ValueError("export target file path is empty")
-    resolved_root = layout.target_root.resolve()
-    path = (resolved_root / relative_path).resolve()
-    if not path.is_relative_to(resolved_root):
+    target_root = layout.target_root.resolve() if resolved_root is None else resolved_root
+    path = (target_root / relative_path).resolve()
+    if not path.is_relative_to(target_root):
         raise ValueError(f"export target file path escapes target root: {relative_path}")
     return path
 


### PR DESCRIPTION
## Summary
- Reuses the resolved export target root while building retention reports.
- Collapses retained/cleanable/deleted/missing retention summaries into the same decision loop.
- Adds a focused plan for the Python-only runtime export retention slice.

## Plan or Spec
- `docs/plans/2026-06-25-runtime-export-retention-single-pass.md`
- Registered PR-scoped probe: `runtime-export-layout-retention` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_layout_retention_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_layout_retention_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_layout_retention_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_layout_retention_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_layout.py services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_layout_retention_report.py scripts/runtime_export_layout_retention_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-layout-retention --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/runtime_export_layout_retention_probe.json`

## Coverage and Metrics
- Focused tests: 21 passed.
- Changed-scope coverage: 100% (29/29 changed measurable lines).
- Local registered probe (`runtime-export-layout-retention`, Linux): base `elapsed_ms_mean=3990.7076`, head `elapsed_ms_mean=3732.8627`, delta `-257.8449ms`, speedup `1.069x` (lower is better).
- Informational metrics stayed stable: `retained_byte_size=12141056`, `retention_decision_count=15`, `target_count=4`.
- GitHub Actions PR-scoped performance is required for registered CI validation before merge.

## Known Gaps
- Python-only slice; no Swift runtime effect is claimed or locally validated.
- Local metrics are from Linux synthetic fixture probes; CI remains the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows an improvement.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
