### PR TITLE
perf: fast path missing tool selection

### DIFF
--- a/docs/plans/2026-06-27-tool-registry-missing-name-fastpath.md
+++ b/docs/plans/2026-06-27-tool-registry-missing-name-fastpath.md
@@ -1,0 +1,22 @@
+# Tool registry missing-name fast path
+
+## Scope
+
+This Python performance slice is limited to the single-name missing selection branch in `services/mlx-worker-python/worker/runtime/tool_registry.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`. The probe watches `tool_registry.py`, focused tool registry tests, `test_pr_scoped_performance.py`, and `scripts/tool_registry_select_probe.py`, and includes focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Slice
+
+For a single requested tool name that misses the registry and has no leading or trailing whitespace, `ToolRegistry.select(...)` can raise the same `ToolRegistryError` immediately. This avoids the extra `strip()` normalization branch used only for names that may trim to a valid known tool or to an empty selection.
+
+Whitespace-padded valid names, blank names, duplicate handling, cache aliasing, and multi-name normalization remain unchanged.
+
+## Validation plan
+
+1. Run the registered focused `test_command` for `tool-registry-select-name-index-cache`.
+2. Run the registered changed-scope `coverage_command` and require at least 95% for touched scope.
+3. Run `scripts/tool_registry_select_probe.py` locally on Linux before and after the change and compare `missing_selection_elapsed_ms_mean` and overall `elapsed_ms_mean` while preserving checksum and selection counts.
+4. Use GitHub Actions PR-scoped performance as the merge gate.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -317,6 +317,10 @@ class ToolRegistry:
                     self._selection_cache.clear()
                 self._selection_cache[requested_names] = selection
                 return selection
+            if raw_name and not raw_name[0].isspace() and not raw_name[-1].isspace():
+                raise ToolRegistryError(
+                    f"Unknown tool registry entry requested: {raw_name}"
+                )
             normalized_name = raw_name.strip()
             if normalized_name:
                 requested_names = (normalized_name,)
@@ -327,10 +331,6 @@ class ToolRegistry:
                     if isinstance(names, tuple) and names != requested_names:
                         self._selection_cache[names] = cached_selection
                     return cached_selection
-                if normalized_name == raw_name:
-                    raise ToolRegistryError(
-                        f"Unknown tool registry entry requested: {normalized_name}"
-                    )
                 tool = tool_by_name.get(normalized_name, missing_tool_sentinel)
                 if tool is missing_tool_sentinel:
                     raise ToolRegistryError(


### PR DESCRIPTION
## Summary
- Fast-path single-name missing tool selections when the raw name has no trim work to do.
- Keep whitespace-padded valid names, blank-name handling, duplicate handling, and cache alias behavior unchanged.
- Document the slice in `docs/plans/2026-06-27-tool-registry-missing-name-fastpath.md`.

## Plan or Spec
- `docs/plans/2026-06-27-tool-registry-missing-name-fastpath.md`
- Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` on `origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=80000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py` on this branch
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-select-name-index-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-tool-registry-openai-schema-locals-20260627 --output /tmp/tool_registry_select_pr_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `89 passed in 1.10s`.
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Manual local probe (`origin/main` -> branch):
  - `elapsed_ms_mean`: `22.32098679523915` -> `21.090645994991064` ms (`-1.2303408002480874` ms, ~`5.51%` lower)
  - `missing_selection_elapsed_ms_mean`: `14.788322197273374` -> `14.078073424752802` ms (`-0.710248772520572` ms, ~`4.80%` lower)
  - checksum and selection counts unchanged.
- Registered local PR-scoped probe (`base` -> `head`):
  - `elapsed_ms_mean`: `21.401828399393708` -> `21.313693409319967` ms (`-0.08813499007374107` ms)
  - `missing_selection_elapsed_ms_mean`: `14.87397380406037` -> `13.623960828408599` ms (`-1.2500129756517703` ms, ~`8.40%` lower)
  - checksum and selection counts unchanged.

## Known Gaps
- Local validation is Linux-only; GitHub Actions PR-scoped performance remains the merge gate.
- Some unrelated timing buckets vary due to microbenchmark noise; the optimized missing-selection bucket improved in both local probe runs.

## Evidence Checklist
- [x] Registered PR-scoped performance probe covers the changed path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally with base/head comparison.
- [ ] GitHub Actions PR-scoped performance completed successfully.
