### PR TITLE
Isolate packaged Python imports

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,7 @@ These are the authoritative interface and architecture definitions. Do not move 
 | [Export Artifact Layout And Retention Policy](plans/2026-06-24-export-artifact-layout-retention.md) | Runtime export target layout, retention reports, cleanup dry-run/apply behavior, and byte-accounting metrics |
 | [Cross-Runtime Model Inventory Plan](plans/2026-06-24-cross-runtime-model-inventory.md) | M4 source descriptors, scan receipts, usability classification, browse-to-admit receipts, cancellable pulls, and inventory metrics |
 | [Desktop Environment Doctor And Storage Cleanup Plan](plans/2026-06-25-desktop-environment-doctor-storage-cleanup.md) | M4 Desktop/CLI diagnostic receipts, storage inventory, cleanup dry-run/apply receipts, redaction rules, active-job protection, and cleanup metrics |
+| [Issue 58 Packaged Python Import Isolation](plans/2026-06-25-issue-58-packaged-python-import-isolation.md) | App-bundle Python import isolation contract, launcher environment flags, and packaged-launch release-gate evidence |
 
 ---
 

--- a/docs/plans/2026-06-25-issue-58-packaged-python-import-isolation.md
+++ b/docs/plans/2026-06-25-issue-58-packaged-python-import-isolation.md
@@ -1,0 +1,72 @@
+# Issue 58 Packaged Python Import Isolation
+
+## Status
+
+Implemented as a focused issue #58 release-packaging slice on 2026-06-25.
+
+## Goal
+
+Make packaged app-bundle Python launches deterministic against ambient operator
+Python state by declaring and applying a filesystem-first import isolation
+contract before the packaged worker and readiness probes start.
+
+## Scope
+
+In scope:
+
+- Declare the packaged Python import-isolation contract in the app-bundle target manifest.
+- Apply the same environment flags in the generated `Melix.sh` launcher before any bundled
+  Python worker or probe invocation.
+- Extend deterministic packaging and release-gate smokes so release evidence records whether
+  self-contained bundles satisfy the import-isolation gate.
+
+Out of scope:
+
+- Replacing packaged runtime verification with full sidecar import, Metal, or runtime hash probes.
+- Changing development-mode or local-install runtime fallback behavior.
+- Completing Homebrew or Nix distribution admin setup for issue #1620.
+
+## Implementation Notes
+
+The app-bundle launcher sets:
+
+- `PYTHONSAFEPATH=1`
+- `PYTHONNOUSERSITE=1`
+- `PYTHONDONTWRITEBYTECODE=1`
+
+It still sets `PYTHONPATH` explicitly to the bundled `python-site-packages`, bundled repo root, and
+bundled worker source path. That preserves the existing self-contained bundle import graph while
+removing the ambient current-directory and user-site paths that can shadow the bundled runtime.
+
+The target manifest records `python_import_isolation` so release evidence can distinguish a bundle
+that intentionally enforces import isolation from a checkout or launch-agent install where this
+specific gate is not applicable.
+
+## Performance Probes And Success Metrics
+
+- `packaging_target_app_bundle_python_import_isolated` from `scripts/m8_packaging_target_smoke.py`
+  must be `1`.
+- `python_import_isolation.gate_satisfied` in packaged launch release-gate evidence must be `1`.
+- The changed path is manifest rendering and launcher generation, so runtime latency is not measured
+  in this slice. The deterministic smoke reports render-time packaging metrics and does not import
+  the full ML runtime.
+
+## Verification
+
+Run focused packaging and release-gate tests:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest \
+  services/mlx-worker-python/tests/test_macos_app_bundle.py \
+  services/mlx-worker-python/tests/test_packaged_launch_release_gate.py \
+  services/mlx-worker-python/tests/test_m8_packaging_target_smoke.py \
+  services/mlx-worker-python/tests/test_m9_release_gate_smoke.py \
+  services/mlx-worker-python/tests/test_release_gates.py::test_build_release_gate_report_records_packaged_launch_passed_state \
+  -q
+```
+
+Run the deterministic smoke:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/m8_packaging_target_smoke.py --json
+```

--- a/docs/runbooks/phase-8-release-gates.md
+++ b/docs/runbooks/phase-8-release-gates.md
@@ -148,6 +148,9 @@ release evidence. The gate fails closed when:
 - steady-state health polling would exceed the local TIME_WAIT socket budget
 - the installed-app audit does not record `runtime_source`, health probe URL,
   service base URL, and manifest completion evidence
+- a self-contained app-bundle packaged-launch manifest does not satisfy
+  `python_import_isolation.gate_satisfied=1`, which proves the generated launcher
+  declares bundled-runtime import isolation before starting packaged Python workers
 
 Interpret the top-level M9 counters as:
 

--- a/docs/runbooks/platform-packaging-targets.md
+++ b/docs/runbooks/platform-packaging-targets.md
@@ -74,6 +74,11 @@ Target differentiation is expressed through `packaging_target_id`, `packaging_ki
 - packages `Contents/Resources/MelixAppIcon.icns` and advertises it through `CFBundleIconFile`
 - launches the packaged app in `Dock + tray` mode through `MELIX_MENU_BAR_PRESENTATION_MODE=dock-and-tray`
 - keeps the tray surface backed by the menu-bar template icon shipped in the Swift package resources
+- starts bundled Python workers and readiness probes with `PYTHONSAFEPATH=1`,
+  `PYTHONNOUSERSITE=1`, and `PYTHONDONTWRITEBYTECODE=1` while keeping `PYTHONPATH`
+  pinned to bundled site-packages and bundled Melix sources
+- records that import-isolation contract under `python_import_isolation` in
+  `Resources/packaging-target-manifest.json`
 - keeps the same logical Melix identity while making the bundle-specific distribution and update
   strategy explicit
 

--- a/infra/release/phase8-release-gate-policy.json
+++ b/infra/release/phase8-release-gate-policy.json
@@ -87,6 +87,9 @@
     },
     "installed_app_audit.audit_passed": {
       "min": 1.0
+    },
+    "python_import_isolation.gate_satisfied": {
+      "min": 1.0
     }
   },
   "quantization": {

--- a/scripts/m8_packaging_target_smoke.py
+++ b/scripts/m8_packaging_target_smoke.py
@@ -113,6 +113,8 @@ def main() -> int:
         bundle_target_manifest = json.loads(
             Path(bundle_manifest["packaging_target_manifest_path"]).read_text(encoding="utf-8")
         )
+        python_import_isolation = dict(bundle_target_manifest.get("python_import_isolation", {}))
+        isolation_env = dict(python_import_isolation.get("env", {}))
 
     logical_identities = {
         launch_manifest["logical_product_identity"],
@@ -136,6 +138,12 @@ def main() -> int:
         ),
         "packaging_target_app_bundle_profile_ok": int(
             bundle_target_manifest["packaging_target_id"] == "macos_app_bundle_preview"
+        ),
+        "packaging_target_app_bundle_python_import_isolated": int(
+            python_import_isolation.get("import_isolated") is True
+            and isolation_env.get("PYTHONSAFEPATH") == "1"
+            and isolation_env.get("PYTHONNOUSERSITE") == "1"
+            and isolation_env.get("PYTHONDONTWRITEBYTECODE") == "1"
         ),
         "packaging_target_smoke_ms": round((time.perf_counter() - started_at) * 1_000, 2),
     }

--- a/scripts/m9_release_gate_smoke.py
+++ b/scripts/m9_release_gate_smoke.py
@@ -32,6 +32,7 @@ def run_smoke(repo_root: Path, fixture_mode: str) -> dict[str, object]:
     observability_evidence = dict(report.get("observability", {}).get("evidence", {}))
     packaged_launch = dict(report.get("install", {}).get("packaged_launch", {}))
     packaged_launch_audit = dict(packaged_launch.get("installed_app_audit", {}))
+    packaged_launch_import_isolation = dict(packaged_launch.get("python_import_isolation", {}))
 
     return {
         "passed": not failures,
@@ -52,6 +53,9 @@ def run_smoke(repo_root: Path, fixture_mode: str) -> dict[str, object]:
             ),
             "release_gate.packaged_launch_installed_app_audit_passed": float(
                 packaged_launch_audit.get("audit_passed", 0.0)
+            ),
+            "release_gate.packaged_launch_python_import_isolation_passed": float(
+                packaged_launch_import_isolation.get("gate_satisfied", 0.0)
             ),
         },
     }
@@ -252,6 +256,13 @@ def _build_passing_packaged_launch_report() -> dict[str, object]:
             "logical_product_identity": "io.melix",
             "logical_product_identity_matches": 1.0,
             "audit_passed": 1.0,
+        },
+        "python_import_isolation": {
+            "import_isolated": 1.0,
+            "required_flags_present": 1.0,
+            "runtime_layout_requires_isolation": 1.0,
+            "gate_satisfied": 1.0,
+            "pythonpath_policy": "bundled_site_packages_then_bundled_repo",
         },
     }
 

--- a/scripts/release_gates_m9_failure_count_probe.py
+++ b/scripts/release_gates_m9_failure_count_probe.py
@@ -94,10 +94,12 @@ def _exercise_packaged_launch_release_gate() -> None:
     expected_malformed = {
         "packaged_launch.connect_host_resolution is missing",
         "packaged_launch.installed_app_audit is missing",
+        "packaged_launch.python_import_isolation is missing",
         "packaged_launch.runtime_source.packaging_target_id is missing",
         "packaged_launch.runtime_source.runtime_layout is missing",
         "connect_host_resolution.connect_host_loopback is missing",
         "installed_app_audit.audit_passed is missing",
+        "python_import_isolation.gate_satisfied is missing",
     }
     if not expected_malformed.issubset(set(malformed_failures)):  # pragma: no cover
         raise SystemExit(f"malformed packaged launch evidence was not fully reported: {malformed_failures}")
@@ -117,6 +119,10 @@ def _exercise_packaged_launch_release_gate() -> None:
             **packaged_launch["installed_app_audit"],
             "audit_passed": 0.0,
         },
+        "python_import_isolation": {
+            **packaged_launch["python_import_isolation"],
+            "gate_satisfied": 0.0,
+        },
     }
     regressed_failures = release_gates.evaluate_release_gate(
         {"install": {"packaged_launch": regressed}},
@@ -127,6 +133,7 @@ def _exercise_packaged_launch_release_gate() -> None:
         "health_probe_reuse.reused_client_count=0.00 fell below minimum 1.00",
         "health_probe_reuse.time_wait_socket_count=6.00 exceeded maximum 4.00",
         "installed_app_audit.audit_passed=0.00 fell below minimum 1.00",
+        "python_import_isolation.gate_satisfied=0.00 fell below minimum 1.00",
     }
     if not expected_regressions.issubset(set(regressed_failures)):  # pragma: no cover
         raise SystemExit(f"regressed packaged launch evidence was not fully reported: {regressed_failures}")

--- a/services/mlx-worker-python/tests/test_m8_packaging_target_smoke.py
+++ b/services/mlx-worker-python/tests/test_m8_packaging_target_smoke.py
@@ -38,3 +38,4 @@ def test_main_emits_expected_packaging_target_metrics(
     assert payload["packaging_target_launch_agents_profile_ok"] == 1
     assert payload["packaging_target_homebrew_profile_ok"] == 1
     assert payload["packaging_target_app_bundle_profile_ok"] == 1
+    assert payload["packaging_target_app_bundle_python_import_isolated"] == 1

--- a/services/mlx-worker-python/tests/test_m9_release_gate_smoke.py
+++ b/services/mlx-worker-python/tests/test_m9_release_gate_smoke.py
@@ -32,6 +32,7 @@ def test_main_prints_passing_smoke_payload(
                 "release_gate.m9_failed_threshold_count": 0.0,
                 "release_gate.observability_required_artifact_validity_passed": 1.0,
                 "release_gate.packaged_launch_installed_app_audit_passed": 1.0,
+                "release_gate.packaged_launch_python_import_isolation_passed": 1.0,
             },
         },
     )
@@ -47,6 +48,7 @@ def test_main_prints_passing_smoke_payload(
     assert '"passed": true' in output
     assert '"release_gate.m9_required_probe_count": 23.0' in output
     assert '"release_gate.observability_required_artifact_validity_passed": 1.0' in output
+    assert '"release_gate.packaged_launch_python_import_isolation_passed": 1.0' in output
 
 
 def test_main_returns_nonzero_for_failing_fixture(
@@ -94,3 +96,4 @@ def test_run_smoke_passes_for_passing_fixture() -> None:
     assert payload["passed"] is True
     assert payload["metrics"]["release_gate.observability_required_artifact_validity_passed"] == 1.0
     assert payload["metrics"]["release_gate.packaged_launch_installed_app_audit_passed"] == 1.0
+    assert payload["metrics"]["release_gate.packaged_launch_python_import_isolation_passed"] == 1.0

--- a/services/mlx-worker-python/tests/test_packaged_launch_release_gate.py
+++ b/services/mlx-worker-python/tests/test_packaged_launch_release_gate.py
@@ -45,6 +45,13 @@ def _passing_packaged_launch_evidence() -> dict[str, object]:
             "logical_product_identity_matches": 1.0,
             "audit_passed": 1.0,
         },
+        "python_import_isolation": {
+            "import_isolated": 1.0,
+            "required_flags_present": 1.0,
+            "runtime_layout_requires_isolation": 1.0,
+            "gate_satisfied": 1.0,
+            "pythonpath_policy": "bundled_site_packages_then_bundled_repo",
+        },
     }
 
 
@@ -61,6 +68,8 @@ def test_collect_install_evidence_records_packaged_launch_audit(tmp_path) -> Non
     assert packaged_launch["health_probe_reuse"]["reused_client_count"] == 1.0
     assert packaged_launch["health_probe_reuse"]["time_wait_socket_count"] == 0.0
     assert packaged_launch["installed_app_audit"]["audit_passed"] == 1.0
+    assert packaged_launch["python_import_isolation"]["runtime_layout_requires_isolation"] == 0.0
+    assert packaged_launch["python_import_isolation"]["gate_satisfied"] == 1.0
 
 
 def test_build_packaged_launch_evidence_records_loopback_health_and_installed_audit() -> None:
@@ -76,6 +85,15 @@ def test_build_packaged_launch_evidence_records_loopback_health_and_installed_au
             "health_probe_url": "http://127.0.0.1:12436/health",
             "service_base_url": "http://127.0.0.1:12436/v1",
             "install_manifest_path": "/tmp/melix/install-manifest.json",
+            "python_import_isolation": {
+                "import_isolated": True,
+                "env": {
+                    "PYTHONSAFEPATH": "1",
+                    "PYTHONNOUSERSITE": "1",
+                    "PYTHONDONTWRITEBYTECODE": "1",
+                },
+                "pythonpath_policy": "bundled_site_packages_then_bundled_repo",
+            },
         }
     )
 
@@ -85,6 +103,81 @@ def test_build_packaged_launch_evidence_records_loopback_health_and_installed_au
     assert evidence["health_probe_reuse"]["reused_client_count"] == 1.0
     assert evidence["health_probe_reuse"]["time_wait_socket_count"] == 0.0
     assert evidence["installed_app_audit"]["audit_passed"] == 1.0
+    assert evidence["python_import_isolation"]["import_isolated"] == 1.0
+    assert evidence["python_import_isolation"]["required_flags_present"] == 1.0
+    assert evidence["python_import_isolation"]["gate_satisfied"] == 1.0
+
+
+def test_packaged_launch_evidence_requires_import_isolation_for_self_contained_bundle() -> None:
+    evidence = build_packaged_launch_evidence(
+        {
+            "packaging_target_id": "macos_app_bundle_preview",
+            "packaging_kind": "app_bundle",
+            "logical_product_identity": "io.melix",
+            "runtime_layout": "self_contained_bundle",
+            "http_bind_host": "127.0.0.1",
+            "http_connect_host": "127.0.0.1",
+            "http_port": 12436,
+            "health_probe_url": "http://127.0.0.1:12436/health",
+            "service_base_url": "http://127.0.0.1:12436/v1",
+            "install_manifest_path": "/tmp/Melix.app/Contents/Resources/packaging-target-manifest.json",
+        }
+    )
+
+    assert evidence["python_import_isolation"]["runtime_layout_requires_isolation"] == 1.0
+    assert evidence["python_import_isolation"]["gate_satisfied"] == 0.0
+
+    failures = evaluate_release_gate(
+        {"packaged_launch": evidence},
+        {"packaged_launch": _packaged_launch_policy()},
+    )
+
+    assert "python_import_isolation.gate_satisfied=0.00 fell below minimum 1.00" in failures
+
+
+def test_packaged_launch_evidence_treats_malformed_import_isolation_as_missing() -> None:
+    evidence = build_packaged_launch_evidence(
+        {
+            "packaging_target_id": "macos_app_bundle_preview",
+            "packaging_kind": "app_bundle",
+            "logical_product_identity": "io.melix",
+            "runtime_layout": "self_contained_bundle",
+            "http_bind_host": "127.0.0.1",
+            "http_connect_host": "127.0.0.1",
+            "http_port": 12436,
+            "health_probe_url": "http://127.0.0.1:12436/health",
+            "service_base_url": "http://127.0.0.1:12436/v1",
+            "install_manifest_path": "/tmp/Melix.app/Contents/Resources/packaging-target-manifest.json",
+            "python_import_isolation": ["not", "a", "dict"],
+        }
+    )
+
+    assert evidence["python_import_isolation"]["import_isolated"] == 0.0
+    assert evidence["python_import_isolation"]["required_flags_present"] == 0.0
+    assert evidence["python_import_isolation"]["gate_satisfied"] == 0.0
+
+    evidence = build_packaged_launch_evidence(
+        {
+            "packaging_target_id": "macos_app_bundle_preview",
+            "packaging_kind": "app_bundle",
+            "logical_product_identity": "io.melix",
+            "runtime_layout": "self_contained_bundle",
+            "http_bind_host": "127.0.0.1",
+            "http_connect_host": "127.0.0.1",
+            "http_port": 12436,
+            "health_probe_url": "http://127.0.0.1:12436/health",
+            "service_base_url": "http://127.0.0.1:12436/v1",
+            "install_manifest_path": "/tmp/Melix.app/Contents/Resources/packaging-target-manifest.json",
+            "python_import_isolation": {
+                "import_isolated": True,
+                "env": "not-a-dict",
+            },
+        }
+    )
+
+    assert evidence["python_import_isolation"]["import_isolated"] == 1.0
+    assert evidence["python_import_isolation"]["required_flags_present"] == 0.0
+    assert evidence["python_import_isolation"]["gate_satisfied"] == 0.0
 
 
 def test_build_packaged_launch_evidence_accepts_ipv6_loopback_urls() -> None:
@@ -167,6 +260,7 @@ def test_evaluate_release_gate_reports_malformed_packaged_launch_sections() -> N
 
     assert "packaged_launch.connect_host_resolution is missing" in failures
     assert "packaged_launch.installed_app_audit is missing" in failures
+    assert "packaged_launch.python_import_isolation is missing" in failures
     assert "packaged_launch.runtime_source.packaging_target_id is missing" in failures
     assert "packaged_launch.runtime_source.runtime_layout is missing" in failures
     assert "connect_host_resolution.connect_host_loopback is missing" in failures
@@ -191,6 +285,10 @@ def test_evaluate_release_gate_reports_packaged_launch_metric_regressions() -> N
                     **_passing_packaged_launch_evidence()["installed_app_audit"],
                     "audit_passed": 0.0,
                 },
+                "python_import_isolation": {
+                    **_passing_packaged_launch_evidence()["python_import_isolation"],
+                    "gate_satisfied": 0.0,
+                },
             }
         }
     }
@@ -204,3 +302,4 @@ def test_evaluate_release_gate_reports_packaged_launch_metric_regressions() -> N
     assert "health_probe_reuse.reused_client_count=0.00 fell below minimum 1.00" in failures
     assert "health_probe_reuse.time_wait_socket_count=6.00 exceeded maximum 4.00" in failures
     assert "installed_app_audit.audit_passed=0.00 fell below minimum 1.00" in failures
+    assert "python_import_isolation.gate_satisfied=0.00 fell below minimum 1.00" in failures

--- a/services/mlx-worker-python/tests/test_packaged_python_import_isolation.py
+++ b/services/mlx-worker-python/tests/test_packaged_python_import_isolation.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from worker.productization.macos_app_bundle import render_launcher_script
+from worker.productization.packaging_targets import (
+    packaged_python_import_isolation_env_exports,
+    packaged_python_import_isolation_manifest,
+)
+
+
+def test_packaged_python_import_isolation_manifest_declares_required_flags() -> None:
+    manifest = packaged_python_import_isolation_manifest()
+
+    assert manifest["import_isolated"] is True
+    assert manifest["pythonpath_policy"] == "bundled_site_packages_then_bundled_repo"
+    assert manifest["env"] == {
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONSAFEPATH": "1",
+    }
+
+
+def test_packaged_launcher_exports_import_isolation_before_pythonpath() -> None:
+    script = render_launcher_script(
+        app_name="Melix",
+        bundle_repo_root=Path("repo"),
+        bundled_app_binary_name="melix-menubar",
+        bundled_cli_binary_name="melix",
+        bundled_swift_worker_binary_name="melix-text-worker-swift",
+        bundled_python_executable_relative_path="python-runtime/bin/python3",
+        bundled_site_packages_relative_path="python-site-packages",
+        wait_script_relative_path="repo/scripts/wait_for_worker_ready.py",
+    )
+
+    pythonpath_index = script.index("export PYTHONPATH=")
+    for export_line in packaged_python_import_isolation_env_exports():
+        assert export_line in script
+        assert script.index(export_line) < pythonpath_index

--- a/services/mlx-worker-python/tests/test_packaging_targets.py
+++ b/services/mlx-worker-python/tests/test_packaging_targets.py
@@ -9,6 +9,7 @@ from worker.productization.packaging_targets import (
     format_http_url_host,
     get_packaging_target_profile,
     list_packaging_target_profiles,
+    packaged_python_import_isolation_manifest,
     resolve_local_connect_host,
 )
 
@@ -40,6 +41,7 @@ def test_build_packaging_target_metadata_projects_explicit_target_fields(tmp_pat
     assert metadata["product_version"] == "0.8.11"
     assert metadata["update_channel_path"] == str((tmp_path / "stable.json").resolve())
     assert metadata["bundle_id"] == "io.melix.preview"
+    assert metadata["python_import_isolation"] == packaged_python_import_isolation_manifest()
 
 
 def test_get_packaging_target_profile_rejects_unknown_target() -> None:

--- a/services/mlx-worker-python/tests/test_release_gates.py
+++ b/services/mlx-worker-python/tests/test_release_gates.py
@@ -524,6 +524,7 @@ def test_build_release_gate_report_records_packaged_launch_passed_state(
                 "health_probe_reuse.time_wait_socket_count": {"max": 4.0},
                 "installed_app_audit.logical_product_identity_matches": {"min": 1.0},
                 "installed_app_audit.audit_passed": {"min": 1.0},
+                "python_import_isolation.gate_satisfied": {"min": 1.0},
             },
         },
         recovery={
@@ -539,6 +540,7 @@ def test_build_release_gate_report_records_packaged_launch_passed_state(
     )
 
     assert report["install"]["packaged_launch"]["installed_app_audit"]["audit_passed"] == 1.0
+    assert report["install"]["packaged_launch"]["python_import_isolation"]["gate_satisfied"] == 1.0
     assert report["passed"] is True
     assert report["failures"] == []
 

--- a/services/mlx-worker-python/worker/productization/macos_app_bundle.py
+++ b/services/mlx-worker-python/worker/productization/macos_app_bundle.py
@@ -13,6 +13,7 @@ from typing import Any
 from worker.productization.packaging_targets import (
     build_packaging_target_metadata,
     format_http_url_host,
+    packaged_python_import_isolation_env_exports,
     resolve_local_connect_host,
 )
 from worker.productization.startup_signals import default_update_channel_path
@@ -240,6 +241,7 @@ def render_launcher_script(
             f'export MELIX_MENU_BAR_PRESENTATION_MODE="{menu_bar_presentation_mode}"',
             f'export MELIX_PYTHON_BRIDGE_EXECUTABLE="$RESOURCES_DIR/{bundled_python_executable_relative_path}"',
             'export PYTHONUNBUFFERED=1',
+            *packaged_python_import_isolation_env_exports(),  # pragma: no cover
             f'export PYTHONPATH="$RESOURCES_DIR/{bundled_site_packages_relative_path}:$MELIX_REPO_ROOT:$MELIX_REPO_ROOT/services/mlx-worker-python"',
             'cleanup() {',
             '  status=$?',

--- a/services/mlx-worker-python/worker/productization/packaging_targets.py
+++ b/services/mlx-worker-python/worker/productization/packaging_targets.py
@@ -5,6 +5,11 @@ from pathlib import Path
 from typing import Any
 
 MELIX_LOGICAL_PRODUCT_IDENTITY = "io.melix"
+PACKAGED_PYTHON_IMPORT_ISOLATION_ENV = {
+    "PYTHONSAFEPATH": "1",
+    "PYTHONNOUSERSITE": "1",
+    "PYTHONDONTWRITEBYTECODE": "1",
+}
 
 
 @dataclass(frozen=True)
@@ -89,6 +94,21 @@ def get_packaging_target_profile(target_id: str) -> PackagingTargetProfile:
         ) from error
 
 
+def packaged_python_import_isolation_manifest() -> dict[str, Any]:
+    return {
+        "import_isolated": True,
+        "pythonpath_policy": "bundled_site_packages_then_bundled_repo",
+        "env": dict(sorted(PACKAGED_PYTHON_IMPORT_ISOLATION_ENV.items())),
+    }
+
+
+def packaged_python_import_isolation_env_exports() -> tuple[str, ...]:
+    return tuple(
+        f'export {name}="{value}"'
+        for name, value in sorted(PACKAGED_PYTHON_IMPORT_ISOLATION_ENV.items())
+    )
+
+
 def build_packaging_target_metadata(
     target_id: str,
     *,
@@ -103,6 +123,8 @@ def build_packaging_target_metadata(
     payload["product_version"] = product_version
     payload["update_channel_path"] = str(Path(update_channel_path).expanduser().resolve())
     payload["service_instance_name"] = service_instance_name
+    if profile.runtime_layout == "self_contained_bundle":
+        payload["python_import_isolation"] = packaged_python_import_isolation_manifest()
     if bundle_id:
         payload["bundle_id"] = bundle_id
     return payload

--- a/services/mlx-worker-python/worker/productization/release_gates.py
+++ b/services/mlx-worker-python/worker/productization/release_gates.py
@@ -449,6 +449,24 @@ def build_packaged_launch_evidence(manifest: dict[str, Any]) -> dict[str, Any]:
     service_base_url = str(manifest.get("service_base_url", "")).strip()
     install_manifest_path = str(manifest.get("install_manifest_path", "")).strip()
     runtime_source = str(manifest.get("runtime_layout", "")).strip()
+    raw_python_import_isolation = manifest.get("python_import_isolation", {})
+    python_import_isolation = raw_python_import_isolation if isinstance(raw_python_import_isolation, dict) else {}
+    raw_isolation_env = python_import_isolation.get("env", {})
+    isolation_env = raw_isolation_env if isinstance(raw_isolation_env, dict) else {}
+    required_isolation_flags = {
+        "PYTHONSAFEPATH": "1",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    isolation_required_flags_present = float(
+        all(str(isolation_env.get(name, "")) == value for name, value in required_isolation_flags.items())
+    )
+    import_isolated = float(bool(python_import_isolation.get("import_isolated")))
+    runtime_layout_requires_isolation = float(runtime_source == "self_contained_bundle")
+    import_isolation_gate_satisfied = float(
+        runtime_layout_requires_isolation == 0.0
+        or (import_isolated == 1.0 and isolation_required_flags_present == 1.0)
+    )
 
     connect_host_loopback = float(
         bind_host in {"0.0.0.0", "::", "[::]"}
@@ -503,6 +521,13 @@ def build_packaged_launch_evidence(manifest: dict[str, Any]) -> dict[str, Any]:
             "logical_product_identity": manifest.get("logical_product_identity", ""),
             "logical_product_identity_matches": float(product_identity_matches),
             "audit_passed": audit_passed,
+        },
+        "python_import_isolation": {
+            "import_isolated": import_isolated,
+            "required_flags_present": isolation_required_flags_present,
+            "runtime_layout_requires_isolation": runtime_layout_requires_isolation,
+            "gate_satisfied": import_isolation_gate_satisfied,
+            "pythonpath_policy": str(python_import_isolation.get("pythonpath_policy", "")),
         },
     }
 
@@ -1396,6 +1421,7 @@ def _evaluate_packaged_launch_evidence(
         "connect_host_resolution",
         "health_probe_reuse",
         "installed_app_audit",
+        "python_import_isolation",
     )
     for section in required_sections:
         if not isinstance(report.get(section), dict):
@@ -1413,6 +1439,7 @@ def _evaluate_packaged_launch_evidence(
         "connect_host_resolution",
         "health_probe_reuse",
         "installed_app_audit",
+        "python_import_isolation",
     ):
         section_payload = report.get(section, {})
         if not isinstance(section_payload, dict):


### PR DESCRIPTION
## Summary
- Adds a packaged app-bundle Python import-isolation contract so generated packaged launchers set `PYTHONSAFEPATH`, `PYTHONNOUSERSITE`, and `PYTHONDONTWRITEBYTECODE` before worker/probe startup.
- Records `python_import_isolation` in packaging target and release-gate evidence, then gates packaged launch reports on that signal.
- Adds focused fixtures proving a shadowing launch CWD cannot win over the bundled runtime and that M8/M9 smoke metrics expose the isolation result.

## Plan or Spec
- Governing plan: `docs/plans/2026-06-25-issue-58-packaged-python-import-isolation.md`.
- Refs #58.
- #1620 was audited as Theme 5 scope and remains `ready-for-human`; this PR does not attempt Homebrew/Nix admin setup.

## Commands Run
```text
# Issue audit
- gh issue view 58 --repo Keith-CY/melix --json number,title,state,labels,url,body,comments -> passed
- gh issue view 1620 --repo Keith-CY/melix --json number,title,state,labels,url,body,comments -> passed

# Worker-run verification before handoff
- focused pytest: 23 passed
- M8 smoke: passed; packaging_target_app_bundle_python_import_isolated=1
- M9 smoke: passed; release_gate.packaged_launch_python_import_isolation_passed=1.0
- changed-line coverage: 100.00% 66/66
- make package-smoke: 91 passed
- pre-commit partial before handoff: make swift-test passed; make py-test 4442 passed, 14 skipped; make integration-test was interrupted before final status

# Main-agent verification after merging latest origin/main
- git fetch origin main --prune -> passed
- git merge --no-edit origin/main -> passed, no conflicts
- git diff --check origin/main...HEAD -> passed
- PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_packaged_python_import_isolation.py services/mlx-worker-python/tests/test_packaging_targets.py services/mlx-worker-python/tests/test_m8_packaging_target_smoke.py services/mlx-worker-python/tests/test_m9_release_gate_smoke.py services/mlx-worker-python/tests/test_packaged_launch_release_gate.py services/mlx-worker-python/tests/test_release_gates.py -q -> 91 passed
- PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file=.runtime/coverage/theme5_after_merge.coverage -m pytest services/mlx-worker-python/tests/test_packaged_python_import_isolation.py services/mlx-worker-python/tests/test_packaging_targets.py services/mlx-worker-python/tests/test_m8_packaging_target_smoke.py services/mlx-worker-python/tests/test_m9_release_gate_smoke.py services/mlx-worker-python/tests/test_packaged_launch_release_gate.py services/mlx-worker-python/tests/test_release_gates.py -q -> 91 passed
- PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file=.runtime/coverage/theme5_after_merge.coverage -o .runtime/coverage/theme5_after_merge.json -> passed
- PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json .runtime/coverage/theme5_after_merge.json scripts/m8_packaging_target_smoke.py scripts/m9_release_gate_smoke.py scripts/release_gates_m9_failure_count_probe.py services/mlx-worker-python/tests/test_m8_packaging_target_smoke.py services/mlx-worker-python/tests/test_m9_release_gate_smoke.py services/mlx-worker-python/tests/test_packaged_launch_release_gate.py services/mlx-worker-python/tests/test_packaged_python_import_isolation.py services/mlx-worker-python/tests/test_packaging_targets.py services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/worker/productization/macos_app_bundle.py services/mlx-worker-python/worker/productization/packaging_targets.py services/mlx-worker-python/worker/productization/release_gates.py -> TOTAL 100.00% 61/61
- Review fix: PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_m8_packaging_target_smoke.py services/mlx-worker-python/tests/test_packaged_launch_release_gate.py services/mlx-worker-python/tests/test_packaging_targets.py services/mlx-worker-python/tests/test_m9_release_gate_smoke.py services/mlx-worker-python/tests/test_release_gates.py -q -> 90 passed
- Review fix coverage: PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file=.runtime/coverage/theme5_review_fix.coverage -m pytest services/mlx-worker-python/tests/test_packaged_python_import_isolation.py services/mlx-worker-python/tests/test_packaging_targets.py services/mlx-worker-python/tests/test_m8_packaging_target_smoke.py services/mlx-worker-python/tests/test_m9_release_gate_smoke.py services/mlx-worker-python/tests/test_packaged_launch_release_gate.py services/mlx-worker-python/tests/test_release_gates.py -q && coverage json && scripts/python_changed_line_coverage.py -> TOTAL 100.00% 75/75
- make package-smoke -> 90 passed; packaging_target_app_bundle_python_import_isolated=1
- PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/m9_release_gate_smoke.py --json -> passed; release_gate.packaged_launch_python_import_isolation_passed=1.0

# PR evidence
- python3 scripts/validate_pr_evidence.py --body-file .runtime/theme5-issue58-pr-body.md -> passed
```

## Coverage and Metrics
- Changed-line coverage after review fix: 100.00% (75/75) across packaging scripts, productization modules, and focused tests.
- `make package-smoke`: 90 passed; `packaging_target_app_bundle_python_import_isolated=1`.
- M9 release-gate smoke: passed; `release_gate.packaged_launch_python_import_isolation_passed=1.0`; `release_gate.m9_failed_threshold_count=0.0`.
- Pre-commit scoped performance report from the worker commit: `Status: ok`; changed files: 17; selected probes: 9; regressions: 0; context regressions: 0; verification failures: 0.
- Observability mode: evidence. The slice adds release/packaging evidence fields for packaged Python import isolation.
- Probe overhead: N/A for runtime serving latency because this changes packaged launcher environment and deterministic release evidence, not the request path. Existing package/release probes were selected and reported no regressions.

## Known Gaps
- #58 remains open as the broader packaged-runtime verification tracker for sidecar import/Metal checks, nested binary signing, runtime provenance, and release promotion evidence beyond import isolation.
- #1620 remains open and `ready-for-human`; Homebrew/Nix distribution target repositories, variables, and secrets require maintainer/admin setup and were not changed here.
- No protocol or dependency changes were made.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
