### PR TITLE
perf(dataset): skip unsupported file path construction

### DIFF
--- a/docs/plans/2026-06-27-dataset-registry-file-format-name-fastpath.md
+++ b/docs/plans/2026-06-27-dataset-registry-file-format-name-fastpath.md
@@ -1,0 +1,46 @@
+# Dataset registry file-format name fast path
+
+## Scope
+
+This Python performance slice targets the dataset registry snapshot file scan in
+`services/mlx-worker-python/worker/dataset_registry/catalog.py`.
+
+The scan already walks snapshot directories with `os.scandir`; this slice keeps
+that traversal model and avoids constructing `Path` objects for regular files
+whose names cannot produce a supported dataset format. The behavior remains
+unchanged: README metadata and supported dataset suffixes are still emitted, and
+unsupported sidecar files remain ignored.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`dataset-registry-snapshot-inference-single-pass` in
+`infra/perf/pr_scoped_probes.json`. The probe has focused `test_command`,
+`coverage_command`, and `probe_command` entries for the catalog path, dataset
+registry tests, PR-scoped performance tests, and
+`scripts/dataset_registry_snapshot_probe.py`.
+
+This slice extends the probe fixture with ignored `.txt` sidecar files so the
+registered probe exercises the unsupported-file branch where the optimization is
+measurable.
+
+## Implementation plan
+
+1. Add a string-name format helper shared by `_dataset_file_format()` and the
+   scandir entry loop.
+2. In `_iter_supported_dataset_file_entries()`, check the entry name before
+   constructing `Path(entry.path)` for regular files.
+3. Add a regression test proving unsupported files do not allocate `Path`
+   objects while supported dataset files and README metadata still do.
+4. Run focused dataset registry tests, changed-scope coverage, and the registered
+   snapshot-inference probe locally on Linux. Compare `origin/main` and HEAD with
+   the same updated probe fixture before accepting the slice.
+5. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage is at least 95% for touched files.
+- The registered probe reports a clear improvement or bounded allocation-path
+  benefit on the sidecar-heavy fixture.
+- The PR-scoped performance workflow completes successfully before merge.

--- a/scripts/dataset_registry_snapshot_probe.py
+++ b/scripts/dataset_registry_snapshot_probe.py
@@ -19,7 +19,7 @@ import worker.dataset_registry.catalog as catalog
 from worker.dataset_registry.catalog import DatasetCatalog
 
 
-def _write_probe_snapshot(home: Path, *, file_count: int) -> tuple[Path, int]:
+def _write_probe_snapshot(home: Path, *, file_count: int, sidecar_count: int) -> tuple[Path, int]:
     cache_repo_dir = home / ".cache" / "huggingface" / "hub" / "datasets--org--probe"
     snapshot_dir = cache_repo_dir / "snapshots" / "snapshot-probe"
     refs_dir = cache_repo_dir / "refs"
@@ -35,12 +35,17 @@ def _write_probe_snapshot(home: Path, *, file_count: int) -> tuple[Path, int]:
         path = data_dir / f"{split}-{index:05d}.jsonl"
         path.write_text('{"prompt":"hello","answer":"world"}\n', encoding="utf-8")
         expected_files += 1
+    for index in range(sidecar_count):
+        config = f"config-{index % 12:02d}"
+        data_dir = snapshot_dir / config
+        data_dir.mkdir(parents=True, exist_ok=True)
+        data_dir.joinpath(f"sidecar-{index:05d}.txt").write_text("ignored\n", encoding="utf-8")
     snapshot_dir.joinpath("README.md").write_text("# Probe dataset\n", encoding="utf-8")
     expected_files += 1
     return snapshot_dir, expected_files
 
 
-def run_probe(*, file_count: int = 2400, samples: int = 5) -> dict[str, Any]:
+def run_probe(*, file_count: int = 2400, samples: int = 5, sidecar_count: int = 2400) -> dict[str, Any]:
     elapsed_samples: list[float] = []
     peak_samples: list[float] = []
     helper_call_samples: list[float] = []
@@ -51,7 +56,11 @@ def run_probe(*, file_count: int = 2400, samples: int = 5) -> dict[str, Any]:
     for _ in range(samples):
         with tempfile.TemporaryDirectory(prefix="melix-dataset-registry-probe-") as tmp:
             home = Path(tmp) / "home"
-            _snapshot_dir, expected_files = _write_probe_snapshot(home, file_count=file_count)
+            _snapshot_dir, expected_files = _write_probe_snapshot(
+                home,
+                file_count=file_count,
+                sidecar_count=sidecar_count,
+            )
             helper_calls = 0
 
             def counted_split(relative_path: str) -> str:
@@ -107,7 +116,9 @@ def run_probe(*, file_count: int = 2400, samples: int = 5) -> dict[str, Any]:
 def main() -> int:
     file_count = int(os.environ.get("MELIX_DATASET_REGISTRY_PROBE_FILE_COUNT", "2400"))
     samples = int(os.environ.get("MELIX_DATASET_REGISTRY_PROBE_SAMPLES", "5"))
-    metrics = run_probe(file_count=file_count, samples=samples)
+    sidecar_count = int(os.environ.get("MELIX_DATASET_REGISTRY_PROBE_SIDECAR_COUNT", str(file_count)))
+    metrics = run_probe(file_count=file_count, samples=samples, sidecar_count=sidecar_count)
+    metrics["sidecar_count_mean"] = float(sidecar_count)
     print(json.dumps(metrics, sort_keys=True))
     return 0
 

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -185,11 +185,42 @@ def test_dataset_catalog_file_format_uses_supported_suffixes() -> None:
     assert catalog._dataset_file_format(Path("train.JSONL")) == "jsonl"
     assert catalog._dataset_file_format(Path("train.jsonl.")) == ""
     assert catalog._dataset_file_format(Path(".jsonl")) == ""
+    assert catalog._dataset_file_format_name("README.md") == "metadata"
+    assert catalog._dataset_file_format_name("train.JSONL") == "jsonl"
+    assert catalog._dataset_file_format_name("notes.txt") == ""
     assert catalog._is_supported_dataset_file_name("train.jsonl") is True
     assert catalog._is_supported_dataset_file_name("train.JSONL") is True
     assert catalog._is_supported_dataset_file_name("notes.txt") is False
     assert catalog._is_supported_dataset_file_name("README") is False
     assert catalog._is_supported_dataset_file_name(".jsonl") is False
+
+
+def test_dataset_catalog_skips_path_construction_for_unsupported_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_dir.mkdir()
+    (snapshot_dir / "README.md").write_text("# Dataset\n", encoding="utf-8")
+    (snapshot_dir / "train.jsonl").write_text("{}\n", encoding="utf-8")
+    (snapshot_dir / "notes.txt").write_text("ignore\n", encoding="utf-8")
+    (snapshot_dir / ".jsonl").write_text("ignore\n", encoding="utf-8")
+
+    real_path = Path
+    constructor_calls = 0
+
+    class CountingPath:
+        def __new__(cls, *args: Any, **kwargs: Any):
+            nonlocal constructor_calls
+            constructor_calls += 1
+            return real_path(*args, **kwargs)
+
+    monkeypatch.setattr(catalog, "Path", CountingPath)
+
+    entries = tuple(catalog._iter_supported_dataset_file_entries(snapshot_dir))
+
+    assert [relative_path for _path, relative_path in entries] == ["README.md", "train.jsonl"]
+    assert constructor_calls == 2
 
 
 def test_dataset_catalog_split_alias_prefix_scan_matches_legacy_delimiters() -> None:

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -988,7 +988,8 @@ def _iter_supported_dataset_file_entries(
     except OSError:
         return
     for entry in child_entries:
-        relative_path = f"{relative_prefix}{entry.name}"
+        name = entry.name
+        relative_path = f"{relative_prefix}{name}"
         try:
             if entry.is_dir():
                 yield from _iter_supported_dataset_file_entries(
@@ -999,13 +1000,15 @@ def _iter_supported_dataset_file_entries(
                 continue
         except OSError:
             continue
-        child_path = Path(entry.path)
-        if _dataset_file_format(child_path):
-            yield child_path, relative_path
+        if _dataset_file_format_name(name):
+            yield Path(entry.path), relative_path
 
 
 def _dataset_file_format(path: Path) -> str:
-    name = path.name
+    return _dataset_file_format_name(path.name)
+
+
+def _dataset_file_format_name(name: str) -> str:
     if name in _README_NAMES:
         return "metadata"
     dot_index = name.rfind(".")


### PR DESCRIPTION
## Summary
- Avoid constructing `Path(entry.path)` for unsupported dataset snapshot sidecar files during dataset registry scans.
- Share dataset file-format suffix resolution through a string-name helper while preserving README metadata and supported suffix behavior.
- Extend the registered snapshot-inference probe fixture with ignored `.txt` sidecars so the allocation path is represented.

## Plan or Spec
- `docs/plans/2026-06-27-dataset-registry-file-format-name-fastpath.md`
- Registered PR-scoped probe: `dataset-registry-snapshot-inference-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py`
- `MELIX_DATASET_REGISTRY_PROBE_REPO_ROOT="$BASE" PYTHONPATH="$BASE:$BASE/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py` (baseline, repeated twice)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 60 passed.
- Changed-scope coverage: 100% (37/37 measurable changed lines).
- Registered probe, same sidecar-heavy fixture (`file_count=2400`, `sidecar_count=2400`, `samples=5`):
  - Baseline `origin/main`: `elapsed_ms_mean=195.9537`, repeat `193.9506` ms.
  - HEAD: `elapsed_ms_mean=140.2213`, repeat `146.3599` ms; direct local run `139.3521` ms.
  - Representative delta: `193.9506 -> 146.3599` ms (`-47.5907` ms, ~24.5% faster). Peak bytes stayed effectively flat around `778.4 KiB`.
- CI PR-scoped performance must run the registered `dataset-registry-snapshot-inference-single-pass` probe before merge.

## Known Gaps
- Linux local verification covers this Python dataset registry scan path. No Swift runtime effect is claimed.
- The elapsed improvement is specific to sidecar-heavy snapshots; snapshots containing only supported dataset files should see behavior parity with limited performance change.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe was run locally on Linux.
- [x] Governing plan/spec updated for the new optimization slice.
- [ ] GitHub Actions and PR-scoped performance report are green.
