### PR TITLE
perf: narrow export diagnostic load markers

### DIFF
--- a/docs/plans/2026-06-26-runtime-export-diagnostic-marker-fastpath.md
+++ b/docs/plans/2026-06-26-runtime-export-diagnostic-marker-fastpath.md
@@ -1,0 +1,26 @@
+# Runtime Export Diagnostic Marker Fast Path
+
+## Scope
+
+This slice keeps the runtime export diagnostic parser behavior unchanged while reducing regex work on noisy progress lines.
+
+Affected registered probe:
+
+- `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`
+
+## Change
+
+- Narrow the `runtime_load_failed` diagnosis marker prefilter from broad single tokens (`load`, `failed`, etc.) to phrases that still cover every registered runtime-load expression.
+- Reuse a precomputed known-diagnosis-code set for report coverage checks instead of rebuilding a temporary set during each metrics report.
+
+## Verification
+
+Linux-local verification for this Python slice must include:
+
+- focused diagnostic parser tests
+- changed-scope coverage through the registered probe coverage command
+- the registered `runtime-export-diagnostic-parser` probe command
+
+## Expected Effect
+
+No receipt schema or diagnostic matching behavior changes. The expected performance effect is lower `diagnosis_matching_elapsed_ms_mean` for progress-heavy excerpts where lines contain broad words such as `loaded` and `failure` but do not contain a runtime-load failure phrase.

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -236,7 +236,50 @@ def test_export_target_diagnostics_lowercases_source_line_once_per_match_scan() 
     )
 
     assert diagnoses == []
-    assert TrackingText.lower_calls == 1
+    assert text.lower_calls == 1
+
+
+def test_export_target_diagnostics_runtime_load_markers_skip_progress_regexes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_load_pattern = next(
+        pattern
+        for pattern in export_target_diagnostics_module._DIAGNOSIS_PATTERNS
+        if pattern.code == CODE_RUNTIME_LOAD_FAILED
+    )
+    expressions = tuple(Mock(wraps=expression) for expression in runtime_load_pattern.expressions)
+    patched_pattern = _DiagnosisPattern(
+        code=runtime_load_pattern.code,
+        severity=runtime_load_pattern.severity,
+        pattern_id=runtime_load_pattern.pattern_id,
+        expressions=expressions,
+        operator_message=runtime_load_pattern.operator_message,
+        remediation=runtime_load_pattern.remediation,
+        markers=runtime_load_pattern.markers,
+    )
+    monkeypatch.setattr(
+        export_target_diagnostics_module,
+        "_DIAGNOSIS_PATTERNS",
+        (patched_pattern,),
+    )
+
+    diagnoses = _diagnoses_from_excerpt(
+        [
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text="progress line loaded shard metadata without failure",
+            ),
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text="runtime load failed while opening model",
+            ),
+        ],
+        {0: 1, 1: 2},
+        "diagnostics/redacted-log-excerpt.txt",
+    )
+
+    assert [diagnosis["code"] for diagnosis in diagnoses] == [CODE_RUNTIME_LOAD_FAILED]
+    assert [expression.search.call_count for expression in expressions] == [1, 1, 1, 0, 0]
 
 
 def test_export_target_diagnostics_skips_secret_regexes_for_plain_path_lines(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -52,6 +52,7 @@ SUPPORTED_DIAGNOSIS_CODES = (
     CODE_UNKNOWN_FAILURE,
 )
 _KNOWN_DIAGNOSIS_CODES = tuple(code for code in SUPPORTED_DIAGNOSIS_CODES if code != CODE_UNKNOWN_FAILURE)
+_KNOWN_DIAGNOSIS_CODE_SET = frozenset(_KNOWN_DIAGNOSIS_CODES)
 
 _ABSOLUTE_PATH_PATTERN = re.compile(r"(?<![A-Za-z0-9_.-])/[^\s:'\"<>|]+")
 _BEARER_SECRET_PATTERN = re.compile(
@@ -266,7 +267,7 @@ _DIAGNOSIS_PATTERNS = (
         ),
         operator_message="The target runtime failed while loading the exported artifact.",
         remediation="Inspect the redacted runtime evidence, then regenerate or repair the target artifact before retrying.",
-        markers=("load", "model", "runtime", "failed", "error"),
+        markers=("failed to load", "model load", "runtime load", "error loading", "load failed"),
     ),
 )
 
@@ -345,7 +346,7 @@ def build_export_diagnostics_receipt(
     required_codes = {
         str(code)
         for code in manifest.diagnostic_policy.required_diagnosis_codes
-        if str(code) in _KNOWN_DIAGNOSIS_CODES
+        if str(code) in _KNOWN_DIAGNOSIS_CODE_SET
     }
     coverage = _diagnostic_coverage(required_codes, matched_codes, status)
     redaction_summary = excerpt.summary.payload(policy_id=manifest.evidence.redaction_policy_id or "export-diagnostics-redaction-v1")
@@ -434,7 +435,7 @@ def build_diagnostic_metrics_report(
                     code = str(diagnosis.get("code", ""))
                     if code and code != CODE_UNKNOWN_FAILURE:
                         matched_codes.add(code)
-    parser_coverage = len(matched_codes & set(_KNOWN_DIAGNOSIS_CODES)) / len(_KNOWN_DIAGNOSIS_CODES)
+    parser_coverage = len(matched_codes & _KNOWN_DIAGNOSIS_CODE_SET) / len(_KNOWN_DIAGNOSIS_CODE_SET)
     return {
         "schema_version": EXPORT_DIAGNOSTICS_METRICS_SCHEMA_VERSION,
         "ok": not errors and parser_coverage == 1.0,


### PR DESCRIPTION
## Summary
- Narrow the runtime export diagnostic `runtime_load_failed` marker prefilter to phrase markers that preserve existing diagnosis matches while skipping noisy progress lines.
- Reuse a precomputed known diagnosis code set for diagnostic coverage calculations.
- Add regression coverage for the marker fast path and document the slice plan.

## Plan or Spec
- `docs/plans/2026-06-26-runtime-export-diagnostic-marker-fastpath.md`

## Commands Run
```text
# Baseline on origin/main
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# exit 0; diagnosis_matching_elapsed_ms_mean=103.34721519611776; elapsed_ms_mean=2883.0344343965407

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_parser_matches_common_runtime_failures services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_lowercases_source_line_once_per_match_scan services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_runtime_load_markers_skip_progress_regexes
# exit 0; 11 passed in 0.29s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 33 passed in 0.62s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# exit 0; changed_line_coverage=100.00% (11/11)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# exit 0; diagnosis_matching_elapsed_ms_mean=78.84949459694326; elapsed_ms_mean=2879.441233992111

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` already covers `services/mlx-worker-python/worker/productization/export_target_diagnostics.py` with focused `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json`.
- Changed-scope coverage: 100.00% (11/11 measurable changed lines).
- Local registered probe delta (default samples/iterations): `diagnosis_matching_elapsed_ms_mean` 103.34721519611776 ms -> 78.84949459694326 ms (delta -24.4977205991745 ms, ~23.70% faster); `elapsed_ms_mean` 2883.0344343965407 ms -> 2879.441233992111 ms (delta -3.593200404429808 ms, ~0.12% faster).
- CI is required to validate the registered PR-scoped performance workflow on the PR branch.

## Known Gaps
- None. This is a Python-only parser hot path and was locally verified on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no new debug artifacts.
- [x] Deferred work and known gaps are stated explicitly.
