### PR TITLE
perf(hub): fast-path exact MLX tag lists

### DIFF
--- a/docs/plans/2026-06-27-hub-catalog-mlx-tag-exact-list.md
+++ b/docs/plans/2026-06-27-hub-catalog-mlx-tag-exact-list.md
@@ -1,0 +1,27 @@
+# Hub Catalog MLX Tag Exact-List Fast Path
+
+## Context
+
+The Hub catalog filters Hugging Face model payloads for MLX compatibility during
+search and card summarization. The registered PR-scoped probe
+`hub-catalog-size-hint-regex-precompile` already covers this path and reports the
+`payload_compatibility_elapsed_ms_mean` metric alongside the size-hint metrics.
+
+## Slice
+
+Optimize only the MLX tag payload check by adding an exact built-in `list` path
+before the generic list-subclass fallback. Hub API payloads arrive as plain Python
+lists after JSON decoding, so the hot path can avoid the slower `isinstance`
+checks while preserving subclass semantics for tests and defensive callers.
+
+## Verification
+
+- Focused hub catalog tests for MLX compatibility and registered probe selection.
+- Changed-scope coverage through the registered probe `coverage_command`.
+- Registered probe command on Linux, using
+  `payload_compatibility_elapsed_ms_mean` as the targeted metric.
+
+## Boundary
+
+This is a Python-only Linux-verifiable slice. It does not change Swift code or
+protocol-generated artifacts.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -124,6 +124,21 @@ def test_mlx_repo_id_detection_preserves_case_insensitive_matches() -> None:
     assert _repo_id_contains_mlx("owner/model-MLX-suffix") is True
 
 
+def test_payload_mlx_tag_detection_preserves_exact_list_and_subclass_semantics() -> None:
+    class TagList(list[str]):
+        pass
+
+    assert _payload_is_mlx_compatible(
+        {"id": "plain/model", "tags": ["Text-Generation", "MLX", object()]}
+    ) is True
+    assert _payload_is_mlx_compatible(
+        {"id": "plain/model", "tags": TagList(["Text-Generation", "mLx"])}
+    ) is True
+    assert _payload_is_mlx_compatible(
+        {"id": "plain/model", "tags": ["Text-Generation"], "cardData": {"tags": ["audio"]}}
+    ) is False
+
+
 class FakeHTTPResponse:
     def __init__(self, payload: object):
         self._payload = json.dumps(payload).encode("utf-8")

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -480,6 +480,13 @@ def _is_mlx_atom(value: str) -> bool:
 
 
 def _tag_payload_contains_mlx(value: Any) -> bool:
+    if type(value) is list:
+        for item in value:
+            if type(item) is str and (
+                item == "MLX" or item == "mlx" or (len(item) == 3 and _is_mlx_atom(item))
+            ):
+                return True
+        return False
     if isinstance(value, list):
         for item in value:
             if isinstance(item, str) and (


### PR DESCRIPTION
## Summary
- Add an exact built-in `list` fast path for Hub MLX tag payload detection while preserving the existing list-subclass fallback.
- Add regression coverage for exact-list, subclass-list, and negative tag payload semantics.

## Plan or Spec
- `docs/plans/2026-06-27-hub-catalog-mlx-tag-exact-list.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/model_ops/hub_catalog.py` and includes `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 89 passed in 1.28s

bash /tmp/hub_cov_cmd.sh
# 89 passed in 0.56s
# changed_scope_coverage: TOTAL 11 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_COMPATIBILITY_ITERATIONS=200000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# {"elapsed_ms_mean": 1850.3740055952221, "payload_compatibility_elapsed_ms_mean": 196.23089057859033, "payload_compatibility_calls_mean": 200000.0, ...}

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 11 0 100%`).
- Local Linux registered probe, targeted compatibility metric:
  - Baseline from `origin/main`: `payload_compatibility_elapsed_ms_mean=197.07268219208345 ms` with 200k calls / 5 samples.
  - Head: `payload_compatibility_elapsed_ms_mean=196.23089057859033 ms` with 200k calls / 5 samples.
  - Delta: `-0.84179161350312 ms` (`~1.0043x` faster) for the compatibility submetric.
- Full size-hint probe elapsed is noisy and not the target of this slice (`origin/main=1759.3591315904632 ms`, head=`1850.3740055952221 ms`); the registered CI probe is required for final validation before merge.

## Known Gaps
- No Swift runtime effect; this is a Python-only Linux-verified slice.
- CI must complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
