### PR TITLE
perf: fast-path code eval json value starts

### DIFF
--- a/docs/plans/2026-06-26-code-eval-json-value-start-fastpath.md
+++ b/docs/plans/2026-06-26-code-eval-json-value-start-fastpath.md
@@ -1,0 +1,36 @@
+# Code evaluation JSON field value-start fast path
+
+## Scope
+
+This Python-only performance slice is limited to the code-evaluation payload
+loader in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+The affected path is already covered by the registered PR-scoped performance
+probe `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for the loader, tests, and probe script.
+
+## Optimization
+
+The code-evaluation subprocess writes JSON payloads where known fields usually
+place the colon immediately after the key token. `_json_field_value_start_for_token(...)`
+now takes that adjacent-colon path first, then skips any post-colon whitespace,
+before falling back to the fully general whitespace-before-colon path.
+
+This preserves fallback behavior for spaced JSON such as `"key" : value`,
+malformed payloads, unknown keys, escaped strings, and full `json.loads` parsing
+when the fast path cannot safely extract all required fields.
+
+## Verification plan
+
+1. Run the registered focused tests for `code-eval-payload-json-bytes` locally on
+   Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run `scripts/code_eval_payload_json_probe.py` before and after the change and
+   compare `elapsed_ms_mean` / `peak_bytes_mean`.
+4. Use the PR-scoped performance GitHub Actions report as the merge gate.
+
+## Validation boundary
+
+This slice is Python-only and locally verifiable on Linux. It does not change
+Swift runtime behavior or generated protobuf artifacts.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -1106,6 +1106,7 @@ def test_payload_fast_path_field_extractors_cover_malformed_edges() -> None:
     assert code_eval_runner._json_object_payload_bounds(b' \n {"runtime_status":"ok"}\t ') == (3, 25)
     assert code_eval_runner._json_object_payload_bounds(b"   ") is None
     assert code_eval_runner._json_object_payload_bounds(b' {"runtime_status":"ok"] ') is None
+    assert code_eval_runner._json_field_value_start(b'{"runtime_status":"ok"}', "runtime_status") == 18
     assert code_eval_runner._json_field_value_start(b'{"runtime_status" : "ok"}', "runtime_status") == 20
     assert code_eval_runner._json_field_value_start(b'{"runtime_status" "ok"}', "runtime_status") is None
     assert code_eval_runner._json_field_value_start(b'{"runtime_status": ', "runtime_status") is None

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -501,9 +501,15 @@ def _json_field_value_start_for_token(
     cursor = key_index + len(key_token)
     payload_length = len(payload_bytes)
     whitespace = _JSON_PAYLOAD_WHITESPACE
+    colon = _ORD_COLON
+    if cursor < payload_length and payload_bytes[cursor] == colon:
+        cursor += 1
+        while cursor < payload_length and payload_bytes[cursor] in whitespace:
+            cursor += 1
+        return cursor if cursor < payload_length else None
+
     while cursor < payload_length and payload_bytes[cursor] in whitespace:
         cursor += 1
-    colon = _ORD_COLON
     if cursor >= payload_length or payload_bytes[cursor] != colon:
         return None
     cursor += 1


### PR DESCRIPTION
## Summary
- Fast-path code-evaluation JSON field lookup when the colon is adjacent to the known key token.
- Preserve the existing whitespace-before-colon fallback and full `json.loads` fallback behavior.
- Add a governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-26-code-eval-json-value-start-fastpath.md`
- Registered PR-scoped probe: `code-eval-payload-json-bytes`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_missing_required_field_falls_back_to_json_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_escaped_fields services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_missing_required_field_falls_back_to_json_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_escaped_fields services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 10 passed.
- Changed-scope coverage: 100.00% (7/7 measurable changed lines covered).
- Local Linux probe baseline (`origin/main`): `elapsed_ms_mean=90.50477871122504`, `peak_bytes_mean=60425.0`, `payload_bytes=55474.0`, `sample_count=7.0`, `iteration_count=1200.0`.
- Local Linux probe after change: `elapsed_ms_mean=88.67233056974199`, `peak_bytes_mean=60425.0`, `payload_bytes=55474.0`, `sample_count=7.0`, `iteration_count=1200.0`.
- Local delta: `-1.83244814148305 ms` mean elapsed, about `1.0207x` faster / `2.02%` lower elapsed. Peak bytes unchanged.
- CI PR-scoped performance must validate the registered probe report before merge.

## Known Gaps
- Python-only slice; no Swift runtime effect is claimed or locally validated.
- Local probe was run on Linux; GitHub Actions PR-scoped performance is still the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registry entry includes focused test, coverage, and probe commands.
- [x] Focused regression tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe ran locally on Linux with a positive elapsed-time delta.
- [ ] GitHub Actions PR-scoped performance completed successfully.
