### PR TITLE
perf: return after terminal equal version parts

### DIFF
--- a/docs/plans/2026-06-25-startup-version-terminal-equal-return.md
+++ b/docs/plans/2026-06-25-startup-version-terminal-equal-return.md
@@ -1,0 +1,32 @@
+# Startup Version Terminal Equal Return Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.productization.startup_signals.compare_versions()` and its inlined
+normalization comparator. It preserves version ordering semantics while avoiding
+one extra empty-part loop when both normalized version streams reach the end
+after an equal numeric segment.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`startup-signals-version-compare-single-pass` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for startup
+signals and the version probe script.
+
+## Expected Behavior
+
+- Equal normalized versions still compare as equal, including `v` prefix and
+  suffix cases.
+- Versions with trailing zero parts such as `2.10` versus `2.10.0.0` still
+  compare as equal.
+- Differing numeric segments still short-circuit before later segments.
+
+## Verification Plan
+
+Run the registered focused startup-signals tests, changed-scope coverage, and
+the registered `startup-signals-version-compare-single-pass` probe locally on
+Linux before pushing. GitHub Actions PR-scoped performance remains the final
+merge gate.

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -210,6 +210,7 @@ def test_compare_versions_ignores_build_metadata_suffix() -> None:
     assert normalized_version_parts("v1.2.3+abcdef1") == [1, 2, 3]
     assert compare_versions("1.2.3+build.4", "1.2.3") == 0
     assert compare_versions("1.2.3", "1.2.3+abcdef1") == 0
+    assert compare_versions("v1.2.3+build.4", "1.2.3+abcdef1") == 0
     assert compare_versions("1.2.4", "1.2.3+abcdef1") == 1
     assert compare_versions("1.2.2", "1.2.3") == -1
 

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -301,6 +301,8 @@ def _compare_normalized_version_parts(
             return -1
         if left_value > right_value:
             return 1
+        if left_index >= left_length and right_index >= right_length:
+            return 0
 
 
 def _next_normalized_version_part(value: str, index: int) -> tuple[int, int, bool]:


### PR DESCRIPTION
## Summary
- Return immediately from the startup version comparator when both normalized streams end after an equal numeric part.
- Add a regression case for equivalent `v`-prefixed/build-metadata versions.
- Document the Python-only performance slice and its registered probe coverage.

## Plan or Spec
- `docs/plans/2026-06-25-startup-version-terminal-equal-return.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version ... services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics
# 21 passed in 19.64s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version ... services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_version_probe.py
# 21 passed in 74.02s; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id startup-signals-version-compare-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-startup-version-terminal-equal-return-20260625 --head-repo "$PWD" --output /tmp/startup_version_terminal_equal_probe.json
# head verification ok; base/head probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Registered probe: `startup-signals-version-compare-single-pass`.
- Local Linux probe metrics:
  - `elapsed_ms_mean`: base `13.102158` ms -> head `12.071830` ms (`-1.030328` ms, `7.86%` improvement, `1.0853x` speedup).
  - `comparison_total`: base/head `-32.0` (behavior parity signal unchanged).
  - `peak_bytes_mean`: base/head `112.0` bytes.
  - `update_result_elapsed_ms_mean`: base `80.871830` ms -> head `75.613631` ms.
- CI PR-scoped performance is still required as the merge gate for the registered probe report.

## Known Gaps
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally; this slice was limited to the registered Python startup-signals probe on Linux.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A, no runtime observability change; probe overhead tracked by existing registered probe.
- [x] Deferred work and known gaps are stated explicitly.
