### PR TITLE
perf(worker): reuse manifest bytes during export validation

### DIFF
--- a/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
+++ b/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
@@ -219,6 +219,9 @@ component shapes instead of allocating `PurePath` helper objects for every file
 row. The registered `runtime-export-manifest-validation` PR-scoped probe remains
 the evidence source for this Python slice and includes focused test, coverage,
 and `command_json` probe commands in `infra/perf/pr_scoped_probes.json`.
+The same validator should derive `manifest_byte_size` from the manifest bytes it
+already read for protobuf JSON parsing instead of issuing a second filesystem
+stat call on every validation.
 
 ### Export Plan Receipt
 

--- a/services/mlx-worker-python/tests/test_export_target_manifest_contract.py
+++ b/services/mlx-worker-python/tests/test_export_target_manifest_contract.py
@@ -70,6 +70,26 @@ def test_export_target_manifest_fixture_reports_machine_readable_metrics() -> No
     assert report.intermediate_file_count == 1
 
 
+def test_export_target_manifest_reuses_read_bytes_for_manifest_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = FIXTURE_ROOT / "melix_managed/export-target-manifest.json"
+    expected_size = len(path.read_bytes())
+
+    def fail_manifest_stat(self: Path, *_args: object, **_kwargs: object) -> None:
+        raise AssertionError("manifest validation should not stat after reading bytes")
+
+    monkeypatch.setattr(Path, "stat", fail_manifest_stat)
+
+    report = validate_export_target_manifest_file(path)
+
+    with pytest.raises(AssertionError):
+        path.stat()
+
+    assert report.ok is True
+    assert report.manifest_byte_size == expected_size
+
+
 def test_export_target_manifest_metrics_cli_aggregates_fixture_set(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/export_target_manifest.py
+++ b/services/mlx-worker-python/worker/productization/export_target_manifest.py
@@ -67,7 +67,8 @@ def validate_export_target_manifest_file(
 ):
     manifest_path = Path(path)
     started = time.perf_counter()
-    payload = manifest_path.read_text(encoding="utf-8")
+    payload_bytes = manifest_path.read_bytes()
+    payload = payload_bytes.decode("utf-8")
     manifest = export_target_manifest_pb2.ExportTargetManifest()
     errors: list[str] = []
 
@@ -88,7 +89,7 @@ def validate_export_target_manifest_file(
         target_type=manifest.target_type,
         fixture_count=fixture_count,
         schema_error_count=len(errors),
-        manifest_byte_size=manifest_path.stat().st_size,
+        manifest_byte_size=len(payload_bytes),
         manifest_validation_latency_ms=elapsed_ms,
         generated_file_count=len(manifest.generated_files),
         required_file_count=len(manifest.required_files),


### PR DESCRIPTION
## Summary
- Reuse the already-read manifest bytes when computing `manifest_byte_size` in export target manifest validation.
- Add a regression test that fails if validation performs a second `Path.stat()` after reading manifest bytes.
- Update the runtime-aware export plan to record this validator hot-path slice.

## Plan or Spec
- `docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md`
- Registered PR-scoped probe: `runtime-export-manifest-validation` in `infra/perf/pr_scoped_probes.json`

## Commands Run
```text
# Baseline probe on origin/main before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_manifest_validation_probe.py
exit 0; {"elapsed_ms_mean": 2203.8290586002404, "fixture_count": 4.0, "iteration_count": 250.0, "manifest_byte_size": 21400.0, "peak_bytes_mean": 36065.4, "sample_count": 5.0, "schema_error_count": 0.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py::test_export_target_manifest_reuses_read_bytes_for_manifest_size
exit 0; 1 passed in 0.11s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
exit 0; 37 passed in 0.29s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_manifest.py services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_manifest_metrics_report.py scripts/runtime_export_manifest_validation_probe.py
exit 0; TOTAL 13 0 100%

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Registered local probe (`runtime-export-manifest-validation`) on Linux:
  - baseline `elapsed_ms_mean=2203.8290586002404`, `schema_error_count=0.0`, `manifest_byte_size=21400.0`
  - head `elapsed_ms_mean=2162.8920713992557`, `schema_error_count=0.0`, `manifest_byte_size=21400.0`
  - delta `-40.93698720098473 ms` (`~1.86%` faster)
- CI PR-scoped performance workflow is required as the registered validation source for merge.

## Known Gaps
- Linux local validation covers this Python slice only; full repository gates and registered PR-scoped probe validation are delegated to GitHub Actions.
- No protocol or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
