### PR TITLE
perf: reuse dry-run export retention reports

### DIFF
--- a/docs/plans/2026-06-24-export-artifact-layout-retention.md
+++ b/docs/plans/2026-06-24-export-artifact-layout-retention.md
@@ -75,7 +75,11 @@ The PR-scoped probe records layout materialization latency, target count,
 retained byte size, cleanable byte size, deleted file count, and retention
 decision count. Runtime-log TTL decisions reuse the file metadata collected
 while checking manifest-row existence, avoiding an extra stat call on the
-retention hot path while preserving the missing-file race fallback.
+retention hot path while preserving the missing-file race fallback. A follow-up
+2026-06-26 metrics slice reuses the retention report already written during
+materialization for `cleanup="dry-run"` metrics reports, avoiding a second
+manifest validation and retention-decision pass when no cleanup side effects are
+requested.
 
 ## Verification
 

--- a/services/mlx-worker-python/tests/test_export_target_layout_retention.py
+++ b/services/mlx-worker-python/tests/test_export_target_layout_retention.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 
 import pytest
 
+from worker.productization import export_target_layout as export_target_layout_module
 from worker.productization.export_target_layout import (
     EXPORT_RETENTION_REPORT_SCHEMA_VERSION,
     build_export_target_layout,
@@ -410,6 +411,29 @@ def test_layout_metrics_report_aggregates_target_retention_counts(tmp_path: Path
     assert payload["cleanable_byte_size"] == 0
     assert payload["deleted_file_count"] == 0
     assert payload["layout_materialization_latency_ms"] >= 0
+
+
+def test_layout_metrics_report_reuses_materialized_dry_run_retention_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_paths = sorted(FIXTURE_ROOT.glob("*/export-target-manifest.json"))
+
+    def fail_cleanup(*_args: object, **_kwargs: object) -> dict[str, object]:  # pragma: no cover
+        raise AssertionError("dry-run metrics should reuse materialized retention reports")
+
+    monkeypatch.setattr(export_target_layout_module, "cleanup_export_target", fail_cleanup)
+
+    payload = build_layout_metrics_report(
+        manifest_paths,
+        tmp_path,
+        cleanup="dry-run",
+        create_placeholder_files=True,
+    )
+
+    assert payload["ok"] is True
+    assert payload["retention_decision_count"] == 15
+    assert payload["retained_byte_size"] == 12141056
 
 
 def test_export_target_layout_retention_cli_writes_metrics(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/productization/export_target_layout.py
+++ b/services/mlx-worker-python/worker/productization/export_target_layout.py
@@ -294,17 +294,17 @@ def build_layout_metrics_report(
         if export_report.get("ok") is not True:
             errors.extend(str(error) for error in export_report.get("errors", []))
             continue
-        if cleanup != "none":
+        if cleanup == "apply":
             retention_reports.append(
                 cleanup_export_target(
                     root / str(export_report["target_root"]) / EXPORT_TARGET_MANIFEST_FILENAME,
                     root,
-                    apply_cleanup=cleanup == "apply",
+                    apply_cleanup=True,
                     now=now,
                 )
             )
         else:
-            retention_report_path = Path(export_report["retention_report_path"])
+            retention_report_path = root / str(export_report["retention_report_path"])
             if retention_report_path.is_file():
                 retention_reports.append(json.loads(retention_report_path.read_text(encoding="utf-8")))
 


### PR DESCRIPTION
## Summary
- Reuse the retention report already emitted during runtime export layout materialization for `cleanup="dry-run"` metrics reports.
- Keep `cleanup="apply"` on the existing cleanup path so delete side effects still recompute and write an applied retention report.
- Add a regression test proving dry-run metrics do not invoke the second cleanup pass.

## Plan or Spec
- Updated `docs/plans/2026-06-24-export-artifact-layout-retention.md` with the 2026-06-26 dry-run metrics reuse slice.
- Registered PR-scoped probe: `runtime-export-layout-retention` already covers `services/mlx-worker-python/worker/productization/export_target_layout.py` with focused test, coverage, and probe commands.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_layout_retention_probe.py` (baseline)
- `git diff --check`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_layout_retention_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_layout_retention_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_layout_retention_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_layout_retention_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_layout.py services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_layout_retention_report.py scripts/runtime_export_layout_retention_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_layout_retention_probe.py` (candidate)

## Coverage and Metrics
- Focused tests: 23 passed.
- Changed-scope coverage: 100% (10/10 measurable changed lines).
- Registered local probe baseline: `elapsed_ms_mean=3769.0242697950453`, `peak_bytes_mean=201917.0`.
- Registered local probe candidate: `elapsed_ms_mean=2814.9356586043723`, `peak_bytes_mean=190838.0`.
- Delta: `elapsed_ms_mean -954.088611190673 ms` (~25.31% faster), `peak_bytes_mean -11079 bytes` (~5.49% lower).

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime behavior is changed.
- CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the changed path.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is >=95%.
- [x] Local registered probe shows improvement.
- [ ] GitHub Actions and registered PR-scoped performance report are green.
