### PR TITLE
perf: fast path common hub quantization tags

### DIFF
--- a/docs/plans/2026-06-27-hub-catalog-common-quantization-fast-path.md
+++ b/docs/plans/2026-06-27-hub-catalog-common-quantization-fast-path.md
@@ -1,0 +1,33 @@
+# Hub catalog common quantization fast path
+
+This Python-only performance slice is limited to `worker.model_ops.hub_catalog._quantization_summary()`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `hub-catalog-tag-normalization-single-pass` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_tag_normalization_probe.py`
+
+## Slice
+
+The Hub catalog normalization probe repeatedly summarizes records with the common `4-BIT` plus `OptiQ` tag pair. Keep the existing general ordered-alias fallback, but short-circuit the common lowered tag set when no higher-priority or additional quantization aliases are present.
+
+## Verification plan
+
+1. Preserve quantization summary ordering for mixed aliases with focused unit coverage.
+2. Run the registered focused test command for `hub-catalog-tag-normalization-single-pass` locally on Linux.
+3. Run the registered changed-scope coverage command locally on Linux.
+4. Run the registered probe locally via `scripts/pr_scoped_performance_run.py` against `origin/main` and this branch.
+5. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage for touched files remains at or above the repository threshold.
+- The registered probe shows a non-regressing direction for `elapsed_ms_mean`.
+- CI PR-scoped performance completes successfully before merge.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -87,6 +87,7 @@ def test_quantization_summary_preserves_alias_order_from_lowered_tags() -> None:
         _quantization_summary(["2-bit", "3bit", "8-bit", "float32", "bf16"])
         == "2-bit, 3-bit, 8-bit, fp32, bf16"
     )
+    assert _quantization_summary([], lowered_tags={"family-test", "4-bit", "optiq"}) == "4-bit, optiq"
 
 
 def test_string_list_preserves_exact_list_and_list_subclass_inputs() -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -54,6 +54,26 @@ _URL_HEX_DIGITS = {
     "F": 15,
 }
 _LOWERCASE_WEIGHT_OR_CONFIG_SUFFIXES = (".safetensors", ".npz", ".gguf", "config.json", "tokenizer.json")
+_COMMON_4BIT_OPTIQ_TAGS = {"4-bit", "4bit"}
+_COMMON_4BIT_OPTIQ_EXCLUDED_TAGS = {
+    "2bit",
+    "2-bit",
+    "3bit",
+    "3-bit",
+    "8bit",
+    "8-bit",
+    "mixed-precision",
+    "mixed_precision",
+    "fp32",
+    "float32",
+    "f32",
+    "bf16",
+    "fp16",
+    "float16",
+    "qat",
+}
+
+
 @dataclass(frozen=True, slots=True)
 class HubModelSummaryRecord:
     repo_id: str
@@ -1107,6 +1127,12 @@ def _bytes_per_parameter_from_tag_substrings(lowered: set[str]) -> float:
 
 def _quantization_summary(tags: list[str], *, lowered_tags: set[str] | None = None) -> str:
     lowered = _normalized_lowered_tags(tags, lowered_tags)
+    if (
+        "optiq" in lowered
+        and not lowered.isdisjoint(_COMMON_4BIT_OPTIQ_TAGS)
+        and lowered.isdisjoint(_COMMON_4BIT_OPTIQ_EXCLUDED_TAGS)
+    ):
+        return "4-bit, optiq"
     values: list[str] = []
     if "2bit" in lowered or "2-bit" in lowered:
         values.append("2-bit")


### PR DESCRIPTION
## Summary
- Add a narrow fast path for the common Hub catalog `4-bit` + `optiq` quantization tag combination.
- Preserve the ordered alias fallback for mixed or higher-priority quantization tags.
- Add the governing performance slice plan and focused regression coverage.

## Plan or Spec
- `docs/plans/2026-06-27-hub-catalog-common-quantization-fast-path.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics
# 88 passed in 1.36s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py
# 88 passed in 0.50s; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-tag-normalization-single-pass --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/hub-catalog-common-quantization-probe.json
# completed successfully

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Registered probe: `hub-catalog-tag-normalization-single-pass`.
- Local Linux probe metrics:
  - base `elapsed_ms_mean=206.73481199191883`, head `elapsed_ms_mean=197.90777559392154`, delta `-8.82703639799729 ms` (`~4.27%` faster).
  - base `peak_bytes_mean=9835660.4`, head `peak_bytes_mean=9570660.4`, delta `-265000 bytes`.
  - `tag_normalization_calls_mean=5000.0` unchanged.
- CI PR-scoped performance is still required as the merge gate.

## Known Gaps
- None. This is a Python-only slice validated locally on Linux; CI remains the final registered probe gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change.
- [x] Deferred work and known gaps are stated explicitly.
