### PR TITLE
perf: stream export smoke manifest rows

### DIFF
--- a/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
+++ b/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
@@ -431,9 +431,12 @@ The metrics-report path may reuse the already validated target manifest object
 when materializing fixture digest files and executing the smoke receipt writer.
 It must preserve the public `run_export_target_smoke()` validation boundary for
 external callers while avoiding an extra manifest parse on each probe iteration.
-The registered `runtime-export-smoke-policy` PR-scoped probe remains the
-evidence source for this Python slice and includes focused test, coverage, and
-`command_json` probe commands in `infra/perf/pr_scoped_probes.json`.
+Smoke metadata and fixture digest loops stream generated and required manifest
+file rows instead of materializing a combined tuple, preserving manifest order
+while reducing per-target allocation in the registered probe. The registered
+`runtime-export-smoke-policy` PR-scoped probe remains the evidence source for
+this Python slice and includes focused test, coverage, and `command_json` probe
+commands in `infra/perf/pr_scoped_probes.json`.
 
 Bounded generation checks must use a repository-owned prompt fixture or a
 synthetic non-private prompt, a fixed token limit, a timeout, and a preview byte

--- a/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
+++ b/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
@@ -227,6 +227,23 @@ def test_export_target_smoke_metrics_report_reuses_validated_manifest(
     assert validation_calls == len(manifest_paths)
 
 
+def test_export_target_smoke_manifest_file_rows_streams_generated_then_required(
+    tmp_path: Path,
+) -> None:
+    _target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "melix_managed/export-target-manifest.json",
+    )
+
+    streamed_paths = [row.path for row in export_target_smoke._manifest_file_rows(manifest)]
+
+    assert streamed_paths == [
+        *(row.path for row in manifest.generated_files),
+        *(row.path for row in manifest.required_files),
+    ]
+    assert "export-target-manifest.json" in streamed_paths
+
+
 def test_runtime_export_smoke_policy_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/services/mlx-worker-python/worker/productization/export_target_smoke.py
+++ b/services/mlx-worker-python/worker/productization/export_target_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+from itertools import chain
 import json
 import time
 from dataclasses import dataclass
@@ -364,7 +365,7 @@ def _check_manifest_files(
 ) -> None:
     missing: list[str] = []
     mismatched: list[str] = []
-    for row in (*manifest.generated_files, *manifest.required_files):
+    for row in _manifest_file_rows(manifest):
         if row.path == "export-target-manifest.json":
             continue
         path = _target_relative_path(layout, row.path)
@@ -621,11 +622,17 @@ def _file_sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _manifest_file_rows(
+    manifest: export_target_manifest_pb2.ExportTargetManifest,
+):
+    return chain(manifest.generated_files, manifest.required_files)
+
+
 def _write_digest_fixture_files(
     target_root: Path,
     manifest: export_target_manifest_pb2.ExportTargetManifest,
 ) -> None:
-    for row in (*manifest.generated_files, *manifest.required_files):
+    for row in _manifest_file_rows(manifest):
         if row.path == "export-target-manifest.json":
             continue
         path = target_root / row.path


### PR DESCRIPTION
## Summary
- Stream generated and required export-target manifest file rows with `itertools.chain` instead of materializing combined tuples in export smoke metadata/digest loops.
- Add a regression test that preserves generated-before-required row order for the helper.
- Update the runtime-aware export plan to record the allocation-reduction slice and registered probe boundary.

## Plan or Spec
- Updated `docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md` under the smoke policy section.
- Registered PR-scoped probe: `runtime-export-smoke-policy` in `infra/perf/pr_scoped_probes.json` already covers `services/mlx-worker-python/worker/productization/export_target_smoke.py` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_smoke_policy_probe.py`
- Baseline probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RUNTIME_EXPORT_SMOKE_PROBE_ITERATIONS=40 MELIX_RUNTIME_EXPORT_SMOKE_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/runtime_export_smoke_policy_probe.py`
- Post-change probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RUNTIME_EXPORT_SMOKE_PROBE_ITERATIONS=40 MELIX_RUNTIME_EXPORT_SMOKE_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/runtime_export_smoke_policy_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 14 passed.
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Baseline registered probe: `elapsed_ms_mean=4318.349947192473`, `peak_bytes_mean=1206336.8`, `iteration_count=40`, `sample_count=5`.
- Post-change registered probe: `elapsed_ms_mean=4276.649000198813`, `peak_bytes_mean=1205841.0`, `iteration_count=40`, `sample_count=5`.
- Delta: `-41.70094699366018 ms` mean elapsed (`0.9656685424665868%` faster), `-495.80000000004657 bytes` mean peak allocation.

## Known Gaps
- Linux local verification covers the Python smoke policy path only; no Swift runtime behavior is changed.
- The local probe delta is small and should be treated as allocation-oriented evidence; CI PR-scoped performance must validate the registered probe on the PR.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe was run locally before pushing.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
