### PR TITLE
perf(worker): reuse export retention stat results

### DIFF
--- a/docs/plans/2026-06-24-export-artifact-layout-retention.md
+++ b/docs/plans/2026-06-24-export-artifact-layout-retention.md
@@ -73,7 +73,9 @@ The export report and retention report include:
 
 The PR-scoped probe records layout materialization latency, target count,
 retained byte size, cleanable byte size, deleted file count, and retention
-decision count.
+decision count. Runtime-log TTL decisions reuse the file metadata collected
+while checking manifest-row existence, avoiding an extra stat call on the
+retention hot path while preserving the missing-file race fallback.
 
 ## Verification
 

--- a/services/mlx-worker-python/tests/test_export_target_layout_retention.py
+++ b/services/mlx-worker-python/tests/test_export_target_layout_retention.py
@@ -311,6 +311,34 @@ def test_runtime_logs_become_cleanable_after_ttl(tmp_path: Path) -> None:
     assert decisions["logs/ollama-create.log"]["reason"] == "runtime_log_ttl_expired"
 
 
+def test_runtime_log_ttl_reuses_existing_stat_result(tmp_path: Path) -> None:
+    manifest_path = FIXTURE_ROOT / "ollama/export-target-manifest.json"
+    manifest, validation_report = validate_export_target_manifest_file(
+        manifest_path,
+        return_manifest=True,
+    )
+    assert validation_report.ok is True
+    log_path = tmp_path / "ollama-create.log"
+    log_path.write_text("log", encoding="utf-8")
+    old_time = 1_700_000_000.0
+    import os
+
+    os.utime(log_path, (old_time, old_time))
+    stat_result = log_path.stat()
+
+    class UnexpectedStatPath:
+        def stat(self) -> object:  # pragma: no cover - must not be called
+            raise AssertionError("runtime TTL should reuse the caller stat result")
+
+    assert _runtime_log_ttl_expired(
+        manifest,
+        UnexpectedStatPath(),  # type: ignore[arg-type]
+        exists=True,
+        now=old_time + 604800 + 1,
+        path_stat=stat_result,
+    ) is True
+
+
 def test_runtime_log_ttl_handles_missing_stat_race() -> None:
     manifest_path = FIXTURE_ROOT / "ollama/export-target-manifest.json"
     manifest, validation_report = validate_export_target_manifest_file(

--- a/services/mlx-worker-python/worker/productization/export_target_layout.py
+++ b/services/mlx-worker-python/worker/productization/export_target_layout.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import json
+import os
 import re
 import shutil
 import time
@@ -432,8 +433,20 @@ def _decide_file(
     now: float,
 ) -> _FileDecision:
     path = _target_relative_path(layout, row.path, resolved_root=resolved_target_root)
-    exists = path.exists()
-    decision, reason = _retention_decision(manifest, row, path, exists, now)
+    try:
+        path_stat = path.stat()
+        exists = True
+    except OSError:
+        path_stat = None
+        exists = False
+    decision, reason = _retention_decision(
+        manifest,
+        row,
+        path,
+        exists,
+        now,
+        path_stat=path_stat,
+    )
     deleted = False
     if (
         apply_cleanup
@@ -463,11 +476,13 @@ def _retention_decision(
     path: Path,
     exists: bool,
     now: float,
+    *,
+    path_stat: os.stat_result | None = None,
 ) -> tuple[str, str]:
     if row.retention_class in _RETAINED_RETENTION_CLASSES:
         return RETENTION_DECISION_RETAIN, "required_or_evidence_artifact"
     if row.retention_class == export_target_manifest_pb2.EXPORT_RETENTION_CLASS_RUNTIME_LOG:
-        if _runtime_log_ttl_expired(manifest, path, exists, now):
+        if _runtime_log_ttl_expired(manifest, path, exists, now, path_stat=path_stat):
             return RETENTION_DECISION_DELETE_AFTER_TTL, "runtime_log_ttl_expired"
         return RETENTION_DECISION_RETAIN, "runtime_log_ttl_active"
     if row.retention_class in _CLEANABLE_AFTER_SUCCESS_RETENTION_CLASSES:
@@ -482,6 +497,8 @@ def _runtime_log_ttl_expired(
     path: Path,
     exists: bool,
     now: float,
+    *,
+    path_stat: os.stat_result | None = None,
 ) -> bool:
     ttl_seconds = int(manifest.retention_policy.runtime_log_ttl_seconds)
     if ttl_seconds <= 0:
@@ -489,7 +506,8 @@ def _runtime_log_ttl_expired(
     if not exists:
         return False
     try:
-        return now - path.stat().st_mtime >= ttl_seconds
+        stat_result = path.stat() if path_stat is None else path_stat
+        return now - stat_result.st_mtime >= ttl_seconds
     except FileNotFoundError:
         return False
 


### PR DESCRIPTION
## Summary
- Reuse the stat result collected during export retention manifest-row existence checks when evaluating runtime-log TTL expiry.
- Add regression coverage proving the TTL helper can consume caller-provided file metadata without re-statting.
- Update the export artifact layout retention plan with the hot-path stat reuse note.

## Plan or Spec
- `docs/plans/2026-06-24-export-artifact-layout-retention.md`
- Registered PR-scoped probe: `runtime-export-layout-retention` in `infra/perf/pr_scoped_probes.json` (existing probe includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# Baseline from origin/main before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_layout_retention_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_layout_retention_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
Result: 21 passed in 1.39s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_layout_retention_probe.py
Result: {"elapsed_ms_mean": 3666.0443979955744, "peak_bytes_mean": 205907.6, "retention_decision_count": 15.0, "sample_count": 5.0, "target_count": 4.0, ...}

# After implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py::test_runtime_log_ttl_reuses_existing_stat_result services/mlx-worker-python/tests/test_export_target_layout_retention.py::test_runtime_logs_become_cleanable_after_ttl services/mlx-worker-python/tests/test_export_target_layout_retention.py::test_runtime_log_ttl_handles_missing_stat_race
Result: 3 passed in 0.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_layout_retention_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_layout_retention_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
Result: 22 passed in 0.47s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_layout_retention_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_layout_retention_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_layout.py services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_layout_retention_report.py scripts/runtime_export_layout_retention_probe.py
Result: 22 passed in 1.30s; changed-scope coverage 100.00% (23/23 lines)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_layout_retention_probe.py
Result: {"elapsed_ms_mean": 3633.876651400351, "peak_bytes_mean": 202443.4, "retention_decision_count": 15.0, "sample_count": 5.0, "target_count": 4.0, ...}

git diff --check
Result: passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (23/23 measurable changed lines).
- Registered local probe: `runtime-export-layout-retention`.
- Probe delta: old_mean=3666.044 ms, new_mean=3633.877 ms, delta_ms=-32.168 ms, speedup=1.0089x, improvement=0.88%.
- Metrics parity: `target_count=4.0`, `retention_decision_count=15.0`, `retained_byte_size=12141056.0`, `cleanable_byte_size=0.0`, `deleted_file_count=0.0`.
- CI PR-scoped performance workflow is required as the merge validation source for the registered probe report.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this focused Python slice.
- Swift runtime effects are not applicable; this is a Linux-verified Python worker slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; probe overhead tracked by CI/local command_json probe.
- [x] Deferred work and known gaps are stated explicitly.
