### PR TITLE
perf: gate runtime export diagnosis regexes

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -77,6 +77,9 @@ It measures:
 - `unknown_failure_count`
 - `redaction_count`
 - `diagnostic_latency_ms`
+- `path_redaction_elapsed_ms_mean`
+- `diagnosis_matching_elapsed_ms_mean`
+- `diagnosis_matching_line_count`
 
 The 2026-06-25 optimization slice keeps the parser contract unchanged and caches
 `layout.target_root.resolve(strict=False)` once per redacted excerpt build. It
@@ -106,6 +109,13 @@ root before constructing a fallback `Path`. Clean target-local paths now produce
 the same `<target>/...` labels through string slicing, while paths with `..`
 segments or paths outside the target root continue through the existing
 normalization fallback.
+
+A follow-up 2026-06-25 diagnosis matching slice keeps the diagnosis semantics
+unchanged while adding cheap lowercase marker gates to each diagnosis pattern.
+Runtime lines whose text cannot contain a given failure class now skip that
+class's regex expressions, while lines that contain a marker continue through the
+same compiled regexes and matched-pattern ids as before. This reduces repeated
+regex scans across bounded excerpts with many non-matching lines.
 
 Focused verification:
 

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -6471,6 +6471,17 @@
         "direction": "informational"
       },
       {
+        "key": "diagnosis_matching_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "diagnosis_matching_line_count",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
         "key": "target_count",
         "unit": "count",
         "direction": "informational"

--- a/scripts/runtime_export_diagnostic_parser_probe.py
+++ b/scripts/runtime_export_diagnostic_parser_probe.py
@@ -20,6 +20,7 @@ for candidate in (ROOT, WORKER_ROOT):
 from worker.productization.export_target_diagnostics import (
     _SourceLine,
     _build_redacted_excerpt,
+    _diagnoses_from_excerpt,
     build_diagnostic_metrics_report,
 )
 
@@ -76,11 +77,53 @@ def _path_redaction_elapsed_ms(
     return statistics.fmean(elapsed_samples)
 
 
+def _diagnosis_matching_elapsed_ms(*, samples: int, iterations: int, line_count: int) -> float:
+    source_lines = [
+        _SourceLine(
+            source_path="logs/ollama-create.log",
+            text=f"progress line {index} loaded shard metadata without failure",
+        )
+        for index in range(line_count)
+    ]
+    source_lines.extend(
+        [
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text="missing blob sha256-777777 not found",
+            ),
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text="runtime binary not installed: ollama",
+            ),
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text="Metal out of memory during load",
+            ),
+        ]
+    )
+    line_numbers = {index: index + 1 for index in range(len(source_lines))}
+    expected_codes = {"missing_blob", "missing_binary", "insufficient_memory"}
+    elapsed_samples: list[float] = []
+    for _sample in range(samples):
+        started = time.perf_counter()
+        for _index in range(iterations):
+            diagnoses = _diagnoses_from_excerpt(
+                source_lines,
+                line_numbers,
+                "diagnostics/redacted-log-excerpt.txt",
+            )
+            if {diagnosis["code"] for diagnosis in diagnoses} != expected_codes:
+                raise SystemExit("export diagnostic diagnosis matching probe failed")  # pragma: no cover
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+    return statistics.fmean(elapsed_samples)
+
+
 def main() -> int:
     manifests = sorted(FIXTURE_ROOT.glob("*/export-target-manifest.json"))
     iterations = _env_int("MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS", 30, 1)
     samples = _env_int("MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES", 5, 1)
     path_count = _env_int("MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PATH_COUNT", 200, 1)
+    matching_line_count = _env_int("MELIX_RUNTIME_EXPORT_DIAGNOSTIC_MATCHING_LINES", 500, 1)
     elapsed_samples: list[float] = []
     peak_samples: list[float] = []
     target_count = 0.0
@@ -130,6 +173,12 @@ def main() -> int:
                     path_count=path_count,
                 ),
                 "path_redaction_count": float(path_count),
+                "diagnosis_matching_elapsed_ms_mean": _diagnosis_matching_elapsed_ms(
+                    samples=samples,
+                    iterations=iterations,
+                    line_count=matching_line_count,
+                ),
+                "diagnosis_matching_line_count": float(matching_line_count + 3),
                 "diagnosis_code_count": diagnosis_code_count,
                 "iteration_count": float(iterations),
                 "sample_count": float(samples),

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -449,6 +449,24 @@ def test_export_target_diagnostics_pattern_markers_preserve_matching_regex() -> 
     expression.search.assert_called_once_with("missing blob sha256-777777")
 
 
+def test_export_target_diagnostics_pattern_markers_normalize_case() -> None:
+    expression = Mock()
+    expression.search.return_value = object()
+    pattern = _DiagnosisPattern(
+        code=CODE_MISSING_BLOB,
+        severity="error",
+        pattern_id="missing-blob-v1",
+        expressions=(expression,),
+        operator_message="message",
+        remediation="remediation",
+        markers=("BLOB",),
+    )
+
+    assert pattern.markers == ("blob",)
+    assert pattern.matches("missing blob sha256-777777") is True
+    expression.search.assert_called_once_with("missing blob sha256-777777")
+
+
 def test_export_target_diagnostics_skips_path_regex_for_slashless_text(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -24,6 +24,7 @@ from worker.productization.export_target_diagnostics import (
     build_export_diagnostics_receipt,
     write_export_diagnostics_receipt,
     _SourceLine,
+    _DiagnosisPattern,
     _build_redacted_excerpt,
     _diagnosis_metric_counts,
 )
@@ -413,6 +414,39 @@ def test_export_target_diagnostics_metric_counts_single_pass() -> None:
     assert parsed_count == 2
     assert unknown_count == 1
     assert matched_codes == {CODE_RUNTIME_LOAD_FAILED, CODE_MISSING_BINARY}
+
+
+def test_export_target_diagnostics_pattern_markers_skip_unrelated_regex() -> None:
+    expression = Mock()
+    pattern = _DiagnosisPattern(
+        code=CODE_MISSING_BLOB,
+        severity="error",
+        pattern_id="missing-blob-v1",
+        expressions=(expression,),
+        operator_message="message",
+        remediation="remediation",
+        markers=("blob",),
+    )
+
+    assert pattern.matches("runtime emitted a harmless progress line") is False
+    expression.search.assert_not_called()
+
+
+def test_export_target_diagnostics_pattern_markers_preserve_matching_regex() -> None:
+    expression = Mock()
+    expression.search.return_value = object()
+    pattern = _DiagnosisPattern(
+        code=CODE_MISSING_BLOB,
+        severity="error",
+        pattern_id="missing-blob-v1",
+        expressions=(expression,),
+        operator_message="message",
+        remediation="remediation",
+        markers=("blob",),
+    )
+
+    assert pattern.matches("missing blob sha256-777777") is True
+    expression.search.assert_called_once_with("missing blob sha256-777777")
 
 
 def test_export_target_diagnostics_skips_path_regex_for_slashless_text(

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -3270,6 +3270,8 @@ def test_runtime_export_diagnostic_parser_probe_script_emits_metrics(
     assert metrics["diagnostic_latency_ms"] >= 0
     assert metrics["path_redaction_elapsed_ms_mean"] >= 0
     assert metrics["path_redaction_count"] >= 1.0
+    assert metrics["diagnosis_matching_elapsed_ms_mean"] >= 0
+    assert metrics["diagnosis_matching_line_count"] >= 4.0
     assert metrics["elapsed_ms_mean"] >= 0
 
 
@@ -4062,6 +4064,8 @@ def test_registered_probe_registry_entries_validate_commands_and_watch_globs() -
     assert runtime_export_diagnostics_metrics["unknown_failure_count"]["direction"] == "informational"
     assert runtime_export_diagnostics_metrics["redaction_count"]["direction"] == "informational"
     assert runtime_export_diagnostics_metrics["diagnostic_latency_ms"]["direction"] == "lower_is_better"
+    assert runtime_export_diagnostics_metrics["diagnosis_matching_elapsed_ms_mean"]["direction"] == "lower_is_better"
+    assert runtime_export_diagnostics_metrics["diagnosis_matching_line_count"]["direction"] == "informational"
 
     probe_policy_metrics = {
         metric["key"]: metric for metric in by_id["probe-policy-noop-overhead"]["metrics"]

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -84,6 +84,9 @@ class _DiagnosisPattern:
     remediation: str
     markers: tuple[str, ...] = ()
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "markers", tuple(marker.lower() for marker in self.markers))
+
     def matches(self, text: str) -> bool:
         if self.markers:
             lowered = text.lower()
@@ -149,7 +152,7 @@ _DIAGNOSIS_PATTERNS = (
         ),
         operator_message="The target runtime cannot load this artifact on the current host architecture.",
         remediation="Use an Apple Silicon compatible runtime binary or export for a compatible target architecture.",
-        markers=("architecture", "cpu type", "arm64"),
+        markers=("arch", "cpu type", "arm64"),
     ),
     _DiagnosisPattern(
         code=CODE_DUPLICATE_TENSOR_NAME,
@@ -162,7 +165,7 @@ _DIAGNOSIS_PATTERNS = (
         ),
         operator_message="The runtime reported duplicate tensor names while loading the export.",
         remediation="Regenerate the export from a clean adapter snapshot and inspect the conversion step that writes tensor names.",
-        markers=("duplicate", "duplicated", "tensor", "already exists"),
+        markers=("duplicate", "tensor", "already exists"),
     ),
     _DiagnosisPattern(
         code=CODE_MISSING_BLOB,
@@ -233,7 +236,7 @@ _DIAGNOSIS_PATTERNS = (
         ),
         operator_message="The runtime cannot read or execute a required export path because of local permissions.",
         remediation="Fix file permissions for the target directory and retry the smoke check from the same worktree.",
-        markers=("permission", "permitted", "eacces"),
+        markers=("permi", "eacces"),
     ),
     _DiagnosisPattern(
         code=CODE_INSUFFICIENT_MEMORY,

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -82,8 +82,13 @@ class _DiagnosisPattern:
     expressions: tuple[re.Pattern[str], ...]
     operator_message: str
     remediation: str
+    markers: tuple[str, ...] = ()
 
     def matches(self, text: str) -> bool:
+        if self.markers:
+            lowered = text.lower()
+            if not any(marker in lowered for marker in self.markers):
+                return False
         return any(expression.search(text) for expression in self.expressions)
 
 
@@ -144,6 +149,7 @@ _DIAGNOSIS_PATTERNS = (
         ),
         operator_message="The target runtime cannot load this artifact on the current host architecture.",
         remediation="Use an Apple Silicon compatible runtime binary or export for a compatible target architecture.",
+        markers=("architecture", "cpu type", "arm64"),
     ),
     _DiagnosisPattern(
         code=CODE_DUPLICATE_TENSOR_NAME,
@@ -156,6 +162,7 @@ _DIAGNOSIS_PATTERNS = (
         ),
         operator_message="The runtime reported duplicate tensor names while loading the export.",
         remediation="Regenerate the export from a clean adapter snapshot and inspect the conversion step that writes tensor names.",
+        markers=("duplicate", "duplicated", "tensor", "already exists"),
     ),
     _DiagnosisPattern(
         code=CODE_MISSING_BLOB,
@@ -170,6 +177,7 @@ _DIAGNOSIS_PATTERNS = (
         ),
         operator_message="The target artifact references a blob or required artifact that is not present.",
         remediation="Re-run target materialization and verify required artifact digests before runtime load.",
+        markers=("blob", "sha256", "artifact", "missing required"),
     ),
     _DiagnosisPattern(
         code=CODE_MISSING_BINARY,
@@ -184,6 +192,7 @@ _DIAGNOSIS_PATTERNS = (
         ),
         operator_message="The target runtime binary is missing or not available on PATH.",
         remediation="Install the required runtime binary or configure the export target to use an available local runtime.",
+        markers=("command", "binary", "executable", "installed", "ollama", "mlx_lm", "llama"),
     ),
     _DiagnosisPattern(
         code=CODE_INVALID_RUNTIME_PATH,
@@ -197,6 +206,7 @@ _DIAGNOSIS_PATTERNS = (
         ),
         operator_message="The runtime was invoked with a path that is invalid for this target.",
         remediation="Use target-relative manifest paths and regenerate the export report before retrying the runtime load.",
+        markers=("invalid", "path", "directory"),
     ),
     _DiagnosisPattern(
         code=CODE_RUNTIME_TIMEOUT,
@@ -210,6 +220,7 @@ _DIAGNOSIS_PATTERNS = (
         ),
         operator_message="The runtime did not finish the load or generation smoke check within the configured timeout.",
         remediation="Inspect runtime logs for slow startup, reduce the target artifact size, or increase the verified timeout policy.",
+        markers=("timed out", "timeout", "deadline"),
     ),
     _DiagnosisPattern(
         code=CODE_PERMISSION_DENIED,
@@ -222,6 +233,7 @@ _DIAGNOSIS_PATTERNS = (
         ),
         operator_message="The runtime cannot read or execute a required export path because of local permissions.",
         remediation="Fix file permissions for the target directory and retry the smoke check from the same worktree.",
+        markers=("permission", "permitted", "eacces"),
     ),
     _DiagnosisPattern(
         code=CODE_INSUFFICIENT_MEMORY,
@@ -236,6 +248,7 @@ _DIAGNOSIS_PATTERNS = (
         ),
         operator_message="The host did not have enough memory for the runtime load or generation check.",
         remediation="Free memory, choose a smaller or more quantized target, or retry on a host with more memory.",
+        markers=("memory", "oom"),
     ),
     _DiagnosisPattern(
         code=CODE_RUNTIME_LOAD_FAILED,
@@ -250,6 +263,7 @@ _DIAGNOSIS_PATTERNS = (
         ),
         operator_message="The target runtime failed while loading the exported artifact.",
         remediation="Inspect the redacted runtime evidence, then regenerate or repair the target artifact before retrying.",
+        markers=("load", "model", "runtime", "failed", "error"),
     ),
 )
 


### PR DESCRIPTION
## Summary
- Add cheap lowercase marker gates before runtime export diagnostic regex scans.
- Extend the registered `runtime-export-diagnostic-parser` probe with a diagnosis matching micro-metric for non-matching log-heavy excerpts.
- Add regression coverage for marker-gated matching and update the diagnostic parser plan.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`

## Commands Run
```text
# Baseline probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=20 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=5 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PATH_COUNT=200 uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
exit 0; elapsed_ms_mean=1910.3887864097487; diagnostic_latency_ms=11.673065047943965; path_redaction_elapsed_ms_mean=21.334340202156454

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
exit 0; 29 passed in 1.36s

# Changed-scope coverage via registered probe command
bash /tmp/runtime_export_diag_coverage.sh
exit 0; TOTAL 34 0 100%

# Registered probe after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=20 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=5 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PATH_COUNT=200 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_MATCHING_LINES=500 uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
exit 0; diagnosis_matching_elapsed_ms_mean=75.8620866050478; diagnostic_latency_ms=9.771774959517643; diagnostic_parser_coverage=1.0

# Baseline diagnosis matching micro-probe on origin/main
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
...
PY
exit 0; diagnosis_matching_elapsed_ms_mean=245.96848580404185; samples=5; iterations=20; line_count=503

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 34 0 100%`.
- Registered probe: `runtime-export-diagnostic-parser`.
- Diagnosis matching slice: old_mean=245.96848580404185ms, new_mean=75.8620866050478ms, delta_ms=-170.10639919899404, speedup=3.24x on 503-line synthetic excerpts with 20 iterations x 5 samples.
- Existing aggregate probe context: `diagnostic_parser_coverage=1.0`, `parsed_failure_count=27.0`, `unknown_failure_count=1.0`.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed.
- The overall `elapsed_ms_mean` remains dominated by fixture materialization and temp directory work; this slice is evaluated on the registered diagnosis matching metric plus unchanged parser coverage.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
