### PR TITLE
perf(worker): elide export diagnostic path objects

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -77,6 +77,8 @@ It measures:
 - `unknown_failure_count`
 - `redaction_count`
 - `diagnostic_latency_ms`
+- `path_redaction_elapsed_ms_mean`
+- `path_redaction_count`
 
 The 2026-06-25 optimization slice keeps the parser contract unchanged and caches
 `layout.target_root.resolve(strict=False)` once per redacted excerpt build. It
@@ -93,6 +95,13 @@ redactor, but skip the bearer-token, named-secret, URL credential, OpenAI key,
 certificate, and identity regex passes. Lines with `:`, `=`, `@`, `sk-`, or a
 certificate preamble continue through the relevant guarded regexes before path
 redaction.
+
+This 2026-06-25 path-prefix slice keeps the same target-relative labels and
+removes per-path `Path(...)` construction for clean absolute paths that are
+lexically under the already-resolved target root. Paths containing `..` still
+fall back to filesystem-normalized `Path.resolve(strict=False)` before deciding
+whether they are target-relative. The registered probe's path-redaction metric is
+the acceptance gate for the slice.
 
 Focused verification:
 

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -22,8 +22,10 @@ from worker.productization.export_target_diagnostics import (
     build_diagnostic_metrics_report,
     build_export_diagnostics_receipt,
     write_export_diagnostics_receipt,
+    _RedactionSummary,
     _SourceLine,
     _build_redacted_excerpt,
+    _redact_absolute_path,
 )
 from worker.productization.export_target_layout import (
     build_export_target_layout,
@@ -170,6 +172,81 @@ def test_export_target_diagnostics_resolves_target_root_once_for_many_path_redac
     assert "<target>/artifacts/model.gguf" in excerpt.text
     assert "<target>/artifacts/blobs/sha256-777777" in excerpt.text
     assert "<target>/logs/ollama-create.log" in excerpt.text
+
+
+def test_export_target_diagnostics_redacts_clean_target_paths_without_path_objects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+
+    class FailingPath:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:  # pragma: no cover
+            raise AssertionError("clean target path redaction should use string prefix matching")
+
+    monkeypatch.setattr(export_target_diagnostics_module, "Path", FailingPath)
+
+    excerpt = _build_redacted_excerpt(
+        layout,
+        [
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text=f"runtime load failed at {target_root / 'artifacts/model.gguf'}",
+            ),
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text=f"missing blob at {target_root / 'artifacts/blobs/sha256-777777'}",
+            ),
+        ],
+        bounded_bytes=4096,
+        bounded_lines=20,
+    )
+
+    assert "<target>/artifacts/model.gguf" in excerpt.text
+    assert "<target>/artifacts/blobs/sha256-777777" in excerpt.text
+    assert excerpt.summary.redacted_absolute_path_count == 2
+
+
+def test_export_target_diagnostics_path_prefix_handles_root_and_normalized_paths(
+    tmp_path: Path,
+) -> None:
+    root_summary = _RedactionSummary()
+    assert _redact_absolute_path("/", Path("/"), "/", root_summary) == "<target>"
+    assert _redact_absolute_path("/var/log.txt", Path("/"), "/", root_summary) == "<target>/var/log.txt"
+
+    class RootLayout:
+        target_root = Path("/")
+
+    root_excerpt = _build_redacted_excerpt(
+        RootLayout(),  # type: ignore[arg-type]
+        [_SourceLine(source_path="logs/root.log", text="failed at /var/log.txt")],
+        bounded_bytes=256,
+        bounded_lines=4,
+    )
+    assert "<target>/var/log.txt" in root_excerpt.text
+
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+    nested = target_root / "nested"
+    nested.mkdir()
+    artifact = target_root / "artifact.gguf"
+    artifact.write_text("model", encoding="utf-8")
+    normalized_summary = _RedactionSummary()
+
+    redacted = _redact_absolute_path(
+        str(nested / ".." / "artifact.gguf"),
+        target_root,
+        target_root.as_posix(),
+        normalized_summary,
+    )
+
+    assert redacted == "<target>/artifact.gguf"
+    assert root_summary.redacted_absolute_path_count == 2
+    assert normalized_summary.redacted_absolute_path_count == 1
 
 
 def test_export_target_diagnostics_skips_secret_regexes_for_plain_path_lines(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -513,11 +513,19 @@ def _build_redacted_excerpt(
         resolved_target_root = layout.target_root.resolve(strict=False)
     except OSError:
         resolved_target_root = layout.target_root
+    resolved_target_root_text = resolved_target_root.as_posix().rstrip("/")
+    if not resolved_target_root_text:
+        resolved_target_root_text = "/"
     for index, source_line in enumerate(source_lines):
         if len(output_lines) >= bounded_lines:
             summary.truncated = True
             break
-        redacted = _redact_text(source_line.text, resolved_target_root, summary)
+        redacted = _redact_text(
+            source_line.text,
+            resolved_target_root,
+            resolved_target_root_text,
+            summary,
+        )
         rendered = f"[{source_line.source_path}] {redacted}"
         rendered_bytes = (rendered + "\n").encode("utf-8")
         if used_bytes + len(rendered_bytes) > bounded_bytes:
@@ -555,6 +563,7 @@ def _build_redacted_excerpt(
 def _redact_text(
     text: str,
     resolved_target_root: Path,
+    resolved_target_root_text: str,
     summary: _RedactionSummary,
 ) -> str:
     if _PRIVATE_TEXT_LINE_PATTERN.search(text):
@@ -589,7 +598,12 @@ def _redact_text(
                 text,
             )
     return _ABSOLUTE_PATH_PATTERN.sub(
-        lambda match: _redact_absolute_path(match.group(0), resolved_target_root, summary),
+        lambda match: _redact_absolute_path(
+            match.group(0),
+            resolved_target_root,
+            resolved_target_root_text,
+            summary,
+        ),
         text,
     )
 
@@ -614,20 +628,26 @@ def _record_identity(summary: _RedactionSummary, key: str) -> str:
 def _redact_absolute_path(
     raw_path: str,
     resolved_target_root: Path,
+    resolved_target_root_text: str,
     summary: _RedactionSummary,
 ) -> str:
     trimmed_path = raw_path.rstrip(".,)")
     suffix = raw_path[len(trimmed_path):]
     replacement = "<absolute-path>"
-    try:
-        path = Path(trimmed_path)
-        if ".." not in path.parts:
-            relative = path.relative_to(resolved_target_root)
-        else:
-            relative = path.resolve(strict=False).relative_to(resolved_target_root)
-        replacement = f"<target>/{relative.as_posix()}"
-    except (ValueError, OSError):
-        pass
+    path_parts = trimmed_path.split("/")
+    if ".." not in path_parts:
+        if trimmed_path == resolved_target_root_text:
+            replacement = "<target>"
+        elif resolved_target_root_text == "/" and trimmed_path.startswith("/"):
+            replacement = f"<target>/{trimmed_path.lstrip('/')}"
+        elif trimmed_path.startswith(f"{resolved_target_root_text}/"):
+            replacement = f"<target>/{trimmed_path[len(resolved_target_root_text) + 1:]}"
+    else:
+        try:
+            relative = Path(trimmed_path).resolve(strict=False).relative_to(resolved_target_root)
+            replacement = f"<target>/{relative.as_posix()}"
+        except (ValueError, OSError):
+            pass
     summary.redacted_absolute_path_count += 1
     summary.redaction_count += 1
     return replacement + suffix


### PR DESCRIPTION
## Summary
- Elides per-path `Path(...)` construction for clean absolute export diagnostic paths that are lexically under the already-resolved target root.
- Keeps normalized `..` paths on the previous `Path.resolve(strict=False)` fallback and preserves target-relative redaction labels.
- Adds regression coverage for the string-prefix fast path and documents the registered path-redaction metric gate.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`

## Commands Run
```text
# Baseline local probe before this slice
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# exit 0; path_redaction_elapsed_ms_mean=278.4641754027689 ms; elapsed_ms_mean=2905.6924986012746 ms

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 32 passed in 0.75s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py infra/perf/pr_scoped_probes.json
# exit 0; TOTAL 45 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# exit 0; path_redaction_elapsed_ms_mean=23.145276997820474 ms; elapsed_ms_mean=2828.2918228011113 ms

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-runtime-export-path-prefix-redaction-20260625 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-runtime-export-path-prefix-redaction-20260625 --output /tmp/runtime-export-path-prefix-redaction.json
# exit 0; head verification coverage=100%; base/head registered probe completed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 45 0 100%`.
- Registered local probe (`runtime-export-diagnostic-parser`, base `origin/main` vs head `707fff8a`):
  - `path_redaction_elapsed_ms_mean`: base `287.0056524028769` ms → head `22.997428991948254` ms (`-264.0082234109286` ms, `-91.99%`).
  - `elapsed_ms_mean`: base `2865.0902446039254` ms → head `2857.693270398886` ms (`-7.396974205039442` ms, `-0.26%`).
  - `peak_bytes_mean`: base `201264.4` bytes → head `198203.8` bytes (`-3060.6` bytes, `-1.52%`).
  - Guard metrics unchanged: `diagnostic_parser_coverage=1.0`, `parsed_failure_count=27.0`, `unknown_failure_count=1.0`, `redaction_count=5.0`, `path_redaction_count=200.0`, `diagnosis_code_count=9.0`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- None for this Python slice. Swift/macOS runtime effects are not involved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
