### PR TITLE
perf(worker): accumulate export manifest evidence metrics once

### DIFF
--- a/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
+++ b/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
@@ -221,7 +221,10 @@ the evidence source for this Python slice and includes focused test, coverage,
 and `command_json` probe commands in `infra/perf/pr_scoped_probes.json`.
 The same validator should derive `manifest_byte_size` from the manifest bytes it
 already read for protobuf JSON parsing instead of issuing a second filesystem
-stat call on every validation.
+stat call on every validation. Its metrics pass should accumulate generated,
+required, and evidence byte totals while iterating each manifest file section
+once instead of materializing a combined file-row tuple solely to count evidence
+bytes.
 
 ### Export Plan Receipt
 

--- a/services/mlx-worker-python/tests/test_export_target_manifest_contract.py
+++ b/services/mlx-worker-python/tests/test_export_target_manifest_contract.py
@@ -12,6 +12,7 @@ from packages.protocol.python.workspace.v1 import export_target_manifest_pb2
 from worker.productization.export_target_manifest import (
     REQUIRED_EXPORT_TARGET_TYPES,
     _safe_relative_path_error,
+    _validate_metrics,
     validate_export_target_manifest_file,
 )
 
@@ -452,6 +453,38 @@ def test_export_target_manifest_rejects_metric_mismatches(tmp_path: Path) -> Non
     assert "metrics.artifact_byte_size must equal generated_files byte_size sum" in report.errors
     assert "metrics.required_byte_size must equal required_files byte_size sum" in report.errors
     assert "metrics.evidence_byte_size must equal evidence file byte_size sum" in report.errors
+
+
+def test_export_target_manifest_metrics_evidence_bytes_cover_all_file_sections() -> None:
+    evidence = export_target_manifest_pb2.EXPORT_RETENTION_CLASS_EVIDENCE
+    manifest = export_target_manifest_pb2.ExportTargetManifest()
+    manifest.generated_files.add(byte_size=11, retention_class=evidence)
+    manifest.generated_files.add(
+        byte_size=13,
+        retention_class=export_target_manifest_pb2.EXPORT_RETENTION_CLASS_REQUIRED,
+    )
+    manifest.required_files.add(byte_size=17, retention_class=evidence)
+    manifest.required_files.add(
+        byte_size=19,
+        retention_class=export_target_manifest_pb2.EXPORT_RETENTION_CLASS_REQUIRED,
+    )
+    manifest.intermediate_files.add(byte_size=23, retention_class=evidence)
+    manifest.intermediate_files.add(
+        byte_size=29,
+        retention_class=export_target_manifest_pb2.EXPORT_RETENTION_CLASS_CACHE,
+    )
+    manifest.metrics.generated_file_count = 2
+    manifest.metrics.required_file_count = 2
+    manifest.metrics.intermediate_file_count = 2
+    manifest.metrics.artifact_byte_size = 24
+    manifest.metrics.required_byte_size = 36
+    manifest.metrics.evidence_byte_size = 51
+
+    assert _validate_metrics(manifest) == []
+
+    manifest.metrics.evidence_byte_size = 50
+
+    assert "metrics.evidence_byte_size must equal evidence file byte_size sum" in _validate_metrics(manifest)
 
 
 def test_export_target_manifest_metrics_cli_returns_nonzero_for_invalid_manifest(

--- a/services/mlx-worker-python/worker/productization/export_target_manifest.py
+++ b/services/mlx-worker-python/worker/productization/export_target_manifest.py
@@ -348,23 +348,30 @@ def _validate_metrics(
 ) -> list[str]:
     metrics = manifest.metrics
     errors: list[str] = []
+    evidence_bytes = 0
     if metrics.generated_file_count != len(manifest.generated_files):
         errors.append("metrics.generated_file_count must equal generated_files count")
     if metrics.required_file_count != len(manifest.required_files):
         errors.append("metrics.required_file_count must equal required_files count")
     if metrics.intermediate_file_count != len(manifest.intermediate_files):
         errors.append("metrics.intermediate_file_count must equal intermediate_files count")
-    generated_bytes = sum(row.byte_size for row in manifest.generated_files)
+    generated_bytes = 0
+    for row in manifest.generated_files:
+        generated_bytes += row.byte_size
+        if row.retention_class == export_target_manifest_pb2.EXPORT_RETENTION_CLASS_EVIDENCE:
+            evidence_bytes += row.byte_size
     if metrics.artifact_byte_size != generated_bytes:
         errors.append("metrics.artifact_byte_size must equal generated_files byte_size sum")
-    required_bytes = sum(row.byte_size for row in manifest.required_files)
+    required_bytes = 0
+    for row in manifest.required_files:
+        required_bytes += row.byte_size
+        if row.retention_class == export_target_manifest_pb2.EXPORT_RETENTION_CLASS_EVIDENCE:
+            evidence_bytes += row.byte_size
     if metrics.required_byte_size != required_bytes:
         errors.append("metrics.required_byte_size must equal required_files byte_size sum")
-    evidence_bytes = sum(
-        row.byte_size
-        for row in (*manifest.generated_files, *manifest.required_files, *manifest.intermediate_files)
-        if row.retention_class == export_target_manifest_pb2.EXPORT_RETENTION_CLASS_EVIDENCE
-    )
+    for row in manifest.intermediate_files:
+        if row.retention_class == export_target_manifest_pb2.EXPORT_RETENTION_CLASS_EVIDENCE:
+            evidence_bytes += row.byte_size
     if metrics.evidence_byte_size != evidence_bytes:
         errors.append("metrics.evidence_byte_size must equal evidence file byte_size sum")
     return errors


### PR DESCRIPTION
## Summary
- Accumulate export manifest generated/required/evidence byte metrics in one pass over each file section.
- Add a regression test that evidence-byte accounting includes generated, required, and intermediate file sections.
- Update the runtime export plan with the metrics-pass optimization requirement.

## Plan or Spec
- `docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md`
- Registered probe: `runtime-export-manifest-validation` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py::test_export_target_manifest_metrics_evidence_bytes_cover_all_file_sections services/mlx-worker-python/tests/test_export_target_manifest_contract.py::test_export_target_manifest_rejects_metric_mismatches`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_manifest.py services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_manifest_metrics_report.py scripts/runtime_export_manifest_validation_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_manifest_validation_probe.py` (baseline and candidate repeated locally)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 38 passed.
- Changed-scope coverage: 100% (32/32 measurable changed lines).
- Local registered probe baseline (origin/main mean from 3 post-warm runs): `old_mean=2142.361759466197 ms`.
- Local registered probe candidate (3 runs): `new_mean=2113.4880226648725 ms`, `delta_ms=-28.873736801324412`, `speedup=1.3477526227185253%`.
- CI PR-scoped performance workflow is required as the authoritative registered probe validation before merge.

## Known Gaps
- Local Linux validates the Python path only; no Swift runtime effect is claimed in this slice.
- The measured local win is small and should be confirmed by CI's registered probe report.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused behavior tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux.
- [ ] PR-scoped performance workflow completed successfully in GitHub Actions.
