### PR TITLE
perf(hub): prefer uppercase size label probes

### DIFF
--- a/docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md
+++ b/docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md
@@ -56,3 +56,12 @@ probe and reorders `_may_contain_model_marker(...)` so uppercase `MODEL SIZE`
 text exits on the first substring scan. Hugging Face card/readme metadata often
 uses uppercase headings, while the helper still checks all four case combinations
 and preserves the downstream regex fallback behavior.
+
+## 2026-06-27 Follow-up: Uppercase Size Label Search Order
+
+This slice keeps the same registered `hub-catalog-size-hint-regex-precompile`
+probe and moves the uppercase `MODEL SIZE` checks ahead of mixed-case checks in
+`_direct_explicit_size_hint_from_text(...)` and `_strip_model_size_label(...)`.
+The probe's hot payloads use uppercase Hub card/readme size labels, so the direct
+parser avoids one failed substring/prefix scan per uppercase label while keeping
+the existing mixed-case and lowercase fallback behavior intact.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -909,9 +909,9 @@ def _direct_card_size_hint_from_text(text: str) -> int:
 
 
 def _direct_explicit_size_hint_from_text(text: str) -> int:
-    marker_index = text.find("Model size")
+    marker_index = text.find("MODEL SIZE")
     if marker_index < 0:
-        marker_index = text.find("MODEL SIZE")
+        marker_index = text.find("Model size")
     if marker_index < 0:
         marker_index = text.find("model size")
     if marker_index < 0:
@@ -940,10 +940,10 @@ def _direct_explicit_size_hint_from_text(text: str) -> int:
 
 
 def _strip_model_size_label(text: str) -> str:
-    if text.startswith("Model size: "):
-        return text[12:]
     if text.startswith("MODEL SIZE:") or text.startswith("MODEL SIZE|"):
         return text[11:]
+    if text.startswith("Model size: "):
+        return text[12:]
     if not _starts_with_model_size_label(text):
         return ""
     cursor = 10


### PR DESCRIPTION
## Summary
- Prefer uppercase `MODEL SIZE` direct-parser checks in Hub catalog size hint parsing.
- Avoid one failed mixed-case substring/prefix scan for uppercase Hub card/readme size labels.

## Plan or Spec
- `docs/plans/2026-05-08-hub-catalog-card-model-size-fast-path.md`
- Registered PR-scoped probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# baseline from /root/.hermes/profiles/coder/workspace/melix at origin/main
MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=7 MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_COMPATIBILITY_ITERATIONS=200000 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# exit 0; elapsed_ms_mean=1754.0507855675448

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# exit 0; 89 passed in 1.27s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# exit 0; 89 passed in 0.58s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# exit 0; wrote coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# exit 0; TOTAL 4 0 100%

MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=7 MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_COMPATIBILITY_ITERATIONS=200000 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# exit 0; elapsed_ms_mean=1725.1406779978424

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Registered probe local Linux comparison (`hub_catalog_size_hint_probe.py`, 7 samples, 200k iterations):
  - old_mean=1754.0507855675448 ms
  - new_mean=1725.1406779978424 ms
  - delta_ms=-28.910107569702404 ms
  - speedup=1.6481910220374936%
  - size_hint_calls_mean=0.0 before/after
- CI PR-scoped performance workflow is required for repository-side registered probe validation.

## Known Gaps
- None for the Python slice. Swift/macOS runtime effects are not touched.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode changes or deferred probe work.
- [x] Deferred work and known gaps are stated explicitly.
