### PR TITLE
perf: skip schema-free JSON empty schema allocation

### DIFF
--- a/docs/plans/2026-06-26-evaluation-json-output-schema-none-fastpath.md
+++ b/docs/plans/2026-06-26-evaluation-json-output-schema-none-fastpath.md
@@ -1,0 +1,60 @@
+# Evaluation JSON Output Schema None Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to the schema-free JSON final-result
+scoring entry point in
+`services/mlx-worker-python/worker/productization/evaluation_final_result.py`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`evaluation-final-result-json-typed-score-aggregate` in
+`infra/perf/pr_scoped_probes.json`. The registry entry watches the final-result
+implementation, focused tests, `scripts/evaluation_json_typed_score_probe.py`,
+and the PR-scoped performance tests, and includes focused `test_command`,
+`coverage_command`, and `probe_command` entries.
+
+## Slice
+
+Most schema-free JSON scoring profiles leave `output_schema` as `None`. The hot
+entry point previously normalized this to a fresh empty dictionary with
+`profile.output_schema or {}` before taking the cached schema-free scoring path.
+This slice keeps the same falsy-schema behavior while reading the profile field
+directly, avoiding a tiny per-call empty-dict allocation before the LRU cached
+scoring helper is consulted.
+
+## Behavior Contract
+
+- `None` and empty-dict output schemas still use the schema-free scoring path.
+- Non-empty schemas still run schema validation before scoring.
+- JSON parsing, invalid JSON status, typed scoring, and ignored paths are
+  unchanged.
+- No Swift runtime behavior or generated protobuf artifacts change.
+
+## Verification Plan
+
+1. Run the registered focused test command for
+   `evaluation-final-result-json-typed-score-aggregate` locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run `scripts/evaluation_json_typed_score_probe.py` before and after the
+   change and accept only if the registered elapsed metric improves or stays
+   within bounded noise while allocation does not regress.
+4. Use the GitHub Actions PR-scoped performance report as the merge gate.
+
+## Local Results
+
+Baseline direct registered probe on Linux from `origin/main` (`518fc229`):
+
+```json
+{"elapsed_ms_mean": 21.269714343361557, "iteration_count": 40.0, "key_count": 2000.0, "peak_bytes_mean": 1189429.6666666667, "score_checksum": 35.0}
+```
+
+Post-change direct registered probe on Linux:
+
+```json
+{"elapsed_ms_mean": 13.870091800345108, "iteration_count": 40.0, "key_count": 2000.0, "peak_bytes_mean": 713689.8, "score_checksum": 35.0}
+```
+
+Focused tests passed (`43 passed`), and changed-scope coverage for the touched
+implementation line was `100%`.

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -315,7 +315,7 @@ def _score_json_result(
     target: str,
     profile: EvaluationProfileDefinition,
 ) -> ScoringOutcome:
-    output_schema = profile.output_schema or {}
+    output_schema = profile.output_schema
     if not output_schema:
         try:
             return _cached_schema_free_json_scoring_outcome(


### PR DESCRIPTION
## Summary
- Avoid allocating a fresh empty dict before the schema-free JSON final-result scoring cache is consulted.
- Keep JSON parsing, ignored-path scoring, invalid JSON status, and schema-validation behavior unchanged.

## Plan or Spec
- `docs/plans/2026-06-26-evaluation-json-output-schema-none-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_json_typed_score_probe.py --samples 3
# baseline from origin/main: exit 0; {"elapsed_ms_mean": 21.269714343361557, "iteration_count": 40.0, "key_count": 2000.0, "peak_bytes_mean": 1189429.6666666667, "score_checksum": 35.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 43 passed in 1.20s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_json_typed_score_probe.py
# exit 0; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_json_typed_score_probe.py
# exit 0; {"elapsed_ms_mean": 13.870091800345108, "iteration_count": 40.0, "key_count": 2000.0, "peak_bytes_mean": 713689.8, "score_checksum": 35.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` for the touched implementation line.
- Registered local probe: `elapsed_ms_mean` 21.269714343361557 ms baseline -> 13.870091800345108 ms head; `peak_bytes_mean` 1189429.6666666667 -> 713689.8; checksum unchanged at 35.0.
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Linux-local validation only; this is Python-only and does not change Swift runtime behavior.
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this one-line focused performance slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change; existing PR-scoped probe is reused.
- [x] Deferred work and known gaps are stated explicitly.
