### PR TITLE
perf: prioritize hub repo-id compatibility match

### DIFF
--- a/docs/plans/2026-06-26-hub-catalog-repo-id-compatibility-fastpath.md
+++ b/docs/plans/2026-06-26-hub-catalog-repo-id-compatibility-fastpath.md
@@ -1,0 +1,28 @@
+# Hub Catalog Repo-ID Compatibility Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.model_ops.hub_catalog._payload_is_mlx_compatible(...)`.
+
+The compatibility helper already treats repository IDs containing an MLX marker as compatible. The slice reorders that positive check before scanning tag payloads so repo-ID hits avoid walking tag lists or inspecting non-string tag values.
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped registered probe:
+
+- `hub-catalog-size-hint-regex-precompile`
+
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries and watches:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+
+## Verification Plan
+
+Run the registered focused test command, changed-scope coverage command, and local Linux registered probe before opening the PR. The PR-scoped performance workflow remains the merge gate for the registered probe report.
+
+## Expected Metrics
+
+The probe reports both size-hint parsing and MLX compatibility metrics. This slice targets `payload_compatibility_elapsed_ms_mean` without increasing compatibility calls or changing matched compatibility counts.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -367,6 +367,19 @@ def test_repo_id_mlx_substring_match_preserves_ascii_case_insensitivity() -> Non
     ) is True
 
 
+def test_payload_repo_id_mlx_match_skips_tag_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    tag_scan = Mock(side_effect=AssertionError("repo-id MLX matches should not scan tag payloads"))
+    monkeypatch.setattr(hub_catalog_module, "_tag_payload_contains_mlx", tag_scan)
+
+    assert (
+        _payload_is_mlx_compatible(
+            {"id": "owner/model-mlx-suffix", "tags": ["slow", object()], "cardData": {}}
+        )
+        is True
+    )
+    tag_scan.assert_not_called()
+
+
 def test_size_hint_single_readme_uses_direct_explicit_marker_before_regex(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -532,11 +532,11 @@ def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:
     library_name = raw_library_name if isinstance(raw_library_name, str) else ""
     if library_name and _is_mlx_atom(library_name):
         return True
-    if _tag_payload_contains_mlx(payload.get("tags")):
-        return True
     raw_repo_id = payload.get("id") or payload.get("modelId")
     repo_id = raw_repo_id if isinstance(raw_repo_id, str) else ""
-    if _repo_id_contains_mlx(repo_id):
+    if repo_id and _repo_id_contains_mlx(repo_id):
+        return True
+    if _tag_payload_contains_mlx(payload.get("tags")):
         return True
     card_data = payload.get("cardData")
     if not isinstance(card_data, dict):


### PR DESCRIPTION
## Summary
- Reorders Hub catalog MLX compatibility checks so repo IDs with an MLX marker return before scanning tag payloads.
- Adds a regression test proving repo-id matches do not invoke tag scanning.

## Plan or Spec
- `docs/plans/2026-06-26-hub-catalog-repo-id-compatibility-fastpath.md`

## Commands Run
```text
# Baseline probe on origin/main (detached worktree at 674fee26)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
exit 0; elapsed_ms_mean=1770.4706467979122; payload_compatibility_elapsed_ms_mean=201.800621394068; payload_compatibility_matched_count=160000.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
exit 0; 88 passed in 1.26s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
exit 0; 88 passed; TOTAL 8 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
exit 0; elapsed_ms_mean=1744.3834631936625; payload_compatibility_elapsed_ms_mean=195.24332599830814; payload_compatibility_matched_count=160000.0

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%`.
- Registered local probe: `hub-catalog-size-hint-regex-precompile`.
- Baseline -> head:
  - `elapsed_ms_mean`: 1770.4706467979122 -> 1744.3834631936625 ms (delta -26.08718360424973 ms, ~1.47% faster).
  - `payload_compatibility_elapsed_ms_mean`: 201.800621394068 -> 195.24332599830814 ms (delta -6.557295395759866 ms, ~3.25% faster).
  - `payload_compatibility_matched_count`: 160000.0 -> 160000.0.
- CI PR-scoped performance is required for the registered probe validation before merge.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime effect is claimed.
- The final merge is gated on GitHub Actions and the registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. (Observability mode: evidence via PR-scoped performance; no production observability changes.)
- [x] Deferred work and known gaps are stated explicitly.
