### PR TITLE
perf: avoid diagnostic source row tuple expansion

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -123,6 +123,12 @@ it across all marker-gated diagnosis patterns. This preserves the per-pattern
 marker checks and regex match ids while avoiding repeated `str.lower()` calls on
 large bounded excerpts with many non-matching progress lines.
 
+A follow-up 2026-06-26 source-row iteration slice keeps source collection
+semantics unchanged while iterating generated, required, and intermediate file
+repeated fields separately instead of expanding them into one temporary tuple.
+This avoids an intermediate container allocation when each diagnostic receipt
+scans manifest rows for runtime logs.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -26,6 +26,7 @@ from worker.productization.export_target_diagnostics import (
     _SourceLine,
     _DiagnosisPattern,
     _build_redacted_excerpt,
+    _collect_source_lines,
     _diagnoses_from_excerpt,
     _diagnosis_metric_counts,
 )
@@ -388,6 +389,34 @@ def test_export_target_diagnostics_reads_only_bounded_log_chunk(
 
     assert read_sizes == [128]
     assert receipt["status"] == "matched"
+
+
+def test_export_target_diagnostics_source_collection_skips_duplicates_and_missing_logs(
+    tmp_path: Path,
+) -> None:
+    target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+    log_path = "logs/ollama-create.log"
+    (target_root / log_path).write_text("runtime load failed\n", encoding="utf-8")
+    duplicate_row = manifest.required_files.add()
+    duplicate_row.path = log_path
+    duplicate_row.role = export_target_manifest_pb2.EXPORT_TARGET_FILE_ROLE_RUNTIME_LOG
+    missing_row = manifest.intermediate_files.add()
+    missing_row.path = "logs/missing-runtime.log"
+    missing_row.role = export_target_manifest_pb2.EXPORT_TARGET_FILE_ROLE_RUNTIME_LOG
+
+    lines = _collect_source_lines(
+        layout,
+        manifest,
+        failure_checks=(),
+        bounded_bytes=1024,
+    )
+
+    assert [line.source_path for line in lines].count(log_path) == 1
+    assert all(line.source_path != "logs/missing-runtime.log" for line in lines)
 
 
 def test_export_target_diagnostics_falls_back_when_path_resolution_raises_oserror(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -462,18 +462,19 @@ def _collect_source_lines(
     seen_paths: set[str] = set()
     source_read_bytes = max(bounded_bytes * _SOURCE_READ_MULTIPLIER, bounded_bytes)
 
-    for row in (*manifest.generated_files, *manifest.required_files, *manifest.intermediate_files):
-        if not _is_runtime_log_row(row):
-            continue
-        if row.path in seen_paths:
-            continue
-        seen_paths.add(row.path)
-        path = _target_relative_path(layout, row.path)
-        if not path.is_file():
-            continue
-        with path.open("rb") as source:
-            text = source.read(source_read_bytes).decode("utf-8", errors="replace")
-        lines.extend(_split_source_lines(row.path, text))
+    for rows in (manifest.generated_files, manifest.required_files, manifest.intermediate_files):
+        for row in rows:
+            if not _is_runtime_log_row(row):
+                continue
+            if row.path in seen_paths:
+                continue
+            seen_paths.add(row.path)
+            path = _target_relative_path(layout, row.path)
+            if not path.is_file():
+                continue
+            with path.open("rb") as source:
+                text = source.read(source_read_bytes).decode("utf-8", errors="replace")
+            lines.extend(_split_source_lines(row.path, text))
 
     for check in failure_checks:
         failure_message = _check_value(check, "failure_message")


### PR DESCRIPTION
## Summary
- Avoid temporary tuple expansion while scanning export target manifest generated/required/intermediate rows for runtime diagnostics sources.
- Add regression coverage for duplicate runtime log rows and missing runtime log candidates in source collection.
- Update the diagnostic parser performance plan with this source-row iteration slice.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_source_collection_skips_duplicates_and_missing_logs
# exit 0; 1 passed in 0.13s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 32 passed in 0.59s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# exit 0; 32 passed; changed-scope coverage TOTAL 27 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=30 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# exit 0; see metrics below

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json` (has focused `test_command`, `coverage_command`, and `probe_command`).
- Local Linux changed-scope coverage: `TOTAL 27 0 100%`.
- Local probe baseline before accepted slice: `elapsed_ms_mean=2893.095470004482`, `path_redaction_elapsed_ms_mean=24.219425406772643`, `diagnosis_matching_elapsed_ms_mean=111.17731179692782`, `peak_bytes_mean=194969.4`.
- Local probe after accepted slice: `elapsed_ms_mean=2817.4391815962736`, `path_redaction_elapsed_ms_mean=23.094503401080146`, `diagnosis_matching_elapsed_ms_mean=101.27831799327396`, `peak_bytes_mean=202131.2`.
- Delta: `elapsed_ms_mean=-75.65628840820842 ms` (~`1.027x` faster). Peak traced bytes increased by ~3.7%, below the registered 5% warning threshold.
- CI must run the registered PR-scoped performance workflow for final validation.

## Known Gaps
- None for the Python/Linux slice. No Swift runtime validation is involved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
