### PR TITLE
perf: cache video uri identity hashes

### DIFF
--- a/docs/plans/2026-06-25-video-uri-identity-hash-cache.md
+++ b/docs/plans/2026-06-25-video-uri-identity-hash-cache.md
@@ -1,0 +1,37 @@
+# Video URI identity hash cache
+
+## Scope
+
+This Python-only performance slice is limited to repeated URI video preprocessing in
+`services/mlx-worker-python/worker/runtime/video_preprocessing.py`.
+
+The hot path prepares many remote video references with the same URI metadata frame.
+The behavior remains unchanged: URI validation, inferred filename/format metadata,
+byte-length accounting, and the SHA-256 identity string are preserved.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`video-preprocessing-uri-byte-length-reuse` in `infra/perf/pr_scoped_probes.json`.
+The registry entry already includes focused `test_command`, `coverage_command`, and
+`probe_command` entries. The probe measures:
+
+- `elapsed_ms_mean` for repeated `prepare_video_input(...)` calls.
+- `byte_length_getattrs_per_call`, which must remain at one metadata read per call.
+- `parse_calls_per_call`, which must remain at the cached parse behavior.
+
+## Implementation plan
+
+1. Add an LRU cache to `_uri_identity_hash(...)`, keyed by its immutable metadata
+   frame inputs, reusing the same bounded cache size as URI parse metadata.
+2. Add regression coverage proving repeated identical metadata frames hit the cache
+   and return the same digest.
+3. Run the registered focused test command, changed-scope coverage command, and
+   registered probe locally on Linux before opening the PR.
+4. Use the GitHub Actions PR-scoped performance report as the merge gate.
+
+## Expected outcome
+
+Repeated URI video preprocessing avoids recomputing the same identity SHA-256
+digest while preserving the existing public `PreparedVideoInput` output shape and
+validation semantics.

--- a/services/mlx-worker-python/tests/test_video_preprocessing.py
+++ b/services/mlx-worker-python/tests/test_video_preprocessing.py
@@ -164,6 +164,36 @@ def test_prepare_video_input_reuses_uri_byte_length_for_metadata_and_identity_ha
     assert len(prepared.sha256_hex) == 64
 
 
+def test_uri_identity_hash_caches_repeated_metadata_frames() -> None:
+    _uri_identity_hash.cache_clear()
+
+    first = _uri_identity_hash(
+        uri="https://example.com/media/demo.mov",
+        mime_type="video/quicktime",
+        format_name="mov",
+        filename="demo.mov",
+        byte_length=123,
+        duration_ms=1_000,
+        frame_budget=8,
+        start_ms=0,
+        end_ms=1_000,
+    )
+    second = _uri_identity_hash(
+        uri="https://example.com/media/demo.mov",
+        mime_type="video/quicktime",
+        format_name="mov",
+        filename="demo.mov",
+        byte_length=123,
+        duration_ms=1_000,
+        frame_budget=8,
+        start_ms=0,
+        end_ms=1_000,
+    )
+
+    assert first == second
+    assert _uri_identity_hash.cache_info().hits == 1
+
+
 def test_prepare_video_input_prefers_explicit_filename_for_uri_format() -> None:
     part = common_pb2.MessagePart(
         video_uri="https://example.com/media/download",

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -289,6 +289,7 @@ def _filename_from_reference(reference: str | ParsedVideoReference) -> str:
     return parsed_reference.path_name
 
 
+@lru_cache(maxsize=VIDEO_REFERENCE_PARSE_CACHE_SIZE)
 def _uri_identity_hash(
     *,
     uri: str,


### PR DESCRIPTION
## Summary
- Cache identity SHA-256 calculation for video URI references that have no inline bytes.
- Add regression coverage proving repeated URI preprocessing reuses the identity hash instead of re-hashing the URI string.
- Document the slice and registered probe evidence plan.

## Plan or Spec
- `docs/plans/2026-06-25-video-uri-identity-hash-cache.md`
- Registered PR-scoped probe: `video-preprocessing-uri-byte-length-reuse`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py::test_validate_video_uri_accepts_parsed_and_string_remote_references services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py::test_validate_video_uri_accepts_parsed_and_string_remote_references services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/video_preprocessing_uri_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id video-preprocessing-uri-byte-length-reuse --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-video-preprocessing-uri-hash-cache-20260625 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-video-preprocessing-host-dot-fastpath-20260625 --output /tmp/video_uri_hash_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: 38 passed.
- Changed-scope coverage: 100% over 7 changed measurable lines.
- Local registered probe (`video-preprocessing-uri-byte-length-reuse`, Linux): base `elapsed_ms_mean=628.340 ms`, head `elapsed_ms_mean=545.756 ms`, delta `-82.584 ms` (`13.14%` faster); `byte_length_getattrs_per_call=1.0` unchanged; `parse_calls_per_call=1.0` unchanged.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- This is a Python/Linux-verifiable slice only; no Swift runtime effect is claimed.
- The registered probe targets repeated URI-only preprocessing and does not cover inline byte payload hashing.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Affected path is covered by registered PR-scoped probe with test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage passes locally.
- [x] Registered probe improves locally.
- [ ] GitHub Actions and PR-scoped performance workflow pass.
