### PR TITLE
perf: reuse runtime export retention metrics

### DIFF
--- a/docs/plans/2026-06-26-runtime-export-layout-retention-memory.md
+++ b/docs/plans/2026-06-26-runtime-export-layout-retention-memory.md
@@ -1,0 +1,29 @@
+# Runtime Export Layout Retention In-Memory Metrics Slice
+
+## Context
+
+`build_layout_metrics_report()` materializes each runtime export target layout and already builds the dry-run retention report for each manifest. The metrics aggregator then re-read the just-written retention JSON from disk to compute aggregate counts. That preserved behavior but added avoidable JSON decode and filesystem read work on the registered runtime export layout retention hot path.
+
+## Slice
+
+Keep the public `materialize_export_target_layout()` API unchanged, but route `build_layout_metrics_report()` through an internal helper that returns both the export report and the dry-run retention report produced during materialization. Dry-run and `cleanup="none"` metrics can then aggregate from the in-memory retention payload instead of calling `Path.read_text()` and `json.loads()` on the generated report.
+
+## Registered Probe Coverage
+
+The affected path is covered by the registered PR-scoped probe `runtime-export-layout-retention` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` values for:
+
+- `services/mlx-worker-python/worker/productization/export_target_layout.py`
+- `services/mlx-worker-python/tests/test_export_target_layout_retention.py`
+- `scripts/runtime_export_layout_retention_probe.py`
+
+## Verification Plan
+
+- Add a regression guard to `test_layout_metrics_report_reuses_materialized_dry_run_retention_report` that fails if dry-run metrics use `Path.read_text()` to reload retention reports.
+- Run the registered focused test command locally on Linux.
+- Run the registered changed-scope coverage command locally on Linux.
+- Run the registered probe command locally on Linux and compare against `origin/main`.
+- Use GitHub Actions PR-scoped performance validation as the merge gate.
+
+## Expected Outcome
+
+Runtime export layout retention metrics should preserve the same aggregate counts while reducing dry-run report aggregation overhead by avoiding redundant retention report read/decode work.

--- a/services/mlx-worker-python/tests/test_export_target_layout_retention.py
+++ b/services/mlx-worker-python/tests/test_export_target_layout_retention.py
@@ -422,7 +422,11 @@ def test_layout_metrics_report_reuses_materialized_dry_run_retention_report(
     def fail_cleanup(*_args: object, **_kwargs: object) -> dict[str, object]:  # pragma: no cover
         raise AssertionError("dry-run metrics should reuse materialized retention reports")
 
+    def fail_read_text(*_args: object, **_kwargs: object) -> str:  # pragma: no cover
+        raise AssertionError("dry-run metrics should keep retention reports in memory")
+
     monkeypatch.setattr(export_target_layout_module, "cleanup_export_target", fail_cleanup)
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
 
     payload = build_layout_metrics_report(
         manifest_paths,

--- a/services/mlx-worker-python/worker/productization/export_target_layout.py
+++ b/services/mlx-worker-python/worker/productization/export_target_layout.py
@@ -135,6 +135,22 @@ def materialize_export_target_layout(
     create_placeholder_files: bool = False,
     now: float | None = None,
 ) -> dict[str, object]:
+    export_report, _retention_report = _materialize_export_target_layout_reports(
+        manifest_path,
+        workspace_root,
+        create_placeholder_files=create_placeholder_files,
+        now=now,
+    )
+    return export_report
+
+
+def _materialize_export_target_layout_reports(
+    manifest_path: Path | str,
+    workspace_root: Path | str,
+    *,
+    create_placeholder_files: bool,
+    now: float | None,
+) -> tuple[dict[str, object], dict[str, object] | None]:
     manifest, validation_report = validate_export_target_manifest_file(
         manifest_path,
         return_manifest=True,
@@ -144,7 +160,7 @@ def materialize_export_target_layout(
             "schema_version": EXPORT_LAYOUT_REPORT_SCHEMA_VERSION,
             "ok": False,
             "errors": list(validation_report.errors),
-        }
+        }, None
 
     layout = build_export_target_layout(workspace_root, manifest)
     _create_layout_directories(layout)
@@ -168,7 +184,7 @@ def materialize_export_target_layout(
     )
     _write_json(layout.export_report_path, export_report)
     _write_json(layout.retention_report_path, retention_report)
-    return export_report
+    return export_report, retention_report
 
 
 def build_export_retention_report(
@@ -284,7 +300,7 @@ def build_layout_metrics_report(
     errors: list[str] = []
 
     for manifest_path in manifest_paths:
-        export_report = materialize_export_target_layout(
+        export_report, retention_report = _materialize_export_target_layout_reports(
             manifest_path,
             root,
             create_placeholder_files=create_placeholder_files,
@@ -303,6 +319,8 @@ def build_layout_metrics_report(
                     now=now,
                 )
             )
+        elif retention_report is not None:
+            retention_reports.append(retention_report)
         else:
             retention_report_path = root / str(export_report["retention_report_path"])
             if retention_report_path.is_file():


### PR DESCRIPTION
## Summary
- Reuse the dry-run runtime export retention report already built during layout materialization when aggregating layout metrics.
- Keep the public `materialize_export_target_layout()` return shape unchanged by adding an internal report-returning helper.
- Add a regression guard that fails if dry-run metrics reload the generated retention report with `Path.read_text()`.

## Plan or Spec
- `docs/plans/2026-06-26-runtime-export-layout-retention-memory.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py::test_layout_metrics_report_reuses_materialized_dry_run_retention_report
# 1 passed in 0.21s

<registered runtime-export-layout-retention test_command>
# 23 passed in 1.26s

<registered runtime-export-layout-retention coverage_command>
# 23 passed in 1.09s
# changed-scope coverage: TOTAL 8 0 100%

PYTHONPATH="$BASE:$BASE/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_layout_retention_probe.py
# origin/main: elapsed_ms_mean=2846.0847446054686, peak_bytes_mean=187249.4

PYTHONPATH="$HEAD:$HEAD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_layout_retention_probe.py
# head: elapsed_ms_mean=2812.877692398615, peak_bytes_mean=183628.0

<registered runtime-export-layout-retention probe_command>
# head: elapsed_ms_mean=2781.1330196040217, retained_byte_size=12141056.0, retention_decision_count=15.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 8 0 100%`).
- Local Linux registered probe comparison:
  - old_mean=2846.0847446054686 ms
  - new_mean=2812.877692398615 ms
  - delta=-33.207052206853405 ms
  - speedup=1.011805366545652x
  - retained_byte_size=12141056.0 and retention_decision_count=15.0 stayed unchanged.
- CI PR-scoped performance validation is still required before merge.

## Known Gaps
- Full Swift/macOS runtime effects are not applicable to this Python-only slice.
- GitHub Actions PR-scoped performance report must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
