### PR TITLE
perf: extend embedding single-cycle copies

### DIFF
--- a/docs/plans/2026-06-26-deterministic-embedding-single-cycle-extend.md
+++ b/docs/plans/2026-06-26-deterministic-embedding-single-cycle-extend.md
@@ -1,0 +1,26 @@
+# Deterministic Embedding Single-Cycle Extend Performance Slice
+
+## Scope
+
+This Python-only slice is limited to `DeterministicEmbeddingRuntime.embed_inputs()` for large requests where every input repeats the same text (`cycle_length == 1`).
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped probe `deterministic-embedding-duplicate-input-cache` in `infra/perf/pr_scoped_probes.json`. The probe entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for the deterministic embedding runtime, its tests, and `scripts/deterministic_embedding_duplicate_probe.py`.
+
+## Optimization
+
+The single-input cycle replay now seeds the result list with the first embedded vector and uses one `list.extend(...)` call for the remaining defensive copies. This preserves the existing behavior that repeated outputs do not share mutable vector lists, while avoiding a Python-level append method call for every replayed input.
+
+## Verification Plan
+
+Run locally on Linux:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_duplicate_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_duplicate_probe.py
+python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-duplicate-input-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/deterministic-embedding-duplicate-input-cache.json
+```
+
+GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.

--- a/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
@@ -74,9 +74,8 @@ class DeterministicEmbeddingRuntime:
         if cycle_length:
             if cycle_length == 1:
                 vector = embed_text(backend, inputs[0], dimensions)
-                append_vector(vector)
-                for _ in range(input_count - 1):
-                    append_vector(vector.copy())
+                vectors = [vector]
+                vectors.extend(vector.copy() for _ in range(input_count - 1))
                 return vectors
             for text in inputs[:cycle_length]:
                 vector = embed_text(backend, text, dimensions)


### PR DESCRIPTION
## Summary
- Optimizes the deterministic embedding single-input cycle replay path by seeding the output list once and extending the remaining defensive copies.
- Preserves mutable-vector isolation for repeated embedding outputs.

## Plan or Spec
- Added `docs/plans/2026-06-26-deterministic-embedding-single-cycle-extend.md`.
- Uses the existing registered PR-scoped probe `deterministic-embedding-duplicate-input-cache`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_duplicate_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_duplicate_probe.py` (3 samples)
- `python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-duplicate-input-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/deterministic-embedding-duplicate-input-cache.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 20 passed.
- Changed-scope coverage: 100.00% (2/2 measurable changed lines).
- Local registered probe comparison:
  - `elapsed_ms_mean`: 18.239004 ms -> 17.509029 ms (-0.729975 ms, ~4.0% faster)
  - `single_cycle_elapsed_ms_mean`: 24.194799 ms -> 16.645916 ms (-7.548883 ms, ~31.2% faster)
  - `peak_bytes_mean`: 3016990.4 -> 3017030.4 bytes (+40 bytes)
  - `single_cycle_peak_bytes_mean`: 2619813.6 -> 2620458.4 bytes (+644.8 bytes)
  - `embed_text_calls_mean` and `single_cycle_embed_text_calls_mean` unchanged.

## Known Gaps
- This is a Python-only slice locally verified on Linux.
- GitHub Actions PR-scoped performance is still required as the merge gate.

## Evidence Checklist
- [x] Registered PR-scoped probe exists and includes focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage reached at least 95% locally.
- [x] Registered probe ran locally with a clear improvement on the targeted single-cycle metric.
- [ ] GitHub Actions PR-scoped performance completed successfully.
