### PR TITLE
perf(export): prefilter diagnostic pattern scans

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -129,6 +129,13 @@ repeated fields separately instead of expanding them into one temporary tuple.
 This avoids an intermediate container allocation when each diagnostic receipt
 scans manifest rows for runtime logs.
 
+A follow-up 2026-06-27 diagnosis prefilter slice keeps the existing per-pattern
+marker gates and regex expressions, but first checks each lowercased source line
+against the union of known diagnosis markers. Lines with no diagnostic marker
+skip the pattern loop entirely, while matching lines still use the same compiled
+regexes and matched-pattern ids as before. This reduces bounded-excerpt scans
+with many progress lines that contain no supported failure terms.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -560,6 +560,25 @@ def test_export_target_diagnostics_pattern_markers_normalize_case() -> None:
     expression.search.assert_called_once_with("missing blob sha256-777777")
 
 
+def test_export_target_diagnostics_prefilters_unmarked_lines_before_pattern_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pattern = Mock()
+    pattern.code = CODE_MISSING_BLOB
+    pattern.matches.return_value = True
+    monkeypatch.setattr(export_target_diagnostics_module, "_DIAGNOSIS_PATTERNS", (pattern,))
+    monkeypatch.setattr(export_target_diagnostics_module, "_DIAGNOSIS_MARKERS", ("blob",))
+
+    diagnoses = export_target_diagnostics_module._diagnoses_from_excerpt(
+        [_SourceLine(source_path="logs/runtime.log", text="progress line without diagnostic terms")],
+        {0: 1},
+        "diagnostics/redacted-log-excerpt.txt",
+    )
+
+    assert diagnoses == []
+    pattern.matches.assert_not_called()
+
+
 def test_export_target_diagnostics_skips_path_regex_for_slashless_text(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -270,6 +270,9 @@ _DIAGNOSIS_PATTERNS = (
         markers=("failed to load", "model load", "runtime load", "error loading", "load failed"),
     ),
 )
+_DIAGNOSIS_MARKERS = tuple(
+    dict.fromkeys(marker for pattern in _DIAGNOSIS_PATTERNS for marker in pattern.markers)
+)
 
 
 def write_export_diagnostics_receipt(
@@ -698,6 +701,8 @@ def _diagnoses_from_excerpt(
     for index, line_number in line_numbers.items():
         text = source_lines[index].text
         lowered_text = text.lower()
+        if not any(marker in lowered_text for marker in _DIAGNOSIS_MARKERS):
+            continue
         for pattern in _DIAGNOSIS_PATTERNS:
             if pattern.code in seen_codes:
                 continue


### PR DESCRIPTION
## Summary
- Prefilter runtime export diagnostic excerpt lines against the union of registered diagnosis markers before entering the per-pattern scan loop.
- Preserve the existing per-pattern marker gates, regex expressions, diagnosis codes, and matched-pattern ids for lines that contain diagnostic terms.
- Document the 2026-06-27 diagnosis prefilter slice in the runtime export diagnostic parser plan.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 34 passed.
- Changed-scope coverage: 100% (12/12 measurable changed lines).
- Local registered probe (Linux): `elapsed_ms_mean=2861.608920979779`, `diagnosis_matching_elapsed_ms_mean=27.28150860639289`, `diagnostic_parser_coverage=1.0`, `diagnosis_code_count=9.0`, `peak_bytes_mean=204469.8`.
- Baseline comparison from a detached `origin/main` worktree using the same probe env (`MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=30`, `SAMPLES=5`) showed `diagnosis_matching_elapsed_ms_mean` around `72.77` and `74.21` ms; head runs showed `27.37` and `32.40` ms for the same diagnosis-matching submetric. Overall `elapsed_ms_mean` stayed within noise because the full probe also materializes temporary export layouts.
- CI PR-scoped performance must run the registered `runtime-export-diagnostic-parser` probe before merge.

## Known Gaps
- Linux local verification covers this Python runtime-export diagnostic parser path. No Swift runtime effect is claimed.
- The total probe elapsed metric is dominated by fixture materialization; this slice targets the registered `diagnosis_matching_elapsed_ms_mean` submetric.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe was run locally on Linux.
- [x] Governing plan/spec updated for the new optimization slice.
- [ ] GitHub Actions and PR-scoped performance report are green.
