### PR TITLE
perf: dispatch code eval status tokens by length

### DIFF
--- a/docs/plans/2026-06-27-code-eval-payload-known-values-order.md
+++ b/docs/plans/2026-06-27-code-eval-payload-known-values-order.md
@@ -1,0 +1,31 @@
+# Code Evaluation Payload Known Status Fast Path
+
+This Python-only performance slice is limited to the byte-level code evaluation payload loader in `worker.engine.code_eval_runner._extract_json_string_field_at()` and its known status value mapping.
+
+## Scope
+
+The common runner payload contains repeated short status strings such as `compiled`, `ok`, `passed`, and an empty `failure_detail`. The current known-value helper checks the full known-value tuple before matching many common hot-path status values.
+
+This slice keeps the existing JSON fast-path behavior and fallback semantics unchanged while dispatching known status tokens by byte length before the exact prefix check. It does not change field extraction, malformed-payload handling, or subprocess execution behavior.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`. The probe has focused `test_command`, `coverage_command`, and `probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_payload_json_probe.py`
+
+## Verification Plan
+
+1. Run the focused registered test command locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux and remove generated `coverage.json` afterwards.
+3. Run the registered PR-scoped probe locally against `origin/main` and this branch.
+4. Use GitHub Actions PR-scoped performance and normal PR checks as the final merge gate.
+
+## Metrics
+
+Primary local metric: `elapsed_ms_mean` from `scripts/code_eval_payload_json_probe.py` via `scripts/pr_scoped_performance_run.py`.
+
+Secondary metric: `peak_bytes_mean` from the same probe, expected to remain stable because the change only reorders existing token checks.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -991,6 +991,27 @@ def test_code_eval_payload_fast_path_decodes_known_status_values() -> None:
         "tests_total": 3,
         "failure_detail": "",
     }
+    for known_value in (
+        "",
+        "compiled",
+        "syntax_error",
+        "not_run",
+        "ok",
+        "error",
+        "timeout",
+        "timed_out",
+        "failed",
+        "passed",
+    ):
+        token = known_value.encode("utf-8")
+        assert (
+            code_eval_runner._known_code_eval_payload_string_value(
+                b'"' + token + b'"',
+                1,
+                len(token) + 1,
+            )
+            == known_value
+        )
     assert (
         code_eval_runner._known_code_eval_payload_string_value(
             b'"custom_failure"',

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -411,20 +411,6 @@ _CODE_EVAL_PAYLOAD_FIELD_TOKENS_RUNNER_FRIENDLY = (
 )
 _CODE_EVAL_PAYLOAD_RUNNER_PREFIX = b'{"compile_status"'
 
-_CODE_EVAL_PAYLOAD_KNOWN_STRING_VALUES = (
-    (b"", ""),
-    (b"compiled", "compiled"),
-    (b"syntax_error", "syntax_error"),
-    (b"not_run", "not_run"),
-    (b"ok", "ok"),
-    (b"error", "error"),
-    (b"timeout", "timeout"),
-    (b"timed_out", "timed_out"),
-    (b"failed", "failed"),
-    (b"passed", "passed"),
-)
-
-
 _JSON_PAYLOAD_WHITESPACE = b" \t\r\n"
 
 
@@ -565,9 +551,26 @@ def _known_code_eval_payload_string_value(
     value_end: int,
 ) -> str | None:
     value_length = value_end - value_start
-    for token, value in _CODE_EVAL_PAYLOAD_KNOWN_STRING_VALUES:
-        if value_length == len(token) and payload_bytes.startswith(token, value_start):
-            return value
+    if value_length == 0:
+        return ""
+    if value_length == 2:
+        return "ok" if payload_bytes.startswith(b"ok", value_start) else None
+    if value_length == 5:
+        return "error" if payload_bytes.startswith(b"error", value_start) else None
+    if value_length == 6:
+        if payload_bytes.startswith(b"failed", value_start):
+            return "failed"
+        return "passed" if payload_bytes.startswith(b"passed", value_start) else None
+    if value_length == 7:
+        if payload_bytes.startswith(b"not_run", value_start):
+            return "not_run"
+        return "timeout" if payload_bytes.startswith(b"timeout", value_start) else None
+    if value_length == 8:
+        return "compiled" if payload_bytes.startswith(b"compiled", value_start) else None
+    if value_length == 9:
+        return "timed_out" if payload_bytes.startswith(b"timed_out", value_start) else None
+    if value_length == 12:
+        return "syntax_error" if payload_bytes.startswith(b"syntax_error", value_start) else None
     return None
 
 


### PR DESCRIPTION
## Summary
- Dispatch code evaluation payload known status strings by byte length before exact prefix checks.
- Extend the focused fast-path test to cover every known status token.
- Add the slice plan documenting the registered `code-eval-payload-json-bytes` probe.

## Plan or Spec
- `docs/plans/2026-06-27-code-eval-payload-known-values-order.md`
- Registered probe: `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_fast_path_decodes_known_status_values services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_missing_required_field_falls_back_to_json_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_escaped_fields services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-payload-json-bytes --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-code-eval-payload-known-values-order-20260627 --head-repo "$PWD" --output /tmp/code_eval_payload_length_dispatch_probe.json`

## Coverage and Metrics
- Focused tests: 11 passed locally on Linux.
- Changed-scope coverage: 100.00% (`TOTAL 23 0 100%`).
- Local registered probe (`code-eval-payload-json-bytes`): `elapsed_ms_mean` base 88.525549 ms, head 83.675668 ms, delta -4.849882 ms (-5.479%); `peak_bytes_mean` base/head 60292 bytes, delta 0.

## Known Gaps
- Local validation is Linux-only for this Python path; GitHub Actions PR-scoped performance is still required as the merge gate.

## Evidence Checklist
- [x] Registered PR-scoped probe exists and covers the changed path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe passed locally with an improved elapsed metric.
- [ ] GitHub Actions PR-scoped performance completed successfully.
- [ ] All required PR checks are green.
