### PR TITLE
perf(worker): elide exact missing tool lookup

### DIFF
--- a/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
+++ b/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
@@ -72,6 +72,17 @@ builder is kept as a module-level helper so the existing vector/keyword paths do
 not pay a per-call nested-function allocation cost. The probe records a separate
 `always_only_planning_elapsed_ms_mean` metric for this bounded-cap routing path.
 
+## Slice update: exact missing single-name error fast path
+
+This incremental slice keeps the same `tool-registry-select-name-index-cache`
+registered probe and narrows the optimization to exact single-name selection
+misses such as `("missing_tool",)`. Once the first cached name-index lookup
+proves the exact non-blank name is absent and there is no selected-registry cache
+hit, `ToolRegistry.select()` now raises the existing unknown-tool error directly
+instead of performing a second equivalent dictionary lookup. Whitespace-trimmed
+single-name requests, cache hits, valid selections, and error messages remain
+unchanged.
+
 ## Acceptance Criteria
 
 - Focused behavior tests pass locally on Linux.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -327,8 +327,10 @@ def test_tool_registry_select_reuses_missing_name_sentinel_between_calls() -> No
         def __init__(self, values: dict[str, ToolDescriptor]) -> None:
             super().__init__(values)
             self.default_ids: list[int] = []
+            self.get_calls = 0
 
         def get(self, key: str, default: object = None) -> ToolDescriptor | object:
+            self.get_calls += 1
             self.default_ids.append(id(default))
             return super().get(key, default)
 
@@ -341,6 +343,7 @@ def test_tool_registry_select_reuses_missing_name_sentinel_between_calls() -> No
             registry.select([missing_name])
 
     assert len(set(index.default_ids)) == 1
+    assert index.get_calls == 2
 
 
 def test_tool_registry_select_reuses_cached_selected_registry() -> None:

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -326,6 +326,10 @@ class ToolRegistry:
                     if isinstance(names, tuple) and names != requested_names:
                         self._selection_cache[names] = cached_selection
                     return cached_selection
+                if normalized_name == raw_name:
+                    raise ToolRegistryError(
+                        f"Unknown tool registry entry requested: {normalized_name}"
+                    )
                 tool = tool_by_name.get(normalized_name, missing_tool_sentinel)
                 if tool is missing_tool_sentinel:
                     raise ToolRegistryError(


### PR DESCRIPTION
## Summary
- Elide the redundant second cached name-index lookup for exact single-name missing tool selections in `ToolRegistry.select()`.
- Extend the focused sentinel test to prove exact missing-name calls perform one lookup per error.
- Document the incremental performance slice in the existing tool registry plan.

## Plan or Spec
- Updated `docs/plans/2026-05-18-tool-registry-select-name-index-cache.md` with the exact missing single-name error fast path slice.
- Registered PR-scoped probe already exists: `tool-registry-select-name-index-cache` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- Base probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` from `origin/main`
- Head probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` from this branch
- `git diff --check`

## Coverage and Metrics
- Focused tests: 87 passed.
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Local Linux registered probe (`tool-registry-select-name-index-cache`, 5 samples):
  - base `missing_selection_elapsed_ms_mean=18.1024 ms`, head `14.6627 ms`, delta `-3.4398 ms` / `-19.0%`.
  - base `elapsed_ms_mean=22.9797 ms`, head `21.7549 ms`, delta `-1.2248 ms` / `-5.3%`.
  - `missing_selection_errors_mean` unchanged at `16000.0`.

## Known Gaps
- This is a Python-only slice validated locally on Linux; no Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance is the merge gate for the registered CI probe.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe shows directional improvement on the targeted metric.
- [ ] GitHub Actions and PR-scoped performance completed successfully.
