### PR TITLE
perf: skip slashless export diagnostic path redaction

### DIFF
--- a/docs/plans/2026-06-25-export-diagnostics-slashless-redaction.md
+++ b/docs/plans/2026-06-25-export-diagnostics-slashless-redaction.md
@@ -1,0 +1,23 @@
+# Export diagnostics slashless redaction fast path
+
+## Scope
+
+This slice keeps the runtime export diagnostics parser behavior unchanged while
+skipping the absolute-path redaction regex for diagnostic lines that contain no
+slash character. The absolute-path redactor only matches `/...` path tokens, so
+slashless lines cannot produce path redactions.
+
+## Probe
+
+The registered PR-scoped probe is `runtime-export-diagnostic-parser` in
+`infra/perf/pr_scoped_probes.json`. It includes focused test, coverage, and
+`scripts/runtime_export_diagnostic_parser_probe.py` commands. The probe reports
+parser coverage, parsed and unknown failure counts, redaction counts, diagnostic
+latency, path-redaction latency, elapsed time, and peak bytes.
+
+## Success criteria
+
+- Parser coverage remains `1.0` with no unknown-count regression.
+- Changed-scope coverage for the diagnostics parser remains at least 95%.
+- Registered probe elapsed time improves or remains neutral without reducing
+  redaction coverage.

--- a/docs/runbooks/runtime-export-smoke-policy.md
+++ b/docs/runbooks/runtime-export-smoke-policy.md
@@ -72,7 +72,8 @@ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
 
 The diagnostic probe reports parser coverage, parsed failure count, unknown
 failure count, redaction count, diagnostic latency, target count, and peak
-bytes.
+bytes. The diagnostics parser bypasses the absolute-path redaction regex for
+slashless diagnostic lines because that regex only matches `/...` path tokens.
 
 ## Waiver Policy
 

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 from packages.protocol.python.workspace.v1 import export_target_manifest_pb2
@@ -412,6 +413,26 @@ def test_export_target_diagnostics_metric_counts_single_pass() -> None:
     assert parsed_count == 2
     assert unknown_count == 1
     assert matched_codes == {CODE_RUNTIME_LOAD_FAILED, CODE_MISSING_BINARY}
+
+
+def test_export_target_diagnostics_skips_path_regex_for_slashless_text(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    path_pattern = Mock()
+    monkeypatch.setattr(export_target_diagnostics_module, "_ABSOLUTE_PATH_PATTERN", path_pattern)
+    summary = export_target_diagnostics_module._RedactionSummary()
+
+    redacted = export_target_diagnostics_module._redact_text(
+        "runtime load failed while opening model",
+        tmp_path,
+        str(tmp_path),
+        summary,
+    )
+
+    assert redacted == "runtime load failed while opening model"
+    path_pattern.sub.assert_not_called()
+    assert summary.redaction_count == 0
 
 
 def test_export_target_diagnostics_not_applicable_without_logs_or_failures(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -591,6 +591,8 @@ def _redact_text(
                 lambda match: _record_identity(summary, match.group(1)),
                 text,
             )
+    if "/" not in text:
+        return text
     return _ABSOLUTE_PATH_PATTERN.sub(
         lambda match: _redact_absolute_path(
             match.group(0),


### PR DESCRIPTION
## Summary
- Skip the runtime export diagnostics absolute-path regex when a diagnostic line contains no slash.
- Add a regression test for the slashless fast path.
- Record the slice plan and update the runtime export smoke runbook note.

## Plan or Spec
- `docs/plans/2026-06-25-export-diagnostics-slashless-redaction.md`
- `docs/runbooks/runtime-export-smoke-policy.md`

## Commands Run
```text
# Baseline registered probe before the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
exit 0; elapsed_ms_mean=2990.62808539893; diagnostic_latency_ms=9.46503299928736; path_redaction_elapsed_ms_mean=23.673750000307336; diagnostic_parser_coverage=1.0

# Focused diagnostics tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_skips_path_regex_for_slashless_text services/mlx-worker-python/tests/test_export_target_diagnostics.py
exit 0; 21 passed in 0.33s

# Registered coverage command for runtime-export-diagnostic-parser
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
exit 0; 27 passed in 1.34s; TOTAL 11 0 100%

# Registered probe after the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
exit 0; elapsed_ms_mean=2967.1872923965566; diagnostic_latency_ms=9.200889995554462; path_redaction_elapsed_ms_mean=23.427841000375338; diagnostic_parser_coverage=1.0

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 11 0 100%`).
- Registered probe: `runtime-export-diagnostic-parser`.
- Baseline vs head local probe:
  - `elapsed_ms_mean`: 2990.628 -> 2967.187 ms (delta -23.441 ms, -0.78%).
  - `diagnostic_latency_ms`: 9.465 -> 9.201 ms (delta -0.264 ms, -2.79%).
  - `path_redaction_elapsed_ms_mean`: 23.674 -> 23.428 ms (delta -0.246 ms, -1.04%).
  - `diagnostic_parser_coverage`: 1.0 -> 1.0.
  - `unknown_failure_count`: 1.0 -> 1.0.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this slice used the registered focused probe/test/coverage commands on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no new runtime telemetry.
- [x] Deferred work and known gaps are stated explicitly.
