### PR TITLE
perf: skip text family config hints for metadata overrides

### DIFF
--- a/docs/plans/2026-06-25-text-family-metadata-override-lazy-hints.md
+++ b/docs/plans/2026-06-25-text-family-metadata-override-lazy-hints.md
@@ -1,0 +1,40 @@
+# Text Family Metadata Override Lazy Hints
+
+## Goal
+
+Reduce repeated Python mapping access during `resolve_text_family_config(...)` when
+metadata already supplies authoritative text-family runtime hints.
+
+## Scope
+
+This Python-only performance slice is limited to:
+
+- `services/mlx-worker-python/worker/runtime/text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/text_family_config_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+The registered PR-scoped probe remains `text-family-config-copy-elision`. This
+slice extends that probe to include `config_key_accesses_mean` so CI and local
+runs can validate that metadata override paths skip unnecessary config hint
+lookups.
+
+## Behavior
+
+When metadata provides these keys:
+
+- `melix.text.attention_profile`
+- `melix.text.rope_profile`
+- `melix.text.moe.gate_dequant`
+
+`resolve_text_family_config(...)` now uses the metadata values directly instead
+of eagerly evaluating the corresponding config inference fallbacks. Family
+detection and expert-count precedence still read the config payload as before,
+so resolution semantics remain unchanged.
+
+## Validation
+
+Run the registered focused test command, changed-scope coverage command, and
+probe command for the text-family config probe before opening the PR. The probe
+reports elapsed time, peak bytes, config copy calls, and config key accesses.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -392,6 +392,12 @@
         "unit": "calls",
         "direction": "lower_is_better",
         "warn_pct": 0.0
+      },
+      {
+        "key": "config_key_accesses_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
       }
     ]
   },

--- a/scripts/text_family_config_probe.py
+++ b/scripts/text_family_config_probe.py
@@ -20,8 +20,10 @@ class CopyCountingConfig(Mapping[str, Any]):
     def __init__(self, payload: Mapping[str, Any]) -> None:
         self._payload = dict(payload)
         self.copy_attempts = 0
+        self.key_accesses = 0
 
     def __getitem__(self, key: str) -> Any:
+        self.key_accesses += 1
         return self._payload[key]
 
     def __iter__(self) -> Iterator[str]:
@@ -50,9 +52,14 @@ def _payload() -> dict[str, Any]:
     return payload
 
 
-def _run_sample(*, iterations: int) -> tuple[float, int, int]:
+def _run_sample(*, iterations: int) -> tuple[float, int, int, int]:
     config = CopyCountingConfig(_payload())
-    metadata = {"text_family_id": "qwen3moe"}
+    metadata = {
+        "text_family_id": "qwen3moe",
+        "melix.text.attention_profile": "gqa",
+        "melix.text.rope_profile": "yarn_interleaved",
+        "melix.text.moe.gate_dequant": "true",
+    }
     checksum = 0
     tracemalloc.start()
     started = time.perf_counter()
@@ -73,7 +80,7 @@ def _run_sample(*, iterations: int) -> tuple[float, int, int]:
     tracemalloc.stop()
     if checksum != iterations * 130:
         raise AssertionError(f"unexpected checksum: {checksum}")
-    return elapsed_ms, peak_bytes, config.copy_attempts
+    return elapsed_ms, peak_bytes, config.copy_attempts, config.key_accesses
 
 
 def main() -> None:
@@ -81,17 +88,20 @@ def main() -> None:
     elapsed: list[float] = []
     peak: list[int] = []
     copy_calls: list[int] = []
+    key_accesses: list[int] = []
     for _ in range(5):
-        elapsed_ms, peak_bytes, copies = _run_sample(iterations=iterations)
+        elapsed_ms, peak_bytes, copies, access_count = _run_sample(iterations=iterations)
         elapsed.append(elapsed_ms)
         peak.append(peak_bytes)
         copy_calls.append(copies)
+        key_accesses.append(access_count)
     print(
         json.dumps(
             {
                 "elapsed_ms_mean": statistics.fmean(elapsed),
                 "peak_bytes_mean": statistics.fmean(peak),
                 "config_copy_calls_mean": statistics.fmean(copy_calls),
+                "config_key_accesses_mean": statistics.fmean(key_accesses),
                 "iterations": iterations,
             },
             sort_keys=True,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -3710,6 +3710,7 @@ def test_text_family_config_probe_script_emits_metrics(
     assert metrics["elapsed_ms_mean"] > 0
     assert metrics["peak_bytes_mean"] > 0
     assert metrics["config_copy_calls_mean"] == 0.0
+    assert metrics["config_key_accesses_mean"] > 0.0
     assert metrics["iterations"] == 10_000
 
 

--- a/services/mlx-worker-python/tests/test_text_family_adapters.py
+++ b/services/mlx-worker-python/tests/test_text_family_adapters.py
@@ -420,3 +420,63 @@ def test_resolve_text_family_config_reads_config_mapping_without_copying() -> No
     assert len(config) == 516
     assert dict(config)["model_type"] == "qwen3_moe"
     assert config.copy_attempts == 1
+
+
+def test_resolve_text_family_config_skips_config_hints_when_metadata_overrides() -> None:
+    class AccessCountingConfig(Mapping[str, Any]):
+        def __init__(self, payload: Mapping[str, Any]) -> None:
+            self._payload = dict(payload)
+            self.keys_read: list[str] = []
+
+        def __getitem__(self, key: str) -> Any:
+            self.keys_read.append(key)
+            return self._payload[key]
+
+        def __iter__(self) -> Iterator[str]:
+            return iter(self._payload)
+
+        def __len__(self) -> int:
+            return len(self._payload)
+
+    config = AccessCountingConfig(
+        {
+            "model_type": "qwen3_moe",
+            "attention_impl": "mla",
+            "rope_scaling": {"type": "yarn", "interleaved": True},
+            "num_local_experts": 128,
+            "moe_gate_dequant": False,
+        }
+    )
+
+    resolved = resolve_text_family_config(
+        {
+            "text_family_id": "qwen3moe",
+            "melix.text.attention_profile": "gqa",
+            "melix.text.rope_profile": "standard",
+            "melix.text.moe.gate_dequant": "true",
+        },
+        model_path="models/qwen3-moe-128e",
+        config_payload=config,
+        default_route_kind="swift_text",
+    )
+
+    assert resolved.attention_profile == "gqa"
+    assert resolved.rope_profile == "standard"
+    assert resolved.moe_gate_dequant is True
+    assert resolved.expert_count == 128
+    assert list(config)[:1] == ["model_type"]
+    assert len(config) == 5
+    assert set(config.keys_read).isdisjoint(
+        {
+            "attention_type",
+            "attn_type",
+            "attention_impl",
+            "attn_impl",
+            "use_mla",
+            "rope_scaling",
+            "rope_interleaved",
+            "moe_gate_dequant",
+            "dequantize_router_logits",
+            "moe_gate_requires_dequant",
+        }
+    )

--- a/services/mlx-worker-python/worker/runtime/text_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/text_family_adapters.py
@@ -263,6 +263,24 @@ def resolve_text_family_config(
         "melix.text.moe.enabled",
         default=expert_count > 0 or descriptor.moe_enabled,
     )
+    attention_profile = _string_value(metadata, "melix.text.attention_profile", "")
+    if not attention_profile:
+        attention_profile = _inferred_attention_profile(
+            config_payload,
+            default=descriptor.attention_profile,
+        )
+    rope_profile = _string_value(metadata, "melix.text.rope_profile", "")
+    if not rope_profile:
+        rope_profile = _inferred_rope_profile(
+            config_payload,
+            default=descriptor.rope_profile,
+        )
+    moe_gate_dequant_metadata = metadata.get("melix.text.moe.gate_dequant", "").strip()
+    moe_gate_dequant = (
+        _bool_from_any(moe_gate_dequant_metadata)
+        if moe_gate_dequant_metadata
+        else _inferred_moe_gate_dequant(config_payload, default=descriptor.moe_gate_dequant)
+    )
     return ResolvedTextFamilyConfig(
         family_id=detection.family_id,
         architecture=_string_value(metadata, "model_architecture", detection.architecture or descriptor.default_architecture),
@@ -279,24 +297,12 @@ def resolve_text_family_config(
             "tool_parser_xml_fallback",
             default=descriptor.tool_parser_xml_fallback,
         ),
-        attention_profile=_string_value(
-            metadata,
-            "melix.text.attention_profile",
-            _inferred_attention_profile(config_payload, default=descriptor.attention_profile),
-        ),
-        rope_profile=_string_value(
-            metadata,
-            "melix.text.rope_profile",
-            _inferred_rope_profile(config_payload, default=descriptor.rope_profile),
-        ),
+        attention_profile=attention_profile,
+        rope_profile=rope_profile,
         moe_enabled=moe_enabled,
         expert_count=expert_count if moe_enabled else 0,
         expert_count_source=expert_count_source if moe_enabled and expert_count > 0 else "none",
-        moe_gate_dequant=_bool_value(
-            metadata,
-            "melix.text.moe.gate_dequant",
-            default=_inferred_moe_gate_dequant(config_payload, default=descriptor.moe_gate_dequant),
-        ),
+        moe_gate_dequant=moe_gate_dequant,
     )
 
 


### PR DESCRIPTION
## Summary
- Lazily resolve text-family attention, rope, and MoE gate-dequant config hints only when metadata does not provide an override.
- Add regression coverage proving override metadata skips unnecessary config hint lookups.
- Extend the registered `text-family-config-copy-elision` probe with `config_key_accesses_mean` for this override path.

## Plan or Spec
- `docs/plans/2026-06-25-text-family-metadata-override-lazy-hints.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/text_family_adapters.py services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/text_family_config_probe.py`
- Baseline comparison: copied the updated probe script to `/tmp/text_family_config_probe_current_slice.py` and ran it from an `origin/main` detached worktree.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 24 passed.
- Changed-scope coverage: 100% (`TOTAL 38 0 100%`).
- Registered probe baseline (`origin/main` code + updated probe): `elapsed_ms_mean=322.79562639887445`, `config_key_accesses_mean=90000.0`, `peak_bytes_mean=1108.6`.
- Registered probe candidate: `elapsed_ms_mean=156.71142620267347`, `config_key_accesses_mean=20000.0`, `peak_bytes_mean=1008.0`.
- Delta: elapsed -166.084 ms mean (~51.45% faster), config key accesses -70,000 per sample.

## Known Gaps
- This is a Python-only Linux-verified slice. No Swift runtime effect is claimed.
- Final registered PR-scoped performance validation must come from CI before merge.

## Evidence Checklist
- [x] Registered probe covers the changed path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows improvement.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
