### PR TITLE
perf: cache report evidence metric prefixes

### DIFF
--- a/docs/plans/2026-06-26-report-evidence-metric-prefix-cache.md
+++ b/docs/plans/2026-06-26-report-evidence-metric-prefix-cache.md
@@ -1,0 +1,33 @@
+# Report evidence metric-prefix rule cache
+
+## Scope
+
+This performance slice keeps report evidence gate matching behavior unchanged while
+reducing repeated normalization overhead for tuple-backed `metric_prefixes` rules.
+It is limited to `worker.productization.report_evidence_gate._rule_matches_report`
+and its focused tests.
+
+## Registered probe
+
+The affected path is already covered by the PR-scoped registered probe
+`report-evidence-gate-run-kind-set-membership` in
+`infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`,
+`coverage_command`, and `probe_command` entries and measures metric-prefix rule
+matching alongside the existing run-kind, target-field, matrix, dict-list, and
+probe-phase paths.
+
+## Implementation plan
+
+- Reuse the existing rule-local cache pattern used for tuple `run_kinds`.
+- Cache the normalized tuple, first-character set, and empty-prefix flag for tuple
+  `metric_prefixes` on the rule dictionary by object identity.
+- Preserve the non-tuple iterable path through `_string_prefix_tuple`.
+- Extend focused regression coverage to prove repeated tuple-prefix matching no
+  longer re-enters the `lru_cache` helper after the rule-local cache is populated.
+
+## Validation plan
+
+- Focused report evidence gate tests.
+- Changed-scope coverage command from the registered probe.
+- Registered PR-scoped performance probe on Linux.
+- GitHub Actions PR-scoped performance workflow after push.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -335,7 +335,7 @@ def test_report_evidence_gate_matrix_roles_select_multiple_run_kind_rules() -> N
 
 def test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple() -> None:
     report_evidence_gate_module._string_prefix_tuple_from_tuple.cache_clear()
-    rule = {"metric_prefixes": ("adapter.", "runtime.")}
+    rule: dict[str, object] = {"metric_prefixes": ("adapter.", "runtime.")}
 
     assert report_evidence_gate_module._rule_matches_report(
         rule=rule,
@@ -353,8 +353,14 @@ def test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple()
     )
 
     cache_info = report_evidence_gate_module._string_prefix_tuple_from_tuple.cache_info()
-    assert cache_info.hits >= 1
+    assert cache_info.hits == 0
     assert cache_info.misses == 1
+    cached_state = rule["_melix_cached_metric_prefix_state"]
+    assert isinstance(cached_state, tuple)
+    assert cached_state[0] is rule["metric_prefixes"]
+    assert cached_state[1] == ("adapter.", "runtime.")
+    assert cached_state[2] == frozenset({"a", "r"})
+    assert cached_state[3] is False
 
 
 def test_report_evidence_gate_metric_prefix_fast_reject_preserves_empty_prefix() -> None:

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -385,11 +385,37 @@ def _rule_matches_report(
                 return True
     metric_prefixes = rule.get("metric_prefixes", ())
     if metric_prefixes:
-        (
-            metric_prefix_tuple,
-            metric_prefix_initials,
-            metric_prefix_matches_empty,
-        ) = _string_prefix_tuple(metric_prefixes)
+        if isinstance(metric_prefixes, tuple):
+            cached_metric_prefix_state = rule.get("_melix_cached_metric_prefix_state")
+            if (
+                isinstance(cached_metric_prefix_state, tuple)
+                and len(cached_metric_prefix_state) == 4
+                and cached_metric_prefix_state[0] is metric_prefixes
+                and isinstance(cached_metric_prefix_state[1], tuple)
+                and isinstance(cached_metric_prefix_state[2], frozenset)
+                and isinstance(cached_metric_prefix_state[3], bool)
+            ):
+                metric_prefix_tuple = cached_metric_prefix_state[1]
+                metric_prefix_initials = cached_metric_prefix_state[2]
+                metric_prefix_matches_empty = cached_metric_prefix_state[3]
+            else:
+                (
+                    metric_prefix_tuple,
+                    metric_prefix_initials,
+                    metric_prefix_matches_empty,
+                ) = _string_prefix_tuple_from_tuple(metric_prefixes)
+                rule["_melix_cached_metric_prefix_state"] = (
+                    metric_prefixes,
+                    metric_prefix_tuple,
+                    metric_prefix_initials,
+                    metric_prefix_matches_empty,
+                )
+        else:
+            (
+                metric_prefix_tuple,
+                metric_prefix_initials,
+                metric_prefix_matches_empty,
+            ) = _string_prefix_tuple(metric_prefixes)
         metric_key = "metric"
         to_string = str
         for metric in metrics:


### PR DESCRIPTION
## Summary
- Cache tuple-backed `metric_prefixes` normalization on report evidence gate rule dictionaries.
- Reuse the cached tuple, initial-character set, and empty-prefix flag by tuple identity on repeated `_rule_matches_report` calls.
- Keep mutable/non-tuple metric prefix iterables on the existing non-cached path.

## Plan or Spec
- Added `docs/plans/2026-06-26-report-evidence-metric-prefix-cache.md`.
- Registered probe coverage already exists in `infra/perf/pr_scoped_probes.json` as `report-evidence-gate-run-kind-set-membership` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (registered focused test command; 26 passed)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py`
- `MELIX_REPORT_EVIDENCE_GATE_ITERATIONS=100000 ... python3 scripts/report_evidence_gate_run_kind_probe.py` on `origin/main` and this branch for local before/after comparison.
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 17 0 100%`).
- Registered local probe on branch: `metric_prefix_elapsed_ms_mean=342.99723499570973`, `elapsed_ms_mean=985.9592436056118`, `iterations=50000`, `sample_count=5`.
- Local 100k-iteration comparison:
  - `origin/main`: `metric_prefix_elapsed_ms_mean=356.1498094059061`, `elapsed_ms_mean=998.1465200020466`
  - branch: `metric_prefix_elapsed_ms_mean=341.9648537936155`, `elapsed_ms_mean=967.9058899579104`
  - delta: `-14.18495561229065 ms` on metric-prefix sampling (`3.982862053457951%` faster, `1.0414807412367928x`).

## Known Gaps
- Linux local validation covers the Python report evidence gate path only.
- CI PR-scoped performance workflow is required before merge to validate the registered probe in GitHub Actions.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions and registered PR-scoped performance report completed successfully.
