### PR TITLE
perf(report): reuse analysis list fields

### DIFF
--- a/docs/plans/2026-06-27-report-evidence-analysis-field-reuse.md
+++ b/docs/plans/2026-06-27-report-evidence-analysis-field-reuse.md
@@ -1,0 +1,28 @@
+# Report evidence analysis payload field reuse
+
+## Slice
+
+Optimize exactly one Python hot path in report evidence analysis:
+`_analyze_report()` in `services/mlx-worker-python/worker/productization/report_evidence_gate.py`.
+
+The registered PR-scoped probe covering this path is `report-evidence-gate-run-kind-set-membership` in
+`infra/perf/pr_scoped_probes.json`. It already includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for `report_evidence_gate.py`, its focused tests, and
+`scripts/report_evidence_gate_run_kind_probe.py`.
+
+## Hypothesis
+
+`_analyze_report()` previously looked up `source_evidence_ids` and `known_gaps` twice each while building
+its result payload. Reusing the looked-up objects removes redundant dictionary lookups while preserving the
+existing list-copy semantics for valid lists and the empty-list fallback for invalid values.
+
+## Scope
+
+- Keep report analysis behavior identical for list and non-list `source_evidence_ids` / `known_gaps`.
+- Do not change report rendering, matrix matching, or probe registry semantics.
+- Use the existing registered probe as the local and CI performance gate.
+
+## Verification
+
+Run the registered probe's focused tests, changed-scope coverage command, and probe command locally on
+Linux. CI PR-scoped performance must also complete successfully before merge.

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -213,21 +213,21 @@ def _analyze_report(
                     "message": f"hardware telemetry failure: {failure}",
                 }
             )
+    source_evidence_ids = report.get("source_evidence_ids")
+    known_gaps = report.get("known_gaps")
     return {
         "path": str(path),
         "report_id": report.get("report_id", ""),
         "report_kind": report.get("report_kind", ""),
-        "source_evidence_ids": list(report.get("source_evidence_ids", []))
-        if isinstance(report.get("source_evidence_ids"), list)
+        "source_evidence_ids": list(source_evidence_ids)
+        if isinstance(source_evidence_ids, list)
         else [],
         "markdown_report_path": artifacts.get("markdown_report_path", ""),
         "validation_errors": validation_errors,
         "gate_result": gate_result.get("overall_result", "fail"),
         "blocking_failures": blocking_failures,
         "informational_results": _dict_list(gate_result.get("informational_results")),
-        "known_gaps": list(report.get("known_gaps", []))
-        if isinstance(report.get("known_gaps"), list)
-        else [],
+        "known_gaps": list(known_gaps) if isinstance(known_gaps, list) else [],
         "telemetry_failures": telemetry_failures,
         "slowest_probe_phases": _slowest_probe_phases(report),
         "evidence_validity_metrics": gate_result.get("evidence_validity_metrics", {})


### PR DESCRIPTION
## Summary
- Reuse `_analyze_report()` lookups for `source_evidence_ids` and `known_gaps` before copying list payload fields.
- Preserve the existing list-copy behavior and non-list fallback semantics while trimming redundant dictionary lookups in the report evidence analysis path.

## Plan or Spec
- `docs/plans/2026-06-27-report-evidence-analysis-field-reuse.md`

## Commands Run
```text
# Registered report-evidence-gate-run-kind-set-membership test_command from infra/perf/pr_scoped_probes.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...
# exit 0; 28 passed in 0.17s

# Registered report-evidence-gate-run-kind-set-membership coverage_command from infra/perf/pr_scoped_probes.json
# exit 0; 28 passed; changed-scope coverage TOTAL 2 0 100%

# Registered report-evidence-gate-run-kind-set-membership probe_command from infra/perf/pr_scoped_probes.json
# exit 0; elapsed_ms_mean=971.2290943833068, release_matrix_elapsed_ms_mean=29.27658560220152

# Repeated local candidate probe (3 runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# exit 0; elapsed_ms_mean runs: 989.9540829588659, 956.5398406120948, 991.1228766199201; mean=979.205600063627
# release_matrix_elapsed_ms_mean runs: 27.771395805757493, 27.30768019100651, 27.739333198405802; mean=27.606136398389935

# Main baseline probe from origin/main (3 runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# exit 0; elapsed_ms_mean runs: 975.1549523556605, 992.6095609669574, 983.8365067495033; mean=983.8670066907071
# release_matrix_elapsed_ms_mean runs: 30.428882397245616, 27.206509793177247, 27.39565478404984; mean=28.343682324824233

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%` for `services/mlx-worker-python/worker/productization/report_evidence_gate.py`.
- Local registered probe repeated mean: `elapsed_ms_mean` improved from `983.8670066907071 ms` to `979.205600063627 ms` (delta `-4.661406627080055 ms`, `0.47378422036520595%` faster).
- Local release-matrix probe metric repeated mean: `release_matrix_elapsed_ms_mean` improved from `28.343682324824233 ms` to `27.606136398389935 ms` (delta `-0.7375459264342972 ms`, `2.602152811275099%` faster).
- PR-scoped performance workflow is still required for registered CI validation before merge.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this small Python-only slice.
- Two attempted report-evidence micro-slices were rejected before commit because the registered local probe did not improve the targeted metric: `_probe_phases()` string fast path and `_release_matrix_rows()` `set.update(map(...))`.
- Swift runtime effects are not applicable to this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: registered PR-scoped performance probe; probe overhead is bounded to the synthetic probe command.
- [x] Deferred work and known gaps are stated explicitly.
