### PR TITLE
perf(dataset): carry snapshot relative paths during scan

### DIFF
--- a/docs/plans/2026-06-27-dataset-registry-inference-slash-fastpath.md
+++ b/docs/plans/2026-06-27-dataset-registry-inference-slash-fastpath.md
@@ -24,7 +24,9 @@ Add `_iter_supported_dataset_file_entries(...)`, which carries the snapshot-rela
 path string while scanning. `_dataset_files(...)` consumes `(Path, relative_path)`
 entries directly and avoids per-file `Path.relative_to(...)`. The existing
 `_iter_supported_dataset_files(...)` API is preserved as a thin wrapper for other
-callers, keeping external behavior and ordering unchanged.
+callers, keeping external behavior and ordering unchanged. The carried logical
+metadata path always uses `/` separators so serialized snapshot payloads remain
+platform-independent even when the host filesystem separator differs.
 
 ## Verification plan
 

--- a/docs/plans/2026-06-27-dataset-registry-inference-slash-fastpath.md
+++ b/docs/plans/2026-06-27-dataset-registry-inference-slash-fastpath.md
@@ -1,0 +1,37 @@
+# Dataset registry snapshot relative-path construction slice
+
+## Scope
+
+This Python-only performance slice targets the dataset registry snapshot build path in
+`services/mlx-worker-python/worker/dataset_registry/catalog.py`.
+
+The registered PR-scoped probe is
+`dataset-registry-snapshot-inference-single-pass` in
+`infra/perf/pr_scoped_probes.json`; it covers the dataset registry catalog path,
+focused tests, changed-scope coverage, and the local/CI probe command.
+
+## Baseline behavior
+
+`_dataset_files(...)` iterated supported files as `Path` objects, then computed each
+snapshot-relative path with `path.relative_to(snapshot_dir)` before constructing the
+`DatasetFile`. For large snapshots this repeats root-relative path calculation for
+every accepted file even though the recursive scanner already knows each directory
+entry name and parent prefix.
+
+## Change
+
+Add `_iter_supported_dataset_file_entries(...)`, which carries the snapshot-relative
+path string while scanning. `_dataset_files(...)` consumes `(Path, relative_path)`
+entries directly and avoids per-file `Path.relative_to(...)`. The existing
+`_iter_supported_dataset_files(...)` API is preserved as a thin wrapper for other
+callers, keeping external behavior and ordering unchanged.
+
+## Verification plan
+
+- Run the registered probe's focused pytest command.
+- Run the registered probe's changed-scope coverage command; changed scope must stay
+  at or above 95%.
+- Run `scripts/pr_scoped_performance_run.py` for
+  `dataset-registry-snapshot-inference-single-pass` comparing `origin/main` against
+  this worktree.
+- Accept only if the registered probe shows a clear non-regression/improvement.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -148,6 +148,24 @@ def test_dataset_catalog_builds_snapshot_inference_in_one_pass(
     }
 
 
+def test_dataset_catalog_snapshot_relative_paths_use_forward_slashes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    snapshot_dir = _write_hf_dataset_snapshot(home)
+
+    monkeypatch.setattr(catalog.os, "sep", "\\")
+
+    payload = DatasetCatalog(environment={"HOME": str(home)}).registry_snapshot_payload()
+
+    dataset = payload["datasets"][0]
+    assert {file["relative_path"] for file in dataset["files"]} == {
+        "README.md",
+        "data/train-00000-of-00001.jsonl",
+    }
+
+
 def test_dataset_catalog_inferred_split_and_config_preserves_legacy_helpers() -> None:
     assert catalog._inferred_split("custom/validation-00000.parquet") == "validation"
     assert catalog._inferred_config("custom/validation-00000.parquet") == "custom"

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -990,7 +990,7 @@ def _iter_supported_dataset_file_entries(
         try:
             if entry.is_dir():
                 yield from _iter_supported_dataset_file_entries(
-                    Path(entry.path), f"{relative_path}{os.sep}"
+                    Path(entry.path), f"{relative_path}/"
                 )
                 continue
             if not entry.is_file():

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -960,28 +960,38 @@ def _build_dataset_snapshot(
 
 
 def _dataset_files(snapshot_dir: Path) -> Iterator[DatasetFile]:
-    for path in _iter_supported_dataset_files(snapshot_dir):
+    for path, relative_path in _iter_supported_dataset_file_entries(snapshot_dir):
         try:
             stat_result = path.stat()
         except OSError:
             continue
         yield DatasetFile(
-            relative_path=os.fspath(path.relative_to(snapshot_dir)),
+            relative_path=relative_path,
             size_bytes=stat_result.st_size,
             file_format=_dataset_file_format(path),
         )
 
 
 def _iter_supported_dataset_files(snapshot_dir: Path) -> Iterator[Path]:
+    for path, _relative_path in _iter_supported_dataset_file_entries(snapshot_dir):
+        yield path
+
+
+def _iter_supported_dataset_file_entries(
+    snapshot_dir: Path, relative_prefix: str = ""
+) -> Iterator[tuple[Path, str]]:
     try:
         with os.scandir(os.fspath(snapshot_dir)) as entries:
             child_entries = sorted(entries, key=lambda entry: entry.name)
     except OSError:
         return
     for entry in child_entries:
+        relative_path = f"{relative_prefix}{entry.name}"
         try:
             if entry.is_dir():
-                yield from _iter_supported_dataset_files(Path(entry.path))
+                yield from _iter_supported_dataset_file_entries(
+                    Path(entry.path), f"{relative_path}{os.sep}"
+                )
                 continue
             if not entry.is_file():
                 continue
@@ -989,7 +999,7 @@ def _iter_supported_dataset_files(snapshot_dir: Path) -> Iterator[Path]:
             continue
         child_path = Path(entry.path)
         if _dataset_file_format(child_path):
-            yield child_path
+            yield child_path, relative_path
 
 
 def _dataset_file_format(path: Path) -> str:


### PR DESCRIPTION
## Summary
- Optimize dataset registry snapshot scanning by carrying each supported file's snapshot-relative path during recursion.
- Avoid repeated `Path.relative_to(snapshot_dir)` calls when constructing `DatasetFile` records.
- Preserve the existing `_iter_supported_dataset_files(...)` API as a wrapper for other callers.

## Plan or Spec
- Plan note: `docs/plans/2026-06-27-dataset-registry-inference-slash-fastpath.md`
- Registered PR-scoped probe: `dataset-registry-snapshot-inference-single-pass`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py`
- `python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-registry-snapshot-inference-single-pass --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/dataset-registry-relative-path-final.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 57 passed.
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Registered probe local comparison (`dataset-registry-snapshot-inference-single-pass`, 5 samples):
  - `elapsed_ms_mean`: base `633.0958047998138` ms, head `129.80830600718036` ms, delta `-503.2874987926334` ms.
  - `peak_bytes_mean`: base `780865.0` bytes, head `778484.6` bytes, delta `-2380.4000000000233` bytes.
  - `legacy_inference_helper_calls_mean`: base `0.0`, head `0.0`.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime behavior is changed in this slice.
- CI remains the source of truth for the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe shows improvement.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
