### PR TITLE
perf(dataset): fast-path common source suffixes

### DIFF
--- a/docs/plans/2026-06-20-dataset-source-empty-check-isspace.md
+++ b/docs/plans/2026-06-20-dataset-source-empty-check-isspace.md
@@ -43,3 +43,16 @@ This slice replaces that guard with `not line or line.isspace()`, preserving
 blank and whitespace-only line skipping while avoiding stripped-copy allocation
 for populated JSONL rows. The existing focused ingest test now includes a
 whitespace-only JSONL line to keep behavior parity explicit.
+
+## 2026-06-27 follow-up: common lowercase source suffix fast path
+
+This Python-only follow-up stays within `_classify_source_kind_name(...)` and
+the existing registered `dataset-source-records-scandir` probe. The source tree
+probe repeatedly classifies lowercase `.md`, `.py`, and `.jsonl` filenames, but
+those names previously fell through to the generic suffix path that finds the
+last dot and lowercases the suffix before set membership checks.
+
+This slice adds exact lowercase suffix returns for `.md`, `.py`, and `.jsonl`
+after the existing text fast paths. Uppercase and mixed-case names still fall
+through to the generic lowercase path, preserving current behavior while
+avoiding generic suffix allocation/work for common generated dataset inputs.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -63,6 +63,9 @@ def test_dataset_ingest_source_kind_uses_single_suffix_fast_path() -> None:
     assert _source_kind(Path("Brief.TXT")) == "text"
     assert _source_kind(Path("notes.text")) == "text"
     assert _source_kind(Path("NOTES.TEXT")) == "text"
+    assert _source_kind(Path("README.md")) == "markdown"
+    assert _source_kind(Path("script.py")) == "code"
+    assert _source_kind(Path("records.jsonl")) == "structured_data"
     assert _source_kind(Path("script.PY")) == "code"
     assert _source_kind(Path("records.JSONL")) == "structured_data"
     assert _source_kind(Path("README")) is None

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -612,6 +612,12 @@ def _classify_source_kind_name(name: str) -> str | None:
         return "text"
     if name[-5:] == ".text":
         return "text"
+    if name[-3:] == ".md":
+        return "markdown"
+    if name[-3:] == ".py":
+        return "code"
+    if name[-6:] == ".jsonl":
+        return "structured_data"
 
     dot_index = name.rfind(".")
     if dot_index < 0:


### PR DESCRIPTION
## Summary
- Add exact lowercase `.md`, `.py`, and `.jsonl` fast paths in dataset source kind classification.
- Preserve mixed/uppercase suffix behavior through the existing generic lowercase fallback.
- Extend the focused source-kind regression test and document the follow-up slice.

## Plan or Spec
- `docs/plans/2026-06-20-dataset-source-empty-check-isspace.md` (2026-06-27 follow-up: common lowercase source suffix fast path)
- Registered probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json` already covers this path with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path
# 1 passed in 0.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_uses_single_suffix_fast_path services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_reuses_cached_basename_classification services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_returns_cached_none_without_reclassifying services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_kind_name_cache_clears_at_bound services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_use_scandir_without_rglob services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_file_paths_skips_scandir_errors services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_emits_typed_operator_failures services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 13 passed in 1.03s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered dataset-source-records-scandir focused selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# 13 passed in 0.38s; TOTAL 9 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=31 uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# head standalone: elapsed_ms_mean=12.1576, source_kind_elapsed_ms_mean=19.7377

(cd /root/.hermes/profiles/coder/workspace/melix && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=31 uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py)
# origin/main baseline standalone: elapsed_ms_mean=12.5684, source_kind_elapsed_ms_mean=21.1495

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=11 uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-dataset-source-path-list-comprehension-20260627 --output .runtime/dataset-source-records-pr-probe.json
# local registered probe completed; coverage 100%; 11-sample source_kind_elapsed_ms_mean base=20.6408 head=20.0579

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%`.
- Registered local PR-scoped probe (`dataset-source-records-scandir`, 11 samples): `source_kind_elapsed_ms_mean` base `20.6408 ms`, head `20.0579 ms`, delta `-0.5830 ms` (~`1.029x`).
- Stabilized standalone 31-sample probe:
  - `elapsed_ms_mean`: base `12.5684 ms`, head `12.1576 ms`, delta `-0.4108 ms`, speedup `1.0338x`.
  - `source_kind_elapsed_ms_mean`: base `21.1495 ms`, head `19.7377 ms`, delta `-1.4118 ms`, speedup `1.0715x`.
- GitHub Actions PR-scoped performance is still required as the merge gate.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this slice used the registered focused Python probe/test/coverage path on Linux.
- No Swift runtime effect is claimed; this is a Python-only source-kind classifier slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no new runtime observability overhead.
- [x] Deferred work and known gaps are stated explicitly.
