### PR TITLE
perf: fast path whitespace-only tool selection

### DIFF
--- a/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
+++ b/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
@@ -83,6 +83,17 @@ instead of performing a second equivalent dictionary lookup. Whitespace-trimmed
 single-name requests, cache hits, valid selections, and error messages remain
 unchanged.
 
+## Slice update: whitespace-only turn fallback fast path
+
+This incremental slice keeps the same `tool-registry-select-name-index-cache`
+registered probe and narrows the optimization to agentic tool routing requests
+that have no vector-selected tool ids, no recent context turns, and an empty or
+whitespace-only current turn. These requests can only return the always-available
+`local_compute` fallback, so `select_agentic_tools_for_turn()` now returns that
+fallback before allocating the selected-name/source containers or invoking the
+keyword matcher. The receipt shape, `vector_available` flag, fallback reason,
+and selected tool list remain unchanged.
+
 ## Acceptance Criteria
 
 - Focused behavior tests pass locally on Linux.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -794,6 +794,35 @@ def test_agentic_tool_selection_whitespace_turn_skips_casefold() -> None:
     assert result.receipt["fallback_reason"] == "no_keyword_match"
 
 
+def test_agentic_tool_selection_whitespace_turn_skips_keyword_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_keyword_tool_matches(text: str) -> tuple[str, ...]:  # pragma: no cover
+        raise AssertionError(f"whitespace fast path should not scan keywords: {text!r}")
+
+    monkeypatch.setattr(
+        tool_registry_module,
+        "_keyword_tool_matches",
+        fail_keyword_tool_matches,
+    )
+
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn=" \t\n  ",
+            vector_available=True,
+            max_selected_tools=4,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute",)
+    assert result.receipt["selection_mode"] == "fallback"
+    assert result.receipt["vector_available"] is True
+    assert result.receipt["fallback_reason"] == "no_keyword_match"
+    assert result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"},
+    ]
+
+
 def test_agentic_tool_selection_skips_empty_context_keyword_scan(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -494,6 +494,13 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
     max_selected_tools = max(1, selection_input.max_selected_tools)
     if max_selected_tools == 1:
         return _build_always_only_tool_selection_result(registry, selection_input)
+    current_user_turn = selection_input.current_user_turn
+    if (
+        not selection_input.vector_selected_tool_ids
+        and not selection_input.recent_user_turns
+        and (not current_user_turn or current_user_turn.isspace())
+    ):
+        return _build_always_only_tool_selection_result(registry, selection_input)
     selected_sources: dict[str, str] = {}
     selected_names: list[str] = []
     has_vector_selection = False


### PR DESCRIPTION
## Summary
- Add a whitespace-only agentic tool routing fast path that returns the always-available `local_compute` fallback before keyword scanning when there are no vector ids or recent context turns.
- Add regression coverage proving the whitespace-only path preserves the fallback receipt and does not call the keyword matcher.
- Update the tool registry select performance plan with the new incremental slice.

## Plan or Spec
- Updated `docs/plans/2026-05-18-tool-registry-select-name-index-cache.md` under the registered `tool-registry-select-name-index-cache` probe.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- Baseline probe on `origin/main`: `MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- Head probe: `MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 89 passed.
- Changed-scope coverage: 100% (`TOTAL 11 0 100%`).
- Registered local probe metric (`whitespace_turn_planning_elapsed_ms_mean`): base `32.0435 ms`, head `22.0041 ms`, delta `-10.0394 ms` / `31.33%` faster.
- Overall probe `elapsed_ms_mean` was noisy and not the optimized subpath (`21.7547 ms` base vs `22.9469 ms` head); the targeted whitespace-only routing metric improved clearly.

## Known Gaps
- Local validation is Linux/Python only. CI PR-scoped performance must run the registered probe before merge.

## Evidence Checklist
- [x] Registered probe exists for the touched path (`tool-registry-select-name-index-cache`).
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe was run on base and head.
- [ ] GitHub Actions / PR-scoped performance completed successfully.
