### PR TITLE
perf(worker): cache export diagnostic target root resolution

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -78,6 +78,14 @@ It measures:
 - `redaction_count`
 - `diagnostic_latency_ms`
 
+The 2026-06-25 optimization slice keeps the parser contract unchanged and caches
+`layout.target_root.resolve(strict=False)` once per redacted excerpt build. It
+also labels absolute paths that are already lexically under the resolved target
+root without per-path filesystem resolution, falling back to the previous
+`Path.resolve(strict=False)` path when `..` segments require normalization. This
+avoids repeated resolution work in multi-path runtime logs while preserving
+safe target-relative redaction labels.
+
 Focused verification:
 
 ```bash

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -6398,6 +6398,17 @@
         "warn_pct": 5.0
       },
       {
+        "key": "path_redaction_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "path_redaction_count",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
         "key": "target_count",
         "unit": "count",
         "direction": "informational"

--- a/scripts/runtime_export_diagnostic_parser_probe.py
+++ b/scripts/runtime_export_diagnostic_parser_probe.py
@@ -17,13 +17,22 @@ for candidate in (ROOT, WORKER_ROOT):
     if str(candidate) not in sys.path:
         sys.path.insert(0, str(candidate))  # pragma: no cover - script bootstrap
 
-from worker.productization.export_target_diagnostics import build_diagnostic_metrics_report
+from worker.productization.export_target_diagnostics import (
+    _SourceLine,
+    _build_redacted_excerpt,
+    build_diagnostic_metrics_report,
+)
 
 
 FIXTURE_ROOT = (
     ROOT
     / "services/mlx-worker-python/fixtures/runtime-export/target-manifests.dev.v1"
 )
+
+
+class _ProbeLayout:
+    def __init__(self, target_root: Path) -> None:
+        self.target_root = target_root
 
 
 def _env_int(name: str, default: int, minimum: int) -> int:
@@ -34,10 +43,44 @@ def _env_int(name: str, default: int, minimum: int) -> int:
     return max(minimum, value)
 
 
+def _path_redaction_elapsed_ms(
+    *,
+    samples: int,
+    iterations: int,
+    path_count: int,
+) -> float:
+    elapsed_samples: list[float] = []
+    with tempfile.TemporaryDirectory(prefix="melix-export-diagnostics-paths-") as directory:
+        target_root = Path(directory) / "target"
+        target_root.mkdir(parents=True)
+        source_lines = [
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text=f"runtime load failed at {target_root / 'artifacts' / f'model-{index}.gguf'}",
+            )
+            for index in range(path_count)
+        ]
+        layout = _ProbeLayout(target_root)
+        for _sample in range(samples):
+            started = time.perf_counter()
+            for _index in range(iterations):
+                excerpt = _build_redacted_excerpt(
+                    layout,  # type: ignore[arg-type]
+                    source_lines,
+                    bounded_bytes=max(path_count * 160, 4096),
+                    bounded_lines=path_count + 4,
+                )
+                if excerpt.summary.redacted_absolute_path_count != path_count:
+                    raise SystemExit("export diagnostic path redaction probe failed")
+            elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+    return statistics.fmean(elapsed_samples)
+
+
 def main() -> int:
     manifests = sorted(FIXTURE_ROOT.glob("*/export-target-manifest.json"))
     iterations = _env_int("MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS", 30, 1)
     samples = _env_int("MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES", 5, 1)
+    path_count = _env_int("MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PATH_COUNT", 200, 1)
     elapsed_samples: list[float] = []
     peak_samples: list[float] = []
     target_count = 0.0
@@ -81,6 +124,12 @@ def main() -> int:
                 "unknown_failure_count": unknown_failure_count,
                 "redaction_count": redaction_count,
                 "diagnostic_latency_ms": diagnostic_latency_ms,
+                "path_redaction_elapsed_ms_mean": _path_redaction_elapsed_ms(
+                    samples=samples,
+                    iterations=iterations,
+                    path_count=path_count,
+                ),
+                "path_redaction_count": float(path_count),
                 "diagnosis_code_count": diagnosis_code_count,
                 "iteration_count": float(iterations),
                 "sample_count": float(samples),

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -21,6 +21,8 @@ from worker.productization.export_target_diagnostics import (
     build_diagnostic_metrics_report,
     build_export_diagnostics_receipt,
     write_export_diagnostics_receipt,
+    _SourceLine,
+    _build_redacted_excerpt,
 )
 from worker.productization.export_target_layout import (
     build_export_target_layout,
@@ -118,6 +120,87 @@ def test_export_target_diagnostics_redacts_paths_secrets_private_text_and_identi
     assert receipt["redaction_summary"]["redacted_identity_count"] >= 1
 
 
+def test_export_target_diagnostics_resolves_target_root_once_for_many_path_redactions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+    source_lines = [
+        _SourceLine(
+            source_path="logs/ollama-create.log",
+            text=f"runtime load failed at {target_root / 'artifacts/model.gguf'}",
+        ),
+        _SourceLine(
+            source_path="logs/ollama-create.log",
+            text=f"missing blob at {target_root / 'artifacts/blobs/sha256-777777'}",
+        ),
+        _SourceLine(
+            source_path="logs/ollama-create.log",
+            text=f"permission denied at {target_root / 'logs/ollama-create.log'}",
+        ),
+    ]
+    original_resolve = Path.resolve
+    target_root_resolves = 0
+
+    def tracking_resolve(path: Path, strict: bool = False) -> Path:
+        nonlocal target_root_resolves
+        if path == target_root:
+            target_root_resolves += 1
+        return original_resolve(path, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", tracking_resolve)
+
+    excerpt = _build_redacted_excerpt(
+        layout,
+        source_lines,
+        bounded_bytes=4096,
+        bounded_lines=20,
+    )
+
+    assert target_root_resolves == 1
+    assert "<target>/artifacts/model.gguf" in excerpt.text
+    assert "<target>/artifacts/blobs/sha256-777777" in excerpt.text
+    assert "<target>/logs/ollama-create.log" in excerpt.text
+
+
+def test_export_target_diagnostics_redaction_uses_unresolved_root_when_root_resolve_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+    source_lines = [
+        _SourceLine(
+            source_path="logs/ollama-create.log",
+            text=f"runtime load failed at {target_root / 'artifacts/model.gguf'}",
+        )
+    ]
+    original_resolve = Path.resolve
+
+    def maybe_raising_resolve(path: Path, strict: bool = False) -> Path:
+        if path == target_root:
+            raise OSError("target root cannot be resolved")
+        return original_resolve(path, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", maybe_raising_resolve)
+
+    excerpt = _build_redacted_excerpt(
+        layout,
+        source_lines,
+        bounded_bytes=4096,
+        bounded_lines=20,
+    )
+
+    assert "<target>/artifacts/model.gguf" in excerpt.text
+
+
 def test_export_target_diagnostics_preserves_bounded_unknown_failure_excerpt(
     tmp_path: Path,
 ) -> None:
@@ -201,7 +284,7 @@ def test_export_target_diagnostics_falls_back_when_path_resolution_raises_oserro
         FIXTURE_ROOT / "ollama/export-target-manifest.json",
     )
     layout = build_export_target_layout(tmp_path, manifest)
-    raw_path = target_root / "artifacts/blobs/sha256-777777"
+    raw_path = target_root / "artifacts" / ".." / "artifacts/blobs/sha256-777777"
     (target_root / "logs/ollama-create.log").write_text(
         f"runtime load failed while opening {raw_path}\n",
         encoding="utf-8",

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -3262,6 +3262,8 @@ def test_runtime_export_diagnostic_parser_probe_script_emits_metrics(
     assert metrics["unknown_failure_count"] == 1.0
     assert metrics["redaction_count"] >= 2.0
     assert metrics["diagnostic_latency_ms"] >= 0
+    assert metrics["path_redaction_elapsed_ms_mean"] >= 0
+    assert metrics["path_redaction_count"] >= 1.0
     assert metrics["elapsed_ms_mean"] >= 0
 
 

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -506,11 +506,15 @@ def _build_redacted_excerpt(
     output_lines: list[str] = []
     line_numbers: dict[int, int] = {}
     used_bytes = 0
+    try:
+        resolved_target_root = layout.target_root.resolve(strict=False)
+    except OSError:
+        resolved_target_root = layout.target_root
     for index, source_line in enumerate(source_lines):
         if len(output_lines) >= bounded_lines:
             summary.truncated = True
             break
-        redacted = _redact_text(source_line.text, layout, summary)
+        redacted = _redact_text(source_line.text, resolved_target_root, summary)
         rendered = f"[{source_line.source_path}] {redacted}"
         rendered_bytes = (rendered + "\n").encode("utf-8")
         if used_bytes + len(rendered_bytes) > bounded_bytes:
@@ -547,7 +551,7 @@ def _build_redacted_excerpt(
 
 def _redact_text(
     text: str,
-    layout: ExportTargetLayout,
+    resolved_target_root: Path,
     summary: _RedactionSummary,
 ) -> str:
     if _PRIVATE_TEXT_LINE_PATTERN.search(text):
@@ -574,7 +578,7 @@ def _redact_text(
         text,
     )
     return _ABSOLUTE_PATH_PATTERN.sub(
-        lambda match: _redact_absolute_path(match.group(0), layout, summary),
+        lambda match: _redact_absolute_path(match.group(0), resolved_target_root, summary),
         text,
     )
 
@@ -598,16 +602,18 @@ def _record_identity(summary: _RedactionSummary, key: str) -> str:
 
 def _redact_absolute_path(
     raw_path: str,
-    layout: ExportTargetLayout,
+    resolved_target_root: Path,
     summary: _RedactionSummary,
 ) -> str:
     trimmed_path = raw_path.rstrip(".,)")
     suffix = raw_path[len(trimmed_path):]
     replacement = "<absolute-path>"
     try:
-        relative = Path(trimmed_path).resolve(strict=False).relative_to(
-            layout.target_root.resolve(strict=False)
-        )
+        path = Path(trimmed_path)
+        if ".." not in path.parts:
+            relative = path.relative_to(resolved_target_root)
+        else:
+            relative = path.resolve(strict=False).relative_to(resolved_target_root)
         replacement = f"<target>/{relative.as_posix()}"
     except (ValueError, OSError):
         pass


### PR DESCRIPTION
## Summary
- Cache `layout.target_root.resolve(strict=False)` once per export diagnostic redaction excerpt.
- Use lexical `relative_to()` for already-normalized absolute paths under the target root, with the existing resolve fallback for `..` segments.
- Extend the registered runtime export diagnostic parser probe with focused path-redaction metrics.

## Plan or Spec
- Updated `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md` with the 2026-06-25 root-resolution cache slice and validation boundary.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- Baseline/new microbench against the same 200-path redaction scenario using a detached HEAD worktree and this branch.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 23 passed.
- Changed-scope coverage: 97% aggregate; `export_target_diagnostics.py` changed lines 100% covered.
- Registered local probe output: `path_redaction_elapsed_ms_mean=336.334ms`, `path_redaction_count=200`, `elapsed_ms_mean=2847.444ms`, `diagnostic_parser_coverage=1.0`.
- Direct before/after microbench for 200 target-root path redactions over 30 iterations x 5 samples: old mean `664.170ms`, new mean `336.264ms`, delta `-327.906ms`, speedup `1.98x`.

## Known Gaps
- Local verification is Linux/Python only. The registered PR-scoped performance workflow must validate the probe in CI before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally and emitted JSON metrics.
- [x] CI PR-scoped performance report required before merge.
