### PR TITLE
perf(worker): guard export diagnostic secret regexes

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -86,6 +86,14 @@ root without per-path filesystem resolution, falling back to the previous
 avoids repeated resolution work in multi-path runtime logs while preserving
 safe target-relative redaction labels.
 
+A follow-up 2026-06-25 slice keeps the same redaction contract but gates the
+secret/identity regex substitutions behind cheap marker checks. Plain runtime
+log lines that only contain an absolute target path still run the absolute-path
+redactor, but skip the bearer-token, named-secret, URL credential, OpenAI key,
+certificate, and identity regex passes. Lines with `:`, `=`, `@`, `sk-`, or a
+certificate preamble continue through the relevant guarded regexes before path
+redaction.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from packages.protocol.python.workspace.v1 import export_target_manifest_pb2
+from worker.productization import export_target_diagnostics as export_target_diagnostics_module
 from worker.productization.export_target_diagnostics import (
     CODE_DUPLICATE_TENSOR_NAME,
     CODE_INSUFFICIENT_MEMORY,
@@ -96,6 +97,8 @@ def test_export_target_diagnostics_redacts_paths_secrets_private_text_and_identi
             "proxy=http://user:secret-proxy-pass@example.test",
             "prompt: private customer prompt that must not leave the log",
             "operator_id=chenyu",
+            "certificate -----BEGIN TOKEN-----abc123-----END TOKEN-----",
+            "openai key sk-liveexample12345678",
         ]
     )
     (target_root / "logs/ollama-create.log").write_text(log_text + "\n", encoding="utf-8")
@@ -112,6 +115,8 @@ def test_export_target_diagnostics_redacts_paths_secrets_private_text_and_identi
     assert "sk-testsecret" not in excerpt
     assert "super-secret-value" not in excerpt
     assert "secret-proxy-pass" not in excerpt
+    assert "abc123" not in excerpt
+    assert "sk-liveexample12345678" not in excerpt
     assert "private customer prompt" not in excerpt
     assert "chenyu" not in excerpt
     assert receipt["redaction_summary"]["redacted_absolute_path_count"] >= 1
@@ -165,6 +170,50 @@ def test_export_target_diagnostics_resolves_target_root_once_for_many_path_redac
     assert "<target>/artifacts/model.gguf" in excerpt.text
     assert "<target>/artifacts/blobs/sha256-777777" in excerpt.text
     assert "<target>/logs/ollama-create.log" in excerpt.text
+
+
+def test_export_target_diagnostics_skips_secret_regexes_for_plain_path_lines(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+
+    class FailingSecretPattern:
+        def sub(self, *_args: object, **_kwargs: object) -> str:  # pragma: no cover
+            raise AssertionError("secret redaction regex should be skipped")
+
+    for pattern_name in (
+        "_CERTIFICATE_PATTERN",
+        "_BEARER_SECRET_PATTERN",
+        "_NAMED_SECRET_PATTERN",
+        "_URL_CREDENTIAL_PATTERN",
+        "_OPENAI_KEY_PATTERN",
+        "_IDENTITY_PATTERN",
+    ):
+        monkeypatch.setattr(
+            export_target_diagnostics_module,
+            pattern_name,
+            FailingSecretPattern(),
+        )
+
+    excerpt = _build_redacted_excerpt(
+        layout,
+        [
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text=f"runtime load failed at {target_root / 'artifacts/model.gguf'}",
+            )
+        ],
+        bounded_bytes=4096,
+        bounded_lines=20,
+    )
+
+    assert "<target>/artifacts/model.gguf" in excerpt.text
+    assert excerpt.summary.redacted_secret_count == 0
 
 
 def test_export_target_diagnostics_redaction_uses_unresolved_root_when_root_resolve_fails(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -69,6 +69,9 @@ _PRIVATE_TEXT_LINE_PATTERN = re.compile(
 _IDENTITY_PATTERN = re.compile(
     r"(?i)\b(user|operator)(?:[_-]?(?:id|name))?\s*[:=]\s*['\"]?[^'\"\s,;]+['\"]?"
 )
+_SECRET_REDACTION_MARKERS = ("=", ":", "@", "sk-", "-----BEGIN ")
+_NAMED_SECRET_MARKERS = ("api", "access", "token", "password", "secret")
+_IDENTITY_MARKERS = ("user", "operator")
 
 
 @dataclass(frozen=True, slots=True)
@@ -559,24 +562,32 @@ def _redact_text(
         summary.redaction_count += 1
         return "<redacted-private-preview>"
 
-    text = _CERTIFICATE_PATTERN.sub(lambda _match: _record_secret(summary), text)
-    text = _BEARER_SECRET_PATTERN.sub(
-        lambda match: match.group(1) + _record_secret(summary),
-        text,
-    )
-    text = _NAMED_SECRET_PATTERN.sub(
-        lambda match: f"{match.group(1)}=<redacted-secret>{_record_secret_count_only(summary)}",
-        text,
-    )
-    text = _URL_CREDENTIAL_PATTERN.sub(
-        lambda match: match.group(1) + _record_secret(summary) + match.group(2),
-        text,
-    )
-    text = _OPENAI_KEY_PATTERN.sub(lambda _match: _record_secret(summary), text)
-    text = _IDENTITY_PATTERN.sub(
-        lambda match: _record_identity(summary, match.group(1)),
-        text,
-    )
+    if any(marker in text for marker in _SECRET_REDACTION_MARKERS):
+        secret_text = text.lower()
+        if "-----begin " in secret_text:
+            text = _CERTIFICATE_PATTERN.sub(lambda _match: _record_secret(summary), text)
+        if "bearer" in secret_text:
+            text = _BEARER_SECRET_PATTERN.sub(
+                lambda match: match.group(1) + _record_secret(summary),
+                text,
+            )
+        if any(marker in secret_text for marker in _NAMED_SECRET_MARKERS):
+            text = _NAMED_SECRET_PATTERN.sub(
+                lambda match: f"{match.group(1)}=<redacted-secret>{_record_secret_count_only(summary)}",
+                text,
+            )
+        if "://" in text and "@" in text:
+            text = _URL_CREDENTIAL_PATTERN.sub(
+                lambda match: match.group(1) + _record_secret(summary) + match.group(2),
+                text,
+            )
+        if "sk-" in text:
+            text = _OPENAI_KEY_PATTERN.sub(lambda _match: _record_secret(summary), text)
+        if any(marker in secret_text for marker in _IDENTITY_MARKERS):
+            text = _IDENTITY_PATTERN.sub(
+                lambda match: _record_identity(summary, match.group(1)),
+                text,
+            )
     return _ABSOLUTE_PATH_PATTERN.sub(
         lambda match: _redact_absolute_path(match.group(0), resolved_target_root, summary),
         text,


### PR DESCRIPTION
## Summary
- Guard runtime export diagnostic secret/identity regex passes behind cheap marker checks.
- Preserve absolute path redaction for plain runtime log lines while skipping unrelated secret regexes.
- Add a regression test proving plain path-only lines do not invoke secret regex passes.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_skips_secret_regexes_for_plain_path_lines services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_redacts_paths_secrets_private_text_and_identity
# 2 passed in 0.11s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 24 passed in 1.30s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# 24 passed in 1.28s; TOTAL 29 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# ok; path_redaction_elapsed_ms_mean=291.8909261992667, diagnostic_parser_coverage=1.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/runtime-export-redaction-secret-guards-pr-probe.json
# ok; head verification coverage=100.0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 29 0 100%`.
- Registered probe: `runtime-export-diagnostic-parser`.
- Base vs head PR-scoped local probe:
  - `path_redaction_elapsed_ms_mean`: base `333.04560279648285` ms, head `278.6427451996133` ms, delta `-54.40285759686955` ms (~16.3% faster).
  - `diagnostic_latency_ms`: base `9.95966799382586` ms, head `9.540187020320445` ms, delta `-0.419480973505415` ms.
  - `elapsed_ms_mean`: base `2849.196790800488` ms, head `2898.034641801496` ms, delta `+48.837851001008` ms (~1.7%, below 5% warn threshold).
  - `peak_bytes_mean`: base `198728.6`, head `202832.4`, delta `+4103.8` bytes (~2.1%, below 5% warn threshold).
  - `diagnostic_parser_coverage`: base/head `1.0`.
- GitHub Actions PR-scoped performance is still required as the merge gate.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed for this slice.
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally for this focused Python slice; CI remains the broad gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
