### PR TITLE
perf: lowercase diagnostic lines once

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -117,6 +117,12 @@ class's regex expressions, while lines that contain a marker continue through th
 same compiled regexes and matched-pattern ids as before. This reduces repeated
 regex scans across bounded excerpts with many non-matching lines.
 
+A follow-up 2026-06-26 diagnosis matching slice keeps the same parser semantics
+but computes each source line's lowercase form once per diagnosis scan and shares
+it across all marker-gated diagnosis patterns. This preserves the per-pattern
+marker checks and regex match ids while avoiding repeated `str.lower()` calls on
+large bounded excerpts with many non-matching progress lines.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -26,6 +26,7 @@ from worker.productization.export_target_diagnostics import (
     _SourceLine,
     _DiagnosisPattern,
     _build_redacted_excerpt,
+    _diagnoses_from_excerpt,
     _diagnosis_metric_counts,
 )
 from worker.productization.export_target_layout import (
@@ -215,6 +216,26 @@ def test_export_target_diagnostics_uses_lexical_target_path_fast_path(
     assert export_target_diagnostics_module._target_relative_text(
         f"{target_root}-sibling/artifact", str(target_root)
     ) is None
+
+
+def test_export_target_diagnostics_lowercases_source_line_once_per_match_scan() -> None:
+    class TrackingText(str):
+        lower_calls = 0
+
+        def lower(self) -> str:
+            type(self).lower_calls += 1
+            return super().lower()
+
+    text = TrackingText("progress line loaded shard metadata without failure")
+
+    diagnoses = _diagnoses_from_excerpt(
+        [_SourceLine(source_path="logs/ollama-create.log", text=text)],
+        {0: 1},
+        "diagnostics/redacted-log-excerpt.txt",
+    )
+
+    assert diagnoses == []
+    assert TrackingText.lower_calls == 1
 
 
 def test_export_target_diagnostics_skips_secret_regexes_for_plain_path_lines(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -87,9 +87,9 @@ class _DiagnosisPattern:
     def __post_init__(self) -> None:
         object.__setattr__(self, "markers", tuple(marker.lower() for marker in self.markers))
 
-    def matches(self, text: str) -> bool:
+    def matches(self, text: str, lowered_text: str | None = None) -> bool:
         if self.markers:
-            lowered = text.lower()
+            lowered = lowered_text if lowered_text is not None else text.lower()
             if not any(marker in lowered for marker in self.markers):
                 return False
         return any(expression.search(text) for expression in self.expressions)
@@ -695,10 +695,11 @@ def _diagnoses_from_excerpt(
     seen_codes: set[str] = set()
     for index, line_number in line_numbers.items():
         text = source_lines[index].text
+        lowered_text = text.lower()
         for pattern in _DIAGNOSIS_PATTERNS:
             if pattern.code in seen_codes:
                 continue
-            if not pattern.matches(text):
+            if not pattern.matches(text, lowered_text):
                 continue
             seen_codes.add(pattern.code)
             diagnoses.append(


### PR DESCRIPTION
## Summary
- Lowercase each runtime export diagnostic source line once per match scan and reuse it across marker-gated diagnosis patterns.
- Add a regression test proving the diagnosis scan no longer calls `lower()` once per pattern on non-matching progress lines.
- Update the runtime export diagnostic parser plan with the 2026-06-26 performance slice.

## Plan or Spec
- Updated `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`.
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json` already covers `export_target_diagnostics.py`, focused tests, coverage, and `scripts/runtime_export_diagnostic_parser_probe.py`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py`
- Baseline probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py` (3 repeated runs after the initial baseline)
- Candidate probe on this branch: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py` (3 repeated runs after the initial candidate run)
- `git diff --check`

## Coverage and Metrics
- Focused tests: `31 passed in 1.49s`.
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Baseline `origin/main` registered probe repeats:
  - `elapsed_ms_mean`: 2843.870 / 2855.285 / 2872.525 ms
  - `diagnosis_matching_elapsed_ms_mean`: 119.385 / 113.123 / 111.975 ms
- Candidate registered probe repeats:
  - `elapsed_ms_mean`: 2820.377 / 2845.252 / 2840.384 ms
  - `diagnosis_matching_elapsed_ms_mean`: 102.916 / 101.646 / 105.678 ms
- Mean delta over the three repeated runs: overall `elapsed_ms_mean` 2857.227 -> 2835.338 ms (`-21.889 ms`, ~0.77% faster); diagnosis matching 114.828 -> 103.413 ms (`-11.415 ms`, ~9.94% faster).

## Known Gaps
- Local validation is Linux/Python only; no Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance validation is still required before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally with baseline/candidate evidence.
- [ ] PR-scoped performance workflow completed on GitHub Actions.
- [ ] All PR checks are green.
