### PR TITLE
perf(worker): reuse validated smoke manifests

### DIFF
--- a/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
+++ b/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
@@ -424,6 +424,14 @@ generation-capable `EXPORT_TARGET_TYPE_MELIX_MANAGED`,
 local runtime is configured, and the waiver must record the missing runtime
 capability.
 
+The metrics-report path may reuse the already validated target manifest object
+when materializing fixture digest files and executing the smoke receipt writer.
+It must preserve the public `run_export_target_smoke()` validation boundary for
+external callers while avoiding an extra manifest parse on each probe iteration.
+The registered `runtime-export-smoke-policy` PR-scoped probe remains the
+evidence source for this Python slice and includes focused test, coverage, and
+`command_json` probe commands in `infra/perf/pr_scoped_probes.json`.
+
 Bounded generation checks must use a repository-owned prompt fixture or a
 synthetic non-private prompt, a fixed token limit, a timeout, and a preview byte
 limit. The preview is diagnostic evidence only; it is not an evaluation score.

--- a/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
+++ b/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 import runpy
 import sys
+from typing import Any
 
 from google.protobuf import json_format
 import pytest
@@ -202,6 +203,28 @@ def test_export_target_smoke_metrics_report_covers_all_fixtures(tmp_path: Path) 
     assert payload["output_preview_byte_count"] > 0
     assert payload["timeout_count"] == 0
     assert payload["waiver_count"] == 0
+
+
+def test_export_target_smoke_metrics_report_reuses_validated_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_paths = [FIXTURE_ROOT / "melix_managed/export-target-manifest.json"]
+    original_validate = export_target_smoke.validate_export_target_manifest_file
+    validation_calls = 0
+
+    def tracked_validate(*args: Any, **kwargs: Any):
+        nonlocal validation_calls
+        validation_calls += 1
+        return original_validate(*args, **kwargs)
+
+    monkeypatch.setattr(export_target_smoke, "validate_export_target_manifest_file", tracked_validate)
+
+    payload = export_target_smoke.build_smoke_metrics_report(manifest_paths, tmp_path)
+
+    assert payload["ok"] is True
+    assert payload["target_count"] == 1
+    assert validation_calls == len(manifest_paths)
 
 
 def test_runtime_export_smoke_policy_probe_script_emits_metrics(

--- a/services/mlx-worker-python/worker/productization/export_target_smoke.py
+++ b/services/mlx-worker-python/worker/productization/export_target_smoke.py
@@ -78,6 +78,24 @@ def run_export_target_smoke(
         )
 
     layout = build_export_target_layout(workspace_root, manifest)
+    return _run_export_target_smoke_validated(
+        manifest,
+        layout,
+        available_runtime_binaries=available_runtime_binaries,
+        operator_id=operator_id,
+        now=current_time,
+    )
+
+
+def _run_export_target_smoke_validated(
+    manifest: export_target_manifest_pb2.ExportTargetManifest,
+    layout,
+    *,
+    available_runtime_binaries: set[str] | None,
+    operator_id: str,
+    now: float,
+) -> dict[str, object]:
+    current_time = now
     timeout_ms = int(manifest.verification_policy.timeout_ms)
     preview_limit = int(manifest.verification_policy.preview_byte_limit)
     receipt_path = _target_relative_path(layout, manifest.evidence.smoke_receipt_path)
@@ -207,17 +225,18 @@ def build_smoke_metrics_report(
 
     from worker.productization.export_target_layout import materialize_export_target_layout
 
+    workspace_path = Path(workspace_root)
     for manifest_path in manifest_paths:
         export_report = materialize_export_target_layout(
             manifest_path,
-            workspace_root,
+            workspace_path,
             create_placeholder_files=True,
             now=now,
         )
         if export_report.get("ok") is not True:
             errors.extend(str(error) for error in export_report.get("errors", []))
             continue
-        target_root = Path(workspace_root) / str(export_report["target_root"])
+        target_root = workspace_path / str(export_report["target_root"])
         manifest, validation_report = validate_export_target_manifest_file(
             target_root / "export-target-manifest.json",
             return_manifest=True,
@@ -228,11 +247,12 @@ def build_smoke_metrics_report(
         _write_digest_fixture_files(target_root, manifest)
         try:
             receipts.append(
-                run_export_target_smoke(
-                    target_root / "export-target-manifest.json",
-                    workspace_root,
+                _run_export_target_smoke_validated(
+                    manifest,
+                    build_export_target_layout(workspace_path, manifest),
                     available_runtime_binaries=_fixture_runtime_binaries(manifest),
-                    now=now,
+                    operator_id="melix-export-smoke",
+                    now=now if now is not None else time.time(),
                 )
             )
         except Exception as exc:  # pragma: no cover - caller needs aggregate errors


### PR DESCRIPTION
## Summary
- Reuses the validated target manifest object when the runtime export smoke metrics report materializes digest fixtures and writes smoke receipts.
- Preserves the public `run_export_target_smoke()` validation boundary for external callers.
- Adds a regression test that the metrics report path does not re-parse manifests through the smoke module.

## Plan or Spec
- `docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md` updated with the smoke metrics-report manifest reuse rule and registered probe evidence source.

## Commands Run
```text
# focused registered test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# result: 13 passed in 1.51s

# changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_smoke_policy_probe.py
# result: 13 passed in 1.58s; TOTAL 18 0 100%

# registered probe script, base vs head on Linux
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RUNTIME_EXPORT_SMOKE_PROBE_ITERATIONS=30 MELIX_RUNTIME_EXPORT_SMOKE_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/runtime_export_smoke_policy_probe.py
# base result: elapsed_ms_mean=3558.022, peak_bytes_mean=1205973.0
# head result: elapsed_ms_mean=3226.628, peak_bytes_mean=1199024.6

git diff --check
# result: pass
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`18/18` changed measurable lines covered).
- Registered probe: `runtime-export-smoke-policy` is already registered with focused `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json`.
- Local Linux probe comparison: `elapsed_ms_mean` improved from `3558.022` to `3226.628` ms (`delta=-331.394 ms`, `-9.31%`, `speedup=1.1027x`); `peak_bytes_mean` changed from `1205973.0` to `1199024.6` bytes (`delta=-6948.4`, `-0.58%`).
- CI PR-scoped performance report is required as the merge validation source.

## Known Gaps
- None. This is a Python-only slice and was locally validated on Linux; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
