### PR TITLE
perf: expand dataset source records probe fixture

### DIFF
--- a/docs/plans/2026-06-25-dataset-source-records-mixed-suffix-probe.md
+++ b/docs/plans/2026-06-25-dataset-source-records-mixed-suffix-probe.md
@@ -1,0 +1,49 @@
+# Dataset source records mixed suffix probe
+
+## Scope
+
+This Python-only performance slice is limited to the registered PR-scoped probe
+for dataset source record ingestion:
+
+- `scripts/dataset_source_records_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+No production ingest behavior changes are included in this slice.
+
+## Registered Probe
+
+The registered PR-scoped performance probe is `dataset-source-records-scandir` in
+`infra/perf/pr_scoped_probes.json`. This slice expands its fixture from a
+text-only source tree to a mixed lowercase suffix tree (`.txt`, `.md`, `.py`,
+`.jsonl`) and clears the source-kind basename cache before each measured
+classification sample so future source-kind classifier optimizations are
+measured instead of hidden by repeated basename cache hits. The probe precomputes
+the full expected source-kind sequence outside the measured loop and uses eleven
+samples by default to reduce p95 sensitivity to a single noisy classifier pass.
+
+## Rationale
+
+A local lowercase suffix fast-path experiment did not produce a stable
+improvement while the old probe was dominated by repeated cached `.txt` basename
+lookups. Before changing production classifier behavior, the registered probe
+must measure the intended suffix-classification work directly.
+
+## Verification
+
+Required local verification for this probe-registration slice:
+
+- focused dataset source records PR-scoped probe tests
+- changed-scope coverage for the modified tests and probe script
+- registered `dataset-source-records-scandir` probe on Linux
+
+## Metrics
+
+The primary metric remains `source_kind_elapsed_ms_mean`; lower is better. The
+probe now also reports `source_kind_variant_count=4` so reports show the mixed
+suffix fixture is active.
+
+## Known Gaps
+
+This is a Linux-local Python probe slice. It does not validate Swift runtime
+effects and intentionally does not claim a production performance speedup.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5272,6 +5272,11 @@
         "key": "file_count_mean",
         "unit": "items",
         "direction": "informational"
+      },
+      {
+        "key": "source_kind_variant_count",
+        "unit": "items",
+        "direction": "informational"
       }
     ]
   },

--- a/scripts/dataset_source_records_probe.py
+++ b/scripts/dataset_source_records_probe.py
@@ -15,16 +15,38 @@ sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
 from worker.productization import dataset_preparation  # noqa: E402
 
+_SOURCE_KIND_SUFFIXES = (
+    (".txt", "text"),
+    (".md", "markdown"),
+    (".py", "code"),
+    (".jsonl", "structured_data"),
+)
+
 
 def _build_tree(root: Path, *, directory_count: int, files_per_directory: int) -> int:
     total = 0
+    suffixes = _SOURCE_KIND_SUFFIXES
     for directory_index in range(directory_count):
         directory = root / f"group-{directory_index:04d}"
         directory.mkdir(parents=True, exist_ok=True)
         for file_index in range(files_per_directory):
-            (directory / f"sample-{file_index:04d}.txt").write_text("Melix source row\n", encoding="utf-8")
+            suffix, _source_kind = suffixes[file_index % len(suffixes)]
+            (directory / f"sample-{directory_index:04d}-{file_index:04d}{suffix}").write_text(
+                "Melix source row\n",
+                encoding="utf-8",
+            )
             total += 1
     return total
+
+
+def _expected_source_kinds(file_count: int) -> list[str]:
+    suffixes = _SOURCE_KIND_SUFFIXES
+    return [suffixes[file_index % len(suffixes)][1] for file_index in range(file_count)]
+
+
+def _expected_source_kind_tree(*, directory_count: int, files_per_directory: int) -> list[str]:
+    expected_directory_kinds = _expected_source_kinds(files_per_directory)
+    return expected_directory_kinds * directory_count
 
 
 def _iter_source_file_paths(input_path: Path) -> list[Path]:
@@ -41,8 +63,17 @@ def measure(*, directory_count: int, files_per_directory: int, samples: int) -> 
     with tempfile.TemporaryDirectory(prefix="melix-dataset-source-records-probe-") as tmp:
         root = Path(tmp) / "raw-inputs"
         expected_count = _build_tree(root, directory_count=directory_count, files_per_directory=files_per_directory)
-        expected_first = root / "group-0000" / "sample-0000.txt"
-        expected_last = root / f"group-{directory_count - 1:04d}" / f"sample-{files_per_directory - 1:04d}.txt"
+        expected_first = root / "group-0000" / "sample-0000-0000.txt"
+        last_suffix, _last_kind = _SOURCE_KIND_SUFFIXES[(files_per_directory - 1) % len(_SOURCE_KIND_SUFFIXES)]
+        expected_last = (
+            root
+            / f"group-{directory_count - 1:04d}"
+            / f"sample-{directory_count - 1:04d}-{files_per_directory - 1:04d}{last_suffix}"
+        )
+        expected_kinds = _expected_source_kind_tree(
+            directory_count=directory_count,
+            files_per_directory=files_per_directory,
+        )
         for _ in range(samples):
             started = time.perf_counter()
             paths = _iter_source_file_paths(root)
@@ -52,10 +83,14 @@ def measure(*, directory_count: int, files_per_directory: int, samples: int) -> 
                 raise RuntimeError(f"unexpected source file count: {len(paths)} != {expected_count}")
             if paths[0] != expected_first or paths[-1] != expected_last:
                 raise RuntimeError("source file ordering changed")
+            cache = getattr(dataset_preparation, "_SOURCE_KIND_BY_NAME", None)
+            clear_cache = getattr(cache, "clear", None)
+            if clear_cache is not None:
+                clear_cache()
             started = time.perf_counter()
             source_kinds = [dataset_preparation._source_kind(path) for path in paths]
             source_kind_elapsed_ms.append((time.perf_counter() - started) * 1000.0)
-            if any(source_kind != "text" for source_kind in source_kinds):
+            if source_kinds != expected_kinds:
                 raise RuntimeError("source kind classification changed")
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_ms),
@@ -67,6 +102,7 @@ def measure(*, directory_count: int, files_per_directory: int, samples: int) -> 
         "directory_count": float(directory_count),
         "files_per_directory": float(files_per_directory),
         "file_count_mean": statistics.fmean(file_counts),
+        "source_kind_variant_count": float(len(_SOURCE_KIND_SUFFIXES)),
         "sample_count": float(samples),
     }
 
@@ -74,7 +110,7 @@ def measure(*, directory_count: int, files_per_directory: int, samples: int) -> 
 def main() -> int:
     directory_count = int(os.environ.get("MELIX_DATASET_SOURCE_RECORDS_PROBE_DIRS", "250"))
     files_per_directory = int(os.environ.get("MELIX_DATASET_SOURCE_RECORDS_PROBE_FILES_PER_DIR", "24"))
-    samples = int(os.environ.get("MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES", "7"))
+    samples = int(os.environ.get("MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES", "11"))
     print(json.dumps(measure(directory_count=directory_count, files_per_directory=files_per_directory, samples=samples), sort_keys=True))
     return 0
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -766,6 +766,7 @@ def test_dataset_source_records_probe_script_emits_metrics(
     assert metrics["directory_count"] == 3.0
     assert metrics["files_per_directory"] == 4.0
     assert metrics["file_count_mean"] == 12.0
+    assert metrics["source_kind_variant_count"] == 4.0
 
 
 def test_dataset_source_records_probe_rejects_changed_source_kind(


### PR DESCRIPTION
## Summary
- Expand the registered `dataset-source-records-scandir` PR-scoped probe from a text-only fixture to a mixed lowercase suffix fixture (`.txt`, `.md`, `.py`, `.jsonl`).
- Clear the source-kind basename cache before each measured classification sample so future classifier changes measure classification work instead of cached repeated basenames.
- Precompute the expected source-kind sequence outside the sample loop, guard cache clearing by checking for `.clear`, and use eleven default samples to reduce p95 noise.
- Add an informational `source_kind_variant_count` metric and document why this is a probe-registration slice before retrying production classifier optimization.

## Plan or Spec
- `docs/plans/2026-06-25-dataset-source-records-mixed-suffix-probe.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_reuses_cached_basename_classification services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_returns_cached_none_without_reclassifying services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_name_cache_clears_at_bound services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 13 passed in 0.23s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_reuses_cached_basename_classification services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_returns_cached_none_without_reclassifying services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_name_cache_clears_at_bound services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# TOTAL 9 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# {"directory_count": 250.0, "elapsed_ms_mean": 12.143514182587916, "elapsed_ms_min": 10.943842004053295, "elapsed_ms_p95": 12.827673999709077, "file_count_mean": 6000.0, "files_per_directory": 24.0, "sample_count": 11.0, "source_kind_elapsed_ms_mean": 20.957644090892494, "source_kind_elapsed_ms_min": 20.37144999485463, "source_kind_elapsed_ms_p95": 21.12042499356903, "source_kind_variant_count": 4.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%` for `scripts/dataset_source_records_probe.py` changed lines; registry coverage command also includes the focused dataset ingest and PR-scoped performance tests.
- Registered local probe metric: `source_kind_elapsed_ms_mean=20.957644090892494ms`, `source_kind_elapsed_ms_p95=21.12042499356903ms`, `source_kind_variant_count=4.0`, `file_count_mean=6000.0`, `sample_count=11.0`.
- Production speedup: N/A for this PR. A lowercase suffix fast-path experiment was rejected locally because the prior probe was dominated by cached repeated `.txt` basenames and did not provide reliable evidence for the intended source-kind classification path.
- CI is required to validate the registered PR-scoped performance workflow/report for this changed probe.

## Known Gaps
- No production ingestion behavior change is included; this prepares the registered probe for a later one-slice classifier optimization.
- Linux-local Python validation only; no Swift runtime effects are claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. (Probe workflow documented; no production behavior change.)
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. (PR-scoped performance probe; overhead is confined to CI/local synthetic probe execution.)
- [x] Deferred work and known gaps are stated explicitly.
