### PR TITLE
perf(dataset): fast-path exact dataset file suffixes

### DIFF
--- a/docs/plans/2026-06-27-dataset-file-format-exact-suffix.md
+++ b/docs/plans/2026-06-27-dataset-file-format-exact-suffix.md
@@ -1,0 +1,33 @@
+# Dataset registry file-format exact suffix fast path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.dataset_registry.catalog._dataset_file_format()` while building dataset registry snapshot payloads. The behavior remains unchanged for metadata files, supported lowercase suffixes, supported uppercase suffixes, dotfiles, and trailing-dot names.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-registry-snapshot-inference-single-pass` in `infra/perf/pr_scoped_probes.json`.
+
+The probe already includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_snapshot_probe.py`
+
+## Optimization
+
+`_dataset_file_format()` previously lowercased every supported data-file suffix after locating the final dot. Dataset registry snapshots are dominated by lowercase files such as `*.jsonl`, so the slice first checks the exact suffix in `_SUPPORTED_DATASET_SUFFIXES` and only falls back to `suffix.lower()` for mixed-case or uppercase suffixes.
+
+## Verification plan
+
+1. Run the focused dataset registry test/probe command from the registered probe locally on Linux.
+2. Run the changed-scope coverage command from the registered probe locally on Linux.
+3. Run the registered PR-scoped performance probe locally against an `origin/main` baseline worktree and this branch.
+4. Use the GitHub Actions PR-scoped performance report as the merge gate.
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage remains at or above the repository threshold.
+- The registered probe reports a lower or non-regressed `elapsed_ms_mean` for the optimized head.

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -1009,7 +1009,11 @@ def _dataset_file_format(path: Path) -> str:
     dot_index = name.rfind(".")
     if dot_index <= 0 or dot_index == len(name) - 1:
         return ""
-    return _SUPPORTED_DATASET_SUFFIXES.get(name[dot_index:].lower(), "")
+    suffix = name[dot_index:]
+    file_format = _SUPPORTED_DATASET_SUFFIXES.get(suffix)
+    if file_format is not None:
+        return file_format
+    return _SUPPORTED_DATASET_SUFFIXES.get(suffix.lower(), "")
 
 
 def _inferred_split(relative_path: str) -> str:


### PR DESCRIPTION
## Summary
- Fast-path exact lowercase dataset suffix lookups in `_dataset_file_format()` before falling back to `suffix.lower()`.
- Add a focused plan note for the dataset registry snapshot slice and its registered probe gate.

## Plan or Spec
- `docs/plans/2026-06-27-dataset-file-format-exact-suffix.md`
- Registered probe: `dataset-registry-snapshot-inference-single-pass`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-registry-snapshot-inference-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-dataset-file-format-exact-suffix-20260627 --head-repo "$PWD" --output /tmp/dataset_file_format_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 58 passed.
- Changed-scope coverage: 100.00% (5/5 changed measurable lines covered).
- Local registered probe (`dataset-registry-snapshot-inference-single-pass`): base `elapsed_ms_mean=131.403076`, head `elapsed_ms_mean=129.928404`, delta `-1.474672 ms`, speedup `1.011350x` (`1.122%` improvement). Peak bytes delta: `+24.0` bytes.

## Known Gaps
- Local validation is Linux/Python-only for this Python slice.
- GitHub Actions PR-scoped performance must complete successfully before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally against `origin/main` baseline and this branch.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
