### PR TITLE
perf: partition failed dataset segments in one pass

### DIFF
--- a/docs/plans/2026-06-07-dataset-version-empty-fail-fastpath.md
+++ b/docs/plans/2026-06-07-dataset-version-empty-fail-fastpath.md
@@ -37,3 +37,18 @@ partition fast path is measured by the existing registered probe.
 
 This is a Python-only slice and is locally verifiable on Linux. No Swift runtime
 behavior changes are included.
+
+## 2026-06-27 follow-up: failed partition single pass
+
+The next focused slice keeps the same `prepare_dataset_version(...)` boundary and
+registered `dataset-quality-lengths-chain` probe, but targets the non-empty
+`fail_segment_ids` path. The empty-failure fast path already returns the original
+segment list without scanning. For non-empty failure ids, `_partition_failed_segments(...)`
+still preserves duplicate failed ids and output order, but can partition
+successful and failed segments in one scan instead of two list-comprehension
+passes over the same segment list.
+
+The registered probe remains the validation gate. This follow-up extends
+`scripts/dataset_quality_lengths_probe.py` with failed-partition metrics so CI
+and local Linux runs report `failed_partition_elapsed_ms_*` together with the
+existing quality-length metrics.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5191,8 +5191,8 @@
       "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
       "scripts/dataset_quality_lengths_probe.py"
     ],
-    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_fast_paths_empty_failures services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_preserves_failed_id_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
-    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_fast_paths_empty_failures services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_preserves_failed_id_semantics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py",
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_fast_paths_empty_failures services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_preserves_failed_id_semantics services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_scans_nonempty_failures_once services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_fast_paths_empty_failures services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_preserves_failed_id_semantics services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_scans_nonempty_failures_once services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py",
     "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/dataset_quality_lengths_probe.py\"; for CANDIDATE in \"${MELIX_PR_SCOPED_PERFORMANCE_HEAD_REPO:-}/$SCRIPT\" \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
     "probe_impl": "command_json",
     "coverage_replays_tests": true,
@@ -5227,6 +5227,33 @@
       {
         "key": "p95_output_length",
         "unit": "chars",
+        "direction": "informational"
+      },
+      {
+        "key": "failed_partition_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "failed_partition_elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better"
+      },
+      {
+        "key": "failed_partition_elapsed_ms_p95",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "failed_partition_segment_count",
+        "unit": "items",
+        "direction": "informational"
+      },
+      {
+        "key": "failed_partition_failed_count",
+        "unit": "items",
         "direction": "informational"
       }
     ]

--- a/scripts/dataset_quality_lengths_probe.py
+++ b/scripts/dataset_quality_lengths_probe.py
@@ -13,7 +13,11 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "services/mlx-worker-python"))
 
-from worker.productization.dataset_preparation import DatasetVersionRequest, _quality_summary  # noqa: E402
+from worker.productization.dataset_preparation import (  # noqa: E402
+    DatasetVersionRequest,
+    _partition_failed_segments,
+    _quality_summary,
+)
 
 
 def _row(index: int, *, messages: bool) -> dict[str, Any]:
@@ -91,11 +95,69 @@ def measure(*, train_count: int, validation_count: int, samples: int) -> dict[st
     }
 
 
+def measure_failed_partition(*, segment_count: int, failed_modulus: int, samples: int) -> dict[str, float]:
+    segments = [
+        {
+            "segment_id": f"segment-{index:05d}",
+            "text": "x" * (32 + (index % 19)),
+        }
+        for index in range(segment_count)
+    ]
+    fail_segment_ids = tuple(
+        segment["segment_id"]
+        for index, segment in enumerate(segments)
+        if index % failed_modulus == 0
+    )
+
+    elapsed_samples: list[float] = []
+    successful_segments: list[dict[str, Any]] | None = None
+    failed_segments: list[dict[str, Any]] | None = None
+    for _ in range(samples):
+        started = time.perf_counter()
+        successful_segments, failed_segments = _partition_failed_segments(
+            segments,
+            fail_segment_ids,
+        )
+        elapsed_samples.append((time.perf_counter() - started) * 1000.0)
+
+    if successful_segments is None or failed_segments is None:  # pragma: no cover - samples>=1 by default
+        raise AssertionError("failed segment partition was not measured")
+    expected_failed = len(fail_segment_ids)
+    if len(failed_segments) != expected_failed:  # pragma: no cover - regression guard
+        raise AssertionError(f"expected {expected_failed} failed segments, got {len(failed_segments)}")
+    expected_successful = segment_count - expected_failed
+    if len(successful_segments) != expected_successful:  # pragma: no cover - regression guard
+        raise AssertionError(
+            f"expected {expected_successful} successful segments, got {len(successful_segments)}"
+        )
+
+    return {
+        "failed_partition_elapsed_ms_mean": round(statistics.fmean(elapsed_samples), 6),
+        "failed_partition_elapsed_ms_min": round(min(elapsed_samples), 6),
+        "failed_partition_elapsed_ms_p95": round(
+            sorted(elapsed_samples)[int(0.95 * (len(elapsed_samples) - 1))],
+            6,
+        ),
+        "failed_partition_segment_count": float(segment_count),
+        "failed_partition_failed_count": float(expected_failed),
+    }
+
+
 def main() -> int:
     train_count = int(os.environ.get("MELIX_DATASET_QUALITY_LENGTHS_TRAIN_ROWS", "12000"))
     validation_count = int(os.environ.get("MELIX_DATASET_QUALITY_LENGTHS_VALIDATION_ROWS", "3000"))
     samples = int(os.environ.get("MELIX_DATASET_QUALITY_LENGTHS_SAMPLES", "7"))
-    print(json.dumps(measure(train_count=train_count, validation_count=validation_count, samples=samples), sort_keys=True))
+    segment_count = int(os.environ.get("MELIX_DATASET_FAILED_PARTITION_SEGMENTS", "15000"))
+    failed_modulus = int(os.environ.get("MELIX_DATASET_FAILED_PARTITION_MODULUS", "5"))
+    metrics = measure(train_count=train_count, validation_count=validation_count, samples=samples)
+    metrics.update(
+        measure_failed_partition(
+            segment_count=segment_count,
+            failed_modulus=failed_modulus,
+            samples=samples,
+        )
+    )
+    print(json.dumps(metrics, sort_keys=True))
     return 0
 
 

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -145,6 +145,29 @@ def test_dataset_version_failed_segment_partition_preserves_failed_id_semantics(
     assert failed_segments == [segments[1], segments[2]]
 
 
+def test_dataset_version_failed_segment_partition_scans_nonempty_failures_once() -> None:
+    class CountingSegments(list[dict[str, object]]):
+        iter_calls = 0
+
+        def __iter__(self):
+            self.iter_calls += 1
+            return super().__iter__()
+
+    segments = CountingSegments(
+        [
+            {"segment_id": "a", "text": "first"},
+            {"segment_id": "b", "text": "second"},
+            {"segment_id": "c", "text": "third"},
+        ]
+    )
+
+    successful_segments, failed_segments = _partition_failed_segments(segments, ("b",))
+
+    assert successful_segments == [segments[0], segments[2]]
+    assert failed_segments == [segments[1]]
+    assert segments.iter_calls == 1
+
+
 def test_dataset_quality_output_lengths_preserve_completion_and_message_semantics() -> None:
     train_rows = [
         {"completion": "abc"},

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -740,6 +740,8 @@ def test_dataset_quality_lengths_probe_script_emits_metrics(
     monkeypatch.setenv("MELIX_DATASET_QUALITY_LENGTHS_TRAIN_ROWS", "5")
     monkeypatch.setenv("MELIX_DATASET_QUALITY_LENGTHS_VALIDATION_ROWS", "2")
     monkeypatch.setenv("MELIX_DATASET_QUALITY_LENGTHS_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_DATASET_FAILED_PARTITION_SEGMENTS", "10")
+    monkeypatch.setenv("MELIX_DATASET_FAILED_PARTITION_MODULUS", "4")
     probe_script = runpy.run_path(str(REPO_ROOT / "scripts/dataset_quality_lengths_probe.py"))
 
     assert probe_script["main"]() == 0
@@ -753,6 +755,10 @@ def test_dataset_quality_lengths_probe_script_emits_metrics(
     assert metrics["row_count"] == 7.0
     assert metrics["mean_output_length"] > 0.0
     assert metrics["p95_output_length"] > 0.0
+    assert metrics["failed_partition_elapsed_ms_mean"] >= 0.0
+    assert metrics["failed_partition_elapsed_ms_p95"] >= 0.0
+    assert metrics["failed_partition_segment_count"] == 10.0
+    assert metrics["failed_partition_failed_count"] == 3.0
 
 
 def test_dataset_source_records_probe_script_emits_metrics(

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -334,12 +334,13 @@ def _partition_failed_segments(
     if not fail_segment_ids:
         return segments, []
     failed_id_set = set(fail_segment_ids)
-    successful_segments = [
-        segment for segment in segments if segment.get("segment_id") not in failed_id_set
-    ]
-    failed_segments = [
-        segment for segment in segments if segment.get("segment_id") in failed_id_set
-    ]
+    successful_segments: list[dict[str, Any]] = []
+    failed_segments: list[dict[str, Any]] = []
+    for segment in segments:
+        if segment.get("segment_id") in failed_id_set:
+            failed_segments.append(segment)
+        else:
+            successful_segments.append(segment)
     return successful_segments, failed_segments
 
 


### PR DESCRIPTION
## Summary
- Partition non-empty failed dataset segments in one pass while preserving output order, duplicate failed-id semantics, and the existing empty-failure fast path.
- Extend the registered `dataset-quality-lengths-chain` PR-scoped probe with failed-partition metrics.
- Add focused regression coverage and update the governing dataset-version performance plan.

## Plan or Spec
- Updated `docs/plans/2026-06-07-dataset-version-empty-fail-fastpath.md` with the 2026-06-27 failed-partition single-pass follow-up.
- Registered probe remains `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `git fetch origin --prune && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_fast_paths_empty_failures services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_preserves_failed_id_semantics services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_scans_nonempty_failures_once services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics`
- Registered `dataset-quality-lengths-chain` test/coverage/probe command extracted from `infra/perf/pr_scoped_probes.json`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-quality-lengths-chain --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/dataset_quality_probe.json`
- Custom local base/head partition microprobe using `python3` imports from `/root/.hermes/profiles/coder/workspace/melix` and this worktree.
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `4 passed in 1.14s`.
- Registered test command: `8 passed in 0.21s`.
- Registered coverage command: `8 passed`; changed-line coverage `100%` (`42/42`).
- Registered local probe head metrics: `elapsed_ms_mean=2.724183`, `failed_partition_elapsed_ms_mean=1.145614`, `failed_partition_elapsed_ms_p95=1.196104`, `failed_partition_segment_count=15000`, `failed_partition_failed_count=3000`.
- Local base/head failed-partition microprobe: `base_mean_ms=1.777194`, `head_mean_ms=1.121685`, `delta_ms=-0.655509`, `speedup=1.5844`, `base_p95_ms=1.979214`, `head_p95_ms=1.433128` over 21 samples, 15k segments, 3k failed ids.

## Known Gaps
- Python-only slice validated locally on Linux. No Swift runtime behavior is changed.
- The registered CI PR-scoped performance workflow is still required as the merge gate.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path covered by registered PR-scoped probe.
- [x] Focused tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux.
- [x] CI PR-scoped performance validation required before merge.
