### PR TITLE
perf(worker): streamline PR scope command summary

### DIFF
--- a/docs/plans/2026-06-25-prscope-command-summary-prefix-scan.md
+++ b/docs/plans/2026-06-25-prscope-command-summary-prefix-scan.md
@@ -1,0 +1,31 @@
+# PR-scoped command summary prefix scan
+
+## Context
+
+The PR-scoped performance workflow summarizes long shell commands for CI
+heartbeat logs. The registered `pr-scoped-performance-scope-matcher` probe
+covers this hot path through `_probe_pr_scoped_scope_matcher`, including a
+20,000-iteration command summary microprobe.
+
+## Slice
+
+Optimize `_summarize_command` only:
+
+- preserve existing compact-summary behavior for blank, single-line, multiline,
+  leading-whitespace, and truncated commands;
+- use `str.index("\n")` in the common multiline path so the summary avoids the
+  additional negative-branch check from `str.find()`;
+- keep the change limited to the command summary prefix path.
+
+## Verification Plan
+
+Run the registered focused commands for `pr-scoped-performance-scope-matcher`:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_prscope_scope_probe.py
+```
+
+The local Linux probe validates Python behavior and direction. CI remains the
+registered PR-scoped performance source of truth for merge gating.

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -78,8 +78,9 @@ def _summarize_command(command: str, *, max_length: int = 180) -> str:
     if not command:
         return "<empty command>"
 
-    newline_index = command.find("\n")
-    if newline_index < 0:
+    try:
+        newline_index = command.index("\n")
+    except ValueError:
         summary = command
     else:
         summary = command[:newline_index].rstrip() + " ..."


### PR DESCRIPTION
## Summary
- Streamline PR-scoped command heartbeat summarization by using the common multiline `str.index("\n")` path with the existing ValueError fallback for single-line commands.
- Add a small plan note for the registered `pr-scoped-performance-scope-matcher` slice.

## Plan or Spec
- `docs/plans/2026-06-25-prscope-command-summary-prefix-scan.md`
- Registered probe coverage: `pr-scoped-performance-scope-matcher` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_summary_keeps_ci_heartbeats_compact services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_pr_scoped_scope_matcher_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 /tmp/run_prscope_job.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 3 passed.
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Registered local probe job (`pr-scoped-performance-scope-matcher`): passed.
  - base `command_summary_ms_mean=10.391213`, head `command_summary_ms_mean=10.022657`, delta `-0.368556 ms` (`-3.55%`).
  - base `build_scope_report_ms_mean=2.648753`, head `build_scope_report_ms_mean=1.458266`, delta `-1.190487 ms`.

## Known Gaps
- Local validation is Linux/Python-only. GitHub Actions remains the merge gate for the registered PR-scoped performance report.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met the 95% requirement.
- [x] Local registered probe job showed non-regressing/improved metrics.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
