### PR TITLE
perf(dataset): bind jsonl row reader hot methods

### DIFF
--- a/docs/plans/2026-06-27-dataset-jsonl-row-reader-binding-performance.md
+++ b/docs/plans/2026-06-27-dataset-jsonl-row-reader-binding-performance.md
@@ -1,0 +1,35 @@
+# Dataset JSONL Row Reader Binding Performance
+
+## Status
+
+Accepted for one focused performance slice on 2026-06-27.
+
+## Scope
+
+Optimize the Python dataset registry JSONL row reader in
+`services/mlx-worker-python/worker/dataset_registry/catalog.py` without changing
+row filtering, limit handling, or supported dataset formats.
+
+## Probe Coverage
+
+The affected path is covered by the registered PR-scoped performance probe
+`dataset-registry-preview-limit-short-circuit` in `infra/perf/pr_scoped_probes.json`.
+That probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for the dataset preview and row-reader path.
+
+## Slice
+
+Bind the hot JSONL row append method and JSON decoder lookup once per file-read
+call so repeated JSONL row parsing avoids repeated attribute lookups while
+preserving the same blank-line skipping, non-dict filtering, and limit semantics.
+
+## Verification
+
+Use the registered probe commands for local Linux verification:
+
+- focused dataset registry tests from the registered probe
+- changed-scope coverage from the registered probe
+- `scripts/dataset_registry_preview_limit_probe.py`
+
+CI must also run the PR-scoped performance workflow and report the registered
+probe result before merge.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -359,6 +359,41 @@ def test_dataset_catalog_row_reader_respects_limit(tmp_path: Path) -> None:
     assert rows == [{"prompt": "first", "answer": "a"}]
 
 
+def test_dataset_catalog_jsonl_row_reader_stops_after_limited_dict_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    jsonl_path = tmp_path / "sample.jsonl"
+    jsonl_path.write_text(
+        '\n'.join(
+            [
+                "",
+                json.dumps(["not", "a", "dict"]),
+                json.dumps({"prompt": "first"}),
+                json.dumps({"prompt": "second"}),
+                json.dumps({"prompt": "third"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    original_loads = catalog.json.loads
+    load_calls = 0
+
+    def counting_loads(payload: str) -> object:
+        nonlocal load_calls
+        load_calls += 1
+        return original_loads(payload)
+
+    monkeypatch.setattr(catalog.json, "loads", counting_loads)
+
+    assert catalog._read_rows_from_file(jsonl_path, limit=2) == [
+        {"prompt": "first"},
+        {"prompt": "second"},
+    ]
+    assert load_calls == 3
+
+
 def test_dataset_catalog_first_preview_scan_skips_readme_without_rescan(tmp_path: Path) -> None:
     snapshot_dir = tmp_path / "snapshot"
     data_dir = snapshot_dir / "data"

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -638,14 +638,16 @@ def _read_rows_from_file(path: Path, *, limit: int | None = None) -> list[dict[s
     suffix = path.suffix.lower()
     if suffix == ".jsonl":
         rows: list[dict[str, Any]] = []
+        append_row = rows.append
+        loads = json.loads
         with path.open("r", encoding="utf-8") as handle:
             for raw_line in handle:
                 line = raw_line.strip()
                 if not line:
                     continue
-                payload = json.loads(line)
+                payload = loads(line)
                 if isinstance(payload, dict):
-                    rows.append(payload)
+                    append_row(payload)
                     if limit is not None and len(rows) >= limit:
                         break
         return rows


### PR DESCRIPTION
## Summary
- Bind the dataset JSONL row reader's `rows.append` and `json.loads` lookups once per file read.
- Add a focused JSONL limit regression test covering blank lines, non-dict payloads, and early stop after the requested dict rows.

## Plan or Spec
- `docs/plans/2026-06-27-dataset-jsonl-row-reader-binding-performance.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_jsonl_row_reader_stops_after_limited_dict_rows services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_respects_limit
# exit 0: 2 passed in 0.24s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...registered dataset preview probe tests...
# exit 0: 29 passed in 1.03s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...registered dataset preview probe tests... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_limit_probe.py scripts/dataset_registry_preview_limit_probe.py
# exit 0: TOTAL 15 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py
# exit 0: {"elapsed_ms_mean": 98.694844, "elapsed_ms_min": 95.342158, "file_count": 50000.0, "multi_limit": 5.0, "multi_limit_dataset_files_yielded_mean": 5.0, "multi_limit_elapsed_ms_mean": 140.277002, "multi_limit_peak_bytes_mean": 20646.857, "peak_bytes_mean": 14749.143, "rows_returned": 1.0, "sample_count": 7.0, "sidecar_count": 1000.0, "zero_limit_elapsed_ms_mean": 0.00139, "zero_limit_peak_bytes_mean": 0.0, "zero_limit_rows_returned": 0.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 15 0 100%`).
- Registered probe: `dataset-registry-preview-limit-short-circuit`.
- Local Linux baseline before change: `elapsed_ms_mean=105.534273`, `multi_limit_elapsed_ms_mean=144.861103`, `peak_bytes_mean=14677.143`, `multi_limit_peak_bytes_mean=20574.571`.
- Local Linux after change: `elapsed_ms_mean=98.694844`, `multi_limit_elapsed_ms_mean=140.277002`, `peak_bytes_mean=14749.143`, `multi_limit_peak_bytes_mean=20646.857`.
- Delta: `elapsed_ms_mean=-6.839429 ms` (~6.48% faster), `multi_limit_elapsed_ms_mean=-4.584101 ms` (~3.16% faster). Peak bytes moved by ~72 bytes and is treated as noise for this slice.
- CI must run the PR-scoped performance workflow and registered probe report before merge.

## Known Gaps
- Full repository gates were not run locally; this PR uses the focused registered dataset preview probe commands on Linux.
- CI is required as the authoritative registered PR-scoped performance validation source before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing registered PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
