### PR TITLE
perf: skip JSONL blank line strip allocation

### DIFF
--- a/docs/plans/2026-06-20-dataset-source-empty-check-isspace.md
+++ b/docs/plans/2026-06-20-dataset-source-empty-check-isspace.md
@@ -30,3 +30,16 @@ Replace `not text.strip()` with `not text or text.isspace()` when detecting empt
 - Focused tests pass and the whitespace-only source remains classified as `DATASET_INGEST_EMPTY_SOURCE`.
 - Changed-scope coverage for touched files remains at or above 95%.
 - The registered local and CI probes show non-regression or improvement for `elapsed_ms_mean` and related source-record metrics.
+
+## 2026-06-27 follow-up: JSONL blank-line skip
+
+The next focused slice keeps the same Python boundary and registered
+`dataset-source-records-scandir` probe, but narrows to JSONL structured data
+ingest in `_structured_records(...)`. Blank JSONL records previously used
+`line.strip()` before skipping empty lines, allocating a stripped copy even
+though the common non-empty line immediately flows into `json.loads(...)`.
+
+This slice replaces that guard with `not line or line.isspace()`, preserving
+blank and whitespace-only line skipping while avoiding stripped-copy allocation
+for populated JSONL rows. The existing focused ingest test now includes a
+whitespace-only JSONL line to keep behavior parity explicit.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -175,6 +175,7 @@ def test_dataset_ingest_receipt_reports_independent_cleaning_controls(
     )
     (input_root / "rows.jsonl").write_text(
         '{"id":"row-1","text":"Alpha structured row"}\n'
+        "   \n"
         '{"id":"row-2","text":"Alpha structured row"}\n'
         '{"id":"row-3","text":"Alpha structured row."}\n',
         encoding="utf-8",
@@ -268,6 +269,7 @@ def test_dataset_ingest_receipt_reports_independent_cleaning_controls(
     assert all("sk-test-secret" not in row["text"] for row in segment_rows)
     assert any(row["source_kind"] == "code" and row["metadata"]["language"] == "python" for row in segment_rows)
     assert any(row["text"] == "JSON array row one" for row in segment_rows)
+    assert not any(row["text"].isspace() for row in segment_rows)
     assert any(row["text"] == "CSV structured row" for row in segment_rows)
     assert any(row["text"] == "TSV structured row" for row in segment_rows)
     assert json.loads(receipt_path.read_text(encoding="utf-8")) == receipt

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -713,7 +713,7 @@ def _structured_records(path: Path, text: str) -> Iterable[dict[str, Any]]:
     suffix = path.suffix.lower()
     if suffix == ".jsonl":
         for index, line in enumerate(text.splitlines(), start=1):
-            if not line.strip():
+            if not line or line.isspace():
                 continue
             payload = json.loads(line)
             yield _record(


### PR DESCRIPTION
## Summary
- Replaced the JSONL blank-line guard in dataset ingest with `not line or line.isspace()` to avoid `strip()` allocation on populated rows.
- Added a whitespace-only JSONL line to the focused ingest regression fixture so blank-line skipping remains explicit.
- Updated the governing dataset source records performance plan with this follow-up slice.

## Plan or Spec
- `docs/plans/2026-06-20-dataset-source-empty-check-isspace.md`
- Registered PR-scoped probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json` (existing entry includes `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls
1 passed in 0.20s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <dataset-source-records-scandir focused test_command selection>
13 passed in 1.03s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <dataset-source-records-scandir focused test_command selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
13 passed in 0.37s
TOTAL 2 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/dataset_source_records_isspace_perf.json
head verification: 13 passed; changed-scope coverage TOTAL 2 0 100%; base/head probes completed ok

$ git diff --check
passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Local Linux registered probe (`dataset-source-records-scandir`, base=`origin/main` at `b685ad86`, head=`ee3ac22f`):
  - `elapsed_ms_mean`: 11.9997 ms -> 11.1091 ms (`delta=-0.8906 ms`, `speedup=1.080x`, `improvement=7.42%`).
  - `elapsed_ms_p95`: 12.4474 ms -> 12.2506 ms (`delta=-0.1967 ms`, `improvement=1.58%`).
  - `source_kind_elapsed_ms_mean`: 20.4619 ms -> 19.3880 ms (`delta=-1.0739 ms`, `improvement=5.25%`).
  - `file_count_mean`: 6000.0 (unchanged, informational).
- CI PR-scoped performance is required as the merge gate and should run the registered probe again on GitHub Actions.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this is a Python-only focused performance slice and the registered focused tests/probe were run locally.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: existing PR-scoped performance evidence; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
