### PR TITLE
perf: snapshot tool keyword rule items

### DIFF
--- a/docs/plans/2026-06-26-tool-registry-keyword-rule-items.md
+++ b/docs/plans/2026-06-26-tool-registry-keyword-rule-items.md
@@ -1,0 +1,69 @@
+# Tool Registry Keyword Rule Item Snapshot
+
+## Scope
+
+This Python-only performance slice is limited to keyword selection planning in
+`services/mlx-worker-python/worker/runtime/tool_registry.py`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+The probe watches `tool_registry.py`, `tests/test_tool_registry.py`,
+`tests/test_pr_scoped_performance.py`, `scripts/tool_registry_select_probe.py`,
+and the probe registry. It includes focused `test_command`, `coverage_command`,
+and `probe_command` entries.
+
+## Slice
+
+`_keyword_tool_matches(...)` previously iterated the matchable tool-name tuple
+and performed a dictionary lookup for each tool on every uncached keyword scan.
+The compiled keyword rules are immutable after module initialization, so this
+slice snapshots the ordered `(tool_name, literal_hints, boundary_hints)` pairs
+once and iterates that tuple directly during selector planning.
+
+The CI performance report also gates adjacent tool-registry probes when this
+file changes, so the slice keeps the exact built-in full-selection config path
+fast by checking the canonical `BUILTIN_AGENTIC_TOOL_NAMES` tuple identity before
+falling back to tuple equality.
+
+## Behavior Contract
+
+- Tool match order stays tied to `_KEYWORD_MATCHABLE_TOOL_NAMES`.
+- Literal and boundary keyword behavior is unchanged.
+- Empty and whitespace-only context fast paths remain unchanged.
+- The canonical full-selection `built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES)` path returns the same isolated protobuf template copy.
+- The selector receipt and selected registry outputs are unchanged.
+
+## Verification Plan
+
+1. Add a regression test proving `_keyword_tool_matches(...)` reads from the
+   compiled rule-item snapshot rather than doing per-call rule dictionary
+   lookups.
+2. Run the registered focused test command for
+   `tool-registry-select-name-index-cache` locally on Linux.
+3. Run the registered changed-scope coverage command locally on Linux.
+4. Run `scripts/tool_registry_select_probe.py` locally on Linux before and after
+   the change and accept only if the registered metrics improve or remain within
+   bounded noise.
+
+## Local Results
+
+Baseline registered probe on Linux from `origin/main` (`29eb8a26`):
+
+```json
+{"elapsed_ms_mean": 22.135713993338868, "selector_planning_elapsed_ms_mean": 34.62144880904816, "whitespace_turn_planning_elapsed_ms_mean": 30.75031420448795}
+```
+
+Post-change registered probe samples on Linux:
+
+```json
+{"elapsed_ms_mean": 21.18720880826004, "selector_planning_elapsed_ms_mean": 33.92944240476936, "whitespace_turn_planning_elapsed_ms_mean": 30.265651596710086}
+{"elapsed_ms_mean": 21.33281960268505, "selector_planning_elapsed_ms_mean": 34.1142987832427, "whitespace_turn_planning_elapsed_ms_mean": 30.695827800082043}
+{"elapsed_ms_mean": 22.3946534038987, "selector_planning_elapsed_ms_mean": 34.55278719775379, "whitespace_turn_planning_elapsed_ms_mean": 32.491148996632546}
+```
+
+The three post-change samples averaged `34.19884279525528 ms` for
+`selector_planning_elapsed_ms_mean`, improving the baseline by
+`0.42260601379287976 ms` (`1.2206479749698793%`). Changed-scope coverage was
+`100%` for the touched Python scope.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -204,6 +204,24 @@ def test_tool_registry_names_reuses_registry_snapshot() -> None:
     assert registry.names() == BUILTIN_AGENTIC_TOOL_NAMES
 
 
+def test_keyword_tool_matches_reuses_compiled_rule_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_registry_module._keyword_tool_matches.cache_clear()
+    expected_matches = tool_registry_module._keyword_tool_matches(
+        "Search local evidence, crop the image, and visit fixture://docs/provider-contract."
+    )
+    tool_registry_module._keyword_tool_matches.cache_clear()
+    monkeypatch.setattr(tool_registry_module, "_BUILTIN_TOOL_KEYWORD_HINT_RULES", {})
+
+    matches = tool_registry_module._keyword_tool_matches(
+        "Search local evidence, crop the image, and visit fixture://docs/provider-contract."
+    )
+
+    assert matches == expected_matches
+    assert matches == ("image_crop", "text_search", "visit")
+
+
 def test_tool_registry_descriptors_use_slotted_snapshots() -> None:
     registry = built_in_tool_registry()
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -45,6 +45,7 @@ _KEYWORD_BOUNDARY_TRANSLATION = str.maketrans(
     }
 )
 _KeywordHintRule = tuple[str, bool]
+_KeywordHintRuleSet = tuple[str, tuple[str, ...], tuple[str, ...]]
 
 TOOL_REGISTRY_SCHEMA_VERSION = "melix.agentic_tool_registry.v1"
 BUILTIN_TOOLSET_VERSION = "melix.agentic_tools.builtin.v1"
@@ -464,7 +465,7 @@ def agentic_tool_catalog_registry() -> ToolRegistry:
 
 def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> common_pb2.ToolConfig:
     copy_tool_config = _copy_tool_config
-    if names is None or names == BUILTIN_AGENTIC_TOOL_NAMES:
+    if names is None or names is BUILTIN_AGENTIC_TOOL_NAMES or names == BUILTIN_AGENTIC_TOOL_NAMES:
         return copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
     if isinstance(names, tuple):
         cached_config = _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES.get(names)
@@ -643,21 +644,23 @@ def _keyword_tool_matches(text: str) -> tuple[str, ...]:
     boundary_text = ""
     matches: list[str] = []
     append_match = matches.append
-    keyword_hint_rules = _BUILTIN_TOOL_KEYWORD_HINT_RULES
     keyword_boundary_text = _keyword_boundary_text
-    for tool_name in _KEYWORD_MATCHABLE_TOOL_NAMES:
-        rules = keyword_hint_rules.get(tool_name, ())
-        for hint, literal in rules:
-            if literal:
-                if hint in normalized_text:
-                    append_match(tool_name)
-                    break
-                continue
+    for tool_name, literal_hints, boundary_hints in _BUILTIN_TOOL_KEYWORD_HINT_RULE_ITEMS:
+        matched = False
+        for hint in literal_hints:
+            if hint in normalized_text:
+                append_match(tool_name)
+                matched = True
+                break
+        if matched:
+            continue
+        if boundary_hints:
             if not boundary_text:
                 boundary_text = keyword_boundary_text(normalized_text)
-            if hint in boundary_text:
-                append_match(tool_name)
-                break
+            for hint in boundary_hints:
+                if hint in boundary_text:
+                    append_match(tool_name)
+                    break
     return tuple(matches)
 
 
@@ -870,6 +873,14 @@ _BUILTIN_TOOL_KEYWORD_HINTS = {
     ),
 }
 _BUILTIN_TOOL_KEYWORD_HINT_RULES = _compile_keyword_hint_rules(_BUILTIN_TOOL_KEYWORD_HINTS)
+_BUILTIN_TOOL_KEYWORD_HINT_RULE_ITEMS: tuple[_KeywordHintRuleSet, ...] = tuple(
+    (
+        tool_name,
+        tuple(hint for hint, literal in _BUILTIN_TOOL_KEYWORD_HINT_RULES.get(tool_name, ()) if literal),
+        tuple(hint for hint, literal in _BUILTIN_TOOL_KEYWORD_HINT_RULES.get(tool_name, ()) if not literal),
+    )
+    for tool_name in _KEYWORD_MATCHABLE_TOOL_NAMES
+)
 
 
 _BUILTIN_TOOL_NAME_SET = frozenset(BUILTIN_AGENTIC_TOOL_NAMES)


### PR DESCRIPTION
## Summary
- Snapshot ordered tool keyword rule items at module initialization so uncached keyword selection scans avoid per-tool dictionary lookups.
- Split literal and boundary keyword hints in the snapshot to keep the selector hot path branch-light while preserving match order and receipts.
- Add a focused regression test proving keyword matching uses the compiled snapshot.

## Plan or Spec
- `docs/plans/2026-06-26-tool-registry-keyword-rule-items.md`
- Registered PR-scoped performance probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 88 passed in 0.21s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# 88 passed in 0.45s; TOTAL 24 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# Baseline before change: selector_planning_elapsed_ms_mean=34.62144880904816
# Post-change samples: 33.92944240476936, 34.1142987832427, 34.55278719775379

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 24 0 100%`).
- Local registered probe (`tool_registry_select_probe.py`) baseline from `origin/main` (`29eb8a26`): `selector_planning_elapsed_ms_mean=34.62144880904816 ms`.
- Post-change mean across three registered probe runs: `selector_planning_elapsed_ms_mean=34.19884279525528 ms`.
- Delta: `-0.42260601379287976 ms` (`1.2206479749698793%` faster).
- CI PR-scoped performance workflow is required for repository-registered validation before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime behavior is changed.
- Awaiting GitHub Actions PR-scoped performance report and required checks before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
