### PR TITLE
perf(worker): aggregate export diagnostic metrics once

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -94,6 +94,12 @@ certificate, and identity regex passes. Lines with `:`, `=`, `@`, `sk-`, or a
 certificate preamble continue through the relevant guarded regexes before path
 redaction.
 
+A 2026-06-25 metric aggregation slice keeps the receipt schema and parser
+semantics unchanged while deriving parsed-failure count, unknown-failure count,
+and matched diagnosis codes in a single pass. The aggregate report also folds
+receipt metrics and diagnosis code discovery into one receipt pass, avoiding the
+previous extra comprehensions and metric summations on every diagnostic report.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -24,6 +24,7 @@ from worker.productization.export_target_diagnostics import (
     write_export_diagnostics_receipt,
     _SourceLine,
     _build_redacted_excerpt,
+    _diagnosis_metric_counts,
 )
 from worker.productization.export_target_layout import (
     build_export_target_layout,
@@ -355,6 +356,20 @@ def test_export_target_diagnostics_falls_back_when_path_resolution_raises_oserro
     assert receipt["status"] == "matched"
     assert str(raw_path) not in excerpt
     assert "<absolute-path>" in excerpt
+
+
+def test_export_target_diagnostics_metric_counts_single_pass() -> None:
+    parsed_count, unknown_count, matched_codes = _diagnosis_metric_counts(
+        [
+            {"code": CODE_RUNTIME_LOAD_FAILED},
+            {"code": CODE_UNKNOWN_FAILURE},
+            {"code": CODE_MISSING_BINARY},
+        ]
+    )
+
+    assert parsed_count == 2
+    assert unknown_count == 1
+    assert matched_codes == {CODE_RUNTIME_LOAD_FAILED, CODE_MISSING_BINARY}
 
 
 def test_export_target_diagnostics_not_applicable_without_logs_or_failures(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -315,9 +315,11 @@ def build_export_diagnostics_receipt(
             }
         ]
 
+    parsed_failure_count, unknown_failure_count, matched_codes = _diagnosis_metric_counts(diagnoses)
+
     if not source_lines:
         status = DIAGNOSTIC_STATUS_NOT_APPLICABLE
-    elif any(diagnosis["code"] != CODE_UNKNOWN_FAILURE for diagnosis in diagnoses):
+    elif parsed_failure_count > 0:
         status = DIAGNOSTIC_STATUS_MATCHED
     else:
         status = DIAGNOSTIC_STATUS_UNKNOWN
@@ -328,22 +330,13 @@ def build_export_diagnostics_receipt(
         for code in manifest.diagnostic_policy.required_diagnosis_codes
         if str(code) in _KNOWN_DIAGNOSIS_CODES
     }
-    matched_codes = {
-        str(diagnosis["code"])
-        for diagnosis in diagnoses
-        if diagnosis["code"] != CODE_UNKNOWN_FAILURE
-    }
     coverage = _diagnostic_coverage(required_codes, matched_codes, status)
     redaction_summary = excerpt.summary.payload(policy_id=manifest.evidence.redaction_policy_id or "export-diagnostics-redaction-v1")
     metrics = {
         "schema_version": EXPORT_DIAGNOSTICS_METRICS_SCHEMA_VERSION,
         "diagnostic_parser_coverage": coverage,
-        "parsed_failure_count": sum(
-            1 for diagnosis in diagnoses if diagnosis["code"] != CODE_UNKNOWN_FAILURE
-        ),
-        "unknown_failure_count": sum(
-            1 for diagnosis in diagnoses if diagnosis["code"] == CODE_UNKNOWN_FAILURE
-        ),
+        "parsed_failure_count": parsed_failure_count,
+        "unknown_failure_count": unknown_failure_count,
         "redaction_count": redaction_summary["redaction_count"],
         "diagnostic_latency_ms": diagnostic_latency_ms,
     }
@@ -405,17 +398,25 @@ def build_diagnostic_metrics_report(
             errors.append(str(exc))
 
     elapsed_ms = (time.perf_counter() - started) * 1000.0
-    metrics = [
-        receipt["metrics"]
-        for receipt in receipts
-        if isinstance(receipt.get("metrics"), dict)
-    ]
-    matched_codes = {
-        str(diagnosis["code"])
-        for receipt in receipts
-        for diagnosis in receipt.get("diagnoses", [])
-        if isinstance(diagnosis, dict) and diagnosis.get("code") != CODE_UNKNOWN_FAILURE
-    }
+    matched_codes: set[str] = set()
+    parsed_failure_count = 0
+    unknown_failure_count = 0
+    redaction_count = 0
+    diagnostic_latency_ms = 0.0
+    for receipt in receipts:
+        metrics = receipt.get("metrics")
+        if isinstance(metrics, dict):
+            parsed_failure_count += int(metrics.get("parsed_failure_count", 0))
+            unknown_failure_count += int(metrics.get("unknown_failure_count", 0))
+            redaction_count += int(metrics.get("redaction_count", 0))
+            diagnostic_latency_ms += float(metrics.get("diagnostic_latency_ms", 0.0))
+        diagnoses = receipt.get("diagnoses", [])
+        if isinstance(diagnoses, list):
+            for diagnosis in diagnoses:
+                if isinstance(diagnosis, dict):
+                    code = str(diagnosis.get("code", ""))
+                    if code and code != CODE_UNKNOWN_FAILURE:
+                        matched_codes.add(code)
     parser_coverage = len(matched_codes & set(_KNOWN_DIAGNOSIS_CODES)) / len(_KNOWN_DIAGNOSIS_CODES)
     return {
         "schema_version": EXPORT_DIAGNOSTICS_METRICS_SCHEMA_VERSION,
@@ -423,10 +424,10 @@ def build_diagnostic_metrics_report(
         "target_count": len(receipts),
         "diagnostic_policy_latency_ms": elapsed_ms,
         "diagnostic_parser_coverage": parser_coverage,
-        "parsed_failure_count": sum(int(metric.get("parsed_failure_count", 0)) for metric in metrics),
-        "unknown_failure_count": sum(int(metric.get("unknown_failure_count", 0)) for metric in metrics),
-        "redaction_count": sum(int(metric.get("redaction_count", 0)) for metric in metrics),
-        "diagnostic_latency_ms": sum(float(metric.get("diagnostic_latency_ms", 0.0)) for metric in metrics),
+        "parsed_failure_count": parsed_failure_count,
+        "unknown_failure_count": unknown_failure_count,
+        "redaction_count": redaction_count,
+        "diagnostic_latency_ms": diagnostic_latency_ms,
         "diagnosis_code_count": len(matched_codes),
         "errors": errors,
         "receipts": receipts,
@@ -676,6 +677,22 @@ def _operator_remedies(diagnoses: list[dict[str, object]]) -> list[dict[str, obj
             }
         )
     return remedies
+
+
+def _diagnosis_metric_counts(
+    diagnoses: list[dict[str, object]],
+) -> tuple[int, int, set[str]]:
+    parsed_failure_count = 0
+    unknown_failure_count = 0
+    matched_codes: set[str] = set()
+    for diagnosis in diagnoses:
+        code = str(diagnosis["code"])
+        if code == CODE_UNKNOWN_FAILURE:
+            unknown_failure_count += 1
+        else:
+            parsed_failure_count += 1
+            matched_codes.add(code)
+    return parsed_failure_count, unknown_failure_count, matched_codes
 
 
 def _diagnostic_coverage(


### PR DESCRIPTION
## Summary
- Aggregate runtime export diagnostic parsed/unknown counts and matched diagnosis codes in a single pass instead of repeated comprehensions.
- Fold diagnostic report metric totals and diagnosis-code discovery into one receipt pass.
- Add a focused regression test for the helper and update the runtime export diagnostic parser plan.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`
- Registered PR-scoped performance probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Synced main before starting
cd /root/.hermes/profiles/coder/workspace/melix
git fetch origin
git reset --hard origin/main

# Focused local tests (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 25 passed in 1.45s

# Changed-scope coverage (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# 25 passed in 1.30s; TOTAL 37 0 100%

# Registered PR-scoped probe, local Linux base/head (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-runtime-export-diagnostic-counts-single-pass-20260625 --head-repo "$PWD" --output /tmp/runtime-export-diagnostic-counts-probe.json
# base/head probes ok; head verification coverage ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 37 0 100%`.
- Registered probe: `runtime-export-diagnostic-parser`.
- Local Linux registered-probe metrics:
  - `elapsed_ms_mean`: base `2862.1478801971534`, head `2837.1903611987364`, delta `-24.957518998417`, speedup `0.87%`.
  - `diagnostic_latency_ms`: base `9.143804985797033`, head `9.052084991708398`, delta `-0.091719994088635`, speedup `1.00%`.
  - `diagnostic_parser_coverage`: base `1.0`, head `1.0`.
  - `parsed_failure_count`: base `27.0`, head `27.0`.
  - `unknown_failure_count`: base `1.0`, head `1.0`.
  - `peak_bytes_mean`: base `198581.6`, head `198680.8`, delta `+99.2` bytes (`+0.05%`, below 5% warn threshold).
  - `path_redaction_elapsed_ms_mean`: base `276.7691819986794`, head `283.8051696016919`, delta `+7.0359876030125` ms (`+2.54%`, below 5% warn threshold and not the optimized counting path).
- CI PR-scoped performance remains the merge gate and must complete successfully before merge.

## Known Gaps
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally; this Python slice was verified with focused tests, changed-scope coverage, and the registered PR-scoped probe on Linux.
- No protocol or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
