### PR TITLE
perf(training): split chunker prefix branch

### DIFF
--- a/docs/plans/2026-06-21-training-dataset-chunker-empty-prefix-fastpath.md
+++ b/docs/plans/2026-06-21-training-dataset-chunker-empty-prefix-fastpath.md
@@ -5,11 +5,13 @@ This Python performance slice is limited to single-turn long-context chunking in
 
 ## Goal
 
-Keep chunking behavior unchanged while avoiding empty-list concatenation when a
-single-turn sample has no system prefix. This is the common synthetic/probe path
+Keep chunking behavior unchanged while avoiding per-segment prefix branching when
+a single-turn sample has no system prefix. This is the common synthetic/probe path
 and many training examples are user/assistant only, so the chunk candidate loop
-can build `[user, assistant]` message lists directly instead of evaluating
-`system_prefix + [...]` for an empty prefix on every candidate segment.
+can build `[user, assistant]` message lists directly on a dedicated branch while
+the system-prefix branch preserves `system_prefix + [...]` semantics. The loop
+also binds the render and segment iterator helpers once per chunk operation to
+avoid repeated global lookups in the candidate hot path.
 
 ## Probe coverage
 

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -263,26 +263,46 @@ def _chunk_single_turn(
                 "chunk_size or pre-reduce the assistant/system prefix."
             ),
         )
-    for k in range(k_floor, word_count + 1):
-        chunks: list[list[dict[str, str]]] = []
-        segment_count = 0
-        for segment in _iter_word_segments(words, k):
-            segment_count += 1
-            user_segment = {"role": "user", "content": segment}
-            if system_prefix:
+    render_len = _render_len
+    iter_word_segments = _iter_word_segments
+    if system_prefix:
+        for k in range(k_floor, word_count + 1):
+            chunks: list[list[dict[str, str]]] = []
+            append_chunk = chunks.append
+            segment_count = 0
+            for segment in iter_word_segments(words, k):
+                segment_count += 1
+                user_segment = {"role": "user", "content": segment}
                 chunk = system_prefix + [user_segment, assistant]
-            else:
+                if render_len(chunk, tokenizer, tools=tools) > chunk_size:
+                    break
+                append_chunk(chunk)
+            if segment_count < k:
+                # User content has fewer words than buckets — caller must try a
+                # smaller K. In practice this only fires when k > word_count,
+                # which the guard above already rejects.
+                continue
+            if len(chunks) == k:
+                return chunks
+    else:
+        for k in range(k_floor, word_count + 1):
+            chunks: list[list[dict[str, str]]] = []
+            append_chunk = chunks.append
+            segment_count = 0
+            for segment in iter_word_segments(words, k):
+                segment_count += 1
+                user_segment = {"role": "user", "content": segment}
                 chunk = [user_segment, assistant]
-            if _render_len(chunk, tokenizer, tools=tools) > chunk_size:
-                break
-            chunks.append(chunk)
-        if segment_count < k:
-            # User content has fewer words than buckets — caller must try a
-            # smaller K. In practice this only fires when k > word_count,
-            # which the guard above already rejects.
-            continue
-        if len(chunks) == k:
-            return chunks
+                if render_len(chunk, tokenizer, tools=tools) > chunk_size:
+                    break
+                append_chunk(chunk)
+            if segment_count < k:
+                # User content has fewer words than buckets — caller must try a
+                # smaller K. In practice this only fires when k > word_count,
+                # which the guard above already rejects.
+                continue
+            if len(chunks) == k:
+                return chunks
 
     raise ModelOperationError(
         code="chunk_size_too_small",


### PR DESCRIPTION
## Summary
- Split the single-turn chunker candidate loop into explicit system-prefix and no-prefix branches.
- Bind the render and word-segment helper lookups once per chunk operation so the no-prefix hot path avoids repeated prefix branching/global lookups while preserving chunk semantics.

## Plan or Spec
- `docs/plans/2026-06-21-training-dataset-chunker-empty-prefix-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_filter_top_level_keys_once_per_source_sample services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_chunking_streams_candidate_segments_without_list_helper services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_without_system_prefix_keeps_two_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_with_system_prefix_keeps_three_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_search_stops_candidate_rendering_after_first_oversized_segment services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_words_into_k_matches_string_helper_output services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_user_content_into_k_handles_trivial_and_word_shortage_cases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_chunker_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_dataset_chunker_top_level_copy_probe_script_emits_metrics
# exit 0; 11 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q [same focused tests]
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py services/mlx-worker-python/tests/test_training_dataset_chunker.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/training_dataset_chunker_top_level_copy_probe.py
# exit 0; aggregate changed-line coverage 100.00% (31/31)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/training_dataset_chunker_top_level_copy_probe.py
# origin/main samples: elapsed_ms_mean 24.552526, 22.801652, 24.006312
# this branch samples: elapsed_ms_mean 22.800492, 22.918026, 22.535512
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (31/31 measurable changed lines).
- Registered local probe: `training-dataset-chunker-top-level-base-copy`.
- Local Linux probe means: old_mean=23.786830 ms, new_mean=22.751343 ms, delta_ms=-1.035487 ms, speedup=1.045513x.
- PR-scoped performance CI is still required as the registered hosted validation source before merge.

## Known Gaps
- Full repository test suite was not run locally; this is a focused Python performance slice.
- No Swift runtime behavior changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability or debug mode changes.
- [x] Deferred work and known gaps are stated explicitly.
