### PR TITLE
perf(worker): fast-path fenced event response prefix

### DIFF
--- a/docs/plans/2026-06-25-event-response-json-fence-prefix-fastpath.md
+++ b/docs/plans/2026-06-25-event-response-json-fence-prefix-fastpath.md
@@ -1,0 +1,38 @@
+# Event response JSON fence-prefix fast path
+
+## Slice
+
+Optimize only `worker.productization.event_extraction._parse_response_json` for
+direct markdown-fenced JSON responses that start with `` ```json\n ``. The
+change keeps direct object, leading-whitespace object, leading-whitespace fence,
+generic fence, non-object rejection, and trailing-data semantics unchanged.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped registered probe
+`event-extraction-response-json-fence-trim` in
+`infra/perf/pr_scoped_probes.json`.
+
+- `test_command`: focused event extraction parser tests and PR-scoped probe
+  registry tests.
+- `coverage_command`: the same focused parser and registry tests with
+  changed-scope coverage for the parser, tests, registry, and probe script.
+- `probe_command`: `scripts/event_extraction_response_json_probe.py`, including
+  `elapsed_ms_mean` for markdown-fenced JSON responses and
+  `direct_elapsed_ms_mean` for direct JSON object responses.
+
+## Implementation plan
+
+1. Preserve the first-byte backtick guard for the common direct-fence path.
+2. Replace the direct-fence `startswith()` call with a bounded prefix slice
+   comparison after confirming the response is at least as long as the JSON
+   fence prefix. This avoids an extra method dispatch on the hot fenced-response
+   path while preserving exact prefix matching.
+3. Leave the leading-whitespace and generic-fence branches unchanged.
+4. Verify locally on Linux with focused tests, changed-scope coverage, and the
+   registered probe before opening the PR.
+
+## Validation boundary
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime
+effect is claimed.

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2860,7 +2860,11 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
             raise json.JSONDecodeError("Extra data", response_text, end_index)
         return parsed
 
-    if response_length and response_text[0] == "`" and response_text.startswith(_JSON_FENCE_PREFIX):
+    if (
+        response_length >= _JSON_FENCE_PREFIX_LENGTH
+        and response_text[0] == "`"
+        and response_text[:_JSON_FENCE_PREFIX_LENGTH] == _JSON_FENCE_PREFIX
+    ):
         parsed, end_index = _JSON_RAW_DECODE(
             response_text,
             _JSON_FENCE_PREFIX_LENGTH,


### PR DESCRIPTION
## Summary
- Fast-path direct markdown-fenced event-extraction JSON responses by replacing the hot-path `startswith()` prefix check with a bounded slice comparison after the first-byte backtick guard.
- Add the governing performance slice plan for the registered `event-extraction-response-json-fence-trim` probe.

## Plan or Spec
- `docs/plans/2026-06-25-event-response-json-fence-prefix-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_leading_whitespace_before_fence services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_generic_fence_after_fast_json_prefix services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_unfenced_json_without_pretrim_copy services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_leading_whitespace_object_skips_fence_prefix_checks services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_leading_whitespace_object_rejects_trailing_text services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_leading_whitespace_rejects_non_object_payload services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_direct_object_fast_path services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_unfenced_closing_fence services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_trailing_text_after_fenced_json services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_fenced_non_object_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics
# 15 passed in 1.58s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_response_json_probe.py
# 15 passed in 0.53s; changed-scope coverage TOTAL 1 0 100%

git diff --check
# exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_response_json_probe.py
# baseline before change: elapsed_ms_mean=1236.5101639996283, direct_elapsed_ms_mean=1248.6518944002455
# after change sample 1: elapsed_ms_mean=1163.1676969933324, direct_elapsed_ms_mean=1252.624365198426
# after change sample 2: elapsed_ms_mean=1151.1850554001285, direct_elapsed_ms_mean=1201.731892398675
# after change sample 3: elapsed_ms_mean=1191.6765564033994, direct_elapsed_ms_mean=1287.1604949992616
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 1 0 100%`).
- Registered local probe: `event-extraction-response-json-fence-trim` via `scripts/event_extraction_response_json_probe.py`.
- Local Linux probe comparison: old/current pre-change `elapsed_ms_mean=1236.510ms`; post-change mean across three probe runs `elapsed_ms_mean≈1168.676ms`; delta `-67.834ms` (`~5.49%` faster) for the direct fenced JSON path.
- CI PR-scoped performance workflow is required as the registered probe validation source before merge.

## Known Gaps
- Full repository gates were not run locally; this slice used focused tests, changed-scope coverage, and the registered local probe on Linux.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
