### PR TITLE
perf: use list literal for trajectory scalar copies

### DIFF
--- a/docs/plans/2026-06-25-trajectory-copy-list-literal.md
+++ b/docs/plans/2026-06-25-trajectory-copy-list-literal.md
@@ -1,0 +1,38 @@
+# Trajectory provenance scalar list literal copy slice
+
+This Python-only performance slice is limited to the scalar-list branch in
+`worker.trajectory_provenance._copy_json_list`.
+
+## Scope
+
+The trajectory provenance normalizer copies JSON-like containers before they are
+attached to training, adapter, and evaluation payloads. Previous slices already
+avoid recursive copying for exact scalar lists; this slice keeps the same
+container isolation semantics while replacing the scalar-list `list.copy()` call
+with a list-display unpack copy (`[*value]`).
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`trajectory-provenance-copy-elision` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` fields for:
+
+- `services/mlx-worker-python/worker/trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_trajectory_provenance.py`
+- `scripts/trajectory_provenance_copy_elision_probe.py`
+
+## Metrics
+
+Target metric: lower `scalar_list_elapsed_ms_mean`, negative
+`scalar_list_delta_ms`, and non-regressed `scalar_list_speedup` in the registered
+`trajectory-provenance-copy-elision` command-json probe while preserving nested
+container copy isolation. The existing full-provenance `optimized_elapsed_ms_mean`
+remains reported as a broader guardrail.
+
+## Verification plan
+
+Run the focused registry test command, changed-scope coverage command, and the
+registered probe locally on Linux before opening the PR. The probe compares the
+deep-copy baseline with the optimized provenance copier and reports elapsed time,
+peak bytes, speedup, sample count, iteration count, and component count.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5379,10 +5379,10 @@
       "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
       "scripts/trajectory_provenance_copy_elision_probe.py",
       "infra/perf/pr_scoped_probes.json",
-      "docs/plans/2026-06-20-trajectory-tuple-copy-fastpath.md"
+      "docs/plans/2026-06-25-trajectory-copy-list-literal.md"
     ],
-    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_reuses_scalar_tuples_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_provenance_copy_elision_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
-    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_reuses_scalar_tuples_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py",
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_uses_literal_copy_for_scalar_lists services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_reuses_scalar_tuples_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_provenance_copy_elision_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_uses_literal_copy_for_scalar_lists services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_reuses_scalar_tuples_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py",
     "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" bash -c 'if [ -f scripts/trajectory_provenance_copy_elision_probe.py ]; then python3 scripts/trajectory_provenance_copy_elision_probe.py; else python3 ../head/scripts/trajectory_provenance_copy_elision_probe.py; fi'",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
@@ -5413,6 +5413,28 @@
         "key": "peak_bytes_mean",
         "unit": "bytes",
         "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "scalar_list_baseline_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "scalar_list_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "scalar_list_delta_ms",
+        "unit": "ms",
+        "direction": "informational"
+      },
+      {
+        "key": "scalar_list_speedup",
+        "unit": "x",
+        "direction": "higher_is_better",
         "warn_pct": 5.0
       },
       {

--- a/scripts/trajectory_provenance_copy_elision_probe.py
+++ b/scripts/trajectory_provenance_copy_elision_probe.py
@@ -20,8 +20,11 @@ if str(WORKER_ROOT) not in sys.path:
 from worker.trajectory_provenance import normalize_trajectory_provenance  # noqa: E402
 
 try:  # noqa: E402
-    from worker.trajectory_provenance import _copy_trajectory_provenance_value
+    from worker.trajectory_provenance import _copy_json_list, _copy_trajectory_provenance_value
 except ImportError:  # base checkout before this slice added the helper
+    def _copy_json_list(value: list[Any]) -> list[Any]:
+        return copy.deepcopy(value)
+
     def _copy_trajectory_provenance_value(value: Any) -> Any:
         return copy.deepcopy(value)
 
@@ -107,6 +110,30 @@ def _measure(func: Callable[[dict[str, Any]], dict[str, Any]], provenance: dict[
     return elapsed_ms, peak_bytes
 
 
+def _baseline_scalar_list_copy(value: list[Any]) -> list[Any]:
+    immutable_types = (str, int, float, bool, type(None))
+    for item in value:
+        if type(item) not in immutable_types:
+            return [_copy_trajectory_provenance_value(item) for item in value]
+    return value.copy()
+
+
+def _measure_scalar_list_copy(
+    func: Callable[[list[Any]], list[Any]],
+    value: list[Any],
+    iterations: int,
+) -> float:
+    start = time.perf_counter()
+    checksum = 0
+    for _ in range(iterations):
+        copied = func(value)
+        checksum += len(copied)
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    if checksum != len(value) * iterations:
+        raise RuntimeError("scalar-list probe checksum mismatch")
+    return elapsed_ms
+
+
 def _mean(values: list[float]) -> float:
     return float(statistics.fmean(values)) if values else 0.0
 
@@ -121,10 +148,14 @@ def main() -> int:
     optimized_ms: list[float] = []
     baseline_peak: list[float] = []
     optimized_peak: list[float] = []
+    scalar_baseline_ms: list[float] = []
+    scalar_optimized_ms: list[float] = []
 
     copied = _copy_trajectory_provenance_value(provenance["trajectory_quality_metrics"])
     if copied is provenance["trajectory_quality_metrics"] or copied["components"] is provenance["trajectory_quality_metrics"]["components"]:
         raise RuntimeError("optimized copy did not isolate nested containers")
+
+    scalar_values = ["agentic", "trajectory", "quality", 3, True, None, 0.75]
 
     for _ in range(samples):
         elapsed, peak = _measure(_baseline_normalize, provenance, iterations)
@@ -133,11 +164,19 @@ def main() -> int:
         elapsed, peak = _measure(normalize_trajectory_provenance, provenance, iterations)
         optimized_ms.append(elapsed)
         optimized_peak.append(float(peak))
+        scalar_baseline_ms.append(
+            _measure_scalar_list_copy(_baseline_scalar_list_copy, scalar_values, iterations)
+        )
+        scalar_optimized_ms.append(
+            _measure_scalar_list_copy(_copy_json_list, scalar_values, iterations)
+        )
 
     baseline_mean = _mean(baseline_ms)
     optimized_mean = _mean(optimized_ms)
     delta_ms = optimized_mean - baseline_mean
     speedup = baseline_mean / optimized_mean if optimized_mean > 0 else 0.0
+    scalar_baseline_mean = _mean(scalar_baseline_ms)
+    scalar_optimized_mean = _mean(scalar_optimized_ms)
     result = {
         "baseline_elapsed_ms_mean": baseline_mean,
         "optimized_elapsed_ms_mean": optimized_mean,
@@ -147,6 +186,12 @@ def main() -> int:
         "baseline_peak_bytes_mean": _mean(baseline_peak),
         "optimized_peak_bytes_mean": _mean(optimized_peak),
         "peak_bytes_mean": _mean(optimized_peak),
+        "scalar_list_baseline_elapsed_ms_mean": scalar_baseline_mean,
+        "scalar_list_elapsed_ms_mean": scalar_optimized_mean,
+        "scalar_list_delta_ms": scalar_optimized_mean - scalar_baseline_mean,
+        "scalar_list_speedup": scalar_baseline_mean / scalar_optimized_mean
+        if scalar_optimized_mean > 0
+        else 0.0,
         "sample_count": float(samples),
         "iteration_count": float(iterations),
         "component_count": float(component_count),

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -605,6 +605,31 @@ def test_copy_json_list_copies_short_scalar_lists_without_recursive_calls(
     assert copied is not source
 
 
+def test_copy_json_list_uses_literal_copy_for_scalar_lists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = ["agentic", "trajectory", 3]
+
+    class CopyBlockedList(list[object]):
+        def copy(self) -> list[object]:
+            raise AssertionError("scalar-list fast path should avoid list.copy()")
+
+    def fail_recursive_copy(value: object) -> object:
+        raise AssertionError(f"unexpected recursive copy for scalar value {value!r}")
+
+    monkeypatch.setattr(
+        trajectory_provenance_module,
+        "_copy_trajectory_provenance_value",
+        fail_recursive_copy,
+    )
+
+    copied = trajectory_provenance_module._copy_json_list(CopyBlockedList(source))
+
+    assert copied == source
+    assert copied is not source
+    assert type(copied) is list
+
+
 def test_copy_json_list_still_copies_nested_mutable_items() -> None:
     source = ["agentic", {"labels": ["trajectory"]}]
 

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -55,7 +55,7 @@ def _copy_json_list(value: list[Any]) -> list[Any]:
     for item in value:
         if type(item) not in immutable_types:
             return [_copy_trajectory_provenance_value(item) for item in value]
-    return value.copy()
+    return [*value]
 
 
 def _copy_json_tuple(value: tuple[Any, ...]) -> tuple[Any, ...]:


### PR DESCRIPTION
## Summary
- Use a list-display unpack copy for trajectory provenance scalar-list normalization instead of `list.copy()`.
- Add a regression test that blocks the old scalar-list `copy()` call while preserving list isolation.
- Extend the registered `trajectory-provenance-copy-elision` probe with scalar-list baseline/head metrics and document the slice plan.

## Plan or Spec
- `docs/plans/2026-06-25-trajectory-copy-list-literal.md`
- Registered PR-scoped probe: `trajectory-provenance-copy-elision` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_uses_literal_copy_for_scalar_lists services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_reuses_scalar_tuples_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_provenance_copy_elision_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` → 19 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q ... && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py` → changed_line_coverage=100.00%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 scripts/trajectory_provenance_copy_elision_probe.py` → command-json metrics emitted
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` for `services/mlx-worker-python/worker/trajectory_provenance.py`.
- Local registered probe output:
  - `baseline_elapsed_ms_mean=2018.5422729991842`
  - `optimized_elapsed_ms_mean=349.84636799781583`
  - `speedup=5.769796281011517`
  - `scalar_list_baseline_elapsed_ms_mean=0.9736489941133186`
  - `scalar_list_elapsed_ms_mean=0.6545049982378259`
  - `scalar_list_delta_ms=-0.3191439958754927`
  - `scalar_list_speedup=1.487611243206314`
  - `component_count=64.0`, `iteration_count=2000.0`, `sample_count=5.0`

## Known Gaps
- Local Linux validation covers the Python worker path only.
- CI is required for the registered PR-scoped performance workflow report before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally and reports scalar-list delta metrics.
- [ ] GitHub Actions completed successfully.
- [ ] PR-scoped performance report completed successfully.
