### PR TITLE
perf(runtime): reuse normalized quantized metadata

### DIFF
--- a/docs/plans/2026-06-27-quantized-metadata-normalized-construction.md
+++ b/docs/plans/2026-06-27-quantized-metadata-normalized-construction.md
@@ -1,0 +1,37 @@
+# Quantized tensor metadata normalized construction slice
+
+This Python performance slice is limited to quantized tensor metadata construction
+inside `worker.runtime.quantized_tensor_metadata`. The runtime already normalizes
+index/header tensor mappings before wrapping them in `QuantizedTensorMetadata`;
+this slice removes the second normalization pass while preserving immutable
+`MappingProxyType` exposure.
+
+## Registered probe
+
+The affected path is covered by the existing PR-scoped probe
+`quantized-tensor-metadata-prepass` in `infra/perf/pr_scoped_probes.json`. The
+probe includes focused `test_command`, `coverage_command`, and `probe_command`
+entries for:
+
+- `services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py`
+- `services/mlx-worker-python/tests/test_mlx_vlm_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/quantized_tensor_metadata_prepass_probe.py`
+
+## Slice
+
+- Add an internal constructor for already-normalized `dict[str, str]` metadata.
+- Reuse it from index-payload and safetensors-header construction to avoid
+  re-stringifying keys and shard names in `QuantizedTensorMetadata.__post_init__`.
+- Iterate `tensor_to_shard` directly in cross-shard fixup counting to avoid an
+  extra `frozenset` allocation.
+- Preserve the public dataclass constructor behavior for arbitrary external
+  mappings and keep returned metadata immutable.
+
+## Local verification
+
+Run the registered focused test command, changed-scope coverage command, and
+registered probe locally on Linux before pushing. Compare the registered probe
+against `origin/main` and this branch; the accepted signal is lower index/header
+construction elapsed time and peak bytes with unchanged tensor counts and
+cross-shard counts.

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -2455,6 +2455,10 @@ def test_quantized_tensor_metadata_merges_cross_shard_index_and_headers(
         ] = "model-00003.safetensors"
     assert not EMPTY_QUANTIZED_TENSOR_METADATA.tensor_names
     assert cross_shard_quantized_metadata_fixup_count(EMPTY_QUANTIZED_TENSOR_METADATA) == 0
+    assert (
+        quantized_tensor_metadata_from_index_payload({"weight_map": {}})
+        is EMPTY_QUANTIZED_TENSOR_METADATA
+    )
 
 
 class _CountingEmptyWeights(dict[str, object]):

--- a/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
+++ b/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
@@ -50,6 +50,16 @@ class QuantizedTensorMetadata:
 
 EMPTY_QUANTIZED_TENSOR_METADATA = QuantizedTensorMetadata({})
 MAX_SAFETENSORS_HEADER_BYTES = 100 * 1024 * 1024
+
+
+def _metadata_from_normalized_mapping(tensor_to_shard: dict[str, str]) -> QuantizedTensorMetadata:
+    if not tensor_to_shard:
+        return EMPTY_QUANTIZED_TENSOR_METADATA
+    metadata = object.__new__(QuantizedTensorMetadata)
+    object.__setattr__(metadata, "tensor_to_shard", MappingProxyType(tensor_to_shard))
+    return metadata
+
+
 _NATIVE_MULTIMODAL_HIGH_PRECISION_PREFIXES = (
     "audio_tower",
     "embed_audio",
@@ -94,7 +104,7 @@ def quantized_tensor_metadata_from_index_payload(
         tensor_name = str(raw_tensor_name)
         if tensor_name:
             tensor_to_shard[tensor_name] = str(raw_shard_name)
-    return QuantizedTensorMetadata(tensor_to_shard)
+    return _metadata_from_normalized_mapping(tensor_to_shard)
 
 
 def quantized_tensor_metadata_from_safetensor_headers(
@@ -108,7 +118,7 @@ def quantized_tensor_metadata_from_safetensor_headers(
             tensor_to_shard[tensor_name] = shard_name
     if not tensor_to_shard:
         return EMPTY_QUANTIZED_TENSOR_METADATA
-    return QuantizedTensorMetadata(tensor_to_shard)
+    return _metadata_from_normalized_mapping(tensor_to_shard)
 
 
 def quantized_tensor_metadata_from_model_dir(
@@ -144,7 +154,7 @@ def cross_shard_quantized_metadata_fixup_count(
     metadata: QuantizedTensorMetadata,
 ) -> int:
     prefixes: set[str] = set()
-    for tensor_name in metadata.tensor_names:
+    for tensor_name in metadata.tensor_to_shard:
         if tensor_name.endswith(".weight"):
             prefixes.add(tensor_name[: -len(".weight")])
         elif tensor_name.endswith(".scales"):


### PR DESCRIPTION
## Summary
- Reuse already-normalized quantized tensor metadata mappings when building metadata from index payloads and safetensors headers.
- Iterate the metadata mapping directly for cross-shard fixup counting to avoid materializing `tensor_names`.
- Add a focused regression assertion for the empty normalized mapping fast path.

## Plan or Spec
- `docs/plans/2026-06-27-quantized-metadata-normalized-construction.md`
- Registered probe: `quantized-tensor-metadata-prepass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_merges_cross_shard_index_and_headers services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_normalizes_index_keys_once services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_model_dir_scans_top_level_headers_and_bad_entries services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_scales_present_skips_empty_weight_lookup services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_multimodal_high_precision_module_segment_scan_preserves_boundaries services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_text_only_language_model_quantizes_from_presanitize_metadata services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_text_backed_loader_uses_tokenizer_for_text_only_exports services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_uses_generate_step_for_mtp_when_available services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantized_tensor_metadata_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_vlm_runtime_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_base_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 16 passed in 0.86s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --include='*/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py,*/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py,*/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py,*/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py,*/services/mlx-worker-python/tests/test_pr_scoped_performance.py,*/scripts/quantized_tensor_metadata_prepass_probe.py' -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantized_tensor_metadata_prepass_probe.py
# 16 passed in 0.62s; changed-scope coverage TOTAL 10 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_QUANTIZED_TENSOR_METADATA_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/quantized_tensor_metadata_prepass_probe.py
# head metrics captured below
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Local registered probe (`quantized-tensor-metadata-prepass`) on Linux:
  - base (`origin/main`): `index_elapsed_ms_mean=1.322864`, `index_peak_bytes_mean=519108.6`, `header_elapsed_ms_mean=46.010279`, `header_peak_bytes_mean=1002693.0`, `metadata_decision_elapsed_ms_mean=28.989963`, `high_precision_decision_elapsed_ms_mean=97.810435`.
  - head: `index_elapsed_ms_mean=0.751795`, `index_peak_bytes_mean=311516.6`, `header_elapsed_ms_mean=48.837617`, `header_peak_bytes_mean=925119.0`, `metadata_decision_elapsed_ms_mean=29.566563`, `high_precision_decision_elapsed_ms_mean=97.617720`.
  - CI PR-scoped performance must provide the merge-gate registered probe report for this branch.

## Known Gaps
- Swift/macOS runtime effects were not locally validated on Linux; this is a Python worker slice, and the registered Linux probe is the relevant local signal.
- `header_elapsed_ms_mean` was informational and locally noisy (+2.827 ms), while index construction latency/peak bytes improved and lower-is-better registered decision metrics stayed within thresholds.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
