### PR TITLE
perf: reuse runtime weight direntry stat

### DIFF
--- a/docs/plans/2026-06-26-runtime-utils-direntry-stat-once.md
+++ b/docs/plans/2026-06-26-runtime-utils-direntry-stat-once.md
@@ -1,0 +1,57 @@
+# Runtime utils DirEntry stat once
+
+## Goal
+
+Reduce per-entry filesystem calls in the Python runtime weight-size estimator by using a single `DirEntry.stat()` result for top-level model weight candidates.
+
+## Scope
+
+This Python-only performance slice is limited to:
+
+- `services/mlx-worker-python/worker/runtime/runtime_utils.py`
+- `services/mlx-worker-python/tests/test_runtime_utils.py`
+
+The slice preserves the existing filename suffix filters, missing-file tolerance, non-regular-file filtering, and resident-byte totals.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `runtime-utils-top-level-weight-streaming` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for the runtime utility path, its focused tests, PR-scoped performance selection tests, and `scripts/runtime_utils_top_level_weights_probe.py`.
+
+## Optimization hypothesis
+
+`_weight_dir_entry_file_size()` previously called `DirEntry.is_file()` and then `DirEntry.stat()` for weight-like filenames. On filesystems where `is_file()` may need metadata, this can duplicate per-entry metadata work. Calling `DirEntry.stat()` once and checking `stat.S_ISREG(st_mode)` reuses the same metadata payload for both regular-file filtering and byte-size accounting.
+
+## Verification path
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards \
+  services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights \
+  services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_skips_missing_index_read \
+  services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries \
+  services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors \
+  services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory \
+  services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/runtime/runtime_utils.py \
+  services/mlx-worker-python/tests/test_runtime_utils.py \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
+  scripts/runtime_utils_top_level_weights_probe.py
+
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py
+```
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope automated coverage is at least 95%.
+- Local registered probe shows non-regression or improvement for `elapsed_ms_mean` and `peak_bytes_mean`.
+- Hosted `runtime-utils-top-level-weight-streaming` PR-scoped CI completes successfully before merge.

--- a/services/mlx-worker-python/tests/test_runtime_utils.py
+++ b/services/mlx-worker-python/tests/test_runtime_utils.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import os
 from pathlib import Path
+import stat
 from typing import Any
 
 import pytest
@@ -363,7 +364,9 @@ def test_top_level_weight_file_bytes_streams_iterdir_entries(
 
 def test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors() -> None:
     class FakeStat:
-        st_size = 13
+        def __init__(self, *, mode: int = stat.S_IFREG, size: int = 13) -> None:
+            self.st_mode = mode
+            self.st_size = size
 
     class FakeEntry:
         def __init__(
@@ -371,29 +374,22 @@ def test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors() -> 
             name: str,
             *,
             is_file: bool = True,
-            is_file_raises: bool = False,
             stat_raises: bool = False,
         ) -> None:
             self.name = name
             self._is_file = is_file
-            self._is_file_raises = is_file_raises
             self._stat_raises = stat_raises
-
-        def is_file(self) -> bool:
-            if self._is_file_raises:
-                raise OSError("entry unavailable")
-            return self._is_file
 
         def stat(self) -> FakeStat:
             if self._stat_raises:
                 raise OSError("stat unavailable")
-            return FakeStat()
+            mode = stat.S_IFREG if self._is_file else stat.S_IFDIR
+            return FakeStat(mode=mode)
 
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("README.md")) == 0
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("notes.txt")) == 0
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry(".bin")) == 0
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("nested.safetensors", is_file=False)) == 0
-    assert runtime_utils._weight_dir_entry_file_size(FakeEntry("broken.safetensors", is_file_raises=True)) == 0
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("missing.safetensors", stat_raises=True)) == 0
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("model.safetensors")) == 13
     assert runtime_utils._weight_dir_entry_file_size(FakeEntry("adapter.SAFEtensors")) == 13

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import os
 from pathlib import Path
+import stat
 from types import FunctionType
 from typing import Any
 
@@ -213,9 +214,10 @@ def _weight_dir_entry_file_size(entry: os.DirEntry[str]) -> int:
     if not _is_model_weight_filename(entry.name):
         return 0
     try:
-        if not entry.is_file():
+        stat_result = entry.stat()
+        if not stat.S_ISREG(stat_result.st_mode):
             return 0
-        return entry.stat().st_size
+        return stat_result.st_size
     except OSError:
         return 0
 


### PR DESCRIPTION
## Summary
- Reuse a single `DirEntry.stat()` payload when accounting top-level model weight files.
- Preserve suffix filtering, regular-file checks, OSError tolerance, and resident-byte totals.
- Add/update the governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-26-runtime-utils-direntry-stat-once.md`
- Registered PR-scoped probe: `runtime-utils-top-level-weight-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git status --short && git branch --show-current`
- `git fetch origin && git reset --hard origin/main`
- Baseline probe x3 on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_uses_indexed_unique_shards services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_falls_back_to_top_level_weights services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_skips_missing_index_read services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_streams_iterdir_entries services/mlx-worker-python/tests/test_runtime_utils.py::test_top_level_weight_file_bytes_handles_direntry_non_files_and_errors services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_ignores_malformed_index_and_unreadable_directory services/mlx-worker-python/tests/test_runtime_utils.py::test_estimate_model_weight_resident_bytes_handles_file_missing_and_stat_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_top_level_weights_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests>`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_top_level_weights_probe.py`
- Candidate probe x3: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_top_level_weights_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 10 passed.
- Changed-scope coverage: 100% (`TOTAL 10 0 100%`).
- Local Linux registered probe (`runtime-utils-top-level-weight-streaming`):
  - Baseline elapsed samples: 161.184577 ms, 168.015369 ms, 157.347522 ms; `old_mean=162.182489 ms`.
  - Candidate elapsed samples: 156.718489 ms, 155.840789 ms, 160.482716 ms; `new_mean=157.680665 ms`.
  - Delta: `-4.501824 ms`; speedup: `1.0286x` (`2.78%`).
  - Peak bytes unchanged at `2040.8`.
- CI PR-scoped registered probe validation is required before merge.

## Known Gaps
- Linux-only local verification; no Swift runtime behavior is touched.
- Local probe improvement is modest and below the registry `warn_pct`; GitHub Actions remains the merge gate.

## Evidence Checklist
- [x] Synced from `origin/main` before branch creation.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage measured at >=95%.
- [x] Registered local probe run with baseline and candidate samples.
- [ ] GitHub Actions PR-scoped performance probe completed successfully.
