### PR TITLE
perf(worker): fast-path export diagnostic path redaction

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -100,6 +100,13 @@ and matched diagnosis codes in a single pass. The aggregate report also folds
 receipt metrics and diagnosis code discovery into one receipt pass, avoiding the
 previous extra comprehensions and metric summations on every diagnostic report.
 
+A follow-up 2026-06-25 path-redaction slice keeps the same redaction contract
+but checks whether a matched absolute path is lexically under the resolved target
+root before constructing a fallback `Path`. Clean target-local paths now produce
+the same `<target>/...` labels through string slicing, while paths with `..`
+segments or paths outside the target root continue through the existing
+normalization fallback.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -173,6 +173,48 @@ def test_export_target_diagnostics_resolves_target_root_once_for_many_path_redac
     assert "<target>/logs/ollama-create.log" in excerpt.text
 
 
+def test_export_target_diagnostics_uses_lexical_target_path_fast_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+
+    def fail_path_construction(*_args: object, **_kwargs: object) -> Path:  # pragma: no cover
+        raise AssertionError("clean target paths should not allocate fallback Path objects")
+
+    monkeypatch.setattr(export_target_diagnostics_module, "Path", fail_path_construction)
+
+    excerpt = _build_redacted_excerpt(
+        layout,
+        [
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text=f"runtime load failed at {target_root / 'artifacts/model.gguf'}.",
+            ),
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text=f"missing blob at {target_root / 'artifacts/blobs/sha256-777777'})",
+            ),
+        ],
+        bounded_bytes=4096,
+        bounded_lines=20,
+    )
+
+    assert "<target>/artifacts/model.gguf." in excerpt.text
+    assert "<target>/artifacts/blobs/sha256-777777)" in excerpt.text
+    assert excerpt.summary.redacted_absolute_path_count == 2
+    assert export_target_diagnostics_module._target_relative_text(
+        str(target_root), str(target_root)
+    ) == "."
+    assert export_target_diagnostics_module._target_relative_text(
+        f"{target_root}-sibling/artifact", str(target_root)
+    ) is None
+
+
 def test_export_target_diagnostics_skips_secret_regexes_for_plain_path_lines(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -514,11 +514,12 @@ def _build_redacted_excerpt(
         resolved_target_root = layout.target_root.resolve(strict=False)
     except OSError:
         resolved_target_root = layout.target_root
+    resolved_target_root_text = str(resolved_target_root)
     for index, source_line in enumerate(source_lines):
         if len(output_lines) >= bounded_lines:
             summary.truncated = True
             break
-        redacted = _redact_text(source_line.text, resolved_target_root, summary)
+        redacted = _redact_text(source_line.text, resolved_target_root, resolved_target_root_text, summary)
         rendered = f"[{source_line.source_path}] {redacted}"
         rendered_bytes = (rendered + "\n").encode("utf-8")
         if used_bytes + len(rendered_bytes) > bounded_bytes:
@@ -556,6 +557,7 @@ def _build_redacted_excerpt(
 def _redact_text(
     text: str,
     resolved_target_root: Path,
+    resolved_target_root_text: str,
     summary: _RedactionSummary,
 ) -> str:
     if _PRIVATE_TEXT_LINE_PATTERN.search(text):
@@ -590,7 +592,12 @@ def _redact_text(
                 text,
             )
     return _ABSOLUTE_PATH_PATTERN.sub(
-        lambda match: _redact_absolute_path(match.group(0), resolved_target_root, summary),
+        lambda match: _redact_absolute_path(
+            match.group(0),
+            resolved_target_root,
+            resolved_target_root_text,
+            summary,
+        ),
         text,
     )
 
@@ -615,11 +622,17 @@ def _record_identity(summary: _RedactionSummary, key: str) -> str:
 def _redact_absolute_path(
     raw_path: str,
     resolved_target_root: Path,
+    resolved_target_root_text: str,
     summary: _RedactionSummary,
 ) -> str:
     trimmed_path = raw_path.rstrip(".,)")
     suffix = raw_path[len(trimmed_path):]
     replacement = "<absolute-path>"
+    relative_text = _target_relative_text(trimmed_path, resolved_target_root_text)
+    if relative_text is not None:
+        summary.redacted_absolute_path_count += 1
+        summary.redaction_count += 1
+        return f"<target>/{relative_text}" + suffix
     try:
         path = Path(trimmed_path)
         if ".." not in path.parts:
@@ -632,6 +645,26 @@ def _redact_absolute_path(
     summary.redacted_absolute_path_count += 1
     summary.redaction_count += 1
     return replacement + suffix
+
+
+def _target_relative_text(raw_path: str, resolved_target_root_text: str) -> str | None:
+    if not resolved_target_root_text or not raw_path.startswith(resolved_target_root_text):
+        return None
+    boundary_index = len(resolved_target_root_text)
+    if len(raw_path) == boundary_index:
+        return "."
+    if raw_path[boundary_index] != "/":
+        return None
+    relative_text = raw_path[boundary_index + 1 :]
+    if (
+        not relative_text
+        or relative_text == ".."
+        or relative_text.startswith("../")
+        or "/../" in relative_text
+        or relative_text.endswith("/..")
+    ):
+        return None
+    return relative_text
 
 
 def _diagnoses_from_excerpt(


### PR DESCRIPTION
## Summary
- Fast-path export diagnostic absolute path redaction for clean target-local paths by slicing against the precomputed resolved target root string before constructing fallback `Path` objects.
- Preserve the existing normalization fallback for outside-target paths and paths containing `..` segments.
- Add regression coverage proving clean target-local paths avoid fallback `Path` allocation while preserving `<target>/...` labels.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_uses_lexical_target_path_fast_path services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_redaction_uses_unresolved_root_when_root_resolve_fails
# 2 passed in 0.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 26 passed in 0.50s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# 26 passed in 1.30s; TOTAL 29 0 100%

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python ruff check services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_diagnostics.py
# All checks passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-runtime-export-diagnostic-pattern-saturation-20260625 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-runtime-export-diagnostic-pattern-saturation-20260625 --output /tmp/runtime_export_diag_pattern_after.json
# completed successfully; head verification 26 passed; changed-line coverage TOTAL 29 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-runtime-export-diagnostic-pattern-saturation-20260625 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-runtime-export-diagnostic-pattern-saturation-20260625 --output /tmp/runtime_export_diag_pattern_after2.json
# completed successfully; head verification 26 passed; changed-line coverage TOTAL 29 0 100%
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 29 0 100%`.
- Registered PR-scoped probe: `runtime-export-diagnostic-parser`.
- Latest repeated local probe (`/tmp/runtime_export_diag_pattern_after2.json`):
  - `path_redaction_elapsed_ms_mean`: base `307.7177915984066 ms`, head `23.623404602403753 ms`, delta `-284.09438699600287 ms`, ~`13.03x` faster.
  - `diagnostic_latency_ms`: base `10.57989899709355 ms`, head `9.209329014993273 ms`, delta `-1.3705699821002781 ms`.
  - `peak_bytes_mean`: base `199487.0`, head `198850.8`, delta `-636.2` bytes.
  - `elapsed_ms_mean`: base `2837.958732797415 ms`, head `2901.116423404892 ms`, delta `+63.15769060747698 ms` (~`+2.23%`, below the registered 5% warning threshold). The targeted path-redaction metric and parser latency improved.

## Known Gaps
- Local validation was run on Linux. CI PR-scoped performance is still required as the authoritative registered probe report for the PR.
- No Swift runtime validation is applicable for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
